### PR TITLE
refactor(macos): launchctl + node runtime service injection

### DIFF
--- a/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
@@ -70,7 +70,7 @@ final class GatewayProcessManager {
     func ensureLaunchAgentEnabledIfNeeded() async {
         guard !CommandResolver.connectionModeIsRemote() else { return }
         guard !AppStateStore.attachExistingGatewayOnly else { return }
-        let enabled = await GatewayLaunchAgentManager.status()
+        let enabled = await GatewayLaunchAgentManager.isLoaded()
         guard !enabled else { return }
         let bundlePath = Bundle.main.bundleURL.path
         let port = GatewayEnvironment.gatewayPort()

--- a/apps/macos/Sources/Clawdbot/Launchctl.swift
+++ b/apps/macos/Sources/Clawdbot/Launchctl.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum Launchctl {
+    struct Result: Sendable {
+        let status: Int32
+        let output: String
+    }
+
+    @discardableResult
+    static func run(_ args: [String]) async -> Result {
+        await Task.detached(priority: .utility) { () -> Result in
+            let process = Process()
+            process.launchPath = "/bin/launchctl"
+            process.arguments = args
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+            do {
+                try process.run()
+                process.waitUntilExit()
+                let data = pipe.fileHandleForReading.readToEndSafely()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                return Result(status: process.terminationStatus, output: output)
+            } catch {
+                return Result(status: -1, output: error.localizedDescription)
+            }
+        }.value
+    }
+}
+
+struct LaunchAgentPlistSnapshot: Equatable, Sendable {
+    let programArguments: [String]
+    let environment: [String: String]
+
+    let port: Int?
+    let bind: String?
+    let token: String?
+    let password: String?
+}
+
+enum LaunchAgentPlist {
+    static func snapshot(url: URL) -> LaunchAgentPlistSnapshot? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let rootAny: Any
+        do {
+            rootAny = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil)
+        } catch {
+            return nil
+        }
+        guard let root = rootAny as? [String: Any] else { return nil }
+        let programArguments = root["ProgramArguments"] as? [String] ?? []
+        let env = root["EnvironmentVariables"] as? [String: String] ?? [:]
+        let port = Self.extractFlagInt(programArguments, flag: "--port")
+        let bind = Self.extractFlagString(programArguments, flag: "--bind")?.lowercased()
+        let token = env["CLAWDBOT_GATEWAY_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        let password = env["CLAWDBOT_GATEWAY_PASSWORD"]?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        return LaunchAgentPlistSnapshot(
+            programArguments: programArguments,
+            environment: env,
+            port: port,
+            bind: bind,
+            token: token,
+            password: password)
+    }
+
+    private static func extractFlagInt(_ args: [String], flag: String) -> Int? {
+        guard let raw = self.extractFlagString(args, flag: flag) else { return nil }
+        return Int(raw)
+    }
+
+    private static func extractFlagString(_ args: [String], flag: String) -> String? {
+        guard let idx = args.firstIndex(of: flag) else { return nil }
+        let valueIdx = args.index(after: idx)
+        guard valueIdx < args.endIndex else { return nil }
+        let token = args[valueIdx].trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.isEmpty ? nil : token
+    }
+}
+

