### PR TITLE
feat(typing): trigger indicator on tool start events

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -300,12 +300,22 @@ export async function runReplyAgent(params: {
                   }
                 : undefined,
             onAgentEvent: (evt) => {
-              if (evt.stream !== "compaction") return;
-              const phase =
-                typeof evt.data.phase === "string" ? evt.data.phase : "";
-              const willRetry = Boolean(evt.data.willRetry);
-              if (phase === "end" && !willRetry) {
-                autoCompactionCompleted = true;
+              // Trigger typing when tools start executing
+              if (evt.stream === "tool") {
+                const phase =
+                  typeof evt.data.phase === "string" ? evt.data.phase : "";
+                if (phase === "start") {
+                  void typingSignals.signalToolStart();
+                }
+              }
+              // Track auto-compaction completion
+              if (evt.stream === "compaction") {
+                const phase =
+                  typeof evt.data.phase === "string" ? evt.data.phase : "";
+                const willRetry = Boolean(evt.data.willRetry);
+                if (phase === "end" && !willRetry) {
+                  autoCompactionCompleted = true;
+                }
               }
             },
             onBlockReply:

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -30,6 +30,7 @@ export type TypingSignaler = {
   signalRunStart: () => Promise<void>;
   signalTextDelta: (text?: string) => Promise<void>;
   signalReasoningDelta: () => Promise<void>;
+  signalToolStart: () => Promise<void>;
 };
 
 export function createTypingSignaler(params: {
@@ -65,6 +66,12 @@ export function createTypingSignaler(params: {
     typing.refreshTypingTtl();
   };
 
+  const signalToolStart = async () => {
+    if (disabled) return;
+    // Keep typing indicator alive during tool execution
+    await typing.startTypingLoop();
+  };
+
   return {
     mode,
     shouldStartImmediately,
@@ -73,5 +80,6 @@ export function createTypingSignaler(params: {
     signalRunStart,
     signalTextDelta,
     signalReasoningDelta,
+    signalToolStart,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #450

Adds `signalToolStart()` to `TypingSignaler` and calls it from `onAgentEvent` when tools begin executing. This keeps the typing indicator visible during long-running tool operations.

## Changes

- `src/auto-reply/reply/typing-mode.ts`: Add `signalToolStart` method to `TypingSignaler` type and `createTypingSignaler` function
- `src/auto-reply/reply/agent-runner.ts`: Call `signalToolStart()` when `onAgentEvent` receives a tool start event

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Manual testing with long-running tools

---

🤖 AI-assisted (Claude Code) - lightly tested locally