### PR TITLE
scripts: fix ad-hoc signing crashes and bash unbound variable error

### DIFF
--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -83,7 +83,10 @@ case "$TIMESTAMP_MODE" in
     ;;
 esac
 
-options_args=("--options" "runtime")
+options_args=()
+if [[ "$IDENTITY" != "-" ]]; then
+  options_args=("--options" "runtime")
+fi
 timestamp_args=("$timestamp_arg")
 
 cat > "$ENT_TMP_BASE" <<'PLIST'
@@ -157,12 +160,12 @@ xattr -cr "$APP_BUNDLE" 2>/dev/null || true
 sign_item() {
   local target="$1"
   local entitlements="$2"
-  codesign --force "${options_args[@]}" "${timestamp_args[@]}" --entitlements "$entitlements" --sign "$IDENTITY" "$target"
+  codesign --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --entitlements "$entitlements" --sign "$IDENTITY" "$target"
 }
 
 sign_plain_item() {
   local target="$1"
-  codesign --force "${options_args[@]}" "${timestamp_args[@]}" --sign "$IDENTITY" "$target"
+  codesign --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --sign "$IDENTITY" "$target"
 }
 
 # Sign main binary


### PR DESCRIPTION
Improves the developer experience when building Clawdis without a valid Apple Developer ID:
1. Skips --options runtime (Hardened Runtime) when using ad-hoc signing (-). Enforcing Hardened Runtime on ad-hoc signed apps often causes "Abort trap 6" crashes due to Team ID mismatches with embedded frameworks.
2. Fixes a bash "unbound variable" error in scripts/codesign-mac-app.sh when options_args is empty.