### PR TITLE
fix(macos): prioritize main bundle for device resources to prevent crash

### DIFF
--- a/apps/macos/Sources/Clawdis/DeviceModelCatalog.swift
+++ b/apps/macos/Sources/Clawdis/DeviceModelCatalog.swift
@@ -122,12 +122,13 @@ enum DeviceModelCatalog {
     }
 
     private static func locateResourceBundle() -> Bundle? {
-        // Prefer module bundle (SwiftPM/tests), then main app bundle (packaged app).
-        if let bundle = self.bundleIfContainsDeviceModels(Bundle.module) {
+        // Prefer main bundle (packaged app), then module bundle (SwiftPM/tests).
+        // Accessing Bundle.module in the packaged app can crash if the bundle isn't where SwiftPM expects it.
+        if let bundle = self.bundleIfContainsDeviceModels(Bundle.main) {
             return bundle
         }
 
-        if let bundle = self.bundleIfContainsDeviceModels(Bundle.main) {
+        if let bundle = self.bundleIfContainsDeviceModels(Bundle.module) {
             return bundle
         }
         return nil


### PR DESCRIPTION
Prioritizes checking 'Bundle.main' for device resources before 'Bundle.module'. This prevents a crash in the packaged application where 'Bundle.module' (generated by SwiftPM) fails to locate the resource bundle, while 'Bundle.main' correctly contains the resources copied by the packaging script.