### PR TITLE
fix(discord): handle voice messages with empty content

### DIFF
--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -662,9 +662,9 @@ export function createDiscordMessageHandler(params: {
 
       const media = await resolveMedia(message, mediaMaxBytes);
       const text =
-        message.content?.trim() ??
-        media?.placeholder ??
-        message.embeds?.[0]?.description ??
+        message.content?.trim() ||
+        media?.placeholder ||
+        message.embeds?.[0]?.description ||
         "";
       if (!text) {
         logVerbose(`discord: drop message ${message.id} (empty content)`);


### PR DESCRIPTION
## Problem

Discord voice messages have empty `content` field — the audio is in the attachment. The code used nullish coalescing (`??`) to fall back to the media placeholder, but empty string (`""`) is not nullish, so voice messages were being silently dropped.

## Solution

Changed `??` to `||` so empty string falls through to `media?.placeholder`, which correctly returns `<media:audio>` for audio attachments.

## Testing

- Sent Discord voice messages before fix: dropped with 'empty content'
- After fix: voice messages are received, transcribed (via `transcribeAudio` config), and processed correctly

## Related

This fix enables the `routing.transcribeAudio` config to work with Discord voice messages.