### PR TITLE
Gateway: ack skipped hook transforms with 204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Skills: add tmux-first coding-agent skill + `requires.anyBins` gate for multi-CLI setup (thanks @sreekaransrinath).
 
 ### Fixes
+- Gog calendar: format date ranges as RFC 3339 with timezone to satisfy Google Calendar API (thanks @jayhickey).
 - Chat UI: keep the chat scrolled to the latest message after switching sessions.
 - Auto-reply: stream completed reply blocks as soon as they finish (configurable default + break); skip empty tool-only blocks unless verbose.
 - Providers: make outbound text chunk limits configurable via `*.textChunkLimit` (defaults remain 4000/Discord 2000).

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -70,6 +70,7 @@ export type HookAction =
 
 export type HookMappingResult =
   | { ok: true; action: HookAction }
+  | { ok: true; action: null; skipped: true }
   | { ok: false; error: string };
 
 const hookPresetMappings: Record<string, HookMappingConfig[]> = {
@@ -145,7 +146,9 @@ export async function applyHookMappings(
     if (mapping.transform) {
       const transform = await loadTransform(mapping.transform);
       override = await transform(ctx);
-      if (override === null) return null;
+      if (override === null) {
+        return { ok: true, action: null, skipped: true };
+      }
     }
 
     const merged = mergeAction(base.action, override, mapping.action);

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1706,6 +1706,11 @@ export async function startGatewayServer(
             sendJson(res, 400, { ok: false, error: mapped.error });
             return true;
           }
+          if (mapped.action === null) {
+            res.statusCode = 204;
+            res.end();
+            return true;
+          }
           if (mapped.action.kind === "wake") {
             dispatchWakeHook({
               text: mapped.action.text,


### PR DESCRIPTION
## Summary
- Treat hook transform `null` as a handled skip rather than returning 4xx
- Returning HTTP 204 for skipped hooks prevents Pub/Sub from retrying
- Added test coverage for skipped-transform behavior

## Why
Gmail hooks using a transform that returns `null` currently fall through to 404, which Pub/Sub treats as a negative ack and retries repeatedly. That caused constant “hook failed: 404” noise even when messages were intentionally skipped. In my case, these were emails I told my bot to ignore (marketing/spam/etc)

See: https://docs.cloud.google.com/pubsub/docs/push#receiving_messages

## Testing
- pnpm test -- src/gateway/hooks-mapping.test.ts

Implemented with codex, ran tests, and saw my issue resolved locally in logs w/ `pnpm gateway:watch`