### PR TITLE
fix(build): import tool-display.json instead of fs.readFileSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Groups: `whatsapp.groups`, `telegram.groups`, and `imessage.groups` now act as allowlists when set. Add `"*"` to keep allow-all behavior.
 
 ### Fixes
+- Build: import tool-display JSON as a module instead of runtime file reads. Thanks @mukhtharcm for PR #312.
 - Messages: stop defaulting ack reactions to 👀 when identity emoji is missing.
 - Auto-reply: require slash for control commands to avoid false triggers in normal text.
 - Auto-reply: treat steer during compaction as a follow-up, queued until compaction completes.

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
 import { redactToolDetail } from "../logging/redact.js";
 import { shortenHomeInString } from "../utils.js";
+import TOOL_DISPLAY_JSON from "./tool-display.json" with { type: "json" };
 
 type ToolDisplayActionSpec = {
   label?: string;
@@ -30,17 +30,7 @@ export type ToolDisplay = {
   detail?: string;
 };
 
-const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = (() => {
-  try {
-    const raw = fs.readFileSync(
-      new URL("./tool-display.json", import.meta.url),
-      "utf8",
-    );
-    return JSON.parse(raw) as ToolDisplayConfig;
-  } catch {
-    return {};
-  }
-})();
+const TOOL_DISPLAY_CONFIG = TOOL_DISPLAY_JSON as ToolDisplayConfig;
 const FALLBACK = TOOL_DISPLAY_CONFIG.fallback ?? { emoji: "🧩" };
 const TOOL_MAP = TOOL_DISPLAY_CONFIG.tools ?? {};
 


### PR DESCRIPTION
## Problem

`tool-display.json` was not being copied to `dist/` during build. This caused tool display to fall back to defaults:
- Wrong emoji (???? instead of ??????? for bash)  
- No command details shown in verbose mode

## Cause

The file was loaded at runtime using `fs.readFileSync()` with `import.meta.url`, which looks for the JSON relative to the compiled JS file in `dist/agents/`. But `tsc` doesnt copy non-imported JSON files.

## Fix

Use ES module JSON import with `with { type: "json" }` syntax. This tells TypeScript to include the JSON in the build output.

## Testing

- `pnpm build` succeeds
- `dist/agents/tool-display.json` now exists after build
- Tool display shows correct emoji and command details