### PR TITLE
feat(skills): add Apple Notes and Reminders skills via memo CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - CLI: add remote gateway client config (gateway.remote.*) with Bonjour-assisted discovery.
 - Skills: allow `bun` as a node manager for skill installs.
 - Skills: add `things-mac` (Things 3 CLI) for read/search plus add/update via URL scheme.
+- Skills: add Apple Notes + Reminders skills via memo CLI (thanks @tylerwince).
 - Tests: add a Docker-based onboarding E2E harness.
 - Tests: harden wizard E2E flows for reset, providers, skills, and remote non-interactive runs.
 - Browser tools: add remote CDP URL support, Linux launcher options (`executablePath`, `noSandbox`), and surface `cdpUrl` in status.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -11,8 +11,8 @@ Use `memo notes` to manage Apple Notes directly from the terminal. Create, view,
 
 Setup
 - Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
-- Alternative (pip): `pip install memo` (after cloning the repo)
-- macOS-only; requires Automation/Accessibility permissions for Notes.app.
+- Manual (pip): `pip install .` (after cloning the repo)
+- macOS-only; if prompted, grant Automation access to Notes.app.
 
 View Notes
 - List all notes: `memo notes`
@@ -47,4 +47,4 @@ Limitations
 Notes
 - macOS-only.
 - Requires Apple Notes.app to be accessible.
-- For automation, grant appropriate permissions in System Settings > Privacy & Security.
+- For automation, grant permissions in System Settings > Privacy & Security > Automation.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: apple-notes
+description: Manage Apple Notes via the `memo` CLI on macOS (create, view, edit, delete, search, move, and export notes). Use when a user asks Clawdis to add a note, list notes, search notes, or manage note folders.
+homepage: https://github.com/antoniorodr/memo
+metadata: {"clawdis":{"emoji":"📝","os":["darwin"],"requires":{"bins":["memo"]},"install":[{"id":"brew","kind":"brew","formula":"antoniorodr/memo/memo","bins":["memo"],"label":"Install memo via Homebrew"}]}}
+---
+
+# Apple Notes CLI
+
+Use `memo notes` to manage Apple Notes directly from the terminal. Create, view, edit, delete, search, move notes between folders, and export to HTML/Markdown.
+
+Setup
+- Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
+- Alternative (pip): `pip install memo` (after cloning the repo)
+- macOS-only; requires Automation/Accessibility permissions for Notes.app.
+
+View Notes
+- List all notes: `memo notes`
+- Filter by folder: `memo notes -f "Folder Name"`
+- Search notes (fuzzy): `memo notes -s "query"`
+
+Create Notes
+- Add a new note: `memo notes -a`
+  - Opens an interactive editor to compose the note.
+- Quick add with title: `memo notes -a "Note Title"`
+
+Edit Notes
+- Edit existing note: `memo notes -e`
+  - Interactive selection of note to edit.
+
+Delete Notes
+- Delete a note: `memo notes -d`
+  - Interactive selection of note to delete.
+
+Move Notes
+- Move note to folder: `memo notes -m`
+  - Interactive selection of note and destination folder.
+
+Export Notes
+- Export to HTML/Markdown: `memo notes -ex`
+  - Exports selected note; uses Mistune for markdown processing.
+
+Limitations
+- Cannot edit notes containing images or attachments.
+- Interactive prompts may require terminal access.
+
+Notes
+- macOS-only.
+- Requires Apple Notes.app to be accessible.
+- For automation, grant appropriate permissions in System Settings > Privacy & Security.

--- a/skills/apple-reminders/SKILL.md
+++ b/skills/apple-reminders/SKILL.md
@@ -11,8 +11,8 @@ Use `memo rem` to manage Apple Reminders directly from the terminal. Create, com
 
 Setup
 - Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
-- Alternative (pip): `pip install memo` (after cloning the repo)
-- macOS-only; requires Automation/Accessibility permissions for Reminders.app.
+- Manual (pip): `pip install .` (after cloning the repo)
+- macOS-only; if prompted, grant Automation access to Reminders.app.
 
 View Reminders
 - List all reminders: `memo rem`
@@ -39,5 +39,5 @@ Examples
 Notes
 - macOS-only.
 - Requires Apple Reminders.app to be accessible.
-- For automation, grant appropriate permissions in System Settings > Privacy & Security.
+- For automation, grant permissions in System Settings > Privacy & Security > Automation.
 - The `memo` CLI shares the same installation for both Notes and Reminders functionality.

--- a/skills/apple-reminders/SKILL.md
+++ b/skills/apple-reminders/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: apple-reminders
+description: Manage Apple Reminders via the `memo` CLI on macOS (create, complete, and delete reminders). Use when a user asks Clawdis to add a reminder, mark reminders as done, or manage their reminder list.
+homepage: https://github.com/antoniorodr/memo
+metadata: {"clawdis":{"emoji":"⏰","os":["darwin"],"requires":{"bins":["memo"]},"install":[{"id":"brew","kind":"brew","formula":"antoniorodr/memo/memo","bins":["memo"],"label":"Install memo via Homebrew"}]}}
+---
+
+# Apple Reminders CLI
+
+Use `memo rem` to manage Apple Reminders directly from the terminal. Create, complete, and delete reminders with simple commands.
+
+Setup
+- Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
+- Alternative (pip): `pip install memo` (after cloning the repo)
+- macOS-only; requires Automation/Accessibility permissions for Reminders.app.
+
+View Reminders
+- List all reminders: `memo rem`
+
+Create Reminders
+- Add a new reminder: `memo rem -a`
+  - Opens interactive prompt to create a reminder.
+- Quick add: `memo rem -a "Buy groceries"`
+
+Complete Reminders
+- Mark reminder as done: `memo rem -c`
+  - Interactive selection of reminder to complete.
+
+Delete Reminders
+- Delete a reminder: `memo rem -d`
+  - Interactive selection of reminder to delete.
+
+Examples
+- Add a quick reminder: `memo rem -a "Call dentist tomorrow"`
+- List all reminders: `memo rem`
+- Complete a reminder: `memo rem -c` (then select from list)
+- Delete a reminder: `memo rem -d` (then select from list)
+
+Notes
+- macOS-only.
+- Requires Apple Reminders.app to be accessible.
+- For automation, grant appropriate permissions in System Settings > Privacy & Security.
+- The `memo` CLI shares the same installation for both Notes and Reminders functionality.


### PR DESCRIPTION
Summary
	∙	Add Apple Notes skill (skills/apple-notes/SKILL.md) for creating, viewing, editing, searching, moving, and exporting notes via the memo CLI
	∙	Add Apple Reminders skill (skills/apple-reminders/SKILL.md) for creating, completing, and deleting reminders via the memo CLI
	∙	Both skills use the memo Python CLI tool, installable via Homebrew (brew tap antoniorodr/memo && brew install antoniorodr/memo/memo)
Test plan
	∙	Verify memo CLI installs correctly via Homebrew on macOS
	∙	Test memo notes commands (list, add, search, edit, delete, move, export)
	∙	Test memo rem commands (list, add, complete, delete)
	∙	Confirm skills are detected by Clawdis skill loader with correct metadata (macOS-only, requires memo binary)
	∙	Verify skill descriptions trigger appropriately when users ask about notes/reminders