### PR TITLE
Thinking: gate xhigh by model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Gateway: add Tailscale binary discovery, custom bind mode, and probe auth retry for password changes. (#740 — thanks @jeffersonwarrior)
 - Agents: add compaction mode config with optional safeguard summarization for long histories. (#700 — thanks @thewilloftheshadow)
 - Tools: add tool profiles plus group shorthands for tool policy allow/deny (global, per-agent, sandbox).
+- Thinking: allow xhigh for GPT-5.2 + Codex models and downgrade on unsupported switches. (#444 — thanks @grp06)
 
 ### Fixes
 - Gateway: honor `CLAWDBOT_LAUNCHD_LABEL` / `CLAWDBOT_SYSTEMD_UNIT` overrides when checking or restarting the daemon.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Send these in WhatsApp/Telegram/Slack/Microsoft Teams/WebChat (group commands ar
 - `/status` — compact session status (model + tokens, cost when available)
 - `/new` or `/reset` — reset the session
 - `/compact` — compact session context (summary)
-- `/think <level>` — off|minimal|low|medium|high
+- `/think <level>` — off|minimal|low|medium|high|xhigh (GPT-5.2 + Codex models only)
 - `/verbose on|off`
 - `/cost on|off` — append per-response token/cost usage lines
 - `/restart` — restart the gateway (owner-only in groups)

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -105,7 +105,7 @@ Isolation options (only for `session=isolated`):
 ### Model and thinking overrides
 Isolated jobs (`agentTurn`) can override the model and thinking level:
 - `model`: Provider/model string (e.g., `anthropic/claude-sonnet-4-20250514`) or alias (e.g., `opus`)
-- `thinking`: Thinking level (`off`, `minimal`, `low`, `medium`, `high`)
+- `thinking`: Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`; GPT-5.2 + Codex models only)
 
 Note: You can set `model` on main-session jobs too, but it changes the shared main
 session model. We recommend model overrides only for isolated jobs to avoid

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -398,7 +398,7 @@ Required:
 Options:
 - `--to <dest>` (for session key and optional delivery)
 - `--session-id <id>`
-- `--thinking <off|minimal|low|medium|high>`
+- `--thinking <off|minimal|low|medium|high|xhigh>` (GPT-5.2 + Codex models only)
 - `--verbose <on|off>`
 - `--provider <whatsapp|telegram|discord|slack|signal|imessage>`
 - `--local`

--- a/docs/experiments/proposals/hooks-gmail-model.md
+++ b/docs/experiments/proposals/hooks-gmail-model.md
@@ -39,7 +39,7 @@ Add `hooks.gmail.model` config option to specify an optional cheaper model for G
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hooks.gmail.model` | `string` | (none) | Model to use for Gmail hook processing. Accepts `provider/model` refs or aliases from `agents.defaults.models`. |
-| `hooks.gmail.thinking` | `string` | (inherited) | Thinking level override (`off`, `minimal`, `low`, `medium`, `high`). If unset, inherits from `agents.defaults.thinkingDefault` or model's default. |
+| `hooks.gmail.thinking` | `string` | (inherited) | Thinking level override (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`; GPT-5.2 + Codex models only). If unset, inherits from `agents.defaults.thinkingDefault` or model's default. |
 
 ### Alias Support
 

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -38,7 +38,7 @@ clawdbot agent --to +15555550123 --message "Summon reply" --deliver
 - `--local`: run locally (requires provider keys in your shell)
 - `--deliver`: send the reply to the chosen provider (requires `--to`)
 - `--provider`: `whatsapp|telegram|discord|slack|signal|imessage` (default: `whatsapp`)
-- `--thinking <off|minimal|low|medium|high>`: persist thinking level
+- `--thinking <off|minimal|low|medium|high|xhigh>`: persist thinking level (GPT-5.2 + Codex models only)
 - `--verbose <on|off>`: persist verbose level
 - `--timeout <seconds>`: override agent timeout
 - `--json`: output structured JSON

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -60,7 +60,7 @@ Text + native (when enabled):
 - `/activation mention|always` (groups only)
 - `/send on|off|inherit` (owner-only)
 - `/reset` or `/new`
-- `/think <level>` (aliases: `/thinking`, `/t`)
+- `/think <off|minimal|low|medium|high|xhigh>` (GPT-5.2 + Codex models only; aliases: `/thinking`, `/t`)
 - `/verbose on|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
 - `/elevated on|off` (alias: `/elev`)

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -7,11 +7,12 @@ read_when:
 
 ## What it does
 - Inline directive in any inbound body: `/t <level>`, `/think:<level>`, or `/thinking <level>`.
-- Levels (aliases): `off | minimal | low | medium | high`
+- Levels (aliases): `off | minimal | low | medium | high | xhigh` (GPT-5.2 + Codex models only)
   - minimal → “think”
   - low → “think hard”
   - medium → “think harder”
   - high → “ultrathink” (max budget)
+  - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
   - `highest`, `max` map to `high`.
 
 ## Resolution order

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -50,7 +50,7 @@ Use SSH tunneling or Tailscale to reach the Gateway WS.
 - `/agent <id>` (or `/agents`)
 - `/session <key>` (or `/sessions`)
 - `/model <provider/model>` (or `/model list`, `/models`)
-- `/think <off|minimal|low|medium|high>`
+- `/think <off|minimal|low|medium|high|xhigh>` (GPT-5.2 + Codex models only)
 - `/verbose <on|off>`
 - `/reasoning <on|off|stream>` (stream = Telegram draft only)
 - `/cost <on|off>`

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -7,7 +7,13 @@ export type ModelRef = {
   model: string;
 };
 
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high";
+export type ThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -1046,7 +1046,7 @@ export function resolveEmbeddedSessionLane(key: string) {
 }
 
 function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
-  // pi-agent-core supports "xhigh" too; Clawdbot doesn't surface it for now.
+  // pi-agent-core supports "xhigh"; Clawdbot enables it for specific models.
   if (!level) return "off";
   return level;
 }

--- a/src/auto-reply/reply.directive.test.ts
+++ b/src/auto-reply/reply.directive.test.ts
@@ -69,6 +69,91 @@ describe("directive behavior", () => {
     vi.restoreAllMocks();
   });
 
+  it("accepts /thinking xhigh for codex models", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+        },
+        {},
+        {
+          agent: {
+            model: "openai-codex/gpt-5.2-codex",
+            workspace: path.join(home, "clawd"),
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: storePath },
+        },
+      );
+
+      const texts = (Array.isArray(res) ? res : [res])
+        .map((entry) => entry?.text)
+        .filter(Boolean);
+      expect(texts).toContain("Thinking level set to xhigh.");
+    });
+  });
+
+  it("accepts /thinking xhigh for openai gpt-5.2", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+        },
+        {},
+        {
+          agent: {
+            model: "openai/gpt-5.2",
+            workspace: path.join(home, "clawd"),
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: storePath },
+        },
+      );
+
+      const texts = (Array.isArray(res) ? res : [res])
+        .map((entry) => entry?.text)
+        .filter(Boolean);
+      expect(texts).toContain("Thinking level set to xhigh.");
+    });
+  });
+
+  it("rejects /thinking xhigh for non-codex models", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+        },
+        {},
+        {
+          agent: {
+            model: "openai/gpt-4.1-mini",
+            workspace: path.join(home, "clawd"),
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: storePath },
+        },
+      );
+
+      const texts = (Array.isArray(res) ? res : [res])
+        .map((entry) => entry?.text)
+        .filter(Boolean);
+      expect(texts).toContain(
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.2-codex or openai-codex/gpt-5.1-codex.',
+      );
+    });
+  });
   it("keeps reserved command aliases from matching after trimming", async () => {
     await withTempHome(async (home) => {
       vi.mocked(runEmbeddedPiAgent).mockReset();

--- a/src/auto-reply/reply.directive.test.ts
+++ b/src/auto-reply/reply.directive.test.ts
@@ -81,9 +81,11 @@ describe("directive behavior", () => {
         },
         {},
         {
-          agent: {
-            model: "openai-codex/gpt-5.2-codex",
-            workspace: path.join(home, "clawd"),
+          agents: {
+            defaults: {
+              model: "openai-codex/gpt-5.2-codex",
+              workspace: path.join(home, "clawd"),
+            },
           },
           whatsapp: { allowFrom: ["*"] },
           session: { store: storePath },
@@ -109,9 +111,11 @@ describe("directive behavior", () => {
         },
         {},
         {
-          agent: {
-            model: "openai/gpt-5.2",
-            workspace: path.join(home, "clawd"),
+          agents: {
+            defaults: {
+              model: "openai/gpt-5.2",
+              workspace: path.join(home, "clawd"),
+            },
           },
           whatsapp: { allowFrom: ["*"] },
           session: { store: storePath },
@@ -137,9 +141,11 @@ describe("directive behavior", () => {
         },
         {},
         {
-          agent: {
-            model: "openai/gpt-4.1-mini",
-            workspace: path.join(home, "clawd"),
+          agents: {
+            defaults: {
+              model: "openai/gpt-4.1-mini",
+              workspace: path.join(home, "clawd"),
+            },
           },
           whatsapp: { allowFrom: ["*"] },
           session: { store: storePath },

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -29,7 +29,10 @@ import {
   type ClawdbotConfig,
   loadConfig,
 } from "../config/config.js";
-import { resolveSessionFilePath } from "../config/sessions.js";
+import {
+  resolveSessionFilePath,
+  saveSessionStore,
+} from "../config/sessions.js";
 import { logVerbose } from "../globals.js";
 import { clearCommandLane, getQueueSize } from "../process/command-queue.js";
 import { getProviderDock } from "../providers/dock.js";

--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -37,6 +37,11 @@ import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { shortenHomePath } from "../../utils.js";
 import { extractModelDirective } from "../model.js";
 import type { MsgContext } from "../templating.js";
+import {
+  formatThinkingLevels,
+  formatXHighModelHint,
+  supportsXHighThinking,
+} from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
   type ElevatedLevel,
@@ -778,6 +783,7 @@ export async function handleDirectiveOnly(params: {
     allowedModelCatalog,
     resetModelOverride,
     provider,
+    model,
     initialModelLabel,
     formatModelSwitchEvent,
     currentThinkLevel,
@@ -943,6 +949,117 @@ export async function handleDirectiveOnly(params: {
     }
   }
 
+  let modelSelection: ModelDirectiveSelection | undefined;
+  let profileOverride: string | undefined;
+  if (directives.hasModelDirective && directives.rawModelDirective) {
+    const raw = directives.rawModelDirective.trim();
+    if (/^[0-9]+$/.test(raw)) {
+      const resolvedDefault = resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider,
+        defaultModel,
+      });
+      const pickerCatalog: ModelPickerCatalogEntry[] = (() => {
+        const keys = new Set<string>();
+        const out: ModelPickerCatalogEntry[] = [];
+
+        const push = (entry: ModelPickerCatalogEntry) => {
+          const provider = normalizeProviderId(entry.provider);
+          const id = String(entry.id ?? "").trim();
+          if (!provider || !id) return;
+          const key = modelKey(provider, id);
+          if (keys.has(key)) return;
+          keys.add(key);
+          out.push({ provider, id, name: entry.name });
+        };
+
+        for (const entry of allowedModelCatalog) push(entry);
+
+        for (const rawKey of Object.keys(
+          params.cfg.agents?.defaults?.models ?? {},
+        )) {
+          const resolved = resolveModelRefFromString({
+            raw: String(rawKey),
+            defaultProvider,
+            aliasIndex,
+          });
+          if (!resolved) continue;
+          push({
+            provider: resolved.ref.provider,
+            id: resolved.ref.model,
+            name: resolved.ref.model,
+          });
+        }
+        if (resolvedDefault.model) {
+          push({
+            provider: resolvedDefault.provider,
+            id: resolvedDefault.model,
+            name: resolvedDefault.model,
+          });
+        }
+        return out;
+      })();
+
+      const items = buildModelPickerItems(pickerCatalog);
+      const index = Number.parseInt(raw, 10) - 1;
+      const item = Number.isFinite(index) ? items[index] : undefined;
+      if (!item) {
+        return {
+          text: `Invalid model selection "${raw}". Use /model to list.`,
+        };
+      }
+      const picked = pickProviderForModel({
+        item,
+        preferredProvider: params.provider,
+      });
+      if (!picked) {
+        return {
+          text: `Invalid model selection "${raw}". Use /model to list.`,
+        };
+      }
+      const key = `${picked.provider}/${picked.model}`;
+      const aliases = aliasIndex.byKey.get(key);
+      const alias = aliases && aliases.length > 0 ? aliases[0] : undefined;
+      modelSelection = {
+        provider: picked.provider,
+        model: picked.model,
+        isDefault:
+          picked.provider === defaultProvider && picked.model === defaultModel,
+        ...(alias ? { alias } : {}),
+      };
+    } else {
+      const resolved = resolveModelDirectiveSelection({
+        raw,
+        defaultProvider,
+        defaultModel,
+        aliasIndex,
+        allowedModelKeys,
+      });
+      if (resolved.error) {
+        return { text: resolved.error };
+      }
+      modelSelection = resolved.selection;
+    }
+    if (modelSelection && directives.rawModelProfile) {
+      const profileResolved = resolveProfileOverride({
+        rawProfile: directives.rawModelProfile,
+        provider: modelSelection.provider,
+        cfg: params.cfg,
+        agentDir,
+      });
+      if (profileResolved.error) {
+        return { text: profileResolved.error };
+      }
+      profileOverride = profileResolved.profileId;
+    }
+  }
+  if (directives.rawModelProfile && !modelSelection) {
+    return { text: "Auth profile override requires a model selection." };
+  }
+
+  const resolvedProvider = modelSelection?.provider ?? provider;
+  const resolvedModel = modelSelection?.model ?? model;
+
   if (directives.hasThinkDirective && !directives.thinkLevel) {
     // If no argument was provided, show the current level
     if (!directives.rawThinkLevel) {
@@ -950,12 +1067,12 @@ export async function handleDirectiveOnly(params: {
       return {
         text: withOptions(
           `Current thinking level: ${level}.`,
-          "off, minimal, low, medium, high",
+          formatThinkingLevels(resolvedProvider, resolvedModel),
         ),
       };
     }
     return {
-      text: `Unrecognized thinking level "${directives.rawThinkLevel}". Valid levels: off, minimal, low, medium, high.`,
+      text: `Unrecognized thinking level "${directives.rawThinkLevel}". Valid levels: ${formatThinkingLevels(resolvedProvider, resolvedModel)}.`,
     };
   }
   if (directives.hasVerboseDirective && !directives.verboseLevel) {
@@ -1098,125 +1215,24 @@ export async function handleDirectiveOnly(params: {
     return { text: errors.join(" ") };
   }
 
-  let modelSelection: ModelDirectiveSelection | undefined;
-  let profileOverride: string | undefined;
-  if (directives.hasModelDirective && directives.rawModelDirective) {
-    const raw = directives.rawModelDirective.trim();
-    if (/^[0-9]+$/.test(raw)) {
-      const resolvedDefault = resolveConfiguredModelRef({
-        cfg: params.cfg,
-        defaultProvider,
-        defaultModel,
-      });
-      const pickerCatalog: ModelPickerCatalogEntry[] = (() => {
-        const keys = new Set<string>();
-        const out: ModelPickerCatalogEntry[] = [];
-
-        const push = (entry: ModelPickerCatalogEntry) => {
-          const provider = normalizeProviderId(entry.provider);
-          const id = String(entry.id ?? "").trim();
-          if (!provider || !id) return;
-          const key = modelKey(provider, id);
-          if (keys.has(key)) return;
-          keys.add(key);
-          out.push({ provider, id, name: entry.name });
-        };
-
-        for (const entry of allowedModelCatalog) push(entry);
-
-        for (const rawKey of Object.keys(
-          params.cfg.agents?.defaults?.models ?? {},
-        )) {
-          const resolved = resolveModelRefFromString({
-            raw: String(rawKey),
-            defaultProvider,
-            aliasIndex,
-          });
-          if (!resolved) continue;
-          push({
-            provider: resolved.ref.provider,
-            id: resolved.ref.model,
-            name: resolved.ref.model,
-          });
-        }
-        if (resolvedDefault.model) {
-          push({
-            provider: resolvedDefault.provider,
-            id: resolvedDefault.model,
-            name: resolvedDefault.model,
-          });
-        }
-        return out;
-      })();
-
-      const items = buildModelPickerItems(pickerCatalog);
-      const index = Number.parseInt(raw, 10) - 1;
-      const item = Number.isFinite(index) ? items[index] : undefined;
-      if (!item) {
-        return {
-          text: `Invalid model selection "${raw}". Use /model to list.`,
-        };
-      }
-      const picked = pickProviderForModel({
-        item,
-        preferredProvider: params.provider,
-      });
-      if (!picked) {
-        return {
-          text: `Invalid model selection "${raw}". Use /model to list.`,
-        };
-      }
-      const key = `${picked.provider}/${picked.model}`;
-      const aliases = aliasIndex.byKey.get(key);
-      const alias = aliases && aliases.length > 0 ? aliases[0] : undefined;
-      modelSelection = {
-        provider: picked.provider,
-        model: picked.model,
-        isDefault:
-          picked.provider === defaultProvider && picked.model === defaultModel,
-        ...(alias ? { alias } : {}),
-      };
-    } else {
-      const resolved = resolveModelDirectiveSelection({
-        raw,
-        defaultProvider,
-        defaultModel,
-        aliasIndex,
-        allowedModelKeys,
-      });
-      if (resolved.error) {
-        return { text: resolved.error };
-      }
-      modelSelection = resolved.selection;
-    }
-    if (modelSelection) {
-      if (directives.rawModelProfile) {
-        const profileResolved = resolveProfileOverride({
-          rawProfile: directives.rawModelProfile,
-          provider: modelSelection.provider,
-          cfg: params.cfg,
-          agentDir,
-        });
-        if (profileResolved.error) {
-          return { text: profileResolved.error };
-        }
-        profileOverride = profileResolved.profileId;
-      }
-      const nextLabel = `${modelSelection.provider}/${modelSelection.model}`;
-      if (nextLabel !== initialModelLabel) {
-        enqueueSystemEvent(
-          formatModelSwitchEvent(nextLabel, modelSelection.alias),
-          {
-            sessionKey,
-            contextKey: `model:${nextLabel}`,
-          },
-        );
-      }
-    }
+  if (
+    directives.hasThinkDirective &&
+    directives.thinkLevel === "xhigh" &&
+    !supportsXHighThinking(resolvedProvider, resolvedModel)
+  ) {
+    return {
+      text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`,
+    };
   }
-  if (directives.rawModelProfile && !modelSelection) {
-    return { text: "Auth profile override requires a model selection." };
-  }
+
+  const nextThinkLevel = directives.hasThinkDirective
+    ? directives.thinkLevel
+    : (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+      currentThinkLevel;
+  const shouldDowngradeXHigh =
+    !directives.hasThinkDirective &&
+    nextThinkLevel === "xhigh" &&
+    !supportsXHighThinking(resolvedProvider, resolvedModel);
 
   if (sessionEntry && sessionStore && sessionKey) {
     const prevElevatedLevel =
@@ -1238,6 +1254,9 @@ export async function handleDirectiveOnly(params: {
     if (directives.hasThinkDirective && directives.thinkLevel) {
       if (directives.thinkLevel === "off") delete sessionEntry.thinkingLevel;
       else sessionEntry.thinkingLevel = directives.thinkLevel;
+    }
+    if (shouldDowngradeXHigh) {
+      sessionEntry.thinkingLevel = "high";
     }
     if (directives.hasVerboseDirective && directives.verboseLevel) {
       applyVerboseOverride(sessionEntry, directives.verboseLevel);
@@ -1295,6 +1314,18 @@ export async function handleDirectiveOnly(params: {
     if (storePath) {
       await saveSessionStore(storePath, sessionStore);
     }
+    if (modelSelection) {
+      const nextLabel = `${modelSelection.provider}/${modelSelection.model}`;
+      if (nextLabel !== initialModelLabel) {
+        enqueueSystemEvent(
+          formatModelSwitchEvent(nextLabel, modelSelection.alias),
+          {
+            sessionKey,
+            contextKey: `model:${nextLabel}`,
+          },
+        );
+      }
+    }
     if (elevatedChanged) {
       const nextElevated = (sessionEntry.elevatedLevel ??
         "off") as ElevatedLevel;
@@ -1344,6 +1375,11 @@ export async function handleDirectiveOnly(params: {
         : formatDirectiveAck("Elevated mode enabled."),
     );
     if (shouldHintDirectRuntime) parts.push(formatElevatedRuntimeHint());
+  }
+  if (shouldDowngradeXHigh) {
+    parts.push(
+      `Thinking level set to high (xhigh not supported for ${resolvedProvider}/${resolvedModel}).`,
+    );
   }
   if (modelSelection) {
     const label = `${modelSelection.provider}/${modelSelection.model}`;

--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -1227,8 +1227,8 @@ export async function handleDirectiveOnly(params: {
 
   const nextThinkLevel = directives.hasThinkDirective
     ? directives.thinkLevel
-    : (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
-      currentThinkLevel;
+    : ((sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+      currentThinkLevel);
   const shouldDowngradeXHigh =
     !directives.hasThinkDirective &&
     nextThinkLevel === "xhigh" &&

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -1,9 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { normalizeReasoningLevel, normalizeThinkLevel } from "./thinking.js";
+import {
+  listThinkingLevels,
+  normalizeReasoningLevel,
+  normalizeThinkLevel,
+} from "./thinking.js";
 
 describe("normalizeThinkLevel", () => {
   it("accepts mid as medium", () => {
     expect(normalizeThinkLevel("mid")).toBe("medium");
+  });
+
+  it("accepts xhigh", () => {
+    expect(normalizeThinkLevel("xhigh")).toBe("xhigh");
+  });
+});
+
+describe("listThinkingLevels", () => {
+  it("includes xhigh for codex models", () => {
+    expect(listThinkingLevels(undefined, "gpt-5.2-codex")).toContain("xhigh");
+  });
+
+  it("includes xhigh for openai gpt-5.2", () => {
+    expect(listThinkingLevels("openai", "gpt-5.2")).toContain("xhigh");
+  });
+
+  it("excludes xhigh for non-codex models", () => {
+    expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain(
+      "xhigh",
+    );
   });
 });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -89,11 +89,11 @@ export function formatThinkingLevels(
 }
 
 export function formatXHighModelHint(): string {
-  if (XHIGH_MODEL_REFS.length === 1) return XHIGH_MODEL_REFS[0];
-  if (XHIGH_MODEL_REFS.length === 2) {
-    return `${XHIGH_MODEL_REFS[0]} or ${XHIGH_MODEL_REFS[1]}`;
-  }
-  return `${XHIGH_MODEL_REFS.slice(0, -1).join(", ")} or ${XHIGH_MODEL_REFS[XHIGH_MODEL_REFS.length - 1]}`;
+  const refs = [...XHIGH_MODEL_REFS] as string[];
+  if (refs.length === 0) return "unknown model";
+  if (refs.length === 1) return refs[0];
+  if (refs.length === 2) return `${refs[0]} or ${refs[1]}`;
+  return `${refs.slice(0, -1).join(", ")} or ${refs[refs.length - 1]}`;
 }
 
 // Normalize verbose flags used to toggle agent verbosity.

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,8 +1,29 @@
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high";
+export type ThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 export type VerboseLevel = "off" | "on";
 export type ElevatedLevel = "off" | "on";
 export type ReasoningLevel = "off" | "on" | "stream";
 export type UsageDisplayLevel = "off" | "on";
+
+export const XHIGH_MODEL_REFS = [
+  "openai/gpt-5.2",
+  "openai-codex/gpt-5.2-codex",
+  "openai-codex/gpt-5.1-codex",
+] as const;
+
+const XHIGH_MODEL_SET = new Set(
+  XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()),
+);
+const XHIGH_MODEL_IDS = new Set(
+  XHIGH_MODEL_REFS.map((entry) => entry.split("/")[1]?.toLowerCase()).filter(
+    (entry): entry is string => Boolean(entry),
+  ),
+);
 
 // Normalize user-provided thinking level strings to the canonical enum.
 export function normalizeThinkLevel(
@@ -32,8 +53,47 @@ export function normalizeThinkLevel(
     ].includes(key)
   )
     return "high";
+  if (["xhigh", "x-high", "x_high"].includes(key)) return "xhigh";
   if (["think"].includes(key)) return "minimal";
   return undefined;
+}
+
+export function supportsXHighThinking(
+  provider?: string | null,
+  model?: string | null,
+): boolean {
+  const modelKey = model?.trim().toLowerCase();
+  if (!modelKey) return false;
+  const providerKey = provider?.trim().toLowerCase();
+  if (providerKey) {
+    return XHIGH_MODEL_SET.has(`${providerKey}/${modelKey}`);
+  }
+  return XHIGH_MODEL_IDS.has(modelKey);
+}
+
+export function listThinkingLevels(
+  provider?: string | null,
+  model?: string | null,
+): ThinkLevel[] {
+  const levels: ThinkLevel[] = ["off", "minimal", "low", "medium", "high"];
+  if (supportsXHighThinking(provider, model)) levels.push("xhigh");
+  return levels;
+}
+
+export function formatThinkingLevels(
+  provider?: string | null,
+  model?: string | null,
+  separator = ", ",
+): string {
+  return listThinkingLevels(provider, model).join(separator);
+}
+
+export function formatXHighModelHint(): string {
+  if (XHIGH_MODEL_REFS.length === 1) return XHIGH_MODEL_REFS[0];
+  if (XHIGH_MODEL_REFS.length === 2) {
+    return `${XHIGH_MODEL_REFS[0]} or ${XHIGH_MODEL_REFS[1]}`;
+  }
+  return `${XHIGH_MODEL_REFS.slice(0, -1).join(", ")} or ${XHIGH_MODEL_REFS[XHIGH_MODEL_REFS.length - 1]}`;
 }
 
 // Normalize verbose flags used to toggle agent verbosity.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1620,7 +1620,7 @@ export type AgentDefaultsConfig = {
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
-  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high";
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on";
   /** Default elevated level when no /elevated directive is present. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1242,6 +1242,7 @@ const AgentDefaultsSchema = z
         z.literal("low"),
         z.literal("medium"),
         z.literal("high"),
+        z.literal("xhigh"),
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on")]).optional(),

--- a/src/cron/isolated-agent.ts
+++ b/src/cron/isolated-agent.ts
@@ -31,7 +31,11 @@ import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
-import { normalizeThinkLevel } from "../auto-reply/thinking.js";
+import {
+  formatXHighModelHint,
+  normalizeThinkLevel,
+  supportsXHighThinking,
+} from "../auto-reply/thinking.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import {
@@ -365,6 +369,11 @@ export async function runCronIsolatedAgentTurn(params: {
       model,
       catalog: await loadCatalog(),
     });
+  }
+  if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+    throw new Error(
+      `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`,
+    );
   }
 
   const timeoutMs = resolveAgentTimeoutMs({

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -1,6 +1,9 @@
 import type { SlashCommand } from "@mariozechner/pi-tui";
+import {
+  formatThinkingLevels,
+  listThinkingLevels,
+} from "../auto-reply/thinking.js";
 
-const THINK_LEVELS = ["off", "minimal", "low", "medium", "high"];
 const VERBOSE_LEVELS = ["on", "off"];
 const REASONING_LEVELS = ["on", "off"];
 const ELEVATED_LEVELS = ["on", "off"];
@@ -10,6 +13,11 @@ const TOGGLE = ["on", "off"];
 export type ParsedCommand = {
   name: string;
   args: string;
+};
+
+export type SlashCommandOptions = {
+  provider?: string;
+  model?: string;
 };
 
 const COMMAND_ALIASES: Record<string, string> = {
@@ -27,7 +35,10 @@ export function parseCommand(input: string): ParsedCommand {
   };
 }
 
-export function getSlashCommands(): SlashCommand[] {
+export function getSlashCommands(
+  options: SlashCommandOptions = {},
+): SlashCommand[] {
+  const thinkLevels = listThinkingLevels(options.provider, options.model);
   return [
     { name: "help", description: "Show slash command help" },
     { name: "status", description: "Show gateway status summary" },
@@ -44,9 +55,9 @@ export function getSlashCommands(): SlashCommand[] {
       name: "think",
       description: "Set thinking level",
       getArgumentCompletions: (prefix) =>
-        THINK_LEVELS.filter((v) => v.startsWith(prefix.toLowerCase())).map(
-          (value) => ({ value, label: value }),
-        ),
+        thinkLevels
+          .filter((v) => v.startsWith(prefix.toLowerCase()))
+          .map((value) => ({ value, label: value })),
     },
     {
       name: "verbose",
@@ -105,7 +116,12 @@ export function getSlashCommands(): SlashCommand[] {
   ];
 }
 
-export function helpText(): string {
+export function helpText(options: SlashCommandOptions = {}): string {
+  const thinkLevels = formatThinkingLevels(
+    options.provider,
+    options.model,
+    "|",
+  );
   return [
     "Slash commands:",
     "/help",
@@ -113,7 +129,7 @@ export function helpText(): string {
     "/agent <id> (or /agents)",
     "/session <key> (or /sessions)",
     "/model <provider/model> (or /models)",
-    "/think <off|minimal|low|medium|high>",
+    `/think <${thinkLevels}>`,
     "/verbose <on|off>",
     "/reasoning <on|off>",
     "/cost <on|off>",


### PR DESCRIPTION
## Summary
- Gate xhigh thinking level to codex models (gpt-5.2-codex, gpt-5.1-codex) and hide it elsewhere.
- Show thinking level help/completions based on the current model in CLI/TUI/inline.
- Update tests for xhigh gating.

## Testing
- pnpm lint
- pnpm test (2 live tests skipped by suite)

## AI-assisted
- AI-assisted: yes.
- Prompts (summary): add xhigh as /thinking level for codex models only; hide from non-codex usage/errors; update CLI/TUI/inline guidance.
- I understand the changes in this PR.
