### PR TITLE
Discord: add reaction notification allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Onboarding: shared wizard engine powering CLI + macOS via gateway wizard RPC.
 - Config: expose schema + UI hints for generic config forms (Web UI + future clients).
 - Skills: add blogwatcher skill for RSS/Atom monitoring — thanks @Hyaxia.
+- Discord: emit system events for reaction add/remove with per-guild reaction notifications (off|own|all|allowlist) — thanks @thewilloftheshadow.
 
 ### Fixes
 - Auto-reply: drop final payloads when block streaming to avoid duplicate Discord sends.

--- a/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
+++ b/apps/macos/Sources/Clawdis/ConnectionsSettings.swift
@@ -516,6 +516,17 @@ struct ConnectionsSettings: View {
                                         .toggleStyle(.checkbox)
                                 }
                                 GridRow {
+                                    self.gridLabel("Reaction notifications")
+                                    Picker("", selection: $guild.reactionNotifications) {
+                                        Text("Off").tag("off")
+                                        Text("Own").tag("own")
+                                        Text("All").tag("all")
+                                        Text("Allowlist").tag("allowlist")
+                                    }
+                                    .labelsHidden()
+                                    .pickerStyle(.segmented)
+                                }
+                                GridRow {
                                     self.gridLabel("Users allowlist")
                                     TextField("123456789, username#1234", text: $guild.users)
                                         .textFieldStyle(.roundedBorder)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,7 @@ Configure the Discord bot by setting the bot token and optional gating:
       "123456789012345678": {               // guild id (preferred) or slug
         slug: "friends-of-clawd",
         requireMention: false,              // per-guild default
+        reactionNotifications: "allowlist", // off | own | all | allowlist
         users: ["987654321098765432"],      // optional per-guild user allowlist
         channels: {
           general: { allow: true },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,11 @@ Configure the Discord bot by setting the bot token and optional gating:
 
 Clawdis starts Discord only when a `discord` config section exists. The token is resolved from `DISCORD_BOT_TOKEN` or `discord.token` (unless `discord.enabled` is `false`). Use `user:<id>` (DM) or `channel:<id>` (guild channel) when specifying delivery targets for cron/CLI commands.
 Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged channel name (no leading `#`). Prefer guild ids as keys to avoid rename ambiguity.
+Reaction notification modes:
+- `off`: no reaction events.
+- `own`: all reactions on the bot's own messages.
+- `all`: all reactions on all messages.
+- `allowlist`: reactions from `guilds.<id>.users` on all messages.
 
 ### `imessage` (imsg CLI)
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -86,6 +86,7 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
       "123456789012345678": {
         slug: "friends-of-clawd",
         requireMention: false,
+        reactionNotifications: "allowlist",
         users: ["987654321098765432", "steipete"],
         channels: {
           general: { allow: true },
@@ -107,6 +108,7 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
 - `guilds.<id>.users`: optional per-guild user allowlist (ids or names).
 - `guilds.<id>.channels`: channel rules (keys are channel slugs or ids).
 - `guilds.<id>.requireMention`: per-guild mention requirement (overridable per channel).
+- `guilds.<id>.reactionNotifications`: reaction system event mode (`off`, `own`, `all`, `allowlist`).
 - `slashCommand`: optional config for user-installed slash commands (ephemeral responses).
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20, `0` disables).
@@ -116,6 +118,8 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
   - `memberInfo`, `roleInfo`, `channelInfo`, `voiceStatus`, `events`
   - `roles` (role add/remove, default `false`)
   - `moderation` (timeout/kick/ban, default `false`)
+
+Reaction notifications use `guilds.<id>.reactionNotifications`; `allowlist` checks `guilds.<id>.users`, while `all` ignores that allowlist.
 
 ### Tool action defaults
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -119,7 +119,11 @@ Note: Guild context `[from:]` lines include `author.tag` + `id` to make ping-rea
   - `roles` (role add/remove, default `false`)
   - `moderation` (timeout/kick/ban, default `false`)
 
-Reaction notifications use `guilds.<id>.reactionNotifications`; `allowlist` checks `guilds.<id>.users`, while `all` ignores that allowlist.
+Reaction notifications use `guilds.<id>.reactionNotifications`:
+- `off`: no reaction events.
+- `own`: all reactions on the bot's own messages.
+- `all`: all reactions on all messages.
+- `allowlist`: reactions from `guilds.<id>.users` on all messages.
 
 ### Tool action defaults
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -203,9 +203,17 @@ export type DiscordGuildChannelConfig = {
   requireMention?: boolean;
 };
 
+export type DiscordReactionNotificationMode =
+  | "off"
+  | "own"
+  | "all"
+  | "allowlist";
+
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
+  /** Reaction notification mode (off|own|all|allowlist). Default: own. */
+  reactionNotifications?: DiscordReactionNotificationMode;
   users?: Array<string | number>;
   channels?: Record<string, DiscordGuildChannelConfig>;
 };
@@ -1153,6 +1161,9 @@ export const ClawdisSchema = z.object({
             .object({
               slug: z.string().optional(),
               requireMention: z.boolean().optional(),
+              reactionNotifications: z
+                .enum(["off", "own", "all", "allowlist"])
+                .optional(),
               users: z.array(z.union([z.string(), z.number()])).optional(),
               channels: z
                 .record(

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -197,6 +197,13 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
                   typeof entry.requireMention === "boolean"
                     ? entry.requireMention
                     : false,
+                reactionNotifications:
+                  entry.reactionNotifications === "off" ||
+                  entry.reactionNotifications === "all" ||
+                  entry.reactionNotifications === "own" ||
+                  entry.reactionNotifications === "allowlist"
+                    ? entry.reactionNotifications
+                    : "allowlist",
                 users: toList(entry.users),
                 channels,
               };

--- a/ui/src/ui/controllers/connections.ts
+++ b/ui/src/ui/controllers/connections.ts
@@ -292,6 +292,14 @@ export async function saveDiscordConfig(state: ConnectionsState) {
       const slug = String(guild.slug ?? "").trim();
       if (slug) entry.slug = slug;
       if (guild.requireMention) entry.requireMention = true;
+      if (
+        guild.reactionNotifications === "off" ||
+        guild.reactionNotifications === "all" ||
+        guild.reactionNotifications === "own" ||
+        guild.reactionNotifications === "allowlist"
+      ) {
+        entry.reactionNotifications = guild.reactionNotifications;
+      }
       const users = parseList(guild.users);
       if (users.length > 0) entry.users = users;
       const channels: Record<string, unknown> = {};

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -31,6 +31,7 @@ export type DiscordGuildForm = {
   key: string;
   slug: string;
   requireMention: boolean;
+  reactionNotifications: "off" | "own" | "all" | "allowlist";
   users: string;
   channels: DiscordGuildChannelForm[];
 };

--- a/ui/src/ui/views/connections.ts
+++ b/ui/src/ui/views/connections.ts
@@ -646,6 +646,26 @@ function renderProvider(
                           </select>
                         </label>
                         <label class="field">
+                          <span>Reaction notifications</span>
+                          <select
+                            .value=${guild.reactionNotifications}
+                            @change=${(e: Event) => {
+                              const next = [...props.discordForm.guilds];
+                              next[guildIndex] = {
+                                ...next[guildIndex],
+                                reactionNotifications: (e.target as HTMLSelectElement)
+                                  .value as "off" | "own" | "all",
+                              };
+                              props.onDiscordChange({ guilds: next });
+                            }}
+                          >
+                            <option value="off">Off</option>
+                            <option value="own">Own</option>
+                            <option value="all">All</option>
+                            <option value="allowlist">Allowlist</option>
+                          </select>
+                        </label>
+                        <label class="field">
                           <span>Users allowlist</span>
                           <input
                             .value=${guild.users}
@@ -812,6 +832,7 @@ function renderProvider(
                         key: "",
                         slug: "",
                         requireMention: false,
+                        reactionNotifications: "allowlist",
                         users: "",
                         channels: [],
                       },


### PR DESCRIPTION
Added `guilds.<id>.reactionNotifications`: reaction system event mode (`off`, `own`, `all`, `allowlist`).

  - off = no reaction events
  - own = all reactions on own messages
  - all = all reactions on all messages
  - allowlist = user reactions on all messages
