### PR TITLE
fix(slack): use named import for @slack/bolt App class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Skills: emit MEDIA token after Nano Banana Pro image generation. Thanks @Iamadig for PR #271.
 - WhatsApp: set sender E.164 for direct chats so owner commands work in DMs.
 - Slack: keep auto-replies in the original thread when responding to thread messages. Thanks @scald for PR #251.
+- Slack: fix Slack provider startup under Bun by using a named import for Bolt `App`. Thanks @snopoke for PR #299.
 - Discord: surface missing-permission hints (muted/role overrides) when replies fail.
 - Discord: use channel IDs for DMs instead of user IDs. Thanks @VACInc for PR #261.
 - Docs: clarify Slack manifest scopes (current vs optional) with references. Thanks @jarvis-medmatic for PR #235.

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -70,7 +70,7 @@ vi.mock("@slack/bolt", () => {
     start = vi.fn().mockResolvedValue(undefined);
     stop = vi.fn().mockResolvedValue(undefined);
   }
-  return { default: { App } };
+  return { App, default: { App } };
 });
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -1,8 +1,8 @@
-import type {
-  SlackCommandMiddlewareArgs,
-  SlackEventMiddlewareArgs,
+import {
+  App,
+  type SlackCommandMiddlewareArgs,
+  type SlackEventMiddlewareArgs,
 } from "@slack/bolt";
-import bolt from "@slack/bolt";
 import { chunkText, resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import { formatAgentEnvelope } from "../auto-reply/envelope.js";
@@ -418,7 +418,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     return false;
   };
 
-  const { App } = bolt;
   const app = new App({
     token: botToken,
     appToken,


### PR DESCRIPTION
The default import `import bolt from '@slack/bolt'` followed by `const { App } = bolt` doesn't work correctly in Bun due to ESM/CJS interop issues. The default export comes through as a function rather than the module object.

Switching to a named import `import { App } from '@slack/bolt'` resolves the issue and allows the Slack provider to start successfully.

(Fix written by Clawdbot itself during a debug session in the web chat.)