### PR TITLE
feat(agent): add simple observation masking extension

### DIFF
--- a/src/agents/observation-masking.test.ts
+++ b/src/agents/observation-masking.test.ts
@@ -1,0 +1,64 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { maskToolResultsForContext } from "./observation-masking.js";
+
+const toolResult = (id: string, text: string): AgentMessage => ({
+  role: "toolResult",
+  toolCallId: id,
+  toolName: "read",
+  content: [{ type: "text", text }],
+  isError: false,
+  timestamp: Date.now(),
+});
+
+const userMessage = (text: string): AgentMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+  timestamp: Date.now(),
+});
+
+describe("maskToolResultsForContext", () => {
+  it("masks all but the most recent tool result", () => {
+    const messages = [
+      userMessage("hello"),
+      toolResult("t1", "first"),
+      toolResult("t2", "second"),
+    ];
+    const masked = maskToolResultsForContext(messages, {
+      keepLast: 1,
+      placeholder: "MASKED",
+    });
+
+    expect(masked[1]).not.toBe(messages[1]);
+    expect((masked[1] as { content?: unknown }).content).toEqual([
+      { type: "text", text: "MASKED" },
+    ]);
+    expect(masked[2]).toBe(messages[2]);
+    expect((masked[2] as { content?: unknown }).content).toEqual([
+      { type: "text", text: "second" },
+    ]);
+  });
+
+  it("returns original messages when no masking is needed", () => {
+    const messages = [userMessage("hello"), toolResult("t1", "only")];
+    const masked = maskToolResultsForContext(messages, {
+      keepLast: 1,
+      placeholder: "MASKED",
+    });
+    expect(masked).toBe(messages);
+  });
+
+  it("masks all tool results when keepLast is 0", () => {
+    const messages = [toolResult("t1", "first"), toolResult("t2", "second")];
+    const masked = maskToolResultsForContext(messages, {
+      keepLast: 0,
+      placeholder: "MASKED",
+    });
+
+    for (const entry of masked) {
+      expect((entry as { content?: unknown }).content).toEqual([
+        { type: "text", text: "MASKED" },
+      ]);
+    }
+  });
+});

--- a/src/agents/observation-masking.ts
+++ b/src/agents/observation-masking.ts
@@ -28,9 +28,9 @@ function isToolResultMessage(
 ): message is AgentMessage & { role: "toolResult" } {
   return Boolean(
     message &&
-    typeof message === "object" &&
-    "role" in message &&
-    (message as { role?: unknown }).role === "toolResult",
+      typeof message === "object" &&
+      "role" in message &&
+      (message as { role?: unknown }).role === "toolResult",
   );
 }
 

