### PR TITLE
fix(auth): write OAuth credentials to multi-agent path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Auto-reply: require slash for control commands to avoid false triggers in normal text.
 - Auto-reply: treat steer during compaction as a follow-up, queued until compaction completes.
 - Auth: lock auth profile refreshes to avoid multi-instance OAuth logouts; keep credentials on refresh failure.
+- Auth: write OAuth credentials to multi-agent path (`~/.clawdbot/agents/main/agent`) so gateway can find them.
 - Gateway/CLI: stop forcing localhost URL in remote mode so remote gateway config works. Thanks @oswalpalash for PR #293.
 - Onboarding: prompt immediately for OpenAI Codex redirect URL on remote/headless logins.
 - Configure: add OpenAI Codex (ChatGPT OAuth) auth choice (align with onboarding).


### PR DESCRIPTION
# Fix: Write OAuth credentials to multi-agent path

## Problem

After running `clawdbot configure` with Anthropic OAuth, the gateway fails with:
```
Embedded agent failed before reply: No credentials found for profile "anthropic:default".
```

The root cause could be that `writeOAuthCredentials` wrote to `~/.clawdbot/agent/auth-profiles.json` (legacy path),
but the gateway reads from `~/.clawdbot/agents/main/agent/auth-profiles.json` (multi-agent path).

## Suggested fix

Update `onboard-auth.ts` to write credentials to the multi-agent path by default, while preserving compatibility with explicit env overrides (`CLAWDBOT_AGENT_DIR`, `PI_CODING_AGENT_DIR`).

## Compatibility notes

### What seems to work
- **Gateway auto-reply** — passes `agentDir` via `resolveAgentDir(cfg, agentId)` → reads from multi-agent path
- **Tests** — set `CLAWDBOT_AGENT_DIR` explicitly → still respected
- **Legacy env overrides** — `PI_CODING_AGENT_DIR` → still respected

### What breaks: CLI commands

Some CLI commands (`clawdbot agent --local`, `clawdbot models list`, etc.) call `ensureAuthProfileStore()` without passing `agentDir`, so they default to the legacy path via `resolveClawdbotAgentDir()`.

After this fix, credentials written by `configure` won't be visible to these CLI commands unless:
1. User also has credentials in the legacy path, OR
2. User sets `CLAWDBOT_AGENT_DIR` or `PI_CODING_AGENT_DIR` env var

But this is looks like a pre-existing inconsistency:  the gateway was already reading from a different path than CLI commands. This PR fixes the write path to match the gateway's read path, which is the primary use case.

A follow-up could unify the read paths by updating `resolveClawdbotAgentDir()` to return the multi-agent path by default, but that's a larger change with broader impact.

