### PR TITLE
feat(memory): cross-session memory consolidation system

### DIFF
--- a/apps/android/app/src/main/assets/tool-display.json
+++ b/apps/android/app/src/main/assets/tool-display.json
@@ -192,6 +192,21 @@
         "kick": { "label": "kick", "detailKeys": ["guildId", "userId"] },
         "ban": { "label": "ban", "detailKeys": ["guildId", "userId"] }
       }
+    },
+    "remember": {
+      "emoji": "🧠",
+      "title": "Remember",
+      "detailKeys": ["content", "type", "importance"]
+    },
+    "memory_consolidate": {
+      "emoji": "📚",
+      "title": "Consolidate Memory",
+      "detailKeys": []
+    },
+    "memory_recall": {
+      "emoji": "🔍",
+      "title": "Recall Memory",
+      "detailKeys": ["query", "scope", "limit"]
     }
   }
 }

--- a/apps/shared/ClawdbotKit/Resources/tool-display.json
+++ b/apps/shared/ClawdbotKit/Resources/tool-display.json
@@ -192,6 +192,21 @@
         "kick": { "label": "kick", "detailKeys": ["guildId", "userId"] },
         "ban": { "label": "ban", "detailKeys": ["guildId", "userId"] }
       }
+    },
+    "remember": {
+      "emoji": "🧠",
+      "title": "Remember",
+      "detailKeys": ["content", "type", "importance"]
+    },
+    "memory_consolidate": {
+      "emoji": "📚",
+      "title": "Consolidate Memory",
+      "detailKeys": []
+    },
+    "memory_recall": {
+      "emoji": "🔍",
+      "title": "Recall Memory",
+      "detailKeys": ["query", "scope", "limit"]
     }
   }
 }

--- a/docs/templates/AGENTS.md
+++ b/docs/templates/AGENTS.md
@@ -50,11 +50,45 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 When you need to remember something from the past, use `qmd` instead of grepping files:
 ```bash
 qmd query "what happened at Christmas"   # Semantic search with reranking
-qmd search "specific phrase"              # BM25 keyword search  
+qmd search "specific phrase"              # BM25 keyword search
 qmd vsearch "conceptual question"         # Pure vector similarity
 ```
 Index your memory folder: `qmd index memory/`
 Vectors + BM25 + reranking finds things even with different wording.
+
+### 🔄 Cross-Session Memory (remember tool)
+
+When you or your human says "remember this", use the `remember` tool to queue it for consolidation:
+
+```typescript
+// The remember tool writes to ~/clawd/memory/inbox/
+remember({
+  content: "User prefers JWT with refresh tokens for auth",
+  type: "decision",        // fact | decision | task | insight
+  importance: "persistent" // ephemeral | persistent
+})
+```
+
+**How it works:**
+1. Memories get written to `~/clawd/memory/inbox/` as markdown files
+2. Every 30 minutes, a consolidation job processes the inbox:
+   - **Ephemeral** memories → daily log (`memory/YYYY-MM-DD.md`)
+   - **Persistent** memories → daily log + `memory.md`
+3. Processed files are archived to `memory/archive/YYYY-MM-DD/`
+
+**Types:**
+- `fact`: A piece of information or knowledge
+- `decision`: A choice or conclusion that was made
+- `task`: Something to do or follow up on
+- `insight`: An observation or realization
+
+**Importance:**
+- `ephemeral`: Daily context, routine notes (default)
+- `persistent`: Long-term preferences, important decisions, durable facts
+
+This works across ALL sessions (main DM, Telegram groups, cron jobs). Every session feeds back to the central memory, making the main assistant the "brain" that knows everything.
+
+**Manual consolidation:** You can also trigger `memory_consolidate` tool manually if needed.
 
 ## Safety
 

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -430,8 +430,10 @@ export async function compactEmbeddedPiSession(params: {
               config: params.config,
             });
 