--- a/src/agents/observation-masking.ts
+++ b/src/agents/observation-masking.ts
@@ -1,0 +1,75 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { ClawdbotConfig } from "../config/config.js";
+
+const DEFAULT_KEEP_LAST = 1;
+const DEFAULT_PLACEHOLDER = "Previous observation omitted for brevity.";
+
+export type ObservationMaskingOptions = {
+  keepLast: number;
+  placeholder: string;
+};
+
+export function resolveObservationMaskingOptions(
+  cfg?: ClawdbotConfig,
+): ObservationMaskingOptions | null {
+  const raw = cfg?.agent?.observationMasking;
+  if (!raw?.enabled) return null;
+  const keepLast =
+    typeof raw.keepLast === "number" && Number.isFinite(raw.keepLast)
+      ? Math.max(0, Math.floor(raw.keepLast))
+      : DEFAULT_KEEP_LAST;
+  const placeholder = raw.placeholder?.trim() || DEFAULT_PLACEHOLDER;
+  return { keepLast, placeholder };
+}
+
+function isToolResultMessage(
+  message: AgentMessage,
+): message is AgentMessage & { role: "toolResult" } {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    "role" in message &&
+    (message as { role?: unknown }).role === "toolResult",
+  );
+}
+
+export function maskToolResultsForContext(
+  messages: AgentMessage[],
+  options: ObservationMaskingOptions,
+): AgentMessage[] {
+  const keepLast = Math.max(0, Math.floor(options.keepLast));
+  let totalToolResults = 0;
+  for (const message of messages) {
+    if (message && isToolResultMessage(message)) totalToolResults += 1;
+  }
+  if (totalToolResults <= keepLast) return messages;
+
+  // Observation masking is applied only at context time so session history keeps full tool outputs.
+  const masked = messages.slice();
+  let remaining = keepLast;
+  for (let i = masked.length - 1; i >= 0; i -= 1) {
+    const message = masked[i];
+    if (!message || !isToolResultMessage(message)) continue;
+    if (remaining > 0) {
+      remaining -= 1;
+      continue;
+    }
+    masked[i] = {
+      ...(message as object),
+      content: [{ type: "text", text: options.placeholder }],
+    } as AgentMessage;
+  }
+  return masked;
+}
+
+export function createObservationMaskingExtension(
+  options: ObservationMaskingOptions,
+): ExtensionFactory {
+  return (pi) => {
+    pi.on("context", (event) => {
+      const masked = maskToolResultsForContext(event.messages, options);
+      return { messages: masked };
+    });
+  };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -96,6 +96,9 @@ const FIELD_LABELS: Record<string, string> = {
   "agent.model.fallbacks": "Model Fallbacks",
   "agent.imageModel.primary": "Image Model",
   "agent.imageModel.fallbacks": "Image Model Fallbacks",
+  "agent.observationMasking.enabled": "Observation Masking (Experimental)",
+  "agent.observationMasking.keepLast": "Observation Masking Window",
+  "agent.observationMasking.placeholder": "Observation Masking Placeholder",
   "commands.native": "Native Commands",
   "commands.text": "Text Commands",
   "commands.useAccessGroups": "Use Access Groups",
@@ -143,6 +146,12 @@ const FIELD_HELP: Record<string, string> = {
     "Optional image model (provider/model) used when the primary model lacks image input.",
   "agent.imageModel.fallbacks":
     "Ordered fallback image models (provider/model).",
+  "agent.observationMasking.enabled":
+    "Experimental: mask older tool results in LLM context to reduce token usage.",
+  "agent.observationMasking.keepLast":
+    "Number of most recent tool result observations to keep unmasked (default: 1).",
+  "agent.observationMasking.placeholder":
+    "Placeholder text to use for masked tool results.",
   "commands.native":
     "Register native commands with connectors that support it (Discord/Slack/Telegram).",
   "commands.text": "Allow text command parsing (slash commands only).",
@@ -173,6 +182,7 @@ const FIELD_HELP: Record<string, string> = {
 const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.remote.url": "ws://host:18789",
   "gateway.controlUi.basePath": "/clawdbot",
+  "agent.observationMasking.placeholder": "Previous observation omitted for brevity.",
 };
 
 const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -182,7 +182,8 @@ const FIELD_HELP: Record<string, string> = {
 const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.remote.url": "ws://host:18789",
   "gateway.controlUi.basePath": "/clawdbot",
-  "agent.observationMasking.placeholder": "Previous observation omitted for brevity.",
+  "agent.observationMasking.placeholder":
+    "Previous observation omitted for brevity.",
 };
 
 const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -38,13 +38,13 @@ export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
   file?: string;
   consoleLevel?:
-    | "silent"
-    | "fatal"
-    | "error"
-    | "warn"
-    | "info"
-    | "debug"
-    | "trace";
+  | "silent"
+  | "fatal"
+  | "error"
+  | "warn"
+  | "info"
+  | "debug"
+  | "trace";
   consoleStyle?: "pretty" | "compact" | "json";
   /** Redact sensitive tokens in tool summaries. Default: "tools". */
   redactSensitive?: "off" | "tools";
@@ -185,13 +185,13 @@ export type HookMappingConfig = {
   textTemplate?: string;
   deliver?: boolean;
   provider?:
-    | "last"
-    | "whatsapp"
-    | "telegram"
-    | "discord"
-    | "slack"
-    | "signal"
-    | "imessage";
+  | "last"
+  | "whatsapp"
+  | "telegram"
+  | "discord"
+  | "slack"
+  | "signal"
+  | "imessage";
   to?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -839,6 +839,15 @@ export type AgentModelListConfig = {
   fallbacks?: string[];
 };
 
+export type ObservationMaskingConfig = {
+  /** Enable experimental observation masking for tool results in LLM context. */
+  enabled?: boolean;
+  /** Keep the most recent N tool result observations unmasked (default: 1). */
+  keepLast?: number;
+  /** Placeholder text used for masked observations. */
+  placeholder?: string;
+};
+
 export type ClawdbotConfig = {
   auth?: AuthConfig;
   env?: {
@@ -884,6 +893,8 @@ export type ClawdbotConfig = {
     userTimezone?: string;
     /** Optional display-only context window override (used for % in status UIs). */
     contextTokens?: number;
+    /** Experimental: mask older tool results in LLM context to reduce token use. */
+    observationMasking?: ObservationMaskingConfig;
     /** Default thinking level when no /think directive is present. */
     thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high";
     /** Default verbose level when no /verbose directive is present. */
@@ -916,14 +927,14 @@ export type ClawdbotConfig = {
       model?: string;
       /** Delivery target (last|whatsapp|telegram|discord|signal|imessage|none). */
       target?:
-        | "last"
-        | "whatsapp"
-        | "telegram"
-        | "discord"
-        | "slack"
-        | "signal"
-        | "imessage"
-        | "none";
+      | "last"
+      | "whatsapp"
+      | "telegram"
+      | "discord"
+      | "slack"
+      | "signal"
+      | "imessage"
+      | "none";
       /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). */
       to?: string;
       /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if exists. Consider outstanding tasks. Checkup sometimes on your human during (user local) day time."). */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -38,13 +38,13 @@ export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
   file?: string;
   consoleLevel?:
-  | "silent"
-  | "fatal"
-  | "error"
-  | "warn"
-  | "info"
-  | "debug"
-  | "trace";
+    | "silent"
+    | "fatal"
+    | "error"
+    | "warn"
+    | "info"
+    | "debug"
+    | "trace";
   consoleStyle?: "pretty" | "compact" | "json";
   /** Redact sensitive tokens in tool summaries. Default: "tools". */
   redactSensitive?: "off" | "tools";
@@ -185,13 +185,13 @@ export type HookMappingConfig = {
   textTemplate?: string;
   deliver?: boolean;
   provider?:
-  | "last"
-  | "whatsapp"
-  | "telegram"
-  | "discord"
-  | "slack"
-  | "signal"
-  | "imessage";
+    | "last"
+    | "whatsapp"
+    | "telegram"
+    | "discord"
+    | "slack"
+    | "signal"
+    | "imessage";
   to?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -927,14 +927,14 @@ export type ClawdbotConfig = {
       model?: string;
       /** Delivery target (last|whatsapp|telegram|discord|signal|imessage|none). */
       target?:
-      | "last"
-      | "whatsapp"
-      | "telegram"
-      | "discord"
-      | "slack"
-      | "signal"
-      | "imessage"
-      | "none";
+        | "last"
+        | "whatsapp"
+        | "telegram"
+        | "discord"
+        | "slack"
+        | "signal"
+        | "imessage"
+        | "none";
       /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). */
       to?: string;
       /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if exists. Consider outstanding tasks. Checkup sometimes on your human during (user local) day time."). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -498,6 +498,13 @@ export const ClawdbotSchema = z.object({
       skipBootstrap: z.boolean().optional(),
       userTimezone: z.string().optional(),
       contextTokens: z.number().int().positive().optional(),
+      observationMasking: z
+        .object({
+          enabled: z.boolean().optional(),
+          keepLast: z.number().int().min(0).optional(),
+          placeholder: z.string().optional(),
+        })
+        .optional(),
       tools: z
         .object({
           allow: z.array(z.string()).optional(),


### PR DESCRIPTION
Adds opt-in observation masking that replaces older tool results with a placeholder before sending context to the LLM. This reduces token usage in long-running sessions based on https://arxiv.org/abs/2508.21433.

Preceded by #381

This PR overlaps with #381 (context pruning). Key differences:

|                      | This PR                   | #381                                  |
|----------------------|---------------------------|---------------------------------------|
| Approach             | Count-based (keep last N) | Ratio-based (soft-trim → hard-clear)  |
| Trigger              | Always (if enabled)       | When context ratio exceeds threshold  |
| Partial preservation | No                        | Yes (keeps head/tail before clearing) |

Trade-off: This is simpler and more predictable but less sophisticated. #381 is smarter about when and how to prune. 

Config:
```json5
{
  agent: {
    observationMasking: {
      enabled: true,
      keepLast: 1,  // default
      placeholder: "Previous observation omitted for brevity."  // default
    }
  }
}
```