### PR TITLE
Fix: Remove duplicate sendMessageSlack imports

### DIFF
--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -3,7 +3,6 @@ import { sendMessageIMessage } from "../imessage/send.js";
 import { logWebSelfId, sendMessageWhatsApp } from "../providers/web/index.js";
 import { sendMessageSlack } from "../slack/send.js";
 import { sendMessageSignal } from "../signal/send.js";
-import { sendMessageSlack } from "../slack/send.js";
 import { sendMessageTelegram } from "../telegram/send.js";
 
 export type CliDeps = {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -23,7 +23,6 @@ import { webAuthExists } from "../providers/web/index.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { sendMessageSlack } from "../slack/send.js";
 import { sendMessageSignal } from "../signal/send.js";
-import { sendMessageSlack } from "../slack/send.js";
 import { sendMessageTelegram } from "../telegram/send.js";
 import { normalizeE164 } from "../utils.js";
 import { getActiveWebListener } from "../web/active-listener.js";


### PR DESCRIPTION
## Description
This PR fixes TypeScript compilation errors caused by duplicate import statements for `sendMessageSlack` in two files.

## Changes
- Removed duplicate `sendMessageSlack` import from `src/cli/deps.ts`
- Removed duplicate `sendMessageSlack` import from `src/infra/heartbeat-runner.ts`

## Impact
- Resolves TypeScript error TS2300 (Duplicate identifier)
- Allows the project to build successfully with `pnpm build`

## Testing
- [x] Verified build passes with `pnpm build`