### PR TITLE
fix(hooks): enable delivery for gmail preset

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -86,6 +86,8 @@ const hookPresetMappings: Record<string, HookMappingConfig[]> = {
       sessionKey: "hook:gmail:{{messages[0].id}}",
       messageTemplate:
         "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
+      deliver: true,
+      provider: "imessage",
     },
   ],
 };


### PR DESCRIPTION
## Summary
- Add `deliver: true` to gmail hook preset to ensure messages are actually sent
- Add `provider: "imessage"` as default delivery channel for gmail notifications

Without these settings, the agent runs complete successfully but no messages are delivered.

## Test plan
- [x] Tested with Gmail push notifications via Pub/Sub
- [x] Verified iMessage delivery works after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)