### PR TITLE
feat: XDG Base Directory Specification for logging

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -4,6 +4,44 @@ import { resolveUserPath } from "../utils.js";
 import type { ClawdbotConfig } from "./types.js";
 
 /**
+ * XDG Base Directory Specification support.
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+
+/**
+ * XDG_STATE_HOME for user-specific state files (logs, history, etc).
+ * Default: ~/.local/state
+ */
+export function resolveXdgStateHome(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const override = env.XDG_STATE_HOME?.trim();
+  if (override) return resolveUserPath(override);
+  return path.join(homedir(), ".local", "state");
+}
+
+/**
+ * Central logging directory following XDG spec.
+ * Can be overridden via CLAWDBOT_LOG_DIR environment variable.
+ *
+ * Precedence:
+ * - CLAWDBOT_LOG_DIR (explicit override)
+ * - $XDG_STATE_HOME/clawdbot/logs (XDG compliant)
+ * - ~/.local/state/clawdbot/logs (XDG default)
+ */
+export function resolveLogDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const override = env.CLAWDBOT_LOG_DIR?.trim();
+  if (override) return resolveUserPath(override);
+  return path.join(resolveXdgStateHome(env, homedir), "clawdbot", "logs");
+}
+
+export const LOG_DIR_CLAWDBOT = resolveLogDir();
+
+/**
  * Nix mode detection: When CLAWDBOT_NIX_MODE=1, the gateway is running under Nix.
  * In this mode:
  * - No auto-install flows should be attempted

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -5,12 +5,16 @@ import util from "node:util";
 import { Chalk } from "chalk";
 import { Logger as TsLogger } from "tslog";
 import { type ClawdbotConfig, loadConfig } from "./config/config.js";
+import { LOG_DIR_CLAWDBOT } from "./config/paths.js";
 import { isVerbose } from "./globals.js";
 import { defaultRuntime, type RuntimeEnv } from "./runtime.js";
 
-// Pin to /tmp so mac Debug UI and docs match; os.tmpdir() can be a per-user
-// randomized path on macOS which made the “Open log” button a no-op.
-export const DEFAULT_LOG_DIR = "/tmp/clawdbot";
+/**
+ * Central logging directory following XDG Base Directory Specification.
+ * Default: $XDG_STATE_HOME/clawdbot/logs (~/.local/state/clawdbot/logs)
+ * Can be overridden via CLAWDBOT_LOG_DIR environment variable.
+ */
+export const DEFAULT_LOG_DIR = LOG_DIR_CLAWDBOT;
 export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "clawdbot.log"); // legacy single-file path
 
 const LOG_PREFIX = "clawdbot";


### PR DESCRIPTION
## Summary
Move logging directory from `/tmp/clawdbot` to XDG-compliant location.

## Changes
- Add `resolveXdgStateHome()` and `resolveLogDir()` to `config/paths.ts`
- Update `logging.ts` to use XDG state directory
- Default: `~/.local/state/clawdbot/logs`
- Override: `CLAWDBOT_LOG_DIR` environment variable

## Benefits
- Logs persist across reboots (no more /tmp cleanup)
- Follows [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/)
- Central location for log monitoring/analysis
- Works with ralph loops and other agent observability tools