### PR TITLE
Messaging: make tool message logging optional

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -539,6 +539,9 @@ Controls inbound/outbound prefixes and optional ack reactions.
 `responsePrefix` is applied to **all outbound replies** (tool summaries, block
 streaming, final replies) across providers unless already present.
 
+`toolMessageLogging` controls whether providers send intermediate tool-result/status
+messages. Set `messages.toolMessageLogging: false` to only send the final reply.
+
 `ackReaction` sends a best-effort emoji reaction to acknowledge inbound messages
 on providers that support reactions (Slack/Discord/Telegram). Defaults to the
 configured `identity.emoji` when set, otherwise `"👀"`. Set it to `""` to disable.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -99,6 +99,7 @@ const FIELD_LABELS: Record<string, string> = {
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
+  "messages.toolMessageLogging": "Tool Message Logging",
   "talk.apiKey": "Talk API Key",
   "telegram.botToken": "Telegram Bot Token",
   "discord.token": "Discord Bot Token",
@@ -137,6 +138,8 @@ const FIELD_HELP: Record<string, string> = {
     "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.toolMessageLogging":
+    "When enabled, providers may send intermediate tool-result/status messages.",
 };
 
 const FIELD_PLACEHOLDERS: Record<string, string> = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -554,6 +554,8 @@ export type MessagesConfig = {
   ackReaction?: string;
   /** When to send ack reactions. Default: "group-mentions". */
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
+  /** When false, suppress intermediate tool-result/status messages; only send final replies. Default: true. */
+  toolMessageLogging?: boolean;
 };
 
 export type BridgeBindMode = "auto" | "lan" | "tailnet" | "loopback";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -160,6 +160,7 @@ const MessagesSchema = z
     ackReactionScope: z
       .enum(["group-mentions", "group-all", "direct", "all"])
       .optional(),
+    toolMessageLogging: z.boolean().optional(),
   })
   .optional();
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -593,7 +593,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       let typingController: TypingController | undefined;
       const dispatcher = createReplyDispatcher({
         responsePrefix: cfg.messages?.responsePrefix,
-        deliver: async (payload) => {
+        deliver: async (payload, info) => {
+          if (info.kind === "tool" && cfg.messages?.toolMessageLogging === false) {
+            return;
+          }
           await deliverReplies({
             replies: [payload],
             target: replyTarget,

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -430,7 +430,10 @@ export async function monitorSignalProvider(
 
       const dispatcher = createReplyDispatcher({
         responsePrefix: cfg.messages?.responsePrefix,
-        deliver: async (payload) => {
+        deliver: async (payload, info) => {
+          if (info.kind === "tool" && cfg.messages?.toolMessageLogging === false) {
+            return;
+          }
           await deliverReplies({
             replies: [payload],
             target: ctxPayload.To,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -363,7 +363,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     let typingController: TypingController | undefined;
     const dispatcher = createReplyDispatcher({
       responsePrefix: cfg.messages?.responsePrefix,
-      deliver: async (payload) => {
+      deliver: async (payload, info) => {
+        if (info.kind === "tool" && cfg.messages?.toolMessageLogging === false) {
+          return;
+        }
         await deliverReplies({
           replies: [payload],
           chatId: String(chatId),

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1138,6 +1138,9 @@ export async function monitorWebProvider(
           }
         },
         deliver: async (payload, info) => {
+          if (info.kind === "tool" && cfg.messages?.toolMessageLogging === false) {
+            return;
+          }
           await deliverWebReply({
             replyResult: payload,
             msg,


### PR DESCRIPTION
Adds  to suppress intermediate tool-result/status replies (send only final replies). Updates Slack/Discord/Telegram/Signal/iMessage/web auto-reply to respect the flag and adds a Slack regression test.\n\nTest: 
> clawdbot@2026.1.5-3 test /Users/ekerber/Developer/clawdbot
> vitest src/slack/monitor.tool-result.test.ts


[1m[46m RUN [49m[22m [36mv4.0.16 [39m[90m/Users/ekerber/Developer/clawdbot[39m

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2msends tool summaries with responsePrefix
[22m[39mslack socket mode connected

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2msends tool summaries with responsePrefix
[22m[39mdelivered reply to user:U1

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2msends tool summaries with responsePrefix
[22m[39mdelivered reply to user:U1

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2maccepts channel messages when mentionPatterns match
[22m[39mslack socket mode connected

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2maccepts channel messages when mentionPatterns match
[22m[39mdelivered reply to channel:C1

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2mthreads replies when incoming message is in a thread
[22m[39mslack socket mode connected

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2mthreads replies when incoming message is in a thread
[22m[39mdelivered reply to user:U1

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2mkeeps replies in channel root when message is not threaded
[22m[39mslack socket mode connected

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2mkeeps replies in channel root when message is not threaded
[22m[39mdelivered reply to user:U1

[90mstdout[2m | src/slack/monitor.tool-result.test.ts[2m > [22m[2mmonitorSlackProvider tool results[2m > [22m[2mreacts to mention-gated room messages when ackReaction is enabled
[22m[39mslack socket mode connected

 [32m✓[39m src/slack/monitor.tool-result.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 12[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m5 passed[39m[22m[90m (5)[39m
[2m   Start at [22m 22:15:33
[2m   Duration [22m 366ms[2m (transform 133ms, setup 18ms, import 265ms, tests 12ms, environment 0ms)[22m