### PR TITLE
feat: add ATLAS knowledge base integration

### DIFF
--- a/docs/ATLAS_BRIDGE_GUIDE.md
+++ b/docs/ATLAS_BRIDGE_GUIDE.md
@@ -1,0 +1,212 @@
+# ATLAS Bridge Integration Guide
+
+This document describes how to prepare ATLAS for the Phase 2 Event Bridge integration with Clawdis.
+
+## Overview
+
+The ATLAS-Clawdis integration has two paths:
+
+| Path | Direction | Status | Description |
+|------|-----------|--------|-------------|
+| **Pull** | Clawdis → ATLAS | **Implemented** | `atlas_query` tool calls ATLAS REST API |
+| **Push** | ATLAS → Clawdis | **Pending** | ATLAS triggers send webhooks to Clawdis |
+
+## Phase 1: Pull Path (Complete)
+
+Clawdis now has an `atlas_query` tool that calls:
+
+```
+ATLAS API (http://localhost:8888)
+├── POST /api/search          → Semantic search
+├── GET  /api/graph/concept/X → Concept details
+├── GET  /api/search/insights → Curated insights
+├── GET  /api/actions         → Pending actions
+└── GET  /api/overview        → Knowledge base stats
+```
+
+**No changes required in ATLAS for Phase 1.**
+
+---
+
+## Phase 2: Push Path (ATLAS Team Preparation)
+
+### Goal
+
+Configure ATLAS triggers to send webhooks to Clawdis when events occur:
+- New insights generated
+- New notes added
+- New content ingested
+- Agent work finished
+
+### Clawdis Webhook Endpoint
+
+```
+POST http://localhost:18789/hooks/agent
+Content-Type: application/json
+
+{
+  "prompt": "ATLAS notification: [event description]",
+  "context": {
+    "source": "atlas",
+    "event_type": "insight_created",
+    "data": { ... }
+  }
+}
+```
+
+### Required ATLAS Changes
+
+#### 1. Add Clawdis Webhook URL Configuration
+
+In `atlas/config.py` or environment:
+
+```python
+CLAWDIS_WEBHOOK_URL = os.getenv("CLAWDIS_WEBHOOK_URL", "http://localhost:18789/hooks/agent")
+```
+
+#### 2. Create Trigger Definitions
+
+Create `atlas/triggers/clawdis_bridge.py` or add to existing triggers:
+
+```python
+from atlas.agents.triggers import TriggerDefinition, WebhookAction
+
+CLAWDIS_TRIGGERS = [
+    TriggerDefinition(
+        name="clawdis_new_insight",
+        event_type="insight_created",
+        action=WebhookAction(
+            url=CLAWDIS_WEBHOOK_URL,
+            payload_template={
+                "prompt": "ATLAS generated a new insight: {{ insight.title }}. Summary: {{ insight.summary }}",
+                "context": {
+                    "source": "atlas",
+                    "event_type": "insight_created",
+                    "insight_id": "{{ insight.id }}"
+                }
+            }
+        )
+    ),
+    TriggerDefinition(
+        name="clawdis_new_note",
+        event_type="note_created",
+        action=WebhookAction(
+            url=CLAWDIS_WEBHOOK_URL,
+            payload_template={
+                "prompt": "New note added to ATLAS: {{ note.title }}",
+                "context": {
+                    "source": "atlas",
+                    "event_type": "note_created",
+                    "note_id": "{{ note.id }}"
+                }
+            }
+        )
+    ),
+    TriggerDefinition(
+        name="clawdis_content_ingested",
+        event_type="content_ingested",
+        action=WebhookAction(
+            url=CLAWDIS_WEBHOOK_URL,
+            payload_template={
+                "prompt": "ATLAS ingested new content: {{ content.source }} ({{ content.item_count }} items)",
+                "context": {
+                    "source": "atlas",
+                    "event_type": "content_ingested",
+                    "content_source": "{{ content.source }}"
+                }
+            }
+        )
+    ),
+    TriggerDefinition(
+        name="clawdis_agent_finished",
+        event_type="agent_task_completed",
+        action=WebhookAction(
+            url=CLAWDIS_WEBHOOK_URL,
+            payload_template={
+                "prompt": "ATLAS agent completed task: {{ task.name }}. Result: {{ task.summary }}",
+                "context": {
+                    "source": "atlas",
+                    "event_type": "agent_task_completed",
+                    "task_id": "{{ task.id }}"
+                }
+            }
+        )
+    ),
+]
+```
+
+#### 3. Loop Prevention (Critical)
+
+Add a guard to prevent feedback loops when Clawdis triggers ATLAS which triggers Clawdis:
+
+```python
+def should_fire_trigger(trigger: TriggerDefinition, context: dict) -> bool:
+    # Prevent loops: don't fire if event originated from Clawdis
+    if context.get("source") == "clawdis":
+        return False
+    return evaluate_condition(trigger, context)
+```
+
+#### 4. Register Triggers
+
+In `atlas/agents/triggers.py` or startup:
+
+```python
+from atlas.triggers.clawdis_bridge import CLAWDIS_TRIGGERS
+
+def register_triggers():
+    for trigger in CLAWDIS_TRIGGERS:
+        trigger_registry.register(trigger)
+```
+
+### Event Types to Emit
+
+Ensure ATLAS emits these events (if not already):
+
+| Event Type | When | Payload |
+|------------|------|---------|
+| `insight_created` | New insight generated | `{ insight: { id, title, summary } }` |
+| `note_created` | New note added | `{ note: { id, title, source } }` |
+| `content_ingested` | Batch content import | `{ content: { source, item_count } }` |
+| `agent_task_completed` | Agent finishes work | `{ task: { id, name, summary, status } }` |
+
+### Testing the Bridge
+
+1. Start Clawdis gateway: `clawdis gateway`
+2. Start ATLAS: `atlas serve`
+3. Trigger an event in ATLAS (e.g., create a note)
+4. Verify Clawdis receives the webhook and agent responds
+
+### Environment Variables
+
+```bash
+# ATLAS side
+export CLAWDIS_WEBHOOK_URL="http://localhost:18789/hooks/agent"
+
+# Clawdis side (already configured)
+export ATLAS_URL="http://localhost:8888"
+```
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  ┌──────────────┐       PULL (sync)        ┌──────────────────┐ │
+│  │   Clawdis    │ ──────────────────────── │      ATLAS       │ │
+│  │    Agent     │   atlas_query tool       │   REST API       │ │
+│  │              │                          │   :8888          │ │
+│  │  Gateway     │                          │                  │ │
+│  │  :18789      │ ◀─────────────────────── │    Triggers      │ │
+│  │              │       PUSH (async)       │                  │ │
+│  │ /hooks/agent │    webhook events        │                  │ │
+│  └──────────────┘                          └──────────────────┘ │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Questions?
+
+Contact the Clawdis team for webhook payload format requirements or integration support.

