### PR TITLE
fix: resolve TypeScript type errors with @types/node@25

### DIFF
--- a/src/agents/clawdis-tools.ts
+++ b/src/agents/clawdis-tools.ts
@@ -2736,7 +2736,7 @@ function createSessionsSendTool(): AnyAgentTool {
           ? Math.max(0, Math.floor(params.timeoutSeconds))
           : 30;
       const idempotencyKey = crypto.randomUUID();
-      let runId = idempotencyKey;
+      let runId: string = idempotencyKey;
       const displayKey = resolveDisplaySessionKey({
         key: sessionKey,
         alias,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1778,7 +1778,7 @@ function applySessionDefaults(cfg: ClawdisConfig): ClawdisConfig {
 
   const trimmed = session.mainKey.trim();
   const next: ClawdisConfig = { ...cfg, session: { ...session } };
-  next.session.mainKey = "main";
+  next.session!.mainKey = "main";
 
   if (trimmed && trimmed !== "main" && !warnedMainKeyOverride) {
     warnedMainKeyOverride = true;


### PR DESCRIPTION
## Summary
- Fixes TypeScript compilation errors caused by stricter type checking in `@types/node@25`
- Explicitly types `runId` variable as `string` to resolve UUID template literal type incompatibility
- Adds non-null assertion for `session` property access

## Changes
- **src/agents/clawdis-tools.ts:2739** - Added explicit `string` type annotation to `runId` variable to fix type mismatch when assigning from `response.runId` (lines 2760, 2787, 2800)
- **src/config/config.ts:1781** - Added non-null assertion (`!`) for `next.session.mainKey` since we guarantee session exists through earlier guard clause

## Test Plan
- ✅ `pnpm build` passes without errors
- ✅ `pnpm test` passes all test suites (324 tests)
- ✅ No functional changes - purely type fixes

## Context
In `@types/node@25`, `crypto.randomUUID()` returns a strict UUID template literal type (`` `${string}-${string}-${string}-${string}-${string}` ``) instead of plain `string`. When declaring `let runId = idempotencyKey`, TypeScript infers the stricter type, causing type errors when later assigning `string` values from API responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)