### PR TITLE
fix(google): repair Cloud Code Assist tool-call ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - Control UI: show a reading indicator bubble while the assistant is responding.
 - Control UI: animate reading indicator dots (honors reduced-motion).
 - Control UI: stabilize chat streaming during tool runs (no flicker/vanishing text; correct run scoping).
+- Google: recover from corrupted transcripts that start with an assistant tool call to avoid Cloud Code Assist 400 ordering errors. (#406)
 - Control UI: let config-form enums select empty-string values. Thanks @sreekaransrinath for PR #268.
 - Control UI: scroll chat to bottom on initial load. Thanks @kiranjd for PR #274.
 - Control UI: add Chat focus mode toggle to collapse header + sidebar.


### PR DESCRIPTION
Fixes #406.

Problem: Google Cloud Code Assist rejects transcripts when the first turn is `assistant` (often `toolCall`), returning 400 `INVALID_ARGUMENT` about function-call ordering.

Changes:
- If Google provider history starts with `assistant`, prepend a tiny synthetic `user` bootstrap turn before sending.
- Log a warning when this repair happens.
- Add regression test for the sanitizer.
- Changelog entry.

Testing:
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`

Links:
- Issue: https://github.com/clawdbot/clawdbot/issues/406
- Context: https://discord.com/channels/1456350064065904867/1456457255208878100/1458464465430511803
