### PR TITLE
feat(telegram): add /stop command to abort running agent

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -584,9 +584,9 @@ export async function runEmbeddedPiAgent(params: {
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
 }): Promise<EmbeddedPiRunResult> {
-  const sessionLane = resolveSessionLane(
-    params.sessionKey?.trim() || params.sessionId,
-  );
+  // Use sessionKey as the lookup key for /stop, falling back to sessionId
+  const activeRunKey = params.sessionKey?.trim() || params.sessionId;
+  const sessionLane = resolveSessionLane(activeRunKey);
   const globalLane = resolveGlobalLane(params.lane);
   const enqueueGlobal =
     params.enqueue ??
@@ -846,7 +846,7 @@ export async function runEmbeddedPiAgent(params: {
             isCompacting: () => subscription.isCompacting(),
             abort: abortRun,
           };
-          ACTIVE_EMBEDDED_RUNS.set(params.sessionId, queueHandle);
+          ACTIVE_EMBEDDED_RUNS.set(activeRunKey, queueHandle);
 
           let abortWarnTimer: NodeJS.Timeout | undefined;
           const abortTimer = setTimeout(
@@ -906,9 +906,9 @@ export async function runEmbeddedPiAgent(params: {
               abortWarnTimer = undefined;
             }
             unsubscribe();
-            if (ACTIVE_EMBEDDED_RUNS.get(params.sessionId) === queueHandle) {
-              ACTIVE_EMBEDDED_RUNS.delete(params.sessionId);
-              notifyEmbeddedRunEnded(params.sessionId);
+            if (ACTIVE_EMBEDDED_RUNS.get(activeRunKey) === queueHandle) {
+              ACTIVE_EMBEDDED_RUNS.delete(activeRunKey);
+              notifyEmbeddedRunEnded(activeRunKey);
             }
             session.dispose();
             params.abortSignal?.removeEventListener?.("abort", onAbort);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -110,6 +110,38 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const mediaGroupBuffer = new Map<string, MediaGroupEntry>();
 
   const cfg = loadConfig();
+
+  // Handle /stop command - abort current agent run
+  // Registered before bot.on("message") to ensure it runs first via grammy's middleware chain
+  bot.command("stop", async (ctx) => {
+    const { abortEmbeddedPiRun, isEmbeddedPiRunActive } = await import(
+      "../agents/pi-embedded.js"
+    );
+    const msg = ctx.message;
+    const chatId = msg?.chat.id;
+    const isGroup =
+      msg?.chat.type === "group" || msg?.chat.type === "supergroup";
+    const messageThreadId = (msg as { message_thread_id?: number })
+      ?.message_thread_id;
+
+    // Build session key matching the format used by the reply flow
+    const sessionCfg = cfg.session;
+    const mainKey = (sessionCfg?.mainKey ?? "main").trim() || "main";
+    const sessionId = isGroup
+      ? messageThreadId
+        ? `telegram:group:${chatId}:topic:${messageThreadId}`
+        : `telegram:group:${chatId}`
+      : mainKey;
+
+    const wasActive = isEmbeddedPiRunActive(sessionId);
+    const aborted = abortEmbeddedPiRun(sessionId);
+    const statusMsg = wasActive
+      ? aborted
+        ? "🛑 stopped"
+        : "🛑 stop requested (finishing current step)"
+      : "nothing running";
+    await ctx.reply(statusMsg);
+  });
   const textLimit = resolveTextChunkLimit(cfg, "telegram");
   const allowFrom = opts.allowFrom ?? cfg.telegram?.allowFrom;
   const groupAllowFrom =


### PR DESCRIPTION
## Summary

Adds a `/stop` command that can interrupt a running agent session mid-execution.

## Changes

### telegram/bot.ts
- Added `bot.command('stop', ...)` handler that runs before the main message handler
- Builds the correct session key for DMs, groups, and forum topics
- Calls `abortEmbeddedPiRun()` and reports status

### pi-embedded-runner.ts
- Fixed session key lookup to use `sessionKey` instead of `sessionId`
- Ensures `/stop` finds the correct active run in `ACTIVE_EMBEDDED_RUNS`

## Behavior

- **In DM**: Uses the configured main session key
- **In group**: Uses `telegram:group:{chatId}`
- **In forum topic**: Uses `telegram:group:{chatId}:topic:{threadId}`

## Response Messages

- `🛑 stopped` - Successfully aborted
- `🛑 stop requested (finishing current step)` - Abort requested but still finishing
- `nothing running` - No active agent run to stop