### PR TITLE
Docker: Add init: true to clawdbot-cli service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,4 +35,5 @@ services:
       - ${CLAWDBOT_WORKSPACE_DIR}:/home/node/clawd
     stdin_open: true
     tty: true
+    init: true
     entrypoint: ["node", "dist/index.js"]


### PR DESCRIPTION
## Problem

When running interactive CLI commands via Docker (e.g., `docker compose run --rm clawdbot-cli login`), pressing Ctrl+C does not terminate the process. The user is stuck and must kill the container from another terminal.

## Root Cause

The `clawdbot-cli` service in `docker-compose.yml` does not have `init: true` set, so Node.js runs as PID 1 inside the container.

By Linux kernel design, PID 1 ignores signals like `SIGINT` (Ctrl+C) and `SIGTERM` unless the process explicitly registers handlers for them. The `clawdbot login` command does not register a `SIGINT` handler, so the kernel silently drops the interrupt signal.

The `clawdbot-gateway` service already has `init: true`, which correctly handles this scenario.

## Fix

Added `init: true` to the `clawdbot-cli` service. This ensures Docker runs a lightweight init process (tini) as PID 1, which properly forwards signals to the Node.js CLI process.

Fixes #462