### PR TITLE
Slack: send assistant thread status while typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Skills: emit MEDIA token after Nano Banana Pro image generation. Thanks @Iamadig for PR #271.
 - WhatsApp: set sender E.164 for direct chats so owner commands work in DMs.
 - Slack: keep auto-replies in the original thread when responding to thread messages. Thanks @scald for PR #251.
+- Slack: send typing status updates via assistant threads. Thanks @thewilloftheshadow for PR #320.
 - Slack: fix Slack provider startup under Bun by using a named import for Bolt `App`. Thanks @snopoke for PR #299.
 - Discord: surface missing-permission hints (muted/role overrides) when replies fail.
 - Discord: use channel IDs for DMs instead of user IDs. Thanks @VACInc for PR #261.

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -12,6 +12,7 @@ import {
   matchesMentionPatterns,
 } from "../auto-reply/reply/mentions.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import type { TypingController } from "../auto-reply/reply/typing.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -487,6 +488,41 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     }
   };
 
+  const setSlackThreadStatus = async (params: {
+    channelId: string;
+    threadTs?: string;
+    status: string;
+  }) => {
+    if (!params.threadTs) return;
+    const payload = {
+      token: botToken,
+      channel_id: params.channelId,
+      thread_ts: params.threadTs,
+      status: params.status,
+    };
+    const client = app.client as unknown as {
+      assistant?: {
+        threads?: {
+          setStatus?: (args: typeof payload) => Promise<unknown>;
+        };
+      };
+      apiCall?: (method: string, args: typeof payload) => Promise<unknown>;
+    };
+    try {
+      if (client.assistant?.threads?.setStatus) {
+        await client.assistant.threads.setStatus(payload);
+        return;
+      }
+      if (typeof client.apiCall === "function") {
+        await client.apiCall("assistant.threads.setStatus", payload);
+      }
+    } catch (err) {
+      logVerbose(
+        `slack status update failed for channel ${params.channelId}: ${String(err)}`,
+      );
+    }
+  };
+
   const isChannelAllowed = (params: {
     channelId?: string;
     channelName?: string;
@@ -801,6 +837,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
     // Only thread replies if the incoming message was in a thread.
     const incomingThreadTs = message.thread_ts;
+    const statusThreadTs = message.thread_ts ?? message.ts;
+    const onReplyStart = async () => {
+      await setSlackThreadStatus({
+        channelId: message.channel,
+        threadTs: statusThreadTs,
+        status: "is typing...",
+      });
+    };
+    let typingController: TypingController | undefined;
     const dispatcher = createReplyDispatcher({
       responsePrefix: cfg.messages?.responsePrefix,
       deliver: async (payload) => {
@@ -813,10 +858,18 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           threadTs: incomingThreadTs,
         });
       },
+      onIdle: () => {
+        typingController?.markDispatchIdle();
+      },
       onError: (err, info) => {
         runtime.error?.(
           danger(`slack ${info.kind} reply failed: ${String(err)}`),
         );
+        void setSlackThreadStatus({
+          channelId: message.channel,
+          threadTs: statusThreadTs,
+          status: "",
+        });
       },
     });
 
@@ -824,8 +877,22 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       ctx: ctxPayload,
       cfg,
       dispatcher,
+      replyOptions: {
+        onReplyStart,
+        onTypingController: (typing) => {
+          typingController = typing;
+        },
+      },
     });
-    if (!queuedFinal) return;
+    typingController?.markDispatchIdle();
+    if (!queuedFinal) {
+      await setSlackThreadStatus({
+        channelId: message.channel,
+        threadTs: statusThreadTs,
+        status: "",
+      });
+      return;
+    }
     if (shouldLogVerbose()) {
       const finalCount = counts.final;
       logVerbose(


### PR DESCRIPTION
Typing in Slack!! :tada:
Thanks to the Discord for telling me about this method, both me and Codex got stuck looking at the old deprecated API for typing and assumed this feature wasn't available based on outdated (4 years old) GH issues on the bolt repo