### PR TITLE
feat(routing): route replies to originating channel

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,20 +1,17 @@
 {
-	"$schema": "https://biomejs.dev/schemas/biome.json",
-	"formatter": {
-		"enabled": true,
-		"indentWidth": 2,
-		"indentStyle": "space"
-	},
-	"files": {
-		"includes": [
-			"src/**/*.ts",
-			"test/**/*.ts"
-		]
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/biome.json",
+  "formatter": {
+    "enabled": true,
+    "indentWidth": 2,
+    "indentStyle": "space"
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "test/**/*.ts"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
 }

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -714,6 +714,9 @@ export async function getReplyFromConfig(
     prompt: queuedBody,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
+    // Originating channel for reply routing.
+    originatingChannel: ctx.OriginatingChannel,
+    originatingTo: ctx.OriginatingTo,
     run: {
       agentId,
       agentDir,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,8 +1,10 @@
 import type { ClawdbotConfig } from "../../config/config.js";
+import { logVerbose } from "../../globals.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
+import { isRoutableChannel, routeReply } from "./route-reply.js";
 
 type DispatchFromConfigResult = {
   queuedFinal: boolean;
@@ -16,18 +18,68 @@ export async function dispatchReplyFromConfig(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof getReplyFromConfig;
 }): Promise<DispatchFromConfigResult> {
+  const { ctx, cfg, dispatcher } = params;
+
+  // Check if we should route replies to originating channel instead of dispatcher.
+  // Only route when the originating channel is DIFFERENT from the current surface.
+  // This handles cross-provider routing (e.g., message from Telegram being processed
+  // by a shared session that's currently on Slack) while preserving normal dispatcher
+  // flow when the provider handles its own messages.
+  const originatingChannel = ctx.OriginatingChannel;
+  const originatingTo = ctx.OriginatingTo;
+  const currentSurface = ctx.Surface?.toLowerCase();
+  const shouldRouteToOriginating =
+    isRoutableChannel(originatingChannel) &&
+    originatingTo &&
+    originatingChannel !== currentSurface;
+
+  /**
+   * Helper to send a payload via route-reply (async).
+   * Only used when actually routing to a different provider.
+   * Note: Only called when shouldRouteToOriginating is true, so
+   * originatingChannel and originatingTo are guaranteed to be defined.
+   */
+  const sendPayloadAsync = async (payload: ReplyPayload): Promise<void> => {
+    // TypeScript doesn't narrow these from the shouldRouteToOriginating check,
+    // but they're guaranteed non-null when this function is called.
+    if (!originatingChannel || !originatingTo) return;
+    const result = await routeReply({
+      payload,
+      channel: originatingChannel,
+      to: originatingTo,
+      cfg,
+    });
+    if (!result.ok) {
+      logVerbose(
+        `dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`,
+      );
+    }
+  };
+
   const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
-    params.ctx,
+    ctx,
     {
       ...params.replyOptions,
       onToolResult: (payload: ReplyPayload) => {
-        params.dispatcher.sendToolResult(payload);
+        if (shouldRouteToOriginating) {
+          // Fire-and-forget for streaming tool results when routing.
+          void sendPayloadAsync(payload);
+        } else {
+          // Synchronous dispatch to preserve callback timing.
+          dispatcher.sendToolResult(payload);
+        }
       },
       onBlockReply: (payload: ReplyPayload) => {
-        params.dispatcher.sendBlockReply(payload);
+        if (shouldRouteToOriginating) {
+          // Fire-and-forget for streaming block replies when routing.
+          void sendPayloadAsync(payload);
+        } else {
+          // Synchronous dispatch to preserve callback timing.
+          dispatcher.sendBlockReply(payload);
+        }
       },
     },
-    params.cfg,
+    cfg,
   );
 
   const replies = replyResult
@@ -38,9 +90,26 @@ export async function dispatchReplyFromConfig(params: {
 
   let queuedFinal = false;
   for (const reply of replies) {
-    queuedFinal = params.dispatcher.sendFinalReply(reply) || queuedFinal;
+    if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+      // Route final reply to originating channel.
+      const result = await routeReply({
+        payload: reply,
+        channel: originatingChannel,
+        to: originatingTo,
+        cfg,
+      });
+      if (!result.ok) {
+        logVerbose(
+          `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
+        );
+      }
+      // Mark as queued since we handled it ourselves.
+      queuedFinal = true;
+    } else {
+      queuedFinal = dispatcher.sendFinalReply(reply) || queuedFinal;
+    }
   }
-  await params.dispatcher.waitForIdle();
+  await dispatcher.waitForIdle();
 
-  return { queuedFinal, counts: params.dispatcher.getQueuedCounts() };
+  return { queuedFinal, counts: dispatcher.getQueuedCounts() };
 }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -82,9 +82,13 @@ export function createFollowupRunner(params: {
           cfg: queued.run.config,
         });
         if (!result.ok) {
-          logVerbose(
-            `followup queue: route-reply failed: ${result.error ?? "unknown error"}`,
-          );
+          // Log error and fall back to dispatcher if available.
+          const errorMsg = result.error ?? "unknown error";
+          logVerbose(`followup queue: route-reply failed: ${errorMsg}`);
+          // Fallback: try the dispatcher if routing failed.
+          if (opts?.onBlockReply) {
+            await opts.onBlockReply(payload);
+          }
         }
       } else if (opts?.onBlockReply) {
         await opts.onBlockReply(payload);

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -3,6 +3,7 @@ import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { ClawdbotConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { defaultRuntime } from "../../runtime.js";
+import type { OriginatingChannelType } from "../templating.js";
 import type { ElevatedLevel, ThinkLevel, VerboseLevel } from "./directives.js";
 export type QueueMode =
   | "steer"
@@ -22,6 +23,17 @@ export type FollowupRun = {
   prompt: string;
   summaryLine?: string;
   enqueuedAt: number;
+  /**
+   * Originating channel for reply routing.
+   * When set, replies should be routed back to this provider
+   * instead of using the session's lastChannel.
+   */
+  originatingChannel?: OriginatingChannelType;
+  /**
+   * Originating destination for reply routing.
+   * The chat/channel/user ID where the reply should be sent.
+   */
+  originatingTo?: string;
   run: {
     agentId: string;
     agentDir: string;

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -1,0 +1,135 @@
+/**
+ * Provider-agnostic reply router.
+ *
+ * Routes replies to the originating channel based on OriginatingChannel/OriginatingTo
+ * instead of using the session's lastChannel. This ensures replies go back to the
+ * provider where the message originated, even when the main session is shared
+ * across multiple providers.
+ */
+
+import type { ClawdbotConfig } from "../../config/config.js";
+import { sendMessageDiscord } from "../../discord/send.js";
+import { sendMessageIMessage } from "../../imessage/send.js";
+import { sendMessageSignal } from "../../signal/send.js";
+import { sendMessageSlack } from "../../slack/send.js";
+import { sendMessageTelegram } from "../../telegram/send.js";
+import type { OriginatingChannelType } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
+
+export type RouteReplyParams = {
+  /** The reply payload to send. */
+  payload: ReplyPayload;
+  /** The originating channel type (telegram, slack, etc). */
+  channel: OriginatingChannelType;
+  /** The destination chat/channel/user ID. */
+  to: string;
+  /** Config for provider-specific settings. */
+  cfg: ClawdbotConfig;
+};
+
+export type RouteReplyResult = {
+  /** Whether the reply was sent successfully. */
+  ok: boolean;
+  /** Optional message ID from the provider. */
+  messageId?: string;
+  /** Error message if the send failed. */
+  error?: string;
+};
+
+/**
+ * Routes a reply payload to the specified channel.
+ *
+ * This function provides a unified interface for sending messages to any
+ * supported provider. It's used by the followup queue to route replies
+ * back to the originating channel when OriginatingChannel/OriginatingTo
+ * are set.
+ */
+export async function routeReply(
+  params: RouteReplyParams,
+): Promise<RouteReplyResult> {
+  const { payload, channel, to } = params;
+  const text = payload.text ?? "";
+  const mediaUrl = payload.mediaUrl ?? payload.mediaUrls?.[0];
+
+  // Skip empty replies.
+  if (!text.trim() && !mediaUrl) {
+    return { ok: true };
+  }
+
+  try {
+    switch (channel) {
+      case "telegram": {
+        const result = await sendMessageTelegram(to, text, { mediaUrl });
+        return { ok: true, messageId: result.messageId };
+      }
+
+      case "slack": {
+        const result = await sendMessageSlack(to, text, { mediaUrl });
+        return { ok: true, messageId: result.messageId };
+      }
+
+      case "discord": {
+        const result = await sendMessageDiscord(to, text, { mediaUrl });
+        return { ok: true, messageId: result.messageId };
+      }
+
+      case "signal": {
+        const result = await sendMessageSignal(to, text, { mediaUrl });
+        return { ok: true, messageId: result.messageId };
+      }
+
+      case "imessage": {
+        const result = await sendMessageIMessage(to, text, { mediaUrl });
+        return { ok: true, messageId: result.messageId };
+      }
+
+      case "whatsapp": {
+        // WhatsApp doesn't have a standalone send function in this codebase.
+        // Falls through to unknown channel handling.
+        return {
+          ok: false,
+          error: `WhatsApp routing not yet implemented`,
+        };
+      }
+
+      case "webchat": {
+        // Webchat is typically handled differently (real-time WebSocket).
+        // Falls through to unknown channel handling.
+        return {
+          ok: false,
+          error: `Webchat routing not supported for queued replies`,
+        };
+      }
+
+      default: {
+        // Exhaustive check for unknown channel types.
+        const _exhaustive: never = channel;
+        return {
+          ok: false,
+          error: `Unknown channel: ${String(_exhaustive)}`,
+        };
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `Failed to route reply to ${channel}: ${message}`,
+    };
+  }
+}
+
+/**
+ * Checks if a channel type is routable via routeReply.
+ *
+ * Some channels (webchat, whatsapp) require special handling and
+ * cannot be routed through this generic interface.
+ */
+export function isRoutableChannel(
+  channel: OriginatingChannelType | undefined,
+): channel is "telegram" | "slack" | "discord" | "signal" | "imessage" {
+  if (!channel) return false;
+  return ["telegram", "slack", "discord", "signal", "imessage"].includes(
+    channel,
+  );
+}

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,3 +1,13 @@
+/** Valid provider channels for message routing. */
+export type OriginatingChannelType =
+  | "telegram"
+  | "slack"
+  | "discord"
+  | "signal"
+  | "imessage"
+  | "whatsapp"
+  | "webchat";
+
 export type MsgContext = {
   Body?: string;
   From?: string;
@@ -34,6 +44,17 @@ export type MsgContext = {
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;
+  /**
+   * Originating channel for reply routing.
+   * When set, replies should be routed back to this provider
+   * instead of using lastChannel from the session.
+   */
+  OriginatingChannel?: OriginatingChannelType;
+  /**
+   * Originating destination for reply routing.
+   * The chat/channel/user ID where the reply should be sent.
+   */
+  OriginatingTo?: string;
 };
 
 export type TemplateContext = MsgContext & {

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -818,22 +818,22 @@ export async function runConfigureWizard(
     runtime.error(controlUiAssets.message);
   }
 
-    note(
-      (() => {
-        const bind = nextConfig.gateway?.bind ?? "loopback";
-        const links = resolveControlUiLinks({
-          bind,
-          port: gatewayPort,
-          basePath: nextConfig.gateway?.controlUi?.basePath,
-        });
-        return [
-          `Web UI: ${links.httpUrl}`,
-          `Gateway WS: ${links.wsUrl}`,
-          "Docs: https://docs.clawd.bot/web/control-ui",
-        ].join("\n");
-      })(),
-      "Control UI",
-    );
+  note(
+    (() => {
+      const bind = nextConfig.gateway?.bind ?? "loopback";
+      const links = resolveControlUiLinks({
+        bind,
+        port: gatewayPort,
+        basePath: nextConfig.gateway?.controlUi?.basePath,
+      });
+      return [
+        `Web UI: ${links.httpUrl}`,
+        `Gateway WS: ${links.wsUrl}`,
+        "Docs: https://docs.clawd.bot/web/control-ui",
+      ].join("\n");
+    })(),
+    "Control UI",
+  );
 
   const browserSupport = await detectBrowserOpenSupport();
   if (!browserSupport.ok) {

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -739,14 +739,13 @@ export function createDiscordMessageHandler(params: {
         combinedBody = `[Replied message - for context]\n${replyContext}\n\n${combinedBody}`;
       }
 
+      const discordTo = `channel:${message.channelId}`;
       const ctxPayload = {
         Body: combinedBody,
         From: isDirectMessage
           ? `discord:${author.id}`
           : `group:${message.channelId}`,
-        To: isDirectMessage
-          ? `user:${author.id}`
-          : `channel:${message.channelId}`,
+        To: discordTo,
         SessionKey: route.sessionKey,
         AccountId: route.accountId,
         ChatType: isDirectMessage ? "direct" : "group",
@@ -770,6 +769,9 @@ export function createDiscordMessageHandler(params: {
         MediaUrl: media?.path,
         CommandAuthorized: commandAuthorized,
         CommandSource: "text" as const,
+        // Originating channel for reply routing.
+        OriginatingChannel: "discord" as const,
+        OriginatingTo: discordTo,
       };
       const replyTarget = ctxPayload.To ?? undefined;
       if (!replyTarget) {

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -366,6 +366,7 @@ export async function monitorIMessageProvider(
       SenderName: sender,
       SenderId: sender,
       Provider: "imessage",
+      Surface: "imessage",
       MessageSid: message.id ? String(message.id) : undefined,
       Timestamp: createdAt,
       MediaPath: mediaPath,

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -351,10 +351,11 @@ export async function monitorIMessageProvider(
           : normalizeIMessageHandle(sender),
       },
     });
+    const imessageTo = chatTarget || `imessage:${sender}`;
     const ctxPayload = {
       Body: body,
       From: isGroup ? `group:${chatId}` : `imessage:${sender}`,
-      To: chatTarget || `imessage:${sender}`,
+      To: imessageTo,
       SessionKey: route.sessionKey,
       AccountId: route.accountId,
       ChatType: isGroup ? "group" : "direct",
@@ -372,6 +373,9 @@ export async function monitorIMessageProvider(
       MediaUrl: mediaPath,
       WasMentioned: mentioned,
       CommandAuthorized: commandAuthorized,
+      // Originating channel for reply routing.
+      OriginatingChannel: "imessage" as const,
+      OriginatingTo: imessageTo,
     };
 
     if (!isGroup) {

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -463,6 +463,7 @@ export async function monitorSignalProvider(
         SenderName: envelope.sourceName ?? sender,
         SenderId: sender,
         Provider: "signal" as const,
+        Surface: "signal" as const,
         MessageSid: envelope.timestamp ? String(envelope.timestamp) : undefined,
         Timestamp: envelope.timestamp ?? undefined,
         MediaPath: mediaPath,

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -451,10 +451,11 @@ export async function monitorSignalProvider(
           id: isGroup ? (groupId ?? "unknown") : normalizeE164(sender),
         },
       });
+      const signalTo = isGroup ? `group:${groupId}` : `signal:${sender}`;
       const ctxPayload = {
         Body: body,
         From: isGroup ? `group:${groupId ?? "unknown"}` : `signal:${sender}`,
-        To: isGroup ? `group:${groupId ?? "unknown"}` : `signal:${sender}`,
+        To: signalTo,
         SessionKey: route.sessionKey,
         AccountId: route.accountId,
         ChatType: isGroup ? "group" : "direct",
@@ -468,6 +469,9 @@ export async function monitorSignalProvider(
         MediaType: mediaType,
         MediaUrl: mediaPath,
         CommandAuthorized: commandAuthorized,
+        // Originating channel for reply routing.
+        OriginatingChannel: "signal" as const,
+        OriginatingTo: signalTo,
       };
 
       if (!isGroup) {

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -821,6 +821,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       SenderName: senderName,
       SenderId: message.user,
       Provider: "slack" as const,
+      Surface: "slack" as const,
       MessageSid: message.ts,
       ReplyToId: message.thread_ts ?? message.ts,
       Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -807,12 +807,13 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     });
 
     const isRoomish = isRoom || isGroupDm;
+    const slackTo = isDirectMessage
+      ? `user:${message.user}`
+      : `channel:${message.channel}`;
     const ctxPayload = {
       Body: body,
       From: slackFrom,
-      To: isDirectMessage
-        ? `user:${message.user}`
-        : `channel:${message.channel}`,
+      To: slackTo,
       SessionKey: route.sessionKey,
       AccountId: route.accountId,
       ChatType: isDirectMessage ? "direct" : isRoom ? "room" : "group",
@@ -828,6 +829,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       MediaType: media?.contentType,
       MediaUrl: media?.path,
       CommandAuthorized: commandAuthorized,
+      // Originating channel for reply routing.
+      OriginatingChannel: "slack" as const,
+      OriginatingTo: slackTo,
     };
 
     const replyTarget = ctxPayload.To ?? undefined;
@@ -1566,6 +1570,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         AccountId: route.accountId,
         CommandSource: "native" as const,
         CommandAuthorized: commandAuthorized,
+        // Originating channel for reply routing.
+        OriginatingChannel: "slack" as const,
+        OriginatingTo: `user:${command.user_id}`,
       };
 
       const replyResult = await getReplyFromConfig(ctxPayload, undefined, cfg);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -401,6 +401,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       SenderId: senderId || undefined,
       SenderUsername: senderUsername || undefined,
       Provider: "telegram",
+      Surface: "telegram",
       MessageSid: String(msg.message_id),
       ReplyToId: replyTarget?.id,
       ReplyToBody: replyTarget?.body,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -418,6 +418,9 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           : undefined,
       ...(locationData ? toLocationContext(locationData) : undefined),
       CommandAuthorized: commandAuthorized,
+      // Originating channel for reply routing.
+      OriginatingChannel: "telegram" as const,
+      OriginatingTo: `telegram:${chatId}`,
     };
 
     if (replyTarget && shouldLogVerbose()) {


### PR DESCRIPTION
## Summary

When multiple messaging providers (Telegram, Slack, WhatsApp, etc.) share the `main` session, replies now route back to the **originating channel** instead of using `lastChannel`.

## Problem

Previously, if you:
1. Message on Telegram → reply goes to Telegram ✓
2. Message on Slack → reply goes to Telegram ✗ (used `lastChannel`)

## Solution

Track `OriginatingChannel` and `OriginatingTo` per-message and route replies accordingly.

### Changes

- **`src/auto-reply/templating.ts`** - Added `OriginatingChannel`/`OriginatingTo` to `MsgContext`
- **`src/auto-reply/reply/route-reply.ts`** (new) - Provider-agnostic reply router
- **`src/auto-reply/reply/dispatch-from-config.ts`** - Route to originating channel when cross-provider
- **`src/auto-reply/reply/queue.ts`** - Track originating channel in followup queue
- **All providers** (Telegram, Slack, Discord, Signal, iMessage) - Set `OriginatingChannel`/`OriginatingTo`

### Behavior

- Same-provider: Uses normal dispatcher (no change)
- Cross-provider: Routes via `routeReply()` to originating channel

## Testing

- ✅ Build passes
- ✅ Lint passes
- ✅ All 1086 tests pass
- ✅ Manual testing: Telegram↔Slack cross-routing works correctly