### PR TITLE
fix(status): show configured model instead of last-run model

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -249,8 +249,8 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultModel: DEFAULT_MODEL,
   });
   const provider =
-    entry?.modelProvider ?? resolved.provider ?? DEFAULT_PROVIDER;
-  let model = entry?.model ?? resolved.model ?? DEFAULT_MODEL;
+    entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+  let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??


### PR DESCRIPTION
## Summary

Fix `/status` to show the **configured model** (or override) instead of the **last-run model**.

## Problem

`/status` was showing `entry.model` which stores the model from the last agent run (e.g. a heartbeat on Haiku). This caused confusion when the configured model was different (e.g. Opus).

Example:
- Config: `agent.model.primary = "anthropic/claude-opus-4-5"`
- Last heartbeat ran on Haiku
- `/status` showed "claude-haiku-4-5" ❌

## Fix

Use `modelOverride` / `providerOverride` (user selection) or `resolved` (configured model) instead of `entry.model` / `entry.modelProvider` (last-run model).

```diff
- entry?.modelProvider ?? resolved.provider ?? DEFAULT_PROVIDER;
- entry?.model ?? resolved.model ?? DEFAULT_MODEL;
+ entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+ entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
```

Now `/status` shows:
1. The model override if user switched with `/model`
2. Otherwise the configured model from `agent.model.primary`
