### PR TITLE
Mac Voice Wake: stabilize tester, keep mic selection, and trigger on wake‑word pause

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -100,6 +100,10 @@ final class AppState {
         }
     }
 
+    var voiceWakeMicName: String {
+        didSet { self.ifNotPreview { UserDefaults.standard.set(self.voiceWakeMicName, forKey: voiceWakeMicNameKey) } }
+    }
+
     var voiceWakeLocaleID: String {
         didSet {
             self.ifNotPreview {
@@ -229,6 +233,7 @@ final class AppState {
         }
         self.showDockIcon = UserDefaults.standard.bool(forKey: showDockIconKey)
         self.voiceWakeMicID = UserDefaults.standard.string(forKey: voiceWakeMicKey) ?? ""
+        self.voiceWakeMicName = UserDefaults.standard.string(forKey: voiceWakeMicNameKey) ?? ""
         self.voiceWakeLocaleID = UserDefaults.standard.string(forKey: voiceWakeLocaleKey) ?? Locale.current.identifier
         self.voiceWakeAdditionalLocaleIDs = UserDefaults.standard
             .stringArray(forKey: voiceWakeAdditionalLocalesKey) ?? []
@@ -583,6 +588,7 @@ extension AppState {
         state.iconAnimationsEnabled = true
         state.showDockIcon = true
         state.voiceWakeMicID = "BuiltInMic"
+        state.voiceWakeMicName = "Built-in Microphone"
         state.voiceWakeLocaleID = Locale.current.identifier
         state.voiceWakeAdditionalLocaleIDs = ["en-US", "de-DE"]
         state.voicePushToTalkEnabled = false

--- a/apps/macos/Sources/Clawdbot/AudioInputDeviceObserver.swift
+++ b/apps/macos/Sources/Clawdbot/AudioInputDeviceObserver.swift
@@ -1,0 +1,216 @@
+import CoreAudio
+import Foundation
+import OSLog
+
+final class AudioInputDeviceObserver {
+    private let logger = Logger(subsystem: "com.clawdbot", category: "audio.devices")
+    private var isActive = false
+    private var devicesListener: AudioObjectPropertyListenerBlock?
+    private var defaultInputListener: AudioObjectPropertyListenerBlock?
+
+    static func defaultInputDeviceUID() -> String? {
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var deviceID = AudioObjectID(0)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            systemObject,
+            &address,
+            0,
+            nil,
+            &size,
+            &deviceID)
+        guard status == noErr, deviceID != 0 else { return nil }
+        return self.deviceUID(for: deviceID)
+    }
+
+    static func aliveInputDeviceUIDs() -> Set<String> {
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(systemObject, &address, 0, nil, &size)
+        guard status == noErr, size > 0 else { return [] }
+
+        let count = Int(size) / MemoryLayout<AudioObjectID>.size
+        var deviceIDs = [AudioObjectID](repeating: 0, count: count)
+        status = AudioObjectGetPropertyData(systemObject, &address, 0, nil, &size, &deviceIDs)
+        guard status == noErr else { return [] }
+
+        var output = Set<String>()
+        for deviceID in deviceIDs {
+            guard self.deviceIsAlive(deviceID) else { continue }
+            guard self.deviceHasInput(deviceID) else { continue }
+            if let uid = self.deviceUID(for: deviceID) {
+                output.insert(uid)
+            }
+        }
+        return output
+    }
+
+    static func defaultInputDeviceSummary() -> String {
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var deviceID = AudioObjectID(0)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            systemObject,
+            &address,
+            0,
+            nil,
+            &size,
+            &deviceID)
+        guard status == noErr, deviceID != 0 else {
+            return "defaultInput=unknown"
+        }
+        let uid = self.deviceUID(for: deviceID) ?? "unknown"
+        let name = self.deviceName(for: deviceID) ?? "unknown"
+        return "defaultInput=\(name) (\(uid))"
+    }
+
+    func start(onChange: @escaping @Sendable () -> Void) {
+        guard !self.isActive else { return }
+        self.isActive = true
+
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        let queue = DispatchQueue.main
+
+        var devicesAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        let devicesListener: AudioObjectPropertyListenerBlock = { _, _ in
+            self.logDefaultInputChange(reason: "devices")
+            onChange()
+        }
+        let devicesStatus = AudioObjectAddPropertyListenerBlock(
+            systemObject,
+            &devicesAddress,
+            queue,
+            devicesListener)
+
+        var defaultInputAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        let defaultInputListener: AudioObjectPropertyListenerBlock = { _, _ in
+            self.logDefaultInputChange(reason: "default")
+            onChange()
+        }
+        let defaultStatus = AudioObjectAddPropertyListenerBlock(
+            systemObject,
+            &defaultInputAddress,
+            queue,
+            defaultInputListener)
+
+        if devicesStatus != noErr || defaultStatus != noErr {
+            self.logger.error("audio device observer install failed devices=\(devicesStatus) default=\(defaultStatus)")
+        }
+
+        self.logger.info("audio device observer started (\(Self.defaultInputDeviceSummary(), privacy: .public))")
+
+        self.devicesListener = devicesListener
+        self.defaultInputListener = defaultInputListener
+    }
+
+    func stop() {
+        guard self.isActive else { return }
+        self.isActive = false
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+
+        if let devicesListener {
+            var devicesAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDevices,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain)
+            _ = AudioObjectRemovePropertyListenerBlock(
+                systemObject,
+                &devicesAddress,
+                DispatchQueue.main,
+                devicesListener)
+        }
+
+        if let defaultInputListener {
+            var defaultInputAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain)
+            _ = AudioObjectRemovePropertyListenerBlock(
+                systemObject,
+                &defaultInputAddress,
+                DispatchQueue.main,
+                defaultInputListener)
+        }
+
+        self.devicesListener = nil
+        self.defaultInputListener = nil
+    }
+
+    private static func deviceUID(for deviceID: AudioObjectID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var uid: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid)
+        guard status == noErr, let uid else { return nil }
+        return uid.takeUnretainedValue() as String
+    }
+
+    private static func deviceName(for deviceID: AudioObjectID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var name: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &name)
+        guard status == noErr, let name else { return nil }
+        return name.takeUnretainedValue() as String
+    }
+
+    private static func deviceIsAlive(_ deviceID: AudioObjectID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsAlive,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var alive: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &alive)
+        return status == noErr && alive != 0
+    }
+
+    private static func deviceHasInput(_ deviceID: AudioObjectID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size)
+        guard status == noErr, size > 0 else { return false }
+
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size),
+            alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { raw.deallocate() }
+        let bufferList = raw.bindMemory(to: AudioBufferList.self, capacity: 1)
+        status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, bufferList)
+        guard status == noErr else { return false }
+
+        let buffers = UnsafeMutableAudioBufferListPointer(bufferList)
+        return buffers.contains(where: { $0.mNumberChannels > 0 })
+    }
+
+    private func logDefaultInputChange(reason: StaticString) {
+        self.logger.info("audio input changed (\(reason)) (\(Self.defaultInputDeviceSummary(), privacy: .public))")
+    }
+}

