### PR TITLE
docs: clarify routing.allowFrom and self-chat mode for group mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - Cron: prevent `every` schedules without an anchor from firing in a tight loop (thanks @jamesgroat).
 - Docs: add manual OAuth setup for remote/headless deployments (#67) — thanks @wstock
 - Docs/agent tools: clarify that browser `wait` should be avoided by default and used only in exceptional cases.
+- Docs: clarify self-chat mode and group mention gating config (#111) — thanks @rafaelreis-r.
 - Browser tools: `upload` supports auto-click refs, direct `inputRef`/`element` file inputs, and emits input/change after `setFiles` so JS-heavy sites pick up attachments.
 - Browser tools: harden CDP readiness (HTTP + WS), retry CDP connects, and auto-restart the clawd browser when the socket handshake stalls.
 - Browser CLI: add `clawdis browser reset-profile` to move the clawd profile to Trash when it gets wedged.


### PR DESCRIPTION
## Summary

- Add documentation for `routing.allowFrom` and its role in enabling "self-chat mode"
- Clarify the difference between `whatsapp.allowFrom` (DM allowlist) and `routing.allowFrom` (controls group mention behavior)
- Explain how metadata mentions vs text patterns work in `routing.groupChat`
- Add example config for responding only to specific text triggers while ignoring native @-mentions

## Problem

The current documentation doesn't clearly explain that:
1. `routing.allowFrom` (not `whatsapp.allowFrom`) controls how group mentions are handled
2. When `routing.allowFrom` contains the bot's own WhatsApp number, it enables "self-chat mode" which ignores native WhatsApp @-mentions
3. Without this setting, the bot responds to both metadata mentions AND text patterns

This caused confusion when trying to configure the bot to only respond to specific text triggers like "reisponde" while ignoring when users @-mention the bot owner's WhatsApp account in groups.

## Changes

- Added new "Self-chat mode" section with example config
- Added `routing.allowFrom` section explaining the setting
- Updated `routing.groupChat` section to explain mention types
- Updated intro bullet points to reference `routing.allowFrom`

## Test plan

- [ ] Review documentation renders correctly on clawdis.ai
- [ ] Verify example configs are valid JSON5

🤖 Generated with [Claude Code](https://claude.com/claude-code)