### PR TITLE
build: fix hardcoded dependency path for ElevenLabsKit

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "d8a19a95c479a3c7cb20aded07bd18cfeda5d85b95284983da83dbee7c941e5c",
+  "originHash" : "9de32b5fc115432dadd84c3ab4d67d2fed22ffaf5675a77033d69ea194ac3862",
   "pins" : [
+    {
+      "identity" : "elevenlabskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/ElevenLabsKit",
+      "state" : {
+        "branch" : "main",
+        "revision" : "9f2d700a546543391c65da4f79165384dc2e7e3d"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",

--- a/apps/shared/ClawdisKit/Package.swift
+++ b/apps/shared/ClawdisKit/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "ClawdisChatUI", targets: ["ClawdisChatUI"]),
     ],
     dependencies: [
-        .package(path: "../../../../ElevenLabsKit"),
+        .package(url: "https://github.com/steipete/ElevenLabsKit", branch: "main"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Fixes a build error where ElevenLabsKit was referenced via a local relative path (../../../../) that assumed a specific folder structure on the host machine.

Updated apps/shared/ClawdisKit/Package.swift to use the remote GitHub URL instead.