### PR TITLE
Bundle Control UI assets in the Mac app

### DIFF
--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -33,6 +33,13 @@ else
   echo "📦 Skipping TS build (SKIP_TSC=1)"
 fi
 
+if [[ "${SKIP_UI_BUILD:-0}" != "1" ]]; then
+  echo "🖥  Building Control UI (pnpm ui:build)"
+  (cd "$ROOT_DIR" && pnpm ui:build)
+else
+  echo "🖥  Skipping Control UI build (SKIP_UI_BUILD=1)"
+fi
+
 cd "$ROOT_DIR/apps/macos"
 
 echo "🔨 Building $PRODUCT ($BUILD_CONFIG)"
@@ -162,6 +169,10 @@ if [[ "${SKIP_GATEWAY_PACKAGE:-0}" != "1" ]]; then
   echo "🎨 Copying gateway A2UI host assets"
   rm -rf "$RELAY_DIR/a2ui"
   cp -R "$ROOT_DIR/src/canvas-host/a2ui" "$RELAY_DIR/a2ui"
+
+  echo "🎛  Copying Control UI assets"
+  rm -rf "$RELAY_DIR/control-ui"
+  cp -R "$ROOT_DIR/dist/control-ui" "$RELAY_DIR/control-ui"
 
   echo "🧠 Copying bundled skills"
   rm -rf "$RELAY_DIR/skills"

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -8,14 +8,23 @@ const ROOT_PREFIX = "/";
 
 function resolveControlUiRoot(): string | null {
   const here = path.dirname(fileURLToPath(import.meta.url));
+  const execDir = (() => {
+    try {
+      return path.dirname(fs.realpathSync(process.execPath));
+    } catch {
+      return null;
+    }
+  })();
   const candidates = [
+    // Packaged relay: Resources/Relay/control-ui
+    execDir ? path.resolve(execDir, "control-ui") : null,
     // Running from dist: dist/gateway/control-ui.js -> dist/control-ui
     path.resolve(here, "../control-ui"),
     // Running from source: src/gateway/control-ui.ts -> dist/control-ui
     path.resolve(here, "../../dist/control-ui"),
     // Fallback to cwd (dev)
     path.resolve(process.cwd(), "dist", "control-ui"),
-  ];
+  ].filter((dir): dir is string => Boolean(dir));
   for (const dir of candidates) {
     if (fs.existsSync(path.join(dir, "index.html"))) return dir;
   }


### PR DESCRIPTION
## Summary
- build Control UI during Mac app packaging
- ship Control UI assets inside the bundle
- allow the relay to locate bundled UI assets

## Testing
- not run (packaging change only)