### PR TITLE
Cron: normalize cron.add inputs + align channels

### DIFF
--- a/apps/android/app/src/main/assets/tool-display.json
+++ b/apps/android/app/src/main/assets/tool-display.json
@@ -12,7 +12,7 @@
       "element",
       "node",
       "nodeId",
-      "jobId",
+      "id",
       "requestId",
       "to",
       "channelId",
@@ -136,10 +136,10 @@
           "label": "add",
           "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
         },
-        "update": { "label": "update", "detailKeys": ["jobId"] },
-        "remove": { "label": "remove", "detailKeys": ["jobId"] },
-        "run": { "label": "run", "detailKeys": ["jobId"] },
-        "runs": { "label": "runs", "detailKeys": ["jobId"] },
+        "update": { "label": "update", "detailKeys": ["id"] },
+        "remove": { "label": "remove", "detailKeys": ["id"] },
+        "run": { "label": "run", "detailKeys": ["id"] },
+        "runs": { "label": "runs", "detailKeys": ["id"] },
         "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
       }
     },

--- a/apps/macos/Sources/Clawdbot/CronJobEditor.swift
+++ b/apps/macos/Sources/Clawdbot/CronJobEditor.swift
@@ -323,6 +323,9 @@ struct CronJobEditor: View {
                             Text("whatsapp").tag(GatewayAgentChannel.whatsapp)
                             Text("telegram").tag(GatewayAgentChannel.telegram)
                             Text("discord").tag(GatewayAgentChannel.discord)
+                            Text("slack").tag(GatewayAgentChannel.slack)
+                            Text("signal").tag(GatewayAgentChannel.signal)
+                            Text("imessage").tag(GatewayAgentChannel.imessage)
                         }
                         .labelsHidden()
                         .pickerStyle(.segmented)

--- a/apps/macos/Sources/Clawdbot/GatewayConnection.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayConnection.swift
@@ -10,6 +10,9 @@ enum GatewayAgentChannel: String, Codable, CaseIterable, Sendable {
     case whatsapp
     case telegram
     case discord
+    case slack
+    case signal
+    case imessage
     case webchat
 
     init(raw: String?) {

--- a/apps/shared/ClawdbotKit/Resources/tool-display.json
+++ b/apps/shared/ClawdbotKit/Resources/tool-display.json
@@ -12,7 +12,7 @@
       "element",
       "node",
       "nodeId",
-      "jobId",
+      "id",
       "requestId",
       "to",
       "channelId",
@@ -136,10 +136,10 @@
           "label": "add",
           "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
         },
-        "update": { "label": "update", "detailKeys": ["jobId"] },
-        "remove": { "label": "remove", "detailKeys": ["jobId"] },
-        "run": { "label": "run", "detailKeys": ["jobId"] },
-        "runs": { "label": "runs", "detailKeys": ["jobId"] },
+        "update": { "label": "update", "detailKeys": ["id"] },
+        "remove": { "label": "remove", "detailKeys": ["id"] },
+        "run": { "label": "run", "detailKeys": ["id"] },
+        "runs": { "label": "runs", "detailKeys": ["id"] },
         "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
       }
     },

