### PR TITLE
fix: TypeScript type errors for process signals and OutboundDeliveryResult

### DIFF
--- a/src/cli/gateway-cli.ts
+++ b/src/cli/gateway-cli.ts
@@ -20,6 +20,7 @@ import {
 } from "../gateway/ws-logging.js";
 import { setVerbose } from "../globals.js";
 import { GatewayLockError } from "../infra/gateway-lock.js";
+import { onSignal, removeSignalListener } from "../infra/process-signals.js";
 import { createSubsystemLogger } from "../logging.js";
 import { defaultRuntime } from "../runtime.js";
 import { createDefaultDeps } from "./deps.js";
@@ -134,9 +135,9 @@ async function runGatewayLoop(params: {
   let restartResolver: (() => void) | null = null;
 
   const cleanupSignals = () => {
-    process.removeListener("SIGTERM", onSigterm);
-    process.removeListener("SIGINT", onSigint);
-    process.removeListener("SIGUSR1", onSigusr1);
+    removeSignalListener("SIGTERM", onSigterm);
+    removeSignalListener("SIGINT", onSigint);
+    removeSignalListener("SIGUSR1", onSigusr1);
   };
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
@@ -182,9 +183,9 @@ async function runGatewayLoop(params: {
   const onSigint = () => request("stop", "SIGINT");
   const onSigusr1 = () => request("restart", "SIGUSR1");
 
-  process.on("SIGTERM", onSigterm);
-  process.on("SIGINT", onSigint);
-  process.on("SIGUSR1", onSigusr1);
+  onSignal("SIGTERM", onSigterm);
+  onSignal("SIGINT", onSigint);
+  onSignal("SIGUSR1", onSigusr1);
 
   try {
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -5,6 +5,10 @@ import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureClawdbotCliOnPath } from "../infra/path-env.js";
+import {
+  onUncaughtException,
+  onUnhandledRejection,
+} from "../infra/process-signals.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture } from "../logging.js";
 
@@ -24,7 +28,7 @@ export async function runCli(argv: string[] = process.argv) {
 
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
-  process.on("unhandledRejection", (reason, _promise) => {
+  onUnhandledRejection((reason: unknown, _promise: Promise<unknown>) => {
     console.error(
       "[clawdbot] Unhandled promise rejection:",
       reason instanceof Error ? (reason.stack ?? reason.message) : reason,
@@ -32,7 +36,7 @@ export async function runCli(argv: string[] = process.argv) {
     process.exit(1);
   });
 
-  process.on("uncaughtException", (error) => {
+  onUncaughtException((error: Error) => {
     console.error(
       "[clawdbot] Uncaught exception:",
       error.stack ?? error.message,

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-
 import {
   type ClawdbotConfig,
   CONFIG_PATH_CLAWDBOT,
@@ -9,6 +8,7 @@ import {
   validateConfigObject,
   writeConfigFile,
 } from "../config/config.js";
+import { onSignal } from "../infra/process-signals.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -333,8 +333,8 @@ export async function runGmailService(opts: GmailRunOptions) {
     child.kill("SIGTERM");
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  onSignal("SIGINT", shutdown);
+  onSignal("SIGTERM", shutdown);
 
   child.on("exit", () => {
     if (shuttingDown) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ import {
   handlePortError,
   PortInUseError,
 } from "./infra/ports.js";
+import {
+  onUncaughtException,
+  onUnhandledRejection,
+} from "./infra/process-signals.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
 import { isUnhandledRejectionHandled } from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
@@ -79,7 +83,7 @@ const isMain = isMainModule({
 if (isMain) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
-  process.on("unhandledRejection", (reason, _promise) => {
+  onUnhandledRejection((reason: unknown, _promise: Promise<unknown>) => {
     if (isUnhandledRejectionHandled(reason)) return;
     console.error(
       "[clawdbot] Unhandled promise rejection:",
@@ -88,7 +92,7 @@ if (isMain) {
     process.exit(1);
   });
 
-  process.on("uncaughtException", (error) => {
+  onUncaughtException((error: Error) => {
     console.error(
       "[clawdbot] Uncaught exception:",
       error.stack ?? error.message,

--- a/src/infra/outbound/format.ts
+++ b/src/infra/outbound/format.ts
@@ -56,10 +56,14 @@ export function buildOutboundDeliveryJson(params: {
     mediaUrl: params.mediaUrl ?? null,
   };
 
-  if (result?.chatId !== undefined) payload.chatId = result.chatId;
-  if (result?.channelId !== undefined) payload.channelId = result.channelId;
-  if (result?.timestamp !== undefined) payload.timestamp = result.timestamp;
-  if (result?.toJid !== undefined) payload.toJid = result.toJid;
+  if (result && "chatId" in result && result.chatId !== undefined)
+    payload.chatId = result.chatId;
+  if (result && "channelId" in result && result.channelId !== undefined)
+    payload.channelId = result.channelId;
+  if (result && "timestamp" in result && result.timestamp !== undefined)
+    payload.timestamp = result.timestamp;
+  if (result && "toJid" in result && result.toJid !== undefined)
+    payload.toJid = result.toJid;
 
   return payload;
 }

--- a/src/infra/process-signals.ts
+++ b/src/infra/process-signals.ts
@@ -1,0 +1,45 @@
+/**
+ * Type-safe process signal handling wrapper.
+ * Works around TypeScript type resolution issues with process.on/removeListener
+ * when using @types/node v25+ with NodeNext module resolution.
+ */
+
+type SignalHandler = () => void;
+
+// Use unknown cast to work around TypeScript module resolution bug where
+// process.on types incorrectly resolve to only allow "loaded" as event name.
+// biome-ignore lint/suspicious/noExplicitAny: Required workaround for @types/node v25 type resolution bug
+const proc = process as any;
+
+export function onSignal(signal: NodeJS.Signals, handler: SignalHandler): void {
+  proc.on(signal, handler);
+}
+
+export function removeSignalListener(
+  signal: NodeJS.Signals,
+  handler: SignalHandler,
+): void {
+  proc.removeListener(signal, handler);
+}
+
+export function onceSignal(
+  signal: NodeJS.Signals,
+  handler: SignalHandler,
+): void {
+  proc.once(signal, handler);
+}
+
+// Process event handlers
+type UnhandledRejectionHandler = (
+  reason: unknown,
+  promise: Promise<unknown>,
+) => void;
+type UncaughtExceptionHandler = (error: Error) => void;
+
+export function onUnhandledRejection(handler: UnhandledRejectionHandler): void {
+  proc.on("unhandledRejection", handler);
+}
+
+export function onUncaughtException(handler: UncaughtExceptionHandler): void {
+  proc.on("uncaughtException", handler);
+}

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import process from "node:process";
 
+import { onSignal, removeSignalListener } from "../infra/process-signals.js";
+
 declare const __CLAWDBOT_VERSION__: string;
 
 const BUNDLED_VERSION =
@@ -101,9 +103,9 @@ async function main() {
   let restartResolver: (() => void) | null = null;
 
   const cleanupSignals = () => {
-    process.removeListener("SIGTERM", onSigterm);
-    process.removeListener("SIGINT", onSigint);
-    process.removeListener("SIGUSR1", onSigusr1);
+    removeSignalListener("SIGTERM", onSigterm);
+    removeSignalListener("SIGINT", onSigint);
+    removeSignalListener("SIGUSR1", onSigusr1);
   };
 
   const request = (action: "stop" | "restart", signal: string) => {
@@ -153,9 +155,9 @@ async function main() {
   const onSigint = () => request("stop", "SIGINT");
   const onSigusr1 = () => request("restart", "SIGUSR1");
 
-  process.on("SIGTERM", onSigterm);
-  process.on("SIGINT", onSigint);
-  process.on("SIGUSR1", onSigusr1);
+  onSignal("SIGTERM", onSigterm);
+  onSignal("SIGINT", onSigint);
+  onSignal("SIGUSR1", onSigusr1);
 
   try {
     // eslint-disable-next-line no-constant-condition

--- a/src/macos/relay.ts
+++ b/src/macos/relay.ts
@@ -48,11 +48,14 @@ async function main() {
   const { isUnhandledRejectionHandled } = await import(
     "../infra/unhandled-rejections.js"
   );
+  const { onUnhandledRejection, onUncaughtException } = await import(
+    "../infra/process-signals.js"
+  );
 
   const { buildProgram } = await import("../cli/program.js");
   const program = buildProgram();
 
-  process.on("unhandledRejection", (reason, _promise) => {
+  onUnhandledRejection((reason: unknown, _promise: Promise<unknown>) => {
     if (isUnhandledRejectionHandled(reason)) return;
     console.error(
       "[clawdbot] Unhandled promise rejection:",
@@ -61,7 +64,7 @@ async function main() {
     process.exit(1);
   });
 
-  process.on("uncaughtException", (error) => {
+  onUncaughtException((error: Error) => {
     console.error(
       "[clawdbot] Uncaught exception:",
       error.stack ?? error.message,

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -39,6 +39,7 @@ import {
 } from "../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { emitHeartbeatEvent } from "../infra/heartbeat-events.js";
+import { onceSignal, removeSignalListener } from "../infra/process-signals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import { createSubsystemLogger, getChildLogger } from "../logging.js";
@@ -971,7 +972,7 @@ export async function monitorWebProvider(
   const handleSigint = () => {
     sigintStop = true;
   };
-  process.once("SIGINT", handleSigint);
+  onceSignal("SIGINT", handleSigint);
 
   let reconnectAttempts = 0;
 
@@ -1666,7 +1667,7 @@ export async function monitorWebProvider(
   status.lastEventAt = Date.now();
   emitStatus();
 
-  process.removeListener("SIGINT", handleSigint);
+  removeSignalListener("SIGINT", handleSigint);
 }
 
 export { DEFAULT_WEB_MEDIA_BYTES };


### PR DESCRIPTION
## Summary

- Fixes TypeScript build errors caused by `@types/node` v25+ type resolution issues with `process.on()`/`process.once()`/`process.removeListener()` for signal handling
- Fixes type narrowing in `OutboundDeliveryResult` union type in `src/infra/outbound/format.ts`

### Root Cause

The `@types/node` v25+ types, when used with TypeScript's NodeNext module resolution, incorrectly resolve `process.on()` overloads. TypeScript reports errors like:
```
Argument of type '"SIGTERM"' is not assignable to parameter of type '"loaded"'
```

### Solution

1. Created `src/infra/process-signals.ts` - a wrapper module that:
   - Provides type-safe `onSignal()`, `onceSignal()`, `removeSignalListener()` functions for signal handling
   - Provides `onUnhandledRejection()` and `onUncaughtException()` for process error handling
   - Uses `as any` internally to bypass the incorrect type resolution while maintaining type safety at the function signature level

2. Updated all files that use `process.on()`/`process.once()`/`process.removeListener()` for signals to use the new wrappers

3. Fixed `src/infra/outbound/format.ts` to use `in` operator for proper type narrowing when accessing properties on `OutboundDeliveryResult` union type

## Files Changed

- `src/infra/process-signals.ts` (new) - Type-safe process signal handling wrappers
- `src/cli/gateway-cli.ts` - Use process-signals wrappers
- `src/cli/run-main.ts` - Use process-signals wrappers
- `src/hooks/gmail-ops.ts` - Use process-signals wrappers
- `src/index.ts` - Use process-signals wrappers
- `src/macos/gateway-daemon.ts` - Use process-signals wrappers
- `src/macos/relay.ts` - Use process-signals wrappers
- `src/web/auto-reply.ts` - Use process-signals wrappers
- `src/infra/outbound/format.ts` - Fix type narrowing

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes (no type errors)
- [x] `pnpm test` passes (207/208 test files, 1 skip due to bun not installed in environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)