### PR TITLE
Fix CI

### DIFF
--- a/apps/macos/Sources/Clawdis/GatewayAutostartPolicy.swift
+++ b/apps/macos/Sources/Clawdis/GatewayAutostartPolicy.swift
@@ -8,9 +8,8 @@ enum GatewayAutostartPolicy {
     static func shouldEnsureLaunchAgent(
         mode: AppState.ConnectionMode,
         paused: Bool,
-        attachExistingOnly: Bool,
-    ) -> Bool
+        attachExistingOnly: Bool) -> Bool
     {
-        shouldStartGateway(mode: mode, paused: paused) && !attachExistingOnly
+        self.shouldStartGateway(mode: mode, paused: paused) && !attachExistingOnly
     }
 }

--- a/apps/macos/Sources/Clawdis/GatewayAutostartPolicy.swift
+++ b/apps/macos/Sources/Clawdis/GatewayAutostartPolicy.swift
@@ -8,9 +8,9 @@ enum GatewayAutostartPolicy {
     static func shouldEnsureLaunchAgent(
         mode: AppState.ConnectionMode,
         paused: Bool,
-        attachExistingOnly: Bool
-    ) -> Bool {
+        attachExistingOnly: Bool,
+    ) -> Bool
+    {
         shouldStartGateway(mode: mode, paused: paused) && !attachExistingOnly
     }
 }
-

--- a/apps/macos/Sources/Clawdis/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/Clawdis/GatewayDiscoveryModel.swift
@@ -277,14 +277,14 @@ final class GatewayDiscoveryModel {
         resolver.start()
     }
 
