### PR TITLE
fix(cron): skip delivery for HEARTBEAT_OK responses

### DIFF
--- a/src/cron/isolated-agent.test.ts
+++ b/src/cron/isolated-agent.test.ts
@@ -377,4 +377,180 @@ describe("runCronIsolatedAgentTurn", () => {
       );
     });
   });
+
+  it("skips delivery when response is exactly HEARTBEAT_OK", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn().mockResolvedValue({
+          messageId: "t1",
+          chatId: "123",
+        }),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "HEARTBEAT_OK" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          deliver: true,
+          channel: "telegram",
+          to: "123",
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      // Job still succeeds, but no delivery happens.
+      expect(res.status).toBe("ok");
+      expect(res.summary).toBe("HEARTBEAT_OK");
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it("skips delivery when response has HEARTBEAT_OK with short padding", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn().mockResolvedValue({
+          messageId: "w1",
+          chatId: "+1234",
+        }),
+        sendMessageTelegram: vi.fn(),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      // Short junk around HEARTBEAT_OK (<=30 chars) should still skip delivery.
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "HEARTBEAT_OK 🦞" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { whatsapp: { allowFrom: ["+1234"] } }),
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          deliver: true,
+          channel: "whatsapp",
+          to: "+1234",
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(deps.sendMessageWhatsApp).not.toHaveBeenCalled();
+    });
+  });
+
+  it("delivers when response has HEARTBEAT_OK but also substantial content", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn().mockResolvedValue({
+          messageId: "t1",
+          chatId: "123",
+        }),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      // Long content after HEARTBEAT_OK should still be delivered.
+      const longContent = `Important alert: ${"a".repeat(50)}`;
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: `HEARTBEAT_OK ${longContent}` }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          deliver: true,
+          channel: "telegram",
+          to: "123",
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(deps.sendMessageTelegram).toHaveBeenCalled();
+    });
+  });
+
+  it("delivers when response has HEARTBEAT_OK but includes media", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn().mockResolvedValue({
+          messageId: "t1",
+          chatId: "123",
+        }),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      // Media should still be delivered even if text is just HEARTBEAT_OK.
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [
+          { text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" },
+        ],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          deliver: true,
+          channel: "telegram",
+          to: "123",
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
+        "123",
+        "HEARTBEAT_OK",
+        expect.objectContaining({ mediaUrl: "https://example.com/img.png" }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Problem
Isolated cron jobs with `deliver: true` were sending HEARTBEAT_OK responses to external channels (Telegram, etc.), causing spam when there was nothing to report.

## Solution
Added `isHeartbeatOnlyResponse()` helper in `src/cron/isolated-agent.ts` that checks if the response is just HEARTBEAT_OK (with optional whitespace). When detected, external delivery is skipped while still posting to main session via `postToMainPrefix`.

## Changes
- `src/cron/isolated-agent.ts`: Added check before delivery block
- `src/cron/isolated-agent.test.ts`: Added 4 tests covering exact match, padding, substantial content, and media presence

## Testing
- HEARTBEAT_OK responses: filtered, not delivered
- Actual content: delivered normally
- Responses with media: delivered regardless of text