### PR TITLE
fix(auth): align resolveClawdbotAgentDir() with multi-agent path

### DIFF
--- a/src/agents/agent-paths.ts
+++ b/src/agents/agent-paths.ts
@@ -1,13 +1,11 @@
-import path from "node:path";
-
-import { resolveConfigDir, resolveUserPath } from "../utils.js";
+import { resolveDefaultAgentDir } from "./agent-scope.js";
+import { resolveUserPath } from "../utils.js";
 
 export function resolveClawdbotAgentDir(): string {
-  const defaultAgentDir = path.join(resolveConfigDir(), "agent");
   const override =
     process.env.CLAWDBOT_AGENT_DIR?.trim() ||
     process.env.PI_CODING_AGENT_DIR?.trim() ||
-    defaultAgentDir;
+    resolveDefaultAgentDir();
   return resolveUserPath(override);
 }
 


### PR DESCRIPTION
# Summary 

## Fix: Align `resolveClawdbotAgentDir()` with multi-agent path

### Problem

PR #327 fixed onboarding to write auth profiles to `~/.clawdbot/agents/main/agent/`, but several code paths still read from the legacy `~/.clawdbot/agent/` path via `resolveClawdbotAgentDir()`.

Affected code paths:
- CLI commands like `clawdbot agent --local` and `clawdbot models list`
- Internal callers: `auth-profiles.ts`, `model-catalog.ts`, `models-config.ts`, `context.ts`, `directive-handling.ts`, `pi-embedded-runner.ts`

This causes "No credentials found" errors when using these code paths after fresh onboarding.

### Fix

Update `resolveClawdbotAgentDir()` to use `resolveDefaultAgentDir()` as its default, aligning all code paths with the multi-agent structure.

```typescript
// Before: default from resolveConfigDir() → ~/.clawdbot/agent
const defaultAgentDir = path.join(resolveConfigDir(), "agent");
const override = process.env.CLAWDBOT_AGENT_DIR?.trim() || 
                 process.env.PI_CODING_AGENT_DIR?.trim() || 
                 defaultAgentDir;

// After: default from resolveDefaultAgentDir() → ~/.clawdbot/agents/main/agent
const override = process.env.CLAWDBOT_AGENT_DIR?.trim() || 
                 process.env.PI_CODING_AGENT_DIR?.trim() || 
                 resolveDefaultAgentDir();
```

### Why this approach

- **Single point of change** — fixes all callers without touching each call site
- **Aligns with docs** — `docs/configuration.md` and `docs/faq.md` describe multi-agent path as default; legacy path as migrated by `clawdbot doctor`
- **Env overrides preserved** — `CLAWDBOT_AGENT_DIR` / `PI_CODING_AGENT_DIR` still respected

### Compatibility

Users with only legacy data (`~/.clawdbot/agent/`) will need to run `clawdbot doctor` to migrate. This is already the documented expectation.
