### PR TITLE
fix(ui): add missing slack variable in config controller

### DIFF
--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -100,6 +100,7 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
   const config = snapshot.config ?? {};
   const telegram = (config.telegram ?? {}) as Record<string, unknown>;
   const discord = (config.discord ?? {}) as Record<string, unknown>;
+  const slack = (config.slack ?? {}) as Record<string, unknown>;
   const signal = (config.signal ?? {}) as Record<string, unknown>;
   const imessage = (config.imessage ?? {}) as Record<string, unknown>;
   const toList = (value: unknown) =>


### PR DESCRIPTION
## Summary
- Fixes `ReferenceError: slack is not defined` error in the web dashboard
- The `slack` config was never extracted from `snapshot.config` in `applyConfigSnapshot()`, unlike `telegram`/`discord`/`signal`/`imessage`

## Changes
Added the missing variable declaration in `ui/src/ui/controllers/config.ts`:
```typescript
const slack = (config.slack ?? {}) as Record<string, unknown>;
```

## Testing
- UI build passes (`pnpm build` in `ui/`)
- Dashboard loads without ReferenceError