-    nonisolated private static func prettifyInstanceName(_ decodedName: String) -> String {
+    private nonisolated static func prettifyInstanceName(_ decodedName: String) -> String {
         let normalized = decodedName.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         let stripped = normalized.replacingOccurrences(of: " (Clawdis)", with: "")
             .replacingOccurrences(of: #"\s+\(\d+\)$"#, with: "", options: .regularExpression)
         return stripped.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    nonisolated private static func prettifyServiceName(_ decodedName: String) -> String {
+    private nonisolated static func prettifyServiceName(_ decodedName: String) -> String {
         let normalized = Self.prettifyInstanceName(decodedName)
         var cleaned = normalized.replacingOccurrences(of: #"\s*-?bridge$"#, with: "", options: .regularExpression)
         cleaned = cleaned
@@ -350,7 +350,7 @@ final class GatewayDiscoveryModel {
         }
     }
 
-    nonisolated private static func mergeLocalIdentity(
+    private nonisolated static func mergeLocalIdentity(
         fast: LocalIdentity,
         slow: LocalIdentity) -> LocalIdentity
     {
@@ -359,7 +359,7 @@ final class GatewayDiscoveryModel {
             displayTokens: fast.displayTokens.union(slow.displayTokens))
     }
 
-    nonisolated private static func buildLocalIdentityFast() -> LocalIdentity {
+    private nonisolated static func buildLocalIdentityFast() -> LocalIdentity {
         var hostTokens: Set<String> = []
         var displayTokens: Set<String> = []
 
@@ -375,7 +375,7 @@ final class GatewayDiscoveryModel {
         return LocalIdentity(hostTokens: hostTokens, displayTokens: displayTokens)
     }
 
-    nonisolated private static func buildLocalIdentitySlow() -> LocalIdentity {
+    private nonisolated static func buildLocalIdentitySlow() -> LocalIdentity {
         var hostTokens: Set<String> = []
         var displayTokens: Set<String> = []
 
@@ -392,7 +392,7 @@ final class GatewayDiscoveryModel {
         return LocalIdentity(hostTokens: hostTokens, displayTokens: displayTokens)
     }
 
-    nonisolated private static func normalizeHostToken(_ raw: String?) -> String? {
+    private nonisolated static func normalizeHostToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
@@ -408,7 +408,7 @@ final class GatewayDiscoveryModel {
         return token.isEmpty ? nil : token
     }
 
-    nonisolated private static func normalizeDisplayToken(_ raw: String?) -> String? {
+    private nonisolated static func normalizeDisplayToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let prettified = Self.prettifyInstanceName(raw)
         let trimmed = prettified.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -416,7 +416,7 @@ final class GatewayDiscoveryModel {
         return trimmed.lowercased()
     }
 
-    nonisolated private static func normalizeServiceToken(_ raw: String?) -> String? {
+    private nonisolated static func normalizeServiceToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }

--- a/apps/macos/Sources/Clawdis/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/Clawdis/GatewayDiscoveryModel.swift
@@ -352,12 +352,11 @@ final class GatewayDiscoveryModel {
 
     nonisolated private static func mergeLocalIdentity(
         fast: LocalIdentity,
-        slow: LocalIdentity
-    ) -> LocalIdentity {
+        slow: LocalIdentity) -> LocalIdentity
+    {
         LocalIdentity(
             hostTokens: fast.hostTokens.union(slow.hostTokens),
-            displayTokens: fast.displayTokens.union(slow.displayTokens)
-        )
+            displayTokens: fast.displayTokens.union(slow.displayTokens))
     }
 
     nonisolated private static func buildLocalIdentityFast() -> LocalIdentity {

--- a/apps/macos/Sources/Clawdis/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/Clawdis/GatewayLaunchAgentManager.swift
@@ -50,9 +50,8 @@ enum GatewayLaunchAgentManager {
     private static func writePlist(bundlePath: String, port: Int) {
         let gatewayBin = self.gatewayExecutablePath(bundlePath: bundlePath)
         let relayDir = self.relayDir(bundlePath: bundlePath)
-        let preferredPath =
-            ([relayDir] + CommandResolver.preferredPaths())
-                .joined(separator: ":")
+        let preferredPath = ([relayDir] + CommandResolver.preferredPaths())
+            .joined(separator: ":")
         let plist = """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/apps/macos/Sources/Clawdis/Onboarding.swift
+++ b/apps/macos/Sources/Clawdis/Onboarding.swift
@@ -99,11 +99,11 @@ struct OnboardingView: View {
         case .remote:
             // Remote setup doesn't need local gateway/CLI/workspace setup pages,
             // and WhatsApp/Telegram setup is optional.
-            return hasIdentity ? [0, 1, 5, 9] : [0, 1, 5, 8, 9]
+            hasIdentity ? [0, 1, 5, 9] : [0, 1, 5, 8, 9]
         case .unconfigured:
-            return hasIdentity ? [0, 1, 9] : [0, 1, 8, 9]
+            hasIdentity ? [0, 1, 9] : [0, 1, 8, 9]
         case .local:
-            return hasIdentity ? [0, 1, 2, 5, 6, 9] : [0, 1, 2, 5, 6, 8, 9]
+            hasIdentity ? [0, 1, 2, 5, 6, 9] : [0, 1, 2, 5, 6, 8, 9]
         }
     }
 

--- a/apps/macos/Sources/Clawdis/SkillsSettings.swift
+++ b/apps/macos/Sources/Clawdis/SkillsSettings.swift
@@ -83,7 +83,7 @@ struct SkillsSettings: View {
                             isPrimary: isPrimary)
                     })
             }
-            if !self.model.skills.isEmpty && self.filteredSkills.isEmpty {
+            if !self.model.skills.isEmpty, self.filteredSkills.isEmpty {
                 Text("No skills match this filter.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
@@ -143,13 +143,13 @@ private enum SkillsFilter: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .all:
-            return "All"
+            "All"
         case .ready:
-            return "Ready"
+            "Ready"
         case .needsSetup:
-            return "Needs Setup"
+            "Needs Setup"
         case .disabled:
-            return "Disabled"
+            "Disabled"
         }
     }
 }
@@ -210,15 +210,15 @@ private struct SkillRow: View {
     private var sourceLabel: String {
         switch self.skill.source {
         case "clawdis-bundled":
-            return "Bundled"
+            "Bundled"
         case "clawdis-managed":
-            return "Managed"
+            "Managed"
         case "clawdis-workspace":
-            return "Workspace"
+            "Workspace"
         case "clawdis-extra":
-            return "Extra"
+            "Extra"
         default:
-            return self.skill.source
+            self.skill.source
         }
     }
 


### PR DESCRIPTION
I'm preparing a PR to allow declaratively configuring Clawdis using nix, but the CI is currently red on main.

This PR hopefully fixes this, so that we can have all proper checks passing on the main branch, before adding a change that touches lots of important things. This should give us confidence that the later change actually works.

It seems like most of the CI issues were just linting, issues, so codex has fixed these.

Amusingly I think the CI workflow here is not yet configured to allow PRs from a fork (like this one) to run the CI suite, so @steipete you might need to push a button to enable that :) 


Shitty codex summary:
## Summary
- Fix Biome import ordering/formatting in TypeScript sources flagged by CI.
- Fix SwiftFormat lint in macOS sources flagged by CI.

## Why
Upstream CI is currently red on style checks. This PR applies the minimal formatting changes required to satisfy Biome + SwiftFormat without touching runtime logic.

## Files touched
- src/agents/pi-tools.ts (import order)
- src/web/login-qr.ts (import order + formatting)
- src/web/qr-image.ts (require formatting + wrapping)
- apps/macos/Sources/Clawdis/SkillsSettings.swift (comma in if, remove redundant returns)
- apps/macos/Sources/Clawdis/GatewayAutostartPolicy.swift (wrap + trailing comma + brace style)
- apps/macos/Sources/Clawdis/GatewayLaunchAgentManager.swift (indent)
