### PR TITLE
fix: send plain string message in tau-rpc instead of structured object

### DIFF
--- a/src/process/tau-rpc.ts
+++ b/src/process/tau-rpc.ts
@@ -121,10 +121,12 @@ class TauRpcClient {
     const child = this.child;
     if (!child) throw new Error("tau rpc child not initialized");
     await new Promise<void>((resolve, reject) => {
+      // Pi-agent-core's Agent.prompt() expects a plain string, not a structured message.
+      // The RPC handler in pi-coding-agent passes input.message directly to agent.prompt().
       const ok = child.stdin.write(
         `${JSON.stringify({
           type: "prompt",
-          message: { role: "user", content: [{ type: "text", text: prompt }] },
+          message: prompt,
         })}\n`,
         (err) => (err ? reject(err) : resolve()),
       );


### PR DESCRIPTION
## Summary
- Fix RPC protocol mismatch in `tau-rpc.ts` that caused "(command produced no output)" errors
- Pi-agent-core's `Agent.prompt()` expects a plain string, not a structured message object
- The RPC handler passes `input.message` directly to `agent.prompt()`

## Problem
When sending prompts through the tau-rpc client, the message was being sent as a structured object:
```typescript
message: { role: "user", content: [{ type: "text", text: prompt }] }
```

This caused the Pi agent to receive malformed input, resulting in "(command produced no output)" errors on Telegram relay responses.

## Solution
Changed to send plain string directly:
```typescript
message: prompt
```

## Test plan
- [x] Verified tau-rpc fix allows proper message passing
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)