### PR TITLE
Discord: lots of new skills to use within Discord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Config: remove `routing.groupChat.requireMention` + `telegram.requireMention`; use `whatsapp.groups`, `imessage.groups`, and `telegram.groups` defaults instead (run `clawdis doctor` to migrate).
 
 ### Features
+- Discord: expand `discord` tool actions (reactions, stickers, polls, threads, search, moderation gates) (#115) — thanks @thewilloftheshadow.
 - Discord/Telegram: add reply tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`) with per-provider `replyToMode` (off|first|all) for native threaded replies.
 - Talk mode: continuous speech conversations (macOS/iOS/Android) with ElevenLabs TTS, reply directives, and optional interrupt-on-speech.
 - UI: add optional `ui.seamColor` accent to tint the Talk Mode side bubble (macOS/iOS/Android).

--- a/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
+++ b/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
@@ -311,12 +311,6 @@ struct ConnectionsSettings: View {
                             .textFieldStyle(.roundedBorder)
                     }
                     GridRow {
-                        self.gridLabel("Reactions")
-                        Toggle("", isOn: self.$store.discordEnableReactions)
-                            .labelsHidden()
-                            .toggleStyle(.checkbox)
-                    }
-                    GridRow {
                         self.gridLabel("Slash command")
                         Toggle("", isOn: self.$store.discordSlashEnabled)
                             .labelsHidden()

--- a/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
+++ b/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
@@ -334,6 +334,105 @@ struct ConnectionsSettings: View {
                     }
                 }
 
+                Divider().padding(.vertical, 2)
+
+                Text("Tool actions")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 10) {
+                    GridRow {
+                        self.gridLabel("Reactions")
+                        Toggle("", isOn: self.$store.discordActionReactions)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Stickers")
+                        Toggle("", isOn: self.$store.discordActionStickers)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Polls")
+                        Toggle("", isOn: self.$store.discordActionPolls)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Permissions")
+                        Toggle("", isOn: self.$store.discordActionPermissions)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Messages")
+                        Toggle("", isOn: self.$store.discordActionMessages)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Threads")
+                        Toggle("", isOn: self.$store.discordActionThreads)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Pins")
+                        Toggle("", isOn: self.$store.discordActionPins)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Search")
+                        Toggle("", isOn: self.$store.discordActionSearch)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Member info")
+                        Toggle("", isOn: self.$store.discordActionMemberInfo)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Role info")
+                        Toggle("", isOn: self.$store.discordActionRoleInfo)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Channel info")
+                        Toggle("", isOn: self.$store.discordActionChannelInfo)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Voice status")
+                        Toggle("", isOn: self.$store.discordActionVoiceStatus)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Events")
+                        Toggle("", isOn: self.$store.discordActionEvents)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Role changes")
+                        Toggle("", isOn: self.$store.discordActionRoles)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                    GridRow {
+                        self.gridLabel("Moderation")
+                        Toggle("", isOn: self.$store.discordActionModeration)
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                    }
+                }
+
                 if self.isDiscordTokenLocked {
                     Text("Token set via DISCORD_BOT_TOKEN env; config edits won’t override it.")
                         .font(.caption)

--- a/apps/macos/Sources/Clawdis/ConnectionsStore.swift
+++ b/apps/macos/Sources/Clawdis/ConnectionsStore.swift
@@ -174,7 +174,6 @@ final class ConnectionsStore {
     var discordGroupChannels: String = ""
     var discordMediaMaxMb: String = ""
     var discordHistoryLimit: String = ""
-    var discordEnableReactions = true
     var discordSlashEnabled = false
     var discordSlashName: String = ""
     var discordSlashSessionPrefix: String = ""
@@ -420,7 +419,6 @@ final class ConnectionsStore {
             } else {
                 self.discordHistoryLimit = ""
             }
-            self.discordEnableReactions = discord?["enableReactions"]?.boolValue ?? true
             let slash = discord?["slashCommand"]?.dictionaryValue
             self.discordSlashEnabled = slash?["enabled"]?.boolValue ?? false
             self.discordSlashName = slash?["name"]?.stringValue ?? ""
@@ -642,12 +640,6 @@ final class ConnectionsStore {
             discord["historyLimit"] = value
         } else {
             discord.removeValue(forKey: "historyLimit")
-        }
-
-        if self.discordEnableReactions {
-            discord.removeValue(forKey: "enableReactions")
-        } else {
-            discord["enableReactions"] = false
         }
 
         var slash: [String: Any] = (discord["slashCommand"] as? [String: Any]) ?? [:]

--- a/apps/macos/Sources/Clawdis/ConnectionsStore.swift
+++ b/apps/macos/Sources/Clawdis/ConnectionsStore.swift
@@ -174,6 +174,21 @@ final class ConnectionsStore {
     var discordGroupChannels: String = ""
     var discordMediaMaxMb: String = ""
     var discordHistoryLimit: String = ""
+    var discordActionReactions = true
+    var discordActionStickers = true
+    var discordActionPolls = true
+    var discordActionPermissions = true
+    var discordActionMessages = true
+    var discordActionThreads = true
+    var discordActionPins = true
+    var discordActionSearch = true
+    var discordActionMemberInfo = true
+    var discordActionRoleInfo = true
+    var discordActionChannelInfo = true
+    var discordActionVoiceStatus = true
+    var discordActionEvents = true
+    var discordActionRoles = false
+    var discordActionModeration = false
     var discordSlashEnabled = false
     var discordSlashName: String = ""
     var discordSlashSessionPrefix: String = ""
@@ -419,6 +434,22 @@ final class ConnectionsStore {
             } else {
                 self.discordHistoryLimit = ""
             }
+            let discordActions = discord?["actions"]?.dictionaryValue
+            self.discordActionReactions = discordActions?["reactions"]?.boolValue ?? true
+            self.discordActionStickers = discordActions?["stickers"]?.boolValue ?? true
+            self.discordActionPolls = discordActions?["polls"]?.boolValue ?? true
+            self.discordActionPermissions = discordActions?["permissions"]?.boolValue ?? true
+            self.discordActionMessages = discordActions?["messages"]?.boolValue ?? true
+            self.discordActionThreads = discordActions?["threads"]?.boolValue ?? true
+            self.discordActionPins = discordActions?["pins"]?.boolValue ?? true
+            self.discordActionSearch = discordActions?["search"]?.boolValue ?? true
+            self.discordActionMemberInfo = discordActions?["memberInfo"]?.boolValue ?? true
+            self.discordActionRoleInfo = discordActions?["roleInfo"]?.boolValue ?? true
+            self.discordActionChannelInfo = discordActions?["channelInfo"]?.boolValue ?? true
+            self.discordActionVoiceStatus = discordActions?["voiceStatus"]?.boolValue ?? true
+            self.discordActionEvents = discordActions?["events"]?.boolValue ?? true
+            self.discordActionRoles = discordActions?["roles"]?.boolValue ?? false
+            self.discordActionModeration = discordActions?["moderation"]?.boolValue ?? false
             let slash = discord?["slashCommand"]?.dictionaryValue
             self.discordSlashEnabled = slash?["enabled"]?.boolValue ?? false
             self.discordSlashName = slash?["name"]?.stringValue ?? ""
@@ -640,6 +671,35 @@ final class ConnectionsStore {
             discord["historyLimit"] = value
         } else {
             discord.removeValue(forKey: "historyLimit")
+        }
+
+        var actions: [String: Any] = (discord["actions"] as? [String: Any]) ?? [:]
+        func setAction(_ key: String, value: Bool, defaultValue: Bool) {
+            if value == defaultValue {
+                actions.removeValue(forKey: key)
+            } else {
+                actions[key] = value
+            }
+        }
+        setAction("reactions", value: self.discordActionReactions, defaultValue: true)
+        setAction("stickers", value: self.discordActionStickers, defaultValue: true)
+        setAction("polls", value: self.discordActionPolls, defaultValue: true)
+        setAction("permissions", value: self.discordActionPermissions, defaultValue: true)
+        setAction("messages", value: self.discordActionMessages, defaultValue: true)
+        setAction("threads", value: self.discordActionThreads, defaultValue: true)
+        setAction("pins", value: self.discordActionPins, defaultValue: true)
+        setAction("search", value: self.discordActionSearch, defaultValue: true)
+        setAction("memberInfo", value: self.discordActionMemberInfo, defaultValue: true)
+        setAction("roleInfo", value: self.discordActionRoleInfo, defaultValue: true)
+        setAction("channelInfo", value: self.discordActionChannelInfo, defaultValue: true)
+        setAction("voiceStatus", value: self.discordActionVoiceStatus, defaultValue: true)
+        setAction("events", value: self.discordActionEvents, defaultValue: true)
+        setAction("roles", value: self.discordActionRoles, defaultValue: false)
+        setAction("moderation", value: self.discordActionModeration, defaultValue: false)
+        if actions.isEmpty {
+            discord.removeValue(forKey: "actions")
+        } else {
+            discord["actions"] = actions
         }
 
         var slash: [String: Any] = (discord["slashCommand"] as? [String: Any]) ?? [:]

--- a/docs/AGENTS.default.md
+++ b/docs/AGENTS.default.md
@@ -94,6 +94,7 @@ git commit -m "Add Clawd workspace"
 - **eightctl** — Control your sleep, from the terminal.
 - **imsg** — Send, read, stream iMessage & SMS.
 - **wacli** — WhatsApp CLI: sync, search, send.
+- **discord** — Discord actions: react, stickers, polls.
 - **gog** — Google Suite CLI: Gmail, Calendar, Drive, Contacts.
 - **spotify-player** — Terminal Spotify client to search/queue/control playback.
 - **sag** — ElevenLabs speech with mac-style say UX; streams to speakers by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,6 @@ Configure the Discord bot by setting the bot token and optional gating:
     enabled: true,
     token: "your-bot-token",
     mediaMaxMb: 8,                          // clamp inbound media size
-    enableReactions: true,                  // allow agent-triggered reactions
     actions: {                              // tool action gates (false disables)
       reactions: true,
       stickers: true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,6 +222,24 @@ Configure the Discord bot by setting the bot token and optional gating:
     token: "your-bot-token",
     mediaMaxMb: 8,                          // clamp inbound media size
     enableReactions: true,                  // allow agent-triggered reactions
+    actions: {                              // tool action gates (false disables)
+      reactions: true,
+      stickers: true,
+      polls: true,
+      permissions: true,
+      messages: true,
+      threads: true,
+      pins: true,
+      search: true,
+      memberInfo: true,
+      roleInfo: true,
+      roles: false,
+      channelInfo: true,
+      voiceStatus: true,
+      events: true,
+      moderation: false
+    },
+    replyToMode: "off",                     // off | first | all
     slashCommand: {                         // user-installed app slash commands
       enabled: true,
       name: "clawd",

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -27,7 +27,7 @@ Status: ready for DM and guild text channels via the official Discord bot gatewa
 8. Optional guild rules: set `discord.guilds` keyed by guild id (preferred) or slug, with per-channel rules.
 9. Optional slash commands: enable `discord.slashCommand` to accept user-installed app commands (ephemeral replies). Slash invocations respect the same DM/guild allowlists.
 10. Optional guild context history: set `discord.historyLimit` (default 20) to include the last N guild messages as context when replying to a mention. Set `0` to disable.
-11. Reactions: the agent can trigger reactions via the `discord` tool (gated by `discord.enableReactions`).
+11. Reactions: the agent can trigger reactions via the `discord` tool (gated by `discord.actions.*`).
 12. Slash commands use isolated session keys (`${sessionPrefix}:${userId}`) rather than the shared `main` session.
 
 Note: Discord does not provide a simple username → id lookup without extra guild context, so prefer ids or `<@id>` mentions for DM delivery targets.
@@ -50,7 +50,6 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
     enabled: true,
     token: "abc.123",
     mediaMaxMb: 8,
-    enableReactions: true,
     actions: {
       reactions: true,
       stickers: true,
@@ -110,7 +109,6 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
 - `slashCommand`: optional config for user-installed slash commands (ephemeral responses).
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20, `0` disables).
-- `enableReactions`: allow agent-triggered reactions via the `discord` tool (default `true`).
 - `actions`: per-action tool gates; omit to allow all (set `false` to disable).
   - `reactions` (covers react + read reactions)
   - `stickers`, `polls`, `permissions`, `messages`, `threads`, `pins`, `search`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -141,8 +141,7 @@ Notes:
 - `to` accepts `channel:<id>` or `user:<id>`.
 - Polls require 2–10 answers and default to 24 hours.
 - `reactions` returns per-emoji user lists (limited to 100 per reaction).
-- Reactions respect `discord.enableReactions` (default `true`).
-- `discord.actions.roles` + `discord.actions.moderation` default to `false`.
+- `discord.actions.*` gates Discord tool actions; `roles` + `moderation` default to `false`.
 - `searchMessages` follows the Discord preview spec (limit max 25, channel/author filters accept arrays).
 
 ## Parameters (common)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -105,6 +105,46 @@ Core actions:
 Notes:
 - Use `delayMs` (defaults to 2000) to avoid interrupting an in-flight reply.
 
+### `discord`
+Send Discord reactions, stickers, or polls.
+
+Core actions:
+- `react` (`channelId`, `messageId`, `emoji`)
+- `reactions` (`channelId`, `messageId`, optional `limit`)
+- `sticker` (`to`, `stickerIds`, optional `content`)
+- `poll` (`to`, `question`, `answers`, optional `allowMultiselect`, `durationHours`, `content`)
+- `permissions` (`channelId`)
+- `readMessages` (`channelId`, optional `limit`/`before`/`after`/`around`)
+- `sendMessage` (`to`, `content`, optional `mediaUrl`, `replyTo`)
+- `editMessage` (`channelId`, `messageId`, `content`)
+- `deleteMessage` (`channelId`, `messageId`)
+- `threadCreate` (`channelId`, `name`, optional `messageId`, `autoArchiveMinutes`)
+- `threadList` (`guildId`, optional `channelId`, `includeArchived`, `before`, `limit`)
+- `threadReply` (`channelId`, `content`, optional `mediaUrl`, `replyTo`)
+- `pinMessage`/`unpinMessage` (`channelId`, `messageId`)
+- `listPins` (`channelId`)
+- `searchMessages` (`guildId`, `content`, optional `channelId`/`channelIds`, `authorId`/`authorIds`, `limit`)
+- `memberInfo` (`guildId`, `userId`)
+- `roleInfo` (`guildId`)
+- `emojiList` (`guildId`)
+- `roleAdd`/`roleRemove` (`guildId`, `userId`, `roleId`)
+- `channelInfo` (`channelId`)
+- `channelList` (`guildId`)
+- `voiceStatus` (`guildId`, `userId`)
+- `eventList` (`guildId`)
+- `eventCreate` (`guildId`, `name`, `startTime`, optional `endTime`, `description`, `channelId`, `entityType`, `location`)
+- `timeout` (`guildId`, `userId`, optional `durationMinutes`, `until`, `reason`)
+- `kick` (`guildId`, `userId`, optional `reason`)
+- `ban` (`guildId`, `userId`, optional `reason`, `deleteMessageDays`)
+
+Notes:
+- `to` accepts `channel:<id>` or `user:<id>`.
+- Polls require 2–10 answers and default to 24 hours.
+- `reactions` returns per-emoji user lists (limited to 100 per reaction).
+- Reactions respect `discord.enableReactions` (default `true`).
+- `discord.actions.roles` + `discord.actions.moderation` default to `false`.
+- `searchMessages` follows the Discord preview spec (limit max 25, channel/author filters accept arrays).
+
 ## Parameters (common)
 
 Gateway-backed tools (`clawdis_canvas`, `clawdis_nodes`, `clawdis_cron`):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3755,11 +3755,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-preview@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)':
+  '@vitest/browser-preview@4.0.16(vite@8.0.0-beta.3(@types/node@25.0.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser': 4.0.16(vite@8.0.0-beta.3(@types/node@25.0.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
       vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(@vitest/browser-preview@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
@@ -5522,8 +5522,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
-      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
-      '@vitest/browser-preview': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@8.0.0-beta.3(@types/node@25.0.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser-preview': 4.0.16(vite@8.0.0-beta.3(@types/node@25.0.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
     transitivePeerDependencies:
       - jiti
       - less

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: discord
-description: Use when you need to control Discord from Clawdis via the discord tool: add reactions, send stickers, or create polls in Discord DMs or channels. Trigger for tasks like reacting to a message, posting a sticker, or running a quick poll for a decision.
+description: Use when you need to control Discord from Clawdis via the discord tool: send messages, react, post stickers, run polls, manage threads/pins/search, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
 ---
 
 # Discord Actions
 
 ## Overview
 
-Use `discord` to manage messages, reactions, threads, and moderation. Reactions are gated by `discord.enableReactions` (default `true`). You can disable groups via `discord.actions.*`. The tool uses the bot token configured for Clawdis.
+Use `discord` to manage messages, reactions, threads, polls, and moderation. You can disable groups via `discord.actions.*` (defaults to enabled, except roles/moderation). The tool uses the bot token configured for Clawdis.
 
 ## Inputs to collect
 
@@ -91,7 +91,7 @@ Message context lines include `discord message id` and `channel` fields you can 
 ## Action gating
 
 Use `discord.actions.*` to disable action groups:
-- `reactions` (react + reactions list)
+- `reactions` (react + reactions list + emojiList)
 - `stickers`, `polls`, `permissions`, `messages`, `threads`, `pins`, `search`
 - `memberInfo`, `roleInfo`, `channelInfo`, `voiceStatus`, `events`
 - `roles` (role add/remove, default `false`)

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: discord
+description: Use when you need to control Discord from Clawdis via the discord tool: add reactions, send stickers, or create polls in Discord DMs or channels. Trigger for tasks like reacting to a message, posting a sticker, or running a quick poll for a decision.
+---
+
+# Discord Actions
+
+## Overview
+
+Use `discord` to manage messages, reactions, threads, and moderation. Reactions are gated by `discord.enableReactions` (default `true`). You can disable groups via `discord.actions.*`. The tool uses the bot token configured for Clawdis.
+
+## Inputs to collect
+
+- For reactions: `channelId`, `messageId`, and an `emoji`.
+- For stickers/polls: a `to` target (`channel:<id>` or `user:<id>`). Optional `content` text.
+- Polls also need a `question` plus 2–10 `answers`.
+
+Message context lines include `discord message id` and `channel` fields you can reuse directly.
+
+## Actions
+
+### React to a message
+
+```json
+{
+  "action": "react",
+  "channelId": "123",
+  "messageId": "456",
+  "emoji": "✅"
+}
+```
+
+### List reactions + users
+
+```json
+{
+  "action": "reactions",
+  "channelId": "123",
+  "messageId": "456",
+  "limit": 100
+}
+```
+
+### Send a sticker
+
+```json
+{
+  "action": "sticker",
+  "to": "channel:123",
+  "stickerIds": ["9876543210"],
+  "content": "Nice work!"
+}
+```
+
+- Up to 3 sticker IDs per message.
+- `to` can be `user:<id>` for DMs.
+
+### Create a poll
+
+```json
+{
+  "action": "poll",
+  "to": "channel:123",
+  "question": "Lunch?",
+  "answers": ["Pizza", "Sushi", "Salad"],
+  "allowMultiselect": false,
+  "durationHours": 24,
+  "content": "Vote now"
+}
+```
+
+- `durationHours` defaults to 24; max 32 days (768 hours).
+
+### Check bot permissions for a channel
+
+```json
+{
+  "action": "permissions",
+  "channelId": "123"
+}
+```
+
+## Ideas to try
+
+- React with ✅/⚠️ to mark status updates.
+- Post a quick poll for release decisions or meeting times.
+- Send celebratory stickers after successful deploys.
+- Run weekly “priority check” polls in team channels.
+- DM stickers as acknowledgements when a user’s request is completed.
+
+## Action gating
+
+Use `discord.actions.*` to disable action groups:
+- `reactions` (react + reactions list)
+- `stickers`, `polls`, `permissions`, `messages`, `threads`, `pins`, `search`
+- `memberInfo`, `roleInfo`, `channelInfo`, `voiceStatus`, `events`
+- `roles` (role add/remove, default `false`)
+- `moderation` (timeout/kick/ban, default `false`)
+### Read recent messages
+
+```json
+{
+  "action": "readMessages",
+  "channelId": "123",
+  "limit": 20
+}
+```
+
+### Send/edit/delete a message
+
+```json
+{
+  "action": "sendMessage",
+  "to": "channel:123",
+  "content": "Hello from Clawdis"
+}
+```
+
+```json
+{
+  "action": "editMessage",
+  "channelId": "123",
+  "messageId": "456",
+  "content": "Fixed typo"
+}
+```
+
+```json
+{
+  "action": "deleteMessage",
+  "channelId": "123",
+  "messageId": "456"
+}
+```
+
+### Threads
+
+```json
+{
+  "action": "threadCreate",
+  "channelId": "123",
+  "name": "Bug triage",
+  "messageId": "456"
+}
+```
+
+```json
+{
+  "action": "threadList",
+  "guildId": "999"
+}
+```
+
+```json
+{
+  "action": "threadReply",
+  "channelId": "777",
+  "content": "Replying in thread"
+}
+```
+
+### Pins
+
+```json
+{
+  "action": "pinMessage",
+  "channelId": "123",
+  "messageId": "456"
+}
+```
+
+```json
+{
+  "action": "listPins",
+  "channelId": "123"
+}
+```
+
+### Search messages
+
+```json
+{
+  "action": "searchMessages",
+  "guildId": "999",
+  "content": "release notes",
+  "channelIds": ["123", "456"],
+  "limit": 10
+}
+```
+
+### Member + role info
+
+```json
+{
+  "action": "memberInfo",
+  "guildId": "999",
+  "userId": "111"
+}
+```
+
+```json
+{
+  "action": "roleInfo",
+  "guildId": "999"
+}
+```
+
+### List available custom emojis
+
+```json
+{
+  "action": "emojiList",
+  "guildId": "999"
+}
+```
+
+### Role changes (disabled by default)
+
+```json
+{
+  "action": "roleAdd",
+  "guildId": "999",
+  "userId": "111",
+  "roleId": "222"
+}
+```
+
+### Channel info
+
+```json
+{
+  "action": "channelInfo",
+  "channelId": "123"
+}
+```
+
+```json
+{
+  "action": "channelList",
+  "guildId": "999"
+}
+```
+
+### Voice status
+
+```json
+{
+  "action": "voiceStatus",
+  "guildId": "999",
+  "userId": "111"
+}
+```
+
+### Scheduled events
+
+```json
+{
+  "action": "eventList",
+  "guildId": "999"
+}
+```
+
+### Moderation (disabled by default)
+
+```json
+{
+  "action": "timeout",
+  "guildId": "999",
+  "userId": "111",
+  "durationMinutes": 10
+}
+```

--- a/src/agents/clawdis-tools.ts
+++ b/src/agents/clawdis-tools.ts
@@ -1758,11 +1758,6 @@ function createDiscordTool(): AnyAgentTool {
           if (!isActionEnabled("reactions")) {
             throw new Error("Discord reactions are disabled.");
           }
-          if (cfg.discord?.enableReactions === false) {
-            throw new Error(
-              "Discord reactions are disabled (set discord.enableReactions=true).",
-            );
-          }
           const channelId = readStringParam(params, "channelId", {
             required: true,
           });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -247,8 +247,6 @@ export type DiscordConfig = {
   textChunkLimit?: number;
   mediaMaxMb?: number;
   historyLimit?: number;
-  /** Allow agent-triggered Discord reactions (default: true). */
-  enableReactions?: boolean;
   /** Per-action tool gating (default: true for all). */
   actions?: DiscordActionConfig;
   /** Control reply threading when reply tags are present (off|first|all). */
@@ -1052,7 +1050,6 @@ const ClawdisSchema = z.object({
         .optional(),
       mediaMaxMb: z.number().positive().optional(),
       historyLimit: z.number().int().min(0).optional(),
-      enableReactions: z.boolean().optional(),
       actions: z
         .object({
           reactions: z.boolean().optional(),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -221,6 +221,24 @@ export type DiscordSlashCommandConfig = {
   ephemeral?: boolean;
 };
 
+export type DiscordActionConfig = {
+  reactions?: boolean;
+  stickers?: boolean;
+  polls?: boolean;
+  permissions?: boolean;
+  messages?: boolean;
+  threads?: boolean;
+  pins?: boolean;
+  search?: boolean;
+  memberInfo?: boolean;
+  roleInfo?: boolean;
+  roles?: boolean;
+  channelInfo?: boolean;
+  voiceStatus?: boolean;
+  events?: boolean;
+  moderation?: boolean;
+};
+
 export type DiscordConfig = {
   /** If false, do not start the Discord provider. Default: true. */
   enabled?: boolean;
@@ -231,6 +249,8 @@ export type DiscordConfig = {
   historyLimit?: number;
   /** Allow agent-triggered Discord reactions (default: true). */
   enableReactions?: boolean;
+  /** Per-action tool gating (default: true for all). */
+  actions?: DiscordActionConfig;
   /** Control reply threading when reply tags are present (off|first|all). */
   replyToMode?: ReplyToMode;
   slashCommand?: DiscordSlashCommandConfig;
@@ -1033,6 +1053,25 @@ const ClawdisSchema = z.object({
       mediaMaxMb: z.number().positive().optional(),
       historyLimit: z.number().int().min(0).optional(),
       enableReactions: z.boolean().optional(),
+      actions: z
+        .object({
+          reactions: z.boolean().optional(),
+          stickers: z.boolean().optional(),
+          polls: z.boolean().optional(),
+          permissions: z.boolean().optional(),
+          messages: z.boolean().optional(),
+          threads: z.boolean().optional(),
+          pins: z.boolean().optional(),
+          search: z.boolean().optional(),
+          memberInfo: z.boolean().optional(),
+          roleInfo: z.boolean().optional(),
+          roles: z.boolean().optional(),
+          channelInfo: z.boolean().optional(),
+          voiceStatus: z.boolean().optional(),
+          events: z.boolean().optional(),
+          moderation: z.boolean().optional(),
+        })
+        .optional(),
       replyToMode: ReplyToModeSchema.optional(),
       dm: z
         .object({

--- a/src/discord/send.test.ts
+++ b/src/discord/send.test.ts
@@ -1,7 +1,27 @@
-import { Routes } from "discord.js";
+import { PermissionsBitField, Routes } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { sendMessageDiscord } from "./send.js";
+import {
+  addRoleDiscord,
+  banMemberDiscord,
+  createThreadDiscord,
+  deleteMessageDiscord,
+  editMessageDiscord,
+  fetchChannelPermissionsDiscord,
+  fetchReactionsDiscord,
+  listGuildEmojisDiscord,
+  listThreadsDiscord,
+  pinMessageDiscord,
+  reactMessageDiscord,
+  readMessagesDiscord,
+  removeRoleDiscord,
+  searchMessagesDiscord,
+  sendMessageDiscord,
+  sendPollDiscord,
+  sendStickerDiscord,
+  timeoutMemberDiscord,
+  unpinMessageDiscord,
+} from "./send.js";
 
 vi.mock("../web/media.js", () => ({
   loadWebMedia: vi.fn().mockResolvedValue({
@@ -14,11 +34,23 @@ vi.mock("../web/media.js", () => ({
 
 const makeRest = () => {
   const postMock = vi.fn();
+  const putMock = vi.fn();
+  const getMock = vi.fn();
+  const patchMock = vi.fn();
+  const deleteMock = vi.fn();
   return {
     rest: {
       post: postMock,
+      put: putMock,
+      get: getMock,
+      patch: patchMock,
+      delete: deleteMock,
     } as unknown as import("discord.js").REST,
     postMock,
+    putMock,
+    getMock,
+    patchMock,
+    deleteMock,
   };
 };
 
@@ -114,5 +146,371 @@ describe("sendMessageDiscord", () => {
       fail_if_not_exists: false,
     });
     expect(secondBody?.message_reference).toBeUndefined();
+  });
+});
+
+describe("reactMessageDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reacts with unicode emoji", async () => {
+    const { rest, putMock } = makeRest();
+    await reactMessageDiscord("chan1", "msg1", "✅", { rest, token: "t" });
+    expect(putMock).toHaveBeenCalledWith(
+      Routes.channelMessageOwnReaction("chan1", "msg1", "%E2%9C%85"),
+    );
+  });
+
+  it("normalizes variation selectors in unicode emoji", async () => {
+    const { rest, putMock } = makeRest();
+    await reactMessageDiscord("chan1", "msg1", "⭐️", { rest, token: "t" });
+    expect(putMock).toHaveBeenCalledWith(
+      Routes.channelMessageOwnReaction("chan1", "msg1", "%E2%AD%90"),
+    );
+  });
+
+  it("reacts with custom emoji syntax", async () => {
+    const { rest, putMock } = makeRest();
+    await reactMessageDiscord("chan1", "msg1", "<:party_blob:123>", {
+      rest,
+      token: "t",
+    });
+    expect(putMock).toHaveBeenCalledWith(
+      Routes.channelMessageOwnReaction("chan1", "msg1", "party_blob%3A123"),
+    );
+  });
+});
+
+describe("fetchReactionsDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns reactions with users", async () => {
+    const { rest, getMock } = makeRest();
+    getMock
+      .mockResolvedValueOnce({
+        reactions: [
+          { count: 2, emoji: { name: "✅", id: null } },
+          { count: 1, emoji: { name: "party_blob", id: "123" } },
+        ],
+      })
+      .mockResolvedValueOnce([
+        { id: "u1", username: "alpha", discriminator: "0001" },
+      ])
+      .mockResolvedValueOnce([{ id: "u2", username: "beta" }]);
+    const res = await fetchReactionsDiscord("chan1", "msg1", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual([
+      {
+        emoji: { id: null, name: "✅", raw: "✅" },
+        count: 2,
+        users: [{ id: "u1", username: "alpha", tag: "alpha#0001" }],
+      },
+      {
+        emoji: { id: "123", name: "party_blob", raw: "party_blob:123" },
+        count: 1,
+        users: [{ id: "u2", username: "beta", tag: "beta" }],
+      },
+    ]);
+  });
+});
+
+describe("fetchChannelPermissionsDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calculates permissions from guild roles", async () => {
+    const { rest, getMock } = makeRest();
+    const perms = new PermissionsBitField([
+      PermissionsBitField.Flags.ViewChannel,
+      PermissionsBitField.Flags.SendMessages,
+    ]);
+    getMock
+      .mockResolvedValueOnce({
+        id: "chan1",
+        guild_id: "guild1",
+        permission_overwrites: [],
+      })
+      .mockResolvedValueOnce({ id: "bot1" })
+      .mockResolvedValueOnce({
+        id: "guild1",
+        roles: [
+          { id: "guild1", permissions: perms.bitfield.toString() },
+          { id: "role2", permissions: "0" },
+        ],
+      })
+      .mockResolvedValueOnce({ roles: ["role2"] });
+    const res = await fetchChannelPermissionsDiscord("chan1", {
+      rest,
+      token: "t",
+    });
+    expect(res.guildId).toBe("guild1");
+    expect(res.permissions).toContain("ViewChannel");
+    expect(res.permissions).toContain("SendMessages");
+    expect(res.isDm).toBe(false);
+  });
+});
+
+describe("readMessagesDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes query params as URLSearchParams", async () => {
+    const { rest, getMock } = makeRest();
+    getMock.mockResolvedValue([]);
+    await readMessagesDiscord(
+      "chan1",
+      { limit: 5, before: "10" },
+      { rest, token: "t" },
+    );
+    const call = getMock.mock.calls[0];
+    const options = call?.[1] as { query?: URLSearchParams };
+    expect(options.query?.toString()).toBe("limit=5&before=10");
+  });
+});
+
+describe("edit/delete message helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("edits message content", async () => {
+    const { rest, patchMock } = makeRest();
+    patchMock.mockResolvedValue({ id: "m1" });
+    await editMessageDiscord(
+      "chan1",
+      "m1",
+      { content: "hello" },
+      { rest, token: "t" },
+    );
+    expect(patchMock).toHaveBeenCalledWith(
+      Routes.channelMessage("chan1", "m1"),
+      expect.objectContaining({ body: { content: "hello" } }),
+    );
+  });
+
+  it("deletes message", async () => {
+    const { rest, deleteMock } = makeRest();
+    deleteMock.mockResolvedValue({});
+    await deleteMessageDiscord("chan1", "m1", { rest, token: "t" });
+    expect(deleteMock).toHaveBeenCalledWith(
+      Routes.channelMessage("chan1", "m1"),
+    );
+  });
+});
+
+describe("pin helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pins and unpins messages", async () => {
+    const { rest, putMock, deleteMock } = makeRest();
+    putMock.mockResolvedValue({});
+    deleteMock.mockResolvedValue({});
+    await pinMessageDiscord("chan1", "m1", { rest, token: "t" });
+    await unpinMessageDiscord("chan1", "m1", { rest, token: "t" });
+    expect(putMock).toHaveBeenCalledWith(Routes.channelPin("chan1", "m1"));
+    expect(deleteMock).toHaveBeenCalledWith(Routes.channelPin("chan1", "m1"));
+  });
+});
+
+describe("searchMessagesDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses URLSearchParams for search", async () => {
+    const { rest, getMock } = makeRest();
+    getMock.mockResolvedValue({ total_results: 0, messages: [] });
+    await searchMessagesDiscord(
+      { guildId: "g1", content: "hello", limit: 5 },
+      { rest, token: "t" },
+    );
+    const call = getMock.mock.calls[0];
+    const options = call?.[1] as { query?: URLSearchParams };
+    expect(options.query?.toString()).toBe("content=hello&limit=5");
+  });
+
+  it("supports channel/author arrays and clamps limit", async () => {
+    const { rest, getMock } = makeRest();
+    getMock.mockResolvedValue({ total_results: 0, messages: [] });
+    await searchMessagesDiscord(
+      {
+        guildId: "g1",
+        content: "hello",
+        channelIds: ["c1", "c2"],
+        authorIds: ["u1"],
+        limit: 99,
+      },
+      { rest, token: "t" },
+    );
+    const call = getMock.mock.calls[0];
+    const options = call?.[1] as { query?: URLSearchParams };
+    expect(options.query?.toString()).toBe(
+      "content=hello&channel_id=c1&channel_id=c2&author_id=u1&limit=25",
+    );
+  });
+});
+
+describe("threads and moderation helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a thread", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", messageId: "m1" },
+      { rest, token: "t" },
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1", "m1"),
+      expect.objectContaining({ body: { name: "thread" } }),
+    );
+  });
+
+  it("lists active threads by guild", async () => {
+    const { rest, getMock } = makeRest();
+    getMock.mockResolvedValue({ threads: [] });
+    await listThreadsDiscord({ guildId: "g1" }, { rest, token: "t" });
+    expect(getMock).toHaveBeenCalledWith(Routes.guildActiveThreads("g1"));
+  });
+
+  it("times out a member", async () => {
+    const { rest, patchMock } = makeRest();
+    patchMock.mockResolvedValue({ id: "m1" });
+    await timeoutMemberDiscord(
+      { guildId: "g1", userId: "u1", durationMinutes: 10 },
+      { rest, token: "t" },
+    );
+    expect(patchMock).toHaveBeenCalledWith(
+      Routes.guildMember("g1", "u1"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          communication_disabled_until: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("adds and removes roles", async () => {
+    const { rest, putMock, deleteMock } = makeRest();
+    putMock.mockResolvedValue({});
+    deleteMock.mockResolvedValue({});
+    await addRoleDiscord(
+      { guildId: "g1", userId: "u1", roleId: "r1" },
+      { rest, token: "t" },
+    );
+    await removeRoleDiscord(
+      { guildId: "g1", userId: "u1", roleId: "r1" },
+      { rest, token: "t" },
+    );
+    expect(putMock).toHaveBeenCalledWith(
+      Routes.guildMemberRole("g1", "u1", "r1"),
+    );
+    expect(deleteMock).toHaveBeenCalledWith(
+      Routes.guildMemberRole("g1", "u1", "r1"),
+    );
+  });
+
+  it("bans a member", async () => {
+    const { rest, putMock } = makeRest();
+    putMock.mockResolvedValue({});
+    await banMemberDiscord(
+      { guildId: "g1", userId: "u1", deleteMessageDays: 2 },
+      { rest, token: "t" },
+    );
+    expect(putMock).toHaveBeenCalledWith(
+      Routes.guildBan("g1", "u1"),
+      expect.objectContaining({ body: { delete_message_days: 2 } }),
+    );
+  });
+});
+
+describe("listGuildEmojisDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists emojis for a guild", async () => {
+    const { rest, getMock } = makeRest();
+    getMock.mockResolvedValue([{ id: "e1", name: "party" }]);
+    await listGuildEmojisDiscord("g1", { rest, token: "t" });
+    expect(getMock).toHaveBeenCalledWith(Routes.guildEmojis("g1"));
+  });
+});
+
+describe("sendStickerDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends sticker payloads", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    const res = await sendStickerDiscord("channel:789", ["123"], {
+      rest,
+      token: "t",
+      content: "hiya",
+    });
+    expect(res).toEqual({ messageId: "msg1", channelId: "789" });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.channelMessages("789"),
+      expect.objectContaining({
+        body: {
+          content: "hiya",
+          sticker_ids: ["123"],
+        },
+      }),
+    );
+  });
+});
+
+describe("sendPollDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends polls with answers", async () => {
+    const { rest, postMock } = makeRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    const res = await sendPollDiscord(
+      "channel:789",
+      {
+        question: "Lunch?",
+        answers: ["Pizza", "Sushi"],
+      },
+      {
+        rest,
+        token: "t",
+      },
+    );
+    expect(res).toEqual({ messageId: "msg1", channelId: "789" });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.channelMessages("789"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          poll: {
+            question: { text: "Lunch?" },
+            answers: [
+              { poll_media: { text: "Pizza" } },
+              { poll_media: { text: "Sushi" } },
+            ],
+            duration: 24,
+            allow_multiselect: false,
+            layout_type: 1,
+          },
+        }),
+      }),
+    );
   });
 });

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -1,4 +1,16 @@
-import { REST, Routes } from "discord.js";
+import { PermissionsBitField, REST, Routes } from "discord.js";
+import { PollLayoutType } from "discord-api-types/payloads/v10";
+import type { RESTAPIPoll } from "discord-api-types/rest/v10";
+import type {
+  APIChannel,
+  APIGuild,
+  APIGuildMember,
+  APIGuildScheduledEvent,
+  APIMessage,
+  APIRole,
+  APIVoiceState,
+  RESTPostAPIGuildScheduledEventJSONBody,
+} from "discord-api-types/v10";
 
 import { chunkText } from "../auto-reply/chunk.js";
 import { loadConfig } from "../config/config.js";
@@ -6,6 +18,10 @@ import { loadWebMedia } from "../web/media.js";
 import { normalizeDiscordToken } from "./token.js";
 
 const DISCORD_TEXT_LIMIT = 2000;
+const DISCORD_MAX_STICKERS = 3;
+const DISCORD_POLL_MIN_ANSWERS = 2;
+const DISCORD_POLL_MAX_ANSWERS = 10;
+const DISCORD_POLL_MAX_DURATION_HOURS = 32 * 24;
 
 type DiscordRecipient =
   | {
@@ -30,9 +46,86 @@ export type DiscordSendResult = {
   channelId: string;
 };
 
+export type DiscordPollInput = {
+  question: string;
+  answers: string[];
+  allowMultiselect?: boolean;
+  durationHours?: number;
+};
+
 export type DiscordReactOpts = {
   token?: string;
   rest?: REST;
+};
+
+export type DiscordReactionUser = {
+  id: string;
+  username?: string;
+  tag?: string;
+};
+
+export type DiscordReactionSummary = {
+  emoji: { id?: string | null; name?: string | null; raw: string };
+  count: number;
+  users: DiscordReactionUser[];
+};
+
+export type DiscordPermissionsSummary = {
+  channelId: string;
+  guildId?: string;
+  permissions: string[];
+  raw: string;
+  isDm: boolean;
+};
+
+export type DiscordMessageQuery = {
+  limit?: number;
+  before?: string;
+  after?: string;
+  around?: string;
+};
+
+export type DiscordMessageEdit = {
+  content: string;
+};
+
+export type DiscordThreadCreate = {
+  name: string;
+  messageId?: string;
+  autoArchiveMinutes?: number;
+};
+
+export type DiscordThreadList = {
+  guildId: string;
+  channelId?: string;
+  includeArchived?: boolean;
+  before?: string;
+  limit?: number;
+};
+
+export type DiscordSearchQuery = {
+  guildId: string;
+  content: string;
+  channelIds?: string[];
+  authorIds?: string[];
+  limit?: number;
+};
+
+export type DiscordRoleChange = {
+  guildId: string;
+  userId: string;
+  roleId: string;
+};
+
+export type DiscordModerationTarget = {
+  guildId: string;
+  userId: string;
+  reason?: string;
+};
+
+export type DiscordTimeoutTarget = DiscordModerationTarget & {
+  durationMinutes?: number;
+  until?: string;
 };
 
 function resolveToken(explicit?: string) {
@@ -56,7 +149,7 @@ function normalizeReactionEmoji(raw: string) {
   const customMatch = trimmed.match(/^<a?:([^:>]+):(\d+)>$/);
   const identifier = customMatch
     ? `${customMatch[1]}:${customMatch[2]}`
-    : trimmed;
+    : trimmed.replace(/[\uFE0E\uFE0F]/g, "");
   return encodeURIComponent(identifier);
 }
 
@@ -88,6 +181,49 @@ function parseRecipient(raw: string): DiscordRecipient {
     return { kind: "user", id: candidate };
   }
   return { kind: "channel", id: trimmed };
+}
+
+function normalizeStickerIds(raw: string[]) {
+  const ids = raw.map((entry) => entry.trim()).filter(Boolean);
+  if (ids.length === 0) {
+    throw new Error("At least one sticker id is required");
+  }
+  if (ids.length > DISCORD_MAX_STICKERS) {
+    throw new Error("Discord supports up to 3 stickers per message");
+  }
+  return ids;
+}
+
+function normalizePollInput(input: DiscordPollInput): RESTAPIPoll {
+  const question = input.question.trim();
+  if (!question) {
+    throw new Error("Poll question is required");
+  }
+  const answers = (input.answers ?? [])
+    .map((answer) => answer.trim())
+    .filter(Boolean);
+  if (answers.length < DISCORD_POLL_MIN_ANSWERS) {
+    throw new Error("Polls require at least 2 answers");
+  }
+  if (answers.length > DISCORD_POLL_MAX_ANSWERS) {
+    throw new Error("Polls support up to 10 answers");
+  }
+  const durationRaw =
+    typeof input.durationHours === "number" &&
+    Number.isFinite(input.durationHours)
+      ? Math.floor(input.durationHours)
+      : 24;
+  const duration = Math.min(
+    Math.max(durationRaw, 1),
+    DISCORD_POLL_MAX_DURATION_HOURS,
+  );
+  return {
+    question: { text: question },
+    answers: answers.map((answer) => ({ poll_media: { text: answer } })),
+    duration,
+    allow_multiselect: input.allowMultiselect ?? false,
+    layout_type: PollLayoutType.Default,
+  };
 }
 
 async function resolveChannelId(
@@ -176,6 +312,31 @@ async function sendDiscordMedia(
   return res;
 }
 
+function buildReactionIdentifier(emoji: {
+  id?: string | null;
+  name?: string | null;
+}) {
+  if (emoji.id && emoji.name) {
+    return `${emoji.name}:${emoji.id}`;
+  }
+  return emoji.name ?? "";
+}
+
+function formatReactionEmoji(emoji: {
+  id?: string | null;
+  name?: string | null;
+}) {
+  return buildReactionIdentifier(emoji);
+}
+
+async function fetchBotUserId(rest: REST) {
+  const me = (await rest.get(Routes.user("@me"))) as { id?: string };
+  if (!me?.id) {
+    throw new Error("Failed to resolve bot user id");
+  }
+  return me.id;
+}
+
 export async function sendMessageDiscord(
   to: string,
   text: string,
@@ -207,6 +368,52 @@ export async function sendMessageDiscord(
   };
 }
 
+export async function sendStickerDiscord(
+  to: string,
+  stickerIds: string[],
+  opts: DiscordSendOpts & { content?: string } = {},
+): Promise<DiscordSendResult> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const recipient = parseRecipient(to);
+  const { channelId } = await resolveChannelId(rest, recipient);
+  const content = opts.content?.trim();
+  const stickers = normalizeStickerIds(stickerIds);
+  const res = (await rest.post(Routes.channelMessages(channelId), {
+    body: {
+      content: content || undefined,
+      sticker_ids: stickers,
+    },
+  })) as { id: string; channel_id: string };
+  return {
+    messageId: res.id ? String(res.id) : "unknown",
+    channelId: String(res.channel_id ?? channelId),
+  };
+}
+
+export async function sendPollDiscord(
+  to: string,
+  poll: DiscordPollInput,
+  opts: DiscordSendOpts & { content?: string } = {},
+): Promise<DiscordSendResult> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const recipient = parseRecipient(to);
+  const { channelId } = await resolveChannelId(rest, recipient);
+  const content = opts.content?.trim();
+  const payload = normalizePollInput(poll);
+  const res = (await rest.post(Routes.channelMessages(channelId), {
+    body: {
+      content: content || undefined,
+      poll: payload,
+    },
+  })) as { id: string; channel_id: string };
+  return {
+    messageId: res.id ? String(res.id) : "unknown",
+    channelId: String(res.channel_id ?? channelId),
+  };
+}
+
 export async function reactMessageDiscord(
   channelId: string,
   messageId: string,
@@ -216,6 +423,428 @@ export async function reactMessageDiscord(
   const token = resolveToken(opts.token);
   const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
   const encoded = normalizeReactionEmoji(emoji);
-  await rest.put(Routes.channelMessageReaction(channelId, messageId, encoded));
+  await rest.put(
+    Routes.channelMessageOwnReaction(channelId, messageId, encoded),
+  );
+  return { ok: true };
+}
+
+export async function fetchReactionsDiscord(
+  channelId: string,
+  messageId: string,
+  opts: DiscordReactOpts & { limit?: number } = {},
+): Promise<DiscordReactionSummary[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const message = (await rest.get(
+    Routes.channelMessage(channelId, messageId),
+  )) as {
+    reactions?: Array<{
+      count: number;
+      emoji: { id?: string | null; name?: string | null };
+    }>;
+  };
+  const reactions = message.reactions ?? [];
+  if (reactions.length === 0) return [];
+  const limit =
+    typeof opts.limit === "number" && Number.isFinite(opts.limit)
+      ? Math.min(Math.max(Math.floor(opts.limit), 1), 100)
+      : 100;
+
+  const summaries: DiscordReactionSummary[] = [];
+  for (const reaction of reactions) {
+    const identifier = buildReactionIdentifier(reaction.emoji);
+    if (!identifier) continue;
+    const encoded = encodeURIComponent(identifier);
+    const users = (await rest.get(
+      Routes.channelMessageReaction(channelId, messageId, encoded),
+      { query: new URLSearchParams({ limit: String(limit) }) },
+    )) as Array<{ id: string; username?: string; discriminator?: string }>;
+    summaries.push({
+      emoji: {
+        id: reaction.emoji.id ?? null,
+        name: reaction.emoji.name ?? null,
+        raw: formatReactionEmoji(reaction.emoji),
+      },
+      count: reaction.count,
+      users: users.map((user) => ({
+        id: user.id,
+        username: user.username,
+        tag:
+          user.username && user.discriminator
+            ? `${user.username}#${user.discriminator}`
+            : user.username,
+      })),
+    });
+  }
+  return summaries;
+}
+
+export async function fetchChannelPermissionsDiscord(
+  channelId: string,
+  opts: DiscordReactOpts = {},
+): Promise<DiscordPermissionsSummary> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const channel = (await rest.get(Routes.channel(channelId))) as APIChannel;
+  const guildId = "guild_id" in channel ? channel.guild_id : undefined;
+  if (!guildId) {
+    return {
+      channelId,
+      permissions: [],
+      raw: "0",
+      isDm: true,
+    };
+  }
+
+  const botId = await fetchBotUserId(rest);
+  const [guild, member] = await Promise.all([
+    rest.get(Routes.guild(guildId)) as Promise<APIGuild>,
+    rest.get(Routes.guildMember(guildId, botId)) as Promise<APIGuildMember>,
+  ]);
+
+  const rolesById = new Map<string, APIRole>(
+    (guild.roles ?? []).map((role) => [role.id, role]),
+  );
+  const base = new PermissionsBitField();
+  const everyoneRole = rolesById.get(guildId);
+  if (everyoneRole?.permissions) {
+    base.add(BigInt(everyoneRole.permissions));
+  }
+  for (const roleId of member.roles ?? []) {
+    const role = rolesById.get(roleId);
+    if (role?.permissions) {
+      base.add(BigInt(role.permissions));
+    }
+  }
+
+  const permissions = new PermissionsBitField(base);
+  const overwrites =
+    "permission_overwrites" in channel
+      ? (channel.permission_overwrites ?? [])
+      : [];
+  for (const overwrite of overwrites) {
+    if (overwrite.id === guildId) {
+      permissions.remove(BigInt(overwrite.deny ?? "0"));
+      permissions.add(BigInt(overwrite.allow ?? "0"));
+    }
+  }
+  for (const overwrite of overwrites) {
+    if (member.roles?.includes(overwrite.id)) {
+      permissions.remove(BigInt(overwrite.deny ?? "0"));
+      permissions.add(BigInt(overwrite.allow ?? "0"));
+    }
+  }
+  for (const overwrite of overwrites) {
+    if (overwrite.id === botId) {
+      permissions.remove(BigInt(overwrite.deny ?? "0"));
+      permissions.add(BigInt(overwrite.allow ?? "0"));
+    }
+  }
+
+  return {
+    channelId,
+    guildId,
+    permissions: permissions.toArray(),
+    raw: permissions.bitfield.toString(),
+    isDm: false,
+  };
+}
+
+export async function readMessagesDiscord(
+  channelId: string,
+  query: DiscordMessageQuery = {},
+  opts: DiscordReactOpts = {},
+): Promise<APIMessage[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const limit =
+    typeof query.limit === "number" && Number.isFinite(query.limit)
+      ? Math.min(Math.max(Math.floor(query.limit), 1), 100)
+      : undefined;
+  const params = new URLSearchParams();
+  if (limit) params.set("limit", String(limit));
+  if (query.before) params.set("before", query.before);
+  if (query.after) params.set("after", query.after);
+  if (query.around) params.set("around", query.around);
+  return (await rest.get(Routes.channelMessages(channelId), {
+    query: params,
+  })) as APIMessage[];
+}
+
+export async function editMessageDiscord(
+  channelId: string,
+  messageId: string,
+  payload: DiscordMessageEdit,
+  opts: DiscordReactOpts = {},
+): Promise<APIMessage> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.patch(Routes.channelMessage(channelId, messageId), {
+    body: { content: payload.content },
+  })) as APIMessage;
+}
+
+export async function deleteMessageDiscord(
+  channelId: string,
+  messageId: string,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.delete(Routes.channelMessage(channelId, messageId));
+  return { ok: true };
+}
+
+export async function pinMessageDiscord(
+  channelId: string,
+  messageId: string,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.put(Routes.channelPin(channelId, messageId));
+  return { ok: true };
+}
+
+export async function unpinMessageDiscord(
+  channelId: string,
+  messageId: string,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.delete(Routes.channelPin(channelId, messageId));
+  return { ok: true };
+}
+
+export async function listPinsDiscord(
+  channelId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIMessage[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(Routes.channelPins(channelId))) as APIMessage[];
+}
+
+export async function createThreadDiscord(
+  channelId: string,
+  payload: DiscordThreadCreate,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const body: Record<string, unknown> = { name: payload.name };
+  if (payload.autoArchiveMinutes) {
+    body.auto_archive_duration = payload.autoArchiveMinutes;
+  }
+  const route = Routes.threads(channelId, payload.messageId);
+  return await rest.post(route, { body });
+}
+
+export async function listThreadsDiscord(
+  payload: DiscordThreadList,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  if (payload.includeArchived) {
+    if (!payload.channelId) {
+      throw new Error("channelId required to list archived threads");
+    }
+    const params = new URLSearchParams();
+    if (payload.before) params.set("before", payload.before);
+    if (payload.limit) params.set("limit", String(payload.limit));
+    return await rest.get(Routes.channelThreads(payload.channelId, "public"), {
+      query: params,
+    });
+  }
+  return await rest.get(Routes.guildActiveThreads(payload.guildId));
+}
+
+export async function searchMessagesDiscord(
+  query: DiscordSearchQuery,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const params = new URLSearchParams();
+  params.set("content", query.content);
+  if (query.channelIds?.length) {
+    for (const channelId of query.channelIds) {
+      params.append("channel_id", channelId);
+    }
+  }
+  if (query.authorIds?.length) {
+    for (const authorId of query.authorIds) {
+      params.append("author_id", authorId);
+    }
+  }
+  if (query.limit) {
+    const limit = Math.min(Math.max(Math.floor(query.limit), 1), 25);
+    params.set("limit", String(limit));
+  }
+  return await rest.get(`/guilds/${query.guildId}/messages/search`, {
+    query: params,
+  });
+}
+
+export async function listGuildEmojisDiscord(
+  guildId: string,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return await rest.get(Routes.guildEmojis(guildId));
+}
+
+export async function fetchMemberInfoDiscord(
+  guildId: string,
+  userId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildMember> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(
+    Routes.guildMember(guildId, userId),
+  )) as APIGuildMember;
+}
+
+export async function fetchRoleInfoDiscord(
+  guildId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIRole[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(Routes.guildRoles(guildId))) as APIRole[];
+}
+
+export async function addRoleDiscord(
+  payload: DiscordRoleChange,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.put(
+    Routes.guildMemberRole(payload.guildId, payload.userId, payload.roleId),
+  );
+  return { ok: true };
+}
+
+export async function removeRoleDiscord(
+  payload: DiscordRoleChange,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.delete(
+    Routes.guildMemberRole(payload.guildId, payload.userId, payload.roleId),
+  );
+  return { ok: true };
+}
+
+export async function fetchChannelInfoDiscord(
+  channelId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIChannel> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(Routes.channel(channelId))) as APIChannel;
+}
+
+export async function listGuildChannelsDiscord(
+  guildId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIChannel[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(Routes.guildChannels(guildId))) as APIChannel[];
+}
+
+export async function fetchVoiceStatusDiscord(
+  guildId: string,
+  userId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIVoiceState> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(
+    Routes.guildVoiceState(guildId, userId),
+  )) as APIVoiceState;
+}
+
+export async function listScheduledEventsDiscord(
+  guildId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildScheduledEvent[]> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.get(
+    Routes.guildScheduledEvents(guildId),
+  )) as APIGuildScheduledEvent[];
+}
+
+export async function createScheduledEventDiscord(
+  guildId: string,
+  payload: RESTPostAPIGuildScheduledEventJSONBody,
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildScheduledEvent> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  return (await rest.post(Routes.guildScheduledEvents(guildId), {
+    body: payload,
+  })) as APIGuildScheduledEvent;
+}
+
+export async function timeoutMemberDiscord(
+  payload: DiscordTimeoutTarget,
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildMember> {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  let until = payload.until;
+  if (!until && payload.durationMinutes) {
+    const ms = payload.durationMinutes * 60 * 1000;
+    until = new Date(Date.now() + ms).toISOString();
+  }
+  return (await rest.patch(
+    Routes.guildMember(payload.guildId, payload.userId),
+    {
+      body: { communication_disabled_until: until ?? null },
+      reason: payload.reason,
+    },
+  )) as APIGuildMember;
+}
+
+export async function kickMemberDiscord(
+  payload: DiscordModerationTarget,
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  await rest.delete(Routes.guildMember(payload.guildId, payload.userId), {
+    reason: payload.reason,
+  });
+  return { ok: true };
+}
+
+export async function banMemberDiscord(
+  payload: DiscordModerationTarget & { deleteMessageDays?: number },
+  opts: DiscordReactOpts = {},
+) {
+  const token = resolveToken(opts.token);
+  const rest = opts.rest ?? new REST({ version: "10" }).setToken(token);
+  const deleteMessageDays =
+    typeof payload.deleteMessageDays === "number" &&
+    Number.isFinite(payload.deleteMessageDays)
+      ? Math.min(Math.max(Math.floor(payload.deleteMessageDays), 0), 7)
+      : undefined;
+  await rest.put(Routes.guildBan(payload.guildId, payload.userId), {
+    body:
+      deleteMessageDays !== undefined
+        ? { delete_message_days: deleteMessageDays }
+        : undefined,
+    reason: payload.reason,
+  });
   return { ok: true };
 }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -143,7 +143,6 @@ export class ClawdisApp extends LitElement {
     groupChannels: "",
     mediaMaxMb: "",
     historyLimit: "",
-    enableReactions: true,
     slashEnabled: false,
     slashName: "",
     slashSessionPrefix: "",

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -26,12 +26,13 @@ import type {
   SkillStatusReport,
   StatusSummary,
 } from "./types";
-import type {
-  CronFormState,
-  DiscordForm,
-  IMessageForm,
-  SignalForm,
-  TelegramForm,
+import {
+  defaultDiscordActions,
+  type CronFormState,
+  type DiscordForm,
+  type IMessageForm,
+  type SignalForm,
+  type TelegramForm,
 } from "./ui-types";
 import { loadChatHistory, sendChat, handleChatEvent } from "./controllers/chat";
 import { loadNodes } from "./controllers/nodes";
@@ -143,6 +144,7 @@ export class ClawdisApp extends LitElement {
     groupChannels: "",
     mediaMaxMb: "",
     historyLimit: "",
+    actions: { ...defaultDiscordActions },
     slashEnabled: false,
     slashName: "",
     slashSessionPrefix: "",

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -99,8 +99,6 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
       typeof discord.mediaMaxMb === "number" ? String(discord.mediaMaxMb) : "",
     historyLimit:
       typeof discord.historyLimit === "number" ? String(discord.historyLimit) : "",
-    enableReactions:
-      typeof discord.enableReactions === "boolean" ? discord.enableReactions : true,
     slashEnabled: typeof slash.enabled === "boolean" ? slash.enabled : false,
     slashName: typeof slash.name === "string" ? slash.name : "",
     slashSessionPrefix:

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -1,6 +1,13 @@
 import type { GatewayBrowserClient } from "../gateway";
 import type { ConfigSnapshot } from "../types";
-import type { DiscordForm, IMessageForm, SignalForm, TelegramForm } from "../ui-types";
+import {
+  defaultDiscordActions,
+  type DiscordActionForm,
+  type DiscordForm,
+  type IMessageForm,
+  type SignalForm,
+  type TelegramForm,
+} from "../ui-types";
 
 export type ConfigState = {
   client: GatewayBrowserClient | null;
@@ -88,6 +95,11 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
 
   const discordDm = (discord.dm ?? {}) as Record<string, unknown>;
   const slash = (discord.slashCommand ?? {}) as Record<string, unknown>;
+  const discordActions = (discord.actions ?? {}) as Record<string, unknown>;
+  const readAction = (key: keyof DiscordActionForm) =>
+    typeof discordActions[key] === "boolean"
+      ? (discordActions[key] as boolean)
+      : defaultDiscordActions[key];
   state.discordForm = {
     enabled: typeof discord.enabled === "boolean" ? discord.enabled : true,
     token: typeof discord.token === "string" ? discord.token : "",
@@ -99,6 +111,23 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
       typeof discord.mediaMaxMb === "number" ? String(discord.mediaMaxMb) : "",
     historyLimit:
       typeof discord.historyLimit === "number" ? String(discord.historyLimit) : "",
+    actions: {
+      reactions: readAction("reactions"),
+      stickers: readAction("stickers"),
+      polls: readAction("polls"),
+      permissions: readAction("permissions"),
+      messages: readAction("messages"),
+      threads: readAction("threads"),
+      pins: readAction("pins"),
+      search: readAction("search"),
+      memberInfo: readAction("memberInfo"),
+      roleInfo: readAction("roleInfo"),
+      channelInfo: readAction("channelInfo"),
+      voiceStatus: readAction("voiceStatus"),
+      events: readAction("events"),
+      roles: readAction("roles"),
+      moderation: readAction("moderation"),
+    },
     slashEnabled: typeof slash.enabled === "boolean" ? slash.enabled : false,
     slashName: typeof slash.name === "string" ? slash.name : "",
     slashSessionPrefix:

--- a/ui/src/ui/controllers/connections.ts
+++ b/ui/src/ui/controllers/connections.ts
@@ -246,12 +246,6 @@ export async function saveDiscordConfig(state: ConnectionsState) {
       }
     }
 
-    if (form.enableReactions) {
-      delete discord.enableReactions;
-    } else {
-      discord.enableReactions = false;
-    }
-
     const slash = { ...(discord.slashCommand ?? {}) } as Record<string, unknown>;
     if (form.slashEnabled) {
       slash.enabled = true;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -16,7 +16,6 @@ export type DiscordForm = {
   groupChannels: string;
   mediaMaxMb: string;
   historyLimit: string;
-  enableReactions: boolean;
   slashEnabled: boolean;
   slashName: string;
   slashSessionPrefix: string;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -16,10 +16,47 @@ export type DiscordForm = {
   groupChannels: string;
   mediaMaxMb: string;
   historyLimit: string;
+  actions: DiscordActionForm;
   slashEnabled: boolean;
   slashName: string;
   slashSessionPrefix: string;
   slashEphemeral: boolean;
+};
+
+export type DiscordActionForm = {
+  reactions: boolean;
+  stickers: boolean;
+  polls: boolean;
+  permissions: boolean;
+  messages: boolean;
+  threads: boolean;
+  pins: boolean;
+  search: boolean;
+  memberInfo: boolean;
+  roleInfo: boolean;
+  channelInfo: boolean;
+  voiceStatus: boolean;
+  events: boolean;
+  roles: boolean;
+  moderation: boolean;
+};
+
+export const defaultDiscordActions: DiscordActionForm = {
+  reactions: true,
+  stickers: true,
+  polls: true,
+  permissions: true,
+  messages: true,
+  threads: true,
+  pins: true,
+  search: true,
+  memberInfo: true,
+  roleInfo: true,
+  channelInfo: true,
+  voiceStatus: true,
+  events: true,
+  roles: false,
+  moderation: false,
 };
 
 export type SignalForm = {

--- a/ui/src/ui/views/connections.ts
+++ b/ui/src/ui/views/connections.ts
@@ -523,19 +523,6 @@ function renderProvider(
               />
             </label>
             <label class="field">
-              <span>Reactions</span>
-              <select
-                .value=${props.discordForm.enableReactions ? "yes" : "no"}
-                @change=${(e: Event) =>
-                  props.onDiscordChange({
-                    enableReactions: (e.target as HTMLSelectElement).value === "yes",
-                  })}
-              >
-                <option value="yes">Enabled</option>
-                <option value="no">Disabled</option>
-              </select>
-            </label>
-            <label class="field">
               <span>Slash command</span>
               <select
                 .value=${props.discordForm.slashEnabled ? "yes" : "no"}

--- a/ui/src/ui/views/connections.ts
+++ b/ui/src/ui/views/connections.ts
@@ -2,7 +2,13 @@ import { html, nothing } from "lit";
 
 import { formatAgo } from "../format";
 import type { ProvidersStatusSnapshot } from "../types";
-import type { DiscordForm, IMessageForm, SignalForm, TelegramForm } from "../ui-types";
+import type {
+  DiscordActionForm,
+  DiscordForm,
+  IMessageForm,
+  SignalForm,
+  TelegramForm,
+} from "../ui-types";
 
 export type ConnectionsProps = {
   connected: boolean;
@@ -48,6 +54,24 @@ export function renderConnections(props: ConnectionsProps) {
   const discord = props.snapshot?.discord ?? null;
   const signal = props.snapshot?.signal ?? null;
   const imessage = props.snapshot?.imessage ?? null;
+  const discordActionOptions: Array<{ key: keyof DiscordActionForm; label: string }> =
+    [
+      { key: "reactions", label: "Reactions" },
+      { key: "stickers", label: "Stickers" },
+      { key: "polls", label: "Polls" },
+      { key: "permissions", label: "Permissions" },
+      { key: "messages", label: "Messages" },
+      { key: "threads", label: "Threads" },
+      { key: "pins", label: "Pins" },
+      { key: "search", label: "Search" },
+      { key: "memberInfo", label: "Member info" },
+      { key: "roleInfo", label: "Role info" },
+      { key: "channelInfo", label: "Channel info" },
+      { key: "voiceStatus", label: "Voice status" },
+      { key: "events", label: "Events" },
+      { key: "roles", label: "Role changes" },
+      { key: "moderation", label: "Moderation" },
+    ];
   const providerOrder: ProviderKey[] = [
     "whatsapp",
     "telegram",
@@ -570,6 +594,28 @@ function renderProvider(
                 <option value="no">No</option>
               </select>
             </label>
+          </div>
+
+          <div class="card-sub" style="margin-top: 16px;">Tool actions</div>
+          <div class="form-grid" style="margin-top: 8px;">
+            ${discordActionOptions.map(
+              (action) => html`<label class="field">
+                <span>${action.label}</span>
+                <select
+                  .value=${props.discordForm.actions[action.key] ? "yes" : "no"}
+                  @change=${(e: Event) =>
+                    props.onDiscordChange({
+                      actions: {
+                        ...props.discordForm.actions,
+                        [action.key]: (e.target as HTMLSelectElement).value === "yes",
+                      },
+                    })}
+                >
+                  <option value="yes">Enabled</option>
+                  <option value="no">Disabled</option>
+                </select>
+              </label>`,
+            )}
           </div>
 
           ${props.discordTokenLocked


### PR DESCRIPTION
## Summary
- extend the discord tool with reactions, sticker sends, and polls plus validation/helpers
- add config gating and tests for new discord send flows
- update docs for discord/tool surfaces and add the discord skill guide
- add UI toggles for Discord tool action gating in macOS + web UI

## Tool action defaults
| Action group | Default | Notes |
| --- | --- | --- |
| reactions | enabled | React + list reactions + emojiList |
| stickers | enabled | Send stickers |
| polls | enabled | Create polls |
| permissions | enabled | Channel permission snapshot |
| messages | enabled | Read/send/edit/delete |
| threads | enabled | Create/list/reply |
| pins | enabled | Pin/unpin/list |
| search | enabled | Message search (preview spec) |
| memberInfo | enabled | Member info |
| roleInfo | enabled | Role list |
| channelInfo | enabled | Channel info + list |
| voiceStatus | enabled | Voice state lookup |
| events | enabled | List/create scheduled events |
| roles | disabled | Role add/remove |
| moderation | disabled | Timeout/kick/ban |

## Skills
- `discord`: reactions, stickers, polls, plus the full Discord tool surface

## Testing
- `pnpm lint` (timed out in CLI harness after completion)