### PR TITLE
feat(telegram): add forum topic support with message_thread_id

### DIFF
--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -27,6 +27,10 @@ export type MsgContext = {
   Surface?: string;
   WasMentioned?: boolean;
   CommandAuthorized?: boolean;
+  /** Telegram forum topic thread ID */
+  MessageThreadId?: number;
+  /** Whether this is a Telegram forum supergroup */
+  IsForum?: boolean;
 };
 
 export type TemplateContext = MsgContext & {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -380,7 +380,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
     const ctxPayload = {
       Body: body,
-      From: isGroup ? `group:${chatId}` : `telegram:${chatId}`,
+      From: isGroup
+        ? messageThreadId
+          ? `telegram:group:${chatId}:topic:${messageThreadId}`
+          : `group:${chatId}`
+        : `telegram:${chatId}`,
       To: `telegram:${chatId}`,
       ChatType: isGroup ? "group" : "direct",
       GroupSubject: isGroup ? (msg.chat.title ?? undefined) : undefined,


### PR DESCRIPTION
## Summary
Adds support for Telegram forum topics (supergroups with topics enabled) by properly routing replies back to the correct topic thread.

## Changes
- Capture `message_thread_id` from incoming messages in forum supergroups
- Pass `message_thread_id` to typing indicators (`sendChatAction`)
- Pass `message_thread_id` to all reply methods (`sendMessage`, `sendPhoto`, `sendAnimation`, `sendVideo`, `sendAudio`, `sendDocument`)
- Add `MessageThreadId` and `IsForum` fields to the context payload for downstream use
- Add tests for forum topic handling

## How it works
When a message comes from a Telegram forum supergroup, it includes a `message_thread_id` that identifies which topic the message belongs to. This PR captures that ID and ensures all replies (text, media, typing indicators) are sent back to the same topic thread.

## Testing
- Added test: "passes message_thread_id to replies in forum supergroups"
- Added test: "handles forum messages without message_thread_id gracefully"
- All existing Telegram tests pass

Closes #187 (partially - adds threading support for Telegram)