### PR TITLE
fix(macos): prevent bonjour ciao cancellation crash

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -6,6 +6,7 @@ import { normalizeEnv } from "../infra/env.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureClawdbotCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
+import { isUnhandledRejectionHandled } from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 
 export async function runCli(argv: string[] = process.argv) {
@@ -25,6 +26,7 @@ export async function runCli(argv: string[] = process.argv) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
   process.on("unhandledRejection", (reason, _promise) => {
+    if (isUnhandledRejectionHandled(reason)) return;
     console.error(
       "[clawdbot] Unhandled promise rejection:",
       reason instanceof Error ? (reason.stack ?? reason.message) : reason,

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 
 import { logDebug, logWarn } from "../logger.js";
 import { getLogger } from "../logging.js";
+import { registerUnhandledRejectionHandler } from "./unhandled-rejections.js";
 
 export type GatewayBonjourAdvertiser = {
   stop: () => Promise<void>;
@@ -143,6 +144,22 @@ export async function startGatewayBonjourAdvertiser(
     });
   }
 
+  let ciaoCancellationRejectionHandler: (() => void) | undefined;
+  if (services.length > 0) {
+    ciaoCancellationRejectionHandler = registerUnhandledRejectionHandler(
+      (reason) => {
+        const message = formatBonjourError(reason).toUpperCase();
+        if (!message.includes("CIAO ANNOUNCEMENT CANCELLED")) {
+          return false;
+        }
+        logDebug(
+          `bonjour: ignoring unhandled ciao rejection: ${formatBonjourError(reason)}`,
+        );
+        return true;
+      },
+    );
+  }
+
   logDebug(
     `bonjour: starting (hostname=${hostname}, instance=${JSON.stringify(
       safeServiceName(instanceName),
@@ -250,6 +267,7 @@ export async function startGatewayBonjourAdvertiser(
           /* ignore */
         }
       }
+      ciaoCancellationRejectionHandler?.();
       try {
         await responder.shutdown();
       } catch {


### PR DESCRIPTION
## Summary
I hit crashes running clawdbot on macOS where a Bonjour re-advertise triggered a ciao cancellation and clawdbot exited with an unhandled rejection. This PR fixes this so clawdbot keeps running.

### Crash
```
[clawdbot] Unhandled promise rejection: CIAO ANNOUNCEMENT CANCELLED
ELIFECYCLE Command failed with exit code 1.
```

### Notes
* I suspect the error may come from having a homebridge instance @homebridge/ciao on this network
* tested locally, AI-assisted