--- a/apps/macos/Sources/Clawdbot/Constants.swift
+++ b/apps/macos/Sources/Clawdbot/Constants.swift
@@ -13,6 +13,7 @@ let voiceWakeSendChimeKey = "clawdbot.voiceWakeSendChime"
 let showDockIconKey = "clawdbot.showDockIcon"
 let defaultVoiceWakeTriggers = ["clawd", "claude"]
 let voiceWakeMicKey = "clawdbot.voiceWakeMicID"
+let voiceWakeMicNameKey = "clawdbot.voiceWakeMicName"
 let voiceWakeLocaleKey = "clawdbot.voiceWakeLocaleID"
 let voiceWakeAdditionalLocalesKey = "clawdbot.voiceWakeAdditionalLocaleIDs"
 let voicePushToTalkEnabledKey = "clawdbot.voicePushToTalkEnabled"

--- a/apps/macos/Sources/Clawdbot/MenuContentView.swift
+++ b/apps/macos/Sources/Clawdbot/MenuContentView.swift
@@ -526,7 +526,7 @@ struct MenuContent: View {
             deviceTypes: [.external, .microphone],
             mediaType: .audio,
             position: .unspecified)
-        let connectedDevices = discovery.devices.filter { $0.isConnected }
+        let connectedDevices = discovery.devices.filter(\.isConnected)
         self.availableMics = connectedDevices
             .sorted { lhs, rhs in
                 lhs.localizedName.localizedCaseInsensitiveCompare(rhs.localizedName) == .orderedAscending

--- a/apps/macos/Sources/Clawdbot/SettingsRootView.swift
+++ b/apps/macos/Sources/Clawdbot/SettingsRootView.swift
@@ -31,7 +31,7 @@ struct SettingsRootView: View {
                     .tabItem { Label("Connections", systemImage: "link") }
                     .tag(SettingsTab.connections)
 
-                VoiceWakeSettings(state: self.state)
+                VoiceWakeSettings(state: self.state, isActive: self.selectedTab == .voiceWake)
                     .tabItem { Label("Voice Wake", systemImage: "waveform.circle") }
                     .tag(SettingsTab.voiceWake)
 

--- a/apps/macos/Sources/Clawdbot/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeRuntime.swift
@@ -38,6 +38,15 @@ actor VoiceWakeRuntime {
     private var overlayToken: UUID?
     private var activeTriggerEndTime: TimeInterval?
     private var scheduledRestartTask: Task<Void, Never>?
+    private var lastLoggedText: String?
+    private var lastLoggedAt: Date?
+    private var lastTapLogAt: Date?
+    private var lastCallbackLogAt: Date?
+    private var lastTranscript: String?
+    private var lastTranscriptAt: Date?
+    private var preDetectTask: Task<Void, Never>?
+    private var isStarting: Bool = false
+    private var triggerOnlyTask: Task<Void, Never>?
 
     // Tunables
     // Silence threshold once we've captured user speech (post-trigger).
@@ -50,6 +59,8 @@ actor VoiceWakeRuntime {
     // Voice activity detection parameters (RMS-based).
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0 // how far above noise floor we require to mark speech
+    private let preDetectSilenceWindow: TimeInterval = 1.0
+    private let triggerPauseWindow: TimeInterval = 0.55
 
     /// Stops the active Speech pipeline without clearing the stored config, so we can restart cleanly.
     private func haltRecognitionPipeline() {
@@ -106,6 +117,19 @@ actor VoiceWakeRuntime {
 
         let config = snapshot.1
 
+        if self.isStarting {
+            return
+        }
+
+        if self.scheduledRestartTask != nil, config == self.currentConfig, self.recognitionTask == nil {
+            return
+        }
+
+        if self.scheduledRestartTask != nil {
+            self.scheduledRestartTask?.cancel()
+            self.scheduledRestartTask = nil
+        }
+
         if config == self.currentConfig, self.recognitionTask != nil {
             return
         }
@@ -115,6 +139,11 @@ actor VoiceWakeRuntime {
     }
 
     private func start(with config: RuntimeConfig) async {
+        if self.isStarting {
+            return
+        }
+        self.isStarting = true
+        defer { self.isStarting = false }
         do {
             self.recognitionGeneration &+= 1
             let generation = self.recognitionGeneration
@@ -148,10 +177,10 @@ actor VoiceWakeRuntime {
             input.removeTap(onBus: 0)
             input.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self, weak request] buffer, _ in
                 request?.append(buffer)
-                if let rms = Self.rmsLevel(buffer: buffer) {
-                    Task.detached { [weak self] in
-                        await self?.noteAudioLevel(rms: rms)
-                    }
+                guard let rms = Self.rmsLevel(buffer: buffer) else { return }
+                Task.detached { [weak self] in
+                    await self?.noteAudioLevel(rms: rms)
+                    await self?.noteAudioTap(rms: rms)
                 }
             }
 
@@ -170,6 +199,7 @@ actor VoiceWakeRuntime {
                         .map { WakeWordSpeechSegments.from(transcription: result.bestTranscription, transcript: $0) }
                 } ?? []
                 let isFinal = result?.isFinal ?? false
+                Task { await self.noteRecognitionCallback(transcript: transcript, isFinal: isFinal, error: error) }
                 let update = RecognitionUpdate(
                     transcript: transcript,
                     segments: segments,
@@ -205,6 +235,12 @@ actor VoiceWakeRuntime {
         self.capturedTranscript = ""
         self.captureStartedAt = nil
         self.triggerChimePlayed = false
+        self.lastTranscript = nil
+        self.lastTranscriptAt = nil
+        self.preDetectTask?.cancel()
+        self.preDetectTask = nil
+        self.triggerOnlyTask?.cancel()
+        self.triggerOnlyTask = nil
         self.haltRecognitionPipeline()
         self.recognizer = nil
         self.currentConfig = nil
@@ -244,7 +280,19 @@ actor VoiceWakeRuntime {
         let now = Date()
         if !transcript.isEmpty {
             self.lastHeard = now
+            if !self.isCapturing {
+                self.lastTranscript = transcript
+                self.lastTranscriptAt = now
+            }
             if self.isCapturing {
+                self.maybeLogRecognition(
+                    transcript: transcript,
+                    segments: update.segments,
+                    triggers: config.triggers,
+                    isFinal: update.isFinal,
+                    match: nil,
+                    usedFallback: false,
+                    capturing: true)
                 let trimmed = Self.commandAfterTrigger(
                     transcript: transcript,
                     segments: update.segments,
@@ -278,23 +326,207 @@ actor VoiceWakeRuntime {
         if self.isCapturing { return }
 
         let gateConfig = WakeWordGateConfig(triggers: config.triggers)
-        if let match = WakeWordGate.match(transcript: transcript, segments: update.segments, config: gateConfig) {
+        var usedFallback = false
+        var match = WakeWordGate.match(transcript: transcript, segments: update.segments, config: gateConfig)
+        if match == nil, update.isFinal {
+            match = self.textOnlyFallbackMatch(
+                transcript: transcript,
+                triggers: config.triggers,
+                config: gateConfig)
+            usedFallback = match != nil
+        }
+        self.maybeLogRecognition(
+            transcript: transcript,
+            segments: update.segments,
+            triggers: config.triggers,
+            isFinal: update.isFinal,
+            match: match,
+            usedFallback: usedFallback,
+            capturing: false)
+
+        if let match {
             if let cooldown = cooldownUntil, now < cooldown {
                 return
             }
+            if usedFallback {
+                self.logger.info("voicewake runtime detected (text-only fallback) len=\(match.command.count)")
+            } else {
+                self.logger.info("voicewake runtime detected len=\(match.command.count)")
+            }
             await self.beginCapture(command: match.command, triggerEndTime: match.triggerEndTime, config: config)
-        } else if update.isFinal {
-            let trimmed = Self.trimmedAfterTrigger(transcript, triggers: config.triggers)
-            if WakeWordGate.matchesTextOnly(text: transcript, triggers: config.triggers),
-               Self.startsWithTrigger(transcript: transcript, triggers: config.triggers),
-               !trimmed.isEmpty
-            {
-                if let cooldown = cooldownUntil, now < cooldown {
-                    return
-                }
-                await self.beginCapture(command: trimmed, triggerEndTime: nil, config: config)
+        } else if !transcript.isEmpty, update.error == nil {
+            if self.isTriggerOnly(transcript: transcript, triggers: config.triggers) {
+                self.preDetectTask?.cancel()
+                self.preDetectTask = nil
+                self.scheduleTriggerOnlyPauseCheck(triggers: config.triggers, config: config)
+            } else {
+                self.triggerOnlyTask?.cancel()
+                self.triggerOnlyTask = nil
+                self.schedulePreDetectSilenceCheck(
+                    triggers: config.triggers,
+                    gateConfig: gateConfig,
+                    config: config)
             }
         }
+    }
+
+    private func maybeLogRecognition(
+        transcript: String,
+        segments: [WakeWordSegment],
+        triggers: [String],
+        isFinal: Bool,
+        match: WakeWordGateMatch?,
+        usedFallback: Bool,
+        capturing: Bool
+    ) {
+        guard !transcript.isEmpty else { return }
+        if transcript == self.lastLoggedText, !isFinal {
+            if let last = self.lastLoggedAt, Date().timeIntervalSince(last) < 0.25 {
+                return
+            }
+        }
+        self.lastLoggedText = transcript
+        self.lastLoggedAt = Date()
+
+        let textOnly = WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers)
+        let timingCount = segments.filter { $0.start > 0 || $0.duration > 0 }.count
+        let matchSummary = match.map {
+            "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"
+        } ?? "match=false"
+        let segmentSummary = segments.map { seg in
+            let start = String(format: "%.2f", seg.start)
+            let end = String(format: "%.2f", seg.end)
+            return "\(seg.text)@\(start)-\(end)"
+        }.joined(separator: ", ")
+
+        self.logger.info(
+            "voicewake runtime transcript='\(transcript, privacy: .public)' textOnly=\(textOnly) " +
+            "isFinal=\(isFinal) timing=\(timingCount)/\(segments.count) " +
+            "capturing=\(capturing) fallback=\(usedFallback) " +
+            "\(matchSummary) segments=[\(segmentSummary, privacy: .public)]")
+    }
+
+    private func noteAudioTap(rms: Double) {
+        let now = Date()
+        if let last = self.lastTapLogAt, now.timeIntervalSince(last) < 1.0 {
+            return
+        }
+        self.lastTapLogAt = now
+        let db = 20 * log10(max(rms, 1e-7))
+        self.logger.debug(
+            "voicewake runtime audio tap rms=\(String(format: "%.6f", rms)) " +
+                "db=\(String(format: "%.1f", db)) capturing=\(self.isCapturing)")
+    }
+
+    private func noteRecognitionCallback(transcript: String?, isFinal: Bool, error: Error?) {
+        guard transcript?.isEmpty ?? true else { return }
+        let now = Date()
+        if let last = self.lastCallbackLogAt, now.timeIntervalSince(last) < 1.0 {
+            return
+        }
+        self.lastCallbackLogAt = now
+        let errorSummary = error?.localizedDescription ?? "none"
+        self.logger.debug(
+            "voicewake runtime callback empty transcript isFinal=\(isFinal) error=\(errorSummary, privacy: .public)")
+    }
+
+    private func scheduleTriggerOnlyPauseCheck(triggers: [String], config: RuntimeConfig) {
+        self.triggerOnlyTask?.cancel()
+        let lastSeenAt = self.lastTranscriptAt
+        let lastText = self.lastTranscript
+        let windowNanos = UInt64(self.triggerPauseWindow * 1_000_000_000)
+        self.triggerOnlyTask = Task { [weak self, lastSeenAt, lastText] in
+            try? await Task.sleep(nanoseconds: windowNanos)
+            guard let self else { return }
+            await self.triggerOnlyPauseCheck(
+                lastSeenAt: lastSeenAt,
+                lastText: lastText,
+                triggers: triggers,
+                config: config)
+        }
+    }
+
+    private func schedulePreDetectSilenceCheck(
+        triggers: [String],
+        gateConfig: WakeWordGateConfig,
+        config: RuntimeConfig)
+    {
+        self.preDetectTask?.cancel()
+        let lastSeenAt = self.lastTranscriptAt
+        let lastText = self.lastTranscript
+        let windowNanos = UInt64(self.preDetectSilenceWindow * 1_000_000_000)
+        self.preDetectTask = Task { [weak self, lastSeenAt, lastText] in
+            try? await Task.sleep(nanoseconds: windowNanos)
+            guard let self else { return }
+            await self.preDetectSilenceCheck(
+                lastSeenAt: lastSeenAt,
+                lastText: lastText,
+                triggers: triggers,
+                gateConfig: gateConfig,
+                config: config)
+        }
+    }
+
+    private func triggerOnlyPauseCheck(
+        lastSeenAt: Date?,
+        lastText: String?,
+        triggers: [String],
+        config: RuntimeConfig
+    ) async {
+        guard !Task.isCancelled else { return }
+        guard !self.isCapturing else { return }
+        guard let lastSeenAt, let lastText else { return }
+        guard self.lastTranscriptAt == lastSeenAt, self.lastTranscript == lastText else { return }
+        guard self.isTriggerOnly(transcript: lastText, triggers: triggers) else { return }
+        if let cooldown = self.cooldownUntil, Date() < cooldown {
+            return
+        }
+        self.logger.info("voicewake runtime detected (trigger-only pause)")
+        await self.beginCapture(command: "", triggerEndTime: nil, config: config)
+    }
+
+    private func textOnlyFallbackMatch(
+        transcript: String,
+        triggers: [String],
+        config: WakeWordGateConfig
+    ) -> WakeWordGateMatch? {
+        guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return nil }
+        guard Self.startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
+        let trimmed = Self.trimmedAfterTrigger(transcript, triggers: triggers)
+        guard trimmed.count >= config.minCommandLength else { return nil }
+        return WakeWordGateMatch(triggerEndTime: 0, postGap: 0, command: trimmed)
+    }
+
+    private func isTriggerOnly(transcript: String, triggers: [String]) -> Bool {
+        guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return false }
+        guard Self.startsWithTrigger(transcript: transcript, triggers: triggers) else { return false }
+        return Self.trimmedAfterTrigger(transcript, triggers: triggers).isEmpty
+    }
+
+    private func preDetectSilenceCheck(
+        lastSeenAt: Date?,
+        lastText: String?,
+        triggers: [String],
+        gateConfig: WakeWordGateConfig,
+        config: RuntimeConfig) async
+    {
+        guard !Task.isCancelled else { return }
+        guard !self.isCapturing else { return }
+        guard let lastSeenAt, let lastText else { return }
+        guard self.lastTranscriptAt == lastSeenAt, self.lastTranscript == lastText else { return }
+        guard let match = self.textOnlyFallbackMatch(
+            transcript: lastText,
+            triggers: triggers,
+            config: gateConfig)
+        else { return }
+        if let cooldown = self.cooldownUntil, Date() < cooldown {
+            return
+        }
+        self.logger.info("voicewake runtime detected (silence fallback) len=\(match.command.count)")
+        await self.beginCapture(
+            command: match.command,
+            triggerEndTime: match.triggerEndTime,
+            config: config)
     }
 
     private func beginCapture(command: String, triggerEndTime: TimeInterval?, config: RuntimeConfig) async {
@@ -309,6 +541,10 @@ actor VoiceWakeRuntime {
         self.heardBeyondTrigger = !command.isEmpty
         self.triggerChimePlayed = false
         self.activeTriggerEndTime = triggerEndTime
+        self.preDetectTask?.cancel()
+        self.preDetectTask = nil
+        self.triggerOnlyTask?.cancel()
+        self.triggerOnlyTask = nil
 
         if config.triggerChime != .none, !self.triggerChimePlayed {
             self.triggerChimePlayed = true
@@ -381,6 +617,12 @@ actor VoiceWakeRuntime {
         self.heardBeyondTrigger = false
         self.triggerChimePlayed = false
         self.activeTriggerEndTime = nil
+        self.lastTranscript = nil
+        self.lastTranscriptAt = nil
+        self.preDetectTask?.cancel()
+        self.preDetectTask = nil
+        self.triggerOnlyTask?.cancel()
+        self.triggerOnlyTask = nil
 
         await MainActor.run { AppStateStore.shared.stopVoiceEars() }
         if let token = self.overlayToken {
@@ -464,8 +706,13 @@ actor VoiceWakeRuntime {
             let nanos = UInt64(max(0, delay) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanos)
             guard let self else { return }
+            await self.consumeScheduledRestart()
             await self.restartRecognizerIfIdleAndOverlayHidden()
         }
+    }
+
+    private func consumeScheduledRestart() {
+        self.scheduledRestartTask = nil
     }
 
     func applyPushToTalkCooldown() {

--- a/apps/macos/Sources/Clawdbot/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeRuntime.swift
@@ -212,7 +212,7 @@ actor VoiceWakeRuntime {
             let preferred = config.micID?.isEmpty == false ? config.micID! : "system-default"
             self.logger.info(
                 "voicewake runtime input preferred=\(preferred, privacy: .public) " +
-                "\(AudioInputDeviceObserver.defaultInputDeviceSummary(), privacy: .public)")
+                    "\(AudioInputDeviceObserver.defaultInputDeviceSummary(), privacy: .public)")
             self.logger.info("voicewake runtime started")
             DiagnosticsFileLog.shared.log(category: "voicewake.runtime", event: "started", fields: [
                 "locale": config.localeID ?? "",
@@ -377,8 +377,8 @@ actor VoiceWakeRuntime {
         isFinal: Bool,
         match: WakeWordGateMatch?,
         usedFallback: Bool,
-        capturing: Bool
-    ) {
+        capturing: Bool)
+    {
         guard !transcript.isEmpty else { return }
         if transcript == self.lastLoggedText, !isFinal {
             if let last = self.lastLoggedAt, Date().timeIntervalSince(last) < 0.25 {
@@ -389,7 +389,7 @@ actor VoiceWakeRuntime {
         self.lastLoggedAt = Date()
 
         let textOnly = WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers)
-        let timingCount = segments.filter { $0.start > 0 || $0.duration > 0 }.count
+        let timingCount = segments.count(where: { $0.start > 0 || $0.duration > 0 })
         let matchSummary = match.map {
             "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"
         } ?? "match=false"
@@ -401,9 +401,9 @@ actor VoiceWakeRuntime {
 
         self.logger.info(
             "voicewake runtime transcript='\(transcript, privacy: .public)' textOnly=\(textOnly) " +
-            "isFinal=\(isFinal) timing=\(timingCount)/\(segments.count) " +
-            "capturing=\(capturing) fallback=\(usedFallback) " +
-            "\(matchSummary) segments=[\(segmentSummary, privacy: .public)]")
+                "isFinal=\(isFinal) timing=\(timingCount)/\(segments.count) " +
+                "capturing=\(capturing) fallback=\(usedFallback) " +
+                "\(matchSummary) segments=[\(segmentSummary, privacy: .public)]")
     }
 
     private func noteAudioTap(rms: Double) {
@@ -471,8 +471,8 @@ actor VoiceWakeRuntime {
         lastSeenAt: Date?,
         lastText: String?,
         triggers: [String],
-        config: RuntimeConfig
-    ) async {
+        config: RuntimeConfig) async
+    {
         guard !Task.isCancelled else { return }
         guard !self.isCapturing else { return }
         guard let lastSeenAt, let lastText else { return }
@@ -488,8 +488,8 @@ actor VoiceWakeRuntime {
     private func textOnlyFallbackMatch(
         transcript: String,
         triggers: [String],
-        config: WakeWordGateConfig
-    ) -> WakeWordGateMatch? {
+        config: WakeWordGateConfig) -> WakeWordGateMatch?
+    {
         guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return nil }
         guard Self.startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
         let trimmed = Self.trimmedAfterTrigger(transcript, triggers: triggers)
@@ -745,13 +745,13 @@ actor VoiceWakeRuntime {
     private static func startsWithTrigger(transcript: String, triggers: [String]) -> Bool {
         let tokens = transcript
             .split(whereSeparator: { $0.isWhitespace })
-            .map { normalizeToken(String($0)) }
+            .map { self.normalizeToken(String($0)) }
             .filter { !$0.isEmpty }
         guard !tokens.isEmpty else { return false }
         for trigger in triggers {
             let triggerTokens = trigger
                 .split(whereSeparator: { $0.isWhitespace })
-                .map { normalizeToken(String($0)) }
+                .map { self.normalizeToken(String($0)) }
                 .filter { !$0.isEmpty }
             guard !triggerTokens.isEmpty, tokens.count >= triggerTokens.count else { continue }
             if zip(triggerTokens, tokens.prefix(triggerTokens.count)).allSatisfy({ $0 == $1 }) {
@@ -763,7 +763,7 @@ actor VoiceWakeRuntime {
 
     private static func normalizeToken(_ token: String) -> String {
         token
-            .trimmingCharacters(in: Self.whitespaceAndPunctuation)
+            .trimmingCharacters(in: self.whitespaceAndPunctuation)
             .lowercased()
     }
 

--- a/apps/macos/Sources/Clawdbot/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeSettings.swift
@@ -1,8 +1,8 @@
 import AppKit
 import AVFoundation
 import Observation
-import SwabbleKit
 import Speech
+import SwabbleKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -371,9 +371,9 @@ struct VoiceWakeSettings: View {
 
     private static func textOnlyCommand(from transcript: String, triggers: [String]) -> String? {
         guard !transcript.isEmpty else { return nil }
-        let normalized = normalizeToken(transcript)
+        let normalized = self.normalizeToken(transcript)
         guard !normalized.isEmpty else { return nil }
-        guard startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
+        guard self.startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
         guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return nil }
         let trimmed = WakeWordGate.stripWake(text: transcript, triggers: triggers)
         return trimmed.isEmpty ? nil : trimmed
@@ -382,13 +382,13 @@ struct VoiceWakeSettings: View {
     private static func startsWithTrigger(transcript: String, triggers: [String]) -> Bool {
         let tokens = transcript
             .split(whereSeparator: { $0.isWhitespace })
-            .map { normalizeToken(String($0)) }
+            .map { self.normalizeToken(String($0)) }
             .filter { !$0.isEmpty }
         guard !tokens.isEmpty else { return false }
         for trigger in triggers {
             let triggerTokens = trigger
                 .split(whereSeparator: { $0.isWhitespace })
-                .map { normalizeToken(String($0)) }
+                .map { self.normalizeToken(String($0)) }
                 .filter { !$0.isEmpty }
             guard !triggerTokens.isEmpty, tokens.count >= triggerTokens.count else { continue }
             if zip(triggerTokens, tokens.prefix(triggerTokens.count)).allSatisfy({ $0 == $1 }) {
@@ -400,7 +400,7 @@ struct VoiceWakeSettings: View {
 
     private static func normalizeToken(_ token: String) -> String {
         token
-            .trimmingCharacters(in: Self.whitespaceAndPunctuation)
+            .trimmingCharacters(in: self.whitespaceAndPunctuation)
             .lowercased()
     }
 
@@ -528,14 +528,14 @@ struct VoiceWakeSettings: View {
 
     @MainActor
     private func loadMicsIfNeeded(force: Bool = false) async {
-        guard (force || self.availableMics.isEmpty), !self.loadingMics else { return }
+        guard force || self.availableMics.isEmpty, !self.loadingMics else { return }
         self.loadingMics = true
         let discovery = AVCaptureDevice.DiscoverySession(
             deviceTypes: [.external, .microphone],
             mediaType: .audio,
             position: .unspecified)
         let aliveUIDs = AudioInputDeviceObserver.aliveInputDeviceUIDs()
-        let connectedDevices = discovery.devices.filter { $0.isConnected }
+        let connectedDevices = discovery.devices.filter(\.isConnected)
         let devices = aliveUIDs.isEmpty
             ? connectedDevices
             : connectedDevices.filter { aliveUIDs.contains($0.uniqueID) }

--- a/apps/macos/Sources/Clawdbot/VoiceWakeTestCard.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeTestCard.swift
@@ -57,6 +57,9 @@ struct VoiceWakeTestCard: View {
                     .symbolEffect(.pulse)
                     .foregroundStyle(Color.accentColor))
 
+        case .finalizing:
+            AnyView(ProgressView().controlSize(.small))
+
         case .detected:
             AnyView(Image(systemName: "checkmark.circle.fill").foregroundStyle(.green))
 
@@ -78,6 +81,9 @@ struct VoiceWakeTestCard: View {
 
         case let .hearing(text):
             "Heard: \(text)"
+
+        case .finalizing:
+            "Finalizing…"
 
         case .detected:
             "Voice wake detected!"

--- a/apps/macos/Sources/Clawdbot/VoiceWakeTester.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeTester.swift
@@ -208,11 +208,8 @@ final class VoiceWakeTester {
         if let match, !match.command.isEmpty {
             self.holdingAfterDetect = true
             self.detectedText = match.command
-            self.logger.info("voice wake detected; forwarding (len=\(match.command.count))")
+            self.logger.info("voice wake detected (test) (len=\(match.command.count))")
             await MainActor.run { AppStateStore.shared.triggerVoiceEars(ttl: nil) }
-            Task.detached {
-                await VoiceWakeForwarder.forward(transcript: match.command)
-            }
             self.stop()
             await MainActor.run {
                 AppStateStore.shared.stopVoiceEars()
@@ -424,11 +421,8 @@ final class VoiceWakeTester {
             ) else { return }
             self.holdingAfterDetect = true
             self.detectedText = match.command
-            self.logger.info("voice wake detected (silence); forwarding (len=\(match.command.count))")
+            self.logger.info("voice wake detected (test, silence) (len=\(match.command.count))")
             await MainActor.run { AppStateStore.shared.triggerVoiceEars(ttl: nil) }
-            Task.detached {
-                await VoiceWakeForwarder.forward(transcript: match.command)
-            }
             self.stop()
             await MainActor.run {
                 AppStateStore.shared.stopVoiceEars()

--- a/apps/macos/Sources/Clawdbot/VoiceWakeTester.swift
+++ b/apps/macos/Sources/Clawdbot/VoiceWakeTester.swift
@@ -8,6 +8,7 @@ enum VoiceWakeTestState: Equatable {
     case requesting
     case listening
     case hearing(String)
+    case finalizing
     case detected(String)
     case failed(String)
 }
@@ -18,8 +19,15 @@ final class VoiceWakeTester {
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var isStopping = false
+    private var isFinalizing = false
     private var detectionStart: Date?
     private var lastHeard: Date?
+    private var lastLoggedText: String?
+    private var lastLoggedAt: Date?
+    private var lastTranscript: String?
+    private var lastTranscriptAt: Date?
+    private var silenceTask: Task<Void, Never>?
+    private var currentTriggers: [String] = []
     private var holdingAfterDetect = false
     private var detectedText: String?
     private let logger = Logger(subsystem: "com.clawdbot", category: "voicewake")
@@ -37,6 +45,17 @@ final class VoiceWakeTester {
     {
         guard self.recognitionTask == nil else { return }
         self.isStopping = false
+        self.isFinalizing = false
+        self.holdingAfterDetect = false
+        self.detectedText = nil
+        self.lastHeard = nil
+        self.lastLoggedText = nil
+        self.lastLoggedAt = nil
+        self.lastTranscript = nil
+        self.lastTranscriptAt = nil
+        self.silenceTask?.cancel()
+        self.silenceTask = nil
+        self.currentTriggers = triggers
         let chosenLocale = localeID.flatMap { Locale(identifier: $0) } ?? Locale.current
         let recognizer = SFSpeechRecognizer(locale: chosenLocale)
         guard let recognizer, recognizer.isAvailable else {
@@ -45,6 +64,7 @@ final class VoiceWakeTester {
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "Speech recognition unavailable"])
         }
+        recognizer.defaultTaskHint = .dictation
 
         guard Self.hasPrivacyStrings else {
             throw NSError(
@@ -70,6 +90,7 @@ final class VoiceWakeTester {
 
         self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
         self.recognitionRequest?.shouldReportPartialResults = true
+        self.recognitionRequest?.taskHint = .dictation
         let request = self.recognitionRequest
 
         let inputNode = self.audioEngine.inputNode
@@ -96,9 +117,21 @@ final class VoiceWakeTester {
             let segments = result.map { WakeWordSpeechSegments.from(
                 transcription: $0.bestTranscription,
                 transcript: text) } ?? []
-            let gateConfig = WakeWordGateConfig(triggers: triggers)
-            let match = WakeWordGate.match(transcript: text, segments: segments, config: gateConfig)
             let isFinal = result?.isFinal ?? false
+            let gateConfig = WakeWordGateConfig(triggers: triggers)
+            var match = WakeWordGate.match(transcript: text, segments: segments, config: gateConfig)
+            if match == nil, isFinal {
+                match = self.textOnlyFallbackMatch(
+                    transcript: text,
+                    triggers: triggers,
+                    config: gateConfig)
+            }
+            self.maybeLogDebug(
+                transcript: text,
+                segments: segments,
+                triggers: triggers,
+                match: match,
+                isFinal: isFinal)
             let errorMessage = error?.localizedDescription
 
             Task { [weak self] in
@@ -114,13 +147,47 @@ final class VoiceWakeTester {
     }
 
     func stop() {
-        self.isStopping = true
+        self.stop(force: true)
+    }
+
+    func finalize(timeout: TimeInterval = 1.5) {
+        guard self.recognitionTask != nil else {
+            self.stop(force: true)
+            return
+        }
+        self.isFinalizing = true
+        self.audioEngine.inputNode.removeTap(onBus: 0)
+        self.recognitionRequest?.endAudio()
+        self.audioEngine.stop()
+        Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            if !self.isStopping {
+                self.stop(force: true)
+            }
+        }
+    }
+
+    private func stop(force: Bool) {
+        if force { self.isStopping = true }
+        self.isFinalizing = false
         self.audioEngine.stop()
         self.recognitionRequest?.endAudio()
         self.recognitionTask?.cancel()
         self.recognitionTask = nil
         self.recognitionRequest = nil
         self.audioEngine.inputNode.removeTap(onBus: 0)
+        self.holdingAfterDetect = false
+        self.detectedText = nil
+        self.lastHeard = nil
+        self.detectionStart = nil
+        self.lastLoggedText = nil
+        self.lastLoggedAt = nil
+        self.lastTranscript = nil
+        self.lastTranscriptAt = nil
+        self.silenceTask?.cancel()
+        self.silenceTask = nil
+        self.currentTriggers = []
     }
 
     private func handleResult(
@@ -132,6 +199,11 @@ final class VoiceWakeTester {
     {
         if !text.isEmpty {
             self.lastHeard = Date()
+            self.lastTranscript = text
+            self.lastTranscriptAt = Date()
+        }
+        if self.holdingAfterDetect {
+            return
         }
         if let match, !match.command.isEmpty {
             self.holdingAfterDetect = true
@@ -141,17 +213,28 @@ final class VoiceWakeTester {
             Task.detached {
                 await VoiceWakeForwarder.forward(transcript: match.command)
             }
-            Task { @MainActor in onUpdate(.detected(match.command)) }
-            self.holdUntilSilence(onUpdate: onUpdate)
+            self.stop()
+            await MainActor.run {
+                AppStateStore.shared.stopVoiceEars()
+                onUpdate(.detected(match.command))
+            }
             return
         }
+        if !isFinal, !text.isEmpty {
+            self.scheduleSilenceCheck(
+                triggers: self.currentTriggers,
+                onUpdate: onUpdate)
+        }
+        if self.isFinalizing {
+            Task { @MainActor in onUpdate(.finalizing) }
+        }
         if let errorMessage {
-            self.stop()
+            self.stop(force: true)
             Task { @MainActor in onUpdate(.failed(errorMessage)) }
             return
         }
         if isFinal {
-            self.stop()
+            self.stop(force: true)
             let state: VoiceWakeTestState = text.isEmpty
                 ? .failed("No speech detected")
                 : .failed("No trigger heard: “\(text)”")
@@ -160,6 +243,139 @@ final class VoiceWakeTester {
             let state: VoiceWakeTestState = text.isEmpty ? .listening : .hearing(text)
             Task { @MainActor in onUpdate(state) }
         }
+    }
+
+    private func maybeLogDebug(
+        transcript: String,
+        segments: [WakeWordSegment],
+        triggers: [String],
+        match: WakeWordGateMatch?,
+        isFinal: Bool) {
+        guard !transcript.isEmpty else { return }
+        if transcript == self.lastLoggedText, !isFinal {
+            if let last = self.lastLoggedAt, Date().timeIntervalSince(last) < 0.25 {
+                return
+            }
+        }
+        self.lastLoggedText = transcript
+        self.lastLoggedAt = Date()
+
+        let textOnly = WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers)
+        let gaps = Self.debugCandidateGaps(triggers: triggers, segments: segments)
+        let segmentSummary = Self.debugSegments(segments)
+        let timingCount = segments.filter { $0.start > 0 || $0.duration > 0 }.count
+        let matchSummary = match.map {
+            "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"
+        } ?? "match=false"
+
+        self.logger.info(
+            "voicewake test transcript='\(transcript, privacy: .public)' textOnly=\(textOnly) " +
+            "isFinal=\(isFinal) timing=\(timingCount)/\(segments.count) " +
+            "\(matchSummary) gaps=[\(gaps, privacy: .public)] segments=[\(segmentSummary, privacy: .public)]")
+    }
+
+    private static func debugSegments(_ segments: [WakeWordSegment]) -> String {
+        segments.map { seg in
+            let start = String(format: "%.2f", seg.start)
+            let end = String(format: "%.2f", seg.end)
+            return "\(seg.text)@\(start)-\(end)"
+        }.joined(separator: ", ")
+    }
+
+    private static func debugCandidateGaps(triggers: [String], segments: [WakeWordSegment]) -> String {
+        let tokens = normalizeSegments(segments)
+        guard !tokens.isEmpty else { return "" }
+        let triggerTokens = normalizeTriggers(triggers)
+        var gaps: [String] = []
+
+        for trigger in triggerTokens {
+            let count = trigger.tokens.count
+            guard count > 0, tokens.count > count else { continue }
+            for i in 0...(tokens.count - count - 1) {
+                let matched = (0..<count).allSatisfy { tokens[i + $0].normalized == trigger.tokens[$0] }
+                if !matched { continue }
+                let triggerEnd = tokens[i + count - 1].end
+                let nextToken = tokens[i + count]
+                let gap = nextToken.start - triggerEnd
+                let formatted = String(format: "%.2f", gap)
+                gaps.append("\(trigger.tokens.joined(separator: " ")):\(formatted)s")
+            }
+        }
+        return gaps.joined(separator: ", ")
+    }
+
+    private struct DebugToken {
+        let normalized: String
+        let start: TimeInterval
+        let end: TimeInterval
+    }
+
+    private struct DebugTriggerTokens {
+        let tokens: [String]
+    }
+
+    private static func normalizeTriggers(_ triggers: [String]) -> [DebugTriggerTokens] {
+        var output: [DebugTriggerTokens] = []
+        for trigger in triggers {
+            let tokens = trigger
+                .split(whereSeparator: { $0.isWhitespace })
+                .map { normalizeToken(String($0)) }
+                .filter { !$0.isEmpty }
+            if tokens.isEmpty { continue }
+            output.append(DebugTriggerTokens(tokens: tokens))
+        }
+        return output
+    }
+
+    private static func normalizeSegments(_ segments: [WakeWordSegment]) -> [DebugToken] {
+        segments.compactMap { segment in
+            let normalized = normalizeToken(segment.text)
+            guard !normalized.isEmpty else { return nil }
+            return DebugToken(
+                normalized: normalized,
+                start: segment.start,
+                end: segment.end)
+        }
+    }
+
+    private static func normalizeToken(_ token: String) -> String {
+        token
+            .trimmingCharacters(in: Self.whitespaceAndPunctuation)
+            .lowercased()
+    }
+
+    private static let whitespaceAndPunctuation = CharacterSet.whitespacesAndNewlines
+        .union(.punctuationCharacters)
+
+    private func textOnlyFallbackMatch(
+        transcript: String,
+        triggers: [String],
+        config: WakeWordGateConfig
+    ) -> WakeWordGateMatch? {
+        guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return nil }
+        guard Self.startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
+        let trimmed = WakeWordGate.stripWake(text: transcript, triggers: triggers)
+        guard trimmed.count >= config.minCommandLength else { return nil }
+        return WakeWordGateMatch(triggerEndTime: 0, postGap: 0, command: trimmed)
+    }
+
+    private static func startsWithTrigger(transcript: String, triggers: [String]) -> Bool {
+        let tokens = transcript
+            .split(whereSeparator: { $0.isWhitespace })
+            .map { normalizeToken(String($0)) }
+            .filter { !$0.isEmpty }
+        guard !tokens.isEmpty else { return false }
+        for trigger in triggers {
+            let triggerTokens = trigger
+                .split(whereSeparator: { $0.isWhitespace })
+                .map { normalizeToken(String($0)) }
+                .filter { !$0.isEmpty }
+            guard !triggerTokens.isEmpty, tokens.count >= triggerTokens.count else { continue }
+            if zip(triggerTokens, tokens.prefix(triggerTokens.count)).allSatisfy({ $0 == $1 }) {
+                return true
+            }
+        }
+        return false
     }
 
     private func holdUntilSilence(onUpdate: @escaping @Sendable (VoiceWakeTestState) -> Void) {
@@ -183,6 +399,40 @@ final class VoiceWakeTester {
                     self.logger.info("voice wake hold finished; len=\(detectedText.count)")
                     Task { @MainActor in onUpdate(.detected(detectedText)) }
                 }
+            }
+        }
+    }
+
+    private func scheduleSilenceCheck(
+        triggers: [String],
+        onUpdate: @escaping @Sendable (VoiceWakeTestState) -> Void
+    ) {
+        self.silenceTask?.cancel()
+        let lastSeenAt = self.lastTranscriptAt
+        let lastText = self.lastTranscript
+        self.silenceTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(self.silenceWindow * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            guard !self.isStopping, !self.holdingAfterDetect else { return }
+            guard let lastSeenAt, let lastText else { return }
+            guard self.lastTranscriptAt == lastSeenAt, self.lastTranscript == lastText else { return }
+            guard let match = self.textOnlyFallbackMatch(
+                transcript: lastText,
+                triggers: triggers,
+                config: WakeWordGateConfig(triggers: triggers)
+            ) else { return }
+            self.holdingAfterDetect = true
+            self.detectedText = match.command
+            self.logger.info("voice wake detected (silence); forwarding (len=\(match.command.count))")
+            await MainActor.run { AppStateStore.shared.triggerVoiceEars(ttl: nil) }
+            Task.detached {
+                await VoiceWakeForwarder.forward(transcript: match.command)
+            }
+            self.stop()
+            await MainActor.run {
+                AppStateStore.shared.stopVoiceEars()
+                onUpdate(.detected(match.command))
             }
         }
     }

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -5,7 +5,7 @@ read_when:
 ---
 # Voice Wake & Push-to-Talk
 
-Updated: 2025-12-23 · Owners: mac app
+Updated: 2026-01-08 · Owners: mac app
 
 ## Modes
 - **Wake-word mode** (default): always-on Speech recognizer waits for trigger tokens (`swabbleTriggerWords`). On match it starts capture, shows the overlay with partial text, and auto-sends after silence.
@@ -13,7 +13,7 @@ Updated: 2025-12-23 · Owners: mac app
 
 ## Runtime behavior (wake-word)
 - Speech recognizer lives in `VoiceWakeRuntime`.
-- Trigger only fires when there’s a **meaningful pause** between the wake word and the next word (~0.45s gap).
+- Trigger only fires when there’s a **meaningful pause** between the wake word and the next word (~0.55s gap). The overlay/chime can start on the pause even before the command begins.
 - Silence windows: 2.0s when speech is flowing, 5.0s if only the trigger was heard.
 - Hard stop: 120s to prevent runaway sessions.
 - Debounce between sessions: 350ms.
@@ -42,6 +42,7 @@ Hardening:
 - **Voice Wake** toggle: enables wake-word runtime.
 - **Hold Cmd+Fn to talk**: enables the push-to-talk monitor. Disabled on macOS < 26.
 - Language & mic pickers, live level meter, trigger-word table, tester (local-only; does not forward).
+- Mic picker preserves the last selection if a device disconnects, shows a disconnected hint, and temporarily falls back to the system default until it returns.
 - **Sounds**: chimes on trigger detect and on send; defaults to the macOS “Glass” system sound. You can pick any `NSSound`-loadable file (e.g. MP3/WAV/AIFF) for each event or choose **No Sound**.
 
 ## Forwarding behavior

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -41,7 +41,7 @@ Hardening:
 ## User-facing settings
 - **Voice Wake** toggle: enables wake-word runtime.
 - **Hold Cmd+Fn to talk**: enables the push-to-talk monitor. Disabled on macOS < 26.
-- Language & mic pickers, live level meter, trigger-word table, tester.
+- Language & mic pickers, live level meter, trigger-word table, tester (local-only; does not forward).
 - **Sounds**: chimes on trigger detect and on send; defaults to the macOS “Glass” system sound. You can pick any `NSSound`-loadable file (e.g. MP3/WAV/AIFF) for each event or choose **No Sound**.
 
 ## Forwarding behavior


### PR DESCRIPTION
TL;DR: Fixes Voice Wake reliability and UX on macOS: the tester is now local‑only and stable, mic selection survives disconnects, and the runtime triggers immediately on a wake‑word pause so the chime/overlay appear before the command.  
  
  ## Problems

  - Start Test reliability: Voice Wake tests often received partial/final transcripts without timing, so wake‑word matching failed. Timeouts overwrote detections and tests/mic capture could keep running after UI changes.
  - Test forwarding: The tester forwarded transcripts to the gateway/chat, which looked like real commands and confused users.
  - Mic selection on disconnect: Bluetooth mic disconnects (e.g., AirPods Max) made the selected mic disappear and left the UI unclear about what was actually being used. App would crash when disconnecting AirPod Max while they were selected as the Microphone.
  - Voice Wake didn't work, wouldn't recognize trigger words.
  - Wake‑word UX delay: The runtime often waited until the full utterance ended before triggering, so trigger chime + send felt like one burst instead of a clear “wake → speak” flow.

  ## Fixes

  1. Stabilize Voice Wake testing
      - Added text‑only/prefix fallback and silence‑based detection when timing metadata is missing.
      - Stopped and cleaned up prior tests; canceled timeouts on detection/stop.
      - Tear down meter/test when the Voice Wake tab is inactive.
      - Runtime detection now falls back to final text‑only matches when timing is absent.
      - UI state reflects “finalizing” to prevent hanging tests.
  2. Keep the tester local‑only
      - Prevented Start test transcripts from being forwarded to the gateway.
      - Clarified this in docs.
  3. Preserve mic selection across disconnects
      - Keep the chosen mic label visible even if disconnected; show a disconnected hint while falling back to system default.
      - Don’t clear the preferred mic on device changes so it auto‑restores when available.
      - Added audio input/default‑input logs to runtime/tester/meter for debugging.
      - Clawdbot macOS app no longer crashes when AirPod Max disconnects.
  4. Trigger on wake‑word pause
      - Added a “trigger‑only pause” path: if we hear the wake word and a short pause (~0.55s), start capture immediately (overlay/chime appear before the command).
      - Kept silence‑fallback for continuous speech.
      - Canceled cross‑tasks to avoid stale triggers.
      - Updated docs for the new pause timing.

  ## Why

  - Make test mode deterministic and non‑confusing (local‑only, no ghost messages, no stuck tests).
  - Improve real‑world mic handling for Bluetooth devices that disconnect/reconnect.
  - Align wake‑word UX with expectations: a pause after the wake word should immediately start capture.

  ## Docs

  - Updated docs/platforms/mac/voicewake.md with new pause window and trigger‑on‑pause behavior.

  ## Testing

  - Manual: multiple Start Test runs with AirPods Max + built‑in mic.
  - Manual: verified with logs and manual testing that mic continues working (falls back to system default when AirPods Max disconnected).
  - Manual: Started app, selected AirPods Max, disconnected AirPods Max (took them off my head), went to Settings. Verified app no longer crashes and "Disconnected" message is displayed.
  - Manual: runtime wake‑word (“Computer … pause … what time is it”) verifies trigger chime/overlay on pause.
  - Manual: verified Voice Wake sends chat message after wake word + commands.


  ## Notes

  - No API/config changes; scope is macOS app behavior + docs.
