### PR TITLE
fix(macOS): keep gateway config sync local

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -416,7 +416,8 @@ final class AppState {
             : nil
 
         Task { @MainActor in
-            var root = await ConfigStore.load()
+            // Keep app-only connection settings local to avoid overwriting remote gateway config.
+            var root = ClawdbotConfigFile.loadDict()
             var gateway = root["gateway"] as? [String: Any] ?? [:]
             var changed = false
 
@@ -446,8 +447,12 @@ final class AppState {
             }
 
             guard changed else { return }
-            root["gateway"] = gateway
-            try? await ConfigStore.save(root)
+            if gateway.isEmpty {
+                root.removeValue(forKey: "gateway")
+            } else {
+                root["gateway"] = gateway
+            }
+            ClawdbotConfigFile.saveDict(root)
         }
     }
 


### PR DESCRIPTION
## What
-keep app connection settings (gateway.mode / gateway.remote.url) local to the macOS app to avoid overwriting remote gateway config in remote mode.

## Why
-remote mode sync currently writes to the gateway via config.set when changing app settings, which surprises operators and overwrites server config.

## How
-use local config file writes for gateway mode / remote url sync in AppState, leaving explicit Config tab saves to continue writing to the gateway.

## Testing
- rebuilt and restarted macOS app - verified my remote gateway config is not getting overwritten anymore

## AI Assistance
-AI-assisted (Codex). I reviewed the changes and understand the code.