### PR TITLE
feat(telegram): add forum topics support

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -69,6 +69,7 @@ vi.mock("grammy", () => ({
     api = apiStub;
     on = onSpy;
     stop = stopSpy;
+    use = vi.fn();
     constructor(public token: string) {}
   },
   InputFile: class {},
@@ -205,7 +206,9 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(sendChatActionSpy).toHaveBeenCalledWith(42, "typing");
+    expect(sendChatActionSpy).toHaveBeenCalledWith(42, "typing", {
+      message_thread_id: undefined,
+    });
   });
 
   it("accepts group messages when mentionPatterns match (without @botUsername)", async () => {


### PR DESCRIPTION
## Summary
Adds support for Telegram forum topics (threads in supergroups). Each topic now gets its own session, and replies are delivered to the correct topic.

## Changes

### 1. Session sequentialization middleware
Messages from the same chat+topic are processed sequentially, while different chats/topics can run in parallel. This prevents race conditions when multiple messages arrive quickly.

### 2. Topic-aware session keys
- Before: `group:{chatId}` (all topics share one session)
- After: `telegram:group:{chatId}:topic:{threadId}` (each topic is isolated)

### 3. Topic-aware typing indicators
Typing status shows in the correct topic, not the main chat.

### 4. Topic-aware reply delivery
All send methods pass `message_thread_id` so replies appear in the correct topic:
- `sendMessage`
- `sendPhoto`, `sendVideo`, `sendAudio`, `sendDocument`, `sendAnimation`

### 5. Topic info in labels/logs
Group labels now include topic info for better context in logs.

## Testing
1. Create a Telegram supergroup with topics enabled
2. Message the bot in different topics
3. Verify each topic gets its own conversation
4. Verify replies appear in the correct topic
5. Verify typing indicator shows in the correct topic