### PR TITLE
feat: Discord transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🦞 CLAWDIS — WhatsApp & Telegram Gateway for AI Agents
+# 🦞 CLAWDIS — WhatsApp, Telegram & Discord Gateway for AI Agents
 
 <p align="center">
   <img src="docs/whatsapp-clawd.jpg" alt="CLAWDIS" width="400">
@@ -14,11 +14,11 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-**CLAWDIS** is a TypeScript/Node gateway that bridges WhatsApp (Web/Baileys) and Telegram (Bot API/grammY) to a local coding agent (**Pi**).
+**CLAWDIS** is a TypeScript/Node gateway that bridges WhatsApp (Web/Baileys), Telegram (Bot API/grammY), and Discord (Bot API/discord.js) to a local coding agent (**Pi**).
 It’s like having a genius lobster in your pocket 24/7 — but with a real control plane, companion apps, and a network model that won’t corrupt sessions.
 
 ```
-WhatsApp / Telegram
+WhatsApp / Telegram / Discord
         │
         ▼
   ┌──────────────────────────┐
@@ -43,6 +43,7 @@ Because every space lobster needs a time-and-space machine. The Doctor has a TAR
 
 - 📱 **WhatsApp Integration** — Personal WhatsApp Web (Baileys)
 - ✈️ **Telegram (Bot API)** — DMs and groups via grammY
+- 🎮 **Discord (Bot API)** — DMs and guild channels via discord.js
 - 🛰️ **Gateway control plane** — One long-lived gateway owns provider state; clients connect over WebSocket
 - 🤖 **Agent runtime** — Pi only (Pi CLI in RPC mode), with tool streaming
 - 💬 **Sessions** — Direct chats collapse into `main` by default; groups are isolated
@@ -88,7 +89,7 @@ pnpm clawdis gateway --port 18789 --verbose
 # Send a WhatsApp message (WhatsApp sends go through the Gateway)
 pnpm clawdis send --to +1234567890 --message "Hello from the CLAWDIS!"
 
-# Talk to the agent (optionally deliver back to WhatsApp/Telegram)
+# Talk to the agent (optionally deliver back to WhatsApp/Telegram/Discord)
 pnpm clawdis agent --message "Ship checklist" --thinking high
 
 # If the port is busy, force-kill listeners then start
@@ -110,9 +111,10 @@ Voice Wake sends messages into the `main` session and replies on the **last used
 
 - WhatsApp: last direct message you sent/received.
 - Telegram: last DM chat id (bot mode).
+- Discord: last DM (user) or guild/channel (channel:<id>) target.
 - WebChat: last WebChat thread you used.
 
-If delivery fails (e.g. WhatsApp disconnected / Telegram token missing), Clawdis logs the error and you can still inspect the run via WebChat/session logs.
+If delivery fails (e.g. WhatsApp disconnected / Telegram/Discord token missing), Clawdis logs the error and you can still inspect the run via WebChat/session logs.
 
 Build/run the mac app with `./scripts/restart-mac.sh` (packages, installs, and launches), or `swift build --package-path apps/macos && open dist/Clawdis.app`.
 
@@ -161,6 +163,7 @@ Optional: enable/configure clawd’s dedicated browser control (defaults are alr
 - [Troubleshooting](./docs/troubleshooting.md)
 - [The Lore](./docs/lore.md) 🦞
 - [Telegram (Bot API)](./docs/telegram.md)
+- [Discord (Bot API)](./docs/discord.md)
 - [iOS node runbook (Iris)](./docs/ios/connect.md)
 - [macOS app spec](./docs/clawdis-mac.md)
 
@@ -186,13 +189,16 @@ clawdis gateway    # run Gateway (WS on 127.0.0.1:18789)
 ### Telegram (Bot API)
 Bot-mode support (grammY only) shares the same `main` session as WhatsApp/WebChat, with groups kept isolated. Text/media sends work via `clawdis send --provider telegram` (reads `TELEGRAM_BOT_TOKEN` or `telegram.botToken`). Webhook mode is supported; see `docs/telegram.md` for setup and limits.
 
+### Discord (Bot API)
+Enable Discord by creating a bot in the [Developer Portal](https://discord.com/developers/applications), inviting it to the servers you want to use, and setting `DISCORD_BOT_TOKEN` (or `discord.token` in `~/.clawdis/clawdis.json`). Use `clawdis send --provider discord --to channel:<channelId>` for guild channels or `user:<userId>`/`@username` for DMs. Allowlist DM senders via `discord.allowFrom`, and adjust mention gating with `discord.requireMention`. See `docs/discord.md` for details.
+
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `clawdis login` | Link WhatsApp Web via QR |
-| `clawdis send` | Send a message (WhatsApp default; `--provider telegram` for bot mode). WhatsApp sends go via the Gateway WS; Telegram sends are direct. |
-| `clawdis agent` | Talk directly to the agent (no WhatsApp send) |
+| `clawdis send` | Send a message (WhatsApp default; `--provider telegram|discord` for bots). WhatsApp sends go via the Gateway WS; Telegram/Discord sends are direct. |
+| `clawdis agent` | Talk directly to the agent (optionally deliver back via WhatsApp/Telegram/Discord). |
 | `clawdis browser ...` | Manage clawd’s dedicated browser (status/tabs/open/screenshot). |
 | `clawdis gateway` | Start the Gateway server (WS control plane). Params: `--port`, `--token`, `--force`, `--verbose`. |
 | `clawdis gateway health|status|send|agent|call` | Gateway WS clients; assume a running gateway. |

--- a/apps/macos/Sources/Clawdis/CronSettings.swift
+++ b/apps/macos/Sources/Clawdis/CronSettings.swift
@@ -804,6 +804,7 @@ struct CronJobEditor: View {
                             Text("last").tag("last")
                             Text("whatsapp").tag("whatsapp")
                             Text("telegram").tag("telegram")
+                            Text("discord").tag("discord")
                         }
                         .labelsHidden()
                         .pickerStyle(.segmented)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,13 +8,13 @@ read_when:
 Last updated: 2025-12-09
 
 ## Overview
-- A single long-lived **Gateway** process owns all messaging surfaces (WhatsApp via Baileys, Telegram when enabled) and the control/event plane.
+- A single long-lived **Gateway** process owns all messaging surfaces (WhatsApp via Baileys, Telegram via grammY, Discord via discord.js) and the control/event plane.
 - All clients (macOS app, CLI, web UI, automations) connect to the Gateway over one transport: **WebSocket on 127.0.0.1:18789** (tunnel or VPN for remote).
 - One Gateway per host; it is the only place that is allowed to open a WhatsApp session. All sends/agent runs go through it.
 
 ## Components and flows
 - **Gateway (daemon)**  
-  - Maintains Baileys/Telegram connections.  
+  - Maintains Baileys/Telegram/Discord connections.  
   - Exposes a typed WS API (req/resp + server push events).  
   - Validates every inbound frame against JSON Schema; rejects anything before a mandatory `connect`.
 - **Clients (mac app / CLI / web admin)**  

--- a/docs/clawd.md
+++ b/docs/clawd.md
@@ -7,14 +7,14 @@ read_when:
 <!-- {% raw %} -->
 # Building a personal assistant with CLAWDIS (Clawd-style)
 
-CLAWDIS is a WhatsApp + Telegram gateway for **Pi** agents. This guide is the “personal assistant” setup: one dedicated WhatsApp number that behaves like your always-on agent.
+CLAWDIS is a WhatsApp + Telegram + Discord gateway for **Pi** agents. This guide is the “personal assistant” setup: one dedicated WhatsApp number that behaves like your always-on agent.
 
 ## ⚠️ Safety first
 
 You’re putting an agent in a position to:
 - run commands on your machine (depending on your Pi tool setup)
 - read/write files in your workspace
-- send messages back out via WhatsApp/Telegram
+- send messages back out via WhatsApp/Telegram/Discord
 
 Start conservative:
 - Always set `inbound.allowFrom` (never run open-to-the-world on your personal Mac).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,23 @@ Defaults:
 }
 ```
 
