### PR TITLE
AI: Z.AI provider alias normalization (auth profiles + CLI coverage)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -859,6 +859,7 @@ in your environment and reference the model by provider/model.
 Notes:
 - `z.ai/*` and `z-ai/*` are accepted aliases and normalize to `zai/*`.
 - If `ZAI_API_KEY` is missing, requests to `zai/*` will fail with an auth error at runtime.
+- Example error: `No API key found for provider "zai".`
 - Z.AI’s general API endpoint is `https://api.z.ai/api/paas/v4`. The GLM Coding
   Plan uses the dedicated Coding endpoint `https://api.z.ai/api/coding/paas/v4`.
   The built-in `zai` provider uses the Coding endpoint. If you need the general

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -842,6 +842,30 @@ Select the model via `agent.model.primary` (provider/model).
 }
 ```
 
+### Z.AI (GLM-4.7) — provider alias support
+
+Z.AI models are available via the built-in `zai` provider. Set `ZAI_API_KEY`
+in your environment and reference the model by provider/model.
+
+```json5
+{
+  agent: {
+    model: "zai/glm-4.7",
+    allowedModels: ["zai/glm-4.7"]
+  }
+}
+```
+
+Notes:
+- `z.ai/*` and `z-ai/*` are accepted aliases and normalize to `zai/*`.
+- If `ZAI_API_KEY` is missing, requests to `zai/*` will fail with an auth error at runtime.
+- Z.AI’s general API endpoint is `https://api.z.ai/api/paas/v4`. The GLM Coding
+  Plan uses the dedicated Coding endpoint `https://api.z.ai/api/coding/paas/v4`.
+  The built-in `zai` provider uses the Coding endpoint. If you need the general
+  endpoint, define a custom provider in `models.providers` with the base URL
+  override (see the custom providers section above).
+- Use a fake placeholder in docs/configs; never commit real API keys.
+
 ### Local models (LM Studio) — recommended setup
 
 Best current local setup (what we’re running): **MiniMax M2.1** on a beefy Mac Studio

--- a/docs/models.md
+++ b/docs/models.md
@@ -89,3 +89,5 @@ Output
 
 - Update `docs/configuration.md` with `agent.models` + `agent.model` + `agent.imageModel`.
 - Keep this doc current when CLI surface or scan logic changes.
+- Note provider aliases like `z.ai/*` -> `zai/*` when relevant.
+- Provider ids in model refs are normalized to lowercase.

--- a/docs/plans/zai-glm-4-7-support.md
+++ b/docs/plans/zai-glm-4-7-support.md
@@ -1,7 +1,7 @@
 ---
 summary: "Exec spec: Z.AI GLM-4.7 integration (provider normalization + docs + CLI/tests)"
 status: "complete"
-owner: "peter"
+owner: "mneves75"
 updated: "2026-01-06"
 ---
 
@@ -56,6 +56,10 @@ allowlists, fallbacks, and docs.
 - [x] Add CLI coverage for `models status` and `models list` canonical output.
 - [x] Add CLI coverage for `models status --plain` and `models list --plain`.
 - [x] Add CLI coverage for `models list --provider z.ai` filter normalization.
+- [x] Add CLI coverage for `models list --provider Z.AI` case normalization.
+- [x] Add CLI coverage for `models list --provider z-ai` alias normalization.
+- [x] Add CLI coverage for missing ZAI auth (available=false).
+- [x] Add auth profile order coverage for Z.AI aliases.
 
 ### Phase 4 — Docs
 - [x] Update `docs/configuration.md` with Z.AI setup snippet.
@@ -63,6 +67,7 @@ allowlists, fallbacks, and docs.
 - [x] Note Z.AI endpoint variants + built-in provider base URL.
 - [x] Add/refresh Z.AI mention in `docs/models.md`.
 - [x] Add UX note for missing `ZAI_API_KEY` auth errors.
+- [x] Add example error message for missing `ZAI_API_KEY`.
 
 ### Phase 5 — Verification
 - [x] Run unit tests (CLI + model parsing).
@@ -73,6 +78,10 @@ allowlists, fallbacks, and docs.
 ## Files touched
 - `src/agents/model-selection.ts`
 - `src/agents/model-selection.test.ts`
+- `src/agents/model-auth.test.ts`
+- `src/agents/auth-profiles.ts`
+- `src/agents/auth-profiles.test.ts`
+- `src/commands/models.list.test.ts`
 - `src/commands/models.set.test.ts`
 - `docs/configuration.md`
 - `docs/models.md`
@@ -86,4 +95,5 @@ allowlists, fallbacks, and docs.
 - Revert Z.AI doc updates.
 
 ## Verification log
-- Tests: `pnpm test` (pass; 2 skipped live tests).
+- Tests: `pnpm test` (pass; 2 skipped live tests) — 2026-01-06.
+- Targeted: `pnpm vitest run src/commands/models.list.test.ts src/agents/auth-profiles.test.ts src/agents/model-selection.test.ts src/agents/model-auth.test.ts` — 2026-01-06.

--- a/docs/plans/zai-glm-4-7-support.md
+++ b/docs/plans/zai-glm-4-7-support.md
@@ -1,0 +1,89 @@
+---
+summary: "Exec spec: Z.AI GLM-4.7 integration (provider normalization + docs + CLI/tests)"
+status: "complete"
+owner: "peter"
+updated: "2026-01-06"
+---
+
+# Exec spec: Z.AI GLM-4.7 integration
+
+## Problem
+Users configure Z.AI with `z.ai/*`, `z-ai/*`, or uppercase provider ids (e.g. `Z.AI/*`).
+Clawdbot expects canonical `zai`, which leads to mismatches across config, CLI,
+allowlists, fallbacks, and docs.
+
+## Goals
+- Accept `z.ai/*` and `z-ai/*` as provider aliases for Z.AI.
+- Normalize provider ids to lowercase, then map aliases to canonical `zai`.
+- Ensure normalization works across config parsing, CLI, allowlists, fallbacks.
+- Add explicit Z.AI documentation (env var, canonical model id, alias note).
+- Add tests to prevent regressions.
+
+## Non-goals
+- No provider runtime changes (pi-ai already supports Z.AI).
+- No OAuth; API key only.
+- No default model changes.
+- No UI changes outside docs.
+
+## Success criteria
+- `agent.model: "z.ai/glm-4.7"` resolves to `zai/glm-4.7`.
+- Provider casing is normalized (`Z.AI/*` → `zai/*`).
+- CLI `models set`/fallbacks accept alias inputs and persist canonical `zai/*`.
+- Docs show Z.AI setup + alias behavior.
+- Tests cover normalization and CLI set/fallbacks.
+
+## Implementation plan (multi-phase todo)
+
+### Phase 0 — Discovery + constraints
+- [x] Identify normalization entry point (`parseModelRef`).
+- [x] Confirm Z.AI provider id in catalog is `zai`.
+- [x] Confirm env var `ZAI_API_KEY` usage in docs.
+
+### Phase 1 — Core implementation
+- [x] Add provider normalization helper in `src/agents/model-selection.ts`.
+- [x] Normalize provider ids to lowercase.
+- [x] Map `z.ai` and `z-ai` to canonical `zai`.
+- [x] Apply normalization to both explicit provider and default provider paths.
+
+### Phase 2 — CLI + config coverage
+- [x] Ensure CLI model parsing uses normalized provider ids.
+- [x] Validate allowlists/fallbacks flow through normalized parsing.
+
+### Phase 3 — Tests
+- [x] Add unit tests for `z.ai` and `z-ai` provider normalization.
+- [x] Add unit tests for provider case normalization.
+- [x] Add CLI tests for `models set` + fallbacks normalization.
+- [x] Add CLI coverage for `models status` and `models list` canonical output.
+- [x] Add CLI coverage for `models status --plain` and `models list --plain`.
+- [x] Add CLI coverage for `models list --provider z.ai` filter normalization.
+
+### Phase 4 — Docs
+- [x] Update `docs/configuration.md` with Z.AI setup snippet.
+- [x] Document alias support (`z.ai`, `z-ai`) and canonical `zai`.
+- [x] Note Z.AI endpoint variants + built-in provider base URL.
+- [x] Add/refresh Z.AI mention in `docs/models.md`.
+- [x] Add UX note for missing `ZAI_API_KEY` auth errors.
+
+### Phase 5 — Verification
+- [x] Run unit tests (CLI + model parsing).
+- [x] Run full test suite (`pnpm test`).
+- [x] Verify `models status`/`models list` JSON output uses `zai/*`.
+- [x] Confirm PR narrative matches Z.AI integration scope.
+
+## Files touched
+- `src/agents/model-selection.ts`
+- `src/agents/model-selection.test.ts`
+- `src/commands/models.set.test.ts`
+- `docs/configuration.md`
+- `docs/models.md`
+
+## Risks
+- Canonical output shows `zai` rather than `z.ai` (intentional but may surprise).
+- Future alias collisions if additional aliases are added without review.
+
+## Rollback plan
+- Revert normalization helper and alias tests.
+- Revert Z.AI doc updates.
+
+## Verification log
+- Tests: `pnpm test` (pass; 2 skipped live tests).

--- a/src/agents/auth-profiles.test.ts
+++ b/src/agents/auth-profiles.test.ts
@@ -89,6 +89,67 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toEqual(["anthropic:work", "anthropic:default"]);
   });
 
+  it("normalizes z.ai aliases in auth.order", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: { "z.ai": ["zai:work", "zai:default"] },
+          profiles: {
+            "zai:default": { provider: "zai", mode: "api_key" },
+            "zai:work": { provider: "zai", mode: "api_key" },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-default",
+          },
+          "zai:work": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-work",
+          },
+        },
+      },
+      provider: "zai",
+    });
+    expect(order).toEqual(["zai:work", "zai:default"]);
+  });
+
+  it("normalizes z.ai aliases in auth.profiles", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "zai:default": { provider: "z.ai", mode: "api_key" },
+            "zai:work": { provider: "Z.AI", mode: "api_key" },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-default",
+          },
+          "zai:work": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-work",
+          },
+        },
+      },
+      provider: "zai",
+    });
+    expect(order).toEqual(["zai:default", "zai:work"]);
+  });
+
   it("prioritizes oauth profiles when order missing", () => {
     const mixedStore: AuthProfileStore = {
       version: 1,

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -12,6 +12,7 @@ import type { ClawdbotConfig } from "../config/config.js";
 import { resolveOAuthPath } from "../config/paths.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveClawdbotAgentDir } from "./agent-paths.js";
+import { normalizeProviderId } from "./model-selection.js";
 
 const AUTH_STORE_VERSION = 1;
 const AUTH_PROFILE_FILENAME = "auth-profiles.json";
@@ -331,8 +332,9 @@ export function listProfilesForProvider(
   store: AuthProfileStore,
   provider: string,
 ): string[] {
+  const providerKey = normalizeProviderId(provider);
   return Object.entries(store.profiles)
-    .filter(([, cred]) => cred.provider === provider)
+    .filter(([, cred]) => normalizeProviderId(cred.provider) === providerKey)
     .map(([id]) => id);
 }
 
@@ -427,17 +429,26 @@ export function resolveAuthProfileOrder(params: {
   preferredProfile?: string;
 }): string[] {
   const { cfg, store, provider, preferredProfile } = params;
-  const configuredOrder = cfg?.auth?.order?.[provider];
+  const providerKey = normalizeProviderId(provider);
+  const configuredOrder =
+    cfg?.auth?.order?.[providerKey] ??
+    cfg?.auth?.order?.[provider] ??
+    (providerKey === "zai"
+      ? (cfg?.auth?.order?.["z.ai"] ?? cfg?.auth?.order?.["z-ai"])
+      : undefined);
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
-        .filter(([, profile]) => profile.provider === provider)
+        .filter(
+          ([, profile]) =>
+            normalizeProviderId(profile.provider) === providerKey,
+        )
         .map(([profileId]) => profileId)
     : [];
   const baseOrder =
     configuredOrder ??
     (explicitProfiles.length > 0
       ? explicitProfiles
-      : listProfilesForProvider(store, provider));
+      : listProfilesForProvider(store, providerKey));
   if (baseOrder.length === 0) return [];
 
   const filtered = baseOrder.filter((profileId) => {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -163,4 +163,40 @@ describe("getApiKeyForModel", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("throws when ZAI API key is missing", async () => {
+    const previousZai = process.env.ZAI_API_KEY;
+    const previousLegacy = process.env.Z_AI_API_KEY;
+
+    try {
+      delete process.env.ZAI_API_KEY;
+      delete process.env.Z_AI_API_KEY;
+
+      vi.resetModules();
+      const { resolveApiKeyForProvider } = await import("./model-auth.js");
+
+      let error: unknown = null;
+      try {
+        await resolveApiKeyForProvider({
+          provider: "zai",
+          store: { version: 1, profiles: {} },
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(String(error)).toContain('No API key found for provider "zai".');
+    } finally {
+      if (previousZai === undefined) {
+        delete process.env.ZAI_API_KEY;
+      } else {
+        process.env.ZAI_API_KEY = previousZai;
+      }
+      if (previousLegacy === undefined) {
+        delete process.env.Z_AI_API_KEY;
+      } else {
+        process.env.Z_AI_API_KEY = previousLegacy;
+      }
+    }
+  });
 });

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { ClawdbotConfig } from "../config/config.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import { resolveConfiguredModelRef } from "./model-selection.js";
+import {
+  normalizeProviderId,
+  resolveConfiguredModelRef,
+} from "./model-selection.js";
 
 describe("resolveConfiguredModelRef", () => {
   it("parses provider/model from agent.model.primary", () => {
@@ -127,5 +130,17 @@ describe("resolveConfiguredModelRef", () => {
     });
 
     expect(resolved).toEqual({ provider: "zai", model: "glm-4.7" });
+  });
+});
+
+describe("normalizeProviderId", () => {
+  it("normalizes z.ai aliases to canonical zai", () => {
+    expect(normalizeProviderId("z.ai")).toBe("zai");
+    expect(normalizeProviderId("z-ai")).toBe("zai");
+  });
+
+  it("normalizes provider casing", () => {
+    expect(normalizeProviderId("OpenAI")).toBe("openai");
+    expect(normalizeProviderId("Z.AI")).toBe("zai");
   });
 });

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -73,9 +73,37 @@ describe("resolveConfiguredModelRef", () => {
     });
   });
 
-  it("still resolves legacy agent.model string", () => {
+  it("normalizes z.ai provider in agent.model", () => {
     const cfg = {
-      agent: { model: "openai/gpt-4.1-mini" },
+      agent: { model: "z.ai/glm-4.7" },
+    } satisfies ClawdbotConfig;
+
+    const resolved = resolveConfiguredModelRef({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
+    expect(resolved).toEqual({ provider: "zai", model: "glm-4.7" });
+  });
+
+  it("normalizes z-ai provider in agent.model", () => {
+    const cfg = {
+      agent: { model: "z-ai/glm-4.7" },
+    } satisfies ClawdbotConfig;
+
+    const resolved = resolveConfiguredModelRef({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
+    expect(resolved).toEqual({ provider: "zai", model: "glm-4.7" });
+  });
+
+  it("normalizes provider casing in agent.model", () => {
+    const cfg = {
+      agent: { model: "OpenAI/gpt-4.1-mini" },
     } satisfies ClawdbotConfig;
 
     const resolved = resolveConfiguredModelRef({
@@ -85,5 +113,19 @@ describe("resolveConfiguredModelRef", () => {
     });
 
     expect(resolved).toEqual({ provider: "openai", model: "gpt-4.1-mini" });
+  });
+
+  it("normalizes z.ai casing in agent.model", () => {
+    const cfg = {
+      agent: { model: "Z.AI/glm-4.7" },
+    } satisfies ClawdbotConfig;
+
+    const resolved = resolveConfiguredModelRef({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
+    expect(resolved).toEqual({ provider: "zai", model: "glm-4.7" });
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -21,7 +21,7 @@ export function modelKey(provider: string, model: string) {
   return `${provider}/${model}`;
 }
 
-function normalizeProvider(provider: string): string {
+export function normalizeProviderId(provider: string): string {
   const normalized = provider.trim().toLowerCase();
   if (normalized === "z.ai" || normalized === "z-ai") return "zai";
   return normalized;
@@ -35,10 +35,10 @@ export function parseModelRef(
   if (!trimmed) return null;
   const slash = trimmed.indexOf("/");
   if (slash === -1) {
-    return { provider: normalizeProvider(defaultProvider), model: trimmed };
+    return { provider: normalizeProviderId(defaultProvider), model: trimmed };
   }
   const providerRaw = trimmed.slice(0, slash).trim();
-  const provider = normalizeProvider(providerRaw);
+  const provider = normalizeProviderId(providerRaw);
   const model = trimmed.slice(slash + 1).trim();
   if (!provider || !model) return null;
   return { provider, model };

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -21,6 +21,12 @@ export function modelKey(provider: string, model: string) {
   return `${provider}/${model}`;
 }
 
+function normalizeProvider(provider: string): string {
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "z.ai" || normalized === "z-ai") return "zai";
+  return normalized;
+}
+
 export function parseModelRef(
   raw: string,
   defaultProvider: string,
@@ -29,9 +35,10 @@ export function parseModelRef(
   if (!trimmed) return null;
   const slash = trimmed.indexOf("/");
   if (slash === -1) {
-    return { provider: defaultProvider, model: trimmed };
+    return { provider: normalizeProvider(defaultProvider), model: trimmed };
   }
-  const provider = trimmed.slice(0, slash).trim();
+  const providerRaw = trimmed.slice(0, slash).trim();
+  const provider = normalizeProvider(providerRaw);
   const model = trimmed.slice(slash + 1).trim();
   if (!provider || !model) return null;
   return { provider, model };

--- a/src/commands/models.list.test.ts
+++ b/src/commands/models.list.test.ts
@@ -156,4 +156,104 @@ describe("models list/status", () => {
     expect(payload.count).toBe(1);
     expect(payload.models[0]?.key).toBe("zai/glm-4.7");
   });
+
+  it("models list provider filter normalizes Z.AI alias casing", async () => {
+    loadConfig.mockReturnValue({ agent: { model: "z.ai/glm-4.7" } });
+    const runtime = makeRuntime();
+
+    const models = [
+      {
+        provider: "zai",
+        id: "glm-4.7",
+        name: "GLM-4.7",
+        input: ["text"],
+        baseUrl: "https://api.z.ai/v1",
+        contextWindow: 128000,
+      },
+      {
+        provider: "openai",
+        id: "gpt-4.1-mini",
+        name: "GPT-4.1 mini",
+        input: ["text"],
+        baseUrl: "https://api.openai.com/v1",
+        contextWindow: 128000,
+      },
+    ];
+
+    discoverModels.mockReturnValue({
+      getAll: () => models,
+      getAvailable: () => models,
+    });
+
+    const { modelsListCommand } = await import("./models/list.js");
+    await modelsListCommand({ all: true, provider: "Z.AI", json: true }, runtime);
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
+    expect(payload.count).toBe(1);
+    expect(payload.models[0]?.key).toBe("zai/glm-4.7");
+  });
+
+  it("models list provider filter normalizes z-ai alias", async () => {
+    loadConfig.mockReturnValue({ agent: { model: "z.ai/glm-4.7" } });
+    const runtime = makeRuntime();
+
+    const models = [
+      {
+        provider: "zai",
+        id: "glm-4.7",
+        name: "GLM-4.7",
+        input: ["text"],
+        baseUrl: "https://api.z.ai/v1",
+        contextWindow: 128000,
+      },
+      {
+        provider: "openai",
+        id: "gpt-4.1-mini",
+        name: "GPT-4.1 mini",
+        input: ["text"],
+        baseUrl: "https://api.openai.com/v1",
+        contextWindow: 128000,
+      },
+    ];
+
+    discoverModels.mockReturnValue({
+      getAll: () => models,
+      getAvailable: () => models,
+    });
+
+    const { modelsListCommand } = await import("./models/list.js");
+    await modelsListCommand({ all: true, provider: "z-ai", json: true }, runtime);
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
+    expect(payload.count).toBe(1);
+    expect(payload.models[0]?.key).toBe("zai/glm-4.7");
+  });
+
+  it("models list marks auth as unavailable when ZAI key is missing", async () => {
+    loadConfig.mockReturnValue({ agent: { model: "z.ai/glm-4.7" } });
+    const runtime = makeRuntime();
+
+    const model = {
+      provider: "zai",
+      id: "glm-4.7",
+      name: "GLM-4.7",
+      input: ["text"],
+      baseUrl: "https://api.z.ai/v1",
+      contextWindow: 128000,
+    };
+
+    discoverModels.mockReturnValue({
+      getAll: () => [model],
+      getAvailable: () => [],
+    });
+
+    const { modelsListCommand } = await import("./models/list.js");
+    await modelsListCommand({ all: true, json: true }, runtime);
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
+    expect(payload.models[0]?.available).toBe(false);
+  });
 });

--- a/src/commands/models.list.test.ts
+++ b/src/commands/models.list.test.ts
@@ -149,7 +149,10 @@ describe("models list/status", () => {
     });
 
     const { modelsListCommand } = await import("./models/list.js");
-    await modelsListCommand({ all: true, provider: "z.ai", json: true }, runtime);
+    await modelsListCommand(
+      { all: true, provider: "z.ai", json: true },
+      runtime,
+    );
 
     expect(runtime.log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
@@ -186,7 +189,10 @@ describe("models list/status", () => {
     });
 
     const { modelsListCommand } = await import("./models/list.js");
-    await modelsListCommand({ all: true, provider: "Z.AI", json: true }, runtime);
+    await modelsListCommand(
+      { all: true, provider: "Z.AI", json: true },
+      runtime,
+    );
 
     expect(runtime.log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
@@ -223,7 +229,10 @@ describe("models list/status", () => {
     });
 
     const { modelsListCommand } = await import("./models/list.js");
-    await modelsListCommand({ all: true, provider: "z-ai", json: true }, runtime);
+    await modelsListCommand(
+      { all: true, provider: "z-ai", json: true },
+      runtime,
+    );
 
     expect(runtime.log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));

--- a/src/commands/models.set.test.ts
+++ b/src/commands/models.set.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshot = vi.fn();
+const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+const loadConfig = vi.fn().mockReturnValue({});
+
+vi.mock("../config/config.js", () => ({
+  CONFIG_PATH_CLAWDBOT: "/tmp/clawdbot.json",
+  readConfigFileSnapshot,
+  writeConfigFile,
+  loadConfig,
+}));
+
+describe("models set + fallbacks", () => {
+  beforeEach(() => {
+    readConfigFileSnapshot.mockReset();
+    writeConfigFile.mockClear();
+  });
+
+  it("normalizes z.ai provider in models set", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/clawdbot.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      valid: true,
+      config: {},
+      issues: [],
+      legacyIssues: [],
+    });
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const { modelsSetCommand } = await import("./models/set.js");
+
+    await modelsSetCommand("z.ai/glm-4.7", runtime);
+
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    const written = writeConfigFile.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(written.agent).toEqual({
+      model: { primary: "zai/glm-4.7" },
+      models: { "zai/glm-4.7": {} },
+    });
+  });
+
+  it("normalizes z-ai provider in models fallbacks add", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/clawdbot.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      valid: true,
+      config: { agent: { model: { fallbacks: [] } } },
+      issues: [],
+      legacyIssues: [],
+    });
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const { modelsFallbacksAddCommand } = await import("./models/fallbacks.js");
+
+    await modelsFallbacksAddCommand("z-ai/glm-4.7", runtime);
+
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    const written = writeConfigFile.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(written.agent).toEqual({
+      model: { fallbacks: ["zai/glm-4.7"] },
+      models: { "zai/glm-4.7": {} },
+    });
+  });
+
+  it("normalizes provider casing in models set", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/clawdbot.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      valid: true,
+      config: {},
+      issues: [],
+      legacyIssues: [],
+    });
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const { modelsSetCommand } = await import("./models/set.js");
+
+    await modelsSetCommand("Z.AI/glm-4.7", runtime);
+
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    const written = writeConfigFile.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(written.agent).toEqual({
+      model: { primary: "zai/glm-4.7" },
+      models: { "zai/glm-4.7": {} },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize provider ids via helper; reuse in model parsing and auth profile resolution.
- Accept z.ai/z-ai/case in auth.order/auth.profiles and models list filter.
- Add tests for alias filtering + missing ZAI key; doc example error.

## Testing
- pnpm test
- pnpm vitest run src/commands/models.list.test.ts src/agents/auth-profiles.test.ts src/agents/model-selection.test.ts src/agents/model-auth.test.ts

## AI-assisted
- [x] AI-assisted (Codex)
- [x] Degree of testing: fully tested
- [x] Prompts/session logs: available in this chat thread
- [x] I understand the changes