### PR TITLE
Docker: fix WhatsApp config typing in onboarding + add tests

### DIFF
--- a/src/commands/onboard-providers.test.ts
+++ b/src/commands/onboard-providers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import {
+  setWhatsAppAllowFrom,
+  setWhatsAppDmPolicy,
+  setWhatsAppSelfChatMode,
+} from "./onboard-providers.js";
+
+describe("onboard-providers WhatsApp setters", () => {
+  it("preserves existing WhatsApp fields when updating allowFrom", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        selfChatMode: true,
+        dmPolicy: "pairing",
+        allowFrom: ["*"],
+        accounts: {
+          default: { enabled: false },
+        },
+      },
+    };
+
+    const next = setWhatsAppAllowFrom(cfg, ["+15555550123"]);
+
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+    expect(next.whatsapp?.dmPolicy).toBe("pairing");
+    expect(next.whatsapp?.allowFrom).toEqual(["+15555550123"]);
+    expect(next.whatsapp?.accounts?.default?.enabled).toBe(false);
+  });
+
+  it("updates dmPolicy without dropping selfChatMode", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        selfChatMode: true,
+        dmPolicy: "pairing",
+      },
+    };
+
+    const next = setWhatsAppDmPolicy(cfg, "open");
+
+    expect(next.whatsapp?.dmPolicy).toBe("open");
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+  });
+
+  it("updates selfChatMode without dropping allowFrom", () => {
+    const cfg: ClawdbotConfig = {
+      whatsapp: {
+        allowFrom: ["+15555550123"],
+      },
+    };
+
+    const next = setWhatsAppSelfChatMode(cfg, true);
+
+    expect(next.whatsapp?.selfChatMode).toBe(true);
+    expect(next.whatsapp?.allowFrom).toEqual(["+15555550123"]);
+  });
+});

--- a/src/commands/onboard-providers.ts
+++ b/src/commands/onboard-providers.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ClawdbotConfig } from "../config/config.js";
-import type { DmPolicy } from "../config/types.js";
+import type { DmPolicy, WhatsAppConfig } from "../config/types.js";
 import {
   listDiscordAccountIds,
   resolveDefaultDiscordAccountId,
@@ -253,30 +253,33 @@ async function noteSlackTokenHelp(
   );
 }
 
-function setWhatsAppDmPolicy(
+export function mergeWhatsAppConfig(
   cfg: ClawdbotConfig,
-  dmPolicy?: DmPolicy,
+  patch: Partial<WhatsAppConfig>,
 ): ClawdbotConfig {
+  const base = cfg.whatsapp ?? {};
   return {
     ...cfg,
     whatsapp: {
-      ...cfg.whatsapp,
-      dmPolicy,
+      selfChatMode: base.selfChatMode,
+      ...base,
+      ...patch,
     },
   };
 }
 
-function setWhatsAppAllowFrom(
+export function setWhatsAppDmPolicy(
+  cfg: ClawdbotConfig,
+  dmPolicy: DmPolicy,
+): ClawdbotConfig {
+  return mergeWhatsAppConfig(cfg, { dmPolicy });
+}
+
+export function setWhatsAppAllowFrom(
   cfg: ClawdbotConfig,
   allowFrom?: string[],
 ): ClawdbotConfig {
-  return {
-    ...cfg,
-    whatsapp: {
-      ...cfg.whatsapp,
-      allowFrom,
-    },
-  };
+  return mergeWhatsAppConfig(cfg, { allowFrom });
 }
 
 function setMessagesResponsePrefix(
@@ -292,17 +295,11 @@ function setMessagesResponsePrefix(
   };
 }
 
-function setWhatsAppSelfChatMode(
+export function setWhatsAppSelfChatMode(
   cfg: ClawdbotConfig,
-  selfChatMode?: boolean,
+  selfChatMode: boolean,
 ): ClawdbotConfig {
-  return {
-    ...cfg,
-    whatsapp: {
-      ...cfg.whatsapp,
-      selfChatMode,
-    },
-  };
+  return mergeWhatsAppConfig(cfg, { selfChatMode });
 }
 
 function setTelegramDmPolicy(cfg: ClawdbotConfig, dmPolicy: DmPolicy) {


### PR DESCRIPTION
AI-assisted (Codex)

Testing: fully tested
- docker build -t clawdbot:local -f Dockerfile .
- docker run --rm clawdbot:local node dist/index.js --help
- pnpm test src/commands/onboard-providers.test.ts
- pnpm test src/agents/tools/whatsapp-actions.test.ts

Issue
Docker build failed with TS2322 in src/commands/onboard-providers.ts due to WhatsApp config object inference where selfChatMode was inferred as optional/incompatible in strict builds.

Fix
Centralize WhatsApp config merging so we always construct a stable whatsapp object with consistent optional fields, preventing TS inference conflicts during Docker builds. Added unit tests to ensure setters preserve existing WhatsApp fields.

Confirmation
Local Docker build succeeds and the image runs (help output works).

Prompts / session logs
- docker build -t clawdbot:local -f Dockerfile . → success (image tagged clawdbot:local)
- docker run --rm clawdbot:local node dist/index.js --help → help output displayed
