### PR TITLE
browser: add Windows Chrome executable detection

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   decorateClawdProfile,
   findChromeExecutableMac,
+  findChromeExecutableWindows,
   isChromeReachable,
   stopClawdChrome,
 } from "./chrome.js";
@@ -152,6 +153,34 @@ describe("browser chrome helpers", () => {
   it("returns null when no Chrome candidate exists", () => {
     const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     expect(findChromeExecutableMac()).toBeNull();
+    exists.mockRestore();
+  });
+
+  it("picks the first existing Chrome candidate on Windows", () => {
+    const exists = vi
+      .spyOn(fs, "existsSync")
+      .mockImplementation((p) => String(p).includes("Chrome SxS"));
+    const exe = findChromeExecutableWindows();
+    expect(exe?.kind).toBe("canary");
+    expect(exe?.path).toMatch(/Chrome SxS/);
+    exists.mockRestore();
+  });
+
+  it("finds Chrome in Program Files on Windows", () => {
+    // Use path.join to match how the function builds paths (cross-platform)
+    const marker = path.join("Program Files", "Google", "Chrome");
+    const exists = vi
+      .spyOn(fs, "existsSync")
+      .mockImplementation((p) => String(p).includes(marker));
+    const exe = findChromeExecutableWindows();
+    expect(exe?.kind).toBe("chrome");
+    expect(exe?.path).toMatch(/chrome\.exe$/);
+    exists.mockRestore();
+  });
+
+  it("returns null when no Chrome candidate exists on Windows", () => {
+    const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(findChromeExecutableWindows()).toBeNull();
     exists.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
Adds Windows support for the browser tool by implementing `findChromeExecutableWindows()`.

Previously, the browser tool only worked on macOS and Linux because `resolveBrowserExecutable()` returned `null` on Windows, throwing "No supported browser found (Chrome/Chromium on macOS or Linux)."

Fixes #437

## Changes
- Added `findChromeExecutableWindows()` in `src/browser/chrome.ts` that checks common Chrome paths:
  - `%LOCALAPPDATA%\Google\Chrome SxS\Application\chrome.exe` (Canary)
  - `%LOCALAPPDATA%\Chromium\Application\chrome.exe`
  - `%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe`
  - `%ProgramFiles%\Google\Chrome\Application\chrome.exe`
  - `%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe`
- Updated `resolveBrowserExecutable()` to call it when `process.platform === "win32"`
- Updated error message to include Windows
- Added 3 tests for Windows Chrome detection

## Testing
- [x] `pnpm lint` — passes
- [x] `pnpm build` — passes
- [x] `pnpm test src/browser/chrome.test.ts` — 12 tests pass

## AI-assisted 🤖
- [x] AI-assisted (Claude)
- [x] Lightly tested on Windows 11
- [x] I understand what the code does