### PR TITLE
Docker: fix WhatsApp config typing in onboarding + add tests

### DIFF
--- a/src/commands/onboard-providers.test.ts
+++ b/src/commands/onboard-providers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import {
+  setWhatsAppAllowFrom,
+  setWhatsAppDmPolicy,
+  setWhatsAppSelfChatMode,
+} from "./onboard-providers.js";
+
+describe("onboard-providers WhatsApp setters", () => {
+  it("preserves existing WhatsApp fields when updating allowFrom", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        selfChatMode: true,
+        dmPolicy: "pairing",
+        allowFrom: ["*"],
+        accounts: {
+          default: { enabled: false },
+        },
+      },
+    };
+
+    const next = setWhatsAppAllowFrom(cfg, ["+15555550123"]);
+
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+    expect(next.whatsapp?.dmPolicy).toBe("pairing");
+    expect(next.whatsapp?.allowFrom).toEqual(["+15555550123"]);
+    expect(next.whatsapp?.accounts?.default?.enabled).toBe(false);
+  });
+
+  it("updates dmPolicy without dropping selfChatMode", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        selfChatMode: true,
+        dmPolicy: "pairing",
+      },
+    };
+
+    const next = setWhatsAppDmPolicy(cfg, "open");
+
+    expect(next.whatsapp?.dmPolicy).toBe("open");
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+  });
+
+  it("updates selfChatMode without dropping allowFrom", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        allowFrom: ["+15555550123"],
+      },
+    };
+
+    const next = setWhatsAppSelfChatMode(cfg, true);
+
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+    expect(next.whatsapp?.allowFrom).toEqual(["+15555550123"]);
+  });
+});

--- a/src/commands/onboard-providers.ts
+++ b/src/commands/onboard-providers.ts
@@ -1,15 +1,95 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ClawdbotConfig } from "../config/config.js";
-import type { DmPolicy } from "../config/types.js";
+import type { DmPolicy, WhatsAppConfig } from "../config/types.js";
+import {
+  listDiscordAccountIds,
+  resolveDefaultDiscordAccountId,
+  resolveDiscordAccount,
+} from "../discord/accounts.js";
+import {
+  listIMessageAccountIds,
+  resolveDefaultIMessageAccountId,
+  resolveIMessageAccount,
+} from "../imessage/accounts.js";
 import { loginWeb } from "../provider-web.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+} from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { normalizeE164 } from "../utils.js";
-import { WA_WEB_AUTH_DIR } from "../web/session.js";
+import {
+  listSignalAccountIds,
+  resolveDefaultSignalAccountId,
+  resolveSignalAccount,
+} from "../signal/accounts.js";
+import {
+  listSlackAccountIds,
+  resolveDefaultSlackAccountId,
+  resolveSlackAccount,
+} from "../slack/accounts.js";
+import {
+  listTelegramAccountIds,
+  resolveDefaultTelegramAccountId,
+  resolveTelegramAccount,
+} from "../telegram/accounts.js";
+import { formatTerminalLink, normalizeE164 } from "../utils.js";
+import {
+  listWhatsAppAccountIds,
+  resolveDefaultWhatsAppAccountId,
+  resolveWhatsAppAuthDir,
+} from "../web/accounts.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { detectBinary } from "./onboard-helpers.js";
 import type { ProviderChoice } from "./onboard-types.js";
 import { installSignalCli } from "./signal-install.js";
