### PR TITLE
fix: sanitize tool schemas for antigravity (AI-assisted)

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -414,6 +414,7 @@ export async function runEmbeddedPiAgent(params: {
         const promptSkills = resolvePromptSkills(skillsSnapshot, skillEntries);
         const tools = createClawdisCodingTools({
           bash: params.config?.agent?.bash,
+          provider,
         });
         const machineName = await getMachineDisplayName();
         const runtimeInfo = {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -362,6 +362,7 @@ function createClawdisReadTool(base: AnyAgentTool): AnyAgentTool {
 
 export function createClawdisCodingTools(options?: {
   bash?: BashToolDefaults & ProcessToolDefaults;
+  provider?: string;
 }): AnyAgentTool[] {
   const bashToolName = "bash";
   const base = (codingTools as unknown as AnyAgentTool[]).flatMap((tool) => {
@@ -380,5 +381,9 @@ export function createClawdisCodingTools(options?: {
     createWhatsAppLoginTool(),
     ...createClawdisTools(),
   ];
-  return tools.map(normalizeToolParameters).map(sanitizeToolParameters);
+  const normalized = tools.map(normalizeToolParameters);
+  if (options?.provider === "google-antigravity") {
+    return normalized.map(sanitizeToolParameters);
+  }
+  return normalized;
 }


### PR DESCRIPTION
## Summary\n- sanitize tool JSON schemas for Cloud Code Assist compatibility (strip patternProperties, const -> enum)\n- scope sanitization to google-antigravity provider only\n- keep existing anyOf merge logic intact\n\n## Why\n- Cloud Code Assist rejects unsupported JSON Schema fields (patternProperties/const/anyOf) and fails tool calls\n- limit impact to antigravity models only\n\n## Testing\n- pnpm lint\n- manual: scripts/restart-mac.sh\n\n## AI-assisted\n- Created with Codex CLI\n- Prompts/logs available on request\n- Confirmed I understand the change