### PR TITLE
fix(cron): pass 'id' instead of 'jobId' to gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **Why this looks different:** the project was renamed from **Clawdis → Clawdbot**. To make the transition clear, releases now use **date-based versions** (`YYYY.M.D`) and the changelog is **compressed** into milestone summaries. Full detail still lives in git history and the docs.
 
+## Unreleased
+
+### Fixes
+- Cron tool passes `id` to the gateway for update/remove/run/runs (keeps `jobId` input). (#180) — thanks @adamgall
+
+
 ## 2026.1.4
 
 ### Highlights

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -102,33 +102,33 @@ export function createCronTool(): AnyAgentTool {
           );
         }
         case "update": {
-          const jobId = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           if (!params.patch || typeof params.patch !== "object") {
             throw new Error("patch required");
           }
           return jsonResult(
             await callGatewayTool("cron.update", gatewayOpts, {
-              jobId,
+              id,
               patch: params.patch,
             }),
           );
         }
         case "remove": {
-          const jobId = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
-            await callGatewayTool("cron.remove", gatewayOpts, { jobId }),
+            await callGatewayTool("cron.remove", gatewayOpts, { id }),
           );
         }
         case "run": {
-          const jobId = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
-            await callGatewayTool("cron.run", gatewayOpts, { jobId }),
+            await callGatewayTool("cron.run", gatewayOpts, { id }),
           );
         }
         case "runs": {
-          const jobId = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
-            await callGatewayTool("cron.runs", gatewayOpts, { jobId }),
+            await callGatewayTool("cron.runs", gatewayOpts, { id }),
           );
         }
         case "wake": {


### PR DESCRIPTION
The cron tool was passing `{ jobId }` to the gateway for update/remove/run/runs actions, but the gateway protocol schema expects `{ id }`. This caused validation errors when trying to update or remove cron jobs via the tool.

Fixes the parameter name while keeping the external tool API unchanged (still accepts `jobId` from callers).

## Testing
All existing tests pass.