### PR TITLE
Update gog Calendar command date format to RFC3339

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -17,7 +17,7 @@ Setup (once)
 Common commands
 - Gmail search: `gog gmail search 'newer_than:7d' --max 10`
 - Gmail send: `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
-- Calendar: `gog calendar events <calendarId> --from <iso> --to <iso>`
+- Calendar: `gog calendar events <calendarId> --from <rfc3339> --to <rfc3339>`
 - Drive: `gog drive search "query" --max 10`
 - Contacts: `gog contacts list --max 20`
 


### PR DESCRIPTION
I am seeing instances where Clawdis is not including timezone in the gog calendar range requests. This results in a 400 bad request from the Google API, e.g.

```
gog calendar events primary --from 2026-01-02T00:00:00 --to 2026-01-03T23:59:59 --account <email>

Google API error (400 badRequest): Bad Request
```

While this is a valid ISO 8601 format, Google Calendar API requires a stricter RFC 3339 format with time zone information, like the following:

```
gog calendar events primary --from 2026-01-02T00:00:00-08:00 --to 2026-01-03T23:59:59-08:00 --account <email>

<calendar events listed successfully>
```