### PR TITLE
UI: improve skill install feedback

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -57,6 +57,7 @@ import {
   saveSkillApiKey,
   updateSkillEdit,
   updateSkillEnabled,
+  type SkillMessage,
 } from "./controllers/skills";
 import { loadNodes } from "./controllers/nodes";
 import { loadChatHistory } from "./controllers/chat";
@@ -162,6 +163,7 @@ export type AppViewState = {
   skillsError: string | null;
   skillsFilter: string;
   skillEdits: Record<string, string>;
+  skillMessages: Record<string, SkillMessage>;
   skillsBusyKey: string | null;
   debugLoading: boolean;
   debugStatus: StatusSummary | null;
@@ -377,6 +379,7 @@ export function renderApp(state: AppViewState) {
               error: state.skillsError,
               filter: state.skillsFilter,
               edits: state.skillEdits,
+              messages: state.skillMessages,
               busyKey: state.skillsBusyKey,
               onFilterChange: (next) => (state.skillsFilter = next),
               onRefresh: () => loadSkills(state),

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -75,6 +75,7 @@ import {
 } from "./controllers/cron";
 import {
   loadSkills,
+  type SkillMessage,
 } from "./controllers/skills";
 import { loadDebug } from "./controllers/debug";
 
@@ -332,6 +333,7 @@ export class ClawdbotApp extends LitElement {
   @state() skillsFilter = "";
   @state() skillEdits: Record<string, string> = {};
   @state() skillsBusyKey: string | null = null;
+  @state() skillMessages: Record<string, SkillMessage> = {};
 
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 
 import { clampText } from "../format";
 import type { SkillStatusEntry, SkillStatusReport } from "../types";
+import type { SkillMessageMap } from "../controllers/skills";
 
 export type SkillsProps = {
   loading: boolean;
@@ -10,6 +11,7 @@ export type SkillsProps = {
   filter: string;
   edits: Record<string, string>;
   busyKey: string | null;
+  messages: SkillMessageMap;
   onFilterChange: (next: string) => void;
   onRefresh: () => void;
   onToggle: (skillKey: string, enabled: boolean) => void;
@@ -73,6 +75,10 @@ export function renderSkills(props: SkillsProps) {
 function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
   const busy = props.busyKey === skill.skillKey || props.busyKey === skill.name;
   const apiKey = props.edits[skill.skillKey] ?? "";
+  const message =
+    props.messages[skill.skillKey] ?? props.messages[skill.name] ?? null;
+  const canInstall =
+    skill.install.length > 0 && skill.missing.bins.length > 0;
   const missing = [
     ...skill.missing.bins.map((b) => `bin:${b}`),
     ...skill.missing.env.map((e) => `env:${e}`),
@@ -120,16 +126,28 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
           >
             ${skill.disabled ? "Enable" : "Disable"}
           </button>
-          ${skill.install.length > 0
+          ${canInstall
             ? html`<button
                 class="btn"
                 ?disabled=${busy}
                 @click=${() => props.onInstall(skill.name, skill.install[0].id)}
               >
-                ${skill.install[0].label}
+                ${busy ? "Installing…" : skill.install[0].label}
               </button>`
             : nothing}
         </div>
+        ${message
+          ? html`<div
+              class="muted"
+              style="margin-top: 8px; color: ${
+                message.kind === "error"
+                  ? "var(--danger-color, #d14343)"
+                  : "var(--success-color, #0a7f5a)"
+              };"
+            >
+              ${message.message}
+            </div>`
+          : nothing}
         ${skill.primaryEnv
           ? html`
               <div class="field" style="margin-top: 10px;">


### PR DESCRIPTION
## Description

Clawdbot’s Control UI didn’t show any feedback when installing skills, so buttons looked broken and stayed enabled after success. This PR makes the install flow transparent.

## Change Summary
 - show “Installing…” while a skill install request is running
 - display per-skill success/error messages under the buttons
 - hide install buttons once required binaries are present so only Enable/Disable remain

 ## Testing
 - bun run lint
 - bun run ui:build
 - bun run test  ✅

 ## Notes
 - AI-assisted (Codex) with manual review; I understand the changes.
 
 
<img width="2175" height="154" alt="Screenshot 2026-01-07 at 9 35 18 PM" src="https://github.com/user-attachments/assets/9f90fcbe-28c4-4306-8ac6-73c119e16e45" />

<img width="2179" height="117" alt="Screenshot 2026-01-07 at 9 35 45 PM" src="https://github.com/user-attachments/assets/e50d1f70-a8af-4a1a-92f8-8ede52eb14f8" />
