### PR TITLE
feat(telegram): use grammyjs/runner for concurrent update processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "@buape/carbon": "0.0.0-beta-20260107085330",
     "@clack/prompts": "^0.11.0",
+    "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.4",
     "@mariozechner/pi-agent-core": "^0.37.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@grammyjs/runner':
+        specifier: ^2.0.3
+        version: 2.0.3(grammy@1.39.2)
       '@grammyjs/transformer-throttler':
         specifier: ^1.2.1
         version: 1.2.1(grammy@1.39.2)
@@ -590,6 +593,12 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@grammyjs/runner@2.0.3':
+    resolution: {integrity: sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==}
+    engines: {node: '>=12.20.0 || >=14.13.1'}
+    peerDependencies:
+      grammy: ^1.13.1
 
   '@grammyjs/transformer-throttler@1.2.1':
     resolution: {integrity: sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==}
@@ -3410,6 +3419,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@grammyjs/runner@2.0.3(grammy@1.39.2)':
+    dependencies:
+      abort-controller: 3.0.0
+      grammy: 1.39.2
 
   '@grammyjs/transformer-throttler@1.2.1(grammy@1.39.2)':
     dependencies:

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -45,6 +45,14 @@ vi.mock("./bot.js", () => ({
   createTelegramWebhookCallback: vi.fn(),
 }));
 
+// Mock the grammyjs/runner to resolve immediately
+vi.mock("@grammyjs/runner", () => ({
+  run: vi.fn(() => ({
+    task: () => Promise.resolve(),
+    stop: vi.fn(),
+  })),
+}));
+
 vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: async (ctx: { Body?: string }) => ({
     text: `echo:${ctx.Body}`,


### PR DESCRIPTION
## Problem

Telegram message processing was **completely sequential**, blocking all messages while one was being handled. This made the `maxConcurrent` config setting ineffective for Telegram users.

### Root Cause

grammY's default `bot.start()` uses sequential update processing:

```javascript
// node_modules/grammy/out/bot.js
async handleUpdates(updates) {
    // handle updates sequentially (!)  <-- grammY's own comment!
    for (const update of updates) {
        await this.handleUpdate(update);  // Blocks until complete
    }
}
```

This meant:
- While responding to one chat, ALL other Telegram messages queued
- Ack reactions (👀) didn't appear until the queue cleared
- Long-running tool calls blocked every other conversation
- Multi-chat parallelism was completely broken

### How Other Providers Handle This

| Provider | Implementation | Concurrent? |
|----------|----------------|-------------|
| **Discord** | `Promise.all(listeners.map(...))` | ✅ Yes |
| **WhatsApp** | `void task.catch(...)` (fire-and-forget) | ✅ Yes |
| **Telegram** | `await handleUpdate()` in for-loop | ❌ No |

Discord and WhatsApp already processed messages in parallel. Only Telegram was affected.

### Visual Example

**Before (sequential):**
```
Msg A arrives → handler starts → [30 sec tool call] → handler ends
Msg B arrives → [BLOCKED 30 sec] → handler starts → ...
Msg C arrives → [BLOCKED 60 sec] → ...
```

**After (concurrent with runner):**
```
Msg A arrives → handler starts in parallel →
Msg B arrives → handler starts in parallel →
Msg C arrives → handler starts in parallel →
(all processing concurrently, limited by maxConcurrent)
```

## Solution

Use [`@grammyjs/runner`](https://grammy.dev/plugins/runner) which is the official grammY plugin for concurrent update processing.

### Changes

1. Added `@grammyjs/runner` dependency
2. Replaced `bot.start()` with `run(bot)` in `src/telegram/monitor.ts`
3. Proper abort signal handling for graceful shutdown

### Code Change

```diff
- await bot.start();
+ const runner = run(bot, {
+   runner: { fetch: { timeout: 30 } },
+ });
+ await runner.task();
```

## Benefits

- ✅ Ack reactions (👀) appear immediately
- ✅ Multiple chats processed in parallel  
- ✅ `maxConcurrent` setting now works for Telegram
- ✅ Long tool calls don't block other conversations
- ✅ Consistent behavior across all providers

## Testing

Tested on dev container with:
- Rapid messages to DM and group simultaneously
- Both processed concurrently without blocking
- Verified parallel execution in logs

## Related

This was discovered while investigating why ack reactions were delayed. The deeper issue was that the entire Telegram provider was single-threaded.
