### PR TITLE
docs: Add manual OAuth setup for remote/headless deployments

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -123,7 +123,46 @@ Daily memory lives under `memory/` in the workspace:
 If the Gateway runs on another machine, the Anthropic OAuth credentials must be created/stored on that host (where the agent runtime runs).
 
 For now, remote onboarding should:
-- explain why OAuth isn’t shown
+- explain why OAuth isn't shown
 - point the user at the credential location (`~/.clawdis/credentials/oauth.json`) and the workspace location on the gateway host
 - mention that the **bootstrap ritual happens on the gateway host** (same BOOTSTRAP/IDENTITY/USER files)
+
+### Manual credential setup
+
+On the gateway host, create `~/.clawdis/credentials/oauth.json` with this exact format:
+
+```json
+{
+  "anthropic": {
+    "access": "sk-ant-oat01-...",
+    "refresh": "sk-ant-ort01-...",
+    "expires": 1767304352803
+  }
+}
+```
+
+Set permissions: `chmod 600 ~/.clawdis/credentials/oauth.json`
+
+**Note:** Clawdis can auto-import from legacy pi-coding-agent paths (`~/.pi/agent/oauth.json`, etc.) but this does NOT work with Claude Code credentials — different file and format.
+
+### Using Claude Code credentials
+
+If Claude Code is installed on the gateway host, convert its credentials:
+
+```bash
+cat ~/.claude/.credentials.json | jq '{
+  anthropic: {
+    access: .claudeAiOauth.accessToken,
+    refresh: .claudeAiOauth.refreshToken,
+    expires: .claudeAiOauth.expiresAt
+  }
+}' > ~/.clawdis/credentials/oauth.json
+chmod 600 ~/.clawdis/credentials/oauth.json
+```
+
+| Claude Code field | Clawdis field |
+|-------------------|---------------|
+| `accessToken` | `access` |
+| `refreshToken` | `refresh` |
+| `expiresAt` | `expires` |
 <!-- {% endraw %} -->


### PR DESCRIPTION
## Summary

Expands the "Remote mode note" section with practical guidance for headless/Docker/SSH deployments:

- Document exact `oauth.json` format required (`access`, `refresh`, `expires`)
- Clarify that auto-import only works for pi-coding-agent legacy paths, not Claude Code
- Add jq script to convert Claude Code credentials to Clawdis format

## Context

When running Clawdis remotely (Docker, SSH, headless server), users cannot use the macOS app OAuth flow and need to manually set up credentials. This was undocumented, causing confusion when credentials copied from Claude Code did not work due to different field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)