### PR TITLE
fix: custom tools not available (browser) + Linux browser docs

### DIFF
--- a/docs/browser-linux-troubleshooting.md
+++ b/docs/browser-linux-troubleshooting.md
@@ -1,0 +1,109 @@
+# Browser Troubleshooting (Linux)
+
+## Problem: "Failed to start Chrome CDP on port 18800"
+
+Clawdbot's browser control server fails to launch Chrome/Chromium with the error:
+```
+{"error":"Error: Failed to start Chrome CDP on port 18800 for profile \"clawd\"."}
+```
+
+### Root Cause
+
+On Ubuntu (and many Linux distros), the default Chromium installation is a **snap package**. Snap's AppArmor confinement interferes with how Clawdbot spawns and monitors the browser process.
+
+The `apt install chromium` command installs a stub package that redirects to snap:
+```
+Note, selecting 'chromium-browser' instead of 'chromium'
+chromium-browser is already the newest version (2:1snap1-0ubuntu2).
+```
+
+This is NOT a real browser — it's just a wrapper.
+
+### Solution 1: Install Google Chrome (Recommended)
+
+Install the official Google Chrome `.deb` package, which is not sandboxed by snap:
+
+```bash
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo dpkg -i google-chrome-stable_current_amd64.deb
+sudo apt --fix-broken install -y  # if there are dependency errors
+```
+
+Then update your Clawdbot config (`~/.clawdbot/clawdbot.json`):
+
+```json
+{
+  "browser": {
+    "enabled": true,
+    "executablePath": "/usr/bin/google-chrome-stable",
+    "headless": true,
+    "noSandbox": true
+  }
+}
+```
+
+### Solution 2: Use Snap Chromium with Attach-Only Mode
+
+If you must use snap Chromium, configure Clawdbot to attach to a manually-started browser:
+
+1. Update config:
+```json
+{
+  "browser": {
+    "enabled": true,
+    "attachOnly": true,
+    "headless": true,
+    "noSandbox": true
+  }
+}
+```
+
+2. Start Chromium manually:
+```bash
+chromium-browser --headless --no-sandbox --disable-gpu \
+  --remote-debugging-port=18800 \
+  --user-data-dir=$HOME/.clawdbot/browser/clawd/user-data \
+  about:blank &
+```
+
+3. Optionally create a systemd user service to auto-start Chrome:
+```ini
+# ~/.config/systemd/user/clawd-browser.service
+[Unit]
+Description=Clawd Browser (Chrome CDP)
+After=network.target
+
+[Service]
+ExecStart=/snap/bin/chromium --headless --no-sandbox --disable-gpu --remote-debugging-port=18800 --user-data-dir=%h/.clawdbot/browser/clawd/user-data about:blank
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+Enable with: `systemctl --user enable --now clawd-browser.service`
+
+### Verifying the Browser Works
+
+Check status:
+```bash
+curl -s http://127.0.0.1:18791/ | jq '{running, pid, chosenBrowser}'
+```
+
+Test browsing:
+```bash
+curl -s -X POST http://127.0.0.1:18791/start
+curl -s http://127.0.0.1:18791/tabs
+```
+
+### Config Reference
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `browser.enabled` | Enable browser control | `true` |
+| `browser.executablePath` | Path to Chrome/Chromium binary | auto-detected |
+| `browser.headless` | Run without GUI | `false` |
+| `browser.noSandbox` | Add `--no-sandbox` flag (needed for some Linux setups) | `false` |
+| `browser.attachOnly` | Don't launch browser, only attach to existing | `false` |
+| `browser.cdpPort` | Chrome DevTools Protocol port | `18800` |

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -287,3 +287,7 @@ Notes:
 - Sharing the user's logged-in Chrome sessions automatically.
 - General-purpose web scraping; this is primarily for "close-the-loop" verification
   and interaction.
+
+## Troubleshooting
+
+For Linux-specific issues (especially Ubuntu with snap Chromium), see [browser-linux-troubleshooting.md](./browser-linux-troubleshooting.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -225,3 +225,26 @@ clawdbot gateway        # start the Gateway again
 *"Have you tried turning it off and on again?"* — Every IT person ever
 
 🦞🔧
+
+### Browser Not Starting (Linux)
+
+If you see `"Failed to start Chrome CDP on port 18800"`:
+
+**Most likely cause:** Snap-packaged Chromium on Ubuntu.
+
+**Quick fix:** Install Google Chrome instead:
+```bash
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo dpkg -i google-chrome-stable_current_amd64.deb
+```
+
+Then set in config:
+```json
+{
+  "browser": {
+    "executablePath": "/usr/bin/google-chrome-stable"
+  }
+}
+```
+
+**Full guide:** See [browser-linux-troubleshooting.md](./browser-linux-troubleshooting.md)

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -409,6 +409,11 @@ export async function runEmbeddedPiAgent(params: {
           agentDir,
         );
 
+        // Split tools into built-in (recognized by pi-coding-agent SDK) and custom (clawdbot-specific)
+        const builtInToolNames = new Set(["read", "bash", "edit", "write"]);
+        const builtInTools = tools.filter((t) => builtInToolNames.has(t.name));
+        const customTools = tools.filter((t) => !builtInToolNames.has(t.name));
+
         const { session } = await createAgentSession({
           cwd: resolvedWorkspace,
           agentDir,
@@ -417,8 +422,10 @@ export async function runEmbeddedPiAgent(params: {
           model,
           thinkingLevel,
           systemPrompt,
-          // Custom tool set: extra bash/process + read image sanitization.
-          tools,
+          // Built-in tools recognized by pi-coding-agent SDK
+          tools: builtInTools,
+          // Custom clawdbot tools (browser, canvas, nodes, cron, etc.)
+          customTools,
           sessionManager,
           settingsManager,
           skills: promptSkills,


### PR DESCRIPTION

## Bug Fix
Custom clawdbot tools (browser, canvas, nodes, cron, etc.) were not available at runtime, causing "Tool not found" errors.

**Cause:** The pi-coding-agent SDK's `tools` parameter only accepts built-in tools (read, bash, edit, write). Custom tools were silently filtered out.

**Solution:** Split tools into `tools:` (built-in) and `customTools:` (clawdbot-specific) parameters.

---

## Docs: Linux Browser Troubleshooting

Covers:
- Snap Chromium issues on Ubuntu
- Solution 1: Install Google Chrome (recommended)
- Solution 2: attachOnly mode workaround
- Systemd service for auto-starting browser
- Config reference