### PR TITLE
docs: add 3 community showcase entries from Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ apps/ios/*.dSYM.zip
 # provisioning profiles (local)
 apps/ios/*.mobileprovision
 .env
+
+# Local untracked files
+.local/

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -43,8 +43,26 @@ Real projects from the community. See what people are building with Clawdbot.
 
 <Card title="Couch Potato Dev Mode" icon="couch" href="https://davekiss.com">
   **@davekiss** • `telegram` `website` `migration` `astro`
-  
+
   Rebuilt entire personal site via Telegram while watching Netflix — Notion → Astro, 18 posts migrated, DNS to Cloudflare. Never opened a laptop.
+</Card>
+
+<Card title="Job Search Agent" icon="briefcase">
+  **@attol8** • `automation` `api` `skill`
+
+  Searches job listings, matches against CV keywords, and returns relevant opportunities with links. Built in 30 minutes using JSearch API.
+</Card>
+
+<Card title="TradingView Analysis" icon="chart-line">
+  **@bheem1798** • `finance` `browser` `automation`
+
+  Logs into TradingView via browser automation, screenshots charts, and performs technical analysis on demand. No API needed—just browser control.
+</Card>
+
+<Card title="Slack Auto-Support" icon="slack">
+  **@henrymascot** • `slack` `automation` `support`
+
+  Watches company Slack channel, responds helpfully, and forwards notifications to Telegram. Autonomously fixed a production bug in a deployed app without being asked.
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
## Summary

Added 3 new showcase entries to `docs/start/showcase.md` sourced from the #showcase Discord channel:

- **Job Search Agent** (@attol8) - Searches job listings and matches against CV keywords using JSearch API
- **TradingView Analysis** (@bheem1798) - Browser-based stock chart analysis via TradingView
- **Slack Auto-Support** (@henrymascot) - Slack bot that autonomously fixed a production bug

Also added `.local/` to `.gitignore` for local untracked tooling.

## Test plan

- [x] Verified markdown syntax is correct
- [x] Entries follow existing Card format in showcase.md

---

🤖 AI-assisted (Claude Code) - fully reviewed and tested locally