### PR TITLE
fix: add pnpm patch for pi-ai to support LiteLLM providerType

### DIFF
--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,0 +1,40 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index a430c2240a37bcc7d05fb8e551c18964e7636c59..869eb60f0724c31b08aba2e2ee37da63d82696b2 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -231,20 +231,26 @@ function buildParams(model, context, options) {
+         stream: true,
+         stream_options: { include_usage: true },
+     };
+-    // Cerebras/xAI/Mistral dont like the "store" field
+-    if (!model.baseUrl.includes("cerebras.ai") &&
+-        !model.baseUrl.includes("api.x.ai") &&
+-        !model.baseUrl.includes("mistral.ai") &&
+-        !model.baseUrl.includes("chutes.ai")) {
++    // Only send OpenAI-specific params (like "store") to actual OpenAI models.
++    // For custom models via proxies like LiteLLM, check providerType.
++    // Fall back to baseUrl detection for known providers.
++    const isOpenAIModel = model.providerType === "openai" ||
++        (!model.providerType &&
++            !model.baseUrl.includes("cerebras.ai") &&
++            !model.baseUrl.includes("api.x.ai") &&
++            !model.baseUrl.includes("mistral.ai") &&
++            !model.baseUrl.includes("chutes.ai") &&
++            (model.baseUrl.includes("api.openai.com") || model.provider === "openai"));
++    if (isOpenAIModel) {
+         params.store = false;
+     }
+     if (options?.maxTokens) {
+-        // Mistral/Chutes uses max_tokens instead of max_completion_tokens
+-        if (model.baseUrl.includes("mistral.ai") || model.baseUrl.includes("chutes.ai")) {
+-            params.max_tokens = options?.maxTokens;
++        // Only OpenAI uses max_completion_tokens. Others (Mistral/Chutes/Anthropic via proxy) use max_tokens
++        if (isOpenAIModel) {
++            params.max_completion_tokens = options?.maxTokens;
+         }
+         else {
+-            params.max_completion_tokens = options?.maxTokens;
++            params.max_tokens = options?.maxTokens;
+         }
+     }
+     if (options?.temperature !== undefined) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ onlyBuiltDependencies:
   - '@whiskeysockets/baileys'
   - esbuild
   - sharp
+
+patchedDependencies:
+  '@mariozechner/pi-ai': patches/@mariozechner__pi-ai.patch


### PR DESCRIPTION
## Summary
- Adds pnpm patch for `@mariozechner/pi-ai` to support `providerType` field for custom models
- When using Claude models via LiteLLM proxy, the bundled pi-ai sends OpenAI-specific parameters (`store`, `max_completion_tokens`) that cause errors with non-OpenAI backends like AWS Bedrock
- This fix checks `model.providerType` to determine if the model is OpenAI-native before sending OpenAI-specific params

## Problem
When configuring custom models in `~/.pi/agent/models.json` that route through LiteLLM to Claude (e.g. AWS Bedrock), the bundled pi-ai would send:
- `store: false` (OpenAI-specific)
- `max_completion_tokens` instead of `max_tokens`

This caused errors like:
```
max_tokens_to_sample: Extra inputs are not permitted
```

## Solution
The patch adds `providerType` support to `openai-completions.js`:
- If `model.providerType === "openai"` or the baseUrl indicates OpenAI, send OpenAI-specific params
- Otherwise (for proxied models), use generic params (`max_tokens`)

Users can now configure custom models with `providerType: "anthropic"` (or `"google"`, etc.) to properly route requests.

## Test plan
- [x] Tested with Claude Opus 4.5 via LiteLLM proxy to AWS Bedrock
- [x] Verified Pi responds correctly with the patched version
- [x] Verified existing OpenAI models still work (fallback to baseUrl detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)