### PR TITLE
Discord: add ignored channel/category filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Minimal `~/.clawdis/clawdis.json`:
 ### Discord
 
 - Set `DISCORD_BOT_TOKEN` or `discord.token` (env wins).
-- Optional: set `discord.requireMention`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
+- Optional: set `discord.requireMention`, `discord.ignoredChannels`, `discord.ignoredCategories`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
 
 ```json5
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,8 @@ Configure the Discord bot by setting the bot token and optional gating:
       users: ["987654321098765432"]        // optional user allowlist (ids)
     },
     requireMention: true,                   // require @bot mentions in guilds
+    ignoredChannels: ["123456789012345678"],// ignore specific guild channels
+    ignoredCategories: ["234567890123456789"],// ignore specific guild categories
     mediaMaxMb: 8,                          // clamp inbound media size
     historyLimit: 20,                       // include last N guild messages as context
     enableReactions: true                   // allow agent-triggered reactions

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -23,8 +23,9 @@ Status: ready for DM and guild text channels via the official Discord bot gatewa
 6. Guild channels: use `channel:<channelId>` for delivery. Mentions are required by default; disable with `discord.requireMention = false`.
 7. Optional DM allowlist: reuse `discord.allowFrom` with user ids (`1234567890` or `discord:1234567890`). Use `"*"` to allow all DMs.
 8. Optional guild allowlist: set `discord.guildAllowFrom` with `guilds` and/or `users` to gate who can invoke the bot in servers.
-9. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
-10. Reactions (default on): set `discord.enableReactions = false` to disable agent-triggered reactions via the `clawdis_discord` tool.
+9. Optional ignore lists: set `discord.ignoredChannels` and/or `discord.ignoredCategories` to skip processing for those guild locations.
+10. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
+11. Reactions (default on): set `discord.enableReactions = false` to disable agent-triggered reactions via the `clawdis_discord` tool.
 
 Note: Discord does not provide a simple username → id lookup without extra guild context, so prefer ids or `<@id>` mentions for DM delivery targets.
 
@@ -47,6 +48,8 @@ Note: Discord does not provide a simple username → id lookup without extra gui
       users: ["987654321098765432"]
     },
     requireMention: true,
+    ignoredChannels: ["123456789012345678"],
+    ignoredCategories: ["234567890123456789"],
     mediaMaxMb: 8,
     historyLimit: 20,
     enableReactions: true
@@ -57,6 +60,8 @@ Note: Discord does not provide a simple username → id lookup without extra gui
 - `allowFrom`: DM allowlist (user ids). Omit or set to `["*"]` to allow any DM sender.
 - `guildAllowFrom`: Optional allowlist for guild messages. Set `guilds` and/or `users` (ids). When both are set, both must match.
 - `requireMention`: when `true`, messages in guild channels must mention the bot.
+- `ignoredChannels`: optional list of guild channel ids to ignore entirely.
+- `ignoredCategories`: optional list of guild category ids to ignore entirely.
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20, `0` disables).
 - `enableReactions`: allow agent-triggered reactions via the `clawdis_discord` tool (default `true`).

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -174,6 +174,8 @@ export type DiscordConfig = {
     users?: Array<string | number>;
   };
   requireMention?: boolean;
+  ignoredChannels?: Array<string | number>;
+  ignoredCategories?: Array<string | number>;
   mediaMaxMb?: number;
   /** Number of recent guild messages to include for context (default: 20). */
   historyLimit?: number;
@@ -916,6 +918,8 @@ const ClawdisSchema = z.object({
         })
         .optional(),
       requireMention: z.boolean().optional(),
+      ignoredChannels: z.array(z.union([z.string(), z.number()])).optional(),
+      ignoredCategories: z.array(z.union([z.string(), z.number()])).optional(),
       mediaMaxMb: z.number().positive().optional(),
       historyLimit: z.number().int().min(0).optional(),
       enableReactions: z.boolean().optional(),

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2156,6 +2156,8 @@ export async function startGatewayServer(
       allowFrom: cfg.discord?.allowFrom,
       guildAllowFrom: cfg.discord?.guildAllowFrom,
       requireMention: cfg.discord?.requireMention,
+      ignoredChannels: cfg.discord?.ignoredChannels,
+      ignoredCategories: cfg.discord?.ignoredCategories,
       mediaMaxMb: cfg.discord?.mediaMaxMb,
       historyLimit: cfg.discord?.historyLimit,
     })


### PR DESCRIPTION
More optional config options for Discord since it has so many channel/guild/user options for messages to come in! This lets you filter specific channels, as well as entire categories, from being responded to at all by Clawdis. It comes in two optional arrays inside the Discord config that get checked before passing the messages off.