### PR TITLE
feat(agent): add skipBootstrap config option

### DIFF
--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -434,7 +434,11 @@ async function dockerContainerState(name: string) {
   return { exists: true, running: result.stdout.trim() === "true" };
 }
 
-async function ensureSandboxWorkspace(workspaceDir: string, seedFrom?: string) {
+async function ensureSandboxWorkspace(
+  workspaceDir: string,
+  seedFrom?: string,
+  skipBootstrap?: boolean,
+) {
   await fs.mkdir(workspaceDir, { recursive: true });
   if (seedFrom) {
     const seed = resolveUserPath(seedFrom);
@@ -461,7 +465,10 @@ async function ensureSandboxWorkspace(workspaceDir: string, seedFrom?: string) {
       }
     }
   }
-  await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
+  await ensureAgentWorkspace({
+    dir: workspaceDir,
+    ensureBootstrapFiles: !skipBootstrap,
+  });
 }
 
 function normalizeDockerLimit(value?: string | number) {
@@ -856,7 +863,11 @@ export async function resolveSandboxContext(params: {
     : workspaceRoot;
   const seedWorkspace =
     params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR;
-  await ensureSandboxWorkspace(workspaceDir, seedWorkspace);
+  await ensureSandboxWorkspace(
+    workspaceDir,
+    seedWorkspace,
+    params.config?.agent?.skipBootstrap,
+  );
 
   const containerName = await ensureSandboxContainer({
     sessionKey: rawSessionKey,
@@ -899,7 +910,11 @@ export async function ensureSandboxWorkspaceForSession(params: {
     : workspaceRoot;
   const seedWorkspace =
     params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR;
-  await ensureSandboxWorkspace(workspaceDir, seedWorkspace);
+  await ensureSandboxWorkspace(
+    workspaceDir,
+    seedWorkspace,
+    params.config?.agent?.skipBootstrap,
+  );
 
   return {
     workspaceDir,

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -219,7 +219,7 @@ export async function getReplyFromConfig(
   const workspaceDirRaw = cfg.agent?.workspace ?? DEFAULT_AGENT_WORKSPACE_DIR;
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
-    ensureBootstrapFiles: true,
+    ensureBootstrapFiles: !cfg.agent?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;
   const timeoutMs = resolveAgentTimeoutMs({ cfg });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -162,7 +162,7 @@ export async function agentCommand(
   const workspaceDirRaw = cfg.agent?.workspace ?? DEFAULT_AGENT_WORKSPACE_DIR;
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
-    ensureBootstrapFiles: true,
+    ensureBootstrapFiles: !cfg.agent?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -803,6 +803,8 @@ export type ClawdbotConfig = {
     models?: Record<string, AgentModelEntryConfig>;
     /** Agent working directory (preferred). Used as the default cwd for agent runs. */
     workspace?: string;
+    /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
+    skipBootstrap?: boolean;
     /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
     userTimezone?: string;
     /** Optional display-only context window override (used for % in status UIs). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -477,6 +477,7 @@ export const ClawdbotSchema = z.object({
         )
         .optional(),
       workspace: z.string().optional(),
+      skipBootstrap: z.boolean().optional(),
       userTimezone: z.string().optional(),
       contextTokens: z.number().int().positive().optional(),
       tools: z

--- a/src/cron/isolated-agent.ts
+++ b/src/cron/isolated-agent.ts
@@ -200,7 +200,7 @@ export async function runCronIsolatedAgentTurn(params: {
     params.cfg.agent?.workspace ?? DEFAULT_AGENT_WORKSPACE_DIR;
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
-    ensureBootstrapFiles: true,
+    ensureBootstrapFiles: !params.cfg.agent?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;
 


### PR DESCRIPTION
## Summary
- Adds `agent.skipBootstrap` config option to skip creation of default bootstrap files (BOOTSTRAP.md, AGENTS.md, SOUL.md, etc.)
- Useful for pre-configured deployments where workspace files are already in place from a repo

## Usage
```json
{
  "agent": {
    "skipBootstrap": true
  }
}
```

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Workspace tests pass (`pnpm test src/agents/workspace.test.ts`)