### PR TITLE
fix(browser): patch playwright-core for Bun WebSocket compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     },
     "patchedDependencies": {
       "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch",
-      "qrcode-terminal": "patches/qrcode-terminal.patch"
+      "qrcode-terminal": "patches/qrcode-terminal.patch",
+      "playwright-core@1.57.0": "patches/playwright-core@1.57.0.patch"
     }
   },
   "vitest": {
@@ -186,5 +187,10 @@
       "apps/macos/.build/**",
       "dist/Clawdbot.app/**"
     ]
+  },
+  "patchedDependencies": {
+    "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch",
+    "qrcode-terminal": "patches/qrcode-terminal.patch",
+    "playwright-core@1.57.0": "patches/playwright-core@1.57.0.patch"
   }
 }

--- a/patches/playwright-core@1.57.0.patch
+++ b/patches/playwright-core@1.57.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/utilsBundle.js b/lib/utilsBundle.js
+index 7dd8831f29c19f2e20468508b77b0a3f9d204ae6..c50a1ac2b3439a5b2fbf8afa61c369360710071f 100644
+--- a/lib/utilsBundle.js
++++ b/lib/utilsBundle.js
+@@ -59,7 +59,7 @@ const program = require("./utilsBundleImpl").program;
+ const ProgramOption = require("./utilsBundleImpl").ProgramOption;
+ const progress = require("./utilsBundleImpl").progress;
+ const SocksProxyAgent = require("./utilsBundleImpl").SocksProxyAgent;
+-const ws = require("./utilsBundleImpl").ws;
++const ws = "Bun" in globalThis ? require("ws") : require("./utilsBundleImpl").ws;
+ const wsServer = require("./utilsBundleImpl").wsServer;
+ const wsReceiver = require("./utilsBundleImpl").wsReceiver;
+ const wsSender = require("./utilsBundleImpl").wsSender;


### PR DESCRIPTION
## Problem

After PR #278 (tsx → bun migration), browser `snapshot` and `act` commands timeout with:
```
TimeoutError: overCDP: Timeout 9000ms exceeded.
Call log:
  - <ws connecting> ws://127.0.0.1:18800/devtools/browser/...
```

## Root Cause

Bun's WebSocket shim works for direct `ws` imports, but Playwright bundles its own copy of `ws` in `utilsBundleImpl.js`. This bundled version doesn't use Bun's shim, causing `connectOverCDP` to hang.

Known issue: https://github.com/oven-sh/bun/issues/9911

## Solution

Apply the official Bun team workaround via `bun patch`:
```diff
-const ws = require("./utilsBundleImpl").ws;
+const ws = "Bun" in globalThis ? require("ws") : require("./utilsBundleImpl").ws;
```

This makes Playwright use the native `ws` module (which Bun shims correctly) when running under Bun.

## Testing

Before patch:
- `bun -e "chromium.connectOverCDP(...)" ` → ❌ Timeout

After patch:
- `bun -e "chromium.connectOverCDP(...)" ` → ✅ Connected!
- `browser snapshot` → ✅ Works
- `browser act` → ✅ Works