### PR TITLE
feat: add eagerTyping config for immediate typing indicator in group chats

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -993,6 +993,23 @@ Block streaming:
   ```
 See [/concepts/streaming](/concepts/streaming) for behavior + chunking details.
 
+### `agent.eagerTyping`
+
+When `true`, shows the typing indicator immediately when a message is received,
+even in group chats without an @mention. By default, typing only starts when
+text begins streaming.
+
+This is useful for group channels where `requireMention: false` — the bot
+responds to all messages, so users expect immediate feedback.
+
+```json
+{
+  "agent": {
+    "eagerTyping": true
+  }
+}
+```
+
 `agent.model.primary` should be set as `provider/model` (e.g. `anthropic/claude-opus-4-5`).
 Aliases come from `agent.models.*.alias` (e.g. `Opus`).
 If you omit the provider, CLAWDBOT currently assumes `anthropic` as a temporary

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -594,7 +594,9 @@ export async function getReplyFromConfig(
   const isGroupChat = sessionCtx.ChatType === "group";
   const wasMentioned = ctx.WasMentioned === true;
   const isHeartbeat = opts?.isHeartbeat === true;
-  const shouldEagerType = (!isGroupChat || wasMentioned) && !isHeartbeat;
+  const eagerTypingConfig = agentCfg?.eagerTyping === true;
+  const shouldEagerType =
+    (eagerTypingConfig || !isGroupChat || wasMentioned) && !isHeartbeat;
   const shouldInjectGroupIntro = Boolean(
     isGroupChat &&
       (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -122,6 +122,12 @@ export function createTypingController(params: {
 
   const markRunComplete = () => {
     runComplete = true;
+    // Stop the typing interval immediately when the run completes.
+    // No need to keep showing "typing" after the response is ready.
+    if (typingTimer) {
+      clearInterval(typingTimer);
+      typingTimer = undefined;
+    }
     maybeStopOnIdle();
   };
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -964,6 +964,8 @@ export type ClawdbotConfig = {
     /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
     mediaMaxMb?: number;
     typingIntervalSeconds?: number;
+    /** Show typing indicator immediately, even in group chats without @mention. */
+    eagerTyping?: boolean;
     /** Periodic background heartbeat runs. */
     heartbeat?: {
       /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -595,6 +595,7 @@ export const ClawdbotSchema = z.object({
       timeoutSeconds: z.number().int().positive().optional(),
       mediaMaxMb: z.number().positive().optional(),
       typingIntervalSeconds: z.number().int().positive().optional(),
+      eagerTyping: z.boolean().optional(),
       heartbeat: HeartbeatSchema,
       maxConcurrent: z.number().int().positive().optional(),
       subagents: z


### PR DESCRIPTION
## Summary

Adds `agent.eagerTyping` config option that shows the typing indicator immediately when a message is received in group chats, even without an @mention.

**Problem:** In group chats with `requireMention: false`, the bot responds to all messages but the typing indicator only appears once text starts streaming. This creates a lag where users don't see any feedback that the bot is processing their message.

**Solution:** New `eagerTyping` boolean config option that, when enabled, starts the typing indicator immediately when an agent run begins - regardless of chat type or mention status.

## Changes

- Add `eagerTyping?: boolean` to agent config schema and types
- Update `shouldEagerType` logic in `reply.ts` to check the new config
- Fix typing interval cleanup in `typing.ts` to stop immediately on run complete

## Config example

```json
{
  "agent": {
    "eagerTyping": true
  }
}
```

## Test plan

- [x] Tested in Discord guild channel with `requireMention: false`
- [x] Typing indicator appears immediately on message receipt
- [x] Typing indicator disappears cleanly after response (no reappearance)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)