### PR TITLE
fix(model): retry fallback on rate limits

### DIFF
--- a/src/agents/pi-embedded-helpers.test.ts
+++ b/src/agents/pi-embedded-helpers.test.ts
@@ -26,6 +26,14 @@ describe("isRateLimitAssistantError", () => {
     expect(isRateLimitAssistantError(msg)).toBe(true);
   });
 
+  it("detects quota exceeded messages", () => {
+    const msg = asAssistant({
+      errorMessage:
+        "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
+    });
+    expect(isRateLimitAssistantError(msg)).toBe(true);
+  });
+
   it("returns false for non-error messages", () => {
     const msg = asAssistant({
       stopReason: "end_turn",

--- a/src/agents/pi-embedded-helpers.test.ts
+++ b/src/agents/pi-embedded-helpers.test.ts
@@ -1,0 +1,32 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+
+import { isRateLimitAssistantError } from "./pi-embedded-helpers.js";
+
+const asAssistant = (overrides: Partial<AssistantMessage>) =>
+  ({ role: "assistant", stopReason: "error", ...overrides }) as AssistantMessage;
+
+describe("isRateLimitAssistantError", () => {
+  it("detects 429 rate limit payloads", () => {
+    const msg = asAssistant({
+      errorMessage:
+        '429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s rate limit. Please try again later."}}',
+    });
+    expect(isRateLimitAssistantError(msg)).toBe(true);
+  });
+
+  it("detects human-readable rate limit messages", () => {
+    const msg = asAssistant({
+      errorMessage: "Too many requests. Rate limit exceeded.",
+    });
+    expect(isRateLimitAssistantError(msg)).toBe(true);
+  });
+
+  it("returns false for non-error messages", () => {
+    const msg = asAssistant({
+      stopReason: "end_turn",
+      errorMessage: "rate limit",
+    });
+    expect(isRateLimitAssistantError(msg)).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -117,7 +117,10 @@ export function isRateLimitAssistantError(
   if (!msg || msg.stopReason !== "error") return false;
   const raw = (msg.errorMessage ?? "").toLowerCase();
   if (!raw) return false;
-  return /rate[_ ]limit|too many requests|429/.test(raw);
+  return (
+    /rate[_ ]limit|too many requests|429/.test(raw) ||
+    raw.includes("exceeded your current quota")
+  );
 }
 
 function extractSupportedValues(raw: string): string[] {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -6,6 +6,7 @@ import type {
   AgentToolResult,
 } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { normalizeThinkLevel, type ThinkLevel } from "../auto-reply/thinking.js";
 
 import { sanitizeContentBlocksImages } from "./tool-images.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
@@ -117,4 +118,39 @@ export function isRateLimitAssistantError(
   const raw = (msg.errorMessage ?? "").toLowerCase();
   if (!raw) return false;
   return /rate[_ ]limit|too many requests|429/.test(raw);
+}
+
+function extractSupportedValues(raw: string): string[] {
+  const match =
+    raw.match(/supported values are:\s*([^\n.]+)/i) ??
+    raw.match(/supported values:\s*([^\n.]+)/i);
+  if (!match?.[1]) return [];
+  const fragment = match[1];
+  const quoted = Array.from(fragment.matchAll(/['"]([^'"]+)['"]/g)).map(
+    (entry) => entry[1]?.trim(),
+  );
+  if (quoted.length > 0) {
+    return quoted.filter((entry): entry is string => Boolean(entry));
+  }
+  return fragment
+    .split(/,|\band\b/gi)
+    .map((entry) => entry.replace(/^[^a-zA-Z]+|[^a-zA-Z]+$/g, "").trim())
+    .filter(Boolean);
+}
+
+export function pickFallbackThinkingLevel(params: {
+  message?: string;
+  attempted: Set<ThinkLevel>;
+}): ThinkLevel | undefined {
+  const raw = params.message?.trim();
+  if (!raw) return undefined;
+  const supported = extractSupportedValues(raw);
+  if (supported.length === 0) return undefined;
+  for (const entry of supported) {
+    const normalized = normalizeThinkLevel(entry);
+    if (!normalized) continue;
+    if (params.attempted.has(normalized)) continue;
+    return normalized;
+  }
+  return undefined;
 }

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -109,3 +109,12 @@ export function formatAssistantErrorText(
   // Keep it short for WhatsApp.
   return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
 }
+
+export function isRateLimitAssistantError(
+  msg: AssistantMessage | undefined,
+): boolean {
+  if (!msg || msg.stopReason !== "error") return false;
+  const raw = (msg.errorMessage ?? "").toLowerCase();
+  if (!raw) return false;
+  return /rate[_ ]limit|too many requests|429/.test(raw);
+}

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -33,6 +33,7 @@ import {
   ensureSessionHeader,
   formatAssistantErrorText,
   isRateLimitAssistantError,
+  pickFallbackThinkingLevel,
   sanitizeSessionMessagesImages,
 } from "./pi-embedded-helpers.js";
 import {
@@ -318,22 +319,27 @@ export async function runEmbeddedPiAgent(params: {
       const apiKey = await getApiKeyForModel(model, authStorage);
       authStorage.setRuntimeApiKey(model.provider, apiKey);
 
-      const thinkingLevel = mapThinkingLevel(params.thinkLevel);
+      let thinkLevel = params.thinkLevel ?? "off";
+      const attemptedThinking = new Set<ThinkLevel>();
 
-      log.debug(
-        `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${provider} model=${modelId} surface=${params.surface ?? "unknown"}`,
-      );
+      while (true) {
+        const thinkingLevel = mapThinkingLevel(thinkLevel);
+        attemptedThinking.add(thinkLevel);
 
-      await fs.mkdir(resolvedWorkspace, { recursive: true });
-      await ensureSessionHeader({
-        sessionFile: params.sessionFile,
-        sessionId: params.sessionId,
-        cwd: resolvedWorkspace,
-      });
+        log.debug(
+          `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${provider} model=${modelId} thinking=${thinkLevel} surface=${params.surface ?? "unknown"}`,
+        );
 
-      let restoreSkillEnv: (() => void) | undefined;
-      process.chdir(resolvedWorkspace);
-      try {
+        await fs.mkdir(resolvedWorkspace, { recursive: true });
+        await ensureSessionHeader({
+          sessionFile: params.sessionFile,
+          sessionId: params.sessionId,
+          cwd: resolvedWorkspace,
+        });
+
+        let restoreSkillEnv: (() => void) | undefined;
+        process.chdir(resolvedWorkspace);
+        try {
         const shouldLoadSkillEntries =
           !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
         const skillEntries = shouldLoadSkillEntries
@@ -390,7 +396,7 @@ export async function runEmbeddedPiAgent(params: {
         const systemPrompt = buildSystemPrompt({
           appendPrompt: buildAgentSystemPromptAppend({
             workspaceDir: resolvedWorkspace,
-            defaultThinkLevel: params.thinkLevel,
+            defaultThinkLevel: thinkLevel,
             extraSystemPrompt: params.extraSystemPrompt,
             ownerNumbers: params.ownerNumbers,
             reasoningTagHint,
@@ -532,6 +538,20 @@ export async function runEmbeddedPiAgent(params: {
           params.abortSignal?.removeEventListener?.("abort", onAbort);
         }
         if (promptError && !aborted) {
+          const fallbackThinking = pickFallbackThinkingLevel({
+            message:
+              promptError instanceof Error
+                ? promptError.message
+                : String(promptError),
+            attempted: attemptedThinking,
+          });
+          if (fallbackThinking) {
+            log.warn(
+              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+            );
+            thinkLevel = fallbackThinking;
+            continue;
+          }
           throw promptError;
         }
 
@@ -541,6 +561,18 @@ export async function runEmbeddedPiAgent(params: {
           .find((m) => (m as AgentMessage)?.role === "assistant") as
           | AssistantMessage
           | undefined;
+
+        const fallbackThinking = pickFallbackThinkingLevel({
+          message: lastAssistant?.errorMessage,
+          attempted: attemptedThinking,
+        });
+        if (fallbackThinking && !aborted) {
+          log.warn(
+            `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+          );
+          thinkLevel = fallbackThinking;
+          continue;
+        }
 
         const fallbackConfigured =
           (params.config?.agent?.modelFallbacks?.length ?? 0) > 0;
@@ -621,9 +653,10 @@ export async function runEmbeddedPiAgent(params: {
             aborted,
           },
         };
-      } finally {
-        restoreSkillEnv?.();
-        process.chdir(prevCwd);
+        } finally {
+          restoreSkillEnv?.();
+          process.chdir(prevCwd);
+        }
       }
     }),
   );

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -32,6 +32,7 @@ import {
   buildBootstrapContextFiles,
   ensureSessionHeader,
   formatAssistantErrorText,
+  isRateLimitAssistantError,
   sanitizeSessionMessagesImages,
 } from "./pi-embedded-helpers.js";
 import {
@@ -540,6 +541,16 @@ export async function runEmbeddedPiAgent(params: {
           .find((m) => (m as AgentMessage)?.role === "assistant") as
           | AssistantMessage
           | undefined;
+
+        const fallbackConfigured =
+          (params.config?.agent?.modelFallbacks?.length ?? 0) > 0;
+        if (fallbackConfigured && isRateLimitAssistantError(lastAssistant)) {
+          const message =
+            lastAssistant?.errorMessage?.trim() ||
+            (lastAssistant ? formatAssistantErrorText(lastAssistant) : "") ||
+            "LLM request rate limited.";
+          throw new Error(message);
+        }
 
         const usage = lastAssistant?.usage;
         const agentMeta: EmbeddedPiAgentMeta = {

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -204,6 +204,7 @@ export async function handleCommands(params: {
     resolvedVerboseLevel,
     resolvedElevatedLevel,
     resolveDefaultThinkingLevel,
+    provider,
     model,
     contextTokens,
     isGroup,


### PR DESCRIPTION
## Summary
- retry model fallback on assistant rate-limit errors
- retry with supported thinking level when a model rejects the default
- treat quota exceeded errors as rate limits
- add rate-limit/thinking fallback detection tests
- fix /status model auth provider lookup

## Testing
- pnpm vitest run src/agents/pi-embedded-helpers.test.ts
- pnpm build
- pnpm ui:build