### PR TITLE
feat(discord): add native reply-to-message support

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -36,6 +36,7 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
 ## Capabilities & limits
 - DMs and guild text channels (threads are treated as separate channels; voice not supported).
 - Typing indicators sent best-effort; message chunking honors Discord’s 2k character limit.
+- Auto-replies are sent as native replies to the triggering message (first chunk only).
 - File uploads supported up to the configured `discord.mediaMaxMb` (default 8 MB).
 - Mention-gated guild replies by default to avoid noisy bots.
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -885,10 +885,8 @@ async function deliverReplies({
   target: string;
   token: string;
   runtime: RuntimeEnv;
-  /** Discord message ID to reply to (creates native reply link for the first message only) */
   originalMessageId?: string;
 }) {
-  // Track whether we've sent the first message (only the first should be a reply)
   let isFirstMessage = true;
   for (const payload of replies) {
     const mediaList =

--- a/src/discord/send.test.ts
+++ b/src/discord/send.test.ts
@@ -82,4 +82,56 @@ describe("sendMessageDiscord", () => {
       }),
     );
   });
+
+  it("includes message_reference when replying", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "hello", {
+      rest,
+      token: "t",
+      replyTo: "orig-123",
+    });
+    const body = postMock.mock.calls[0]?.[1]?.body;
+    expect(body?.message_reference).toEqual({
+      message_id: "orig-123",
+      fail_if_not_exists: false,
+    });
+  });
+
+  it("replies only on the first chunk", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "a".repeat(2001), {
+      rest,
+      token: "t",
+      replyTo: "orig-123",
+    });
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstBody = postMock.mock.calls[0]?.[1]?.body;
+    const secondBody = postMock.mock.calls[1]?.[1]?.body;
+    expect(firstBody?.message_reference).toEqual({
+      message_id: "orig-123",
+      fail_if_not_exists: false,
+    });
+    expect(secondBody?.message_reference).toBeUndefined();
+  });
+
+  it("replies only on the first media send", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "b".repeat(2001), {
+      rest,
+      token: "t",
+      mediaUrl: "file:///tmp/photo.jpg",
+      replyTo: "orig-123",
+    });
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstBody = postMock.mock.calls[0]?.[1]?.body;
+    const secondBody = postMock.mock.calls[1]?.[1]?.body;
+    expect(firstBody?.message_reference).toEqual({
+      message_id: "orig-123",
+      fail_if_not_exists: false,
+    });
+    expect(secondBody?.message_reference).toBeUndefined();
+  });
 });

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -22,7 +22,6 @@ type DiscordSendOpts = {
   mediaUrl?: string;
   verbose?: boolean;
   rest?: REST;
-  /** Discord message ID to reply to (creates native reply link) */
   replyTo?: string;
 };
 
@@ -132,7 +131,6 @@ async function sendDiscordText(
     last = (await rest.post(Routes.channelMessages(channelId), {
       body: {
         content: chunk,
-        // Only the first chunk should be a reply; subsequent chunks are regular messages
         message_reference: isFirst ? messageReference : undefined,
       },
     })) as { id: string; channel_id: string };
@@ -172,7 +170,6 @@ async function sendDiscordMedia(
   if (text.length > DISCORD_TEXT_LIMIT) {
     const remaining = text.slice(DISCORD_TEXT_LIMIT).trim();
     if (remaining) {
-      // Remaining text is not a reply; only the first message with media is the reply
       await sendDiscordText(rest, channelId, remaining);
     }
   }

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -116,7 +116,9 @@ async function sendDiscordText(
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Discord sends");
   }
-  const messageReference = replyTo ? { message_id: replyTo } : undefined;
+  const messageReference = replyTo
+    ? { message_id: replyTo, fail_if_not_exists: false }
+    : undefined;
   if (text.length <= DISCORD_TEXT_LIMIT) {
     const res = (await rest.post(Routes.channelMessages(channelId), {
       body: { content: text, message_reference: messageReference },
@@ -152,7 +154,9 @@ async function sendDiscordMedia(
   const media = await loadWebMedia(mediaUrl);
   const caption =
     text.length > DISCORD_TEXT_LIMIT ? text.slice(0, DISCORD_TEXT_LIMIT) : text;
-  const messageReference = replyTo ? { message_id: replyTo } : undefined;
+  const messageReference = replyTo
+    ? { message_id: replyTo, fail_if_not_exists: false }
+    : undefined;
   const res = (await rest.post(Routes.channelMessages(channelId), {
     body: {
       content: caption || undefined,


### PR DESCRIPTION
## Summary
- Bot responses now use Discord's native reply feature, visually linking to the original message
- Added `replyTo` option to `sendMessageDiscord`, `sendDiscordText`, and `sendDiscordMedia`
- Only the first chunk/attachment uses the reply link; subsequent chunks are regular messages

## Changes
- `src/discord/send.ts`: Added `replyTo?: string` to `DiscordSendOpts` and plumbed through to API calls using `message_reference`
- `src/discord/monitor.ts`: `deliverReplies()` now passes `originalMessageId` (from `MessageSid`) to create reply links

## Test plan
- [x] All existing Discord tests pass (11/11)
- [ ] Manual test: send message to bot in Discord, verify response shows as reply with link to original