### PR TITLE
Gateway: avoid duplicate block stream replies 

### DIFF
--- a/src/agents/pi-embedded-subscribe.test.ts
+++ b/src/agents/pi-embedded-subscribe.test.ts
@@ -231,6 +231,48 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["Hello block"]);
   });
 
+  it("does not duplicate when text_end repeats full content", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onBlockReply = vi.fn();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<
+        typeof subscribeEmbeddedPiSession
+      >[0]["session"],
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Good morning!",
+      },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_end",
+        content: "Good morning!",
+      },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(subscription.assistantTexts).toEqual(["Good morning!"]);
+  });
+
   it("streams soft chunks with paragraph preference", () => {
     let handler: ((evt: unknown) => void) | undefined;
     const session: StubSession = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -453,13 +453,13 @@ export function subscribeEmbeddedPiSession(params: {
               if (delta) {
                 chunk = delta;
               } else if (content) {
-                if (
-                  !deltaBuffer ||
-                  content.startsWith(deltaBuffer) ||
-                  deltaBuffer.startsWith(content)
-                ) {
+                if (!deltaBuffer) {
                   chunk = content;
                   replaceBuffers = true;
+                } else if (content.startsWith(deltaBuffer)) {
+                  chunk = content.slice(deltaBuffer.length);
+                } else if (deltaBuffer.startsWith(content)) {
+                  chunk = "";
                 } else if (!deltaBuffer.includes(content)) {
                   chunk = content;
                 }


### PR DESCRIPTION
Possible fix for duplicate messages:

- Some providers send full content on text_end, and we were appending that on top of deltas, doubling the reply.
- Update the block streaming buffer logic to treat text_start/text_end content as authoritative and replace buffers when it matches or extends the current buffer, instead of always appending.
- Add a regression test that simulates a full-content text_end and asserts only one block reply is emitted.
- now handles both single message and multi-chunk

(coded by codex, tested locally)