### PR TITLE
fix(macos): lazy-init AVAudioEngine to prevent Bluetooth audio ducking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.0 — Unreleased
 
-_No changes since 2.0.0-beta1._
+### Bug Fixes
+- macOS: Voice Wake / push-to-talk no longer initialize `AVAudioEngine` at app launch, preventing Bluetooth headphones from switching into headset profile when voice features are unused. (Thanks @Nachx639)
 
 ## 2.0.0-beta1 — 2025-12-14
 


### PR DESCRIPTION
## Summary
- Make `audioEngine` optional in `VoiceWakeRuntime` and `VoicePushToTalk`
- Create the engine only when voice recognition actually starts
- Prevents macOS from switching Bluetooth profile at app launch

## Problem
When Clawdis launches, it creates `AVAudioEngine()` instances at singleton init time (even with Voice Wake disabled). This causes macOS to switch Bluetooth headphones from A2DP (high quality stereo) to HFP (headset profile), resulting in noticeably degraded audio quality.

## Solution
Make the `AVAudioEngine` property optional and lazy-initialize it only when `start()` is called. This way, users who don't use Voice Wake won't experience the Bluetooth profile switch.

## Testing
- Verified with Bluetooth headphones that audio quality no longer degrades when launching Clawdis
- Voice Wake functionality remains intact when enabled

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)