--- a/skills/atlas/SKILL.md
+++ b/skills/atlas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: atlas
 description: Query the user's ATLAS personal knowledge base for search, concepts, insights, actions, and stats.
-homepage: https://github.com/filipdam/atlas
+homepage: local
 metadata: {"clawdis":{"emoji":"🧠"}}
 ---
 

--- a/skills/atlas/SKILL.md
+++ b/skills/atlas/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: atlas
+description: Query the user's ATLAS personal knowledge base for search, concepts, insights, actions, and stats.
+homepage: https://github.com/filipdam/atlas
+metadata: {"clawdis":{"emoji":"🧠"}}
+---
+
+# ATLAS Knowledge Base
+
+ATLAS is the user's personal knowledge management system. You have direct access via the `atlas_query` tool.
+
+## Available Actions
+
+| Action | Description | Required Params |
+|--------|-------------|-----------------|
+| `search` | Semantic search across all knowledge | `query` |
+| `concept` | Get details about a specific concept | `concept_name` or `query` |
+| `insights` | Get curated insights | `query` (optional topic filter) |
+| `actions` | Get pending action items | none |
+| `stats` | Get knowledge base overview | none |
+
+## When to Use
+
+- User asks "What do I know about X?" → `atlas_query({ action: "search", query: "X" })`
+- User asks for their tasks/actions → `atlas_query({ action: "actions" })`
+- User asks about a specific concept → `atlas_query({ action: "concept", concept_name: "concept-name" })`
+- User wants insights on a topic → `atlas_query({ action: "insights", query: "topic" })`
+- User wants an overview → `atlas_query({ action: "stats" })`
+
+## Example Usage
+
+Search for knowledge:
+```
+atlas_query({ action: "search", query: "machine learning transformers", limit: 5 })
+```
+
+Get concept details:
+```
+atlas_query({ action: "concept", concept_name: "attention-mechanism" })
+```
+
+Get all insights (no filter):
+```
+atlas_query({ action: "insights", limit: 10 })
+```
+
+Get insights on a topic:
+```
+atlas_query({ action: "insights", query: "productivity", limit: 5 })
+```
+
+Get pending actions:
+```
+atlas_query({ action: "actions" })
+```
+
+Get knowledge base stats:
+```
+atlas_query({ action: "stats" })
+```
+
+## Notes
+
+- ATLAS must be running locally (`atlas serve` on port 8888 by default)
+- Results are returned as JSON; summarize for the user
+- The knowledge base contains notes, bookmarks, insights, and action items from various sources
+- Use semantic search for broad queries; use concept lookup for specific known concepts

