### PR TITLE
Failover Models and Gemini Model Support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,11 +266,17 @@ Controls the embedded agent runtime (model/thinking/verbose/timeouts).
 `allowedModels` lets `/model` list/filter and enforce a per-session allowlist
 (omit to show the full catalog).
 `modelAliases` adds short names for `/model` (alias -> provider/model).
+`failoverModels` provides an ordered list of backup models to try when the
+primary model returns an error (quota, rate limit, network, etc).
 
 ```json5
 {
   agent: {
     model: "anthropic/claude-opus-4-5",
+    failoverModels: [
+      "anthropic/claude-sonnet-4-1",
+      "openai/gpt-4o"
+    ],
     allowedModels: [
       "anthropic/claude-opus-4-5",
       "anthropic/claude-sonnet-4-1"
@@ -304,6 +310,10 @@ If you omit the provider, CLAWDIS currently assumes `anthropic` as a temporary
 deprecation fallback.
 Z.AI models are available as `zai/<model>` (e.g. `zai/glm-4.7`) and require
 `ZAI_API_KEY` (or legacy `Z_AI_API_KEY`) in the environment.
+
+`agent.failoverModels` accepts an ordered list of fallback models (`provider/model`
+or alias). CLAWDIS uses them only for the current turn when the model errors
+before a successful reply; it does not persist as a `/model` override.
 
 `agent.heartbeat` configures periodic heartbeat runs:
 - `every`: duration string (`ms`, `s`, `m`, `h`); default unit minutes. Omit or set

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -454,6 +454,8 @@ export type ClawdisConfig = {
   agent?: {
     /** Model id (provider/model), e.g. "anthropic/claude-opus-4-5". */
     model?: string;
+    /** Ordered fallback models for failover (provider/model or alias). */
+    failoverModels?: string[];
     /** Agent working directory (preferred). Used as the default cwd for agent runs. */
     workspace?: string;
     /** Optional allowlist for /model (provider/model or model-only). */
@@ -825,6 +827,7 @@ const ClawdisSchema = z.object({
   agent: z
     .object({
       model: z.string().optional(),
+      failoverModels: z.array(z.string()).optional(),
       workspace: z.string().optional(),
       allowedModels: z.array(z.string()).optional(),
       modelAliases: z.record(z.string(), z.string()).optional(),

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -18,7 +18,7 @@ export type HookMappingResolved = {
   messageTemplate?: string;
   textTemplate?: string;
   deliver?: boolean;
-  channel?: "last" | "whatsapp" | "telegram" | "discord";
+  channel?: "last" | "whatsapp" | "telegram" | "discord" | "signal" | "imessage";
   to?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -50,7 +50,7 @@ export type HookAction =
       wakeMode: "now" | "next-heartbeat";
       sessionKey?: string;
       deliver?: boolean;
-      channel?: "last" | "whatsapp" | "telegram" | "discord";
+      channel?: "last" | "whatsapp" | "telegram" | "discord" | "signal" | "imessage";
       to?: string;
       thinking?: string;
       timeoutSeconds?: number;
@@ -86,7 +86,7 @@ type HookTransformResult = Partial<{
   name: string;
   sessionKey: string;
   deliver: boolean;
-  channel: "last" | "whatsapp" | "telegram" | "discord";
+  channel: "last" | "whatsapp" | "telegram" | "discord" | "signal" | "imessage";
   to: string;
   thinking: string;
   timeoutSeconds: number;


### PR DESCRIPTION
This adds two related improvements to the embedded agent runtime:

- Configurable model failover: new agent.failoverModels array lets Clawdis try secondary/tertiary models when the primary errors (per‑turn only; no /model override persistence).
- Gemini support hardening: sanitize tool schemas and session history for Google models so Gemini accepts function‑call payloads and ordering.

Gemini usage note:

- Set GEMINI_API_KEY (from aistudio.google.com) in the gateway host environment.

Question for @steipete steipete

Should we add Gemini as an onboarding option and prompt for GEMINI_API_KEY there (similar to Anthropic API key), or keep it as an env‑only setup?