### PR TITLE
fix: add ~/.local/bin to PATH for uv tool binaries

### DIFF
--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -74,6 +74,7 @@ function candidateBinDirs(opts: EnsureClawdisPathOpts): string[] {
   if (platform === "darwin") {
     candidates.push(path.join(homeDir, "Library", "pnpm"));
   }
+  candidates.push(path.join(homeDir, ".local", "bin"));
   candidates.push(path.join(homeDir, ".local", "share", "pnpm"));
   candidates.push(path.join(homeDir, ".bun", "bin"));
   candidates.push(path.join(homeDir, ".yarn", "bin"));


### PR DESCRIPTION
Fixes #78

## Summary
Skills installed via `uv tool install` place binaries in `~/.local/bin`, but this directory wasn't included in the gateway's PATH bootstrap. This caused skills like `nano-pdf` to install successfully but never be marked as eligible.

## Changes
- Added `~/.local/bin` to candidate directories in `src/infra/path-env.ts`

## Testing
- After this change, `uv`-installed skills should be detected immediately after installation
- No restart required (PATH is bootstrapped on gateway startup)

---
*Generated via parallel Codex worktree workflow* 🥷