### PR TITLE
docs: add missing ui:install step to README setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Groups: `whatsapp.groups`, `telegram.groups`, and `imessage.groups` now act as allowlists when set. Add `"*"` to keep allow-all behavior.
 
 ### Fixes
-- Docs: add missing `ui:install` setup step in the README. Thanks @hugobarauna for PR #300.
 - Messages: stop defaulting ack reactions to 👀 when identity emoji is missing.
 - Auto-reply: require slash for control commands to avoid false triggers in normal text.
 - Auto-reply: treat steer during compaction as a follow-up, queued until compaction completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Groups: `whatsapp.groups`, `telegram.groups`, and `imessage.groups` now act as allowlists when set. Add `"*"` to keep allow-all behavior.
 
 ### Fixes
+- Docs: add missing `ui:install` setup step in the README. Thanks @hugobarauna for PR #300.
 - Messages: stop defaulting ack reactions to 👀 when identity emoji is missing.
 - Auto-reply: require slash for control commands to avoid false triggers in normal text.
 - Auto-reply: treat steer during compaction as a follow-up, queued until compaction completes.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cd clawdbot
 
 bun install
 bun run build
+bun run ui:install
 bun run ui:build
 bun run clawdbot onboard
 ```


### PR DESCRIPTION
## Summary
- Adds missing `bun run ui:install` step before `bun run ui:build` in the "Recommended setup" section

The current instructions fail because `ui:build` depends on dependencies in the `ui/` subdirectory that aren't installed by the root `bun install`.

## Test plan
- [x] Verified the fix works by running the full setup sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)