### PR TITLE
feat(web): enforce allowFrom in group chats

### DIFF
--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1381,6 +1381,14 @@ export async function monitorWebProvider(
             );
             return;
           }
+
+          // Enforce allowFrom in groups: only process messages from allowed senders
+          if (!isOwner) {
+            logVerbose(
+              `Ignoring group message from non-owner ${msg.senderE164} in ${conversationId}`,
+            );
+            return;
+          }
         }
 
         return processMessage(msg);


### PR DESCRIPTION
## Description
Adds `allowFrom` enforcement for group chats. Currently, non-owner messages in groups bypass `allowFrom` checks, allowing any group member to trigger the agent.

## Changes
- Added owner check for group messages in `monitorWebProvider`
- Non-owner messages are now logged (verbose) and ignored
- Prevents unauthorized group members from triggering agent when `allowFrom` restrictions are configured

## Testing
- [x] Tested locally with group chat containing non-owner members
- [x] Verified owner messages still work
- [x] Checked verbose logging output

## AI-Assisted
⚠️ This PR was built with Claude Code assistance. Code has been tested locally but may benefit from additional review of edge cases.