### PR TITLE
Discord: add slash command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Minimal `~/.clawdis/clawdis.json`:
 ### Discord
 
 - Set `DISCORD_BOT_TOKEN` or `discord.token` (env wins).
-- Optional: set `discord.requireMention`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
+- Optional: set `discord.requireMention`, `discord.slashCommand`, `discord.allowFrom`, or `discord.mediaMaxMb` as needed.
 
 ```json5
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,12 @@ Configure the Discord bot by setting the bot token and optional gating:
       users: ["987654321098765432"]        // optional user allowlist (ids)
     },
     requireMention: true,                   // require @bot mentions in guilds
+    slashCommand: {                         // user-installed app slash commands
+      enabled: true,
+      name: "clawd",
+      sessionPrefix: "discord:slash",
+      ephemeral: true
+    },
     mediaMaxMb: 8,                          // clamp inbound media size
     historyLimit: 20,                       // include last N guild messages as context
     enableReactions: true                   // allow agent-triggered reactions

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -23,8 +23,9 @@ Status: ready for DM and guild text channels via the official Discord bot gatewa
 6. Guild channels: use `channel:<channelId>` for delivery. Mentions are required by default; disable with `discord.requireMention = false`.
 7. Optional DM allowlist: reuse `discord.allowFrom` with user ids (`1234567890` or `discord:1234567890`). Use `"*"` to allow all DMs.
 8. Optional guild allowlist: set `discord.guildAllowFrom` with `guilds` and/or `users` to gate who can invoke the bot in servers.
-9. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
-10. Reactions (default on): set `discord.enableReactions = false` to disable agent-triggered reactions via the `clawdis_discord` tool.
+9. Optional slash commands: enable `discord.slashCommand` to accept user-installed app commands (ephemeral replies).
+10. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
+11. Reactions (default on): set `discord.enableReactions = false` to disable agent-triggered reactions via the `clawdis_discord` tool.
 
 Note: Discord does not provide a simple username → id lookup without extra guild context, so prefer ids or `<@id>` mentions for DM delivery targets.
 
@@ -47,6 +48,12 @@ Note: Discord does not provide a simple username → id lookup without extra gui
       users: ["987654321098765432"]
     },
     requireMention: true,
+    slashCommand: {
+      enabled: true,
+      name: "clawd",
+      sessionPrefix: "discord:slash",
+      ephemeral: true
+    },
     mediaMaxMb: 8,
     historyLimit: 20,
     enableReactions: true
@@ -57,9 +64,14 @@ Note: Discord does not provide a simple username → id lookup without extra gui
 - `allowFrom`: DM allowlist (user ids). Omit or set to `["*"]` to allow any DM sender.
 - `guildAllowFrom`: Optional allowlist for guild messages. Set `guilds` and/or `users` (ids). When both are set, both must match.
 - `requireMention`: when `true`, messages in guild channels must mention the bot.
+- `slashCommand`: optional config for user-installed slash commands (ephemeral responses).
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20, `0` disables).
 - `enableReactions`: allow agent-triggered reactions via the `clawdis_discord` tool (default `true`).
+
+Slash command notes:
+- Register a chat input command in Discord with at least one string option (e.g., `prompt`).
+- The first non-empty string option is treated as the prompt.
 
 ## Reactions
 When `discord.enableReactions = true`, the agent can call `clawdis_discord` with:

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -72,6 +72,7 @@ Note: Discord does not provide a simple username → id lookup without extra gui
 Slash command notes:
 - Register a chat input command in Discord with at least one string option (e.g., `prompt`).
 - The first non-empty string option is treated as the prompt.
+- Clawdis will auto-register `/clawd` (or configured name) if it doesn't already exist.
 
 ## Reactions
 When `discord.enableReactions = true`, the agent can call `clawdis_discord` with:

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -2,6 +2,7 @@ export type MsgContext = {
   Body?: string;
   From?: string;
   To?: string;
+  SessionKey?: string;
   MessageSid?: string;
   ReplyToId?: string;
   ReplyToBody?: string;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -164,6 +164,17 @@ export type TelegramConfig = {
   webhookPath?: string;
 };
 
+export type DiscordSlashCommandConfig = {
+  /** Enable handling for the configured slash command (default: false). */
+  enabled?: boolean;
+  /** Slash command name (default: "clawd"). */
+  name?: string;
+  /** Session key prefix for slash commands (default: "discord:slash"). */
+  sessionPrefix?: string;
+  /** Reply ephemerally (default: true). */
+  ephemeral?: boolean;
+};
+
 export type DiscordConfig = {
   /** If false, do not start the Discord provider. Default: true. */
   enabled?: boolean;
@@ -174,6 +185,7 @@ export type DiscordConfig = {
     users?: Array<string | number>;
   };
   requireMention?: boolean;
+  slashCommand?: DiscordSlashCommandConfig;
   mediaMaxMb?: number;
   /** Number of recent guild messages to include for context (default: 20). */
   historyLimit?: number;
@@ -916,6 +928,14 @@ const ClawdisSchema = z.object({
         })
         .optional(),
       requireMention: z.boolean().optional(),
+      slashCommand: z
+        .object({
+          enabled: z.boolean().optional(),
+          name: z.string().optional(),
+          sessionPrefix: z.string().optional(),
+          ephemeral: z.boolean().optional(),
+        })
+        .optional(),
       mediaMaxMb: z.number().positive().optional(),
       historyLimit: z.number().int().min(0).optional(),
       enableReactions: z.boolean().optional(),

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -177,6 +177,8 @@ export function resolveSessionKey(
   ctx: MsgContext,
   mainKey?: string,
 ) {
+  const explicit = ctx.SessionKey?.trim();
+  if (explicit) return explicit;
   const raw = deriveSessionKey(scope, ctx);
   if (scope === "global") return raw;
   // Default to a single shared direct-chat session called "main"; groups stay isolated.

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationCommandOptionType,
   type CommandInteractionOption,
   Client,
   Events,
@@ -102,6 +103,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
   client.once(Events.ClientReady, () => {
     runtime.log?.(`logged in as ${client.user?.tag ?? "unknown"}`);
+    if (slashCommand.enabled) {
+      void ensureSlashCommand(client, slashCommand, runtime);
+    }
   });
 
   client.on(Events.Error, (err) => {
@@ -466,6 +470,58 @@ function resolveSlashPrompt(
   const direct = findFirstStringOption(options);
   if (direct) return direct;
   return undefined;
+}
+
+async function ensureSlashCommand(
+  client: Client,
+  slashCommand: Required<DiscordSlashCommandConfig>,
+  runtime: RuntimeEnv,
+) {
+  try {
+    const appCommands = client.application?.commands;
+    if (!appCommands) {
+      runtime.error?.(danger("discord slash commands unavailable"));
+      return;
+    }
+    const existing = await appCommands.fetch();
+    let hasCommand = false;
+    for (const entry of existing.values()) {
+      if (entry.name === slashCommand.name) {
+        hasCommand = true;
+        continue;
+      }
+      await entry.delete();
+    }
+    if (hasCommand) return;
+    await appCommands.create({
+      name: slashCommand.name,
+      description: "Ask Clawdis a question",
+      options: [
+        {
+          name: "prompt",
+          description: "What should Clawdis help with?",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+        },
+      ],
+    });
+    runtime.log?.(`registered discord slash command /${slashCommand.name}`);
+  } catch (err) {
+    const status = (err as { status?: number | string })?.status;
+    const code = (err as { code?: number | string })?.code;
+    const message = String(err);
+    const isRateLimit =
+      status === 429 ||
+      code === 429 ||
+      /rate ?limit/i.test(message);
+    const text = `discord slash command setup failed: ${message}`;
+    if (isRateLimit) {
+      logVerbose(text);
+      runtime.error?.(warn(text));
+    } else {
+      runtime.error?.(danger(text));
+    }
+  }
 }
 
 function findFirstStringOption(

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2156,6 +2156,7 @@ export async function startGatewayServer(
       allowFrom: cfg.discord?.allowFrom,
       guildAllowFrom: cfg.discord?.guildAllowFrom,
       requireMention: cfg.discord?.requireMention,
+      slashCommand: cfg.discord?.slashCommand,
       mediaMaxMb: cfg.discord?.mediaMaxMb,
       historyLimit: cfg.discord?.historyLimit,
     })


### PR DESCRIPTION
Discord has the concept of User Apps, where instead of installing a bot to a server, you can install it to your user account
you dont get the full bot scope, so no reading messages, but you CAN use interactions, aka slash commands, where the user can then run the installed bot's slash commands anywhere in any server. 

I talked with Clawd in the Discord server, and he said that doing a stable slash-session for this was the best idea, so I did this PR.

This PR adds support for Discord User App interactions (slash commands) so users can install Clawdis to their account and invoke it anywhere without bot read access. The gateway listens for chat input interactions via discord.js and replies ephemerally, giving “ask in place” behavior without channel snooping. Each user gets a stable slash‑session key (discord:slash:<userId>), so it behaves like another surface with shared memory but an isolated thread.

Convo start with Clawd: https://discord.com/channels/1456350064065904867/1456350065223270435/1456526329829658655