--- a/src/agents/atlas-tool.ts
+++ b/src/agents/atlas-tool.ts
@@ -1,0 +1,192 @@
+/**
+ * ATLAS Knowledge Base Integration Tool
+ *
+ * Provides access to the user's ATLAS knowledge management system via HTTP API.
+ * ATLAS runs on localhost:8888 by default.
+ */
+
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+
+// biome-ignore lint/suspicious/noExplicitAny: TypeBox schema type from pi-ai uses a different module instance.
+type AnyAgentTool = AgentTool<any, unknown>;
+
+const ATLAS_URL = process.env.ATLAS_URL || "http://localhost:8888";
+
+const AtlasToolSchema = Type.Object({
+  action: Type.Union(
+    [
+      Type.Literal("search"),
+      Type.Literal("concept"),
+      Type.Literal("insights"),
+      Type.Literal("actions"),
+      Type.Literal("stats"),
+    ],
+    {
+      description:
+        "Action to perform: search (semantic search), concept (get concept details), insights (curated insights), actions (pending tasks), stats (overview)",
+    },
+  ),
+  query: Type.Optional(
+    Type.String({
+      description: "Search query or topic (required for search/insights)",
+    }),
+  ),
+  concept_name: Type.Optional(
+    Type.String({
+      description: "Concept name for concept lookup",
+    }),
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Maximum number of results to return (default: 10)",
+    }),
+  ),
+});
+
+function jsonResult(payload: unknown): AgentToolResult<unknown> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+    details: payload,
+  };
+}
+
+function errorResult(message: string): AgentToolResult<unknown> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: `ATLAS Error: ${message}`,
+      },
+    ],
+    details: { error: message },
+  };
+}
+
+async function fetchAtlas(
+  endpoint: string,
+  options?: {
+    method?: "GET" | "POST";
+    body?: Record<string, unknown>;
+  },
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  const { method = "GET", body } = options ?? {};
+  const url = `${ATLAS_URL}${endpoint}`;
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      return {
+        ok: false,
+        error: `HTTP ${response.status}: ${response.statusText}${text ? ` - ${text}` : ""}`,
+      };
+    }
+
+    const data = await response.json();
+    return { ok: true, data };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("ECONNREFUSED")) {
+      return {
+        ok: false,
+        error: `Cannot reach ATLAS at ${ATLAS_URL}. Is the ATLAS server running? (atlas serve)`,
+      };
+    }
+    return { ok: false, error: message };
+  }
+}
+
+export function createAtlasTool(): AnyAgentTool {
+  return {
+    label: "ATLAS Knowledge Base",
+    name: "atlas_query",
+    description: `Query the user's ATLAS personal knowledge base. Actions:
+- search: Semantic search across all knowledge (requires 'query')
+- concept: Get details about a specific concept (requires 'concept_name' or 'query')
+- insights: Get curated insights, optionally filtered by topic
+- actions: Get pending action items and tasks
+- stats: Get knowledge base overview and statistics`,
+    parameters: AtlasToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as {
+        action: string;
+        query?: string;
+        concept_name?: string;
+        limit?: number;
+      };
+
+      const { action, query, concept_name, limit = 10 } = params;
+
+      switch (action) {
+        case "search": {
+          if (!query?.trim()) {
+            return errorResult("'query' parameter required for search action");
+          }
+          const result = await fetchAtlas("/api/search", {
+            method: "POST",
+            body: { query: query.trim(), limit },
+          });
+          if (!result.ok) return errorResult(result.error);
+          return jsonResult(result.data);
+        }
+
+        case "concept": {
+          const conceptQuery = concept_name?.trim() || query?.trim();
+          if (!conceptQuery) {
+            return errorResult(
+              "'concept_name' or 'query' parameter required for concept action",
+            );
+          }
+          const result = await fetchAtlas(
+            `/api/graph/concept/${encodeURIComponent(conceptQuery)}`,
+          );
+          if (!result.ok) return errorResult(result.error);
+          return jsonResult(result.data);
+        }
+
+        case "insights": {
+          // Insights endpoint can be filtered by topic
+          const endpoint = query?.trim()
+            ? `/api/search/insights?topic=${encodeURIComponent(query.trim())}&limit=${limit}`
+            : `/api/search/insights?limit=${limit}`;
+          const result = await fetchAtlas(endpoint);
+          if (!result.ok) return errorResult(result.error);
+          return jsonResult(result.data);
+        }
+
+        case "actions": {
+          const result = await fetchAtlas(`/api/actions?limit=${limit}`);
+          if (!result.ok) return errorResult(result.error);
+          return jsonResult(result.data);
+        }
+
+        case "stats": {
+          const result = await fetchAtlas("/api/overview");
+          if (!result.ok) return errorResult(result.error);
+          return jsonResult(result.data);
+        }
+
+        default:
+          return errorResult(
+            `Unknown action: ${action}. Valid actions: search, concept, insights, actions, stats`,
+          );
+      }
+    },
+  };
+}
+
+export const atlasTool = createAtlasTool();

