### PR TITLE
Cron: enqueue system events into resolved main session

### DIFF
--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -32,7 +32,11 @@ import {
   deriveDefaultBridgePort,
   deriveDefaultCanvasHostPort,
 } from "../config/port-defaults.js";
-import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import {
+  loadSessionStore,
+  resolveMainSessionKey,
+  resolveStorePath,
+} from "../config/sessions.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPath } from "../cron/run-log.js";
 import { CronService } from "../cron/service.js";
@@ -689,7 +693,9 @@ export async function startGatewayServer(
     const cron = new CronService({
       storePath,
       cronEnabled,
-      enqueueSystemEvent,
+      enqueueSystemEvent: (text) => {
+        enqueueSystemEvent(text, { sessionKey: resolveMainSessionKey(cfg) });
+      },
       requestHeartbeatNow,
       runIsolatedAgentJob: async ({ job, message }) => {
         const runtimeConfig = loadConfig();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -12,6 +12,7 @@ import type { ClawdbotConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
+  resolveMainSessionKey,
   resolveStorePath,
   type SessionEntry,
   saveSessionStore,
@@ -113,8 +114,8 @@ function resolveHeartbeatAckMaxChars(cfg: ClawdbotConfig) {
 function resolveHeartbeatSession(cfg: ClawdbotConfig) {
   const sessionCfg = cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
-  const mainKey = (sessionCfg?.mainKey ?? "main").trim() || "main";
-  const sessionKey = scope === "global" ? "global" : mainKey;
+  const sessionKey =
+    scope === "global" ? "global" : resolveMainSessionKey(cfg);
   const storePath = resolveStorePath(sessionCfg?.store);
   const store = loadSessionStore(storePath);
   const entry = store[sessionKey];


### PR DESCRIPTION
## Summary
- enqueue cron system events with the resolved main session key so the heartbeat drains the same queue
- use resolveMainSessionKey(cfg) when wiring CronService in the gateway

all `pnpm test` pass
