### PR TITLE
Fix path traversal vulnerability in media server

### DIFF
--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -49,4 +49,14 @@ describe("media server", () => {
     await expect(fs.stat(file)).rejects.toThrow();
     await new Promise((r) => server.close(r));
   });
+
+  it("blocks path traversal attempts", async () => {
+    const server = await startMediaServer(0, 5_000);
+    const port = (server.address() as AddressInfo).port;
+    // URL-encoded "../" to bypass client-side path normalization
+    const res = await fetch(`http://localhost:${port}/media/%2e%2e%2fpackage.json`);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("invalid path");
+    await new Promise((r) => server.close(r));
+  });
 });

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -17,7 +17,12 @@ export function attachMediaRoutes(
 
   app.get("/media/:id", async (req, res) => {
     const id = req.params.id;
-    const file = path.join(mediaDir, id);
+    const file = path.resolve(mediaDir, id);
+    const mediaRoot = path.resolve(mediaDir) + path.sep;
+    if (!file.startsWith(mediaRoot)) {
+      res.status(400).send("invalid path");
+      return;
+    }
     try {
       const stat = await fs.stat(file);
       if (Date.now() - stat.mtimeMs > ttlMs) {


### PR DESCRIPTION
## Summary

- The `/media/:id` endpoint was vulnerable to path traversal attacks via URL-encoded `../` sequences (e.g., `%2e%2e%2f`)
- Since this endpoint is exposed via Tailscale Funnel (unlike the WhatsApp webhook which requires Twilio signature validation), attackers could directly access sensitive files
- Attack could reach `~/.warelay/` files or even escape to the user's home directory

## Fix

Validate that resolved paths stay within the media directory before serving files.

## Test plan

- [x] Added regression test for path traversal attempts
- [x] Existing media server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)