### PR TITLE
fix(auth): prioritize round-robin over lastGood for multi-account rotation

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -453,7 +453,10 @@ export function resolveAuthProfileOrder(params: {
   if (configuredOrder && configuredOrder.length > 0) {
     // Still put preferredProfile first if specified
     if (preferredProfile && deduped.includes(preferredProfile)) {
-      return [preferredProfile, ...deduped.filter((e) => e !== preferredProfile)];
+      return [
+        preferredProfile,
+        ...deduped.filter((e) => e !== preferredProfile),
+      ];
     }
     return deduped;
   }

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -433,19 +433,14 @@ export function resolveAuthProfileOrder(params: {
         .filter(([, profile]) => profile.provider === provider)
         .map(([profileId]) => profileId)
     : [];
-  const lastGood = store.lastGood?.[provider];
   const baseOrder =
     configuredOrder ??
     (explicitProfiles.length > 0
       ? explicitProfiles
       : listProfilesForProvider(store, provider));
   if (baseOrder.length === 0) return [];
-  const order =
-    configuredOrder && configuredOrder.length > 0
-      ? baseOrder
-      : orderProfilesByMode(baseOrder, store);
 
-  const filtered = order.filter((profileId) => {
+  const filtered = baseOrder.filter((profileId) => {
     const cred = store.profiles[profileId];
     return cred ? cred.provider === provider : true;
   });
@@ -453,21 +448,26 @@ export function resolveAuthProfileOrder(params: {
   for (const entry of filtered) {
     if (!deduped.includes(entry)) deduped.push(entry);
   }
-  if (preferredProfile && deduped.includes(preferredProfile)) {
-    const rest = deduped.filter((entry) => entry !== preferredProfile);
-    if (lastGood && rest.includes(lastGood)) {
-      return [
-        preferredProfile,
-        lastGood,
-        ...rest.filter((entry) => entry !== lastGood),
-      ];
+
+  // If user specified explicit order in config, respect it exactly
+  if (configuredOrder && configuredOrder.length > 0) {
+    // Still put preferredProfile first if specified
+    if (preferredProfile && deduped.includes(preferredProfile)) {
+      return [preferredProfile, ...deduped.filter((e) => e !== preferredProfile)];
     }
-    return [preferredProfile, ...rest];
+    return deduped;
   }
-  if (lastGood && deduped.includes(lastGood)) {
-    return [lastGood, ...deduped.filter((entry) => entry !== lastGood)];
+
+  // Otherwise, use round-robin: sort by lastUsed (oldest first)
+  // preferredProfile goes first if specified (for explicit user choice)
+  // lastGood is NOT prioritized - that would defeat round-robin
+  const sorted = orderProfilesByMode(deduped, store);
+
+  if (preferredProfile && sorted.includes(preferredProfile)) {
+    return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
   }
-  return deduped;
+
+  return sorted;
 }
 
 function orderProfilesByMode(


### PR DESCRIPTION
## Summary

Fixes multi-account OAuth rotation so accounts actually alternate instead of always using the same one.

## Problem

When multiple OAuth accounts are configured for a provider (e.g., 2 Google Antigravity accounts), the round-robin rotation was not working. All requests used the same account.

## Root Cause

In `resolveAuthProfileOrder()`, the code checked `lastGood` after sorting and always put it first:

```javascript
if (lastGood && deduped.includes(lastGood)) {
    return [lastGood, ...deduped.filter((entry) => entry !== lastGood)];
}
```

Once any profile succeeded (became `lastGood`), it would always be selected first, defeating the round-robin logic entirely.

## Solution

- Remove `lastGood` prioritization - let round-robin handle selection
- Only use explicit `configuredOrder` when user specifies it in config  
- `orderProfilesByMode()` now always runs, sorting by `lastUsed` (oldest first)
- `preferredProfile` still takes priority (for explicit user choice)

## Note on clawdbot configure

Currently `clawdbot configure` automatically creates an `auth.order` key when adding multiple accounts. This explicit order takes precedence over round-robin (by design - explicit config = user intent).

Users who want round-robin should remove the `order` key from their `clawdbot.json`:

```json
"auth": {
  "profiles": { ... },
  "order": { ... }  // <- remove this for round-robin
}
```

A follow-up issue could update the configure wizard to not create order by default.

## Testing

Tested with 2 Google Antigravity accounts. Verified alternating usage - each request picks the account with oldest lastUsed timestamp.

## Related

Follow-up fix to PR #269 (multi-account OAuth support).