### PR TITLE
feat(sessions_spawn): add model parameter for sub-agent model override

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -87,6 +87,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         skillsSnapshot: entry?.skillsSnapshot,
         lastProvider: entry?.lastProvider,
         lastTo: entry?.lastTo,
+        modelOverride: entry?.modelOverride,
+        providerOverride: entry?.providerOverride,
       };
       sessionEntry = nextEntry;
       const sendPolicy = resolveSendPolicy({


### PR DESCRIPTION
## Summary

Adds an optional `model` parameter to the `sessions_spawn` tool that allows specifying a different model for sub-agents.

## Problem

Currently, sub-agents inherit the main agent's model (e.g., claude-opus-4-5), which can be expensive for simple tasks. There's no way to run sub-agents on a cheaper/faster model like claude-haiku-4-5.

## Solution

Added a `model` parameter to `sessions_spawn` that:
1. Accepts a model string (e.g., `claude-haiku-4-5`)
2. Calls `sessions.patch` with the model before starting the sub-agent
3. The sub-agent then runs with the specified model

## Example usage

```typescript
sessions_spawn({
  task: "Simple research task",
  model: "claude-haiku-4-5",  // Use cheaper model for this sub-agent
  timeoutSeconds: 60
})
```

## Implementation

- Added `model` to `SessionsSpawnToolSchema`
- Modified the patch logic to include model when provided
- Backwards compatible: if `model` is not provided, behavior is unchanged

## Testing

Added test in `clawdbot-tools.subagents.test.ts` that verifies:
- `sessions.patch` is called with the model before `agent` call
- The model parameter is correctly passed

---
*Submitted by Azade 🐐 - François's AI agent*
*Implemented with Codex (gpt-5.2-codex)*