### PR TITLE
fix(typing): refresh TTL on every startTypingLoop call

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -102,11 +102,13 @@ export function createTypingController(params: {
   const startTypingLoop = async () => {
     if (sealed) return;
     if (runComplete) return;
+    // Always refresh TTL when called, even if loop already running.
+    // This keeps typing alive during long tool executions.
+    refreshTypingTtl();
     if (!onReplyStart) return;
     if (typingIntervalMs <= 0) return;
     if (typingTimer) return;
     await ensureStart();
-    refreshTypingTtl();
     typingTimer = setInterval(() => {
       void triggerTyping();
     }, typingIntervalMs);


### PR DESCRIPTION
## Summary

Fixes #447

Moves `refreshTypingTtl()` earlier in `startTypingLoop()` so the TTL is refreshed even when the typing loop is already running. This prevents the typing indicator from stopping prematurely during long tool executions.

## Changes

- `src/auto-reply/reply/typing.ts`: Move `refreshTypingTtl()` call to happen after `if (runComplete) return;` but before other guards

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm test -- src/auto-reply/reply/typing.test.ts` passes
- [ ] Manual testing with long-running tools

---

🤖 AI-assisted (Claude Code) - lightly tested locally