### PR TITLE
CI: split independent checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,33 @@ on:
   pull_request:
 
 jobs:
-  build:
+  checks:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        runtime: [node, bun]
+        include:
+          - runtime: node
+            task: lint
+            command: pnpm lint
+          - runtime: node
+            task: test
+            command: pnpm test
+          - runtime: node
+            task: build
+            command: pnpm build
+          - runtime: node
+            task: protocol
+            command: pnpm protocol:check
+          - runtime: bun
+            task: lint
+            command: bunx biome check src
+          - runtime: bun
+            task: test
+            command: bunx vitest run
+          - runtime: bun
+            task: build
+            command: bunx tsc -p tsconfig.json
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -77,37 +98,42 @@ jobs:
           pnpm -v
           pnpm install --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
-      - name: Lint (node)
-        if: matrix.runtime == 'node'
-        run: pnpm lint
-
-      - name: Test (node)
-        if: matrix.runtime == 'node'
-        run: pnpm test
-
-      - name: Build (node)
-        if: matrix.runtime == 'node'
-        run: pnpm build
-
-      - name: Protocol check (node)
-        if: matrix.runtime == 'node'
-        run: pnpm protocol:check
-
-      - name: Lint (bun)
-        if: matrix.runtime == 'bun'
-        run: bunx biome check src
-
-      - name: Test (bun)
-        if: matrix.runtime == 'bun'
-        run: bunx vitest run
-
-      - name: Build (bun)
-        if: matrix.runtime == 'bun'
-        run: bunx tsc -p tsconfig.json
+      - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
+        run: ${{ matrix.command }}
 
   macos-app:
     if: github.event_name == 'pull_request'
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint
+            command: |
+              swiftlint --config .swiftlint.yml
+              swiftformat --lint apps/macos/Sources --config .swiftformat
+          - task: build
+            command: |
+              set -euo pipefail
+              for attempt in 1 2 3; do
+                if swift build --package-path apps/macos --configuration release; then
+                  exit 0
+                fi
+                echo "swift build failed (attempt $attempt/3). Retrying…"
+                sleep $((attempt * 20))
+              done
+              exit 1
+          - task: test
+            command: |
+              set -euo pipefail
+              for attempt in 1 2 3; do
+                if swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path; then
+                  exit 0
+                fi
+                echo "swift test failed (attempt $attempt/3). Retrying…"
+                sleep $((attempt * 20))
+              done
+              exit 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -142,35 +168,8 @@ jobs:
           xcodebuild -version
           swift --version
 
-      - name: SwiftLint
-        run: swiftlint --config .swiftlint.yml
-
-      - name: SwiftFormat (lint mode)
-        run: swiftformat --lint apps/macos/Sources --config .swiftformat
-
-      - name: Swift build (release)
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            if swift build --package-path apps/macos --configuration release; then
-              exit 0
-            fi
-            echo "swift build failed (attempt $attempt/3). Retrying…"
-            sleep $((attempt * 20))
-          done
-          exit 1
-
-      - name: Swift tests (coverage)
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            if swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path; then
-              exit 0
-            fi
-            echo "swift test failed (attempt $attempt/3). Retrying…"
-            sleep $((attempt * 20))
-          done
-          exit 1
+      - name: Run ${{ matrix.task }}
+        run: ${{ matrix.command }}
   ios:
     if: false # ignore iOS in CI for now
     runs-on: macos-latest
@@ -346,6 +345,14 @@ jobs:
 
   android:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: test
+            command: ./gradlew --no-daemon :app:testDebugUnitTest
+          - task: build
+            command: ./gradlew --no-daemon :app:assembleDebug
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -385,6 +392,6 @@ jobs:
             "platforms;android-36" \
             "build-tools;36.0.0"
 
-      - name: Android unit tests + debug build
+      - name: Run Android ${{ matrix.task }}
         working-directory: apps/android
-        run: ./gradlew --no-daemon :app:testDebugUnitTest :app:assembleDebug
+        run: ${{ matrix.command }}


### PR DESCRIPTION
Split the various CIs into independent matrix tasks so (for example) lint/build/test run separately and failures don’t block unrelated checks, while keeping existing setup steps intact.
