### PR TITLE
fix(whatsapp): populate senderE164 for direct chats to enable owner commands

### DIFF
--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -144,10 +144,14 @@ export async function monitorWebInbox(options: {
         continue;
       const group = isJidGroup(remoteJid);
       const participantJid = msg.key?.participant ?? undefined;
-      const senderE164 = participantJid ? jidToE164(participantJid) : null;
       const from = group ? remoteJid : jidToE164(remoteJid);
       // Skip if we still can't resolve an id to key conversation
       if (!from) continue;
+      const senderE164 = group
+        ? participantJid
+          ? jidToE164(participantJid)
+          : null
+        : from;
       let groupSubject: string | undefined;
       let groupParticipants: string[] | undefined;
       if (group) {


### PR DESCRIPTION
## Summary
Fixes owner commands (`/status`, `/help`) not working in WhatsApp direct chats by correctly populating `senderE164` from the conversation's `from` number.

## Root Cause
- `/status` and `/help` are gated in `src/auto-reply/reply/commands.ts`, returning early unless `command.isAuthorizedSender` is true
- `isAuthorizedSender` is built from `senderE164` + `whatsapp.allowFrom` configuration
- The original code only populated `senderE164` from `participantJid` (which only exists in group messages to identify the group member who sent it)
- In direct chats, `participantJid` is undefined, leaving `senderE164` as `null` and causing the global owner check to fail

## Fix
Set `senderE164` appropriately for both contexts:
- **Group chats**: use `participantJid` (the group member who sent the message)
- **Direct chats**: use `from` (the person you're chatting with)

Note: Group-only logic in `src/web/auto-reply.ts` controls mention requirements for `/activation` and `/status`, but doesn't remove the owner check. The authorization gate is global; groups just have additional mention gating on top.