### PR TITLE
fix: filter internal JSON events in command-reply output

### DIFF
--- a/src/auto-reply/command-reply.ts
+++ b/src/auto-reply/command-reply.ts
@@ -26,6 +26,7 @@ import {
   TOOL_RESULT_FLUSH_COUNT,
 } from "./tool-meta.js";
 import type { ReplyPayload } from "./types.js";
+import { stripJsonEventLines } from "./strip-json-events.js";
 
 function stripStructuralPrefixes(text: string): string {
   return text
@@ -993,10 +994,12 @@ export async function runCommandReply(
         mediaUrls = filtered;
       }
 
+      // Filter out internal JSON events before building payload
+      const cleanedText = item.text ? stripJsonEventLines(item.text) : undefined;
       const payload =
-        item.text || mediaUrls?.length
+        cleanedText || mediaUrls?.length
           ? {
-              text: item.text || undefined,
+              text: cleanedText || undefined,
               mediaUrl: mediaUrls?.[0],
               mediaUrls,
             }

--- a/src/auto-reply/strip-json-events.ts
+++ b/src/auto-reply/strip-json-events.ts
@@ -1,0 +1,45 @@
+/**
+ * Filter out raw JSON event lines from text before external delivery.
+ * These are internal gateway/agent events that should never be sent to WhatsApp.
+ */
+export function stripJsonEventLines(text: string): string {
+  if (!text) return "";
+  const lines = text.split(/\n/);
+  const kept: string[] = [];
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      kept.push(line);
+      continue;
+    }
+    if (trimmedLine.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(trimmedLine);
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          typeof parsed.type === "string" &&
+          [
+            "message_start",
+            "message_update",
+            "message_end",
+            "turn_start",
+            "turn_end",
+            "agent_start",
+            "agent_end",
+            "tool_start",
+            "tool_end",
+            "heartbeat",
+            "input_audio_buffer.append",
+          ].includes(parsed.type)
+        ) {
+          continue;
+        }
+      } catch {
+        // Not valid JSON, keep the line
+      }
+    }
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}


### PR DESCRIPTION
## Problem
Internal JSON events (`message_end`, `turn_end`, etc.) were leaking to WhatsApp during heartbeats and regular responses.

## Solution
- Created `src/auto-reply/strip-json-events.ts` as a shared module with `stripJsonEventLines()` function
- Applied the filter in `command-reply.ts` before building payloads

## Changes
- `src/auto-reply/strip-json-events.ts` - new file with shared filter function  
- `src/auto-reply/command-reply.ts` - import and apply filter before payload construction

## Testing
- Build passes (`npm run build`)