### PR TITLE
fix(macOS): honor discovered gateway ports

### DIFF
--- a/apps/macos/Sources/Clawdbot/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayDiscoveryModel.swift
@@ -18,6 +18,7 @@ final class GatewayDiscoveryModel {
         var lanHost: String?
         var tailnetDns: String?
         var sshPort: Int
+        var gatewayPort: Int?
         var cliPath: String?
         var stableID: String
         var debugID: String
@@ -138,6 +139,7 @@ final class GatewayDiscoveryModel {
                 lanHost: parsedTXT.lanHost,
                 tailnetDns: parsedTXT.tailnetDns,
                 sshPort: parsedTXT.sshPort,
+                gatewayPort: parsedTXT.gatewayPort,
                 cliPath: parsedTXT.cliPath,
                 stableID: stableID,
                 debugID: BridgeEndpointID.prettyDescription(result.endpoint),
@@ -207,11 +209,12 @@ final class GatewayDiscoveryModel {
     }
 
     static func parseGatewayTXT(_ txt: [String: String])
-        -> (lanHost: String?, tailnetDns: String?, sshPort: Int, cliPath: String?)
+        -> (lanHost: String?, tailnetDns: String?, sshPort: Int, gatewayPort: Int?, cliPath: String?)
     {
         var lanHost: String?
         var tailnetDns: String?
         var sshPort = 22
+        var gatewayPort: Int?
         var cliPath: String?
 
         if let value = txt["lanHost"] {
@@ -228,12 +231,18 @@ final class GatewayDiscoveryModel {
         {
             sshPort = parsed
         }
+        if let value = txt["gatewayPort"],
+           let parsed = Int(value.trimmingCharacters(in: .whitespacesAndNewlines)),
+           parsed > 0
+        {
+            gatewayPort = parsed
+        }
         if let value = txt["cliPath"] {
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             cliPath = trimmed.isEmpty ? nil : trimmed
         }
 
-        return (lanHost, tailnetDns, sshPort, cliPath)
+        return (lanHost, tailnetDns, sshPort, gatewayPort, cliPath)
     }
 
     static func buildSSHTarget(user: String, host: String, port: Int) -> String {

--- a/apps/macos/Sources/Clawdbot/GeneralSettings.swift
+++ b/apps/macos/Sources/Clawdbot/GeneralSettings.swift
@@ -694,6 +694,7 @@ extension GeneralSettings {
             host: host,
             port: gateway.sshPort)
         self.state.remoteCliPath = gateway.cliPath ?? ""
+        ClawdbotConfigFile.setRemoteGatewayUrl(host: host, port: gateway.gatewayPort)
     }
 }
 

--- a/apps/macos/Sources/Clawdbot/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/Clawdbot/OnboardingView+Actions.swift
@@ -29,6 +29,7 @@ extension OnboardingView {
                 user: user,
                 host: host,
                 port: gateway.sshPort)
+            ClawdbotConfigFile.setRemoteGatewayUrl(host: host, port: gateway.gatewayPort)
         }
         self.state.remoteCliPath = gateway.cliPath ?? ""
 

--- a/apps/macos/Sources/Clawdbot/OnboardingView+Testing.swift
+++ b/apps/macos/Sources/Clawdbot/OnboardingView+Testing.swift
@@ -12,6 +12,7 @@ extension OnboardingView {
             lanHost: "bridge.local",
             tailnetDns: "bridge.ts.net",
             sshPort: 2222,
+            gatewayPort: 18789,
             cliPath: "/usr/local/bin/clawdbot",
             stableID: "bridge-1",
             debugID: "bridge-1",

--- a/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
+++ b/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
@@ -38,7 +38,11 @@ final class RemotePortTunnel {
         Task { await PortGuardian.shared.removeRecord(pid: pid) }
     }
 
-    static func create(remotePort: Int, preferredLocalPort: UInt16? = nil) async throws -> RemotePortTunnel {
+    static func create(
+        remotePort: Int,
+        preferredLocalPort: UInt16? = nil,
+        allowRemoteUrlOverride: Bool = true
+    ) async throws -> RemotePortTunnel {
         let settings = CommandResolver.connectionSettings()
         guard settings.mode == .remote, let parsed = CommandResolver.parseSSHTarget(settings.target) else {
             throw NSError(
@@ -49,7 +53,7 @@ final class RemotePortTunnel {
 
         let localPort = try await Self.findPort(preferred: preferredLocalPort)
         let sshHost = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
-        let remotePortOverride = Self.resolveRemotePortOverride(for: sshHost)
+        let remotePortOverride = allowRemoteUrlOverride ? Self.resolveRemotePortOverride(for: sshHost) : nil
         let resolvedRemotePort = remotePortOverride ?? remotePort
         if let override = remotePortOverride {
             Self.logger.info(


### PR DESCRIPTION
## Summary
- parse gatewayPort from Bonjour TXT and retain it on discovered gateways
- update gateway.remote.url when selecting a discovered gateway so remote ports stay accurate
- derive the remote bridge tunnel port from the remote gateway port and avoid remote-url overrides

## Testing
- swift build (apps/macos)