### PR TITLE
Slack: multi-account tool routing + suppress duplicate follow-ups

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -19,6 +19,7 @@ export function createClawdbotTools(options?: {
   browserControlUrl?: string;
   agentSessionKey?: string;
   agentProvider?: string;
+  agentAccountId?: string;
   agentDir?: string;
   sandboxed?: boolean;
   config?: ClawdbotConfig;
@@ -33,7 +34,10 @@ export function createClawdbotTools(options?: {
     createNodesTool(),
     createCronTool(),
     createDiscordTool(),
-    createSlackTool(),
+    createSlackTool({
+      agentAccountId: options?.agentAccountId,
+      config: options?.config,
+    }),
     createTelegramTool(),
     createWhatsAppTool(),
     createGatewayTool({ agentSessionKey: options?.agentSessionKey }),

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -290,6 +290,8 @@ export type EmbeddedPiRunResult = {
   didSendViaMessagingTool?: boolean;
   // Texts successfully sent via messaging tools during the run.
   messagingToolSentTexts?: string[];
+  // Messaging tool names that successfully sent a message during the run.
+  messagingToolSentTools?: string[];
 };
 
 export type EmbeddedPiCompactResult = {
@@ -737,6 +739,7 @@ export async function compactEmbeddedPiSession(params: {
   sessionId: string;
   sessionKey?: string;
   messageProvider?: string;
+  agentAccountId?: string;
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
@@ -842,6 +845,7 @@ export async function compactEmbeddedPiSession(params: {
           },
           sandbox,
           messageProvider: params.messageProvider,
+          agentAccountId: params.agentAccountId,
           sessionKey: params.sessionKey ?? params.sessionId,
           agentDir,
           config: params.config,
@@ -1153,6 +1157,7 @@ export async function runEmbeddedPiAgent(params: {
             },
             sandbox,
             messageProvider: params.messageProvider,
+            agentAccountId: params.agentAccountId,
             sessionKey: params.sessionKey ?? params.sessionId,
             agentDir,
             config: params.config,
@@ -1283,6 +1288,7 @@ export async function runEmbeddedPiAgent(params: {
             unsubscribe,
             waitForCompactionRetry,
             getMessagingToolSentTexts,
+            getMessagingToolSentTools,
             didSendViaMessagingTool,
           } = subscription;
 
@@ -1567,6 +1573,7 @@ export async function runEmbeddedPiAgent(params: {
             },
             didSendViaMessagingTool: didSendViaMessagingTool(),
             messagingToolSentTexts: getMessagingToolSentTexts(),
+            messagingToolSentTools: getMessagingToolSentTools(),
           };
         } finally {
           restoreSkillEnv?.();

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -625,6 +625,7 @@ function shouldIncludeWhatsAppTool(messageProvider?: string): boolean {
 export function createClawdbotCodingTools(options?: {
   bash?: BashToolDefaults & ProcessToolDefaults;
   messageProvider?: string;
+  agentAccountId?: string;
   sandbox?: SandboxContext | null;
   sessionKey?: string;
   agentDir?: string;
@@ -695,6 +696,7 @@ export function createClawdbotCodingTools(options?: {
       browserControlUrl: sandbox?.browser?.controlUrl,
       agentSessionKey: options?.sessionKey,
       agentProvider: options?.messageProvider,
+      agentAccountId: options?.agentAccountId,
       agentDir: options?.agentDir,
       sandboxed: !!sandbox,
       config: options?.config,

--- a/src/agents/tools/slack-schema.ts
+++ b/src/agents/tools/slack-schema.ts
@@ -9,28 +9,35 @@ export const SlackToolSchema = Type.Union([
       messageId: Type.String(),
     },
     includeRemove: true,
+    extras: {
+      accountId: Type.Optional(Type.String()),
+    },
   }),
   Type.Object({
     action: Type.Literal("reactions"),
     channelId: Type.String(),
     messageId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("sendMessage"),
     to: Type.String(),
     content: Type.String(),
     mediaUrl: Type.Optional(Type.String()),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("editMessage"),
     channelId: Type.String(),
     messageId: Type.String(),
     content: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("deleteMessage"),
     channelId: Type.String(),
     messageId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("readMessages"),
@@ -38,26 +45,32 @@ export const SlackToolSchema = Type.Union([
     limit: Type.Optional(Type.Number()),
     before: Type.Optional(Type.String()),
     after: Type.Optional(Type.String()),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("pinMessage"),
     channelId: Type.String(),
     messageId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("unpinMessage"),
     channelId: Type.String(),
     messageId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("listPins"),
     channelId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("memberInfo"),
     userId: Type.String(),
+    accountId: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("emojiList"),
+    accountId: Type.Optional(Type.String()),
   }),
 ]);

--- a/src/agents/tools/slack-tool.test.ts
+++ b/src/agents/tools/slack-tool.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handleSlackActionMock = vi.fn();
+
+vi.mock("./slack-actions.js", () => ({
+  handleSlackAction: (params: unknown, cfg: unknown) =>
+    handleSlackActionMock(params, cfg),
+}));
+
+import { createSlackTool } from "./slack-tool.js";
+
+describe("slack tool", () => {
+  beforeEach(() => {
+    handleSlackActionMock.mockReset();
+    handleSlackActionMock.mockResolvedValue({
+      content: [],
+      details: { ok: true },
+    });
+  });
+
+  it("injects agentAccountId when accountId is missing", async () => {
+    const tool = createSlackTool({
+      agentAccountId: " Kev ",
+      config: { slack: { accounts: { kev: {} } } },
+    });
+
+    await tool.execute("call-1", {
+      action: "sendMessage",
+      to: "channel:C1",
+      content: "hello",
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledTimes(1);
+    const [params] = handleSlackActionMock.mock.calls[0] ?? [];
+    expect(params).toMatchObject({ accountId: "kev" });
+  });
+
+  it("keeps explicit accountId when provided", async () => {
+    const tool = createSlackTool({
+      agentAccountId: "kev",
+      config: {},
+    });
+
+    await tool.execute("call-2", {
+      action: "sendMessage",
+      to: "channel:C1",
+      content: "hello",
+      accountId: "rex",
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledTimes(1);
+    const [params] = handleSlackActionMock.mock.calls[0] ?? [];
+    expect(params).toMatchObject({ accountId: "rex" });
+  });
+
+  it("does not inject accountId when agentAccountId is missing", async () => {
+    const tool = createSlackTool({ config: {} });
+
+    await tool.execute("call-3", {
+      action: "sendMessage",
+      to: "channel:C1",
+      content: "hello",
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledTimes(1);
+    const [params] = handleSlackActionMock.mock.calls[0] ?? [];
+    expect(params).not.toHaveProperty("accountId");
+  });
+
+  it("does not inject unknown agentAccountId when not configured", async () => {
+    const tool = createSlackTool({
+      agentAccountId: "unknown",
+      config: { slack: { accounts: { kev: {} } } },
+    });
+
+    await tool.execute("call-4", {
+      action: "sendMessage",
+      to: "channel:C1",
+      content: "hello",
+    });
+
+    const [params] = handleSlackActionMock.mock.calls[0] ?? [];
+    expect(params).not.toHaveProperty("accountId");
+  });
+});

--- a/src/agents/tools/slack-tool.ts
+++ b/src/agents/tools/slack-tool.ts
@@ -1,9 +1,44 @@
+import type { ClawdbotConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import { logVerbose } from "../../globals.js";
+import { normalizeAccountId } from "../../routing/session-key.js";
 import type { AnyAgentTool } from "./common.js";
 import { handleSlackAction } from "./slack-actions.js";
 import { SlackToolSchema } from "./slack-schema.js";
 
-export function createSlackTool(): AnyAgentTool {
+type SlackToolOptions = {
+  agentAccountId?: string;
+  config?: ClawdbotConfig;
+};
+
+function resolveAgentAccountId(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return normalizeAccountId(trimmed);
+}
+
+function resolveConfiguredAccountId(
+  cfg: ClawdbotConfig,
+  accountId: string,
+): string | undefined {
+  if (accountId === "default") return accountId;
+  const accounts = cfg.slack?.accounts;
+  if (!accounts || typeof accounts !== "object") return undefined;
+  if (accountId in accounts) return accountId;
+  const match = Object.keys(accounts).find(
+    (key) => key.toLowerCase() === accountId.toLowerCase(),
+  );
+  return match;
+}
+
+function hasAccountId(params: Record<string, unknown>): boolean {
+  const raw = params.accountId;
+  if (typeof raw !== "string") return false;
+  return raw.trim().length > 0;
+}
+
+export function createSlackTool(options?: SlackToolOptions): AnyAgentTool {
+  const agentAccountId = resolveAgentAccountId(options?.agentAccountId);
   return {
     label: "Slack",
     name: "slack",
@@ -11,8 +46,22 @@ export function createSlackTool(): AnyAgentTool {
     parameters: SlackToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = loadConfig();
-      return await handleSlackAction(params, cfg);
+      const cfg = options?.config ?? loadConfig();
+      const resolvedAccountId = agentAccountId
+        ? resolveConfiguredAccountId(cfg, agentAccountId)
+        : undefined;
+      const resolvedParams =
+        resolvedAccountId && !hasAccountId(params)
+          ? { ...params, accountId: resolvedAccountId }
+          : params;
+      if (hasAccountId(resolvedParams)) {
+        logVerbose(
+          `slack tool: action=${String(params.action ?? "unknown")} accountId=${String(
+            resolvedParams.accountId,
+          ).trim()}`,
+        );
+      }
+      return await handleSlackAction(resolvedParams, cfg);
     },
   };
 }

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -791,6 +791,7 @@ export async function getReplyFromConfig(
       sessionId: sessionIdFinal,
       sessionKey,
       messageProvider: sessionCtx.Provider?.trim().toLowerCase() || undefined,
+      agentAccountId: sessionCtx.AccountId,
       sessionFile,
       workspaceDir,
       config: cfg,

--- a/src/auto-reply/reply/agent-runner.messaging-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner.messaging-tools.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await run(provider, model),
+    provider,
+    model,
+  }),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("./queue.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function createRun(messageProvider = "slack") {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: messageProvider,
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun,
+    queueKey: "main",
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing,
+    sessionCtx,
+    defaultModel: "anthropic/claude-opus-4-5",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent messaging tool suppression", () => {
+  it("drops replies when a messaging tool sent via the same provider", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTools: ["slack"],
+      meta: {},
+    });
+
+    const result = await createRun("slack");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("delivers replies when tool provider does not match", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTools: ["discord"],
+      meta: {},
+    });
+
+    const result = await createRun("slack");
+
+    expect(result).toEqual({ text: "hello world!" });
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,6 +36,7 @@ import {
   applyReplyThreading,
   filterMessagingToolDuplicates,
   isRenderablePayload,
+  shouldSuppressMessagingToolReplies,
 } from "./reply-payloads.js";
 import {
   createReplyToModeFilter,
@@ -240,6 +241,7 @@ export async function runReplyAgent(params: {
             sessionKey,
             messageProvider:
               sessionCtx.Provider?.trim().toLowerCase() || undefined,
+            agentAccountId: sessionCtx.AccountId,
             sessionFile: followupRun.run.sessionFile,
             workspaceDir: followupRun.run.workspaceDir,
             agentDir: followupRun.run.agentDir,
@@ -539,6 +541,11 @@ export async function runReplyAgent(params: {
     const shouldDropFinalPayloads =
       blockStreamingEnabled && didStreamBlockReply;
     const messagingToolSentTexts = runResult.messagingToolSentTexts ?? [];
+    const messagingToolSentTools = runResult.messagingToolSentTools ?? [];
+    const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
+      messageProvider: followupRun.run.messageProvider,
+      messagingToolSentTools,
+    });
     const dedupedPayloads = filterMessagingToolDuplicates({
       payloads: replyTaggedPayloads,
       sentTexts: messagingToolSentTexts,
@@ -550,10 +557,11 @@ export async function runReplyAgent(params: {
             (payload) => !streamedPayloadKeys.has(buildPayloadKey(payload)),
           )
         : dedupedPayloads;
+    const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
 
-    if (filteredPayloads.length === 0) return finalizeWithFollowup(undefined);
+    if (replyPayloads.length === 0) return finalizeWithFollowup(undefined);
 
-    const shouldSignalTyping = filteredPayloads.some((payload) => {
+    const shouldSignalTyping = replyPayloads.some((payload) => {
       const trimmed = payload.text?.trim();
       if (trimmed && trimmed !== SILENT_REPLY_TOKEN) return true;
       if (payload.mediaUrl) return true;
@@ -618,7 +626,7 @@ export async function runReplyAgent(params: {
     }
 
     // If verbose is enabled and this is a new session, prepend a session hint.
-    let finalPayloads = filteredPayloads;
+    let finalPayloads = replyPayloads;
     if (autoCompactionCompleted) {
       const count = await incrementCompactionCount({
         sessionEntry,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -17,6 +17,7 @@ import type { FollowupRun } from "./queue.js";
 import {
   applyReplyThreading,
   filterMessagingToolDuplicates,
+  shouldSuppressMessagingToolReplies,
 } from "./reply-payloads.js";
 import {
   createReplyToModeFilter,
@@ -136,6 +137,7 @@ export function createFollowupRunner(params: {
               sessionId: queued.run.sessionId,
               sessionKey: queued.run.sessionKey,
               messageProvider: queued.run.messageProvider,
+              agentAccountId: queued.run.agentAccountId,
               sessionFile: queued.run.sessionFile,
               workspaceDir: queued.run.workspaceDir,
               config: queued.run.config,
@@ -205,8 +207,15 @@ export function createFollowupRunner(params: {
         payloads: replyTaggedPayloads,
         sentTexts: runResult.messagingToolSentTexts ?? [],
       });
+      const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
+        messageProvider: queued.run.messageProvider,
+        messagingToolSentTools: runResult.messagingToolSentTools,
+      });
+      const finalPayloads = suppressMessagingToolReplies
+        ? []
+        : dedupedPayloads;
 
-      if (dedupedPayloads.length === 0) return;
+      if (finalPayloads.length === 0) return;
 
       if (autoCompactionCompleted) {
         const count = await incrementCompactionCount({
@@ -217,7 +226,7 @@ export function createFollowupRunner(params: {
         });
         if (queued.run.verboseLevel === "on") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
-          replyTaggedPayloads.unshift({
+          finalPayloads.unshift({
             text: `🧹 Auto-compaction complete${suffix}.`,
           });
         }
@@ -271,7 +280,7 @@ export function createFollowupRunner(params: {
         }
       }
 
-      await sendFollowupPayloads(dedupedPayloads, queued);
+      await sendFollowupPayloads(finalPayloads, queued);
     } finally {
       typing.markRunComplete();
     }

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "../../config/config.js";
 import { resolveProviderGroupRequireMention } from "../../config/group-policy.js";
+import { resolveSlackAccount } from "../../slack/accounts.js";
 import type {
   GroupKeyResolution,
   SessionEntry,
@@ -148,7 +149,8 @@ export function resolveGroupRequireMention(params: {
     return true;
   }
   if (provider === "slack") {
-    const channels = cfg.slack?.channels ?? {};
+    const account = resolveSlackAccount({ cfg, accountId: ctx.AccountId });
+    const channels = account.channels ?? {};
     const keys = Object.keys(channels);
     if (keys.length === 0) return true;
     const channelId = groupId?.trim();

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -50,6 +50,7 @@ export type FollowupRun = {
     sessionId: string;
     sessionKey?: string;
     messageProvider?: string;
+    agentAccountId?: string;
     sessionFile: string;
     workspaceDir: string;
     config: ClawdbotConfig;

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -50,3 +50,16 @@ export function filterMessagingToolDuplicates(params: {
     (payload) => !isMessagingToolDuplicate(payload.text ?? "", sentTexts),
   );
 }
+
+export function shouldSuppressMessagingToolReplies(params: {
+  messageProvider?: string;
+  messagingToolSentTools?: string[];
+}): boolean {
+  const provider = params.messageProvider?.trim().toLowerCase();
+  if (!provider) return false;
+  const sentTools = params.messagingToolSentTools ?? [];
+  if (sentTools.length === 0) return false;
+  return sentTools.some(
+    (tool) => tool.trim().toLowerCase() === provider,
+  );
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -123,6 +123,7 @@ const FIELD_LABELS: Record<string, string> = {
   "discord.retry.jitter": "Discord Retry Jitter",
   "discord.maxLinesPerMessage": "Discord Max Lines Per Message",
   "slack.dm.policy": "Slack DM Policy",
+  "slack.allowBots": "Slack Allow Bot Messages",
   "discord.token": "Discord Bot Token",
   "slack.botToken": "Slack Bot Token",
   "slack.appToken": "Slack App Token",
@@ -141,6 +142,8 @@ const FIELD_HELP: Record<string, string> = {
     'Hot reload strategy for config changes ("hybrid" recommended).',
   "gateway.reload.debounceMs":
     "Debounce window (ms) before applying config changes.",
+  "slack.allowBots":
+    "Allow bot-authored messages to trigger Slack replies (default: false).",
   "auth.profiles": "Named auth profiles (provider + mode + optional email).",
   "auth.order":
     "Ordered auth profile IDs per provider (used for automatic failover).",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -455,6 +455,8 @@ export type SlackChannelConfig = {
   allow?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
   /** Allowlist of users that can invoke the bot in this channel. */
   users?: Array<string | number>;
   /** Optional skill filter for this channel. */
@@ -494,6 +496,8 @@ export type SlackAccountConfig = {
   enabled?: boolean;
   botToken?: string;
   appToken?: string;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
   /**
    * Controls how channel messages are handled:
    * - "open" (default): channels bypass allowlists; mention-gating applies

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,6 +309,7 @@ const SlackChannelSchema = z.object({
   enabled: z.boolean().optional(),
   allow: z.boolean().optional(),
   requireMention: z.boolean().optional(),
+  allowBots: z.boolean().optional(),
   users: z.array(z.union([z.string(), z.number()])).optional(),
   skills: z.array(z.string()).optional(),
   systemPrompt: z.string().optional(),
@@ -319,11 +320,13 @@ const SlackAccountSchema = z.object({
   enabled: z.boolean().optional(),
   botToken: z.string().optional(),
   appToken: z.string().optional(),
+  allowBots: z.boolean().optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
   textChunkLimit: z.number().int().positive().optional(),
   mediaMaxMb: z.number().positive().optional(),
   reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
   reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
+  replyToMode: ReplyToModeSchema.optional(),
   actions: z
     .object({
       reactions: z.boolean().optional(),
@@ -1183,7 +1186,6 @@ export const ClawdbotSchema = z.object({
       });
     })
     .optional(),
-
   telegram: TelegramConfigSchema.optional(),
   discord: DiscordConfigSchema.optional(),
   slack: SlackConfigSchema.optional(),

--- a/src/slack/accounts.ts
+++ b/src/slack/accounts.ts
@@ -17,6 +17,16 @@ export type ResolvedSlackAccount = {
   botTokenSource: SlackTokenSource;
   appTokenSource: SlackTokenSource;
   config: SlackAccountConfig;
+  groupPolicy?: SlackAccountConfig["groupPolicy"];
+  textChunkLimit?: SlackAccountConfig["textChunkLimit"];
+  mediaMaxMb?: SlackAccountConfig["mediaMaxMb"];
+  reactionNotifications?: SlackAccountConfig["reactionNotifications"];
+  reactionAllowlist?: SlackAccountConfig["reactionAllowlist"];
+  replyToMode?: SlackAccountConfig["replyToMode"];
+  actions?: SlackAccountConfig["actions"];
+  slashCommand?: SlackAccountConfig["slashCommand"];
+  dm?: SlackAccountConfig["dm"];
+  channels?: SlackAccountConfig["channels"];
 };
 
 function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
@@ -66,31 +76,26 @@ export function resolveSlackAccount(params: {
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
-
-  const botToken = resolveSlackBotToken(
-    merged.botToken ??
-      (allowEnv ? process.env.SLACK_BOT_TOKEN : undefined) ??
-      (allowEnv ? params.cfg.slack?.botToken : undefined),
-  );
-  const appToken = resolveSlackAppToken(
-    merged.appToken ??
-      (allowEnv ? process.env.SLACK_APP_TOKEN : undefined) ??
-      (allowEnv ? params.cfg.slack?.appToken : undefined),
-  );
-  const botTokenSource: SlackTokenSource = merged.botToken
-    ? "config"
-    : allowEnv && process.env.SLACK_BOT_TOKEN
-      ? "env"
-      : allowEnv && params.cfg.slack?.botToken
-        ? "config"
-        : "none";
-  const appTokenSource: SlackTokenSource = merged.appToken
-    ? "config"
-    : allowEnv && process.env.SLACK_APP_TOKEN
-      ? "env"
-      : allowEnv && params.cfg.slack?.appToken
-        ? "config"
-        : "none";
+  const envBot = allowEnv
+    ? resolveSlackBotToken(process.env.SLACK_BOT_TOKEN)
+    : undefined;
+  const envApp = allowEnv
+    ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN)
+    : undefined;
+  const configBot = resolveSlackBotToken(merged.botToken);
+  const configApp = resolveSlackAppToken(merged.appToken);
+  const botToken = envBot ?? configBot;
+  const appToken = envApp ?? configApp;
+  const botTokenSource: SlackTokenSource = envBot
+    ? "env"
+    : configBot
+      ? "config"
+      : "none";
+  const appTokenSource: SlackTokenSource = envApp
+    ? "env"
+    : configApp
+      ? "config"
+      : "none";
 
   return {
     accountId,
@@ -101,6 +106,16 @@ export function resolveSlackAccount(params: {
     botTokenSource,
     appTokenSource,
     config: merged,
+    groupPolicy: merged.groupPolicy,
+    textChunkLimit: merged.textChunkLimit,
+    mediaMaxMb: merged.mediaMaxMb,
+    reactionNotifications: merged.reactionNotifications,
+    reactionAllowlist: merged.reactionAllowlist,
+    replyToMode: merged.replyToMode,
+    actions: merged.actions,
+    slashCommand: merged.slashCommand,
+    dm: merged.dm,
+    channels: merged.channels,
   };
 }
 

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -13,6 +13,12 @@ export {
   sendSlackMessage,
   unpinSlackMessage,
 } from "./actions.js";
+export {
+  listEnabledSlackAccounts,
+  listSlackAccountIds,
+  resolveDefaultSlackAccountId,
+  resolveSlackAccount,
+} from "./accounts.js";
 export { monitorSlackProvider } from "./monitor.js";
 export { probeSlack } from "./probe.js";
 export { sendMessageSlack } from "./send.js";

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -80,6 +80,7 @@ type SlackMessageEvent = {
   user?: string;
   bot_id?: string;
   subtype?: string;
+  username?: string;
   text?: string;
   ts?: string;
   thread_ts?: string;
@@ -93,6 +94,7 @@ type SlackAppMentionEvent = {
   type: "app_mention";
   user?: string;
   bot_id?: string;
+  username?: string;
   text?: string;
   ts?: string;
   thread_ts?: string;
@@ -706,15 +708,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
   ) => {
     if (opts.source === "message" && message.type !== "message") return;
-    if (message.bot_id) return;
     if (
       opts.source === "message" &&
       message.subtype &&
-      message.subtype !== "file_share"
+      message.subtype !== "file_share" &&
+      message.subtype !== "bot_message"
     ) {
       return;
     }
-    if (!message.user) return;
     if (markMessageSeen(message.channel, message.ts)) return;
 
     let channelInfo: {
@@ -734,6 +735,39 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     const isGroupDm = resolvedChannelType === "mpim";
     const isRoom =
       resolvedChannelType === "channel" || resolvedChannelType === "group";
+
+    const channelConfig = isRoom
+      ? resolveSlackChannelConfig({
+          channelId: message.channel,
+          channelName,
+          channels: channelsConfig,
+        })
+      : null;
+
+    const allowBots =
+      channelConfig?.allowBots ??
+      account.config?.allowBots ??
+      cfg.slack?.allowBots ??
+      false;
+    const isBotMessage = Boolean(message.bot_id);
+    if (isBotMessage) {
+      if (message.user && botUserId && message.user === botUserId) return;
+      if (!allowBots) {
+        logVerbose(
+          `slack: drop bot message ${message.bot_id ?? "unknown"} (allowBots=false)`,
+        );
+        return;
+      }
+    }
+    if (isDirectMessage && !message.user) {
+      logVerbose("slack: drop dm message (missing user id)");
+      return;
+    }
+    const senderId = message.user ?? (isBotMessage ? message.bot_id : undefined);
+    if (!senderId) {
+      logVerbose("slack: drop message (missing sender id)");
+      return;
+    }
 
     if (
       !isChannelAllowed({
@@ -811,31 +845,26 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       }
     }
 
-    const channelConfig = isRoom
-      ? resolveSlackChannelConfig({
-          channelId: message.channel,
-          channelName,
-          channels: channelsConfig,
-        })
-      : null;
-
     const wasMentioned =
       opts.wasMentioned ??
       (!isDirectMessage &&
         (Boolean(botUserId && message.text?.includes(`<@${botUserId}>`)) ||
           matchesMentionPatterns(message.text ?? "", mentionRegexes)));
-    const sender = await resolveUserName(message.user);
-    const senderName = sender?.name ?? message.user;
+    const sender = message.user ? await resolveUserName(message.user) : null;
+    const senderName =
+      sender?.name ??
+      message.username?.trim() ??
+      (message.user ?? message.bot_id ?? "unknown");
     const channelUserAuthorized = isRoom
       ? resolveSlackUserAllowed({
           allowList: channelConfig?.users,
-          userId: message.user,
+          userId: senderId,
           userName: senderName,
         })
       : true;
     if (isRoom && !channelUserAuthorized) {
       logVerbose(
-        `Blocked unauthorized slack sender ${message.user} (not in channel users)`,
+        `Blocked unauthorized slack sender ${senderId} (not in channel users)`,
       );
       return;
     }
@@ -844,7 +873,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       (allowList.length === 0 ||
         allowListMatches({
           allowList,
-          id: message.user,
+          id: senderId,
           name: senderName,
         })) &&
       channelUserAuthorized;
@@ -1010,7 +1039,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       GroupSubject: isRoomish ? roomLabel : undefined,
       GroupSystemPrompt: isRoomish ? groupSystemPrompt : undefined,
       SenderName: senderName,
-      SenderId: message.user,
+      SenderId: senderId,
       Provider: "slack" as const,
       Surface: "slack" as const,
       MessageSid: message.ts,


### PR DESCRIPTION
This PR brings over our Slack multi-agent / multi-account routing improvements (multi-app accounts, account fallback/guarding, tool routing updates) + related tests.

Note: we’ve observed occasional weird behaviour where a message is posted via the  tool and then a near-identical ‘normal’ follow-up message is also sent (looks like a duplicate). The code includes dedupe/suppression logic for messaging-tool duplicates; please keep an eye on any remaining edge cases.