### PR TITLE
fix(bash): add missing path import and DEFAULT_PATH constant

### DIFF
--- a/src/agents/bash-tools.ts
+++ b/src/agents/bash-tools.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { homedir } from "node:os";
+import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 
@@ -33,6 +34,8 @@ const DEFAULT_MAX_OUTPUT = clampNumber(
   1_000,
   150_000,
 );
+const DEFAULT_PATH =
+  "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 const stringEnum = (
   values: readonly string[],


### PR DESCRIPTION
Fixing the breaking changes that prevented me from building clawdis, going through onboarding and setting everything up. Only after making these changes did everything go through.

## Error when doing `pnpm build`

```bash
clawdis main ❯ pnpm build

> clawdis@2.0.0-beta5 build /home/radek/Developer/clawdis
> tsc -p tsconfig.json && tsx scripts/canvas-a2ui-copy.ts

src/agents/pi-embedded-runner.ts:489:27 - error TS2339: Property 'queueMessage' does not exist on type 'AgentSession'.

489             await session.queueMessage(text);
                              ~~~~~~~~~~~~

src/gateway/server.ts:860:26 - error TS18047: 'bridge' is possibly 'null'.

860       bridge ? (opts) => bridge.sendEvent(opts) : undefined,
                             ~~~~~~

src/gateway/server.ts:866:26 - error TS18047: 'bridge' is possibly 'null'.

866       bridge ? (opts) => bridge.sendEvent(opts) : undefined,
                             ~~~~~~

src/gateway/server.ts:872:22 - error TS18047: 'bridge' is possibly 'null'.

872       bridge ? () => bridge.listConnected() : undefined,
                         ~~~~~~

src/gateway/server.ts:873:26 - error TS18047: 'bridge' is possibly 'null'.

873       bridge ? (opts) => bridge.sendEvent(opts) : undefined,
                             ~~~~~~


Found 5 errors in 2 files.

Errors  Files
     1  src/agents/pi-embedded-runner.ts:489
     4  src/gateway/server.ts:860
 ELIFECYCLE  Command failed with exit code 1.
```

## Summary

- Add missing `import path from "node:path"` required for `path.sep`, `path.posix.sep`, `path.posix.join` usage
- Add missing `DEFAULT_PATH` constant used in `buildSandboxEnv()`

These were introduced in 3b075dff (feat: add per-session agent sandbox) and break the build:

```
src/agents/bash-tools.ts(831,11): error TS2304: Cannot find name 'DEFAULT_PATH'.
src/agents/bash-tools.ts(888,33): error TS2304: Cannot find name 'path'.
src/agents/bash-tools.ts(888,48): error TS2304: Cannot find name 'path'.
src/agents/bash-tools.ts(891,9): error TS2304: Cannot find name 'path'.
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)