### PR TITLE
fix: add @lid format support and allowFrom wildcard handling

### DIFF
--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -148,7 +148,8 @@ export async function getReplyFromConfig(
   const allowFrom = cfg.inbound?.allowFrom;
   if (Array.isArray(allowFrom) && allowFrom.length > 0) {
     const from = (ctx.From ?? "").replace(/^whatsapp:/, "");
-    if (!allowFrom.includes(from)) {
+    // Support "*" as wildcard to allow all senders
+    if (!allowFrom.includes("*") && !allowFrom.includes(from)) {
       logVerbose(
         `Skipping auto-reply: sender ${from || "<unknown>"} not in allowFrom list`,
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,9 +38,26 @@ export function toWhatsappJid(number: string): string {
 export function jidToE164(jid: string): string | null {
   // Convert a WhatsApp JID (with optional device suffix, e.g. 1234:1@s.whatsapp.net) back to +1234.
   const match = jid.match(/^(\d+)(?::\d+)?@s\.whatsapp\.net$/);
-  if (!match) return null;
-  const digits = match[1];
-  return `+${digits}`;
+  if (match) {
+    const digits = match[1];
+    return `+${digits}`;
+  }
+
+  // Support @lid format (WhatsApp Linked ID) - look up reverse mapping
+  const lidMatch = jid.match(/^(\d+)(?::\d+)?@lid$/);
+  if (lidMatch) {
+    const lid = lidMatch[1];
+    try {
+      const mappingPath = `${CONFIG_DIR}/credentials/lid-mapping-${lid}_reverse.json`;
+      const data = fs.readFileSync(mappingPath, "utf8");
+      const phone = JSON.parse(data);
+      if (phone) return `+${phone}`;
+    } catch {
+      // Mapping not found, fall through
+    }
+  }
+
+  return null;
 }
 
 export function sleep(ms: number) {


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs that prevent the web relay from processing inbound messages on newer WhatsApp versions:

1. **LID format not recognized**: WhatsApp now uses Linked ID (`@lid`) format for message senders instead of the traditional `@s.whatsapp.net` format. The current `jidToE164()` function silently drops these messages.

2. **Wildcard `"*"` in allowFrom doesn't work**: The `allowFrom: ["*"]` configuration is documented to allow all senders, but the code performs an exact string match, so `"*"` never matches any phone number.

---

## Bug 1: LID Format Not Supported

### Problem

WhatsApp has transitioned to using Linked IDs (LID) for identifying users in newer API versions. Messages now arrive with JIDs in the format:

```
142326760485098@lid
```

Instead of the traditional format:

```
5561983297558@s.whatsapp.net
```

The current `jidToE164()` function in `src/utils.ts` only matches the `@s.whatsapp.net` format, causing all inbound messages from `@lid` JIDs to be silently dropped.

### Solution

Updated `jidToE164()` to check for `@lid` format and use the existing reverse mapping files that warelay already creates in `~/.warelay/credentials/lid-mapping-*_reverse.json`.

---

## Bug 2: allowFrom Wildcard Not Working

### Problem

The `allowFrom` configuration is documented to support `"*"` as a wildcard to allow messages from all senders. However, the implementation performs an exact string match:

```typescript
if (!allowFrom.includes(from)) {  // Exact match only!
```

When `allowFrom: ["*"]` is configured, the check fails because `"+556183297558"` is not literally in `["*"]`.

### Solution

Added a check for the wildcard before performing the exact match:

```typescript
if (!allowFrom.includes("*") && !allowFrom.includes(from)) {
```

---

## Testing

1. **LID Format Resolution**: Messages from `@lid` JIDs are now correctly resolved to E.164 phone numbers
2. **allowFrom Wildcard**: `allowFrom: ["*"]` now correctly allows all senders
3. **Backward Compatibility**: Traditional `@s.whatsapp.net` JIDs and explicit phone number lists continue to work

---

## Files Changed

| File | Change |
|------|--------|
| `src/utils.ts` | Add `@lid` format support to `jidToE164()` |
| `src/auto-reply/reply.ts` | Add wildcard check in `allowFrom` validation |

---

## Breaking Changes

None. These changes are backward compatible.

---

## Environment

- **warelay version**: 1.1.0
- **Node.js version**: v24.11.0
- **WhatsApp**: Latest iOS/Android versions using LID format