### PR TITLE
feat: add heartbeatProvider and heartbeatModel config options

### DIFF
--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -170,8 +170,16 @@ export async function getReplyFromConfig(
 
   const defaultProvider = agentCfg?.provider?.trim() || DEFAULT_PROVIDER;
   const defaultModel = agentCfg?.model?.trim() || DEFAULT_MODEL;
-  let provider = defaultProvider;
-  let model = defaultModel;
+
+  // Use heartbeat-specific model/provider if configured and this is a heartbeat
+  const isHeartbeat = opts?.isHeartbeat === true;
+  let provider = isHeartbeat
+    ? (agentCfg?.heartbeatProvider?.trim() || defaultProvider)
+    : defaultProvider;
+  let model = isHeartbeat
+    ? (agentCfg?.heartbeatModel?.trim() || defaultModel)
+    : defaultModel;
+
   let contextTokens =
     agentCfg?.contextTokens ??
     lookupContextTokens(model) ??

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -264,6 +264,10 @@ export type ClawdisConfig = {
     typingIntervalSeconds?: number;
     /** Periodic background heartbeat runs (minutes). 0 disables. */
     heartbeatMinutes?: number;
+    /** Provider id for heartbeat runs (defaults to main provider). */
+    heartbeatProvider?: string;
+    /** Model id for heartbeat runs (defaults to main model). */
+    heartbeatModel?: string;
   };
   routing?: RoutingConfig;
   messages?: MessagesConfig;
@@ -449,6 +453,8 @@ const ClawdisSchema = z.object({
       mediaMaxMb: z.number().positive().optional(),
       typingIntervalSeconds: z.number().int().positive().optional(),
       heartbeatMinutes: z.number().nonnegative().optional(),
+      heartbeatProvider: z.string().optional(),
+      heartbeatModel: z.string().optional(),
     })
     .optional(),
   routing: RoutingSchema,


### PR DESCRIPTION
Allow using a different (cheaper) model for periodic heartbeat runs. When configured, heartbeat runs will use heartbeatProvider/heartbeatModel instead of the main provider/model, enabling cost optimization (e.g., using Haiku for heartbeats while keeping Opus for conversations).

Example config:
```
  "agent": {
    "provider": "anthropic",
    "model": "claude-opus-4-5",
    "heartbeatProvider": "anthropic",
    "heartbeatModel": "claude-haiku-4-5-20251001",
    "heartbeatMinutes": 5
  }
```