### PR TITLE
fix(onboard): add explicit return types to config setters [AI-assisted]

### DIFF
--- a/src/commands/onboard-providers.ts
+++ b/src/commands/onboard-providers.ts
@@ -192,7 +192,10 @@ function setWhatsAppDmPolicy(cfg: ClawdbotConfig, dmPolicy?: DmPolicy) {
   };
 }
 
-function setWhatsAppAllowFrom(cfg: ClawdbotConfig, allowFrom?: string[]) {
+function setWhatsAppAllowFrom(
+  cfg: ClawdbotConfig,
+  allowFrom?: string[],
+): ClawdbotConfig {
   return {
     ...cfg,
     whatsapp: {
@@ -205,7 +208,7 @@ function setWhatsAppAllowFrom(cfg: ClawdbotConfig, allowFrom?: string[]) {
 function setMessagesResponsePrefix(
   cfg: ClawdbotConfig,
   responsePrefix?: string,
-) {
+): ClawdbotConfig {
   return {
     ...cfg,
     messages: {
@@ -218,7 +221,7 @@ function setMessagesResponsePrefix(
 function setWhatsAppSelfChatMode(
   cfg: ClawdbotConfig,
   selfChatMode?: boolean,
-) {
+): ClawdbotConfig {
   return {
     ...cfg,
     whatsapp: {


### PR DESCRIPTION
## Summary

Fixes TypeScript build error introduced in 54960d1 where chained config setter functions lost type information.

The issue: when calling `setWhatsAppSelfChatMode()` followed by `setWhatsAppAllowFrom()`, TypeScript inferred that `selfChatMode` became optional in the return type, causing 7 type errors.

The fix: add explicit `: ClawdbotConfig` return types to the setter functions so TypeScript preserves the full type through the chain.

## Changes

- `setWhatsAppAllowFrom`: added explicit return type
- `setMessagesResponsePrefix`: added explicit return type  
- `setWhatsAppSelfChatMode`: added explicit return type

## Test plan

- [x] `pnpm build` passes (was failing with 7 errors)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (1376 tests)

---

🤖 **AI-assisted**: This fix was developed with Claude Code (Opus 4.5)

**Testing level**: Fully tested - build, lint, and all tests pass

**What the code does**: The setter functions create new config objects with updated properties. Adding explicit return types prevents TypeScript from inferring a narrower type that loses information about properties set by previous chained calls.