### PR TITLE
Discord: add per-guild mention requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Minimal `~/.clawdis/clawdis.json`:
 ### Discord
 
 - Set `DISCORD_BOT_TOKEN` or `discord.token` (env wins).
-- Optional: set `discord.requireMention`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
+- Optional: set `discord.requireMention`, `discord.requireMentionGuilds`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
 
 ```json5
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,7 @@ Configure the Discord bot by setting the bot token and optional gating:
       users: ["987654321098765432"]        // optional user allowlist (ids)
     },
     requireMention: true,                   // require @bot mentions in guilds
+    requireMentionGuilds: ["123"],          // require mentions only in these guilds
     mediaMaxMb: 8,                          // clamp inbound media size
     historyLimit: 20,                       // include last N guild messages as context
     enableReactions: true                   // allow agent-triggered reactions

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -20,7 +20,7 @@ Status: ready for DM and guild text channels via the official Discord bot gatewa
 3. Configure Clawdis with `DISCORD_BOT_TOKEN` (or `discord.token` in `~/.clawdis/clawdis.json`).
 4. Run the gateway; it auto-starts the Discord provider when the token is set (unless `discord.enabled = false`).
 5. Direct chats: use `user:<id>` (or a `<@id>` mention) when delivering; all turns land in the shared `main` session.
-6. Guild channels: use `channel:<channelId>` for delivery. Mentions are required by default; disable with `discord.requireMention = false`.
+6. Guild channels: use `channel:<channelId>` for delivery. Mentions are required by default; disable with `discord.requireMention = false`, or limit to specific guilds with `discord.requireMentionGuilds`.
 7. Optional DM allowlist: reuse `discord.allowFrom` with user ids (`1234567890` or `discord:1234567890`). Use `"*"` to allow all DMs.
 8. Optional guild allowlist: set `discord.guildAllowFrom` with `guilds` and/or `users` to gate who can invoke the bot in servers.
 9. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
@@ -47,6 +47,7 @@ Note: Discord does not provide a simple username → id lookup without extra gui
       users: ["987654321098765432"]
     },
     requireMention: true,
+    requireMentionGuilds: ["123456789012345678"],
     mediaMaxMb: 8,
     historyLimit: 20,
     enableReactions: true
@@ -57,6 +58,7 @@ Note: Discord does not provide a simple username → id lookup without extra gui
 - `allowFrom`: DM allowlist (user ids). Omit or set to `["*"]` to allow any DM sender.
 - `guildAllowFrom`: Optional allowlist for guild messages. Set `guilds` and/or `users` (ids). When both are set, both must match.
 - `requireMention`: when `true`, messages in guild channels must mention the bot.
+- `requireMentionGuilds`: optional list of guild ids that require mentions; when set, only those guilds require mentions (use `["*"]` to require mentions everywhere).
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20, `0` disables).
 - `enableReactions`: allow agent-triggered reactions via the `clawdis_discord` tool (default `true`).

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -174,6 +174,7 @@ export type DiscordConfig = {
     users?: Array<string | number>;
   };
   requireMention?: boolean;
+  requireMentionGuilds?: Array<string | number>;
   mediaMaxMb?: number;
   /** Number of recent guild messages to include for context (default: 20). */
   historyLimit?: number;
@@ -916,6 +917,7 @@ const ClawdisSchema = z.object({
         })
         .optional(),
       requireMention: z.boolean().optional(),
+      requireMentionGuilds: z.array(z.union([z.string(), z.number()])).optional(),
       mediaMaxMb: z.number().positive().optional(),
       historyLimit: z.number().int().min(0).optional(),
       enableReactions: z.boolean().optional(),

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2156,6 +2156,7 @@ export async function startGatewayServer(
       allowFrom: cfg.discord?.allowFrom,
       guildAllowFrom: cfg.discord?.guildAllowFrom,
       requireMention: cfg.discord?.requireMention,
+      requireMentionGuilds: cfg.discord?.requireMentionGuilds,
       mediaMaxMb: cfg.discord?.mediaMaxMb,
       historyLimit: cfg.discord?.historyLimit,
     })


### PR DESCRIPTION
I wanted to be able to require a mention in a specific guild so it wasn't always replying to me in that guild only, so I added this optional config variable. Any guilds listed in this array will require a mention, just like the more global requireMention config option