--- a/apps/macos/Sources/Clawdbot/NodeMode/MacNodeRuntimeMainActorServices.swift
+++ b/apps/macos/Sources/Clawdbot/NodeMode/MacNodeRuntimeMainActorServices.swift
@@ -1,0 +1,60 @@
+import ClawdbotKit
+import CoreLocation
+import Foundation
+
+@MainActor
+protocol MacNodeRuntimeMainActorServices: Sendable {
+    func recordScreen(
+        screenIndex: Int?,
+        durationMs: Int?,
+        fps: Double?,
+        includeAudio: Bool?,
+        outPath: String?) async throws -> (path: String, hasAudio: Bool)
+
+    func locationAuthorizationStatus() -> CLAuthorizationStatus
+    func locationAccuracyAuthorization() -> CLAccuracyAuthorization
+    func currentLocation(
+        desiredAccuracy: ClawdbotLocationAccuracy,
+        maxAgeMs: Int?,
+        timeoutMs: Int?) async throws -> CLLocation
+}
+
+@MainActor
+final class LiveMacNodeRuntimeMainActorServices: MacNodeRuntimeMainActorServices, @unchecked Sendable {
+    private let screenRecorder = ScreenRecordService()
+    private let locationService = MacNodeLocationService()
+
+    func recordScreen(
+        screenIndex: Int?,
+        durationMs: Int?,
+        fps: Double?,
+        includeAudio: Bool?,
+        outPath: String?) async throws -> (path: String, hasAudio: Bool)
+    {
+        try await self.screenRecorder.record(
+            screenIndex: screenIndex,
+            durationMs: durationMs,
+            fps: fps,
+            includeAudio: includeAudio,
+            outPath: outPath)
+    }
+
+    func locationAuthorizationStatus() -> CLAuthorizationStatus {
+        self.locationService.authorizationStatus()
+    }
+
+    func locationAccuracyAuthorization() -> CLAccuracyAuthorization {
+        self.locationService.accuracyAuthorization()
+    }
+
+    func currentLocation(
+        desiredAccuracy: ClawdbotLocationAccuracy,
+        maxAgeMs: Int?,
+        timeoutMs: Int?) async throws -> CLLocation
+    {
+        try await self.locationService.currentLocation(
+            desiredAccuracy: desiredAccuracy,
+            maxAgeMs: maxAgeMs,
+            timeoutMs: timeoutMs)
+    }
+}

