### PR TITLE
fix(discord): include channel_id in message body

### DIFF
--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -417,12 +417,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         isGuildMessage && channelSlug ? `#${channelSlug}` : undefined;
       const groupSubject = isDirectMessage ? undefined : groupRoom;
       const messageText = text;
-      const bodyWithHints = `${messageText}\n[channel_id: ${message.channelId}]`;
       let combinedBody = formatAgentEnvelope({
         surface: "Discord",
         from: fromLabel,
         timestamp: message.createdTimestamp,
-        body: bodyWithHints,
+        body: messageText,
       });
       let shouldClearHistory = false;
       if (!isDirectMessage) {
@@ -494,9 +493,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         From: isDirectMessage
           ? `discord:${message.author.id}`
           : `group:${message.channelId}`,
-        To: isDirectMessage
-          ? `user:${message.author.id}`
-          : `channel:${message.channelId}`,
+        To: `channel:${message.channelId}`,
         ChatType: isDirectMessage ? "direct" : "group",
         SenderName: message.member?.displayName ?? message.author.tag,
         SenderId: message.author.id,

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -417,11 +417,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         isGuildMessage && channelSlug ? `#${channelSlug}` : undefined;
       const groupSubject = isDirectMessage ? undefined : groupRoom;
       const messageText = text;
+      const bodyWithHints = `${messageText}\n[channel_id: ${message.channelId}]`;
       let combinedBody = formatAgentEnvelope({
         surface: "Discord",
         from: fromLabel,
         timestamp: message.createdTimestamp,
-        body: messageText,
+        body: bodyWithHints,
       });
       let shouldClearHistory = false;
       if (!isDirectMessage) {


### PR DESCRIPTION
## Context
When receiving DMs, the context passed to the agent lacks the DM channel ID (using `user:<id>` instead). This prevents the agent from using tools like `discord react` which require a valid `channelId`.

## Fix
Appends `[channel_id: <id>]` to the message body in `formatAgentEnvelope`. This ensures the channel ID is always available in the agent's context window, whether it's a guild channel or a DM.

Closes #260