### PR TITLE
Handle 413 context overflow errors gracefully

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -89,12 +89,32 @@ export function buildBootstrapContextFiles(
   }));
 }
 
+export function isContextOverflowError(errorMessage?: string): boolean {
+  if (!errorMessage) return false;
+  const lower = errorMessage.toLowerCase();
+  return (
+    lower.includes("request_too_large") ||
+    lower.includes("request exceeds the maximum size") ||
+    lower.includes("context length exceeded") ||
+    lower.includes("maximum context length") ||
+    (lower.includes("413") && lower.includes("too large"))
+  );
+}
+
 export function formatAssistantErrorText(
   msg: AssistantMessage,
 ): string | undefined {
   if (msg.stopReason !== "error") return undefined;
   const raw = (msg.errorMessage ?? "").trim();
   if (!raw) return "LLM request failed with an unknown error.";
+
+  // Check for context overflow (413) errors
+  if (isContextOverflowError(raw)) {
+    return (
+      "Context overflow: the conversation history is too large. " +
+      "Use /new or /reset to start a fresh session."
+    );
+  }
 
   const invalidRequest = raw.match(
     /"type":"invalid_request_error".*?"message":"([^"]+)"/,


### PR DESCRIPTION
## Problem

When the conversation context exceeds the model's limit, the gateway returns a raw 413 error that makes the assistant completely unresponsive. Users have no indication of what went wrong or how to fix it.

This happened to me on Jan 6-7, 2026 - the assistant was stuck returning 413 errors for hours until I manually cleared the context.

## Solution

This PR adds graceful handling of context overflow errors:

1. **New helper function** `isContextOverflowError()` in `pi-embedded-helpers.ts` detects various forms of the error (413, request_too_large, context length exceeded, etc.)

2. **User-friendly error message** in `formatAssistantErrorText()` returns a helpful message instead of raw JSON

3. **Early return in runner** - When `session.prompt()` throws a context overflow error, we return a helpful response instead of propagating the error

## Changes

- `src/agents/pi-embedded-helpers.ts`: Added `isContextOverflowError()` function and updated `formatAssistantErrorText()` to detect and handle 413 errors
- `src/agents/pi-embedded-runner.ts`: Import the new helper and catch context overflow errors in the prompt execution path

## Testing

- Build passes (`pnpm build`)
- Error detection covers: `request_too_large`, `request exceeds the maximum size`, `context length exceeded`, `maximum context length`

## Future Improvements

This is a minimal fix. A more complete solution could:
- Automatically truncate old messages and retry
- Proactively warn when approaching context limits
- Write a summary to memory before truncating

Addresses #394