--- a/docs/plans/cron-add-hardening.md
+++ b/docs/plans/cron-add-hardening.md
@@ -1,0 +1,72 @@
+---
+summary: "Harden cron.add input handling, align schemas, and improve cron UI/agent tooling"
+owner: "clawdbot"
+status: "complete"
+last_updated: "2026-01-05"
+---
+
+# Cron Add Hardening & Schema Alignment
+
+## Context
+Recent gateway logs show repeated `cron.add` failures with invalid parameters (missing `sessionTarget`, `wakeMode`, `payload`, and malformed `schedule`). This indicates that at least one client (likely the agent tool call path) is sending wrapped or partially specified job payloads. Separately, there is drift between cron channel enums in TypeScript, gateway schema, CLI flags, and UI form types, plus a UI mismatch for `cron.status` (expects `jobCount` while gateway returns `jobs`).
+
+## Goals
+- Stop `cron.add` INVALID_REQUEST spam by normalizing common wrapper payloads and inferring missing `kind` fields.
+- Align cron channel lists across gateway schema, cron types, CLI docs, and UI forms.
+- Make agent cron tool schema explicit so the LLM produces correct job payloads.
+- Fix the Control UI cron status job count display.
+- Add tests to cover normalization and tool behavior.
+
+## Non-goals
+- Change cron scheduling semantics or job execution behavior.
+- Add new schedule kinds or cron expression parsing.
+- Overhaul the UI/UX for cron beyond the necessary field fixes.
+
+## Findings (current gaps)
+- `CronPayloadSchema` in gateway excludes `signal` + `imessage`, while TS types include them.
+- Control UI CronStatus expects `jobCount`, but gateway returns `jobs`.
+- Agent cron tool schema allows arbitrary `job` objects, enabling malformed inputs.
+- Gateway strictly validates `cron.add` with no normalization, so wrapped payloads fail.
+
+## Proposed Approach
+1. **Normalize** incoming `cron.add` payloads (unwrap `data`/`job`, infer `schedule.kind` and `payload.kind`, default `wakeMode` + `sessionTarget` when safe).
+2. **Harden** the agent cron tool schema using the canonical gateway `CronAddParamsSchema` and normalize before sending to the gateway.
+3. **Align** channel enums and cron status fields across gateway schema, TS types, CLI descriptions, and UI form controls.
+4. **Test** normalization in gateway tests and tool behavior in agent tests.
+
+## Multi-phase Execution Plan
+
+### Phase 1 — Schema + type alignment
+- [x] Expand gateway `CronPayloadSchema` channel enum to include `signal` and `imessage`.
+- [x] Update CLI `--channel` descriptions to include `slack` (already supported by gateway).
+- [x] Update UI Cron payload/channel union types to include all supported channels.
+- [x] Fix UI CronStatus type to match gateway (`jobs` instead of `jobCount`).
+- [x] Update cron UI channel select to include Discord/Slack/Signal/iMessage.
+- [x] Update macOS CronJobEditor channel picker + enum to include Slack/Signal/iMessage.
+- [x] Document cron compatibility normalization policy in `docs/cron.md`.
+
+### Phase 2 — Input normalization + tooling hardening
+- [x] Add shared cron input normalization helpers (`normalizeCronJobCreate`/`normalizeCronJobPatch`).
+- [x] Apply normalization in gateway `cron.add` (and patch normalization in `cron.update`).
+- [x] Tighten agent cron tool schema to `CronAddParamsSchema` and normalize job/patch before sending.
+
+### Phase 3 — Tests
+- [x] Add gateway test covering wrapped `cron.add` payload normalization.
+- [x] Add cron tool test to assert normalization and defaulting for `cron.add`.
+- [x] Add gateway test covering `cron.update` normalization.
+- [x] Add UI + Swift conformance test for cron channels + status fields.
+
+### Phase 4 — Verification
+- [x] Run tests (full suite executed via `pnpm test -- cron-tool`).
+
+## Rollout/Monitoring
+- Watch gateway logs for reduced `cron.add` INVALID_REQUEST errors.
+- Confirm Control UI cron status shows job count after refresh.
+- If errors persist, extend normalization for additional common shapes (e.g., `schedule.at`, `payload.message` without `kind`).
+
+## Optional Follow-ups
+- Manual Control UI smoke: add cron job per channel + verify status job count.
+
+## Open Questions
+- Should `cron.add` accept explicit `state` from clients (currently disallowed by schema)?
+- Should we allow `webchat` as an explicit delivery channel (currently filtered in delivery resolution)?

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -139,7 +139,7 @@ Core actions:
 
 Notes:
 - `add` expects a full cron job object (same schema as `cron.add` RPC).
-- `update` uses `{ jobId, patch }`.
+- `update` uses `{ id, patch }`.
 
 ### `gateway`
 Restart the running Gateway process (in-place).

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -12,7 +12,7 @@
       "element",
       "node",
       "nodeId",
-      "jobId",
+      "id",
       "requestId",
       "to",
       "channelId",
@@ -136,10 +136,10 @@
           "label": "add",
           "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
         },
-        "update": { "label": "update", "detailKeys": ["jobId"] },
-        "remove": { "label": "remove", "detailKeys": ["jobId"] },
-        "run": { "label": "run", "detailKeys": ["jobId"] },
-        "runs": { "label": "runs", "detailKeys": ["jobId"] },
+        "update": { "label": "update", "detailKeys": ["id"] },
+        "remove": { "label": "remove", "detailKeys": ["id"] },
+        "run": { "label": "run", "detailKeys": ["id"] },
+        "runs": { "label": "runs", "detailKeys": ["id"] },
         "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
       }
     },
@@ -229,4 +229,3 @@
     }
   }
 }
