### PR TITLE
feat: Antigravity multi-account round-robin with automatic failover

### DIFF
--- a/src/cli/antigravity-cli.ts
+++ b/src/cli/antigravity-cli.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import {
   antigravityAddCommand,
   antigravityListCommand,
+  antigravityRemoveCommand,
 } from "../commands/antigravity.js";
 import { defaultRuntime } from "../runtime.js";
 
@@ -28,6 +29,18 @@ export function registerAntigravityCli(program: Command) {
     .action(async () => {
       try {
         await antigravityListCommand(defaultRuntime);
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  antigravity
+    .command("remove <email>")
+    .description("Remove an Antigravity account")
+    .action(async (email: string) => {
+      try {
+        await antigravityRemoveCommand(defaultRuntime, email);
       } catch (err) {
         defaultRuntime.error(String(err));
         defaultRuntime.exit(1);

--- a/src/cli/antigravity-cli.ts
+++ b/src/cli/antigravity-cli.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import {
+  antigravityAddCommand,
+  antigravityListCommand,
+} from "../commands/antigravity.js";
+import { defaultRuntime } from "../runtime.js";
+
+export function registerAntigravityCli(program: Command) {
+  const antigravity = program
+    .command("antigravity")
+    .description("Manage Google Antigravity accounts");
+
+  antigravity
+    .command("add")
+    .description("Add a new Antigravity account")
+    .action(async () => {
+      try {
+        await antigravityAddCommand(defaultRuntime);
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  antigravity
+    .command("list")
+    .description("List Antigravity accounts")
+    .action(async () => {
+      try {
+        await antigravityListCommand(defaultRuntime);
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -15,6 +15,7 @@ import { danger, setVerbose } from "../globals.js";
 import { loginWeb, logoutWeb } from "../provider-web.js";
 import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
+import { registerAntigravityCli } from "./antigravity-cli.js";
 import { registerBrowserCli } from "./browser-cli.js";
 import { registerCanvasCli } from "./canvas-cli.js";
 import { registerCronCli } from "./cron-cli.js";
@@ -418,6 +419,7 @@ Examples:
   registerGatewayCli(program);
   registerModelsCli(program);
   registerNodesCli(program);
+  registerAntigravityCli(program);
   registerTuiCli(program);
   registerCronCli(program);
   registerDnsCli(program);

--- a/src/commands/antigravity.ts
+++ b/src/commands/antigravity.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { loginAntigravityVpsAware } from "./antigravity-oauth.js";
 import { writeOAuthCredentials } from "./onboard-auth.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveOAuthPath } from "../config/paths.js";
+import { resolveOAuthPath, resolveOAuthDir } from "../config/paths.js";
 import { getAntigravityAccounts } from "../agents/model-auth.js";
 
 // Re-implementing simplified loadOAuthStorage to avoid circular deps or complexity
@@ -15,6 +15,26 @@ async function loadOAuthStorage() {
   } catch {
     return {};
   }
+}
+
+async function saveOAuthStorage(storage: Record<string, unknown>) {
+  const p = resolveOAuthPath();
+  await fs.writeFile(p, JSON.stringify(storage, null, 2), "utf8");
+}
+
+async function loadAntigravityState(): Promise<Record<string, unknown>> {
+  const p = path.join(resolveOAuthDir(), "antigravity-state.json");
+  try {
+    const content = await fs.readFile(p, "utf8");
+    return JSON.parse(content);
+  } catch {
+    return {};
+  }
+}
+
+async function saveAntigravityState(state: Record<string, unknown>) {
+  const p = path.join(resolveOAuthDir(), "antigravity-state.json");
+  await fs.writeFile(p, JSON.stringify(state, null, 2), "utf8");
 }
 
 export async function antigravityAddCommand(runtime: RuntimeEnv) {
@@ -52,4 +72,51 @@ export async function antigravityListCommand(runtime: RuntimeEnv) {
   for (const acc of accounts) {
     runtime.log(`- ${acc}`);
   }
+}
+
+export async function antigravityRemoveCommand(
+  runtime: RuntimeEnv,
+  emailOrKey: string,
+) {
+  const storage = await loadOAuthStorage();
+  const accounts = getAntigravityAccounts(storage);
+
+  // Normalize: accept either email or full key
+  let keyToRemove: string | undefined;
+  for (const acc of accounts) {
+    if (acc === emailOrKey || acc === `google-antigravity:${emailOrKey}`) {
+      keyToRemove = acc;
+      break;
+    }
+    // Also match just the email part
+    if (acc.startsWith("google-antigravity:")) {
+      const email = acc.slice("google-antigravity:".length);
+      if (email === emailOrKey) {
+        keyToRemove = acc;
+        break;
+      }
+    }
+  }
+
+  if (!keyToRemove) {
+    runtime.error(`Account not found: ${emailOrKey}`);
+    runtime.log("Available accounts:");
+    for (const acc of accounts) {
+      runtime.log(`  - ${acc}`);
+    }
+    return;
+  }
+
+  // Remove from oauth storage
+  delete storage[keyToRemove];
+  await saveOAuthStorage(storage);
+
+  // Remove from antigravity state if present
+  const state = await loadAntigravityState();
+  if (keyToRemove in state) {
+    delete state[keyToRemove];
+    await saveAntigravityState(state);
+  }
+
+  runtime.log(`Removed account: ${keyToRemove}`);
 }

--- a/src/commands/antigravity.ts
+++ b/src/commands/antigravity.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { loginAntigravityVpsAware } from "./antigravity-oauth.js";
+import { writeOAuthCredentials } from "./onboard-auth.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveOAuthPath } from "../config/paths.js";
+import { getAntigravityAccounts } from "../agents/model-auth.js";
+
+// Re-implementing simplified loadOAuthStorage to avoid circular deps or complexity
+async function loadOAuthStorage() {
+  const p = resolveOAuthPath();
+  try {
+    const content = await fs.readFile(p, "utf8");
+    return JSON.parse(content);
+  } catch {
+    return {};
+  }
+}
+
+export async function antigravityAddCommand(runtime: RuntimeEnv) {
+  runtime.log("Starting Antigravity login...");
+
+  const creds = await loginAntigravityVpsAware(
+    (url) => {
+      runtime.log("\nOpen this URL to authorize:");
+      runtime.log(url + "\n");
+    },
+    (msg) => runtime.log(msg),
+  );
+
+  if (creds && creds.email) {
+    const key = `google-antigravity:${creds.email}`;
+    // We cast to any because OAuthProvider is a strict union type in the library,
+    // but the storage underlying implementation handles string keys.
+    await writeOAuthCredentials(key as any, creds);
+    runtime.log(`Successfully added account: ${creds.email}`);
+  } else {
+    throw new Error("Login failed or email could not be retrieved.");
+  }
+}
+
+export async function antigravityListCommand(runtime: RuntimeEnv) {
+  const storage = await loadOAuthStorage();
+  const accounts = getAntigravityAccounts(storage);
+
+  if (accounts.length === 0) {
+    runtime.log("No Antigravity accounts found.");
+    return;
+  }
+
+  runtime.log("Antigravity Accounts:");
+  for (const acc of accounts) {
+    runtime.log(`- ${acc}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for multiple Antigravity accounts with automatic round-robin load balancing and failover.

## Problem

- Single Antigravity account can get rate limited, blocking all requests
- Antigravity rate limits cause requests to **hang indefinitely** rather than returning errors
- Upstream `@mariozechner/pi-ai` expects credentials under a single `google-antigravity` key

## Solution

### Multi-account storage
Accounts stored with namespaced keys in `oauth.json`:
```json
{
  "google-antigravity": { ... },
  "google-antigravity:account2@gmail.com": { ... }
}
```

### Round-robin selection
Each request picks the account with the oldest `lastUsed` timestamp (least-recently-used).

### Automatic failover
On retryable errors (401, 403, 429, quota, rate limit, timeout), marks the account as failed and automatically retries with the next available account.

### Timeout-based failover (new)
Since Antigravity rate limits cause hangs rather than errors, we added timeout detection:
- When a request times out (based on `agent.timeoutSeconds`), treat it as a rate limit
- Mark the account as failed and try the next available account
- Logs: `Antigravity account X timed out (possible rate limit). Trying next account...`

### Exponential backoff
Failed accounts get cooldown: 1min → 5min → 25min → 1hr max. State tracked in `antigravity-state.json`.

### The storage swap trick
We create a temp storage object with the selected account mapped to `google-antigravity`, so the upstream library's token refresh works transparently without modification.

## CLI Commands
```bash
clawdbot antigravity add     # Add new account (opens browser auth)
clawdbot antigravity list    # List all accounts  
clawdbot antigravity remove  # Remove an account
```

## Files changed
- `src/agents/model-auth.ts` - Core multi-account logic
- `src/agents/pi-embedded-runner.ts` - Failover retry loop with timeout detection
- `src/cli/antigravity-cli.ts` - CLI command registration
- `src/cli/program.ts` - Register antigravity subcommand
- `src/commands/antigravity.ts` - Add/list/remove implementations

## Configuration

The failover timeout is controlled by `agent.timeoutSeconds` (default: 600s / 10 min). For faster failover on rate limits, lower this value:

```json
{
  "agent": {
    "timeoutSeconds": 180
  }
}
```

**Trade-off:** Lower timeout = faster failover but may cut off legitimately long-running tasks.

## Testing
- Tested with 4 accounts - round-robin alternation confirmed via `antigravity-state.json` timestamps
- Timeout failover confirmed in production: account marked failed after timeout, switched to next account successfully
- Verified failover logs appear correctly