### PR TITLE
fix(slack): preserve thread context in auto-replies

### DIFF
--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -738,7 +738,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
     // Only thread replies if the incoming message was in a thread.
     const incomingThreadTs = message.thread_ts;
-
     const dispatcher = createReplyDispatcher({
       responsePrefix: cfg.messages?.responsePrefix,
       deliver: async (payload) => {


### PR DESCRIPTION
## Summary
When replying to a message in a Slack thread, the response now stays in the thread instead of going to the channel root.

## Changes
- Added optional `threadTs` parameter to `deliverReplies`
- Passes `ctxPayload.ReplyToId` (which contains `thread_ts ?? ts`) through to message delivery
- Removes hardcoded `const threadTs = undefined` in favor of using the passed value

## Testing
- Existing Slack tests pass
- Tested manually in GUMBO workspace

Fixes #250