### PR TITLE
Agents: add weekday to user time (codex assisted)

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -213,6 +213,7 @@ function formatUserTime(date: Date, timeZone: string): string | undefined {
   try {
     const parts = new Intl.DateTimeFormat("en-CA", {
       timeZone,
+      weekday: "long",
       year: "numeric",
       month: "2-digit",
       day: "2-digit",
@@ -224,10 +225,17 @@ function formatUserTime(date: Date, timeZone: string): string | undefined {
     for (const part of parts) {
       if (part.type !== "literal") map[part.type] = part.value;
     }
-    if (!map.year || !map.month || !map.day || !map.hour || !map.minute) {
+    if (
+      !map.weekday ||
+      !map.year ||
+      !map.month ||
+      !map.day ||
+      !map.hour ||
+      !map.minute
+    ) {
       return undefined;
     }
-    return `${map.year}-${map.month}-${map.day} ${map.hour}:${map.minute}`;
+    return `${map.weekday} ${map.year}-${map.month}-${map.day} ${map.hour}:${map.minute}`;
   } catch {
     return undefined;
   }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -51,12 +51,12 @@ describe("buildAgentSystemPromptAppend", () => {
     const prompt = buildAgentSystemPromptAppend({
       workspaceDir: "/tmp/clawd",
       userTimezone: "America/Chicago",
-      userTime: "2026-01-05 15:26",
+      userTime: "Monday 2026-01-05 15:26",
     });
 
     expect(prompt).toContain("## Time");
     expect(prompt).toContain("User timezone: America/Chicago");
-    expect(prompt).toContain("Current user time: 2026-01-05 15:26");
+    expect(prompt).toContain("Current user time: Monday 2026-01-05 15:26");
   });
 
   it("includes model alias guidance when aliases are provided", () => {


### PR DESCRIPTION
## Summary
- Add weekday to the injected user time string in the system prompt
- Update system prompt test expectation

## Testing
- pnpm lint
- pnpm exec vitest run --testNamePattern "includes user time when provided"

## AI-assisted
- Yes (Codex)
- Prompt: "The system prompt is auto injected with user timezone and current time, can we extend to use day of week also? I think it is in pi-embedded-runner"
- I understand the changes and verified the targeted test.