--- a/src/agents/clawdis-tools.ts
+++ b/src/agents/clawdis-tools.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
+
+import { createAtlasTool } from "./atlas-tool.js";
 import {
   browserCloseTab,
   browserFocusTab,
@@ -1515,5 +1517,6 @@ export function createClawdisTools(): AnyAgentTool[] {
     createCronTool(),
     createDiscordTool(),
     createGatewayTool(),
+    createAtlasTool(),
   ];
 }


### PR DESCRIPTION
## Summary

- Add `atlas_query` tool with 5 actions: search, concept, insights, actions, stats
- Register tool in clawdis-tools.ts
- Add ATLAS skill documentation for agent usage
- Add ATLAS Bridge Guide for Phase 2 preparation (Push Path)

## Phase 1: Pull Path (This PR)

Enables Clawdis agent to query the user's ATLAS personal knowledge base via HTTP API.

### New Files

| File | Description |
|------|-------------|
| `src/agents/atlas-tool.ts` | ATLAS query tool implementation |
| `skills/atlas/SKILL.md` | Agent documentation for ATLAS usage |
| `docs/ATLAS_BRIDGE_GUIDE.md` | Guide for ATLAS team to prepare Phase 2 |

### Tool Actions

| Action | Description | Required Params |
|--------|-------------|-----------------|
| `search` | Semantic search across knowledge | `query` |
| `concept` | Get concept details | `concept_name` or `query` |
| `insights` | Get curated insights | `query` (optional) |
| `actions` | Get pending action items | none |
| `stats` | Get knowledge base overview | none |

## Phase 2: Push Path (Future)

The included `docs/ATLAS_BRIDGE_GUIDE.md` documents how the ATLAS team should prepare for webhook-based event notifications (new insights, notes, content ingested, agent finished).

## Testing

1. Start ATLAS: `atlas serve` (port 8888)
2. Start Clawdis gateway
3. Ask agent: "What do I know about [topic]?"

## Environment Variables

```bash
ATLAS_URL=http://localhost:8888  # Default, configurable
```