### PR TITLE
fix: add workaround for Claude Code OAuth token collision

### DIFF
--- a/docs/claude-code-oauth-collision.md
+++ b/docs/claude-code-oauth-collision.md
@@ -1,0 +1,139 @@
+# Claude Code OAuth Collision
+
+This document describes a token collision issue when running Clawdbot and Claude Code on the same machine, and provides a workaround.
+
+## Problem
+
+When running both **Clawdbot** and **Claude Code** on the same machine with the same Anthropic Max account, OAuth tokens repeatedly fail with `invalid_grant` errors every few hours.
+
+### Error Message
+
+```
+Embedded agent failed before reply: OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.
+```
+
+### Root Cause
+
+Both tools use the **same hardcoded OAuth client_id**: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+
+When Claude Code refreshes its token, Anthropic's OAuth server invalidates Clawdbot's refresh token (and vice versa) because they appear to be the same application.
+
+### Symptoms
+
+- Token works for a few hours after re-auth, then fails
+- `invalid_grant` error: "Refresh token not found or invalid"
+- Claude Code continues working fine while Clawdbot fails
+
+## Diagnosis
+
+Test if your refresh token is valid:
+
+```bash
+REFRESH=$(jq -r '.profiles["anthropic:default"].refresh' ~/.clawdbot/agent/auth-profiles.json)
+curl -s -X POST https://console.anthropic.com/v1/oauth/token \
+  -H "Content-Type: application/json" \
+  -d "{\"grant_type\":\"refresh_token\",\"client_id\":\"9d1c250a-e61b-44d9-88ed-5944d1962f5e\",\"refresh_token\":\"$REFRESH\"}"
+```
+
+If you see `{"error": "invalid_grant", ...}` - Claude Code has invalidated your token.
+
+## Solution: Token Sync Script
+
+Since Claude Code successfully refreshes (and "wins" the token battle), we can make Clawdbot piggyback on Claude Code's valid tokens.
+
+### How It Works
+
+```
+Claude Code authenticates
+       ↓
+Gets fresh tokens → saves to ~/.claude/.credentials.json
+       ↓
+Sync script copies tokens → ~/.clawdbot/agent/auth-profiles.json
+       ↓
+Clawdbot uses Claude Code's valid tokens
+       ↓
+When Claude Code refreshes → sync script copies new tokens
+       ↓
+Clawdbot always has valid tokens
+```
+
+### Setup
+
+#### 1. Use the sync script
+
+The script is included at `scripts/sync-claude-code-auth.sh`.
+
+Run manually:
+```bash
+./scripts/sync-claude-code-auth.sh
+```
+
+#### 2. Set up cron job (recommended)
+
+Run every 30 minutes to keep tokens in sync:
+
+```bash
+(crontab -l 2>/dev/null; echo "*/30 * * * * /path/to/clawdbot/scripts/sync-claude-code-auth.sh --cron >> /tmp/clawdbot-auth-sync.log 2>&1") | crontab -
+```
+
+#### 3. Manual sync after Claude Code re-login
+
+When Claude Code's OAuth completely expires and you run `/login`, manually sync:
+
+```bash
+./scripts/sync-claude-code-auth.sh
+systemctl --user restart clawdbot  # or however you run clawdbot
+```
+
+### Token Format Mapping
+
+| Claude Code | Clawdbot |
+|-------------|----------|
+| `claudeAiOauth.accessToken` | `profiles["anthropic:default"].access` |
+| `claudeAiOauth.refreshToken` | `profiles["anthropic:default"].refresh` |
+| `claudeAiOauth.expiresAt` | `profiles["anthropic:default"].expires` |
+
+### File Locations
+
+| File | Purpose |
+|------|---------|
+| `~/.claude/.credentials.json` | Claude Code's OAuth tokens (source) |
+| `~/.clawdbot/agent/auth-profiles.json` | Clawdbot's OAuth tokens (destination) |
+| `scripts/sync-claude-code-auth.sh` | Sync script |
+| `/tmp/clawdbot-auth-sync.log` | Cron sync log |
+
+## Alternative Solutions
+
+1. **Use API key for one tool** - If you have Anthropic API credits, use `api_key` mode for Clawdbot instead of OAuth
+2. **Run on separate machines** - Keep Clawdbot and Claude Code on different servers
+3. **Different Anthropic accounts** - Use separate Max subscriptions (not practical for most)
+
+## Mobile Widget (Termux)
+
+If you use Termux on Android, you can create a widget to manually trigger sync after a `/login`:
+
+Save to `~/.shortcuts/sync-clawdbot.sh` on your phone:
+
+```bash
+#!/data/data/com.termux/files/usr/bin/bash
+termux-toast "Syncing Clawdbot auth..."
+
+RESULT=$(ssh your-server '/path/to/clawdbot/scripts/sync-claude-code-auth.sh' 2>&1)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    EXPIRY=$(echo "$RESULT" | grep "Token expires:" | cut -d: -f2-)
+    termux-vibrate -d 100
+    termux-toast "Clawdbot synced! Expires:${EXPIRY}"
+    ssh your-server 'systemctl --user restart clawdbot' 2>/dev/null
+else
+    termux-vibrate -d 300
+    termux-toast "Sync failed: ${RESULT}"
+fi
+```
+
+Then add a Termux:Widget to your homescreen.
+
+## Contributors
+
+- [@tonynolanki](https://github.com/tonynolanki) - Discovered issue and developed solution

--- a/scripts/sync-claude-code-auth.sh
+++ b/scripts/sync-claude-code-auth.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Sync Claude Code OAuth tokens to Clawdbot
+# This fixes the token collision issue when both tools use the same client_id
+#
+# Usage:
+#   ./sync-claude-code-auth.sh        # One-time sync
+#   ./sync-claude-code-auth.sh --cron # For cron (silent unless error)
+
+set -euo pipefail
+
+CLAUDE_CREDS="$HOME/.claude/.credentials.json"
+CLAWDBOT_AUTH="$HOME/.clawdbot/agent/auth-profiles.json"
+CRON_MODE="${1:-}"
+
+log() {
+    if [[ "$CRON_MODE" != "--cron" ]]; then
+        echo "$1"
+    fi
+}
+
+error() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+# Check Claude Code credentials exist
+if [[ ! -f "$CLAUDE_CREDS" ]]; then
+    error "Claude Code credentials not found at $CLAUDE_CREDS"
+fi
+
+# Check if Claude Code has Anthropic OAuth
+if ! jq -e '.claudeAiOauth' "$CLAUDE_CREDS" > /dev/null 2>&1; then
+    error "No claudeAiOauth found in Claude Code credentials"
+fi
+
+# Extract Claude Code tokens
+CC_ACCESS=$(jq -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDS")
+CC_REFRESH=$(jq -r '.claudeAiOauth.refreshToken // empty' "$CLAUDE_CREDS")
+CC_EXPIRES=$(jq -r '.claudeAiOauth.expiresAt // empty' "$CLAUDE_CREDS")
+
+if [[ -z "$CC_ACCESS" || -z "$CC_REFRESH" || -z "$CC_EXPIRES" ]]; then
+    error "Claude Code credentials incomplete"
+fi
+
+# Check if Claude Code token is still valid (with 5 min buffer)
+NOW_MS=$(date +%s)000
+BUFFER_MS=300000  # 5 minutes
+EXPIRES_WITH_BUFFER=$((CC_EXPIRES - BUFFER_MS))
+
+if [[ "$NOW_MS" -gt "$EXPIRES_WITH_BUFFER" ]]; then
+    log "WARNING: Claude Code token expires soon or already expired"
+    log "  Expires: $(date -d @$((CC_EXPIRES / 1000)))"
+    log "  You may need to use Claude Code first to refresh its token"
+fi
+
+# Get current clawdbot tokens for comparison
+if [[ -f "$CLAWDBOT_AUTH" ]]; then
+    CB_REFRESH=$(jq -r '.profiles["anthropic:default"].refresh // empty' "$CLAWDBOT_AUTH" 2>/dev/null || echo "")
+else
+    CB_REFRESH=""
+fi
+
+# Check if sync is needed
+if [[ "$CC_REFRESH" == "$CB_REFRESH" ]]; then
+    log "Tokens already in sync - no update needed"
+    exit 0
+fi
+
+# Backup current clawdbot auth
+if [[ -f "$CLAWDBOT_AUTH" ]]; then
+    cp "$CLAWDBOT_AUTH" "${CLAWDBOT_AUTH}.bak"
+fi
+
+# Ensure directory exists
+mkdir -p "$(dirname "$CLAWDBOT_AUTH")"
+
+# Update clawdbot auth-profiles.json
+if [[ -f "$CLAWDBOT_AUTH" ]]; then
+    # Update existing file
+    jq --arg access "$CC_ACCESS" \
+       --arg refresh "$CC_REFRESH" \
+       --argjson expires "$CC_EXPIRES" \
+       '.profiles["anthropic:default"].access = $access |
+        .profiles["anthropic:default"].refresh = $refresh |
+        .profiles["anthropic:default"].expires = $expires' \
+       "$CLAWDBOT_AUTH" > "${CLAWDBOT_AUTH}.tmp"
+    mv "${CLAWDBOT_AUTH}.tmp" "$CLAWDBOT_AUTH"
+else
+    # Create new file
+    jq -n --arg access "$CC_ACCESS" \
+          --arg refresh "$CC_REFRESH" \
+          --argjson expires "$CC_EXPIRES" \
+          '{
+            version: 1,
+            profiles: {
+              "anthropic:default": {
+                type: "oauth",
+                provider: "anthropic",
+                access: $access,
+                refresh: $refresh,
+                expires: $expires
+              }
+            }
+          }' > "$CLAWDBOT_AUTH"
+fi
+
+chmod 600 "$CLAWDBOT_AUTH"
+
+log "Synced Claude Code tokens to Clawdbot"
+log "  Token expires: $(date -d @$((CC_EXPIRES / 1000)))"


### PR DESCRIPTION
## Summary

When running both Clawdbot and Claude Code on the same machine with the same Anthropic Max account, OAuth tokens repeatedly fail with `invalid_grant` errors every few hours.

**Root cause:** Both tools use the same hardcoded OAuth client_id (`9d1c250a-e61b-44d9-88ed-5944d1962f5e`). When one refreshes its token, Anthropic invalidates the other's refresh token.

**Solution:** A sync script that copies Claude Code's valid tokens to Clawdbot's auth store. Since Claude Code "wins" the refresh battle, Clawdbot can piggyback on its tokens.

## Changes

- `scripts/sync-claude-code-auth.sh` - Sync script to copy Claude Code tokens to Clawdbot
- `docs/claude-code-oauth-collision.md` - Full documentation of the issue and workaround

## Usage

```bash
# One-time sync
./scripts/sync-claude-code-auth.sh

# Set up cron for automatic sync every 30 min
(crontab -l 2>/dev/null; echo "*/30 * * * * /path/to/clawdbot/scripts/sync-claude-code-auth.sh --cron >> /tmp/clawdbot-auth-sync.log 2>&1") | crontab -
```

## Test plan

- [x] Manually tested sync script on Ubuntu 22.04
- [x] Verified tokens are correctly copied from Claude Code to Clawdbot format
- [x] Confirmed Clawdbot works with synced tokens after Claude Code refresh

## Contributors

- [@tonynolanki](https://github.com/tonynolanki) - Discovered the issue and developed the solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)