### PR TITLE
Docker setup: Make WhatsApp pairing optional

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -101,8 +101,14 @@ echo ""
 docker compose -f "$COMPOSE_FILE" run --rm clawdbot-cli onboard
 
 echo ""
-echo "==> WhatsApp login (QR will print in this terminal)"
-docker compose -f "$COMPOSE_FILE" run --rm clawdbot-cli login
+read -p "==> Do you want to pair WhatsApp now? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo "==> WhatsApp login (QR will print in this terminal)"
+  docker compose -f "$COMPOSE_FILE" run --rm clawdbot-cli login
+else
+  echo "Skipping WhatsApp login."
+fi
 
 echo ""
 echo "==> Starting gateway"


### PR DESCRIPTION
## Description

This PR updates `docker-setup.sh` to make the WhatsApp login step optional.

Previously, the script unconditionally ran `clawdbot-cli login` after onboarding, which forced users into the WhatsApp QR code flow even if they had configured a different provider (like Telegram or Discord).

## Changes

- Added a confirmation prompt before running the WhatsApp login command:
  `read -p "==> Do you want to pair WhatsApp now? (y/N) "`

## Rationale

This reduces friction for users who are setting up Clawdbot for providers other than WhatsApp.

Fixes #459