### PR TITLE
fix(macos): prevent gateway launchd race condition on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Auto-reply: removed `autoReply` from Discord/Slack/Telegram channel configs; use `requireMention` instead (Telegram topics now support `requireMention` overrides).
 
 ### Fixes
+- macOS: fix gateway launchd race condition where the Mac app would kill a just-started gateway by skipping `bootout` if the service is already running; also call `launchctl enable` to ensure auto-start on login. (#306)
 - Pairing: generate DM pairing codes with CSPRNG, expire pending codes after 1 hour, and avoid re-sending codes for already pending requests.
 - Pairing: lock + atomically write pairing stores with 0600 perms and stop logging pairing codes in provider logs.
 - Discord: include all inbound attachments in `MediaPaths`/`MediaUrls` (back-compat `MediaPath`/`MediaUrl` still first).


### PR DESCRIPTION
## Summary

Fixes #306 - macOS app menubar icon disappears + gateway launchd start timeout.

**Root cause:** Race condition during startup where:
1. launchd starts the gateway service on login (via `KeepAlive`)
2. Mac app starts shortly after
3. Mac app's `GatewayLaunchAgentManager.set(enabled: true, ...)` unconditionally calls `launchctl bootout` → kills the just-started gateway
4. Then calls `launchctl bootstrap` to start it again
5. If the gateway wasn't fully ready, the Mac app can't attach and retries, causing a loop

**Changes:**
- `GatewayLaunchAgentManager.swift`: Skip `bootout` if service is already running; add `launchctl enable` calls to ensure auto-start on login

## Test plan

- [x] Verified gateway auto-starts on login via launchd
- [x] Mac app detects running gateway and logs `"launchd service already running, skipping bootout"`
- [x] Gateway survives Mac app startup and health checks pass
- [x] Tested across multiple restarts

## AI-assisted

🤖 This PR was developed with Claude Code assistance. The fix was iteratively debugged and tested on a real macOS system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)