### PR TITLE
fix(telegram): use concurrent runner to prevent message blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "@buape/carbon": "^0.13.0",
     "@clack/prompts": "^0.11.0",
+    "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.4",
     "@mariozechner/pi-agent-core": "^0.37.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@grammyjs/runner':
+        specifier: ^2.0.3
+        version: 2.0.3(grammy@1.39.2)
       '@grammyjs/transformer-throttler':
         specifier: ^1.2.1
         version: 1.2.1(grammy@1.39.2)
@@ -586,6 +589,12 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@grammyjs/runner@2.0.3':
+    resolution: {integrity: sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==}
+    engines: {node: '>=12.20.0 || >=14.13.1'}
+    peerDependencies:
+      grammy: ^1.13.1
 
   '@grammyjs/transformer-throttler@1.2.1':
     resolution: {integrity: sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==}
@@ -3380,6 +3389,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@grammyjs/runner@2.0.3(grammy@1.39.2)':
+    dependencies:
+      abort-controller: 3.0.0
+      grammy: 1.39.2
 
   '@grammyjs/transformer-throttler@1.2.1(grammy@1.39.2)':
     dependencies:


### PR DESCRIPTION
## Summary

- **Problem:** When one Telegram message handler takes a long time (e.g., a 10-minute agent timeout), ALL other messages are blocked until it completes
- **Root Cause:** grammy's default `bot.start()` processes updates sequentially
- **Fix:** Use `@grammyjs/runner` to process updates concurrently

## The Problem

When using grammy's default long polling with `bot.start()`, updates are processed one at a time:

```javascript
// From grammy source:
// handle updates sequentially (!)
await this.handleUpdate(update);
```

This means if one message handler hangs (e.g., waiting for an LLM response that times out after 10 minutes), every other message in every other chat waits in a queue behind it. The entire bot becomes unresponsive.

## The Solution

The `@grammyjs/runner` plugin is specifically designed to solve this. It processes updates concurrently, so multiple conversations can be handled in parallel. A slow or stuck handler in one chat doesn't block handlers in other chats.

## Changes

1. Added `@grammyjs/runner` dependency
2. Replaced `bot.start()` with `run(bot)` in `monitor.ts`
3. Updated abort signal handling to work with the runner
4. Added tests verifying the runner is used and responds to abort signals

## Test plan

- [x] All existing telegram tests pass (66 tests)
- [x] New tests verify runner is invoked for long polling
- [x] New tests verify abort signal stops the runner
- [ ] Manual testing: send multiple messages while one is processing slowly

🤖 Generated with [Claude Code](https://claude.com/claude-code)