### PR TITLE
Discord: chunk outbound messages by chars + lines

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -190,7 +190,11 @@ describe("config identity defaults", () => {
             routing: {},
             whatsapp: { allowFrom: ["+15555550123"], textChunkLimit: 4444 },
             telegram: { enabled: true, textChunkLimit: 3333 },
-            discord: { enabled: true, textChunkLimit: 1999 },
+            discord: {
+              enabled: true,
+              textChunkLimit: 1999,
+              maxLinesPerMessage: 17,
+            },
             signal: { enabled: true, textChunkLimit: 2222 },
             imessage: { enabled: true, textChunkLimit: 1111 },
           },
@@ -207,6 +211,7 @@ describe("config identity defaults", () => {
       expect(cfg.whatsapp?.textChunkLimit).toBe(4444);
       expect(cfg.telegram?.textChunkLimit).toBe(3333);
       expect(cfg.discord?.textChunkLimit).toBe(1999);
+      expect(cfg.discord?.maxLinesPerMessage).toBe(17);
       expect(cfg.signal?.textChunkLimit).toBe(2222);
       expect(cfg.imessage?.textChunkLimit).toBe(1111);
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -344,6 +344,12 @@ export type DiscordConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 2000. */
   textChunkLimit?: number;
+  /**
+   * Soft max line count per Discord message.
+   * Discord clients can clip/collapse very tall messages; splitting by lines
+   * keeps replies readable in-channel.
+   */
+  maxLinesPerMessage?: number;
   mediaMaxMb?: number;
   historyLimit?: number;
   /** Per-action tool gating (default: true for all). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -786,6 +786,7 @@ export const ClawdbotSchema = z.object({
       token: z.string().optional(),
       groupPolicy: GroupPolicySchema.optional().default("open"),
       textChunkLimit: z.number().int().positive().optional(),
+      maxLinesPerMessage: z.number().int().positive().optional(),
       slashCommand: z
         .object({
           enabled: z.boolean().optional(),

--- a/src/discord/chunk.test.ts
+++ b/src/discord/chunk.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { chunkDiscordText } from "./chunk.js";
+
+function countLines(text: string) {
+  return text.split("\n").length;
+}
+
+function hasBalancedFences(chunk: string) {
+  let open = false;
+  for (const line of chunk.split("\n")) {
+    if (line.trim().startsWith("```")) open = !open;
+  }
+  return open === false;
+}
+
+describe("chunkDiscordText", () => {
+  it("splits tall messages even when under 2000 chars", () => {
+    const text = Array.from({ length: 45 }, (_, i) => `line-${i + 1}`).join(
+      "\n",
+    );
+    expect(text.length).toBeLessThan(2000);
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(countLines(chunk)).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("keeps fenced code blocks balanced across chunks", () => {
+    const body = Array.from(
+      { length: 30 },
+      (_, i) => `console.log(${i});`,
+    ).join("\n");
+    const text = `Here is code:\n\n\`\`\`js\n${body}\n\`\`\`\n\nDone.`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 10 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+    }
+
+    expect(chunks[0]).toContain("```js");
+    expect(chunks.at(-1)).toContain("Done.");
+  });
+});

--- a/src/discord/chunk.ts
+++ b/src/discord/chunk.ts
@@ -1,0 +1,120 @@
+export type ChunkDiscordTextOpts = {
+  /** Max characters per Discord message. Default: 2000. */
+  maxChars?: number;
+  /**
+   * Soft max line count per message.
+   *
+   * Discord clients can "clip"/collapse very tall messages in the UI; splitting
+   * by lines keeps long multi-paragraph replies readable.
+   */
+  maxLines?: number;
+};
+
+const DEFAULT_MAX_CHARS = 2000;
+const DEFAULT_MAX_LINES = 20;
+
+function countLines(text: string) {
+  if (!text) return 0;
+  return text.split("\n").length;
+}
+
+function isFenceLine(line: string) {
+  return line.trim().startsWith("```");
+}
+
+function splitLongLine(line: string, maxChars: number): string[] {
+  if (line.length <= maxChars) return [line];
+  const out: string[] = [];
+  let remaining = line;
+  while (remaining.length > maxChars) {
+    out.push(remaining.slice(0, maxChars));
+    remaining = remaining.slice(maxChars);
+  }
+  if (remaining.length) out.push(remaining);
+  return out;
+}
+
+function closeFenceIfNeeded(text: string, fenceOpen: string | null) {
+  if (!fenceOpen) return text;
+  if (!text.endsWith("\n")) return `${text}\n\`\`\``;
+  return `${text}\`\`\``;
+}
+
+/**
+ * Chunks outbound Discord text by both character count and (soft) line count,
+ * while keeping fenced code blocks balanced across chunks.
+ */
+export function chunkDiscordText(
+  text: string,
+  opts: ChunkDiscordTextOpts = {},
+): string[] {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
+
+  const trimmed = text ?? "";
+  if (!trimmed) return [];
+
+  const alreadyOk =
+    trimmed.length <= maxChars && countLines(trimmed) <= maxLines;
+  if (alreadyOk) return [trimmed];
+
+  const lines = trimmed.split("\n");
+  const chunks: string[] = [];
+
+  let current = "";
+  let currentLines = 0;
+  let openFence: string | null = null;
+
+  const flush = () => {
+    const payload = closeFenceIfNeeded(current, openFence);
+    if (payload.trim().length) chunks.push(payload);
+    current = "";
+    currentLines = 0;
+    if (openFence) {
+      current = openFence;
+      currentLines = 1;
+    }
+  };
+
+  for (const originalLine of lines) {
+    if (isFenceLine(originalLine)) {
+      openFence = openFence ? null : originalLine;
+    }
+
+    const segments = splitLongLine(originalLine, maxChars);
+    for (let segIndex = 0; segIndex < segments.length; segIndex++) {
+      const segment = segments[segIndex];
+      const isLineContinuation = segIndex > 0;
+      const delimiter = isLineContinuation
+        ? ""
+        : current.length > 0
+          ? "\n"
+          : "";
+      const addition = `${delimiter}${segment}`;
+      const nextLen = current.length + addition.length;
+      const nextLines = currentLines + (isLineContinuation ? 0 : 1);
+
+      const wouldExceedChars = nextLen > maxChars;
+      const wouldExceedLines = nextLines > maxLines;
+
+      if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
+        flush();
+      }
+
+      if (current.length > 0) {
+        current += addition;
+        if (!isLineContinuation) currentLines += 1;
+      } else {
+        current = segment;
+        currentLines = 1;
+      }
+    }
+  }
+
+  if (current.length) {
+    const payload = closeFenceIfNeeded(current, openFence);
+    if (payload.trim().length) chunks.push(payload);
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
Fixes Discord messages appearing clipped/truncated in-channel by chunking outbound Discord replies by both the 2000 character limit and a soft line limit.

Changes:
- Add Discord-specific chunker that respects max chars + max lines and keeps fenced code blocks balanced.
- Wire chunker into Discord provider outbound sends.
- Add config `discord.maxLinesPerMessage`.

AI-assisted: yes (Codex).
Testing: `npm test -- src/discord/chunk.test.ts src/config/config.test.ts`; `npm run lint`.
