### PR TITLE
docs: redesign showcase page with card layout

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -1,39 +1,182 @@
 ---
-summary: "Real-world showcases of what Clawdbot can do"
-read_when:
-  - You want inspiration or proof of capability
+title: "Showcase"
+description: "Real-world Clawdbot projects from the community"
 ---
+
 # Showcase
 
-Real projects from the community. Highlights from #showcase (Jan 2–5, 2026).
+Real projects from the community. See what people are building with Clawdbot.
 
-## Automation & real-world outcomes
-- **Grocery autopilot (Picnic)** — Skill built around an unofficial Picnic API client. Pulls order history, infers preferred brands, maps recipes to cart, completes order in minutes. https://github.com/timkrase/clawdis-picnic-skill
-- **Grocery autopilot (Picnic, alt)** — Another Picnic-based skill built via the `picnic-api` package. https://github.com/MRVDH/picnic-api
-- **German rail planning** — Go CLI for Deutsche Bahn; skill picks best connections given time windows and preferences. https://github.com/timkrase/dbrest-cli + https://github.com/timkrase/clawdis-skills/tree/main/db-bahn
-- **padel-cli** — Playtomic availability + booking CLI with a Clawdbot plugin output. <span class="showcase-link"><a href="https://github.com/joshp123/padel-cli">github.com/joshp123/padel-cli</a><span class="showcase-preview"><img src="/assets/showcase/padel-screenshot.jpg" alt="padel-cli availability screenshot" loading="lazy" decoding="async" /></span></span>
-- **Accounting intake** — Collect PDFs from email, prep for tax consultant (monthly accounting batch). (No link shared.)
+<Info>
+**Want to be featured?** Share your project in [#showcase on Discord](https://discord.gg/clawdbot) or [tag @clawdbot on X](https://x.com/clawdbot).
+</Info>
 
-## Knowledge & memory systems
-- **xuezh** — Chinese learning engine + Clawdbot skill for pronunciation feedback and study flows. <span class="showcase-link"><a href="https://github.com/joshp123/xuezh">github.com/joshp123/xuezh</a><span class="showcase-preview"><img src="/assets/showcase/xuezh-pronunciation.jpeg" alt="xuezh pronunciation feedback in Clawdbot" loading="lazy" decoding="async" /></span></span>
-- **WhatsApp memory vault** — Ingests full exports, transcribes 1k+ voice notes, cross‑checks with git logs, outputs linked MD reports + ongoing indexing. (No link shared.)
-- **Karakeep semantic search** — Sidecar adds vector search to Karakeep bookmarks (Qdrant + OpenAI/Ollama), includes Clawdis skill. https://github.com/jamesbrooksco/karakeep-semantic-search
-- **Inside‑Out‑2 style memory** — Separate memory manager app turns session files into memories → beliefs → self model. (No link shared.)
+## 🤖 Automation & Workflows
 
-## Voice, docs, and assistants on the phone
-- **Clawdia phone bridge** — Vapi voice assistant ↔ Clawdis HTTP bridge; near‑real‑time phone calls. https://github.com/alejandroOPI/clawdia-bridge
-- **Google Docs edit skill** — Rich‑text editing skill built fast with Claude Code. (No link shared.)
-- **OpenRouter transcription skill** — Multi‑lingual audio transcription via OpenRouter (Gemini etc). ClawdHub: https://clawdhub.com/obviyus/openrouter-transcribe (user/slug link)
+<CardGroup cols={2}>
 
-## Infrastructure & deployment
-- **Home Assistant OS gateway add‑on** — Clawdbot gateway running on HA OS (Raspberry Pi), with SSH tunnel support + persistent state in /config. https://github.com/ngutman/clawdbot-ha-addon
-- **Home Assistant skill** — Control/automate HA via ClawdHub. https://clawdhub.com/skills/homeassistant
-- **Nix packaging** — Batteries‑included nixified clawdbot config. https://github.com/clawdbot/nix-clawdbot
-- **CalDAV skill** — khal/vdirsyncer based calendar skill. ClawdHub: caldav-calendar → https://clawdhub.com/skills/caldav-calendar
+<Card title="Grocery Autopilot" icon="cart-shopping" href="https://github.com/timkrase/clawdis-picnic-skill">
+  **@timkrase** • `automation` `groceries` `api`
+  
+  Skill built around the Picnic API. Pulls order history, infers preferred brands, maps recipes to cart, completes orders in minutes.
+</Card>
 
-## Home + hardware
-- **gohome** — Nix-native home automation with Clawdbot as the interface, plus Grafana dashboards. <span class="showcase-link"><a href="https://github.com/joshp123/gohome">github.com/joshp123/gohome</a><span class="showcase-preview"><img src="/assets/showcase/gohome-grafana.png" alt="GoHome Grafana dashboard" loading="lazy" decoding="async" /></span></span>
-- **Roborock integration** — Plugin for robot vacuum control. <span class="showcase-link"><a href="https://github.com/joshp123/gohome/tree/main/plugins/roborock">github.com/joshp123/gohome/tree/main/plugins/roborock</a><span class="showcase-preview"><img src="/assets/showcase/roborock-screenshot.jpg" alt="GoHome Roborock status screenshot" loading="lazy" decoding="async" /></span></span>
+<Card title="German Rail Planning" icon="train" href="https://github.com/timkrase/clawdis-skills/tree/main/db-bahn">
+  **@timkrase** • `automation` `travel` `cli`
+  
+  Go CLI for Deutsche Bahn; skill picks best train connections given time windows and preferences.
+</Card>
 
-## Community builds (non‑Clawdis but made with/around it)
-- **StarSwap marketplace** — Full astronomy gear marketplace. https://star-swap.com/
+<Card title="Padel Court Booking" icon="calendar-check" href="https://github.com/joshp123/padel-cli">
+  **@joshp123** • `automation` `booking` `cli`
+  
+  Playtomic availability checker + booking CLI. Never miss an open court again.
+  
+  <img src="/assets/showcase/padel-screenshot.jpg" alt="padel-cli screenshot" />
+</Card>
+
+<Card title="Accounting Intake" icon="file-invoice-dollar">
+  **Community** • `automation` `email` `pdf`
+  
+  Collects PDFs from email, preps documents for tax consultant. Monthly accounting on autopilot.
+</Card>
+
+</CardGroup>
+
+## 🧠 Knowledge & Memory
+
+<CardGroup cols={2}>
+
+<Card title="xuezh Chinese Learning" icon="language" href="https://github.com/joshp123/xuezh">
+  **@joshp123** • `learning` `voice` `skill`
+  
+  Chinese learning engine with pronunciation feedback and study flows via Clawdbot.
+  
+  <img src="/assets/showcase/xuezh-pronunciation.jpeg" alt="xuezh pronunciation feedback" />
+</Card>
+
+<Card title="WhatsApp Memory Vault" icon="vault">
+  **Community** • `memory` `transcription` `indexing`
+  
+  Ingests full WhatsApp exports, transcribes 1k+ voice notes, cross-checks with git logs, outputs linked markdown reports.
+</Card>
+
+<Card title="Karakeep Semantic Search" icon="magnifying-glass" href="https://github.com/jamesbrooksco/karakeep-semantic-search">
+  **@jamesbrooksco** • `search` `vector` `bookmarks`
+  
+  Adds vector search to Karakeep bookmarks using Qdrant + OpenAI/Ollama embeddings.
+</Card>
+
+<Card title="Inside-Out-2 Memory" icon="brain">
+  **Community** • `memory` `beliefs` `self-model`
+  
+  Separate memory manager that turns session files into memories → beliefs → evolving self model.
+</Card>
+
+</CardGroup>
+
+## 🎙️ Voice & Phone
+
+<CardGroup cols={2}>
+
+<Card title="Clawdia Phone Bridge" icon="phone" href="https://github.com/alejandroOPI/clawdia-bridge">
+  **@alejandroOPI** • `voice` `vapi` `bridge`
+  
+  Vapi voice assistant ↔ Clawdbot HTTP bridge. Near real-time phone calls with your agent.
+</Card>
+
+<Card title="OpenRouter Transcription" icon="microphone" href="https://clawdhub.com/obviyus/openrouter-transcribe">
+  **@obviyus** • `transcription` `multilingual` `skill`
+  
+  Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on ClawdHub.
+</Card>
+
+<Card title="Google Docs Editor" icon="file-word">
+  **Community** • `docs` `editing` `skill`
+  
+  Rich-text Google Docs editing skill. Built rapidly with Claude Code.
+</Card>
+
+</CardGroup>
+
+## 🏗️ Infrastructure & Deployment
+
+<CardGroup cols={2}>
+
+<Card title="Home Assistant Add-on" icon="home" href="https://github.com/ngutman/clawdbot-ha-addon">
+  **@ngutman** • `homeassistant` `docker` `raspberry-pi`
+  
+  Clawdbot gateway running on Home Assistant OS with SSH tunnel support and persistent state.
+</Card>
+
+<Card title="Home Assistant Skill" icon="toggle-on" href="https://clawdhub.com/skills/homeassistant">
+  **ClawdHub** • `homeassistant` `skill` `automation`
+  
+  Control and automate Home Assistant devices via natural language.
+</Card>
+
+<Card title="Nix Packaging" icon="snowflake" href="https://github.com/clawdbot/nix-clawdbot">
+  **@clawdbot** • `nix` `packaging` `deployment`
+  
+  Batteries-included nixified Clawdbot configuration for reproducible deployments.
+</Card>
+
+<Card title="CalDAV Calendar" icon="calendar" href="https://clawdhub.com/skills/caldav-calendar">
+  **ClawdHub** • `calendar` `caldav` `skill`
+  
+  Calendar skill using khal/vdirsyncer. Self-hosted calendar integration.
+</Card>
+
+</CardGroup>
+
+## 🏠 Home & Hardware
+
+<CardGroup cols={2}>
+
+<Card title="GoHome Automation" icon="house-signal" href="https://github.com/joshp123/gohome">
+  **@joshp123** • `home` `nix` `grafana`
+  
+  Nix-native home automation with Clawdbot as the interface, plus beautiful Grafana dashboards.
+  
+  <img src="/assets/showcase/gohome-grafana.png" alt="GoHome Grafana dashboard" />
+</Card>
+
+<Card title="Roborock Vacuum" icon="robot" href="https://github.com/joshp123/gohome/tree/main/plugins/roborock">
+  **@joshp123** • `vacuum` `iot` `plugin`
+  
+  Control your Roborock robot vacuum through natural conversation.
+  
+  <img src="/assets/showcase/roborock-screenshot.jpg" alt="Roborock status" />
+</Card>
+
+</CardGroup>
+
+## 🌟 Community Projects
+
+<CardGroup cols={2}>
+
+<Card title="StarSwap Marketplace" icon="star" href="https://star-swap.com/">
+  **Community** • `marketplace` `astronomy` `webapp`
+  
+  Full astronomy gear marketplace. Built with/around the Clawdbot ecosystem.
+</Card>
+
+</CardGroup>
+
+---
+
+## Submit Your Project
+
+Have something to share? We'd love to feature it!
+
+<Steps>
+  <Step title="Share It">
+    Post in [#showcase on Discord](https://discord.gg/clawdbot) or [tweet @clawdbot](https://x.com/clawdbot)
+  </Step>
+  <Step title="Include Details">
+    Tell us what it does, link to the repo/demo, share a screenshot if you have one
+  </Step>
+  <Step title="Get Featured">
+    We'll add standout projects to this page
+  </Step>
+</Steps>


### PR DESCRIPTION
## Summary

Redesigns the showcase page from a flat bullet list to a visually appealing card-based layout using Mintlify components.

## Changes

- Convert flat bullet list to `CardGroup`/`Card` components
- Add icons for each project category
- Include author attribution (`@username`) and tags
- Organize by category with emoji headers:
  - 🤖 Automation & Workflows
  - 🧠 Knowledge & Memory
  - 🎙️ Voice & Phone
  - 🏗️ Infrastructure & Deployment
  - 🏠 Home & Hardware
  - 🌟 Community Projects
- Add "Submit Your Project" section with Steps component
- Add Info callout with links to Discord and X

## Preview

The new layout makes it easier to scan projects and see at a glance what each one does. Each card includes:
- Catchy title with icon
- Author attribution
- Tags/keywords
- Brief description
- Optional screenshot

---

*This PR is part of a larger effort to make it easier to submit and display community showcases.*