### PR TITLE
Discord: fix Clawdis not sending "typing" notifications in replies

### DIFF
--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -107,6 +107,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       if (!message.author) return;
 
       const isDirectMessage = !message.guild;
+      const shouldRequireMention = !isDirectMessage && requireMention;
       const botId = client.user?.id;
       const wasMentioned =
         !isDirectMessage && Boolean(botId && message.mentions.has(botId));
@@ -129,7 +130,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         guildHistories.set(message.channelId, history);
       }
 
-      if (!isDirectMessage && requireMention) {
+      if (shouldRequireMention) {
         if (botId && !wasMentioned) {
           logger.info(
             {
@@ -243,7 +244,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
             ? message.channel.name
             : undefined,
         Surface: "discord" as const,
-        WasMentioned: wasMentioned,
+        WasMentioned: wasMentioned || !shouldRequireMention,
         MessageSid: message.id,
         Timestamp: message.createdTimestamp,
         MediaPath: media?.path,


### PR DESCRIPTION
Discord was only working with the bot typing in the initial message in a session, any followups weren't showing the "Clawd is typing..." properly when mentions were disabled, this PR fixes that by treating the bot as mentioned in Discord if mentions are disabled to let the upstream code take over with the normal flow like the rest of the systems are.