-        const bootstrapFiles =
-          await loadWorkspaceBootstrapFiles(resolvedWorkspace);
+        const bootstrapFiles = await loadWorkspaceBootstrapFiles(
+          resolvedWorkspace,
+          { sessionKey: params.sessionKey ?? params.sessionId },
+        );
         const contextFiles = buildBootstrapContextFiles(bootstrapFiles);
         const promptSkills = resolvePromptSkills(skillsSnapshot, skillEntries);
         const tools = createClawdbotCodingTools({
@@ -719,8 +721,10 @@ export async function runEmbeddedPiAgent(params: {
                 config: params.config,
               });
 
-          const bootstrapFiles =
-            await loadWorkspaceBootstrapFiles(resolvedWorkspace);
+          const bootstrapFiles = await loadWorkspaceBootstrapFiles(
+            resolvedWorkspace,
+            { sessionKey: params.sessionKey ?? params.sessionId },
+          );
           const contextFiles = buildBootstrapContextFiles(bootstrapFiles);
           const promptSkills = resolvePromptSkills(
             skillsSnapshot,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -17,6 +17,9 @@ import {
   type ProcessToolDefaults,
 } from "./bash-tools.js";
 import { createClawdbotTools } from "./clawdbot-tools.js";
+import { createMemoryConsolidateTool } from "./tools/memory-consolidate.js";
+import { createMemoryRecallTool } from "./tools/memory-recall-tool.js";
+import { createRememberTool } from "./tools/remember-tool.js";
 import type { SandboxContext, SandboxToolPolicy } from "./sandbox.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
@@ -559,6 +562,22 @@ export function createClawdbotCodingTools(options?: {
       sandboxed: !!sandbox,
       config: options?.config,
     }),
+    // Memory tools - available in all sessions
+    ...(options?.config?.memory?.enabled !== false
+      ? [
+          createRememberTool({
+            sessionKey: options?.sessionKey ?? "main",
+            memoryWorkspace: options?.config?.memory?.workspace,
+          }),
+          createMemoryConsolidateTool({
+            memoryWorkspace: options?.config?.memory?.workspace,
+            maxContextPercent: options?.config?.memory?.maxContextPercent,
+          }),
+          createMemoryRecallTool({
+            memoryWorkspace: options?.config?.memory?.workspace,
+          }),
+        ]
+      : []),
   ];
   const allowDiscord = shouldIncludeDiscordTool(options?.surface);
   const allowSlack = shouldIncludeSlackTool(options?.surface);

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -231,6 +231,21 @@
         "memberInfo": { "label": "member", "detailKeys": ["userId"] },
         "emojiList": { "label": "emoji list" }
       }
+    },
+    "remember": {
+      "emoji": "🧠",
+      "title": "Remember",
+      "detailKeys": ["content", "type", "importance"]
+    },
+    "memory_consolidate": {
+      "emoji": "📚",
+      "title": "Consolidate Memory",
+      "detailKeys": []
+    },
+    "memory_recall": {
+      "emoji": "🔍",
+      "title": "Recall Memory",
+      "detailKeys": ["query", "scope", "limit"]
     }
   }
 }

