### PR TITLE
ui: add Connect button to Overview for credential changes

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -246,6 +246,7 @@ export function renderApp(state: AppViewState) {
                 state.resetToolStream();
                 state.applySettings({ ...state.settings, sessionKey: next });
               },
+              onConnect: () => state.connect(),
               onRefresh: () => state.loadOverview(),
             })
           : nothing}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -19,6 +19,7 @@ export type OverviewProps = {
   onSettingsChange: (next: UiSettings) => void;
   onPasswordChange: (next: string) => void;
   onSessionKeyChange: (next: string) => void;
+  onConnect: () => void;
   onRefresh: () => void;
 };
 
@@ -82,9 +83,10 @@ export function renderOverview(props: OverviewProps) {
             />
           </label>
         </div>
-        <div class="row" style="margin-top: 14px;">
+        <div class="row" style="margin-top: 14px; gap: 8px;">
+          <button class="btn" @click=${() => props.onConnect()}>Connect</button>
           <button class="btn" @click=${() => props.onRefresh()}>Refresh</button>
-          <span class="muted">Reconnect to apply changes.</span>
+          <span class="muted">Click Connect to apply credential changes.</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Adds a dedicated **Connect** button to the Overview page to apply gateway credential changes (URL, token, or password).

## Problem
The existing **Refresh** button was confusing - it displayed the text "Reconnect to apply changes" but only refreshed data without actually reconnecting to the gateway. This made password authentication unusable in the UI, as there was no way to apply the password without manually triggering a reconnect via the browser console.

## Solution
- Added a new **Connect** button that calls `state.connect()` to reconnect the gateway client
- Kept the **Refresh** button for refreshing overview data
- Updated the helper text to "Click Connect to apply credential changes" for clarity
- Added proper spacing between buttons with `gap: 8px`

## Testing
Tested with password authentication on tailscale funnel mode:
1. Entered password in the "Password (not stored)" field
2. Clicked the **Connect** button
3. Connection status changed to "Connected" and authentication succeeded
4. Overview page data loaded successfully

## Files Changed
- `ui/src/ui/app-render.ts`: Added `onConnect` callback that triggers `state.connect()`
- `ui/src/ui/views/overview.ts`: Added Connect button to UI and updated props type

Fixes the password authentication workflow in the control panel.