### PR TITLE
🐐 Fix: add missing path import and DEFAULT_PATH constant

### DIFF
--- a/src/agents/bash-tools.ts
+++ b/src/agents/bash-tools.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { homedir } from "node:os";
+import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 
@@ -27,6 +28,7 @@ import {
 } from "./shell-utils.js";
 
 const CHUNK_LIMIT = 8 * 1024;
+const DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_MAX_OUTPUT = clampNumber(
   readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
   30_000,


### PR DESCRIPTION
Hey again!

After pulling the latest changes (including my previous PR 🎉), I noticed the build was failing with:

```
error TS2304: Cannot find name 'DEFAULT_PATH'
error TS2304: Cannot find name 'path'
```

## The problem

The sandbox Docker feature (commit d8a417f7) introduced code using `path.sep`, `path.posix.sep`, and `DEFAULT_PATH`, but the import and constant declaration were missing from `bash-tools.ts`.

## The fix

- Added `import path from "node:path";`
- Added `const DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";`

Minimal fix — 2 lines added. 🐐