--- a/apps/macos/Sources/Clawdbot/ProcessInfo+Clawdbot.swift
+++ b/apps/macos/Sources/Clawdbot/ProcessInfo+Clawdbot.swift
@@ -2,11 +2,12 @@ import Foundation
 
 extension ProcessInfo {
     var isPreview: Bool {
-        self.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+        guard let raw = getenv("XCODE_RUNNING_FOR_PREVIEWS") else { return false }
+        return String(cString: raw) == "1"
     }
 
     var isNixMode: Bool {
-        if self.environment["CLAWDBOT_NIX_MODE"] == "1" { return true }
+        if let raw = getenv("CLAWDBOT_NIX_MODE"), String(cString: raw) == "1" { return true }
         return UserDefaults.standard.bool(forKey: "clawdbot.nixMode")
     }
 

--- a/apps/macos/Tests/ClawdbotIPCTests/ClawdbotConfigFileTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/ClawdbotConfigFileTests.swift
@@ -5,26 +5,26 @@ import Testing
 @Suite(.serialized)
 struct ClawdbotConfigFileTests {
     @Test
-    func configPathRespectsEnvOverride() {
+    func configPathRespectsEnvOverride() async {
         let override = FileManager.default.temporaryDirectory
             .appendingPathComponent("clawdbot-config-\(UUID().uuidString)")
             .appendingPathComponent("clawdbot.json")
             .path
 
-        self.withEnv("CLAWDBOT_CONFIG_PATH", value: override) {
+        await TestIsolation.withEnvValues(["CLAWDBOT_CONFIG_PATH": override]) {
             #expect(ClawdbotConfigFile.url().path == override)
         }
     }
 
     @MainActor
     @Test
-    func remoteGatewayPortParsesAndMatchesHost() {
+    func remoteGatewayPortParsesAndMatchesHost() async {
         let override = FileManager.default.temporaryDirectory
             .appendingPathComponent("clawdbot-config-\(UUID().uuidString)")
             .appendingPathComponent("clawdbot.json")
             .path
 
-        self.withEnv("CLAWDBOT_CONFIG_PATH", value: override) {
+        await TestIsolation.withEnvValues(["CLAWDBOT_CONFIG_PATH": override]) {
             ClawdbotConfigFile.saveDict([
                 "gateway": [
                     "remote": [
@@ -41,13 +41,13 @@ struct ClawdbotConfigFileTests {
 
     @MainActor
     @Test
-    func setRemoteGatewayUrlPreservesScheme() {
+    func setRemoteGatewayUrlPreservesScheme() async {
         let override = FileManager.default.temporaryDirectory
             .appendingPathComponent("clawdbot-config-\(UUID().uuidString)")
             .appendingPathComponent("clawdbot.json")
             .path
 
-        self.withEnv("CLAWDBOT_CONFIG_PATH", value: override) {
+        await TestIsolation.withEnvValues(["CLAWDBOT_CONFIG_PATH": override]) {
             ClawdbotConfigFile.saveDict([
                 "gateway": [
                     "remote": [
@@ -63,33 +63,17 @@ struct ClawdbotConfigFileTests {
     }
 
     @Test
-    func stateDirOverrideSetsConfigPath() {
+    func stateDirOverrideSetsConfigPath() async {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("clawdbot-state-\(UUID().uuidString)", isDirectory: true)
             .path
 
-        self.withEnv("CLAWDBOT_CONFIG_PATH", value: nil) {
-            self.withEnv("CLAWDBOT_STATE_DIR", value: dir) {
-                #expect(ClawdbotConfigFile.stateDirURL().path == dir)
-                #expect(ClawdbotConfigFile.url().path == "\(dir)/clawdbot.json")
-            }
+        await TestIsolation.withEnvValues([
+            "CLAWDBOT_CONFIG_PATH": nil,
+            "CLAWDBOT_STATE_DIR": dir,
+        ]) {
+            #expect(ClawdbotConfigFile.stateDirURL().path == dir)
+            #expect(ClawdbotConfigFile.url().path == "\(dir)/clawdbot.json")
         }
-    }
-
-    private func withEnv(_ key: String, value: String?, _ body: () -> Void) {
-        let previous = ProcessInfo.processInfo.environment[key]
-        if let value {
-            setenv(key, value, 1)
-        } else {
-            unsetenv(key)
-        }
-        defer {
-            if let previous {
-                setenv(key, previous, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-        body()
     }
 }

--- a/apps/macos/Tests/ClawdbotIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/GatewayEnvironmentTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Clawdbot
 
-@Suite(.serialized) struct GatewayEnvironmentTests {
+@Suite struct GatewayEnvironmentTests {
     @Test func semverParsesCommonForms() {
         #expect(Semver.parse("1.2.3") == Semver(major: 1, minor: 2, patch: 3))
         #expect(Semver.parse("v2.0.0") == Semver(major: 2, minor: 0, patch: 0))
@@ -19,29 +19,19 @@ import Testing
         #expect(Semver(major: 1, minor: 9, patch: 9).compatible(with: required) == false)
     }
 
-    @Test func gatewayPortDefaultsAndRespectsOverride() {
-        let envKey = "CLAWDBOT_CONFIG_PATH"
-        let previousEnv = getenv(envKey).map { String(cString: $0) }
-        let configPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("clawdbot-test-config-\(UUID().uuidString).json")
-            .path
-        setenv(envKey, configPath, 1)
-        defer {
-            if let previousEnv {
-                setenv(envKey, previousEnv, 1)
-            } else {
-                unsetenv(envKey)
-            }
+    @Test func gatewayPortDefaultsAndRespectsOverride() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(
+            env: ["CLAWDBOT_CONFIG_PATH": configPath],
+            defaults: ["gatewayPort": nil])
+        {
+            let defaultPort = GatewayEnvironment.gatewayPort()
+            #expect(defaultPort == 18789)
+
+            UserDefaults.standard.set(19999, forKey: "gatewayPort")
+            defer { UserDefaults.standard.removeObject(forKey: "gatewayPort") }
+            #expect(GatewayEnvironment.gatewayPort() == 19999)
         }
-
-        UserDefaults.standard.removeObject(forKey: "gatewayPort")
-        defer { UserDefaults.standard.removeObject(forKey: "gatewayPort") }
-
-        let defaultPort = GatewayEnvironment.gatewayPort()
-        #expect(defaultPort == 18789)
-
-        UserDefaults.standard.set(19999, forKey: "gatewayPort")
-        #expect(GatewayEnvironment.gatewayPort() == 19999)
     }
 
     @Test func expectedGatewayVersionFromStringUsesParser() {

--- a/apps/macos/Tests/ClawdbotIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -1,49 +1,41 @@
+import Foundation
 import Testing
 @testable import Clawdbot
 
 @Suite struct GatewayLaunchAgentManagerTests {
-    @Test func parseLaunchctlPrintSnapshotParsesQuotedArgs() {
-        let output = """
-        service = com.clawdbot.gateway
-        program arguments = (
-            "/Applications/Clawdbot.app/Contents/Resources/Relay/clawdbot",
-            "gateway-daemon",
-            "--port",
-            "18789",
-            "--bind",
-            "loopback"
-        )
-        pid = 123
-        """
-        let snapshot = GatewayLaunchAgentManager.parseLaunchctlPrintSnapshot(output)
-        #expect(snapshot.pid == 123)
+    @Test func launchAgentPlistSnapshotParsesArgsAndEnv() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clawdbot-launchd-\(UUID().uuidString).plist")
+        let plist: [String: Any] = [
+            "ProgramArguments": ["clawdbot", "gateway-daemon", "--port", "18789", "--bind", "loopback"],
+            "EnvironmentVariables": [
+                "CLAWDBOT_GATEWAY_TOKEN": " secret ",
+                "CLAWDBOT_GATEWAY_PASSWORD": "pw",
+            ],
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: url, options: [.atomic])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let snapshot = try #require(LaunchAgentPlist.snapshot(url: url))
         #expect(snapshot.port == 18789)
         #expect(snapshot.bind == "loopback")
-        #expect(snapshot.matches(port: 18789, bind: "loopback"))
-        #expect(snapshot.matches(port: 18789, bind: "tailnet") == false)
-        #expect(snapshot.matches(port: 19999, bind: "loopback") == false)
+        #expect(snapshot.token == "secret")
+        #expect(snapshot.password == "pw")
     }
 
-    @Test func parseLaunchctlPrintSnapshotParsesUnquotedArgs() {
-        let output = """
-        argv[] = { /usr/local/bin/clawdbot, gateway-daemon, --port, 19999, --bind, tailnet }
-        pid = 0
-        """
-        let snapshot = GatewayLaunchAgentManager.parseLaunchctlPrintSnapshot(output)
-        #expect(snapshot.pid == 0)
-        #expect(snapshot.port == 19999)
-        #expect(snapshot.bind == "tailnet")
-    }
+    @Test func launchAgentPlistSnapshotAllowsMissingBind() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clawdbot-launchd-\(UUID().uuidString).plist")
+        let plist: [String: Any] = [
+            "ProgramArguments": ["clawdbot", "gateway-daemon", "--port", "18789"],
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: url, options: [.atomic])
+        defer { try? FileManager.default.removeItem(at: url) }
 
-    @Test func parseLaunchctlPrintSnapshotAllowsMissingBind() {
-        let output = """
-        program arguments = ( "clawdbot", "gateway-daemon", "--port", "18789" )
-        pid = 456
-        """
-        let snapshot = GatewayLaunchAgentManager.parseLaunchctlPrintSnapshot(output)
+        let snapshot = try #require(LaunchAgentPlist.snapshot(url: url))
         #expect(snapshot.port == 18789)
         #expect(snapshot.bind == nil)
-        #expect(snapshot.matches(port: 18789, bind: "loopback"))
     }
 }
-

--- a/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
@@ -94,7 +94,7 @@ struct LowCoverageHelperTests {
     }
 
     @Test func gatewayLaunchAgentHelpers() async throws {
-        try await TestIsolation.withEnvValues(
+        await TestIsolation.withEnvValues(
             [
                 "CLAWDBOT_GATEWAY_BIND": "Lan",
                 "CLAWDBOT_GATEWAY_TOKEN": " secret ",

--- a/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
@@ -93,34 +93,22 @@ struct LowCoverageHelperTests {
         _ = PresenceReporter._testPrimaryIPv4Address()
     }
 
-    @Test func gatewayLaunchAgentHelpers() {
-        let keyBind = "CLAWDBOT_GATEWAY_BIND"
-        let keyToken = "CLAWDBOT_GATEWAY_TOKEN"
-        let previousBind = ProcessInfo.processInfo.environment[keyBind]
-        let previousToken = ProcessInfo.processInfo.environment[keyToken]
-        defer {
-            if let previousBind {
-                setenv(keyBind, previousBind, 1)
-            } else {
-                unsetenv(keyBind)
-            }
-            if let previousToken {
-                setenv(keyToken, previousToken, 1)
-            } else {
-                unsetenv(keyToken)
-            }
+    @Test func gatewayLaunchAgentHelpers() async throws {
+        try await TestIsolation.withEnvValues(
+            [
+                "CLAWDBOT_GATEWAY_BIND": "Lan",
+                "CLAWDBOT_GATEWAY_TOKEN": " secret ",
+            ])
+        {
+            #expect(GatewayLaunchAgentManager._testPreferredGatewayBind() == "lan")
+            #expect(GatewayLaunchAgentManager._testPreferredGatewayToken() == "secret")
+            #expect(
+                GatewayLaunchAgentManager._testEscapePlistValue("a&b<c>\"'") ==
+                    "a&amp;b&lt;c&gt;&quot;&apos;")
+
+            #expect(GatewayLaunchAgentManager._testGatewayExecutablePath(bundlePath: "/App") == "/App/Contents/Resources/Relay/clawdbot")
+            #expect(GatewayLaunchAgentManager._testRelayDir(bundlePath: "/App") == "/App/Contents/Resources/Relay")
         }
-
-        setenv(keyBind, "Lan", 1)
-        setenv(keyToken, " secret ", 1)
-        #expect(GatewayLaunchAgentManager._testPreferredGatewayBind() == "lan")
-        #expect(GatewayLaunchAgentManager._testPreferredGatewayToken() == "secret")
-        #expect(
-            GatewayLaunchAgentManager._testEscapePlistValue("a&b<c>\"'") ==
-                "a&amp;b&lt;c&gt;&quot;&apos;")
-
-        #expect(GatewayLaunchAgentManager._testGatewayExecutablePath(bundlePath: "/App") == "/App/Contents/Resources/Relay/clawdbot")
-        #expect(GatewayLaunchAgentManager._testRelayDir(bundlePath: "/App") == "/App/Contents/Resources/Relay")
     }
 
     @Test func portGuardianParsesListenersAndBuildsReports() {

--- a/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
@@ -6,7 +6,7 @@ actor TestIsolationLock {
     private var locked = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
-    private func lock() async {
+    func acquire() async {
         if !self.locked {
             self.locked = true
             return
@@ -17,7 +17,7 @@ actor TestIsolationLock {
         // `unlock()` resumed us; lock is now held for this caller.
     }
 
-    private func unlock() {
+    func release() {
         if self.waiters.isEmpty {
             self.locked = false
             return
@@ -25,78 +25,90 @@ actor TestIsolationLock {
         let next = self.waiters.removeFirst()
         next.resume()
     }
-
-    func withLock<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
-        await self.lock()
-        defer { self.unlock() }
-        return try await body()
-    }
 }
 
+@MainActor
 enum TestIsolation {
-    static func withIsolatedState<T: Sendable>(
+    static func withIsolatedState<T>(
         env: [String: String?] = [:],
         defaults: [String: Any?] = [:],
-        _ body: @Sendable () async throws -> T) async rethrows -> T
+        _ body: () async throws -> T) async rethrows -> T
     {
-        try await TestIsolationLock.shared.withLock {
-            var previousEnv: [String: String?] = [:]
-            for (key, value) in env {
-                previousEnv[key] = getenv(key).map { String(cString: $0) }
-                if let value {
-                    setenv(key, value, 1)
-                } else {
-                    unsetenv(key)
-                }
+        await TestIsolationLock.shared.acquire()
+        var previousEnv: [String: String?] = [:]
+        for (key, value) in env {
+            previousEnv[key] = getenv(key).map { String(cString: $0) }
+            if let value {
+                setenv(key, value, 1)
+            } else {
+                unsetenv(key)
             }
+        }
 
-            let userDefaults = UserDefaults.standard
-            var previousDefaults: [String: Any?] = [:]
-            for (key, value) in defaults {
-                previousDefaults[key] = userDefaults.object(forKey: key)
+        let userDefaults = UserDefaults.standard
+        var previousDefaults: [String: Any?] = [:]
+        for (key, value) in defaults {
+            previousDefaults[key] = userDefaults.object(forKey: key)
+            if let value {
+                userDefaults.set(value, forKey: key)
+            } else {
+                userDefaults.removeObject(forKey: key)
+            }
+        }
+
+        do {
+            let result = try await body()
+            for (key, value) in previousDefaults {
                 if let value {
                     userDefaults.set(value, forKey: key)
                 } else {
                     userDefaults.removeObject(forKey: key)
                 }
             }
-
-            defer {
-                for (key, value) in previousDefaults {
-                    if let value {
-                        userDefaults.set(value, forKey: key)
-                    } else {
-                        userDefaults.removeObject(forKey: key)
-                    }
-                }
-                for (key, value) in previousEnv {
-                    if let value {
-                        setenv(key, value, 1)
-                    } else {
-                        unsetenv(key)
-                    }
+            for (key, value) in previousEnv {
+                if let value {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
                 }
             }
-
-            return try await body()
+            await TestIsolationLock.shared.release()
+            return result
+        } catch {
+            for (key, value) in previousDefaults {
+                if let value {
+                    userDefaults.set(value, forKey: key)
+                } else {
+                    userDefaults.removeObject(forKey: key)
+                }
+            }
+            for (key, value) in previousEnv {
+                if let value {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+            await TestIsolationLock.shared.release()
+            throw error
         }
     }
 
-    static func withEnvValues<T: Sendable>(
+    static func withEnvValues<T>(
         _ values: [String: String?],
-        _ body: @Sendable () async throws -> T) async rethrows -> T
+        _ body: () async throws -> T) async rethrows -> T
     {
         try await Self.withIsolatedState(env: values, defaults: [:], body)
     }
 
-    static func withUserDefaultsValues<T: Sendable>(
+    static func withUserDefaultsValues<T>(
         _ values: [String: Any?],
-        _ body: @Sendable () async throws -> T) async rethrows -> T
+        _ body: () async throws -> T) async rethrows -> T
     {
         try await Self.withIsolatedState(env: [:], defaults: values, body)
     }
 
-    static func tempConfigPath() -> String {
+    nonisolated static func tempConfigPath() -> String {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("clawdbot-test-config-\(UUID().uuidString).json")
             .path

--- a/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
@@ -26,7 +26,7 @@ actor TestIsolationLock {
         next.resume()
     }
 
-    func withLock<T>(_ body: () async throws -> T) async rethrows -> T {
+    func withLock<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
         await self.lock()
         defer { self.unlock() }
         return try await body()
@@ -34,10 +34,10 @@ actor TestIsolationLock {
 }
 
 enum TestIsolation {
-    static func withIsolatedState<T>(
+    static func withIsolatedState<T: Sendable>(
         env: [String: String?] = [:],
         defaults: [String: Any?] = [:],
-        _ body: () async throws -> T) async rethrows -> T
+        _ body: @Sendable () async throws -> T) async rethrows -> T
     {
         try await TestIsolationLock.shared.withLock {
             var previousEnv: [String: String?] = [:]
@@ -82,16 +82,16 @@ enum TestIsolation {
         }
     }
 
-    static func withEnvValues<T>(
+    static func withEnvValues<T: Sendable>(
         _ values: [String: String?],
-        _ body: () async throws -> T) async rethrows -> T
+        _ body: @Sendable () async throws -> T) async rethrows -> T
     {
         try await Self.withIsolatedState(env: values, defaults: [:], body)
     }
 
-    static func withUserDefaultsValues<T>(
+    static func withUserDefaultsValues<T: Sendable>(
         _ values: [String: Any?],
-        _ body: () async throws -> T) async rethrows -> T
+        _ body: @Sendable () async throws -> T) async rethrows -> T
     {
         try await Self.withIsolatedState(env: [:], defaults: values, body)
     }

--- a/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/TestIsolation.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+actor TestIsolationLock {
+    static let shared = TestIsolationLock()
+
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func lock() async {
+        if !self.locked {
+            self.locked = true
+            return
+        }
+        await withCheckedContinuation { cont in
+            self.waiters.append(cont)
+        }
+        // `unlock()` resumed us; lock is now held for this caller.
+    }
+
+    private func unlock() {
+        if self.waiters.isEmpty {
+            self.locked = false
+            return
+        }
+        let next = self.waiters.removeFirst()
+        next.resume()
+    }
+
+    func withLock<T>(_ body: () async throws -> T) async rethrows -> T {
+        await self.lock()
+        defer { self.unlock() }
+        return try await body()
+    }
+}
+
+enum TestIsolation {
+    static func withIsolatedState<T>(
+        env: [String: String?] = [:],
+        defaults: [String: Any?] = [:],
+        _ body: () async throws -> T) async rethrows -> T
+    {
+        try await TestIsolationLock.shared.withLock {
+            var previousEnv: [String: String?] = [:]
+            for (key, value) in env {
+                previousEnv[key] = getenv(key).map { String(cString: $0) }
+                if let value {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+
+            let userDefaults = UserDefaults.standard
+            var previousDefaults: [String: Any?] = [:]
+            for (key, value) in defaults {
+                previousDefaults[key] = userDefaults.object(forKey: key)
+                if let value {
+                    userDefaults.set(value, forKey: key)
+                } else {
+                    userDefaults.removeObject(forKey: key)
+                }
+            }
+
+            defer {
+                for (key, value) in previousDefaults {
+                    if let value {
+                        userDefaults.set(value, forKey: key)
+                    } else {
+                        userDefaults.removeObject(forKey: key)
+                    }
+                }
+                for (key, value) in previousEnv {
+                    if let value {
+                        setenv(key, value, 1)
+                    } else {
+                        unsetenv(key)
+                    }
+                }
+            }
+
+            return try await body()
+        }
+    }
+
+    static func withEnvValues<T>(
+        _ values: [String: String?],
+        _ body: () async throws -> T) async rethrows -> T
+    {
+        try await Self.withIsolatedState(env: values, defaults: [:], body)
+    }
+
+    static func withUserDefaultsValues<T>(
+        _ values: [String: Any?],
+        _ body: () async throws -> T) async rethrows -> T
+    {
+        try await Self.withIsolatedState(env: [:], defaults: values, body)
+    }
+
+    static func tempConfigPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("clawdbot-test-config-\(UUID().uuidString).json")
+            .path
+    }
+}

--- a/src/commands/onboard-providers.ts
+++ b/src/commands/onboard-providers.ts
@@ -182,7 +182,10 @@ async function noteSlackTokenHelp(
   );
 }
 
-function setWhatsAppDmPolicy(cfg: ClawdbotConfig, dmPolicy?: DmPolicy) {
+function setWhatsAppDmPolicy(
+  cfg: ClawdbotConfig,
+  dmPolicy?: DmPolicy,
+): ClawdbotConfig {
   return {
     ...cfg,
     whatsapp: {
@@ -192,7 +195,10 @@ function setWhatsAppDmPolicy(cfg: ClawdbotConfig, dmPolicy?: DmPolicy) {
   };
 }
 
-function setWhatsAppAllowFrom(cfg: ClawdbotConfig, allowFrom?: string[]) {
+function setWhatsAppAllowFrom(
+  cfg: ClawdbotConfig,
+  allowFrom?: string[],
+): ClawdbotConfig {
   return {
     ...cfg,
     whatsapp: {
@@ -218,7 +224,7 @@ function setMessagesResponsePrefix(
 function setWhatsAppSelfChatMode(
   cfg: ClawdbotConfig,
   selfChatMode?: boolean,
-) {
+): ClawdbotConfig {
   return {
     ...cfg,
     whatsapp: {


### PR DESCRIPTION
Follow-up refactors + test hardening.

- Extract launchctl runner + plist snapshot parsing into Launchctl.swift
- GatewayLaunchAgentManager.status() -> isLoaded(); compare desired config vs our own plist (no launchctl print heuristics)
- Disable path now also runs launchctl disable gui/501/<label>
- ProcessInfo preview/nix flags via getenv for deterministic tests
- TestIsolation helper for env/UserDefaults isolation; drop .serialized where safe
- MacNodeRuntime: inject main-actor services via protocol container + unit test