--- a/src/agents/tools/memory-consolidate.ts
+++ b/src/agents/tools/memory-consolidate.ts
@@ -1,0 +1,546 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { Type } from "@sinclair/typebox";
+
+import type {
+  MemoryFragmentImportance,
+  MemoryFragmentType,
+} from "../../config/types.js";
+import { type AnyAgentTool, jsonResult } from "./common.js";
+
+/**
+ * Calculate max bytes for memory.md based on context percentage.
+ * 200K tokens ≈ 800KB characters (4 chars/token avg).
+ * Default 10% = ~80KB.
+ */
+const CONTEXT_WINDOW_BYTES = 800 * 1024; // ~200K tokens
+
+export function calculateMemoryMaxBytes(contextPercent: number = 10): number {
+  const clamped = Math.max(1, Math.min(50, contextPercent));
+  return Math.floor((clamped / 100) * CONTEXT_WINDOW_BYTES);
+}
+
+/** Default max size for memory.md (10% of context = ~80KB) */
+export const MEMORY_MD_MAX_BYTES = calculateMemoryMaxBytes(10);
+
+export interface MemoryFragment {
+  filename: string;
+  content: string;
+  type: MemoryFragmentType;
+  importance: MemoryFragmentImportance;
+  session: string;
+  sessionName?: string;
+  timestamp: string;
+}
+
+export interface ConsolidationResult {
+  processed: number;
+  archived: number;
+  ephemeral: number;
+  persistent: number;
+  errors: string[];
+  /** Number of old entries evicted from memory.md to stay under 50KB cap */
+  evicted?: number;
+}
+
+/**
+ * Resolves the memory workspace path.
+ */
+function resolveMemoryWorkspace(explicit?: string): string {
+  if (explicit) {
+    return explicit.startsWith("~")
+      ? path.join(os.homedir(), explicit.slice(1))
+      : explicit;
+  }
+  return path.join(os.homedir(), "clawd");
+}
+
+/**
+ * Parses YAML frontmatter from a memory fragment file.
+ */
+function parseMemoryFragment(
+  filename: string,
+  content: string,
+): MemoryFragment | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const [, frontmatter, body] = match;
+  const lines = frontmatter.split("\n");
+
+  let type: MemoryFragmentType = "fact";
+  let importance: MemoryFragmentImportance = "ephemeral";
+  let session = "unknown";
+  let sessionName: string | undefined;
+  let timestamp = new Date().toISOString();
+
+  for (const line of lines) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    let value = line.slice(colonIndex + 1).trim();
+
+    // Remove quotes if present
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+
+    switch (key) {
+      case "type":
+        if (["fact", "decision", "task", "insight"].includes(value)) {
+          type = value as MemoryFragmentType;
+        }
+        break;
+      case "importance":
+        if (["ephemeral", "persistent"].includes(value)) {
+          importance = value as MemoryFragmentImportance;
+        }
+        break;
+      case "session":
+        session = value;
+        break;
+      case "sessionName":
+        sessionName = value;
+        break;
+      case "timestamp":
+        timestamp = value;
+        break;
+    }
+  }
+
+  return {
+    filename,
+    content: body.trim(),
+    type,
+    importance,
+    session,
+    sessionName,
+    timestamp,
+  };
+}
+
+/**
+ * Formats a memory fragment for the daily log.
+ */
+function formatForDailyLog(fragment: MemoryFragment): string {
+  const time = new Date(fragment.timestamp).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const sessionLabel = fragment.sessionName || fragment.session;
+  const typeEmoji = {
+    fact: "📝",
+    decision: "✅",
+    task: "📋",
+    insight: "💡",
+  }[fragment.type];
+
+  return `- ${typeEmoji} **${time}** [${sessionLabel}] ${fragment.content}`;
+}
+
+/**
+ * Formats a memory fragment for memory.md (persistent storage).
+ */
+function formatForMemoryMd(fragment: MemoryFragment): string {
+  const date = new Date(fragment.timestamp).toISOString().split("T")[0];
+  const sessionLabel = fragment.sessionName || fragment.session;
+
+  return `- [${date}] [${sessionLabel}] ${fragment.content}`;
+}
+
+/**
+ * Ensures a file exists with optional initial content.
+ */
+async function ensureFile(
+  filePath: string,
+  initialContent = "",
+): Promise<void> {
+  try {
+    await fs.access(filePath);
+  } catch {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, initialContent, "utf-8");
+  }
+}
+
+/**
+ * Appends content to a file, creating it if necessary.
+ */
+async function appendToFile(filePath: string, content: string): Promise<void> {
+  await ensureFile(filePath);
+  const existing = await fs.readFile(filePath, "utf-8");
+  const separator = existing.trim() ? "\n" : "";
+  await fs.writeFile(filePath, existing + separator + content, "utf-8");
+}
+
+/**
+ * Truncates memory.md to stay under the size cap.
+ * Uses oldest-first eviction: removes oldest entries (bottom of file) until under cap.
+ * Returns number of lines removed.
+ */
+async function enforceMemoryMdSizeCap(
+  filePath: string,
+  maxBytes: number = MEMORY_MD_MAX_BYTES,
+): Promise<{ removed: number; sizeBefore: number; sizeAfter: number }> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return { removed: 0, sizeBefore: 0, sizeAfter: 0 };
+  }
+
+  const sizeBefore = Buffer.byteLength(content, "utf-8");
+  if (sizeBefore <= maxBytes) {
+    return { removed: 0, sizeBefore, sizeAfter: sizeBefore };
+  }
+
+  // Split into header (everything before first "- [") and entries
+  const firstEntryIdx = content.indexOf("\n- [");
+  if (firstEntryIdx === -1) {
+    // No entries found, can't truncate
+    return { removed: 0, sizeBefore, sizeAfter: sizeBefore };
+  }
+
+  const header = content.slice(0, firstEntryIdx + 1);
+  const entriesSection = content.slice(firstEntryIdx + 1);
+  const entries = entriesSection.split("\n").filter((line) => line.startsWith("- ["));
+
+  // Remove oldest entries (from start) until under cap
+  let removed = 0;
+  let newEntries = [...entries];
+
+  while (newEntries.length > 0) {
+    const newContent = header + newEntries.join("\n") + "\n";
+    const newSize = Buffer.byteLength(newContent, "utf-8");
+    if (newSize <= maxBytes) {
+      break;
+    }
+    // Remove oldest (first entry)
+    newEntries.shift();
+    removed++;
+  }
+
+  if (removed > 0) {
+    const finalContent = header + newEntries.join("\n") + "\n";
+    await fs.writeFile(filePath, finalContent, "utf-8");
+    const sizeAfter = Buffer.byteLength(finalContent, "utf-8");
+    return { removed, sizeBefore, sizeAfter };
+  }
+
+  return { removed: 0, sizeBefore, sizeAfter: sizeBefore };
+}
+
+/**
+ * Consolidates memory fragments from the inbox.
+ *
+ * - Scans ~/clawd/memory/inbox/ for .md files
+ * - Parses YAML frontmatter
+ * - Appends ephemeral items to daily log
+ * - Appends persistent items to daily log AND memory.md
+ * - Moves processed files to archive
+ * - Enforces size cap on memory.md
+ */
+export async function consolidateMemory(options?: {
+  memoryWorkspace?: string;
+  /** Max memory.md size as % of context (1-50). Default: 10. */
+  maxContextPercent?: number;
+}): Promise<ConsolidationResult> {
+  const workspace = resolveMemoryWorkspace(options?.memoryWorkspace);
+  const maxBytes = calculateMemoryMaxBytes(options?.maxContextPercent ?? 10);
+  const inboxDir = path.join(workspace, "memory", "inbox");
+  const memoryDir = path.join(workspace, "memory");
+
+  const result: ConsolidationResult = {
+    processed: 0,
+    archived: 0,
+    ephemeral: 0,
+    persistent: 0,
+    errors: [],
+  };
+
+  // Ensure directories exist
+  try {
+    await fs.mkdir(inboxDir, { recursive: true });
+  } catch {
+    // Directory exists
+  }
+
+  // List inbox files
+  let files: string[];
+  try {
+    const entries = await fs.readdir(inboxDir);
+    files = entries.filter((f) => f.endsWith(".md")).sort();
+  } catch {
+    return result; // Empty inbox or doesn't exist
+  }
+
+  if (files.length === 0) {
+    return result;
+  }
+
+  // Parse all fragments
+  const fragments: MemoryFragment[] = [];
+  for (const filename of files) {
+    try {
+      const filePath = path.join(inboxDir, filename);
+      const content = await fs.readFile(filePath, "utf-8");
+      const fragment = parseMemoryFragment(filename, content);
+      if (fragment) {
+        fragments.push(fragment);
+      } else {
+        result.errors.push(`Failed to parse ${filename}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Error reading ${filename}: ${message}`);
+    }
+  }
+
+  // Group by date for daily logs
+  const byDate = new Map<string, MemoryFragment[]>();
+  for (const fragment of fragments) {
+    const date = fragment.timestamp.split("T")[0];
+    const existing = byDate.get(date) || [];
+    existing.push(fragment);
+    byDate.set(date, existing);
+  }
+
+  // Process each date's fragments
+  for (const [date, dateFragments] of byDate) {
+    const dailyLogPath = path.join(memoryDir, `${date}.md`);
+
+    // Build daily log entries
+    const dailyEntries = dateFragments.map(formatForDailyLog).join("\n");
+
+    // Append to daily log
+    try {
+      const header = `## Memory Consolidation\n\n`;
+      await ensureFile(dailyLogPath, `# ${date}\n\n`);
+      const existing = await fs.readFile(dailyLogPath, "utf-8");
+
+      // Only add header if not already present
+      if (!existing.includes("## Memory Consolidation")) {
+        await appendToFile(dailyLogPath, `\n${header}${dailyEntries}\n`);
+      } else {
+        await appendToFile(dailyLogPath, `\n${dailyEntries}\n`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Error updating daily log ${date}: ${message}`);
+    }
+  }
+
+  // Process persistent fragments to memory.md
+  const persistentFragments = fragments.filter(
+    (f) => f.importance === "persistent",
+  );
+  const memoryMdPath = path.join(workspace, "memory.md");
+
+  if (persistentFragments.length > 0) {
+    const persistentEntries = persistentFragments
+      .map(formatForMemoryMd)
+      .join("\n");
+
+    try {
+      await ensureFile(
+        memoryMdPath,
+        `# Long-Term Memory\n\nPersistent facts, decisions, and preferences.\n\n`,
+      );
+      await appendToFile(memoryMdPath, `\n${persistentEntries}\n`);
+      result.persistent = persistentFragments.length;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Error updating memory.md: ${message}`);
+    }
+  }
+
+  // Enforce size cap on memory.md (oldest-first eviction)
+  try {
+    const capResult = await enforceMemoryMdSizeCap(memoryMdPath, maxBytes);
+    if (capResult.removed > 0) {
+      result.evicted = capResult.removed;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.errors.push(`Error enforcing memory.md cap: ${message}`);
+  }
+
+  result.ephemeral = fragments.length - persistentFragments.length;
+
+  // Archive processed files
+  const today = new Date().toISOString().split("T")[0];
+  const archiveDir = path.join(memoryDir, "archive", today);
+
+  try {
+    await fs.mkdir(archiveDir, { recursive: true });
+
+    for (const fragment of fragments) {
+      try {
+        const srcPath = path.join(inboxDir, fragment.filename);
+        const dstPath = path.join(archiveDir, fragment.filename);
+        await fs.rename(srcPath, dstPath);
+        result.archived++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        result.errors.push(`Error archiving ${fragment.filename}: ${message}`);
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.errors.push(`Error creating archive directory: ${message}`);
+  }
+
+  result.processed = fragments.length;
+  return result;
+}
+
+const MemoryConsolidateToolSchema = Type.Object({});
+
+export type MemoryConsolidateToolContext = {
+  /** Memory workspace path (default: ~/clawd) */
+  memoryWorkspace?: string;
+  /** Max memory.md size as % of context (1-50). Default: 10. */
+  maxContextPercent?: number;
+};
+
+/**
+ * Creates the memory consolidation tool for processing the inbox.
+ *
+ * This tool processes memory fragments from ~/clawd/memory/inbox/:
+ * - Parses YAML frontmatter from each fragment
+ * - Appends ephemeral items to daily logs (memory/YYYY-MM-DD.md)
+ * - Appends persistent items to daily logs AND memory.md
+ * - Archives processed files to memory/archive/YYYY-MM-DD/
+ */
+export function createMemoryConsolidateTool(
+  context: MemoryConsolidateToolContext,
+): AnyAgentTool {
+  return {
+    label: "Consolidate Memory",
+    name: "memory_consolidate",
+    description: `Process memory fragments from the inbox. This tool scans ~/clawd/memory/inbox/ for pending memories, consolidates them into daily logs and long-term memory.md, then archives processed files. Run this periodically (every 30 min via cron) to keep memories organized.
+
+What it does:
+- Ephemeral memories → daily log only
+- Persistent memories → daily log + memory.md
+- All processed files → archived by date`,
+    parameters: MemoryConsolidateToolSchema,
+    execute: async () => {
+      const maxPct = context.maxContextPercent ?? 10;
+      try {
+        const result = await consolidateMemory({
+          memoryWorkspace: context.memoryWorkspace,
+          maxContextPercent: maxPct,
+        });
+
+        if (result.processed === 0) {
+          return jsonResult({
+            success: true,
+            message: "📭 Memory inbox empty - nothing to consolidate",
+            ...result,
+          });
+        }
+
+        // Build user-friendly summary
+        const parts: string[] = [];
+        if (result.ephemeral > 0) {
+          parts.push(`${result.ephemeral} → daily log`);
+        }
+        if (result.persistent > 0) {
+          parts.push(`${result.persistent} → long-term memory`);
+        }
+
+        const summary = `📚 Consolidated ${result.processed} memories (${parts.join(", ")})`;
+
+        const details = [
+          summary,
+          result.evicted && result.evicted > 0
+            ? `🗑️ Evicted ${result.evicted} old entries (${maxPct}% cap)`
+            : null,
+          result.errors.length > 0
+            ? `⚠️ ${result.errors.length} errors during processing`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n");
+
+        return jsonResult({
+          success: result.errors.length === 0,
+          message: details,
+          ...result,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return jsonResult({
+          success: false,
+          error: `Failed to consolidate memory: ${message}`,
+        });
+      }
+    },
+  };
+}
+
+/**
+ * Parses a duration string (e.g., "30m", "1h", "2h30m") into milliseconds.
+ * Returns null if unparseable.
+ */
+export function parseDurationMs(duration: string): number | null {
+  const trimmed = duration.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  let totalMs = 0;
+  const patterns = [
+    { regex: /(\d+)h/, multiplier: 60 * 60 * 1000 },
+    { regex: /(\d+)m/, multiplier: 60 * 1000 },
+    { regex: /(\d+)s/, multiplier: 1000 },
+  ];
+
+  for (const { regex, multiplier } of patterns) {
+    const match = trimmed.match(regex);
+    if (match) {
+      totalMs += parseInt(match[1], 10) * multiplier;
+    }
+  }
+
+  // If no patterns matched, try parsing as minutes (bare number)
+  if (totalMs === 0 && /^\d+$/.test(trimmed)) {
+    totalMs = parseInt(trimmed, 10) * 60 * 1000;
+  }
+
+  return totalMs > 0 ? totalMs : null;
+}
+
+/** ID for the memory consolidation cron job */
+export const MEMORY_CONSOLIDATE_CRON_ID = "memory-consolidate";
+
+/**
+ * Returns the cron job spec for memory consolidation.
+ */
+export function buildMemoryConsolidateCronJob(consolidateEvery: string): {
+  name: string;
+  schedule: { kind: "every"; everyMs: number };
+  sessionTarget: "isolated";
+  wakeMode: "next-heartbeat";
+  payload: { kind: "agentTurn"; message: string };
+  isolation: { postToMainPrefix: string };
+} | null {
+  const everyMs = parseDurationMs(consolidateEvery);
+  if (!everyMs) return null;
+
+  return {
+    name: "Memory consolidation",
+    schedule: { kind: "every", everyMs },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: {
+      kind: "agentTurn",
+      message:
+        "Run memory consolidation. Process inbox, update daily log, integrate persistent memories.",
+    },
+    isolation: { postToMainPrefix: "Memory" },
+  };
+}

--- a/src/agents/tools/memory-recall-tool.ts
+++ b/src/agents/tools/memory-recall-tool.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { Type } from "@sinclair/typebox";
+
+import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
+
+const MemoryRecallToolSchema = Type.Object({
+  query: Type.String({
+    description:
+      "Search term or phrase to find in memories. Case-insensitive.",
+  }),
+  scope: Type.Optional(
+    Type.Union([
+      Type.Literal("all"),
+      Type.Literal("persistent"),
+      Type.Literal("daily"),
+    ]),
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Max results to return (default: 10)",
+    }),
+  ),
+});
+
+export type MemoryRecallToolContext = {
+  /** Memory workspace path (default: ~/clawd) */
+  memoryWorkspace?: string;
+};
+
+/**
+ * Resolves the memory workspace path.
+ */
+function resolveMemoryWorkspace(explicit?: string): string {
+  if (explicit) {
+    return explicit.startsWith("~")
+      ? path.join(os.homedir(), explicit.slice(1))
+      : explicit;
+  }
+  return path.join(os.homedir(), "clawd");
+}
+
+interface MemoryMatch {
+  source: string;
+  line: string;
+  context?: string;
+}
+
+/**
+ * Searches a file for lines matching the query.
+ */
+async function searchFile(
+  filePath: string,
+  query: string,
+  sourceName: string,
+): Promise<MemoryMatch[]> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    const matches: MemoryMatch[] = [];
+    const lowerQuery = query.toLowerCase();
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.toLowerCase().includes(lowerQuery)) {
+        // Get context: one line before and after
+        const before = i > 0 ? lines[i - 1] : undefined;
+        const after = i < lines.length - 1 ? lines[i + 1] : undefined;
+        const context = [before, after]
+          .filter((l) => l && l.trim())
+          .join("\n");
+
+        matches.push({
+          source: sourceName,
+          line: line.trim(),
+          context: context || undefined,
+        });
+      }
+    }
+    return matches;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Gets list of daily log files (sorted newest first).
+ */
+async function getDailyLogFiles(memoryDir: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(memoryDir);
+    return entries
+      .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Creates the memory recall tool for searching memories.
+ *
+ * This tool provides just-in-time memory queries without loading everything
+ * into context upfront. Use it to search for specific facts, decisions,
+ * or notes from past sessions.
+ */
+export function createMemoryRecallTool(
+  context: MemoryRecallToolContext,
+): AnyAgentTool {
+  const memoryWorkspace = resolveMemoryWorkspace(context.memoryWorkspace);
+
+  return {
+    label: "Recall Memory",
+    name: "memory_recall",
+    description: `Search through stored memories for specific information. Use this for just-in-time recall of facts, decisions, tasks, or insights from past sessions.
+
+Scopes:
+- all: Search both persistent memory.md and daily logs
+- persistent: Only search memory.md (long-term facts)
+- daily: Only search recent daily logs
+
+This is more efficient than loading all memories into context - use it when you need to look up specific information.`,
+    parameters: MemoryRecallToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      const scope =
+        (readStringParam(params, "scope") as "all" | "persistent" | "daily") ||
+        "all";
+      const limit =
+        typeof params.limit === "number" ? Math.min(params.limit, 50) : 10;
+
+      const memoryDir = path.join(memoryWorkspace, "memory");
+      const memoryMdPath = path.join(memoryWorkspace, "memory.md");
+
+      const allMatches: MemoryMatch[] = [];
+
+      // Search persistent memory
+      if (scope === "all" || scope === "persistent") {
+        const persistentMatches = await searchFile(
+          memoryMdPath,
+          query,
+          "memory.md",
+        );
+        allMatches.push(...persistentMatches);
+      }
+
+      // Search daily logs
+      if (scope === "all" || scope === "daily") {
+        const dailyFiles = await getDailyLogFiles(memoryDir);
+        // Search last 7 days of logs
+        for (const file of dailyFiles.slice(0, 7)) {
+          const filePath = path.join(memoryDir, file);
+          const matches = await searchFile(filePath, query, file);
+          allMatches.push(...matches);
+        }
+      }
+
+      if (allMatches.length === 0) {
+        return jsonResult({
+          success: true,
+          message: `🔍 No memories found matching "${query}"`,
+          matches: [],
+          count: 0,
+        });
+      }
+
+      // Limit results
+      const limitedMatches = allMatches.slice(0, limit);
+
+      // Format results
+      const formattedResults = limitedMatches.map((m) => ({
+        source: m.source,
+        content: m.line,
+        ...(m.context ? { context: m.context } : {}),
+      }));
+
+      const summary =
+        allMatches.length > limit
+          ? `🔍 Found ${allMatches.length} memories (showing ${limit})`
+          : `🔍 Found ${allMatches.length} memories`;
+
+      return jsonResult({
+        success: true,
+        message: summary,
+        matches: formattedResults,
+        count: allMatches.length,
+        showing: limitedMatches.length,
+      });
+    },
+  };
+}

--- a/src/agents/tools/remember-tool.ts
+++ b/src/agents/tools/remember-tool.ts
@@ -1,0 +1,168 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { Type } from "@sinclair/typebox";
+
+import type {
+  MemoryFragmentImportance,
+  MemoryFragmentType,
+} from "../../config/types.js";
+import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
+
+const RememberToolSchema = Type.Object({
+  content: Type.String({
+    description:
+      "What to remember - the fact, decision, task, or insight to store",
+  }),
+  type: Type.Optional(
+    Type.Union([
+      Type.Literal("fact"),
+      Type.Literal("decision"),
+      Type.Literal("task"),
+      Type.Literal("insight"),
+    ]),
+  ),
+  importance: Type.Optional(
+    Type.Union([Type.Literal("ephemeral"), Type.Literal("persistent")]),
+  ),
+});
+
+export type RememberToolContext = {
+  /** Session key (e.g., "main", "telegram:group:-123456") */
+  sessionKey: string;
+  /** Human-readable session name (e.g., "Deep Work") */
+  sessionDisplayName?: string;
+  /** Memory workspace path (default: ~/clawd) */
+  memoryWorkspace?: string;
+};
+
+/**
+ * Resolves the memory workspace path.
+ * Priority: explicit config > ~/clawd
+ */
+function resolveMemoryWorkspace(explicit?: string): string {
+  if (explicit) {
+    return explicit.startsWith("~")
+      ? path.join(os.homedir(), explicit.slice(1))
+      : explicit;
+  }
+  return path.join(os.homedir(), "clawd");
+}
+
+/**
+ * Creates a memory fragment file in the inbox.
+ * File format: YAML frontmatter + markdown content
+ */
+async function writeMemoryFragment(params: {
+  content: string;
+  type: MemoryFragmentType;
+  importance: MemoryFragmentImportance;
+  sessionKey: string;
+  sessionDisplayName?: string;
+  memoryWorkspace: string;
+}): Promise<{ filename: string; path: string }> {
+  const inboxDir = path.join(params.memoryWorkspace, "memory", "inbox");
+
+  // Ensure inbox directory exists
+  await fs.mkdir(inboxDir, { recursive: true });
+
+  const timestamp = new Date().toISOString();
+  const hash = crypto.randomBytes(4).toString("hex");
+  const filename = `${Date.now()}_${hash}.md`;
+  const filePath = path.join(inboxDir, filename);
+
+  // Build YAML frontmatter
+  const frontmatter = [
+    "---",
+    `type: ${params.type}`,
+    `importance: ${params.importance}`,
+    `session: ${params.sessionKey}`,
+    params.sessionDisplayName
+      ? `sessionName: "${params.sessionDisplayName}"`
+      : null,
+    `timestamp: ${timestamp}`,
+    "---",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const fileContent = `${frontmatter}\n${params.content}`;
+  await fs.writeFile(filePath, fileContent, "utf-8");
+
+  return { filename, path: filePath };
+}
+
+/**
+ * Creates the remember tool for storing memories to the inbox.
+ *
+ * This tool writes memory fragments to ~/clawd/memory/inbox/ (or configured workspace).
+ * A consolidation job processes the inbox and updates daily logs + memory.md.
+ */
+export function createRememberTool(context: RememberToolContext): AnyAgentTool {
+  const memoryWorkspace = resolveMemoryWorkspace(context.memoryWorkspace);
+
+  return {
+    label: "Remember",
+    name: "remember",
+    description: `Store a memory fragment for consolidation. Use this when the user says "remember", "note", "log this", or you need to persist important information across sessions. Memories are written to an inbox and consolidated every 30 minutes into daily logs and long-term memory.
+
+Types:
+- fact: A piece of information or knowledge
+- decision: A choice or conclusion that was made
+- task: Something to do or follow up on
+- insight: An observation or realization
+
+Importance:
+- ephemeral: Daily log only (routine notes, temporary info)
+- persistent: Daily log + long-term memory.md (preferences, decisions, durable facts)`,
+    parameters: RememberToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const content = readStringParam(params, "content", { required: true });
+      const type =
+        (readStringParam(params, "type") as MemoryFragmentType) || "fact";
+      const importance =
+        (readStringParam(params, "importance") as MemoryFragmentImportance) ||
+        "ephemeral";
+
+      try {
+        const result = await writeMemoryFragment({
+          content,
+          type,
+          importance,
+          sessionKey: context.sessionKey,
+          sessionDisplayName: context.sessionDisplayName,
+          memoryWorkspace,
+        });
+
+        // Build user-friendly status message
+        const typeEmoji = {
+          fact: "📝",
+          decision: "✅",
+          task: "📋",
+          insight: "💡",
+        }[type];
+        const importanceLabel =
+          importance === "persistent" ? "→ long-term memory" : "→ daily log";
+        const preview =
+          content.length > 50 ? `${content.slice(0, 50)}...` : content;
+
+        return jsonResult({
+          success: true,
+          message: `${typeEmoji} Remembered: "${preview}" ${importanceLabel}`,
+          filename: result.filename,
+          type,
+          importance,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return jsonResult({
+          success: false,
+          error: `Failed to write memory: ${message}`,
+        });
+      }
+    },
+  };
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -589,6 +589,28 @@ export type CanvasHostConfig = {
   liveReload?: boolean;
 };
 
+export type MemoryFragmentType = "fact" | "decision" | "task" | "insight";
+export type MemoryFragmentImportance = "ephemeral" | "persistent";
+
+export type MemoryConfig = {
+  /** If false, disable memory tools. Default: true. */
+  enabled?: boolean;
+  /**
+   * Central memory workspace (independent of agent.workspace).
+   * Default: ~/clawd
+   */
+  workspace?: string;
+  /** Consolidation cron interval (duration string). Default: "30m". */
+  consolidateEvery?: string;
+  /** Archive retention in days (0 = keep forever). Default: 30. */
+  archiveRetentionDays?: number;
+  /**
+   * Max memory.md size as percentage of context window (1-50). Default: 10.
+   * 10% of 200K tokens ≈ 80KB. For conversation-heavy sessions, 20-50% is fine.
+   */
+  maxContextPercent?: number;
+};
+
 export type TalkConfig = {
   /** Default ElevenLabs voice ID for Talk mode. */
   voiceId?: string;
@@ -990,6 +1012,7 @@ export type ClawdbotConfig = {
   canvasHost?: CanvasHostConfig;
   talk?: TalkConfig;
   gateway?: GatewayConfig;
+  memory?: MemoryConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -209,6 +209,21 @@
         "memberInfo": { "label": "member", "detailKeys": ["userId"] },
         "emojiList": { "label": "emoji list" }
       }
+    },
+    "remember": {
+      "emoji": "🧠",
+      "title": "Remember",
+      "detailKeys": ["content", "type", "importance"]
+    },
+    "memory_consolidate": {
+      "emoji": "📚",
+      "title": "Consolidate Memory",
+      "detailKeys": []
+    },
+    "memory_recall": {
+      "emoji": "🔍",
+      "title": "Recall Memory",
+      "detailKeys": ["query", "scope", "limit"]
     }
   }
 }


### PR DESCRIPTION
Implements inbox & librarian pattern for cross-session memory:

- remember tool: write memory fragments to inbox (any session)
- memory_consolidate tool: process inbox → daily logs + memory.md
- memory_recall tool: just-in-time queries without loading all

Key features:
- Configurable size cap (maxContextPercent, default 10% = ~80KB)
- Oldest-first eviction when cap exceeded
- Session isolation: groups don't load memory.md
- Auto-creates consolidation cron job from config

Config example:
  memory: enabled: true workspace: ~/clawd consolidateEvery: "30m" maxContextPercent: 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)