+### `discord` (bot transport)
+
+Configure the Discord bot by setting the bot token and optional gating:
+
+```json5
+{
+  discord: {
+    token: "Bot <token>",
+    allowFrom: ["discord:1234567890", "*"], // optional DM allowlist (user ids)
+    requireMention: true,                   // require @bot mentions in guilds
+    mediaMaxMb: 8                           // clamp inbound media size
+  }
+}
+```
+
+Clawdis reads `DISCORD_BOT_TOKEN` or `discord.token` to start the provider. Use `user:<id>` (DM) or `channel:<id>` (guild channel) when specifying delivery targets for cron/CLI commands.
+
 ## Template variables
 
 Template placeholders are expanded in `inbound.reply.command`, `sessionIntro`, `bodyPrefix`, and other templated strings.

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -263,7 +263,7 @@ Add a `cron` command group (all commands should also support `--json` where sens
     - `--wake now|next-heartbeat`
   - payload flags (choose one):
     - `--system-event "<text>"`
-    - `--message "<agent message>" [--deliver] [--channel last|whatsapp|telegram] [--to <dest>]`
+    - `--message "<agent message>" [--deliver] [--channel last|whatsapp|telegram|discord] [--to <dest>]`
 
 - `clawdis cron edit <id> ...` (patch-by-flags, non-interactive)
 - `clawdis cron rm <id>`

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,52 @@
+---
+summary: "Discord bot support status, capabilities, and configuration"
+read_when:
+  - Working on Discord surface features
+---
+# Discord (Bot API)
+
+Updated: 2025-12-07
+
+Status: ready for DM and guild text channels via the official Discord bot gateway.
+
+## Goals
+- Talk to Clawdis via Discord DMs or guild channels.
+- Share the same `main` session used by WhatsApp/Telegram/WebChat; guild channels stay isolated as `group:<channelId>`.
+- Keep routing deterministic: replies always go back to the surface they arrived on.
+
+## How it works
+1. Create a Discord application → Bot, enable the intents you need (DMs + guild messages + message content), and grab the bot token.
+2. Invite the bot to your server with the permissions required to read/send messages where you want to use it.
+3. Configure Clawdis with `DISCORD_BOT_TOKEN` (or `discord.token` in `~/.clawdis/clawdis.json`).
+4. Run the gateway; it auto-starts the Discord provider when the token is set.
+5. Direct chats: use `user:<id>` (or `@username`) when delivering; all turns land in the shared `main` session.
+6. Guild channels: use `channel:<channelId>` for delivery. Mentions are required by default; disable with `discord.requireMention = false`.
+7. Optional DM allowlist: reuse `discord.allowFrom` with user ids (`1234567890` or `discord:1234567890`). Use `"*"` to allow all DMs.
+
+## Capabilities & limits
+- DMs and guild text channels (no threads/voice yet).
+- Typing indicators sent best-effort; message chunking honors Discord’s 2k character limit.
+- File uploads supported up to the configured `discord.mediaMaxMb` (default 8 MB).
+- Mention-gated guild replies by default to avoid noisy bots.
+
+## Config
+
+```json5
+{
+  discord: {
+    token: "Bot abc.123",
+    allowFrom: ["123456789012345678"],
+    requireMention: true,
+    mediaMaxMb: 8
+  }
+}
+```
+
+- `allowFrom`: DM allowlist (user ids). Omit or set to `["*"]` to allow any DM sender.
+- `requireMention`: when `true`, messages in guild channels must mention the bot.
+- `mediaMaxMb`: clamp inbound media saved to disk.
+
+## Safety & ops
+- Treat the bot token like a password; prefer the `DISCORD_BOT_TOKEN` env var on supervised hosts or lock down the config file permissions.
+- Only grant the bot permissions it needs (typically Read/Send Messages).
+- If the bot is stuck or rate limited, restart the gateway (`clawdis gateway --force`) after confirming no other processes own the Discord session.

--- a/docs/health.md
+++ b/docs/health.md
@@ -9,7 +9,7 @@ Short guide to verify the WhatsApp Web / Baileys stack without guessing.
 
 ## Quick checks
 - `clawdis status` — local summary: whether creds exist, auth age, session store path + recent sessions.
-- `clawdis status --deep` — also probes the running Gateway (WA connect + Telegram API).
+- `clawdis status --deep` — also probes the running Gateway (WhatsApp connect + Telegram + Discord APIs).
 - `clawdis health --json` — asks the running Gateway for a full health snapshot (WS-only; no direct Baileys socket).
 - Send `/status` in WhatsApp/WebChat to get a status reply without invoking the agent.
 - Logs: tail `/tmp/clawdis/clawdis-*.log` and filter for `web-heartbeat`, `web-reconnect`, `web-auto-reply`, `web-inbound`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ read_when:
 </p>
 
 <p align="center">
-  <strong>WhatsApp + Telegram gateway for AI agents (Pi).</strong><br>
+  <strong>WhatsApp + Telegram + Discord gateway for AI agents (Pi).</strong><br>
   Send a message, get an agent response — from your pocket.
 </p>
 
@@ -23,13 +23,13 @@ read_when:
   <a href="./clawd">Clawd setup</a>
 </p>
 
-CLAWDIS bridges WhatsApp (via WhatsApp Web / Baileys) and Telegram (Bot API / grammY) to coding agents like [Pi](https://github.com/badlogic/pi-mono).
+CLAWDIS bridges WhatsApp (via WhatsApp Web / Baileys), Telegram (Bot API / grammY), and Discord (Bot API / discord.js) to coding agents like [Pi](https://github.com/badlogic/pi-mono).
 It’s built for [Clawd](https://clawd.me), a space lobster who needed a TARDIS.
 
 ## How it works
 
 ```
-WhatsApp / Telegram
+WhatsApp / Telegram / Discord
         │
         ▼
   ┌──────────────────────────┐
@@ -57,6 +57,7 @@ Most operations flow through the **Gateway** (`clawdis gateway`), a single long-
 
 - 📱 **WhatsApp Integration** — Uses Baileys for WhatsApp Web protocol
 - ✈️ **Telegram Bot** — DMs + groups via grammY
+- 🎮 **Discord Bot** — DMs + guild channels via discord.js
 - 🤖 **Agent bridge** — Pi (RPC mode) with tool streaming
 - 💬 **Sessions** — Direct chats collapse into shared `main` (default); groups are isolated
 - 👥 **Group Chat Support** — Mention-based triggering in group chats
@@ -123,6 +124,7 @@ Example:
 - Providers and UX:
   - [WebChat](./webchat.md)
   - [Telegram](./telegram.md)
+  - [Discord](./discord.md)
   - [Group messages](./group-messages.md)
   - [Media: images](./images.md)
   - [Media: audio](./audio.md)

--- a/docs/mac/voicewake.md
+++ b/docs/mac/voicewake.md
@@ -45,7 +45,7 @@ Hardening:
 
 ## Forwarding behavior
 - When Voice Wake is enabled, transcripts are forwarded to the active gateway/agent (the same local vs remote mode used by the rest of the mac app).
-- Replies are delivered to the **last-used main surface** (WhatsApp/Telegram/WebChat). If delivery fails, the error is logged and the run is still visible via WebChat/session logs.
+- Replies are delivered to the **last-used main surface** (WhatsApp/Telegram/Discord/WebChat). If delivery fails, the error is logged and the run is still visible via WebChat/session logs.
 
 ## Forwarding payload
 - `VoiceWakeForwarder.prefixedTranscript(_:)` prepends the machine hint before sending. Shared between wake-word and push-to-talk paths.

--- a/docs/mac/webchat.md
+++ b/docs/mac/webchat.md
@@ -19,7 +19,7 @@ The macOS menu bar app embeds the WebChat UI in a WKWebView and reuses the **pri
 ## How it’s wired
 - Assets: `apps/macos/Sources/Clawdis/Resources/WebChat/` contains the `pi-web-ui` dist plus a local import map pointing at bundled vendor modules and a tiny `pi-ai` stub. Everything is served from the static host at `/` (legacy `/webchat/*` still works).
 - Bridge: none. The web UI connects directly to the Gateway WebSocket (default 18789) and uses `chat.history`/`chat.send` plus `chat/presence/tick/health` events. No `/rpc` or file-watcher socket path remains.
-- Session: always primary; multiple transports (WhatsApp/Telegram/Desktop) share the same session key so context is unified.
+- Session: always primary; multiple transports (WhatsApp/Telegram/Discord/Desktop) share the same session key so context is unified.
 - Debug-only: a native SwiftUI “glass” chat UI (same WS transport, attachments + thinking selector) can replace the WKWebView. Enable it via Debug → “Use SwiftUI web chat (glass, gateway WS)” (default off).
 
 ## Security / surface area

--- a/docs/session.md
+++ b/docs/session.md
@@ -20,7 +20,7 @@ All session state is **owned by the gateway** (the “master” Clawdis). UI cli
 - The store is a map `sessionKey -> { sessionId, updatedAt, ... }`. Deleting entries is safe; they are recreated on demand.
 
 ## Mapping transports → session keys
-- Direct chats (WhatsApp, Telegram, desktop Web Chat) all collapse to the **primary key** so they share context.
+- Direct chats (WhatsApp, Telegram, Discord, desktop Web Chat) all collapse to the **primary key** so they share context.
 - Multiple phone numbers can map to that same key; they act as transports into the same conversation.
 - Group chats still isolate state with `group:<jid>` keys; do not reuse the primary key for groups.
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -1,5 +1,5 @@
 ---
-summary: "Routing rules per surface (WhatsApp, Telegram, web) and shared context"
+summary: "Routing rules per surface (WhatsApp, Telegram, Discord, web) and shared context"
 read_when:
   - Changing surface routing or inbox behavior
 ---
@@ -9,11 +9,11 @@ Updated: 2025-12-07
 
 Goal: make replies deterministic per channel while keeping one shared context for direct chats.
 
-- **Surfaces** (channel labels): `whatsapp`, `webchat`, `telegram`, `voice`, etc. Add `Surface` to inbound `MsgContext` so templates/agents can log which channel a turn came from. Routing is fixed: replies go back to the origin surface; the model doesn’t choose.
+- **Surfaces** (channel labels): `whatsapp`, `webchat`, `telegram`, `discord`, `voice`, etc. Add `Surface` to inbound `MsgContext` so templates/agents can log which channel a turn came from. Routing is fixed: replies go back to the origin surface; the model doesn’t choose.
 - **Canonical direct session:** All direct chats collapse into the single `main` session by default (no config needed). Groups stay `group:<jid>`, so they remain isolated.
 - **Session store:** Keys are resolved via `resolveSessionKey(scope, ctx, mainKey)`; the agent JSONL path lives under `~/.clawdis/sessions/<SessionId>.jsonl`.
 - **WebChat:** Always attaches to `main`, loads the full session transcript so desktop reflects cross-surface history, and writes new turns back to the same session.
 - **Implementation hints:**
-  - Set `Surface` in each ingress (WhatsApp gateway, WebChat bridge, future Telegram). 
+  - Set `Surface` in each ingress (WhatsApp gateway, WebChat bridge, Telegram bot, Discord bot). 
   - Keep routing deterministic: originate → same surface. Use the gateway WebSocket for sends; avoid side channels.
   - Do not let the agent emit “send to X” decisions; keep that policy in the host code.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,7 +83,7 @@ Or use the `process` tool to background long commands.
 ```bash
 # Check local status (creds, sessions, queued events)
 clawdis status
-# Probe the running gateway + providers (WA connect + Telegram API)
+# Probe the running gateway + providers (WA connect + Telegram + Discord APIs)
 clawdis status --deep
 
 # View recent connection events

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "packageManager": "pnpm@10.23.0",
   "dependencies": {
+    "@buape/carbon": "^0.13.0",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.4",
     "@mariozechner/pi-ai": "^0.21.0",
@@ -48,6 +49,7 @@
     "commander": "^14.0.2",
     "croner": "^9.1.0",
     "detect-libc": "^2.1.2",
+    "discord.js": "^14.25.1",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "grammy": "^1.38.4",

--- a/src/auto-reply/reply.triggers.test.ts
+++ b/src/auto-reply/reply.triggers.test.ts
@@ -174,3 +174,87 @@ describe("trigger handling", () => {
     expect(rpcMock).toHaveBeenCalledOnce();
   });
 });
+
+describe("group intro prompts", () => {
+  it("labels Discord groups using the surface metadata", async () => {
+    const commandSpy = vi
+      .spyOn(commandReply, "runCommandReply")
+      .mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+
+    await getReplyFromConfig(
+      {
+        Body: "status update",
+        From: "group:dev",
+        To: "+1888",
+        ChatType: "group",
+        GroupSubject: "Release Squad",
+        GroupMembers: "Alice, Bob",
+        Surface: "discord",
+      },
+      {},
+      baseCfg,
+    );
+
+    expect(commandSpy).toHaveBeenCalledOnce();
+    const body =
+      commandSpy.mock.calls.at(-1)?.[0]?.templatingCtx.Body ?? "";
+    const intro = body.split("\n\n")[0];
+    expect(intro).toBe(
+      'You are replying inside the Discord group "Release Squad". Group members: Alice, Bob. Address the specific sender noted in the message context.',
+    );
+  });
+
+  it("keeps WhatsApp labeling for WhatsApp group chats", async () => {
+    const commandSpy = vi
+      .spyOn(commandReply, "runCommandReply")
+      .mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+
+    await getReplyFromConfig(
+      {
+        Body: "ping",
+        From: "123@g.us",
+        To: "+1999",
+        ChatType: "group",
+        GroupSubject: "Ops",
+        Surface: "whatsapp",
+      },
+      {},
+      baseCfg,
+    );
+
+    expect(commandSpy).toHaveBeenCalledOnce();
+    const body =
+      commandSpy.mock.calls.at(-1)?.[0]?.templatingCtx.Body ?? "";
+    const intro = body.split("\n\n")[0];
+    expect(intro).toBe(
+      'You are replying inside the Whatsapp group "Ops". Address the specific sender noted in the message context.',
+    );
+  });
+
+  it("labels Telegram groups using their own surface", async () => {
+    const commandSpy = vi
+      .spyOn(commandReply, "runCommandReply")
+      .mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+
+    await getReplyFromConfig(
+      {
+        Body: "ping",
+        From: "group:tg",
+        To: "+1777",
+        ChatType: "group",
+        GroupSubject: "Dev Chat",
+        Surface: "telegram",
+      },
+      {},
+      baseCfg,
+    );
+
+    expect(commandSpy).toHaveBeenCalledOnce();
+    const body =
+      commandSpy.mock.calls.at(-1)?.[0]?.templatingCtx.Body ?? "";
+    const intro = body.split("\n\n")[0];
+    expect(intro).toBe(
+      'You are replying inside the Telegram group "Dev Chat". Address the specific sender noted in the message context.',
+    );
+  });
+});

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -610,9 +610,13 @@ export async function getReplyFromConfig(
       ? (() => {
           const subject = sessionCtx.GroupSubject?.trim();
           const members = sessionCtx.GroupMembers?.trim();
+          const surface = sessionCtx.Surface?.trim().toLowerCase();
+          const surfaceLabel = surface
+            ? `${surface.at(0)?.toUpperCase() ?? ""}${surface.slice(1)}`
+            : "chat";
           const subjectLine = subject
-            ? `You are replying inside the WhatsApp group "${subject}".`
-            : "You are replying inside a WhatsApp group chat.";
+            ? `You are replying inside the ${surfaceLabel} group "${subject}".`
+            : `You are replying inside a ${surfaceLabel} group chat.`;
           const membersLine = members
             ? `Group members: ${members}.`
             : undefined;

--- a/src/cli/cron-cli.ts
+++ b/src/cli/cron-cli.ts
@@ -154,10 +154,13 @@ export function registerCronCli(program: Command) {
       .option("--deliver", "Deliver agent output", false)
       .option(
         "--channel <channel>",
-        "Delivery channel (last|whatsapp|telegram)",
+        "Delivery channel (last|whatsapp|telegram|discord)",
         "last",
       )
-      .option("--to <dest>", "Delivery destination (E.164 or Telegram chatId)")
+      .option(
+        "--to <dest>",
+        "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
+      )
       .option(
         "--best-effort-deliver",
         "Do not fail the job if delivery fails",
@@ -403,9 +406,12 @@ export function registerCronCli(program: Command) {
       .option("--deliver", "Deliver agent output", false)
       .option(
         "--channel <channel>",
-        "Delivery channel (last|whatsapp|telegram)",
+        "Delivery channel (last|whatsapp|telegram|discord)",
       )
-      .option("--to <dest>", "Delivery destination")
+      .option(
+        "--to <dest>",
+        "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
+      )
       .option(
         "--best-effort-deliver",
         "Do not fail job if delivery fails",

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -1,15 +1,18 @@
+import { sendMessageDiscord } from "../discord/send.js";
 import { logWebSelfId, sendMessageWhatsApp } from "../providers/web/index.js";
 import { sendMessageTelegram } from "../telegram/send.js";
 
 export type CliDeps = {
   sendMessageWhatsApp: typeof sendMessageWhatsApp;
   sendMessageTelegram: typeof sendMessageTelegram;
+  sendMessageDiscord: typeof sendMessageDiscord;
 };
 
 export function createDefaultDeps(): CliDeps {
   return {
     sendMessageWhatsApp,
     sendMessageTelegram,
+    sendMessageDiscord,
   };
 }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -138,10 +138,10 @@ export function buildProgram() {
 
   program
     .command("send")
-    .description("Send a message (WhatsApp web or Telegram bot)")
+    .description("Send a message (WhatsApp Web, Telegram bot, or Discord)")
     .requiredOption(
       "-t, --to <number>",
-      "Recipient: E.164 for WhatsApp (e.g. +15555550123) or Telegram chat id/@username",
+      "Recipient: E.164 for WhatsApp, Telegram chat id/@username, or Discord channel/user",
     )
     .requiredOption("-m, --message <text>", "Message body")
     .option(
@@ -150,7 +150,7 @@ export function buildProgram() {
     )
     .option(
       "--provider <provider>",
-      "Delivery provider: whatsapp|telegram (default: whatsapp)",
+      "Delivery provider: whatsapp|telegram|discord (default: whatsapp)",
     )
     .option("--dry-run", "Print payload and skip sending", false)
     .option("--json", "Output result as JSON", false)
@@ -192,8 +192,12 @@ Examples:
     )
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
+      "--provider <provider>",
+      "Delivery provider: whatsapp|telegram|discord (default: whatsapp)",
+    )
+    .option(
       "--deliver",
-      "Send the agent's reply back to WhatsApp (requires --to)",
+      "Send the agent's reply back to the selected provider (requires --to)",
       false,
     )
     .option("--json", "Output result as JSON", false)
@@ -233,7 +237,11 @@ Examples:
     .command("status")
     .description("Show web session health and recent session recipients")
     .option("--json", "Output JSON instead of text", false)
-    .option("--deep", "Probe providers (WA connect + Telegram API)", false)
+    .option(
+      "--deep",
+      "Probe providers (WhatsApp Web + Telegram + Discord)",
+      false,
+    )
     .option("--timeout <ms>", "Probe timeout in milliseconds", "10000")
     .option("--verbose", "Verbose logging", false)
     .addHelpText(
@@ -242,7 +250,7 @@ Examples:
 Examples:
   clawdis status                   # show linked account + session store summary
   clawdis status --json            # machine-readable output
-  clawdis status --deep            # run provider probes (WA + Telegram)
+  clawdis status --deep            # run provider probes (WA + Telegram + Discord)
   clawdis status --deep --timeout 5000 # tighten probe timeout`,
     )
     .action(async (opts) => {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -53,6 +53,35 @@ export async function sendCommand(
     return;
   }
 
+  if (provider === "discord") {
+    const result = await deps.sendMessageDiscord(opts.to, opts.message, {
+      token: process.env.DISCORD_BOT_TOKEN,
+      mediaUrl: opts.media,
+    });
+    runtime.log(
+      success(
+        `✅ Sent via discord. Message ID: ${result.messageId} (channel ${result.channelId})`,
+      ),
+    );
+    if (opts.json) {
+      runtime.log(
+        JSON.stringify(
+          {
+            provider: "discord",
+            via: "direct",
+            to: opts.to,
+            channelId: result.channelId,
+            messageId: result.messageId,
+            mediaUrl: opts.media ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+    return;
+  }
+
   // Always send via gateway over WS to avoid multi-session corruption.
   const sendViaGateway = async () =>
     callGateway<{

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -78,6 +78,13 @@ export type TelegramConfig = {
   webhookPath?: string;
 };
 
+export type DiscordConfig = {
+  token?: string;
+  allowFrom?: Array<string | number>;
+  requireMention?: boolean;
+  mediaMaxMb?: number;
+};
+
 export type GroupChatConfig = {
   requireMention?: boolean;
   mentionPatterns?: string[];
@@ -133,6 +140,7 @@ export type ClawdisConfig = {
   };
   web?: WebConfig;
   telegram?: TelegramConfig;
+  discord?: DiscordConfig;
   webchat?: WebChatConfig;
   cron?: CronConfig;
 };
@@ -301,6 +309,14 @@ const ClawdisSchema = z.object({
       webhookUrl: z.string().optional(),
       webhookSecret: z.string().optional(),
       webhookPath: z.string().optional(),
+    })
+    .optional(),
+  discord: z
+    .object({
+      token: z.string().optional(),
+      allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+      requireMention: z.boolean().optional(),
+      mediaMaxMb: z.number().positive().optional(),
     })
     .optional(),
 });

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -21,7 +21,7 @@ export type SessionEntry = {
   totalTokens?: number;
   model?: string;
   contextTokens?: number;
-  lastChannel?: "whatsapp" | "telegram" | "webchat";
+  lastChannel?: "whatsapp" | "telegram" | "discord" | "webchat";
   lastTo?: string;
   // Optional flag to mirror Mac app UI and future sync states.
   syncing?: boolean | string;

--- a/src/cron/isolated-agent.ts
+++ b/src/cron/isolated-agent.ts
@@ -61,7 +61,7 @@ function pickSummaryFromPayloads(
 function resolveDeliveryTarget(
   cfg: ClawdisConfig,
   jobPayload: {
-    channel?: "last" | "whatsapp" | "telegram";
+    channel?: "last" | "whatsapp" | "telegram" | "discord";
     to?: string;
   },
 ) {
@@ -84,7 +84,11 @@ function resolveDeliveryTarget(
   const lastTo = typeof main?.lastTo === "string" ? main.lastTo.trim() : "";
 
   const channel = (() => {
-    if (requestedChannel === "whatsapp" || requestedChannel === "telegram") {
+    if (
+      requestedChannel === "whatsapp" ||
+      requestedChannel === "telegram" ||
+      requestedChannel === "discord"
+    ) {
       return requestedChannel;
     }
     return lastChannel ?? "whatsapp";
@@ -333,6 +337,50 @@ export async function runCronIsolatedAgentTurn(params: {
               first = false;
               await params.deps.sendMessageTelegram(chatId, caption, {
                 verbose: false,
+                mediaUrl: url,
+              });
+            }
+          }
+        }
+      } catch (err) {
+        if (!bestEffortDeliver)
+          return { status: "error", summary, error: String(err) };
+        return { status: "ok", summary };
+      }
+    } else if (resolvedDelivery.channel === "discord") {
+      if (!resolvedDelivery.to) {
+        if (!bestEffortDeliver)
+          return {
+            status: "error",
+            summary,
+            error:
+              "Cron delivery to Discord requires --channel discord and --to <channelId|user:ID>",
+          };
+        return {
+          status: "skipped",
+          summary: "Delivery skipped (no Discord destination).",
+        };
+      }
+      const discordTarget = resolvedDelivery.to;
+      try {
+        for (const payload of payloads) {
+          const mediaList =
+            payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+          if (mediaList.length === 0) {
+            await params.deps.sendMessageDiscord(
+              discordTarget,
+              payload.text ?? "",
+              {
+                token: process.env.DISCORD_BOT_TOKEN,
+              },
+            );
+          } else {
+            let first = true;
+            for (const url of mediaList) {
+              const caption = first ? (payload.text ?? "") : "";
+              first = false;
+              await params.deps.sendMessageDiscord(discordTarget, caption, {
+                token: process.env.DISCORD_BOT_TOKEN,
                 mediaUrl: url,
               });
             }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -14,7 +14,7 @@ export type CronPayload =
       thinking?: string;
       timeoutSeconds?: number;
       deliver?: boolean;
-      channel?: "last" | "whatsapp" | "telegram";
+      channel?: "last" | "whatsapp" | "telegram" | "discord";
       to?: string;
       bestEffortDeliver?: boolean;
     };

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -1,0 +1,2 @@
+export { monitorDiscordProvider } from "./monitor.js";
+export { sendMessageDiscord } from "./send.js";

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -1,0 +1,318 @@
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  type Message,
+  Partials,
+} from "discord.js";
+
+import { chunkText } from "../auto-reply/chunk.js";
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import { getReplyFromConfig } from "../auto-reply/reply.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { loadConfig } from "../config/config.js";
+import { resolveStorePath, updateLastRoute } from "../config/sessions.js";
+import { danger, isVerbose, logVerbose } from "../globals.js";
+import { getChildLogger } from "../logging.js";
+import { detectMime } from "../media/mime.js";
+import { saveMediaBuffer } from "../media/store.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { sendMessageDiscord } from "./send.js";
+
+export type MonitorDiscordOpts = {
+  token?: string;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  allowFrom?: Array<string | number>;
+  requireMention?: boolean;
+  mediaMaxMb?: number;
+};
+
+type DiscordMediaInfo = {
+  path: string;
+  contentType?: string;
+  placeholder: string;
+};
+
+export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
+  const cfg = loadConfig();
+  const token =
+    opts.token ??
+    process.env.DISCORD_BOT_TOKEN ??
+    cfg.discord?.token ??
+    undefined;
+  if (!token) {
+    throw new Error(
+      "DISCORD_BOT_TOKEN or discord.token is required for Discord gateway",
+    );
+  }
+
+  const runtime: RuntimeEnv = opts.runtime ?? {
+    log: console.log,
+    error: console.error,
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+
+  const allowFrom = opts.allowFrom ?? cfg.discord?.allowFrom;
+  const requireMention =
+    opts.requireMention ?? cfg.discord?.requireMention ?? true;
+  const mediaMaxBytes =
+    (opts.mediaMaxMb ?? cfg.discord?.mediaMaxMb ?? 8) * 1024 * 1024;
+
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel],
+  });
+
+  const logger = getChildLogger({ module: "discord-auto-reply" });
+
+  client.once(Events.ClientReady, () => {
+    runtime.log?.(`discord: logged in as ${client.user?.tag ?? "unknown"}`);
+  });
+
+  client.on(Events.Error, (err) => {
+    runtime.error?.(danger(`discord client error: ${String(err)}`));
+  });
+
+  client.on(Events.MessageCreate, async (message) => {
+    try {
+      if (message.author?.bot) return;
+      if (!message.author) return;
+
+      const isDirectMessage = !message.guild;
+      if (!isDirectMessage && requireMention) {
+        const botId = client.user?.id;
+        if (botId && !message.mentions.has(botId)) {
+          logger.info(
+            {
+              channelId: message.channelId,
+              reason: "no-mention",
+            },
+            "discord: skipping guild message",
+          );
+          return;
+        }
+      }
+
+      if (isDirectMessage && Array.isArray(allowFrom) && allowFrom.length > 0) {
+        const allowed = allowFrom.map(String);
+        const prefixed = allowed.map((val) => `discord:${val}`);
+        const candidate = message.author.id;
+        const permitted =
+          allowed.includes(candidate) ||
+          prefixed.includes(`discord:${candidate}`) ||
+          allowed.includes("*");
+        if (!permitted) {
+          logVerbose(
+            `Blocked unauthorized discord sender ${candidate} (not in allowFrom)`,
+          );
+          return;
+        }
+      }
+
+      const media = await resolveMedia(message, mediaMaxBytes);
+      const text =
+        message.content?.trim() ??
+        media?.placeholder ??
+        message.embeds[0]?.description ??
+        "";
+      if (!text) return;
+
+      const fromLabel = isDirectMessage
+        ? buildDirectLabel(message)
+        : buildGuildLabel(message);
+      const body = formatAgentEnvelope({
+        surface: "Discord",
+        from: fromLabel,
+        timestamp: message.createdTimestamp,
+        body: text,
+      });
+
+      const ctxPayload = {
+        Body: body,
+        From: isDirectMessage
+          ? `discord:${message.author.id}`
+          : `group:${message.channelId}`,
+        To: isDirectMessage
+          ? `user:${message.author.id}`
+          : `channel:${message.channelId}`,
+        ChatType: isDirectMessage ? "direct" : "group",
+        SenderName: message.member?.displayName ?? message.author.tag,
+        GroupSubject:
+          !isDirectMessage && "name" in message.channel
+            ? message.channel.name
+            : undefined,
+        Surface: "discord" as const,
+        MessageSid: message.id,
+        Timestamp: message.createdTimestamp,
+        MediaPath: media?.path,
+        MediaType: media?.contentType,
+        MediaUrl: media?.path,
+      };
+
+      if (isDirectMessage) {
+        const sessionCfg = cfg.inbound?.reply?.session;
+        const mainKey = (sessionCfg?.mainKey ?? "main").trim() || "main";
+        const storePath = resolveStorePath(sessionCfg?.store);
+        await updateLastRoute({
+          storePath,
+          sessionKey: mainKey,
+          channel: "discord",
+          to: `user:${message.author.id}`,
+        });
+      }
+
+      if (isVerbose()) {
+        const preview = body.slice(0, 200).replace(/\n/g, "\\n");
+        logVerbose(
+          `discord inbound: channel=${message.channelId} from=${ctxPayload.From} preview="${preview}"`,
+        );
+      }
+
+      const replyResult = await getReplyFromConfig(
+        ctxPayload,
+        {
+          onReplyStart: () => sendTyping(message),
+        },
+        cfg,
+      );
+      const replies = replyResult
+        ? Array.isArray(replyResult)
+          ? replyResult
+          : [replyResult]
+        : [];
+      if (replies.length === 0) return;
+
+      await deliverReplies({
+        replies,
+        target: ctxPayload.To,
+        token,
+        runtime,
+      });
+    } catch (err) {
+      runtime.error?.(danger(`Discord handler failed: ${String(err)}`));
+    }
+  });
+
+  await client.login(token.trim());
+
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      client.destroy();
+      resolve();
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      opts.abortSignal?.removeEventListener("abort", onAbort);
+      client.off(Events.Error, onError);
+    };
+    opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    client.on(Events.Error, onError);
+  });
+}
+
+async function resolveMedia(
+  message: import("discord.js").Message,
+  maxBytes: number,
+): Promise<DiscordMediaInfo | null> {
+  const attachment = message.attachments.first();
+  if (!attachment) return null;
+  const res = await fetch(attachment.url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to download discord attachment: HTTP ${res.status}`,
+    );
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  const saved = await saveMediaBuffer(
+    buffer,
+    detectMime({
+      buffer,
+      headerMime: attachment.contentType ?? res.headers.get("content-type"),
+      filePath: attachment.name ?? attachment.url,
+    }),
+    "inbound",
+    maxBytes,
+  );
+  return {
+    path: saved.path,
+    contentType: saved.contentType,
+    placeholder: inferPlaceholder(attachment),
+  };
+}
+
+function inferPlaceholder(attachment: import("discord.js").Attachment): string {
+  const mime = attachment.contentType ?? "";
+  if (mime.startsWith("image/")) return "<media:image>";
+  if (mime.startsWith("video/")) return "<media:video>";
+  if (mime.startsWith("audio/")) return "<media:audio>";
+  return "<media:document>";
+}
+
+function buildDirectLabel(message: import("discord.js").Message) {
+  const username = message.author.tag;
+  return `${username} id:${message.author.id}`;
+}
+
+function buildGuildLabel(message: import("discord.js").Message) {
+  const channelName =
+    "name" in message.channel ? message.channel.name : message.channelId;
+  return `${message.guild?.name ?? "Guild"} #${channelName} id:${message.channelId}`;
+}
+
+async function sendTyping(message: Message) {
+  try {
+    const channel = message.channel;
+    if (channel.isSendable()) {
+      await channel.sendTyping();
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+async function deliverReplies({
+  replies,
+  target,
+  token,
+  runtime,
+}: {
+  replies: ReplyPayload[];
+  target: string;
+  token: string;
+  runtime: RuntimeEnv;
+}) {
+  for (const payload of replies) {
+    const mediaList =
+      payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const text = payload.text ?? "";
+    if (!text && mediaList.length === 0) continue;
+    if (mediaList.length === 0) {
+      for (const chunk of chunkText(text, 2000)) {
+        await sendMessageDiscord(target, chunk, { token });
+      }
+    } else {
+      let first = true;
+      for (const mediaUrl of mediaList) {
+        const caption = first ? text : "";
+        first = false;
+        await sendMessageDiscord(target, caption, {
+          token,
+          mediaUrl,
+        });
+      }
+    }
+    runtime.log?.(`discord: delivered reply to ${target}`);
+  }
+}

--- a/src/discord/send.test.ts
+++ b/src/discord/send.test.ts
@@ -1,0 +1,85 @@
+import { Routes } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendMessageDiscord } from "./send.js";
+
+vi.mock("../web/media.js", () => ({
+  loadWebMedia: vi.fn().mockResolvedValue({
+    buffer: Buffer.from("img"),
+    fileName: "photo.jpg",
+    contentType: "image/jpeg",
+    kind: "image",
+  }),
+}));
+
+const makeRest = () => {
+  const postMock = vi.fn();
+  return {
+    rest: {
+      post: postMock,
+    } as unknown as import("discord.js").REST,
+    postMock,
+  };
+};
+
+describe("sendMessageDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends basic channel messages", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({
+      id: "msg1",
+      channel_id: "789",
+    });
+    const res = await sendMessageDiscord("channel:789", "hello world", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual({ messageId: "msg1", channelId: "789" });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.channelMessages("789"),
+      expect.objectContaining({ body: { content: "hello world" } }),
+    );
+  });
+
+  it("starts DM when recipient is a user", async () => {
+    const { rest, postMock } = makeRest();
+    postMock
+      .mockResolvedValueOnce({ id: "chan1" })
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "chan1" });
+    const res = await sendMessageDiscord("user:123", "hiya", {
+      rest,
+      token: "t",
+    });
+    expect(postMock).toHaveBeenNthCalledWith(
+      1,
+      Routes.userChannels(),
+      expect.objectContaining({ body: { recipient_id: "123" } }),
+    );
+    expect(postMock).toHaveBeenNthCalledWith(
+      2,
+      Routes.channelMessages("chan1"),
+      expect.objectContaining({ body: { content: "hiya" } }),
+    );
+    expect(res.channelId).toBe("chan1");
+  });
+
+  it("uploads media attachments", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg", channel_id: "789" });
+    const res = await sendMessageDiscord("channel:789", "photo", {
+      rest,
+      token: "t",
+      mediaUrl: "file:///tmp/photo.jpg",
+    });
+    expect(res.messageId).toBe("msg");
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.channelMessages("789"),
+      expect.objectContaining({
+        files: [expect.objectContaining({ name: "photo.jpg" })],
+      }),
+    );
+  });
+});

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -1,0 +1,154 @@
+import { REST, Routes } from "discord.js";
+
+import { chunkText } from "../auto-reply/chunk.js";
+import { loadConfig } from "../config/config.js";
+import { loadWebMedia } from "../web/media.js";
+
+const DISCORD_TEXT_LIMIT = 2000;
+
+type DiscordRecipient =
+  | {
+      kind: "user";
+      id: string;
+    }
+  | {
+      kind: "channel";
+      id: string;
+    };
+
+type DiscordSendOpts = {
+  token?: string;
+  mediaUrl?: string;
+  verbose?: boolean;
+  rest?: REST;
+};
+
+export type DiscordSendResult = {
+  messageId: string;
+  channelId: string;
+};
+
+function resolveToken(explicit?: string) {
+  const cfgToken = loadConfig().discord?.token;
+  const token =
+    explicit ?? process.env.DISCORD_BOT_TOKEN ?? cfgToken ?? undefined;
+  if (!token) {
+    throw new Error(
+      "DISCORD_BOT_TOKEN or discord.token is required for Discord sends",
+    );
+  }
+  return token.trim();
+}
+
+function parseRecipient(raw: string): DiscordRecipient {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Recipient is required for Discord sends");
+  }
+  if (trimmed.startsWith("user:")) {
+    return { kind: "user", id: trimmed.slice("user:".length) };
+  }
+  if (trimmed.startsWith("channel:")) {
+    return { kind: "channel", id: trimmed.slice("channel:".length) };
+  }
+  if (trimmed.startsWith("discord:")) {
+    return { kind: "user", id: trimmed.slice("discord:".length) };
+  }
+  if (trimmed.startsWith("@")) {
+    return { kind: "user", id: trimmed.slice(1) };
+  }
+  return { kind: "channel", id: trimmed };
+}
+
+async function resolveChannelId(
+  rest: REST,
+  recipient: DiscordRecipient,
+): Promise<{ channelId: string; dm?: boolean }> {
+  if (recipient.kind === "channel") {
+    return { channelId: recipient.id };
+  }
+  const dmChannel = (await rest.post(Routes.userChannels(), {
+    body: { recipient_id: recipient.id },
+  })) as { id: string };
+  if (!dmChannel?.id) {
+    throw new Error("Failed to create Discord DM channel");
+  }
+  return { channelId: dmChannel.id, dm: true };
+}
+
+async function sendDiscordText(rest: REST, channelId: string, text: string) {
+  if (!text.trim()) {
+    throw new Error("Message must be non-empty for Discord sends");
+  }
+  if (text.length <= DISCORD_TEXT_LIMIT) {
+    const res = (await rest.post(Routes.channelMessages(channelId), {
+      body: { content: text },
+    })) as { id: string; channel_id: string };
+    return res;
+  }
+  const chunks = chunkText(text, DISCORD_TEXT_LIMIT);
+  let last: { id: string; channel_id: string } | null = null;
+  for (const chunk of chunks) {
+    last = (await rest.post(Routes.channelMessages(channelId), {
+      body: { content: chunk },
+    })) as { id: string; channel_id: string };
+  }
+  if (!last) {
+    throw new Error("Discord send failed (empty chunk result)");
+  }
+  return last;
+}
+
+async function sendDiscordMedia(
+  rest: REST,
+  channelId: string,
+  text: string,
+  mediaUrl: string,
+) {
+  const media = await loadWebMedia(mediaUrl);
+  const caption =
+    text.length > DISCORD_TEXT_LIMIT ? text.slice(0, DISCORD_TEXT_LIMIT) : text;
+  const res = (await rest.post(Routes.channelMessages(channelId), {
+    body: {
+      content: caption || undefined,
+    },
+    files: [
+      {
+        data: media.buffer,
+        name: media.fileName ?? "upload",
+      },
+    ],
+  })) as { id: string; channel_id: string };
+  if (text.length > DISCORD_TEXT_LIMIT) {
+    const remaining = text.slice(DISCORD_TEXT_LIMIT).trim();
+    if (remaining) {
+      await sendDiscordText(rest, channelId, remaining);
+    }
+  }
+  return res;
+}
+
+export async function sendMessageDiscord(
+  to: string,
+  text: string,
+  opts: DiscordSendOpts = {},
+): Promise<DiscordSendResult> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const recipient = parseRecipient(to);
+  const { channelId } = await resolveChannelId(rest, recipient);
+  let result:
+    | { id: string; channel_id: string }
+    | { id: string | null; channel_id: string };
+
+  if (opts.mediaUrl) {
+    result = await sendDiscordMedia(rest, channelId, text, opts.mediaUrl);
+  } else {
+    result = await sendDiscordText(rest, channelId, text);
+  }
+
+  return {
+    messageId: result.id ? String(result.id) : "unknown",
+    channelId: String(result.channel_id ?? channelId),
+  };
+}

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -324,6 +324,7 @@ export const CronPayloadSchema = Type.Union([
           Type.Literal("last"),
           Type.Literal("whatsapp"),
           Type.Literal("telegram"),
+          Type.Literal("discord"),
         ]),
       ),
       to: Type.Optional(Type.String()),

--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1242,6 +1242,61 @@ describe("gateway server", () => {
     await server.close();
   });
 
+  test("agent routes main last-channel discord", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdis-gw-"));
+    testSessionStorePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      testSessionStorePath,
+      JSON.stringify(
+        {
+          main: {
+            sessionId: "sess-discord",
+            updatedAt: Date.now(),
+            lastChannel: "discord",
+            lastTo: "channel:discord-123",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    ws.send(
+      JSON.stringify({
+        type: "req",
+        id: "agent-last-discord",
+        method: "agent",
+        params: {
+          message: "hi",
+          sessionKey: "main",
+          channel: "last",
+          deliver: true,
+          idempotencyKey: "idem-agent-last-discord",
+        },
+      }),
+    );
+    await onceMessage(
+      ws,
+      (o) => o.type === "res" && o.id === "agent-last-discord",
+    );
+
+    const spy = vi.mocked(agentCommand);
+    expect(spy).toHaveBeenCalled();
+    const call = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(call.provider).toBe("discord");
+    expect(call.to).toBe("channel:discord-123");
+    expect(call.deliver).toBe(true);
+    expect(call.bestEffortDeliver).toBe(true);
+    expect(call.sessionId).toBe("sess-discord");
+
+    ws.close();
+    await server.close();
+  });
+
   test("agent ignores webchat last-channel for routing", async () => {
     testAllowFrom = ["+1555"];
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdis-gw-"));

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -13,14 +13,14 @@ export function isVerbose() {
 }
 
 export function logVerbose(message: string) {
-  if (globalVerbose) {
-    console.log(chalk.gray(message));
-    try {
-      getLogger().debug({ message }, "verbose");
-    } catch {
-      // ignore logger failures to avoid breaking verbose printing
-    }
+  // if (globalVerbose) {
+  console.log(chalk.gray(message));
+  try {
+    getLogger().debug({ message }, "verbose");
+  } catch {
+    // ignore logger failures to avoid breaking verbose printing
   }
+  // }
 }
 
 export function setYes(v: boolean) {


### PR DESCRIPTION
 - Introduced a discord.js-based provider (src/discord/*) that ingests DM/guild messages, saves media, updates session routing, and delivers agent replies via the Discord REST API.
  - Wired Discord through gateway, CLI, cron, and UI schemas: --provider discord works for clawdis send/agent, cron jobs can target channel=discord, and macOS cron picker gained the new option. Gateway startup, session routing, and send RPC support the new provider.
  - Updated docs/configs (README, config guide, new docs/discord.md, etc.) so setup is documented, plus added tests covering the Discord helpers.
- Added a Surface key to the payload to accurately label platforms in the session intros 