### PR TITLE
fix(cron-tool): flatten schema to avoid nested anyOf for google-antigravity

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -16,8 +16,9 @@ describe("cron tool", () => {
   it.each([
     [
       "update",
-      { action: "update", id: "job-1", patch: { foo: "bar" } },
-      { id: "job-1", patch: { foo: "bar" } },
+      // Flattened schema: patch fields are at the top level
+      { action: "update", id: "job-1", name: "new-name" },
+      { id: "job-1", patch: { name: "new-name" } },
     ],
     ["remove", { action: "remove", id: "job-1" }, { id: "job-1" }],
     ["run", { action: "run", id: "job-1" }, { id: "job-1" }],
@@ -37,15 +38,16 @@ describe("cron tool", () => {
 
   it("normalizes cron.add job payloads", async () => {
     const tool = createCronTool();
+    // Flattened schema: job fields are at the top level with prefixes
     await tool.execute("call2", {
       action: "add",
-      job: {
-        data: {
-          name: "wake-up",
-          schedule: { atMs: 123 },
-          payload: { text: "hello" },
-        },
-      },
+      name: "wake-up",
+      scheduleKind: "at",
+      scheduleAtMs: 123,
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payloadKind: "systemEvent",
+      payloadText: "hello",
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -60,6 +62,42 @@ describe("cron tool", () => {
       sessionTarget: "main",
       wakeMode: "next-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
+    });
+  });
+
+  it("handles agentTurn payload with optional fields", async () => {
+    const tool = createCronTool();
+    await tool.execute("call3", {
+      action: "add",
+      name: "daily-check",
+      scheduleKind: "cron",
+      scheduleCronExpr: "0 9 * * *",
+      scheduleTz: "Europe/Vienna",
+      sessionTarget: "main",
+      wakeMode: "now",
+      payloadKind: "agentTurn",
+      payloadMessage: "Good morning!",
+      payloadChannel: "telegram",
+      payloadDeliver: true,
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: unknown;
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params).toEqual({
+      name: "daily-check",
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "Europe/Vienna" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "Good morning!",
+        channel: "telegram",
+        deliver: true,
+      },
     });
   });
 });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -3,80 +3,262 @@ import {
   normalizeCronJobCreate,
   normalizeCronJobPatch,
 } from "../../cron/normalize.js";
-import { CronAddParamsSchema } from "../../gateway/protocol/schema.js";
 import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
 
-const CronJobPatchSchema = Type.Partial(CronAddParamsSchema);
+// Flattened schema for LLM tool use - avoids nested anyOf unions that fail
+// strict JSON Schema validation on some providers (e.g., google-antigravity).
+// Uses string enums instead of Type.Union([Type.Literal()]) to produce cleaner
+// JSON Schema without anyOf constructs.
+// The execute() function validates the actual structure at runtime.
+const CronToolSchema = Type.Object({
+  action: Type.String({
+    enum: ["status", "list", "add", "update", "remove", "run", "runs", "wake"],
+  }),
+  gatewayUrl: Type.Optional(Type.String()),
+  gatewayToken: Type.Optional(Type.String()),
+  timeoutMs: Type.Optional(Type.Number()),
 
-const CronToolSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("status"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-  }),
-  Type.Object({
-    action: Type.Literal("list"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    includeDisabled: Type.Optional(Type.Boolean()),
-  }),
-  Type.Object({
-    action: Type.Literal("add"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    job: CronAddParamsSchema,
-  }),
-  Type.Object({
-    action: Type.Literal("update"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
-    patch: CronJobPatchSchema,
-  }),
-  Type.Object({
-    action: Type.Literal("remove"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
-  }),
-  Type.Object({
-    action: Type.Literal("run"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
-  }),
-  Type.Object({
-    action: Type.Literal("runs"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    id: Type.String(),
-  }),
-  Type.Object({
-    action: Type.Literal("wake"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-    text: Type.String(),
-    mode: Type.Optional(
-      Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
-    ),
-  }),
-]);
+  // For "list" action
+  includeDisabled: Type.Optional(Type.Boolean()),
+
+  // For "update", "remove", "run", "runs" actions
+  id: Type.Optional(Type.String()),
+
+  // For "wake" action
+  text: Type.Optional(Type.String()),
+  mode: Type.Optional(Type.String({ enum: ["now", "next-heartbeat"] })),
+
+  // For "add" action - flattened job fields
+  name: Type.Optional(Type.String()),
+  description: Type.Optional(Type.String()),
+  enabled: Type.Optional(Type.Boolean()),
+
+  // Schedule - flattened (kind determines which fields are used)
+  scheduleKind: Type.Optional(Type.String({ enum: ["at", "every", "cron"] })),
+  scheduleAtMs: Type.Optional(Type.Number()),
+  scheduleEveryMs: Type.Optional(Type.Number()),
+  scheduleAnchorMs: Type.Optional(Type.Number()),
+  scheduleCronExpr: Type.Optional(Type.String()),
+  scheduleTz: Type.Optional(Type.String()),
+
+  // Session/wake mode
+  sessionTarget: Type.Optional(Type.String({ enum: ["main", "isolated"] })),
+  wakeMode: Type.Optional(Type.String({ enum: ["next-heartbeat", "now"] })),
+
+  // Payload - flattened (payloadKind determines which fields are used)
+  payloadKind: Type.Optional(
+    Type.String({ enum: ["systemEvent", "agentTurn"] }),
+  ),
+  payloadText: Type.Optional(Type.String()),
+  payloadMessage: Type.Optional(Type.String()),
+  payloadThinking: Type.Optional(Type.String()),
+  payloadTimeoutSeconds: Type.Optional(Type.Number()),
+  payloadDeliver: Type.Optional(Type.Boolean()),
+  payloadChannel: Type.Optional(
+    Type.String({
+      enum: [
+        "last",
+        "whatsapp",
+        "telegram",
+        "discord",
+        "slack",
+        "signal",
+        "imessage",
+      ],
+    }),
+  ),
+  payloadTo: Type.Optional(Type.String()),
+  payloadBestEffortDeliver: Type.Optional(Type.Boolean()),
+
+  // Isolation
+  isolationPostToMainPrefix: Type.Optional(Type.String()),
+
+  // For "update" action - patch fields (same as add fields, all optional)
+  // Uses the same flattened fields as add, applied as a patch
+});
+
+/**
+ * Reconstruct nested job object from flattened params.
+ */
+function buildJobFromFlatParams(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const schedule: Record<string, unknown> = {};
+  const scheduleKind = params.scheduleKind as string | undefined;
+  if (scheduleKind === "at") {
+    schedule.kind = "at";
+    schedule.atMs = params.scheduleAtMs;
+  } else if (scheduleKind === "every") {
+    schedule.kind = "every";
+    schedule.everyMs = params.scheduleEveryMs;
+    if (params.scheduleAnchorMs !== undefined) {
+      schedule.anchorMs = params.scheduleAnchorMs;
+    }
+  } else if (scheduleKind === "cron") {
+    schedule.kind = "cron";
+    schedule.expr = params.scheduleCronExpr;
+    if (params.scheduleTz !== undefined) {
+      schedule.tz = params.scheduleTz;
+    }
+  }
+
+  const payload: Record<string, unknown> = {};
+  const payloadKind = params.payloadKind as string | undefined;
+  if (payloadKind === "systemEvent") {
+    payload.kind = "systemEvent";
+    payload.text = params.payloadText;
+  } else if (payloadKind === "agentTurn") {
+    payload.kind = "agentTurn";
+    payload.message = params.payloadMessage;
+    if (params.payloadThinking !== undefined) {
+      payload.thinking = params.payloadThinking;
+    }
+    if (params.payloadTimeoutSeconds !== undefined) {
+      payload.timeoutSeconds = params.payloadTimeoutSeconds;
+    }
+    if (params.payloadDeliver !== undefined) {
+      payload.deliver = params.payloadDeliver;
+    }
+    if (params.payloadChannel !== undefined) {
+      payload.channel = params.payloadChannel;
+    }
+    if (params.payloadTo !== undefined) {
+      payload.to = params.payloadTo;
+    }
+    if (params.payloadBestEffortDeliver !== undefined) {
+      payload.bestEffortDeliver = params.payloadBestEffortDeliver;
+    }
+  }
+
+  const job: Record<string, unknown> = {
+    name: params.name,
+    schedule,
+    sessionTarget: params.sessionTarget,
+    wakeMode: params.wakeMode,
+    payload,
+  };
+
+  if (params.description !== undefined) {
+    job.description = params.description;
+  }
+  if (params.enabled !== undefined) {
+    job.enabled = params.enabled;
+  }
+  if (params.isolationPostToMainPrefix !== undefined) {
+    job.isolation = { postToMainPrefix: params.isolationPostToMainPrefix };
+  }
+
+  return job;
+}
+
+/**
+ * Build a patch object from flattened params (only includes defined fields).
+ */
+function buildPatchFromFlatParams(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  if (params.name !== undefined) {
+    patch.name = params.name;
+  }
+  if (params.description !== undefined) {
+    patch.description = params.description;
+  }
+  if (params.enabled !== undefined) {
+    patch.enabled = params.enabled;
+  }
+  if (params.sessionTarget !== undefined) {
+    patch.sessionTarget = params.sessionTarget;
+  }
+  if (params.wakeMode !== undefined) {
+    patch.wakeMode = params.wakeMode;
+  }
+
+  // Build schedule if any schedule fields are present
+  const scheduleKind = params.scheduleKind as string | undefined;
+  if (scheduleKind) {
+    const schedule: Record<string, unknown> = { kind: scheduleKind };
+    if (scheduleKind === "at" && params.scheduleAtMs !== undefined) {
+      schedule.atMs = params.scheduleAtMs;
+    } else if (scheduleKind === "every" && params.scheduleEveryMs !== undefined) {
+      schedule.everyMs = params.scheduleEveryMs;
+      if (params.scheduleAnchorMs !== undefined) {
+        schedule.anchorMs = params.scheduleAnchorMs;
+      }
+    } else if (scheduleKind === "cron" && params.scheduleCronExpr !== undefined) {
+      schedule.expr = params.scheduleCronExpr;
+      if (params.scheduleTz !== undefined) {
+        schedule.tz = params.scheduleTz;
+      }
+    }
+    patch.schedule = schedule;
+  }
+
+  // Build payload if any payload fields are present
+  const payloadKind = params.payloadKind as string | undefined;
+  if (payloadKind) {
+    const payload: Record<string, unknown> = { kind: payloadKind };
+    if (payloadKind === "systemEvent" && params.payloadText !== undefined) {
+      payload.text = params.payloadText;
+    } else if (payloadKind === "agentTurn") {
+      if (params.payloadMessage !== undefined) {
+        payload.message = params.payloadMessage;
+      }
+      if (params.payloadThinking !== undefined) {
+        payload.thinking = params.payloadThinking;
+      }
+      if (params.payloadTimeoutSeconds !== undefined) {
+        payload.timeoutSeconds = params.payloadTimeoutSeconds;
+      }
+      if (params.payloadDeliver !== undefined) {
+        payload.deliver = params.payloadDeliver;
+      }
+      if (params.payloadChannel !== undefined) {
+        payload.channel = params.payloadChannel;
+      }
+      if (params.payloadTo !== undefined) {
+        payload.to = params.payloadTo;
+      }
+      if (params.payloadBestEffortDeliver !== undefined) {
+        payload.bestEffortDeliver = params.payloadBestEffortDeliver;
+      }
+    }
+    patch.payload = payload;
+  }
+
+  if (params.isolationPostToMainPrefix !== undefined) {
+    patch.isolation = { postToMainPrefix: params.isolationPostToMainPrefix };
+  }
+
+  return patch;
+}
 
 export function createCronTool(): AnyAgentTool {
   return {
     label: "Cron",
     name: "cron",
-    description:
-      "Manage Gateway cron jobs (status/list/add/update/remove/run/runs) and send wake events.",
+    description: `Manage Gateway cron jobs and send wake events.
+
+Actions:
+- status: Get cron system status
+- list: List all cron jobs (use includeDisabled=true to include disabled jobs)
+- add: Create a new cron job (requires name, scheduleKind, sessionTarget, wakeMode, payloadKind, and related fields)
+- update: Update an existing cron job (requires id, plus any fields to update)
+- remove: Delete a cron job (requires id)
+- run: Manually trigger a cron job (requires id)
+- runs: Get run history for a job (requires id)
+- wake: Send a wake event (requires text, optionally mode=now|next-heartbeat)
+
+Schedule types (set scheduleKind):
+- "at": One-time at scheduleAtMs (epoch ms)
+- "every": Recurring every scheduleEveryMs (ms), optional scheduleAnchorMs
+- "cron": Cron expression in scheduleCronExpr, optional scheduleTz
+
+Payload types (set payloadKind):
+- "systemEvent": Simple event with payloadText
+- "agentTurn": Agent message with payloadMessage, optional payloadThinking, payloadChannel, etc.`,
     parameters: CronToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -100,24 +282,20 @@ export function createCronTool(): AnyAgentTool {
             }),
           );
         case "add": {
-          if (!params.job || typeof params.job !== "object") {
-            throw new Error("job required");
-          }
-          const job = normalizeCronJobCreate(params.job) ?? params.job;
+          const job = buildJobFromFlatParams(params);
+          const normalized = normalizeCronJobCreate(job) ?? job;
           return jsonResult(
-            await callGatewayTool("cron.add", gatewayOpts, job),
+            await callGatewayTool("cron.add", gatewayOpts, normalized),
           );
         }
         case "update": {
           const id = readStringParam(params, "id", { required: true });
-          if (!params.patch || typeof params.patch !== "object") {
-            throw new Error("patch required");
-          }
-          const patch = normalizeCronJobPatch(params.patch) ?? params.patch;
+          const patch = buildPatchFromFlatParams(params);
+          const normalized = normalizeCronJobPatch(patch) ?? patch;
           return jsonResult(
             await callGatewayTool("cron.update", gatewayOpts, {
               id,
-              patch,
+              patch: normalized,
             }),
           );
         }


### PR DESCRIPTION
The cron tool schema used nested `Type.Union()` constructs which compiled to deeply nested `anyOf` structures. Google Cloud Code Assist (`google-antigravity` provider) enforces strict JSON Schema draft 2020-12 validation and rejected these schemas with:

```
Cloud Code Assist API error (400): tools.9.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12
```

## Changes

- Flatten `CronToolSchema` to a single object with all fields at the top level
- Use `Type.String({ enum: [...] })` instead of `Type.Union([Type.Literal()])` to avoid `anyOf`
- Add helper functions (`buildJobFromFlatParams`, `buildPatchFromFlatParams`) to reconstruct nested job/patch objects at runtime
- Improve tool description to document the flattened parameter structure
- Update tests to use the new flattened format

## Before (nested anyOf)
```json
{
  "job": {
    "schedule": { "anyOf": [...] },
    "payload": { "anyOf": [...] }
  }
}
```

## After (flat with enums)
```json
{
  "action": { "type": "string", "enum": ["status", "list", "add", ...] },
  "scheduleKind": { "type": "string", "enum": ["at", "every", "cron"] },
  "scheduleAtMs": { "type": "number" },
  ...
}
```

Fixes #288