### PR TITLE
feat(macos): add Swift 6 strict concurrency compatibility

### DIFF
--- a/apps/macos/Sources/Clawdis/OnboardingWizard.swift
+++ b/apps/macos/Sources/Clawdis/OnboardingWizard.swift
@@ -6,6 +6,20 @@ import SwiftUI
 
 private let onboardingWizardLogger = Logger(subsystem: "com.clawdis", category: "onboarding.wizard")
 
+// MARK: - Swift 6 AnyCodable Bridging Helpers
+// These helpers bridge between ClawdisProtocol.AnyCodable and the local module
+// to avoid Swift 6 strict concurrency type conflicts.
+
+private typealias ProtocolAnyCodable = ClawdisProtocol.AnyCodable
+
+private func bridgeToProtocol(_ value: Any) -> ProtocolAnyCodable {
+    ProtocolAnyCodable(value)
+}
+
+private func bridgeDict(_ dict: [String: Any]) -> [String: ProtocolAnyCodable] {
+    dict.mapValues { ProtocolAnyCodable($0) }
+}
+
 @MainActor
 @Observable
 final class OnboardingWizardModel {
@@ -307,12 +321,12 @@ private struct WizardOptionItem: Identifiable {
 }
 
 private struct WizardOption {
-    let value: AnyCodable?
+    let value: ProtocolAnyCodable?
     let label: String
     let hint: String?
 }
 
-private func decodeWizardStep(_ raw: [String: AnyCodable]?) -> WizardStep? {
+private func decodeWizardStep(_ raw: [String: ProtocolAnyCodable]?) -> WizardStep? {
     guard let raw else { return nil }
     do {
         let data = try JSONEncoder().encode(raw)
@@ -323,7 +337,7 @@ private func decodeWizardStep(_ raw: [String: AnyCodable]?) -> WizardStep? {
     }
 }
 
-private func parseWizardOptions(_ raw: [[String: AnyCodable]]?) -> [WizardOption] {
+private func parseWizardOptions(_ raw: [[String: ProtocolAnyCodable]]?) -> [WizardOption] {
     guard let raw else { return [] }
     return raw.map { entry in
         let value = entry["value"]
@@ -337,7 +351,7 @@ private func wizardStepType(_ step: WizardStep) -> String {
     (step.type.value as? String) ?? ""
 }
 
-private func anyCodableString(_ value: AnyCodable?) -> String {
+private func anyCodableString(_ value: ProtocolAnyCodable?) -> String {
     switch value?.value {
     case let string as String:
         return string
@@ -352,11 +366,11 @@ private func anyCodableString(_ value: AnyCodable?) -> String {
     }
 }
 
-private func anyCodableStringValue(_ value: AnyCodable?) -> String? {
+private func anyCodableStringValue(_ value: ProtocolAnyCodable?) -> String? {
     value?.value as? String
 }
 
-private func anyCodableBool(_ value: AnyCodable?) -> Bool {
+private func anyCodableBool(_ value: ProtocolAnyCodable?) -> Bool {
     switch value?.value {
     case let bool as Bool:
         return bool
@@ -367,18 +381,18 @@ private func anyCodableBool(_ value: AnyCodable?) -> Bool {
     }
 }
 
-private func anyCodableArray(_ value: AnyCodable?) -> [AnyCodable] {
+private func anyCodableArray(_ value: ProtocolAnyCodable?) -> [ProtocolAnyCodable] {
     switch value?.value {
-    case let arr as [AnyCodable]:
+    case let arr as [ProtocolAnyCodable]:
         return arr
     case let arr as [Any]:
-        return arr.map { AnyCodable($0) }
+        return arr.map { ProtocolAnyCodable($0) }
     default:
         return []
     }
 }
 
-private func anyCodableEqual(_ lhs: AnyCodable?, _ rhs: AnyCodable?) -> Bool {
+private func anyCodableEqual(_ lhs: ProtocolAnyCodable?, _ rhs: ProtocolAnyCodable?) -> Bool {
     switch (lhs?.value, rhs?.value) {
     case let (l as String, r as String):
         return l == r

--- a/apps/macos/Sources/Clawdis/PermissionManager.swift
+++ b/apps/macos/Sources/Clawdis/PermissionManager.swift
@@ -289,10 +289,14 @@ final class LocationPermissionRequester: NSObject, CLLocationManagerDelegate {
         }
     }
 
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        guard let cont = self.continuation else { return }
-        self.continuation = nil
-        cont.resume(returning: manager.authorizationStatus)
+    // nonisolated for Swift 6 strict concurrency compatibility
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            guard let cont = self.continuation else { return }
+            self.continuation = nil
+            cont.resume(returning: status)
+        }
     }
 }
 

--- a/apps/macos/Sources/ClawdisProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/ClawdisProtocol/GatewayModels.swift
@@ -871,7 +871,7 @@ public struct WizardStep: Codable {
     }
 }
 
-public struct WizardNextResult: Codable {
+public struct WizardNextResult: Codable, Sendable {
     public let done: Bool
     public let step: [String: AnyCodable]?
     public let status: AnyCodable?
@@ -896,7 +896,7 @@ public struct WizardNextResult: Codable {
     }
 }
 
-public struct WizardStartResult: Codable {
+public struct WizardStartResult: Codable, Sendable {
     public let sessionid: String
     public let done: Bool
     public let step: [String: AnyCodable]?
@@ -925,7 +925,7 @@ public struct WizardStartResult: Codable {
     }
 }
 
-public struct WizardStatusResult: Codable {
+public struct WizardStatusResult: Codable, Sendable {
     public let status: AnyCodable
     public let error: String?
 


### PR DESCRIPTION
## Summary

Prepares the macOS app for Swift 6 strict concurrency mode (Xcode 26+). These changes are forward-compatible and don't affect behavior on current Swift versions.

**Changes:**

1. **GatewayModels.swift**: Added `Sendable` conformance to `WizardNextResult`, `WizardStartResult`, and `WizardStatusResult`

2. **OnboardingWizard.swift**: Added AnyCodable bridging helpers to handle type conflicts between ClawdisProtocol and local module under strict concurrency

3. **MacNodeLocationService.swift & PermissionManager.swift**: Made `CLLocationManagerDelegate` methods `nonisolated` with `Task { @MainActor in }` pattern to safely access MainActor state from protocol requirements

## Related Issue

Addresses #164 (Swift 6 / Xcode 26 compatibility) - forward-compatibility changes

## Test Plan

- [x] Verified code compiles on Xcode 26 beta with Swift 6.2.3
- [x] Verified code still compiles on stable Xcode versions
- [x] Location permission flow works correctly
- [x] Onboarding wizard works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)