### PR TITLE
fix: delete legacy auth.json after migration to prevent stale token overwrites

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -305,6 +305,18 @@ export function ensureAuthProfileStore(agentDir?: string): AuthProfileStore {
   if (shouldWrite) {
     saveJsonFile(authPath, store);
   }
+
+  // Delete legacy auth.json after successful migration to prevent stale tokens
+  // from being re-migrated and overwriting fresh credentials (fixes #363)
+  if (legacy !== null) {
+    const legacyPath = resolveLegacyAuthStorePath(agentDir);
+    try {
+      fs.unlinkSync(legacyPath);
+    } catch {
+      // Ignore if already deleted or permission issues
+    }
+  }
+
   return store;
 }
 


### PR DESCRIPTION
## Summary

Fixes #363 - Anthropic OAuth token spontaneously expires/fails to refresh

The root cause was that legacy `auth.json` files persisted after migration to `auth-profiles.json`. When the code loaded credentials from different agent directories, it would re-migrate stale tokens from these legacy files, overwriting fresh credentials.

This fix deletes the legacy `auth.json` file after successful migration to `auth-profiles.json`, preventing stale tokens from being re-migrated.

## Changes

- Delete legacy `auth.json` after successful migration in `ensureAuthProfileStore()`

## Test plan

- [x] Existing tests pass (`bun test src/agents/auth-profiles.test.ts`)
- [x] Lint and build pass
- Manually verified: after deleting legacy auth files, OAuth refresh works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)