### PR TITLE
fix: remove duplicate daemon-runtime imports

### DIFF
--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -65,11 +65,6 @@ import { setupProviders } from "./onboard-providers.js";
 import { promptRemoteGatewayConfig } from "./onboard-remote.js";
 import { setupSkills } from "./onboard-skills.js";
 import {
-  DEFAULT_GATEWAY_DAEMON_RUNTIME,
-  GATEWAY_DAEMON_RUNTIME_OPTIONS,
-  type GatewayDaemonRuntime,
-} from "./daemon-runtime.js";
-import {
   applyOpenAICodexModelDefault,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "./openai-codex-model-default.js";

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -50,11 +50,6 @@ import {
   guardCancel,
   printWizardHeader,
 } from "./onboard-helpers.js";
-import {
-  DEFAULT_GATEWAY_DAEMON_RUNTIME,
-  GATEWAY_DAEMON_RUNTIME_OPTIONS,
-  type GatewayDaemonRuntime,
-} from "./daemon-runtime.js";
 import { ensureSystemdUserLingerInteractive } from "./systemd-linger.js";
 
 function resolveMode(cfg: ClawdbotConfig): "local" | "remote" {

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -34,10 +34,6 @@ import type {
   OnboardMode,
   OnboardOptions,
 } from "./onboard-types.js";
-import {
-  DEFAULT_GATEWAY_DAEMON_RUNTIME,
-  isGatewayDaemonRuntime,
-} from "./daemon-runtime.js";
 import { ensureSystemdUserLingerNonInteractive } from "./systemd-linger.js";
 
 export async function runNonInteractiveOnboarding(

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -58,11 +58,6 @@ import type {
   ResetScope,
 } from "../commands/onboard-types.js";
 import {
-  DEFAULT_GATEWAY_DAEMON_RUNTIME,
-  GATEWAY_DAEMON_RUNTIME_OPTIONS,
-  type GatewayDaemonRuntime,
-} from "../commands/daemon-runtime.js";
-import {
   applyOpenAICodexModelDefault,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "../commands/openai-codex-model-default.js";


### PR DESCRIPTION
## Summary

Removes duplicate imports of `daemon-runtime.js` that were introduced in commit `55278c1c` (feat: add daemon runtime prompts).

**Files fixed:**
- `src/commands/configure.ts` - removed duplicate import at line 67-71
- `src/commands/doctor.ts` - removed duplicate import at line 53-57
- `src/commands/onboard-non-interactive.ts` - removed duplicate import at line 37-40
- `src/wizard/onboarding.ts` - removed duplicate import at line 60-64

## Testing

- [x] `pnpm lint` - passed
- [x] `pnpm build` - passed  
- [x] `pnpm test` - 1164 tests passed

## AI Disclosure

🤖 This PR was created with AI assistance (Claude). The fix is straightforward - removing duplicate import statements that cause TypeScript compilation errors. I understand what the code does: the same module was imported twice in each file, causing "Duplicate identifier" errors.

---

🦞 Thanks for the great project!