### PR TITLE
feat: add hooks.gmail.model for cheaper Gmail PubSub processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@
 - CLI: improve `logs` output (pretty/plain/JSONL), add gateway unreachable hint, and document logging.
 - Hooks: default hook agent delivery to true. (#533) — thanks @mcinteerj
 - Hooks: normalize hook agent providers (aliases + msteams support).
+- Hooks: add Gmail hook model/thinking defaults with auth/rate-limit/timeout fallback and allowlist warnings. (#472) — thanks @koala73
 - WhatsApp: route queued replies to the original sender instead of the bot's own number. (#534) — thanks @mcinteerj
 - iMessage: isolate group-ish threads by chat_id. (#535) — thanks @mdahmann
 - Models: add OAuth expiry checks in doctor, expanded `models status` auth output (missing auth + `--check` exit codes). (#538) — thanks @latitudeki5223
+- Models: only advance fallbacks on auth/rate-limit/timeout errors. (#472) — thanks @koala73
 - Deps: bump Pi to 0.40.0 and drop pi-ai patch (upstream 429 fix). (#543) — thanks @mcinteerj
 - Agent: skip empty error assistant messages when rebuilding session context to avoid tool-chain corruption. (#561) — thanks @mukhtharcm
 - Security: per-agent mention patterns and group elevated directives now require explicit mention to avoid cross-agent toggles.

--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -65,6 +65,25 @@ uses the last delivery route (falls back to WhatsApp).
 To force a cheaper model for Gmail runs, set `model` in the mapping
 (`provider/model` or alias). If you enforce `agents.defaults.models`, include it there.
 
+To set a default model and thinking level specifically for Gmail hooks, add
+`hooks.gmail.model` / `hooks.gmail.thinking` in your config:
+
+```json5
+{
+  hooks: {
+    gmail: {
+      model: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+      thinking: "off"
+    }
+  }
+}
+```
+
+Notes:
+- Per-hook `model`/`thinking` in the mapping still overrides these defaults.
+- Fallback order: `hooks.gmail.model` → `agents.defaults.model.fallbacks` → primary (auth/rate-limit/timeouts).
+- If `agents.defaults.models` is set, the Gmail model must be in the allowlist.
+
 To customize payload handling further, add `hooks.mappings` or a JS/TS transform module
 under `hooks.transformsDir` (see [`docs/webhook.md`](https://docs.clawd.bot/automation/webhook)).
 

--- a/docs/experiments/proposals/hooks-gmail-model.md
+++ b/docs/experiments/proposals/hooks-gmail-model.md
@@ -1,0 +1,306 @@
+---
+summary: "Spec for hooks.gmail.model - cheaper model for Gmail PubSub processing"
+read_when:
+  - Implementing hooks.gmail.model feature
+  - Modifying Gmail hook processing
+  - Working on hook model selection
+---
+# hooks.gmail.model: Cheaper Model for Gmail PubSub Processing
+
+## Problem
+
+Gmail PubSub hook processing (`/gmail-pubsub`) currently uses the session's primary model (`agents.defaults.model.primary`), which may be an expensive model like `claude-opus-4-5`. For automated email processing that doesn't require the most capable model, this wastes tokens/cost.
+
+## Solution
+
+Add `hooks.gmail.model` config option to specify an optional cheaper model for Gmail PubSub processing, with intelligent fallback to the primary model on auth/rate-limit/timeout failures.
+
+## Config Structure
+
+```json5
+{
+  hooks: {
+    gmail: {
+      account: "user@gmail.com",
+      // ... existing gmail config ...
+
+      // NEW: Optional model override for Gmail hook processing
+      model: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+
+      // NEW: Optional thinking level override
+      thinking: "off"
+    }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hooks.gmail.model` | `string` | (none) | Model to use for Gmail hook processing. Accepts `provider/model` refs or aliases from `agents.defaults.models`. |
+| `hooks.gmail.thinking` | `string` | (inherited) | Thinking level override (`off`, `minimal`, `low`, `medium`, `high`). If unset, inherits from `agents.defaults.thinkingDefault` or model's default. |
+
+### Alias Support
+
+`hooks.gmail.model` accepts:
+- Full refs: `"openrouter/meta-llama/llama-3.3-70b-instruct:free"`
+- Aliases from `agents.defaults.models`: `"Opus"`, `"Sonnet"`, `"GLM"`
+
+Resolution uses `buildModelAliasIndex()` from `model-selection.ts`.
+
+## Fallback Behavior
+
+### Fallback Triggers
+
+Auth, rate-limit, and timeout errors trigger fallback:
+- `401 Unauthorized`
+- `403 Forbidden`
+- `429 Too Many Requests`
+- Timeouts (provider hangs / network timeouts)
+
+Other errors (500s, content errors) fail in place.
+
+### Fallback Chain
+
+```
+hooks.gmail.model (if set)
+    ↓ (on auth/rate-limit/timeout)
+agents.defaults.model.fallbacks[0..n]
+    ↓ (exhausted)
+agents.defaults.model.primary
+```
+
+### Uncatalogued Model
+
+If `hooks.gmail.model` is set but not found in the model catalog or allowlist:
+- **Config load**: Log warning (surfaced in `clawdbot doctor`)
+- **Allowlist**: If `agents.defaults.models` is set and the model isn't listed, the hook falls back to primary.
+
+### Cooldown Integration
+
+Uses existing model-failover cooldown from `model-failover.ts`:
+- After auth/rate-limit failure, model enters cooldown
+- Next hook invocation respects cooldown before retrying
+- Integrates with auth profile rotation
+
+## Implementation
+
+### Type Changes
+
+```typescript
+// src/config/types.ts
+export type HooksGmailConfig = {
+  account?: string;
+  label?: string;
+  // ... existing fields ...
+
+  /** Optional model override for Gmail hook processing (provider/model or alias). */
+  model?: string;
+  /** Optional thinking level override for Gmail hook processing. */
+  thinking?: "off" | "minimal" | "low" | "medium" | "high";
+};
+```
+
+### Model Resolution
+
+New function in `src/cron/isolated-agent.ts` or `src/agents/model-selection.ts`:
+
+```typescript
+export function resolveHooksGmailModel(params: {
+  cfg: ClawdbotConfig;
+  defaultProvider: string;
+  defaultModel: string;
+}): { provider: string; model: string; isHooksOverride: boolean } | null {
+  const hooksModel = params.cfg.hooks?.gmail?.model;
+  if (!hooksModel) return null;
+
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+
+  const resolved = resolveModelRefFromString({
+    raw: hooksModel,
+    defaultProvider: params.defaultProvider,
+    aliasIndex,
+  });
+
+  if (!resolved) return null;
+  return {
+    provider: resolved.ref.provider,
+    model: resolved.ref.model,
+    isHooksOverride: true,
+  };
+}
+```
+
+### Processing Flow
+
+In `runCronIsolatedAgentTurn()` (or new wrapper for hooks):
+
+```typescript
+// Resolve model - prefer hooks.gmail.model for Gmail hooks
+const isGmailHook = params.sessionKey.startsWith("hook:gmail:");
+const hooksModelRef = isGmailHook
+  ? resolveHooksGmailModel({ cfg, defaultProvider, defaultModel })
+  : null;
+
+const { provider, model } = hooksModelRef ?? resolveConfiguredModelRef({
+  cfg: params.cfg,
+  defaultProvider: DEFAULT_PROVIDER,
+  defaultModel: DEFAULT_MODEL,
+});
+
+// Run with fallback - on auth/rate-limit/timeout, fall through to agents.defaults.model.fallbacks
+const fallbackResult = await runWithModelFallback({
+  cfg: params.cfg,
+  provider,
+  model,
+  hooksOverride: hooksModelRef?.isHooksOverride,
+  run: (providerOverride, modelOverride) => runEmbeddedPiAgent({
+    // ... existing params ...
+  }),
+});
+```
+
+### Fallback Detection
+
+Extend `runWithModelFallback()` to detect auth/rate-limit:
+
+```typescript
+function isAuthRateLimitError(err: unknown): boolean {
+  if (err instanceof ApiError) {
+    return [401, 403, 429].includes(err.status);
+  }
+  // Check for common patterns in error messages
+  const msg = String(err).toLowerCase();
+  return msg.includes("unauthorized")
+    || msg.includes("rate limit")
+    || msg.includes("quota exceeded");
+}
+```
+
+## Validation
+
+### Config Load Time
+
+In config validation (for `clawdbot doctor`):
+
+```typescript
+if (cfg.hooks?.gmail?.model) {
+  const resolved = resolveHooksGmailModel({ cfg, defaultProvider, defaultModel });
+  if (!resolved) {
+    issues.push({
+      path: "hooks.gmail.model",
+      message: `Model "${cfg.hooks.gmail.model}" could not be resolved`,
+    });
+  } else {
+    const catalog = await loadModelCatalog({ config: cfg });
+    const key = modelKey(resolved.provider, resolved.model);
+    const inCatalog = catalog.some(e => modelKey(e.provider, e.id) === key);
+    if (!inCatalog) {
+      issues.push({
+        path: "hooks.gmail.model",
+        message: `Model "${key}" not found in agents.defaults.models catalog (will fall back to primary)`,
+      });
+    }
+  }
+}
+```
+
+### Runtime
+
+At hook invocation time, validate and fall back:
+- If model not in catalog → log warning, use primary
+- If model auth fails → log warning, enter cooldown, fall back
+
+## Observability
+
+### Log Messages
+
+```
+[hooks] Gmail hook: using model openrouter/meta-llama/llama-3.3-70b-instruct:free
+[hooks] Gmail hook: model llama auth failed (429), falling back to claude-opus-4-5
+```
+
+### Hook Event Summary
+
+Include fallback info in the hook summary sent to session:
+
+```
+Hook Gmail (fallback:llama→opus): <summary>
+```
+
+## Hot Reload
+
+`hooks.gmail.model` and `hooks.gmail.thinking` are hot-reloadable:
+- Changes apply to the next hook invocation
+- No gateway restart required
+- Hooks config is already in the hot-reload matrix
+
+## Test Plan
+
+### Unit Tests
+
+1. **Model resolution** (`model-selection.test.ts`):
+   - `resolveHooksGmailModel()` with valid ref
+   - `resolveHooksGmailModel()` with alias
+   - `resolveHooksGmailModel()` with invalid input → null
+
+2. **Config validation** (`config.test.ts`):
+   - Warning on uncatalogued model
+   - No warning on valid model
+   - Graceful handling of missing hooks.gmail section
+
+3. **Fallback triggers** (`model-fallback.test.ts`):
+   - 401/403/429 → triggers fallback
+   - timeouts → triggers fallback
+   - 500/content error → no fallback
+   - Content error → no fallback
+
+### Integration Tests
+
+1. **Hook processing** (`server.hooks.test.ts`):
+   - Gmail hook uses `hooks.gmail.model` when set
+   - Fallback to primary on auth failure
+   - Thinking level override applied
+
+2. **Hot reload** (`config-reload.test.ts`):
+   - Change `hooks.gmail.model` → next hook uses new model
+
+## Documentation
+
+Update `docs/gateway/configuration.md`:
+
+```json5
+{
+  hooks: {
+    gmail: {
+      account: "user@gmail.com",
+      topic: "projects/my-project/topics/gmail-watch",
+      // ... existing config ...
+
+      // Optional: Use a cheaper model for Gmail processing
+      // Falls back to agents.defaults.model.primary on auth/rate-limit errors
+      model: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+
+      // Optional: Override thinking level for Gmail processing
+      thinking: "off"
+    }
+  }
+}
+```
+
+## Scope Limitation
+
+This PR is Gmail-specific. Future hooks (`hooks.github.model`, etc.) would follow the same pattern but are out of scope.
+
+## Changelog Entry
+
+```
+- feat: add hooks.gmail.model for cheaper Gmail PubSub processing (#XXX)
+  - Falls back to agents.defaults.model.primary on auth/rate-limit/timeouts (401/403/429)
+  - Supports aliases from agents.defaults.models
+  - Add hooks.gmail.thinking override
+```

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1884,10 +1884,24 @@ Gmail helper config (used by `clawdbot hooks gmail setup` / `run`):
       renewEveryMinutes: 720,
       serve: { bind: "127.0.0.1", port: 8788, path: "/" },
       tailscale: { mode: "funnel", path: "/gmail-pubsub" },
+
+      // Optional: use a cheaper model for Gmail hook processing
+      // Falls back to agents.defaults.model.fallbacks, then primary, on auth/rate-limit/timeout
+      model: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+      // Optional: default thinking level for Gmail hooks
+      thinking: "off",
     }
   }
 }
 ```
+
+Model override for Gmail hooks:
+- `hooks.gmail.model` specifies a model to use for Gmail hook processing (defaults to session primary).
+- Accepts `provider/model` refs or aliases from `agents.defaults.models`.
+- Falls back to `agents.defaults.model.fallbacks`, then `agents.defaults.model.primary`, on auth/rate-limit/timeouts.
+- If `agents.defaults.models` is set, include the hooks model in the allowlist.
+- At startup, warns if the configured model is not in the model catalog or allowlist.
+- `hooks.gmail.thinking` sets the default thinking level for Gmail hooks and is overridden by per-hook `thinking`.
 
 Gateway auto-start:
 - If `hooks.enabled=true` and `hooks.gmail.account` is set, the Gateway starts

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { runWithModelFallback } from "./model-fallback.js";
+
+function makeCfg(overrides: Partial<ClawdbotConfig> = {}): ClawdbotConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["anthropic/claude-haiku-3-5"],
+        },
+      },
+    },
+    ...overrides,
+  } as ClawdbotConfig;
+}
+
+describe("runWithModelFallback", () => {
+  it("does not fall back on non-auth errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("bad request"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("bad request");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on auth errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("nope"), { status: 401 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("appends the configured primary as a last fallback", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openrouter",
+      model: "meta-llama/llama-3.3-70b:free",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-4.1-mini");
+  });
+});

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -211,3 +211,28 @@ export function resolveThinkingDefault(params: {
   if (candidate?.reasoning) return "low";
   return "off";
 }
+
+/**
+ * Resolve the model configured for Gmail hook processing.
+ * Returns null if hooks.gmail.model is not set.
+ */
+export function resolveHooksGmailModel(params: {
+  cfg: ClawdbotConfig;
+  defaultProvider: string;
+}): ModelRef | null {
+  const hooksModel = params.cfg.hooks?.gmail?.model;
+  if (!hooksModel?.trim()) return null;
+
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+
+  const resolved = resolveModelRefFromString({
+    raw: hooksModel,
+    defaultProvider: params.defaultProvider,
+    aliasIndex,
+  });
+
+  return resolved?.ref ?? null;
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -265,6 +265,10 @@ export type HooksGmailConfig = {
     mode?: HooksGmailTailscaleMode;
     path?: string;
   };
+  /** Optional model override for Gmail hook processing (provider/model or alias). */
+  model?: string;
+  /** Optional thinking level override for Gmail hook processing. */
+  thinking?: "off" | "minimal" | "low" | "medium" | "high";
 };
 
 export type HooksConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -911,6 +911,16 @@ const HooksGmailSchema = z
         path: z.string().optional(),
       })
       .optional(),
+    model: z.string().optional(),
+    thinking: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+      ])
+      .optional(),
   })
   .optional();
 


### PR DESCRIPTION
## Summary
- Add `hooks.gmail.model` config option to specify a cheaper model for Gmail PubSub processing
- Add `hooks.gmail.thinking` to override thinking level for Gmail hooks
- Falls back to `agent.model.fallbacks` on error

## Changes
- `HooksGmailConfig` type + Zod schema updated
- `resolveHooksGmailModel()` in model-selection.ts
- `isolated-agent.ts` uses hooks model for `hook:gmail:*` sessions
- Gateway startup warns if model not in catalog
- 5 unit tests added
- Docs updated

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm test` passes (1632 tests)