### PR TITLE
fix(macos): fix node bridge tunnel port override

### DIFF
--- a/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
+++ b/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
@@ -49,7 +49,10 @@ final class RemotePortTunnel {
 
         let localPort = try await Self.findPort(preferred: preferredLocalPort)
         let sshHost = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
-        let remotePortOverride = Self.resolveRemotePortOverride(for: sshHost)
+        let remotePortOverride =
+            remotePort == GatewayEnvironment.gatewayPort()
+                ? Self.resolveRemotePortOverride(for: sshHost)
+                : nil
         let resolvedRemotePort = remotePortOverride ?? remotePort
         if let override = remotePortOverride {
             Self.logger.info(


### PR DESCRIPTION
## Summary
Resolves an issue where the macOS app node was failing to connect to the gateway bridge when running in remote mode. The app was tunnelling the bridge port (18790) to the gateway WS port (18789), which caused the node handshake to hit the wrong service and fail with "Unexpected bridge response."

## Problem

After a clean install of Clawd on a vps server and a local macOS app build with `cd apps/macos && swift build` and `./scripts/package-mac-app.sh`, we could connect to the server as a `remote` via tailscale, have the mac appear as an instance, and chat to Clawd via the statusbar ui, but the mac was not appearing as a node for Clawd to access/control.  

After investigation, we discovered that when the macOS app is in remote mode, it opens SSH tunnels for:
- the gateway control channel (WS port)
- the node bridge (TCP bridge port)

We saw:
- Mac console.app log: `mac node bridge connect failed: Unexpected bridge response`
- no nodes in the server's `clawdbot nodes status`
- bridge listener on the server was healthy and reachable locally

## Root cause
`RemotePortTunnel` applies a "remote URL port override" based on `gateway.remote.url`. That is correct for the *gateway control tunnel*, but it was also being applied to the *node bridge tunnel*. Because the app keeps the SSH host and `gateway.remote.url` host in sync, the override always triggers and forces the bridge tunnel to use the gateway WS port (18789). The node then connects to the wrong service and fails handshake.

## Fix
Only apply the remote URL port override when tunnelling the gateway control port. The node bridge tunnel respects its own port (18790).

This preserves the intended behaviour (control tunnel follows `gateway.remote.url` port) while restoring correct node bridge connectivity.

## Testing
  - Manual validation in a remote gateway setup:
    - mac app connects successfully as a node
    - `clawdbot nodes status` shows the mac node
    - bridge tunnel now forwards to 18790