+
+const DOCS_BASE = "https://docs.clawd.bot";
+
+function docsLink(path: string, label?: string): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  const url = `${DOCS_BASE}${cleanPath}`;
+  return formatTerminalLink(label ?? url, url, { fallback: url });
+}
+
+async function promptAccountId(params: {
+  cfg: ClawdbotConfig;
+  prompter: WizardPrompter;
+  label: string;
+  currentId?: string;
+  listAccountIds: (cfg: ClawdbotConfig) => string[];
+  defaultAccountId: string;
+}): Promise<string> {
+  const existingIds = params.listAccountIds(params.cfg);
+  const initial =
+    params.currentId?.trim() || params.defaultAccountId || DEFAULT_ACCOUNT_ID;
+  const choice = (await params.prompter.select({
+    message: `${params.label} account`,
+    options: [
+      ...existingIds.map((id) => ({
+        value: id,
+        label: id === DEFAULT_ACCOUNT_ID ? "default (primary)" : id,
+      })),
+      { value: "__new__", label: "Add a new account" },
+    ],
+    initialValue: initial,
+  })) as string;
+
+  if (choice !== "__new__") return normalizeAccountId(choice);
+
+  const entered = await params.prompter.text({
+    message: `New ${params.label} account id`,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const normalized = normalizeAccountId(String(entered));
+  if (String(entered).trim() !== normalized) {
+    await params.prompter.note(
+      `Normalized account id to "${normalized}".`,
+      `${params.label} account`,
+    );
+  }
+  return normalized;
+}
 
 function addWildcardAllowFrom(
   allowFrom?: Array<string | number> | null,
@@ -28,8 +108,12 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
-async function detectWhatsAppLinked(): Promise<boolean> {
-  const credsPath = path.join(WA_WEB_AUTH_DIR, "creds.json");
+async function detectWhatsAppLinked(
+  cfg: ClawdbotConfig,
+  accountId: string,
+): Promise<boolean> {
+  const { authDir } = resolveWhatsAppAuthDir({ cfg, accountId });
+  const credsPath = path.join(authDir, "creds.json");
   return await pathExists(credsPath);
 }
 
@@ -39,14 +123,14 @@ async function noteProviderPrimer(prompter: WizardPrompter): Promise<void> {
       "DM security: default is pairing; unknown DMs get a pairing code.",
       "Approve with: clawdbot pairing approve --provider <provider> <code>",
       'Public DMs require dmPolicy="open" + allowFrom=["*"].',
+      `Docs: ${docsLink("/start/pairing", "start/pairing")}`,
       "",
-      "WhatsApp: links via WhatsApp Web (scan QR), stores creds for future sends.",
-      "WhatsApp: dedicated second number recommended; primary number OK (self-chat).",
-      "Telegram: Bot API (token from @BotFather), replies via your bot.",
-      "Discord: Bot token from Discord Developer Portal; invite bot to your server.",
-      "Slack: Socket Mode app token + bot token, DMs via App Home Messages tab.",
-      "Signal: signal-cli as a linked device; separate number recommended.",
-      "iMessage: local imsg CLI; separate Apple ID recommended only on a separate Mac.",
+      "Telegram: simplest way to get started — register a bot with @BotFather and get going.",
+      "WhatsApp: works with your own number; recommend a separate phone + eSIM.",
+      "Discord: very well supported right now.",
+      "Slack: supported (Socket Mode).",
+      'Signal: signal-cli linked device; more setup (David Reagans: "Hop on Discord.").',
+      "iMessage: this is still a work in progress.",
     ].join("\n"),
     "How providers work",
   );
@@ -59,6 +143,7 @@ async function noteTelegramTokenHelp(prompter: WizardPrompter): Promise<void> {
       "2) Run /newbot (or /mybots)",
       "3) Copy the token (looks like 123456:ABC...)",
       "Tip: you can also set TELEGRAM_BOT_TOKEN in your env.",
+      `Docs: ${docsLink("/telegram", "telegram")}`,
     ].join("\n"),
     "Telegram bot token",
   );
@@ -71,6 +156,7 @@ async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
       "2) Bot → Add Bot → Reset Token → copy token",
       "3) OAuth2 → URL Generator → scope 'bot' → invite to your server",
       "Tip: enable Message Content Intent if you need message text.",
+      `Docs: ${docsLink("/discord", "discord")}`,
     ].join("\n"),
     "Discord bot token",
   );
@@ -158,6 +244,7 @@ async function noteSlackTokenHelp(
       "4) Enable Event Subscriptions (socket) for message events",
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
+      `Docs: ${docsLink("/slack", "slack")}`,
       "",
       "Manifest (JSON):",
       manifest,
@@ -166,24 +253,53 @@ async function noteSlackTokenHelp(
   );
 }
 
