### PR TITLE
fix(telegram): add textLimit to block reply chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - macOS: prioritize main bundle for device resources to prevent crash (#73) — thanks @petter-b
 - macOS remote: route settings through gateway config and avoid local config reads in remote mode.
 - Telegram: align token resolution for cron/agent/CLI sends (env/config/tokenFile) to prevent isolated delivery failures (#76).
+- Telegram: chunk block-stream replies to avoid “message is too long” errors (#124) — thanks @mukhtharcm.
 - Telegram: honor per-group mention gating defaults/overrides via `telegram.groups` and `"*"` defaults (thanks @joshp123).
 - Chat UI: clear composer input immediately and allow clear while editing to prevent duplicate sends (#72) — thanks @hrdwdmrbl
 - Restart: use systemd on Linux (and report actual restart method) instead of always launchctl.

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -217,6 +217,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
               runtime,
               bot,
               replyToMode,
+              textLimit,
             });
           })
           .catch((err) => {


### PR DESCRIPTION
## Problem

Block streaming replies in Telegram were failing with `message is too long` error when the AI generated long responses.

```
[telegram] telegram block reply failed: GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message is too long)
```

## Cause

The `onBlockReply` callback was calling `deliverReplies()` without passing the `textLimit` parameter, so messages weren't being chunked before sending.

The final reply path already included `textLimit`, but the streaming/block reply path did not.

## Fix

One-line fix: add `textLimit` to the `deliverReplies()` call in `sendBlockReply`.

## Testing

Tested by triggering a long AI response in Telegram. Previously failed with the error above, now properly chunks at ~4000 characters.