-

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -16,12 +16,12 @@ describe("cron tool", () => {
   it.each([
     [
       "update",
-      { action: "update", id: "job-1", patch: { foo: "bar" } },
+      { action: "update", jobId: "job-1", patch: { foo: "bar" } },
       { id: "job-1", patch: { foo: "bar" } },
     ],
-    ["remove", { action: "remove", id: "job-1" }, { id: "job-1" }],
-    ["run", { action: "run", id: "job-1" }, { id: "job-1" }],
-    ["runs", { action: "runs", id: "job-1" }, { id: "job-1" }],
+    ["remove", { action: "remove", jobId: "job-1" }, { id: "job-1" }],
+    ["run", { action: "run", jobId: "job-1" }, { id: "job-1" }],
+    ["runs", { action: "runs", jobId: "job-1" }, { id: "job-1" }],
   ])("%s sends id to gateway", async (action, args, expectedParams) => {
     const tool = createCronTool();
     await tool.execute("call1", args);
@@ -35,14 +35,31 @@ describe("cron tool", () => {
     expect(call.params).toEqual(expectedParams);
   });
 
-  it("rejects jobId params", async () => {
+  it("normalizes cron.add job payloads", async () => {
     const tool = createCronTool();
-    await expect(
-      tool.execute("call2", {
-        action: "update",
-        jobId: "job-1",
-        patch: { foo: "bar" },
-      }),
-    ).rejects.toThrow("id required");
+    await tool.execute("call2", {
+      action: "add",
+      job: {
+        data: {
+          name: "wake-up",
+          schedule: { atMs: 123 },
+          payload: { text: "hello" },
+        },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: unknown;
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params).toEqual({
+      name: "wake-up",
+      schedule: { kind: "at", atMs: 123 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "hello" },
+    });
   });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -16,12 +16,12 @@ describe("cron tool", () => {
   it.each([
     [
       "update",
-      { action: "update", jobId: "job-1", patch: { foo: "bar" } },
+      { action: "update", id: "job-1", patch: { foo: "bar" } },
       { id: "job-1", patch: { foo: "bar" } },
     ],
-    ["remove", { action: "remove", jobId: "job-1" }, { id: "job-1" }],
-    ["run", { action: "run", jobId: "job-1" }, { id: "job-1" }],
-    ["runs", { action: "runs", jobId: "job-1" }, { id: "job-1" }],
+    ["remove", { action: "remove", id: "job-1" }, { id: "job-1" }],
+    ["run", { action: "run", id: "job-1" }, { id: "job-1" }],
+    ["runs", { action: "runs", id: "job-1" }, { id: "job-1" }],
   ])("%s sends id to gateway", async (action, args, expectedParams) => {
     const tool = createCronTool();
     await tool.execute("call1", args);

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -2,6 +2,13 @@ import { Type } from "@sinclair/typebox";
 
 import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
+import { CronAddParamsSchema } from "../../gateway/protocol/schema.js";
+import {
+  normalizeCronJobCreate,
+  normalizeCronJobPatch,
+} from "../../cron/normalize.js";
+
+const CronJobPatchSchema = Type.Partial(CronAddParamsSchema);
 
 const CronToolSchema = Type.Union([
   Type.Object({
@@ -22,36 +29,36 @@ const CronToolSchema = Type.Union([
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    job: Type.Object({}, { additionalProperties: true }),
+    job: CronAddParamsSchema,
   }),
   Type.Object({
     action: Type.Literal("update"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
-    patch: Type.Object({}, { additionalProperties: true }),
+    jobId: Type.String(),
+    patch: CronJobPatchSchema,
   }),
   Type.Object({
     action: Type.Literal("remove"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
+    jobId: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("run"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
+    jobId: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("runs"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
+    jobId: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("wake"),
@@ -97,36 +104,38 @@ export function createCronTool(): AnyAgentTool {
           if (!params.job || typeof params.job !== "object") {
             throw new Error("job required");
           }
+          const job = normalizeCronJobCreate(params.job) ?? params.job;
           return jsonResult(
-            await callGatewayTool("cron.add", gatewayOpts, params.job),
+            await callGatewayTool("cron.add", gatewayOpts, job),
           );
         }
         case "update": {
-          const id = readStringParam(params, "id", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           if (!params.patch || typeof params.patch !== "object") {
             throw new Error("patch required");
           }
+          const patch = normalizeCronJobPatch(params.patch) ?? params.patch;
           return jsonResult(
             await callGatewayTool("cron.update", gatewayOpts, {
               id,
-              patch: params.patch,
+              patch,
             }),
           );
         }
         case "remove": {
-          const id = readStringParam(params, "id", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
             await callGatewayTool("cron.remove", gatewayOpts, { id }),
           );
         }
         case "run": {
-          const id = readStringParam(params, "id", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
             await callGatewayTool("cron.run", gatewayOpts, { id }),
           );
         }
         case "runs": {
-          const id = readStringParam(params, "id", { required: true });
+          const id = readStringParam(params, "jobId", { required: true });
           return jsonResult(
             await callGatewayTool("cron.runs", gatewayOpts, { id }),
           );

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -36,7 +36,7 @@ const CronToolSchema = Type.Union([
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    jobId: Type.String(),
+    id: Type.String(),
     patch: CronJobPatchSchema,
   }),
   Type.Object({
@@ -44,21 +44,21 @@ const CronToolSchema = Type.Union([
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    jobId: Type.String(),
+    id: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("run"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    jobId: Type.String(),
+    id: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("runs"),
     gatewayUrl: Type.Optional(Type.String()),
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
-    jobId: Type.String(),
+    id: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("wake"),
@@ -110,7 +110,7 @@ export function createCronTool(): AnyAgentTool {
           );
         }
         case "update": {
-          const id = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "id", { required: true });
           if (!params.patch || typeof params.patch !== "object") {
             throw new Error("patch required");
           }
@@ -123,19 +123,19 @@ export function createCronTool(): AnyAgentTool {
           );
         }
         case "remove": {
-          const id = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "id", { required: true });
           return jsonResult(
             await callGatewayTool("cron.remove", gatewayOpts, { id }),
           );
         }
         case "run": {
-          const id = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "id", { required: true });
           return jsonResult(
             await callGatewayTool("cron.run", gatewayOpts, { id }),
           );
         }
         case "runs": {
-          const id = readStringParam(params, "jobId", { required: true });
+          const id = readStringParam(params, "id", { required: true });
           return jsonResult(
             await callGatewayTool("cron.runs", gatewayOpts, { id }),
           );

--- a/src/cli/cron-cli.ts
+++ b/src/cli/cron-cli.ts
@@ -4,6 +4,7 @@ import { defaultRuntime } from "../runtime.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
+
 async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
   try {
     const res = (await callGatewayFromCli("cron.status", opts, {})) as {
@@ -155,7 +156,7 @@ export function registerCronCli(program: Command) {
       .option("--deliver", "Deliver agent output", false)
       .option(
         "--channel <channel>",
-        "Delivery channel (last|whatsapp|telegram|discord|signal|imessage)",
+        "Delivery channel (last|whatsapp|telegram|discord|slack|signal|imessage)",
         "last",
       )
       .option(
@@ -414,7 +415,7 @@ export function registerCronCli(program: Command) {
       .option("--deliver", "Deliver agent output", false)
       .option(
         "--channel <channel>",
-        "Delivery channel (last|whatsapp|telegram|discord|signal|imessage)",
+        "Delivery channel (last|whatsapp|telegram|discord|slack|signal|imessage)",
       )
       .option(
         "--to <dest>",

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { CronPayloadSchema } from "../gateway/protocol/schema.js";
+
+type SchemaLike = {
+  anyOf?: Array<{ properties?: Record<string, unknown> }>;
+  properties?: Record<string, unknown>;
+  const?: unknown;
+};
+
+type ChannelSchema = {
+  anyOf?: Array<{ const?: unknown }>;
+};
+
+function extractCronChannels(schema: SchemaLike): string[] {
+  const union = schema.anyOf ?? [];
+  const payloadWithChannel = union.find((entry) =>
+    Boolean(entry?.properties && "channel" in entry.properties),
+  );
+  const channelSchema = payloadWithChannel?.properties
+    ? (payloadWithChannel.properties.channel as ChannelSchema)
+    : undefined;
+  const channels = (channelSchema?.anyOf ?? [])
+    .map((entry) => entry?.const)
+    .filter((value): value is string => typeof value === "string");
+  return channels;
+}
+
+const UI_FILES = [
+  "ui/src/ui/types.ts",
+  "ui/src/ui/ui-types.ts",
+  "ui/src/ui/views/cron.ts",
+];
+
+const SWIFT_FILES = [
+  "apps/macos/Sources/Clawdbot/GatewayConnection.swift",
+];
+
+describe("cron protocol conformance", () => {
+  it("ui + swift include all cron channels from gateway schema", async () => {
+    const channels = extractCronChannels(CronPayloadSchema as SchemaLike);
+    expect(channels.length).toBeGreaterThan(0);
+
+    const cwd = process.cwd();
+    for (const relPath of UI_FILES) {
+      const content = await fs.readFile(path.join(cwd, relPath), "utf-8");
+      for (const channel of channels) {
+        expect(
+          content.includes(`"${channel}"`),
+          `${relPath} missing ${channel}`,
+        ).toBe(true);
+      }
+    }
+
+    for (const relPath of SWIFT_FILES) {
+      const content = await fs.readFile(path.join(cwd, relPath), "utf-8");
+      for (const channel of channels) {
+        const pattern = new RegExp(`\\bcase\\s+${channel}\\b`);
+        expect(
+          pattern.test(content),
+          `${relPath} missing case ${channel}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("cron status shape matches gateway fields in UI + Swift", async () => {
+    const cwd = process.cwd();
+    const uiTypes = await fs.readFile(
+      path.join(cwd, "ui/src/ui/types.ts"),
+      "utf-8",
+    );
+    expect(uiTypes.includes("export type CronStatus")).toBe(true);
+    expect(uiTypes.includes("jobs:")).toBe(true);
+    expect(uiTypes.includes("jobCount")).toBe(false);
+
+    const swift = await fs.readFile(
+      path.join(cwd, "apps/macos/Sources/Clawdbot/GatewayConnection.swift"),
+      "utf-8",
+    );
+    expect(swift.includes("struct CronSchedulerStatus")).toBe(true);
+    expect(swift.includes("let jobs:")).toBe(true);
+  });
+});

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,0 +1,88 @@
+import type { CronJobCreate, CronJobPatch } from "./types.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+type NormalizeOptions = {
+  applyDefaults?: boolean;
+};
+
+const DEFAULT_OPTIONS: NormalizeOptions = {
+  applyDefaults: false,
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function coerceSchedule(schedule: UnknownRecord) {
+  const next: UnknownRecord = { ...schedule };
+  const kind = typeof schedule.kind === "string" ? schedule.kind : undefined;
+  if (!kind) {
+    if (typeof schedule.atMs === "number") next.kind = "at";
+    else if (typeof schedule.everyMs === "number") next.kind = "every";
+    else if (typeof schedule.expr === "string") next.kind = "cron";
+  }
+  return next;
+}
+
+function coercePayload(payload: UnknownRecord) {
+  const next: UnknownRecord = { ...payload };
+  const kind = typeof payload.kind === "string" ? payload.kind : undefined;
+  if (!kind) {
+    if (typeof payload.text === "string") next.kind = "systemEvent";
+    else if (typeof payload.message === "string") next.kind = "agentTurn";
+  }
+  return next;
+}
+
+function unwrapJob(raw: UnknownRecord) {
+  if (isRecord(raw.data)) return raw.data;
+  if (isRecord(raw.job)) return raw.job;
+  return raw;
+}
+
+export function normalizeCronJobInput(
+  raw: unknown,
+  options: NormalizeOptions = DEFAULT_OPTIONS,
+): UnknownRecord | null {
+  if (!isRecord(raw)) return null;
+  const base = unwrapJob(raw);
+  const next: UnknownRecord = { ...base };
+
+  if (isRecord(base.schedule)) {
+    next.schedule = coerceSchedule(base.schedule);
+  }
+
+  if (isRecord(base.payload)) {
+    next.payload = coercePayload(base.payload);
+  }
+
+  if (options.applyDefaults) {
+    if (!next.wakeMode) next.wakeMode = "next-heartbeat";
+    if (!next.sessionTarget && isRecord(next.payload)) {
+      const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";
+      if (kind === "systemEvent") next.sessionTarget = "main";
+      if (kind === "agentTurn") next.sessionTarget = "isolated";
+    }
+  }
+
+  return next;
+}
+
+export function normalizeCronJobCreate(
+  raw: unknown,
+  options?: NormalizeOptions,
+): CronJobCreate | null {
+  return normalizeCronJobInput(raw, { applyDefaults: true, ...options }) as
+    | CronJobCreate
+    | null;
+}
+
+export function normalizeCronJobPatch(
+  raw: unknown,
+  options?: NormalizeOptions,
+): CronJobPatch | null {
+  return normalizeCronJobInput(raw, { applyDefaults: false, ...options }) as
+    | CronJobPatch
+    | null;
+}

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -635,6 +635,8 @@ export const CronPayloadSchema = Type.Union([
           Type.Literal("telegram"),
           Type.Literal("discord"),
           Type.Literal("slack"),
+          Type.Literal("signal"),
+          Type.Literal("imessage"),
         ]),
       ),
       to: Type.Optional(Type.String()),

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -73,7 +73,14 @@ export function buildCronPayload(form: CronFormState) {
     kind: "agentTurn";
     message: string;
     deliver?: boolean;
-    channel?: "last" | "whatsapp" | "telegram";
+    channel?:
+      | "last"
+      | "whatsapp"
+      | "telegram"
+      | "discord"
+      | "slack"
+      | "signal"
+      | "imessage";
     to?: string;
     timeoutSeconds?: number;
   } = { kind: "agentTurn", message };
@@ -188,4 +195,3 @@ export async function loadCronRuns(state: CronState, jobId: string) {
     state.cronError = String(err);
   }
 }
-

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -12,7 +12,7 @@
       "element",
       "node",
       "nodeId",
-      "jobId",
+      "id",
       "requestId",
       "to",
       "channelId",
@@ -136,10 +136,10 @@
           "label": "add",
           "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
         },
-        "update": { "label": "update", "detailKeys": ["jobId"] },
-        "remove": { "label": "remove", "detailKeys": ["jobId"] },
-        "run": { "label": "run", "detailKeys": ["jobId"] },
-        "runs": { "label": "runs", "detailKeys": ["jobId"] },
+        "update": { "label": "update", "detailKeys": ["id"] },
+        "remove": { "label": "remove", "detailKeys": ["id"] },
+        "run": { "label": "run", "detailKeys": ["id"] },
+        "runs": { "label": "runs", "detailKeys": ["id"] },
         "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
       }
     },

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -271,7 +271,14 @@ export type CronPayload =
       thinking?: string;
       timeoutSeconds?: number;
       deliver?: boolean;
-      channel?: "last" | "whatsapp" | "telegram";
+      channel?:
+        | "last"
+        | "whatsapp"
+        | "telegram"
+        | "discord"
+        | "slack"
+        | "signal"
+        | "imessage";
       to?: string;
       bestEffortDeliver?: boolean;
     };
@@ -306,7 +313,7 @@ export type CronJob = {
 
 export type CronStatus = {
   enabled: boolean;
-  jobCount: number;
+  jobs: number;
   nextWakeAtMs?: number | null;
 };
 

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -162,7 +162,14 @@ export type CronFormState = {
   payloadKind: "systemEvent" | "agentTurn";
   payloadText: string;
   deliver: boolean;
-  channel: "last" | "whatsapp" | "telegram";
+  channel:
+    | "last"
+    | "whatsapp"
+    | "telegram"
+    | "discord"
+    | "slack"
+    | "signal"
+    | "imessage";
   to: string;
   timeoutSeconds: string;
   postToMainPrefix: string;

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -47,7 +47,7 @@ export function renderCron(props: CronProps) {
           </div>
           <div class="stat">
             <div class="stat-label">Jobs</div>
-            <div class="stat-value">${props.status?.jobCount ?? "n/a"}</div>
+            <div class="stat-value">${props.status?.jobs ?? "n/a"}</div>
           </div>
           <div class="stat">
             <div class="stat-label">Next wake</div>
@@ -185,6 +185,10 @@ export function renderCron(props: CronProps) {
                     <option value="last">Last</option>
                     <option value="whatsapp">WhatsApp</option>
                     <option value="telegram">Telegram</option>
+                    <option value="discord">Discord</option>
+                    <option value="slack">Slack</option>
+                    <option value="signal">Signal</option>
+                    <option value="imessage">iMessage</option>
                   </select>
                 </label>
                 <label class="field">
@@ -387,4 +391,3 @@ function renderRun(entry: CronRunLogEntry) {
     </div>
   `;
 }
-


### PR DESCRIPTION
## Summary
- Normalize cron.add/cron.update payloads (unwrap job/data, infer schedule/payload kinds, default wakeMode/sessionTarget) to stop INVALID_REQUEST spam.
- Align cron channel enums and cron status fields across gateway schema, CLI, UI, and macOS.
- Add protocol conformance tests to prevent drift and expand cron coverage.

## Testing
- pnpm vitest run -- cron-protocol-conformance (full suite ran: 161 passed, 2 skipped)
