### PR TITLE
fix(relay): implement CLAWDBOT_SMOKE_QR handler for packaging

### DIFF
--- a/src/macos/relay.ts
+++ b/src/macos/relay.ts
@@ -32,6 +32,19 @@ async function main() {
     process.exit(0);
   }
 
+  // Smoke test for QR modules in bun-compiled binaries.
+  // Verifies that QR code generation works in the bundled relay.
+  if (process.env.CLAWDBOT_SMOKE_QR === "1") {
+    try {
+      const { renderQrPngBase64 } = await import("../web/qr-image.js");
+      await renderQrPngBase64("smoke-test");
+      process.exit(0);
+    } catch (err) {
+      console.error("QR smoke test failed:", err);
+      process.exit(1);
+    }
+  }
+
   await patchBunLongForProtobuf();
 
   const { loadDotEnv } = await import("../infra/dotenv.js");


### PR DESCRIPTION
## Summary
- Add missing `CLAWDBOT_SMOKE_QR` environment variable handler to `src/macos/relay.ts`
- The packaging script (`scripts/package-mac-app.sh`) calls the bundled relay with `CLAWDBOT_SMOKE_QR=1` to verify QR code generation works in the bun-compiled binary
- Previously, this test always failed because the relay didn't check for the env var - it would show help and exit with code 1

## Test plan
- [x] Verified `pnpm build` succeeds
- [x] Verified `./scripts/restart-mac.sh` completes successfully (smoke test passes)
- [x] Verified the app launches and gateway is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)