### PR TITLE
fix(macOS): remove redundant kickstart -k causing gateway restart loop

### DIFF
--- a/apps/macos/Sources/Clawdis/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/Clawdis/GatewayLaunchAgentManager.swift
@@ -36,7 +36,9 @@ enum GatewayLaunchAgentManager {
                     ? "Failed to bootstrap gateway launchd job"
                     : bootstrap.output.trimmingCharacters(in: .whitespacesAndNewlines)
             }
-            _ = await self.runLaunchctl(["kickstart", "-k", "gui/\(getuid())/\(gatewayLaunchdLabel)"])
+            // Note: removed redundant `kickstart -k` that caused race condition.
+            // bootstrap already starts the job; kickstart -k would kill it immediately
+            // and with KeepAlive=true, cause a restart loop with port conflicts.
             return nil
         }
 


### PR DESCRIPTION
## Summary
- Remove redundant `launchctl kickstart -k` call after `bootstrap` in `GatewayLaunchAgentManager`
- The `bootstrap` command already starts the gateway job; the subsequent `kickstart -k` was killing it immediately
- Combined with `KeepAlive=true`, this caused a port-conflict restart loop

## Problem
The gateway would fail to start with:
- `Bootstrap failed: 5: Input/output error`
- `Gateway failed to start: another gateway instance is already listening on ws://127.0.0.1:18789`

## Root Cause
1. `bootstrap` starts gateway → it begins binding port
2. `kickstart -k` sends SIGTERM before port is fully bound
3. launchd's KeepAlive sees process died → tries to restart
4. Old process still holding port during shutdown
5. New instance fails with port conflict → SIGTERM → repeat

## Test plan
- [x] Rebuild app with `scripts/restart-mac.sh`
- [x] Verify gateway starts cleanly via launchd
- [x] Confirm no SIGTERM cascade in `/tmp/clawdis/clawdis-gateway.log`
- [x] App successfully connects to gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
