### PR TITLE
feat(agent): add maxConcurrent config for parallel message handling

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -325,6 +325,8 @@ export type ClawdisConfig = {
     typingIntervalSeconds?: number;
     /** Periodic background heartbeat runs (minutes). 0 disables. */
     heartbeatMinutes?: number;
+    /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
+    maxConcurrent?: number;
   };
   routing?: RoutingConfig;
   messages?: MessagesConfig;
@@ -573,6 +575,7 @@ const ClawdisSchema = z.object({
       mediaMaxMb: z.number().positive().optional(),
       typingIntervalSeconds: z.number().int().positive().optional(),
       heartbeatMinutes: z.number().nonnegative().optional(),
+      maxConcurrent: z.number().int().positive().optional(),
     })
     .optional(),
   routing: RoutingSchema,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1733,6 +1733,7 @@ export async function startGatewayServer(
     { controller: AbortController; sessionId: string; sessionKey: string }
   >();
   setCommandLaneConcurrency("cron", cfgAtStart.cron?.maxConcurrentRuns ?? 1);
+  setCommandLaneConcurrency("main", cfgAtStart.agent?.maxConcurrent ?? 1);
 
   const cronStorePath = resolveCronStorePath(cfgAtStart.cron?.store);
   const cronLogger = getChildLogger({


### PR DESCRIPTION
## Summary
Adds `agent.maxConcurrent` config option to control how many agent runs can execute in parallel across all conversations. Default remains 1

Problem: running multiple groups, long running tasks in one group would block everything else in other groups or in DMs

## Example config
```json
{
  "agent": {
    "maxConcurrent": 5
  }
}
```