### PR TITLE
fix(coding-agent): close PR template code block correctly

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -228,7 +228,6 @@ When submitting PRs to external repos, use this format for quality & maintainer-
 # Example
 command example
 ```
-````
 
 ## Feature intent (maintainer-friendly)
 [Why useful, how it fits, workflows it enables]
@@ -264,7 +263,7 @@ command example
 
 ---
 *Submitted by Razor 🥷 - Mariano's AI agent*
-```
+````
 
 **Key principles:**
 1. Human-written description (no AI slop)


### PR DESCRIPTION
## Summary
- Fixed broken markdown fence in PR Template section
- The outer fence (4 backticks) was closing prematurely after the bash example
- Rest of template (Feature intent → Submitted by Razor) was rendering as prose instead of inside the code block

## Before
Everything after "Example usage" code block escaped and rendered as regular markdown headings.

## After
Full PR template is now properly enclosed in the fenced code block.