### PR TITLE
WIP fix (bug): prevent system prompt duplication from SDK double-processing

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -10,7 +10,6 @@ import type {
 } from "@mariozechner/pi-agent-core";
 import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
 import {
-  buildSystemPrompt,
   createAgentSession,
   discoverAuthStorage,
   discoverModels,
@@ -637,28 +636,26 @@ export async function compactEmbeddedPiSession(params: {
           params.config?.agent?.userTimezone,
         );
         const userTime = formatUserTime(new Date(), userTimezone);
-        const systemPrompt = buildSystemPrompt({
-          appendPrompt: buildAgentSystemPromptAppend({
-            workspaceDir: effectiveWorkspace,
-            defaultThinkLevel: params.thinkLevel,
-            extraSystemPrompt: params.extraSystemPrompt,
-            ownerNumbers: params.ownerNumbers,
-            reasoningTagHint,
-            heartbeatPrompt: resolveHeartbeatPrompt(
-              params.config?.agent?.heartbeat?.prompt,
-            ),
-            runtimeInfo,
-            sandboxInfo,
-            toolNames: tools.map((tool) => tool.name),
-            modelAliasLines: buildModelAliasLines(params.config),
-            userTimezone,
-            userTime,
-          }),
-          contextFiles,
-          skills: promptSkills,
-          cwd: effectiveWorkspace,
-          tools,
+        const appendPrompt = buildAgentSystemPromptAppend({
+          workspaceDir: effectiveWorkspace,
+          defaultThinkLevel: params.thinkLevel,
+          extraSystemPrompt: params.extraSystemPrompt,
+          ownerNumbers: params.ownerNumbers,
+          reasoningTagHint,
+          heartbeatPrompt: resolveHeartbeatPrompt(
+            params.config?.agent?.heartbeat?.prompt,
+          ),
+          runtimeInfo,
+          sandboxInfo,
+          toolNames: tools.map((tool) => tool.name),
+          modelAliasLines: buildModelAliasLines(params.config),
+          userTimezone,
+          userTime,
         });
+        const systemPrompt = (defaultPrompt: string) =>
+          appendPrompt.trim().length > 0
+            ? `${defaultPrompt}\n\n${appendPrompt}`
+            : defaultPrompt;
 
         const sessionManager = SessionManager.open(params.sessionFile);
         const settingsManager = SettingsManager.create(
@@ -956,28 +953,26 @@ export async function runEmbeddedPiAgent(params: {
             params.config?.agent?.userTimezone,
           );
           const userTime = formatUserTime(new Date(), userTimezone);
-          const systemPrompt = buildSystemPrompt({
-            appendPrompt: buildAgentSystemPromptAppend({
-              workspaceDir: effectiveWorkspace,
-              defaultThinkLevel: thinkLevel,
-              extraSystemPrompt: params.extraSystemPrompt,
-              ownerNumbers: params.ownerNumbers,
-              reasoningTagHint,
-              heartbeatPrompt: resolveHeartbeatPrompt(
-                params.config?.agent?.heartbeat?.prompt,
-              ),
-              runtimeInfo,
-              sandboxInfo,
-              toolNames: tools.map((tool) => tool.name),
-              modelAliasLines: buildModelAliasLines(params.config),
-              userTimezone,
-              userTime,
-            }),
-            contextFiles,
-            skills: promptSkills,
-            cwd: effectiveWorkspace,
-            tools,
+          const appendPrompt = buildAgentSystemPromptAppend({
+            workspaceDir: effectiveWorkspace,
+            defaultThinkLevel: thinkLevel,
+            extraSystemPrompt: params.extraSystemPrompt,
+            ownerNumbers: params.ownerNumbers,
+            reasoningTagHint,
+            heartbeatPrompt: resolveHeartbeatPrompt(
+              params.config?.agent?.heartbeat?.prompt,
+            ),
+            runtimeInfo,
+            sandboxInfo,
+            toolNames: tools.map((tool) => tool.name),
+            modelAliasLines: buildModelAliasLines(params.config),
+            userTimezone,
+            userTime,
           });
+          const systemPrompt = (defaultPrompt: string) =>
+            appendPrompt.trim().length > 0
+              ? `${defaultPrompt}\n\n${appendPrompt}`
+              : defaultPrompt;
 
           const sessionManager = SessionManager.open(params.sessionFile);
           const settingsManager = SettingsManager.create(


### PR DESCRIPTION
This is a bit of a hack to fix a duplication system prompt issue. Currently Clawdbot builds a system prompt string and passes it to pi-mono. Codex leads me to believe pi-mono also then builds a system prompt based on the passed string and auto-loads files like AGENTS.md etc. This more or less causes the whole system prompt to be duplicated when sending to the model.

I'm not really sure if this PR should be implemented, or fixed in pi-mono https://github.com/badlogic/pi-mono/issues/543. Agent seems to be convinced it is a pi-mono issue.

When passing a pre-built system prompt string to createAgentSession(), the SDK still appends context files and skills even if they're already present, causing duplication.

*Workaround:* Pass a function instead of a string, which receives the SDK's default prompt and only appends our Clawdbot-specific additions.
