### PR TITLE
fix(agent): protect bootstrap prefix from context pruning

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -823,6 +823,7 @@ This is intended to reduce token usage for chatty agents that accumulate large t
 High level:
 - Never touches user/assistant messages.
 - Protects the last `keepLastAssistants` assistant messages (no tool results after that point are pruned).
+- Protects the bootstrap prefix (nothing before the first user message is pruned).
 - Modes:
   - `adaptive`: soft-trims oversized tool results (keep head/tail) when the estimated context ratio crosses `softTrimRatio`.
     Then hard-clears the oldest eligible tool results when the estimated context ratio crosses `hardClearRatio` **and**


### PR DESCRIPTION
Follow-up safety fix for the opt-in tool-result context pruning that recently landed on `main`.

## What changed

- Never prune anything before the first `role:"user"` message in the session (“bootstrap prefix” protection).

## Why

Some sessions start with assistant/tool bootstrap work (reading user/system files, etc) before the first user message. In aggressive pruning, those early tool results can get cleared even though they function as part of the initial context, leading to missing details later.

## Notes

- Still in-memory only (context hook); session `*.jsonl` history remains complete.
- No config changes.
- PR diff is small because the base pruning feature + tests/docs were pushed directly to `main` after this PR was opened; this PR now only adds the bootstrap-prefix guard.

## Testing

- `pnpm lint && pnpm build && pnpm test`
