### PR TITLE
fix(chat): prevent duplicate messages

### DIFF
--- a/apps/shared/ClawdisKit/Sources/ClawdisChatUI/ChatComposer.swift
+++ b/apps/shared/ClawdisKit/Sources/ClawdisChatUI/ChatComposer.swift
@@ -412,7 +412,11 @@ private struct ChatComposerTextView: NSViewRepresentable {
         }
 
         let isEditing = scrollView.window?.firstResponder == textView
-        if isEditing { return }
+
+        // Always allow clearing the text (e.g. after send), even while editing.
+        // Only skip other updates while editing to avoid cursor jumps.
+        let shouldClear = self.text.isEmpty && !textView.string.isEmpty
+        if isEditing && !shouldClear { return }
 
         if textView.string != self.text {
             context.coordinator.isProgrammaticUpdate = true

--- a/apps/shared/ClawdisKit/Sources/ClawdisChatUI/ChatViewModel.swift
+++ b/apps/shared/ClawdisKit/Sources/ClawdisChatUI/ChatViewModel.swift
@@ -243,6 +243,10 @@ public final class ClawdisChatViewModel {
                 content: userContent,
                 timestamp: Date().timeIntervalSince1970 * 1000))
 
+        // Clear input immediately for responsive UX (before network await)
+        self.input = ""
+        self.attachments = []
+
         do {
             let response = try await self.transport.sendMessage(
                 sessionKey: self.sessionKey,
@@ -261,8 +265,6 @@ public final class ClawdisChatViewModel {
             chatUILogger.error("chat.send failed \(error.localizedDescription, privacy: .public)")
         }
 
-        self.input = ""
-        self.attachments = []
         self.isSending = false
     }
 


### PR DESCRIPTION
# Issue

Messages were being sent twice

# Cause

Two issues were causing the input field to retain text after sending:

1. ChatComposer's NSViewRepresentable was skipping all updates while the text view was first responder. Now it allows clearing (empty binding) even during editing, only skipping other updates to avoid cursor jumps.

2. ChatViewModel cleared input after awaiting the network response, leaving text visible during the round trip. Now clears immediately after capturing the message content, before the async send.

Together these prevent accidentally re-sending messages when the input appeared unchanged after pressing Enter.