-function setWhatsAppDmPolicy(cfg: ClawdbotConfig, dmPolicy?: DmPolicy) {
+export function mergeWhatsAppConfig(
+  cfg: ClawdbotConfig,
+  patch: Partial<WhatsAppConfig>,
+): ClawdbotConfig {
+  const base = cfg.whatsapp ?? {};
   return {
     ...cfg,
     whatsapp: {
-      ...cfg.whatsapp,
-      dmPolicy,
+      selfChatMode: base.selfChatMode,
+      ...base,
+      ...patch,
     },
   };
 }
 
-function setWhatsAppAllowFrom(cfg: ClawdbotConfig, allowFrom?: string[]) {
+export function setWhatsAppDmPolicy(
+  cfg: ClawdbotConfig,
+  dmPolicy: DmPolicy,
+): ClawdbotConfig {
+  return mergeWhatsAppConfig(cfg, { dmPolicy });
+}
+
+export function setWhatsAppAllowFrom(
+  cfg: ClawdbotConfig,
+  allowFrom?: string[],
+): ClawdbotConfig {
+  return mergeWhatsAppConfig(cfg, { allowFrom });
+}
+
+function setMessagesResponsePrefix(
+  cfg: ClawdbotConfig,
+  responsePrefix?: string,
+): ClawdbotConfig {
   return {
     ...cfg,
-    whatsapp: {
-      ...cfg.whatsapp,
-      allowFrom,
+    messages: {
+      ...cfg.messages,
+      responsePrefix,
     },
   };
+}
+
+export function setWhatsAppSelfChatMode(
+  cfg: ClawdbotConfig,
+  selfChatMode: boolean,
+): ClawdbotConfig {
+  return mergeWhatsAppConfig(cfg, { selfChatMode });
 }
 
 function setTelegramDmPolicy(cfg: ClawdbotConfig, dmPolicy: DmPolicy) {
@@ -298,6 +414,7 @@ async function maybeConfigureDmPolicies(params: {
         "Default: pairing (unknown DMs get a pairing code).",
         `Approve: clawdbot pairing approve --provider ${params.provider} <code>`,
         `Public DMs: ${params.policyKey}="open" + ${params.allowFromKey} includes "*".`,
+        `Docs: ${docsLink("/start/pairing", "start/pairing")}`,
       ].join("\n"),
       `${params.label} DM access`,
     );
@@ -373,6 +490,7 @@ async function promptWhatsAppAllowFrom(
   const existingAllowFrom = cfg.whatsapp?.allowFrom ?? [];
   const existingLabel =
     existingAllowFrom.length > 0 ? existingAllowFrom.join(", ") : "unset";
+  const existingResponsePrefix = cfg.messages?.responsePrefix;
 
   await prompter.note(
     [
@@ -383,9 +501,60 @@ async function promptWhatsAppAllowFrom(
       "- disabled: ignore WhatsApp DMs",
       "",
       `Current: dmPolicy=${existingPolicy}, allowFrom=${existingLabel}`,
+      `Docs: ${docsLink("/whatsapp", "whatsapp")}`,
     ].join("\n"),
     "WhatsApp DM access",
   );
+
+  const phoneMode = (await prompter.select({
+    message: "WhatsApp phone setup",
+    options: [
+      { value: "personal", label: "This is my personal phone number" },
+      { value: "separate", label: "Separate phone just for Clawdbot" },
+    ],
+  })) as "personal" | "separate";
+
+  if (phoneMode === "personal") {
+    const entry = await prompter.text({
+      message: "Your WhatsApp number (E.164)",
+      placeholder: "+15555550123",
+      initialValue: existingAllowFrom[0],
+      validate: (value) => {
+        const raw = String(value ?? "").trim();
+        if (!raw) return "Required";
+        const normalized = normalizeE164(raw);
+        if (!normalized) return `Invalid number: ${raw}`;
+        return undefined;
+      },
+    });
+    const normalized = normalizeE164(String(entry).trim());
+    const merged = [
+      ...existingAllowFrom
+        .filter((item) => item !== "*")
+        .map((item) => normalizeE164(item))
+        .filter(Boolean),
+      normalized,
+    ];
+    const unique = [...new Set(merged.filter(Boolean))];
+    let next = setWhatsAppSelfChatMode(cfg, true);
+    next = setWhatsAppDmPolicy(next, "allowlist");
+    next = setWhatsAppAllowFrom(next, unique);
+    if (existingResponsePrefix === undefined) {
+      next = setMessagesResponsePrefix(next, "[clawdbot]");
+    }
+    await prompter.note(
+      [
+        "Personal phone mode enabled.",
+        "- dmPolicy set to allowlist (pairing skipped)",
+        `- allowFrom includes ${normalized}`,
+        existingResponsePrefix === undefined
+          ? "- responsePrefix set to [clawdbot]"
+          : "- responsePrefix left unchanged",
+      ].join("\n"),
+      "WhatsApp personal phone",
+    );
+    return next;
+  }
 
   const policy = (await prompter.select({
     message: "WhatsApp DM policy",
@@ -397,8 +566,11 @@ async function promptWhatsAppAllowFrom(
     ],
   })) as DmPolicy;
 
-  const next = setWhatsAppDmPolicy(cfg, policy);
-  if (policy === "open") return setWhatsAppAllowFrom(next, ["*"]);
+  let next = setWhatsAppSelfChatMode(cfg, false);
+  next = setWhatsAppDmPolicy(next, policy);
+  if (policy === "open") {
+    next = setWhatsAppAllowFrom(next, ["*"]);
+  }
   if (policy === "disabled") return next;
 
   const options =
@@ -421,74 +593,104 @@ async function promptWhatsAppAllowFrom(
     options: options.map((opt) => ({ value: opt.value, label: opt.label })),
   })) as (typeof options)[number]["value"];
 
-  if (mode === "keep") return next;
-  if (mode === "unset") return setWhatsAppAllowFrom(next, undefined);
+  if (mode === "keep") {
+    // Keep allowFrom as-is.
+  } else if (mode === "unset") {
+    next = setWhatsAppAllowFrom(next, undefined);
+  } else {
+    const allowRaw = await prompter.text({
+      message: "Allowed sender numbers (comma-separated, E.164)",
+      placeholder: "+15555550123, +447700900123",
+      validate: (value) => {
+        const raw = String(value ?? "").trim();
+        if (!raw) return "Required";
+        const parts = raw
+          .split(/[\n,;]+/g)
+          .map((p) => p.trim())
+          .filter(Boolean);
+        if (parts.length === 0) return "Required";
+        for (const part of parts) {
+          if (part === "*") continue;
+          const normalized = normalizeE164(part);
+          if (!normalized) return `Invalid number: ${part}`;
+        }
+        return undefined;
+      },
+    });
 
-  const allowRaw = await prompter.text({
-    message: "Allowed sender numbers (comma-separated, E.164)",
-    placeholder: "+15555550123, +447700900123",
-    validate: (value) => {
-      const raw = String(value ?? "").trim();
-      if (!raw) return "Required";
-      const parts = raw
-        .split(/[\n,;]+/g)
-        .map((p) => p.trim())
-        .filter(Boolean);
-      if (parts.length === 0) return "Required";
-      for (const part of parts) {
-        if (part === "*") continue;
-        const normalized = normalizeE164(part);
-        if (!normalized) return `Invalid number: ${part}`;
-      }
-      return undefined;
-    },
-  });
+    const parts = String(allowRaw)
+      .split(/[\n,;]+/g)
+      .map((p) => p.trim())
+      .filter(Boolean);
+    const normalized = parts.map((part) =>
+      part === "*" ? "*" : normalizeE164(part),
+    );
+    const unique = [...new Set(normalized.filter(Boolean))];
+    next = setWhatsAppAllowFrom(next, unique);
+  }
 
-  const parts = String(allowRaw)
-    .split(/[\n,;]+/g)
-    .map((p) => p.trim())
-    .filter(Boolean);
-  const normalized = parts.map((part) =>
-    part === "*" ? "*" : normalizeE164(part),
-  );
-  const unique = [...new Set(normalized.filter(Boolean))];
-  return setWhatsAppAllowFrom(next, unique);
+  return next;
 }
+
+type SetupProvidersOptions = {
+  allowDisable?: boolean;
+  allowSignalInstall?: boolean;
+  onSelection?: (selection: ProviderChoice[]) => void;
+  accountIds?: Partial<Record<ProviderChoice, string>>;
+  onAccountId?: (provider: ProviderChoice, accountId: string) => void;
+  promptAccountIds?: boolean;
+  whatsappAccountId?: string;
+  promptWhatsAppAccountId?: boolean;
+  onWhatsAppAccountId?: (accountId: string) => void;
+};
 
 export async function setupProviders(
   cfg: ClawdbotConfig,
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
-  options?: { allowDisable?: boolean; allowSignalInstall?: boolean },
+  options?: SetupProvidersOptions,
 ): Promise<ClawdbotConfig> {
-  const whatsappLinked = await detectWhatsAppLinked();
+  let whatsappAccountId =
+    options?.whatsappAccountId?.trim() || resolveDefaultWhatsAppAccountId(cfg);
+  let whatsappLinked = await detectWhatsAppLinked(cfg, whatsappAccountId);
   const telegramEnv = Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim());
   const discordEnv = Boolean(process.env.DISCORD_BOT_TOKEN?.trim());
   const slackBotEnv = Boolean(process.env.SLACK_BOT_TOKEN?.trim());
   const slackAppEnv = Boolean(process.env.SLACK_APP_TOKEN?.trim());
-  const telegramConfigured = Boolean(
-    telegramEnv || cfg.telegram?.botToken || cfg.telegram?.tokenFile,
+  const telegramConfigured = listTelegramAccountIds(cfg).some((accountId) =>
+    Boolean(resolveTelegramAccount({ cfg, accountId }).token),
   );
-  const discordConfigured = Boolean(discordEnv || cfg.discord?.token);
-  const slackConfigured = Boolean(
-    (slackBotEnv && slackAppEnv) ||
-      (cfg.slack?.botToken && cfg.slack?.appToken),
+  const discordConfigured = listDiscordAccountIds(cfg).some((accountId) =>
+    Boolean(resolveDiscordAccount({ cfg, accountId }).token),
   );
-  const signalConfigured = Boolean(
-    cfg.signal?.account || cfg.signal?.httpUrl || cfg.signal?.httpPort,
+  const slackConfigured = listSlackAccountIds(cfg).some((accountId) => {
+    const account = resolveSlackAccount({ cfg, accountId });
+    return Boolean(account.botToken && account.appToken);
+  });
+  const signalConfigured = listSignalAccountIds(cfg).some(
+    (accountId) => resolveSignalAccount({ cfg, accountId }).configured,
   );
   const signalCliPath = cfg.signal?.cliPath ?? "signal-cli";
   const signalCliDetected = await detectBinary(signalCliPath);
-  const imessageConfigured = Boolean(
-    cfg.imessage?.cliPath || cfg.imessage?.dbPath || cfg.imessage?.allowFrom,
-  );
+  const imessageConfigured = listIMessageAccountIds(cfg).some((accountId) => {
+    const account = resolveIMessageAccount({ cfg, accountId });
+    return Boolean(
+      account.config.cliPath ||
+        account.config.dbPath ||
+        account.config.allowFrom ||
+        account.config.service ||
+        account.config.region,
+    );
+  });
   const imessageCliPath = cfg.imessage?.cliPath ?? "imsg";
   const imessageCliDetected = await detectBinary(imessageCliPath);
 
+  const waAccountLabel =
+    whatsappAccountId === DEFAULT_ACCOUNT_ID ? "default" : whatsappAccountId;
   await prompter.note(
     [
-      `WhatsApp: ${whatsappLinked ? "linked" : "not linked"}`,
       `Telegram: ${telegramConfigured ? "configured" : "needs token"}`,
+      `WhatsApp (${waAccountLabel}): ${whatsappLinked ? "linked" : "not linked"}`,
       `Discord: ${discordConfigured ? "configured" : "needs token"}`,
       `Slack: ${slackConfigured ? "configured" : "needs tokens"}`,
       `Signal: ${signalConfigured ? "configured" : "needs setup"}`,
@@ -511,14 +713,16 @@ export async function setupProviders(
     message: "Select providers",
     options: [
       {
+        value: "telegram",
+        label: "Telegram (Bot API)",
+        hint: telegramConfigured
+          ? "recommended · configured"
+          : "recommended · newcomer-friendly",
+      },
+      {
         value: "whatsapp",
         label: "WhatsApp (QR link)",
         hint: whatsappLinked ? "linked" : "not linked",
-      },
-      {
-        value: "telegram",
-        label: "Telegram (Bot API)",
-        hint: telegramConfigured ? "configured" : "needs token",
       },
       {
         value: "discord",
@@ -543,14 +747,84 @@ export async function setupProviders(
     ],
   })) as ProviderChoice[];
 
+  options?.onSelection?.(selection);
+  const accountOverrides: Partial<Record<ProviderChoice, string>> = {
+    ...options?.accountIds,
+  };
+  if (options?.whatsappAccountId?.trim()) {
+    accountOverrides.whatsapp = options.whatsappAccountId.trim();
+  }
+  const recordAccount = (provider: ProviderChoice, accountId: string) => {
+    options?.onAccountId?.(provider, accountId);
+    if (provider === "whatsapp") {
+      options?.onWhatsAppAccountId?.(accountId);
+    }
+  };
+
+  const selectionNotes: Record<ProviderChoice, string> = {
+    telegram: `Telegram — simplest way to get started: register a bot with @BotFather and get going. Docs: ${docsLink("/telegram", "telegram")}`,
+    whatsapp: `WhatsApp — works with your own number; recommend a separate phone + eSIM. Docs: ${docsLink("/whatsapp", "whatsapp")}`,
+    discord: `Discord — very well supported right now. Docs: ${docsLink("/discord", "discord")}`,
+    slack: `Slack — supported (Socket Mode). Docs: ${docsLink("/slack", "slack")}`,
+    signal: `Signal — signal-cli linked device; more setup (David Reagans: "Hop on Discord."). Docs: ${docsLink("/signal", "signal")}`,
+    imessage: `iMessage — this is still a work in progress. Docs: ${docsLink("/imessage", "imessage")}`,
+  };
+  const selectedLines = selection
+    .map((provider) => selectionNotes[provider])
+    .filter(Boolean);
+  if (selectedLines.length > 0) {
+    await prompter.note(selectedLines.join("\n"), "Selected providers");
+  }
+
+  const shouldPromptAccountIds = options?.promptAccountIds === true;
+
   let next = cfg;
 
   if (selection.includes("whatsapp")) {
+    const overrideId = accountOverrides.whatsapp?.trim();
+    if (overrideId) {
+      whatsappAccountId = normalizeAccountId(overrideId);
+    } else if (shouldPromptAccountIds || options?.promptWhatsAppAccountId) {
+      whatsappAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "WhatsApp",
+        currentId: whatsappAccountId,
+        listAccountIds: listWhatsAppAccountIds,
+        defaultAccountId: resolveDefaultWhatsAppAccountId(next),
+      });
+    }
+
+    if (whatsappAccountId !== DEFAULT_ACCOUNT_ID) {
+      next = {
+        ...next,
+        whatsapp: {
+          ...next.whatsapp,
+          accounts: {
+            ...next.whatsapp?.accounts,
+            [whatsappAccountId]: {
+              ...next.whatsapp?.accounts?.[whatsappAccountId],
+              enabled:
+                next.whatsapp?.accounts?.[whatsappAccountId]?.enabled ?? true,
+            },
+          },
+        },
+      };
+    }
+
+    recordAccount("whatsapp", whatsappAccountId);
+    whatsappLinked = await detectWhatsAppLinked(next, whatsappAccountId);
+    const { authDir } = resolveWhatsAppAuthDir({
+      cfg: next,
+      accountId: whatsappAccountId,
+    });
+
     if (!whatsappLinked) {
       await prompter.note(
         [
           "Scan the QR with WhatsApp on your phone.",
-          `Credentials are stored under ${WA_WEB_AUTH_DIR}/ for future runs.`,
+          `Credentials are stored under ${authDir}/ for future runs.`,
+          `Docs: ${docsLink("/whatsapp", "whatsapp")}`,
         ].join("\n"),
         "WhatsApp linking",
       );
@@ -563,9 +837,13 @@ export async function setupProviders(
     });
     if (wantsLink) {
       try {
-        await loginWeb(false, "web");
+        await loginWeb(false, "web", undefined, runtime, whatsappAccountId);
       } catch (err) {
         runtime.error(`WhatsApp login failed: ${String(err)}`);
+        await prompter.note(
+          `Docs: ${docsLink("/whatsapp", "whatsapp")}`,
+          "WhatsApp help",
+        );
       }
     } else if (!whatsappLinked) {
       await prompter.note(
@@ -578,11 +856,39 @@ export async function setupProviders(
   }
 
   if (selection.includes("telegram")) {
+    const telegramOverride = accountOverrides.telegram?.trim();
+    const defaultTelegramAccountId = resolveDefaultTelegramAccountId(next);
+    let telegramAccountId = telegramOverride
+      ? normalizeAccountId(telegramOverride)
+      : defaultTelegramAccountId;
+    if (shouldPromptAccountIds && !telegramOverride) {
+      telegramAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "Telegram",
+        currentId: telegramAccountId,
+        listAccountIds: listTelegramAccountIds,
+        defaultAccountId: defaultTelegramAccountId,
+      });
+    }
+    recordAccount("telegram", telegramAccountId);
+
+    const resolvedAccount = resolveTelegramAccount({
+      cfg: next,
+      accountId: telegramAccountId,
+    });
+    const accountConfigured = Boolean(resolvedAccount.token);
+    const allowEnv = telegramAccountId === DEFAULT_ACCOUNT_ID;
+    const canUseEnv = allowEnv && telegramEnv;
+    const hasConfigToken = Boolean(
+      resolvedAccount.config.botToken || resolvedAccount.config.tokenFile,
+    );
+
     let token: string | null = null;
-    if (!telegramConfigured) {
+    if (!accountConfigured) {
       await noteTelegramTokenHelp(prompter);
     }
-    if (telegramEnv && !cfg.telegram?.botToken) {
+    if (canUseEnv && !resolvedAccount.config.botToken) {
       const keepEnv = await prompter.confirm({
         message: "TELEGRAM_BOT_TOKEN detected. Use env var?",
         initialValue: true,
@@ -603,7 +909,7 @@ export async function setupProviders(
           }),
         ).trim();
       }
-    } else if (cfg.telegram?.botToken) {
+    } else if (hasConfigToken) {
       const keep = await prompter.confirm({
         message: "Telegram token already configured. Keep it?",
         initialValue: true,
@@ -626,23 +932,68 @@ export async function setupProviders(
     }
 
     if (token) {
-      next = {
-        ...next,
-        telegram: {
-          ...next.telegram,
-          enabled: true,
-          botToken: token,
-        },
-      };
+      if (telegramAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          telegram: {
+            ...next.telegram,
+            enabled: true,
+            botToken: token,
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          telegram: {
+            ...next.telegram,
+            enabled: true,
+            accounts: {
+              ...next.telegram?.accounts,
+              [telegramAccountId]: {
+                ...next.telegram?.accounts?.[telegramAccountId],
+                enabled:
+                  next.telegram?.accounts?.[telegramAccountId]?.enabled ?? true,
+                botToken: token,
+              },
+            },
+          },
+        };
+      }
     }
   }
 
   if (selection.includes("discord")) {
+    const discordOverride = accountOverrides.discord?.trim();
+    const defaultDiscordAccountId = resolveDefaultDiscordAccountId(next);
+    let discordAccountId = discordOverride
+      ? normalizeAccountId(discordOverride)
+      : defaultDiscordAccountId;
+    if (shouldPromptAccountIds && !discordOverride) {
+      discordAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "Discord",
+        currentId: discordAccountId,
+        listAccountIds: listDiscordAccountIds,
+        defaultAccountId: defaultDiscordAccountId,
+      });
+    }
+    recordAccount("discord", discordAccountId);
+
+    const resolvedAccount = resolveDiscordAccount({
+      cfg: next,
+      accountId: discordAccountId,
+    });
+    const accountConfigured = Boolean(resolvedAccount.token);
+    const allowEnv = discordAccountId === DEFAULT_ACCOUNT_ID;
+    const canUseEnv = allowEnv && discordEnv;
+    const hasConfigToken = Boolean(resolvedAccount.config.token);
+
     let token: string | null = null;
-    if (!discordConfigured) {
+    if (!accountConfigured) {
       await noteDiscordTokenHelp(prompter);
     }
-    if (discordEnv && !cfg.discord?.token) {
+    if (canUseEnv && !resolvedAccount.config.token) {
       const keepEnv = await prompter.confirm({
         message: "DISCORD_BOT_TOKEN detected. Use env var?",
         initialValue: true,
@@ -663,7 +1014,7 @@ export async function setupProviders(
           }),
         ).trim();
       }
-    } else if (cfg.discord?.token) {
+    } else if (hasConfigToken) {
       const keep = await prompter.confirm({
         message: "Discord token already configured. Keep it?",
         initialValue: true,
@@ -686,18 +1037,67 @@ export async function setupProviders(
     }
 
     if (token) {
-      next = {
-        ...next,
-        discord: {
-          ...next.discord,
-          enabled: true,
-          token,
-        },
-      };
+      if (discordAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          discord: {
+            ...next.discord,
+            enabled: true,
+            token,
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          discord: {
+            ...next.discord,
+            enabled: true,
+            accounts: {
+              ...next.discord?.accounts,
+              [discordAccountId]: {
+                ...next.discord?.accounts?.[discordAccountId],
+                enabled:
+                  next.discord?.accounts?.[discordAccountId]?.enabled ?? true,
+                token,
+              },
+            },
+          },
+        };
+      }
     }
   }
 
   if (selection.includes("slack")) {
+    const slackOverride = accountOverrides.slack?.trim();
+    const defaultSlackAccountId = resolveDefaultSlackAccountId(next);
+    let slackAccountId = slackOverride
+      ? normalizeAccountId(slackOverride)
+      : defaultSlackAccountId;
+    if (shouldPromptAccountIds && !slackOverride) {
+      slackAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "Slack",
+        currentId: slackAccountId,
+        listAccountIds: listSlackAccountIds,
+        defaultAccountId: defaultSlackAccountId,
+      });
+    }
+    recordAccount("slack", slackAccountId);
+
+    const resolvedAccount = resolveSlackAccount({
+      cfg: next,
+      accountId: slackAccountId,
+    });
+    const accountConfigured = Boolean(
+      resolvedAccount.botToken && resolvedAccount.appToken,
+    );
+    const allowEnv = slackAccountId === DEFAULT_ACCOUNT_ID;
+    const canUseEnv = allowEnv && slackBotEnv && slackAppEnv;
+    const hasConfigTokens = Boolean(
+      resolvedAccount.config.botToken && resolvedAccount.config.appToken,
+    );
+
     let botToken: string | null = null;
     let appToken: string | null = null;
     const slackBotName = String(
@@ -706,13 +1106,12 @@ export async function setupProviders(
         initialValue: "Clawdbot",
       }),
     ).trim();
-    if (!slackConfigured) {
+    if (!accountConfigured) {
       await noteSlackTokenHelp(prompter, slackBotName);
     }
     if (
-      slackBotEnv &&
-      slackAppEnv &&
-      (!cfg.slack?.botToken || !cfg.slack?.appToken)
+      canUseEnv &&
+      (!resolvedAccount.config.botToken || !resolvedAccount.config.appToken)
     ) {
       const keepEnv = await prompter.confirm({
         message: "SLACK_BOT_TOKEN + SLACK_APP_TOKEN detected. Use env vars?",
@@ -740,7 +1139,7 @@ export async function setupProviders(
           }),
         ).trim();
       }
-    } else if (cfg.slack?.botToken && cfg.slack?.appToken) {
+    } else if (hasConfigTokens) {
       const keep = await prompter.confirm({
         message: "Slack tokens already configured. Keep them?",
         initialValue: true,
@@ -775,21 +1174,63 @@ export async function setupProviders(
     }
 
     if (botToken && appToken) {
-      next = {
-        ...next,
-        slack: {
-          ...next.slack,
-          enabled: true,
-          botToken,
-          appToken,
-        },
-      };
+      if (slackAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          slack: {
+            ...next.slack,
+            enabled: true,
+            botToken,
+            appToken,
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          slack: {
+            ...next.slack,
+            enabled: true,
+            accounts: {
+              ...next.slack?.accounts,
+              [slackAccountId]: {
+                ...next.slack?.accounts?.[slackAccountId],
+                enabled:
+                  next.slack?.accounts?.[slackAccountId]?.enabled ?? true,
+                botToken,
+                appToken,
+              },
+            },
+          },
+        };
+      }
     }
   }
 
   if (selection.includes("signal")) {
-    let resolvedCliPath = signalCliPath;
-    let cliDetected = signalCliDetected;
+    const signalOverride = accountOverrides.signal?.trim();
+    const defaultSignalAccountId = resolveDefaultSignalAccountId(next);
+    let signalAccountId = signalOverride
+      ? normalizeAccountId(signalOverride)
+      : defaultSignalAccountId;
+    if (shouldPromptAccountIds && !signalOverride) {
+      signalAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "Signal",
+        currentId: signalAccountId,
+        listAccountIds: listSignalAccountIds,
+        defaultAccountId: defaultSignalAccountId,
+      });
+    }
+    recordAccount("signal", signalAccountId);
+
+    const resolvedAccount = resolveSignalAccount({
+      cfg: next,
+      accountId: signalAccountId,
+    });
+    const accountConfig = resolvedAccount.config;
+    let resolvedCliPath = accountConfig.cliPath ?? signalCliPath;
+    let cliDetected = await detectBinary(resolvedCliPath);
     if (options?.allowSignalInstall) {
       const wantsInstall = await prompter.confirm({
         message: cliDetected
@@ -829,7 +1270,7 @@ export async function setupProviders(
       );
     }
 
-    let account = cfg.signal?.account ?? "";
+    let account = accountConfig.account ?? "";
     if (account) {
       const keep = await prompter.confirm({
         message: `Signal account set (${account}). Keep it?`,
@@ -848,15 +1289,35 @@ export async function setupProviders(
     }
 
     if (account) {
-      next = {
-        ...next,
-        signal: {
-          ...next.signal,
-          enabled: true,
-          account,
-          cliPath: resolvedCliPath ?? "signal-cli",
-        },
-      };
+      if (signalAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          signal: {
+            ...next.signal,
+            enabled: true,
+            account,
+            cliPath: resolvedCliPath ?? "signal-cli",
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          signal: {
+            ...next.signal,
+            enabled: true,
+            accounts: {
+              ...next.signal?.accounts,
+              [signalAccountId]: {
+                ...next.signal?.accounts?.[signalAccountId],
+                enabled:
+                  next.signal?.accounts?.[signalAccountId]?.enabled ?? true,
+                account,
+                cliPath: resolvedCliPath ?? "signal-cli",
+              },
+            },
+          },
+        };
+      }
     }
 
     await prompter.note(
@@ -864,14 +1325,37 @@ export async function setupProviders(
         'Link device with: signal-cli link -n "Clawdbot"',
         "Scan QR in Signal → Linked Devices",
         "Then run: clawdbot gateway call providers.status --params '{\"probe\":true}'",
+        `Docs: ${docsLink("/signal", "signal")}`,
       ].join("\n"),
       "Signal next steps",
     );
   }
 
   if (selection.includes("imessage")) {
-    let resolvedCliPath = imessageCliPath;
-    if (!imessageCliDetected) {
+    const imessageOverride = accountOverrides.imessage?.trim();
+    const defaultIMessageAccountId = resolveDefaultIMessageAccountId(next);
+    let imessageAccountId = imessageOverride
+      ? normalizeAccountId(imessageOverride)
+      : defaultIMessageAccountId;
+    if (shouldPromptAccountIds && !imessageOverride) {
+      imessageAccountId = await promptAccountId({
+        cfg: next,
+        prompter,
+        label: "iMessage",
+        currentId: imessageAccountId,
+        listAccountIds: listIMessageAccountIds,
+        defaultAccountId: defaultIMessageAccountId,
+      });
+    }
+    recordAccount("imessage", imessageAccountId);
+
+    const resolvedAccount = resolveIMessageAccount({
+      cfg: next,
+      accountId: imessageAccountId,
+    });
+    let resolvedCliPath = resolvedAccount.config.cliPath ?? imessageCliPath;
+    const cliDetected = await detectBinary(resolvedCliPath);
+    if (!cliDetected) {
       const entered = await prompter.text({
         message: "imsg CLI path",
         initialValue: resolvedCliPath,
@@ -887,21 +1371,42 @@ export async function setupProviders(
     }
 
     if (resolvedCliPath) {
-      next = {
-        ...next,
-        imessage: {
-          ...next.imessage,
-          enabled: true,
-          cliPath: resolvedCliPath,
-        },
-      };
+      if (imessageAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          imessage: {
+            ...next.imessage,
+            enabled: true,
+            cliPath: resolvedCliPath,
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          imessage: {
+            ...next.imessage,
+            enabled: true,
+            accounts: {
+              ...next.imessage?.accounts,
+              [imessageAccountId]: {
+                ...next.imessage?.accounts?.[imessageAccountId],
+                enabled:
+                  next.imessage?.accounts?.[imessageAccountId]?.enabled ?? true,
+                cliPath: resolvedCliPath,
+              },
+            },
+          },
+        };
+      }
     }
 
     await prompter.note(
       [
+        "This is still a work in progress.",
         "Ensure Clawdbot has Full Disk Access to Messages DB.",
         "Grant Automation permission for Messages when prompted.",
         "List chats with: imsg chats --limit 20",
+        `Docs: ${docsLink("/imessage", "imessage")}`,
       ].join("\n"),
       "iMessage next steps",
     );


### PR DESCRIPTION
AI-assisted (Codex)

Testing: fully tested
- docker build -t clawdbot:local -f Dockerfile .
- docker run --rm clawdbot:local node dist/index.js --help
- pnpm test src/commands/onboard-providers.test.ts
- pnpm test src/agents/tools/whatsapp-actions.test.ts

Issue
Docker build failed with TS2322 in src/commands/onboard-providers.ts due to WhatsApp config object inference where selfChatMode was inferred as optional/incompatible in strict builds.

Fix
Centralize WhatsApp config merging so we always construct a stable whatsapp object with consistent optional fields, preventing TS inference conflicts during Docker builds. Added unit tests to ensure setters preserve existing WhatsApp fields.

Confirmation
Local Docker build succeeds and the image runs (help output works).

Prompts / session logs
- docker build -t clawdbot:local -f Dockerfile . → success (image tagged clawdbot:local)
- docker run --rm clawdbot:local node dist/index.js --help → help output displayed
