### PR TITLE
Remove hardcoded pnpm path

### DIFF
--- a/apps/macos/Sources/Clawdis/CommandResolver.swift
+++ b/apps/macos/Sources/Clawdis/CommandResolver.swift
@@ -274,7 +274,7 @@ enum CommandResolver {
             "/bin",
             "/usr/sbin",
             "/sbin",
-            "/Users/steipete/Library/pnpm",
+            "$HOME/Library/pnpm",
             "$PATH",
         ].joined(separator: ":")
         let quotedArgs = ([subcommand] + extraArgs).map(self.shellQuote).joined(separator: " ")


### PR DESCRIPTION
## Summary
- use $HOME/Library/pnpm instead of a user-specific path for SSH PATH exports

## Testing
- not run (path cleanup only)