### PR TITLE
fix(daemon): use minimal PATH for gateway services

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -31,6 +31,29 @@ Doctor/daemon will show runtime state (PID/last exit) and log hints.
 - Linux systemd (if installed): `journalctl --user -u clawdbot-gateway.service -n 200 --no-pager`
 - Windows: `schtasks /Query /TN "Clawdbot Gateway" /V /FO LIST`
 
+### Service Environment (PATH)
+
+The gateway daemon uses a **minimal PATH** that includes only:
+- `~/.bun/bin` (bun runtime)
+- `/usr/local/bin`, `/usr/bin`, `/bin` (system tools: git, ssh, curl, chromium, etc.)
+
+This intentionally **excludes** version managers (nvm, fnm, volta) and package managers
+(pnpm, npm) since they're only needed at install time, not runtime. This keeps the
+service environment clean and avoids breaking when you upgrade Node or switch versions.
+
+**Runtime variables** like `DISPLAY` (for headless browser) should be set in the
+`.env` file (`~/.clawdbot/.env`), which is loaded early by the gateway.
+
+Example `.env`:
+```bash
+DISPLAY=:99
+TELEGRAM_BOT_TOKEN=your_token_here
+```
+
+If your gateway can't find a binary at runtime, check:
+1. Is it in `/usr/local/bin`, `/usr/bin`, or `/bin`?
+2. Or symlink it to one of those directories.
+
 ### Service Running but Port Not Listening
 
 If the service reports **running** but nothing is listening on the gateway port,

--- a/src/cli/daemon-cli.ts
+++ b/src/cli/daemon-cli.ts
@@ -29,6 +29,7 @@ import { resolveGatewayLogPaths } from "../daemon/launchd.js";
 import { findLegacyGatewayServices } from "../daemon/legacy.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import { callGateway } from "../gateway/call.js";
 import { resolveGatewayBindHost } from "../gateway/net.js";
 import {
@@ -798,19 +799,16 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       dev: devMode,
       runtime: runtimeRaw,
     });
-  const environment: Record<string, string | undefined> = {
-    PATH: process.env.PATH,
-    CLAWDBOT_PROFILE: process.env.CLAWDBOT_PROFILE,
-    CLAWDBOT_STATE_DIR: process.env.CLAWDBOT_STATE_DIR,
-    CLAWDBOT_CONFIG_PATH: process.env.CLAWDBOT_CONFIG_PATH,
-    CLAWDBOT_GATEWAY_PORT: String(port),
-    CLAWDBOT_GATEWAY_TOKEN:
+  const environment = buildServiceEnvironment({
+    env: process.env,
+    port,
+    token:
       opts.token ||
       cfg.gateway?.auth?.token ||
       process.env.CLAWDBOT_GATEWAY_TOKEN,
-    CLAWDBOT_LAUNCHD_LABEL:
+    launchdLabel:
       process.platform === "darwin" ? GATEWAY_LAUNCH_AGENT_LABEL : undefined,
-  };
+  });
 
   try {
     await service.install({

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -32,6 +32,7 @@ import {
 import { GATEWAY_LAUNCH_AGENT_LABEL } from "../daemon/constants.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -617,12 +618,13 @@ async function maybeInstallDaemon(params: {
         dev: devMode,
         runtime: daemonRuntime,
       });
-    const environment: Record<string, string | undefined> = {
-      PATH: process.env.PATH,
-      CLAWDBOT_GATEWAY_TOKEN: params.gatewayToken,
-      CLAWDBOT_LAUNCHD_LABEL:
+    const environment = buildServiceEnvironment({
+      env: process.env,
+      port: params.port,
+      token: params.gatewayToken,
+      launchdLabel:
         process.platform === "darwin" ? GATEWAY_LAUNCH_AGENT_LABEL : undefined,
-    };
+    });
     await service.install({
       env: process.env,
       stdout: process.stdout,

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -15,6 +15,7 @@ import {
 } from "../daemon/legacy.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   DEFAULT_GATEWAY_DAEMON_RUNTIME,
@@ -96,13 +97,13 @@ export async function maybeMigrateLegacyGatewayService(
       dev: devMode,
       runtime: daemonRuntime,
     });
-  const environment: Record<string, string | undefined> = {
-    PATH: process.env.PATH,
-    CLAWDBOT_GATEWAY_TOKEN:
-      cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN,
-    CLAWDBOT_LAUNCHD_LABEL:
+  const environment = buildServiceEnvironment({
+    env: process.env,
+    port,
+    token: cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN,
+    launchdLabel:
       process.platform === "darwin" ? GATEWAY_LAUNCH_AGENT_LABEL : undefined,
-  };
+  });
   await service.install({
     env: process.env,
     stdout: process.stdout,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import { GATEWAY_LAUNCH_AGENT_LABEL } from "../daemon/constants.js";
 import { readLastGatewayErrorLine } from "../daemon/diagnostics.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -272,19 +273,16 @@ export async function doctorCommand(
               dev: devMode,
               runtime: daemonRuntime,
             });
-          const environment: Record<string, string | undefined> = {
-            PATH: process.env.PATH,
-            CLAWDBOT_PROFILE: process.env.CLAWDBOT_PROFILE,
-            CLAWDBOT_STATE_DIR: process.env.CLAWDBOT_STATE_DIR,
-            CLAWDBOT_CONFIG_PATH: process.env.CLAWDBOT_CONFIG_PATH,
-            CLAWDBOT_GATEWAY_PORT: String(port),
-            CLAWDBOT_GATEWAY_TOKEN:
+          const environment = buildServiceEnvironment({
+            env: process.env,
+            port,
+            token:
               cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN,
-            CLAWDBOT_LAUNCHD_LABEL:
+            launchdLabel:
               process.platform === "darwin"
                 ? GATEWAY_LAUNCH_AGENT_LABEL
                 : undefined,
-          };
+          });
           await service.install({
             env: process.env,
             stdout: process.stdout,

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -14,6 +14,7 @@ import {
 import { GATEWAY_LAUNCH_AGENT_LABEL } from "../daemon/constants.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath, sleep } from "../utils.js";
@@ -278,12 +279,13 @@ export async function runNonInteractiveOnboarding(
         dev: devMode,
         runtime: daemonRuntimeRaw,
       });
-    const environment: Record<string, string | undefined> = {
-      PATH: process.env.PATH,
-      CLAWDBOT_GATEWAY_TOKEN: gatewayToken,
-      CLAWDBOT_LAUNCHD_LABEL:
+    const environment = buildServiceEnvironment({
+      env: process.env,
+      port,
+      token: gatewayToken,
+      launchdLabel:
         process.platform === "darwin" ? GATEWAY_LAUNCH_AGENT_LABEL : undefined,
-    };
+    });
     await service.install({
       env: process.env,
       stdout: process.stdout,

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildMinimalServicePath,
+  buildServiceEnvironment,
+} from "./service-env.js";
+
+describe("buildMinimalServicePath", () => {
+  it("includes bun directory from BUN_INSTALL", () => {
+    const result = buildMinimalServicePath({
+      env: { BUN_INSTALL: "/custom/bun", HOME: "/home/user" },
+    });
+    expect(result).toContain("/custom/bun/bin");
+  });
+
+  it("falls back to ~/.bun/bin when BUN_INSTALL not set", () => {
+    const result = buildMinimalServicePath({
+      env: { HOME: "/home/user" },
+    });
+    expect(result).toContain("/home/user/.bun/bin");
+  });
+
+  it("includes system directories", () => {
+    const result = buildMinimalServicePath({
+      env: { HOME: "/home/user" },
+    });
+    expect(result).toContain("/usr/local/bin");
+    expect(result).toContain("/usr/bin");
+    expect(result).toContain("/bin");
+  });
+
+  it("does not include nvm, pnpm, or npm directories", () => {
+    const result = buildMinimalServicePath({
+      env: {
+        HOME: "/home/user",
+        PATH: "/home/user/.nvm/versions/node/v22.0.0/bin:/home/user/.local/share/pnpm:/usr/bin",
+      },
+    });
+    expect(result).not.toContain(".nvm");
+    expect(result).not.toContain("pnpm");
+  });
+
+  it("includes extra directories when provided", () => {
+    const result = buildMinimalServicePath({
+      env: { HOME: "/home/user" },
+      extraDirs: ["/custom/tools"],
+    });
+    expect(result).toContain("/custom/tools");
+  });
+
+  it("deduplicates directories", () => {
+    const result = buildMinimalServicePath({
+      env: { HOME: "/home/user" },
+      extraDirs: ["/usr/bin", "/home/user/.bun/bin"],
+    });
+    const parts = result.split(path.delimiter);
+    const unique = [...new Set(parts)];
+    expect(parts.length).toBe(unique.length);
+  });
+
+  it("orders directories: bun → extra → system", () => {
+    const result = buildMinimalServicePath({
+      env: { HOME: "/home/user" },
+      extraDirs: ["/custom/tools"],
+    });
+    const parts = result.split(path.delimiter);
+    const bunIndex = parts.findIndex((p) => p.includes(".bun"));
+    const customIndex = parts.findIndex((p) => p.includes("/custom/tools"));
+    const systemIndex = parts.indexOf("/usr/bin");
+    expect(bunIndex).toBeLessThan(customIndex);
+    expect(customIndex).toBeLessThan(systemIndex);
+  });
+});
+
+describe("buildServiceEnvironment", () => {
+  it("uses minimal PATH", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", PATH: "/full/complex/path" },
+      port: 18789,
+    });
+    expect(env.PATH).toContain(".bun");
+    expect(env.PATH).not.toContain("/full/complex/path");
+  });
+
+  it("includes CLAWDBOT_GATEWAY_PORT", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    expect(env.CLAWDBOT_GATEWAY_PORT).toBe("18789");
+  });
+
+  it("includes token when provided", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      token: "secret",
+    });
+    expect(env.CLAWDBOT_GATEWAY_TOKEN).toBe("secret");
+  });
+
+  it("includes launchd label when provided", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      launchdLabel: "com.clawdbot.gateway",
+    });
+    expect(env.CLAWDBOT_LAUNCHD_LABEL).toBe("com.clawdbot.gateway");
+  });
+
+  it("passes through CLAWDBOT_* env vars", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        CLAWDBOT_PROFILE: "work",
+        CLAWDBOT_STATE_DIR: "/custom/state",
+        CLAWDBOT_CONFIG_PATH: "/custom/config.json",
+      },
+      port: 18789,
+    });
+    expect(env.CLAWDBOT_PROFILE).toBe("work");
+    expect(env.CLAWDBOT_STATE_DIR).toBe("/custom/state");
+    expect(env.CLAWDBOT_CONFIG_PATH).toBe("/custom/config.json");
+  });
+});

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,0 +1,118 @@
+/**
+ * Build a minimal PATH for gateway daemon services.
+ *
+ * The gateway runtime only needs:
+ * - bun (to execute the gateway)
+ * - system binaries (git, ssh, curl, chromium, etc.)
+ *
+ * We intentionally exclude package managers (pnpm, npm) and version managers
+ * (nvm, fnm, volta) since they're only needed at install/dev time, not runtime.
+ * This keeps the service environment clean and avoids hardcoding version-specific
+ * paths that break when you upgrade Node or switch versions.
+ *
+ * DISPLAY and other runtime variables should be set in the .env file
+ * (~/.clawdbot/.env) which is loaded early by the gateway via loadDotEnv().
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+const SYSTEM_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"];
+
+/**
+ * Resolve the bun binary directory.
+ * Checks common install locations in order of preference.
+ */
+function resolveBunDir(env: Record<string, string | undefined>): string | null {
+  const home = env.HOME ?? os.homedir();
+  const candidates = [
+    env.BUN_INSTALL ? path.join(env.BUN_INSTALL, "bin") : null,
+    path.join(home, ".bun", "bin"),
+    "/usr/local/bin", // homebrew or manual install
+  ].filter(Boolean) as string[];
+
+  // Return first candidate that's likely valid
+  // We don't check file existence here to keep it fast and pure
+  for (const dir of candidates) {
+    if (dir.includes(".bun") || dir.includes("bun")) {
+      return dir;
+    }
+  }
+  return candidates[0] ?? null;
+}
+
+export type BuildServicePathOptions = {
+  env?: Record<string, string | undefined>;
+  /**
+   * Extra directories to include in PATH (e.g., for custom tools).
+   * Added after bun but before system directories.
+   */
+  extraDirs?: string[];
+};
+
+/**
+ * Build a minimal PATH for the gateway service.
+ *
+ * Order: bun → extra → system
+ *
+ * @example
+ * ```ts
+ * const PATH = buildMinimalServicePath({ env: process.env });
+ * // → "/home/user/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+ * ```
+ */
+export function buildMinimalServicePath(
+  options: BuildServicePathOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const extraDirs = options.extraDirs ?? [];
+
+  const parts: string[] = [];
+
+  // 1. Bun directory (required for gateway execution)
+  const bunDir = resolveBunDir(env);
+  if (bunDir) {
+    parts.push(bunDir);
+  }
+
+  // 2. Extra directories (optional, for custom tools)
+  for (const dir of extraDirs) {
+    if (dir && !parts.includes(dir)) {
+      parts.push(dir);
+    }
+  }
+
+  // 3. System directories
+  for (const dir of SYSTEM_PATH_DIRS) {
+    if (!parts.includes(dir)) {
+      parts.push(dir);
+    }
+  }
+
+  return parts.join(path.delimiter);
+}
+
+/**
+ * Build the environment record for the gateway service.
+ *
+ * Uses a minimal PATH and includes only necessary CLAWDBOT_* variables.
+ * Runtime variables like DISPLAY should be in ~/.clawdbot/.env instead.
+ */
+export function buildServiceEnvironment(params: {
+  env: Record<string, string | undefined>;
+  port: number;
+  token?: string;
+  launchdLabel?: string;
+}): Record<string, string | undefined> {
+  const { env, port, token, launchdLabel } = params;
+
+  return {
+    PATH: buildMinimalServicePath({ env }),
+    CLAWDBOT_PROFILE: env.CLAWDBOT_PROFILE,
+    CLAWDBOT_STATE_DIR: env.CLAWDBOT_STATE_DIR,
+    CLAWDBOT_CONFIG_PATH: env.CLAWDBOT_CONFIG_PATH,
+    CLAWDBOT_GATEWAY_PORT: String(port),
+    CLAWDBOT_GATEWAY_TOKEN: token,
+    CLAWDBOT_LAUNCHD_LABEL: launchdLabel,
+  };
+}

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -47,6 +47,7 @@ import {
 import { GATEWAY_LAUNCH_AGENT_LABEL } from "../daemon/constants.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { buildServiceEnvironment } from "../daemon/service-env.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -472,14 +473,15 @@ export async function runOnboardingWizard(
           dev: devMode,
           runtime: daemonRuntime,
         });
-      const environment: Record<string, string | undefined> = {
-        PATH: process.env.PATH,
-        CLAWDBOT_GATEWAY_TOKEN: gatewayToken,
-        CLAWDBOT_LAUNCHD_LABEL:
+      const environment = buildServiceEnvironment({
+        env: process.env,
+        port,
+        token: gatewayToken,
+        launchdLabel:
           process.platform === "darwin"
             ? GATEWAY_LAUNCH_AGENT_LABEL
             : undefined,
-      };
+      });
       await service.install({
         env: process.env,
         stdout: process.stdout,


### PR DESCRIPTION
## Summary

The gateway daemon now uses a **minimal PATH** that includes only:
- `~/.bun/bin` (bun runtime)
- `/usr/local/bin`, `/usr/bin`, `/bin` (system tools)

This intentionally **excludes** version managers (nvm, fnm, volta) and package managers (pnpm, npm) since they're only needed at install time, not runtime.

## Benefits

- **Cleaner service environment** — no cruft from user shell
- **No hardcoded version-specific paths** — won't break when you upgrade Node or switch versions via nvm
- **Consistent behavior** across different user setups

## Runtime variables

Variables like `DISPLAY` (for headless browser) should be set in `~/.clawdbot/.env`, which is loaded early by the gateway via `loadDotEnv()`. This keeps runtime config separate from the service definition.

## Changes

- Add `buildServiceEnvironment()` helper in `src/daemon/service-env.ts`
- Add `buildMinimalServicePath()` to construct a minimal PATH
- Update all `service.install()` call sites to use the new helper
- Add unit tests for the new helpers
- Add documentation section in `docs/gateway/troubleshooting.md`

## Testing

```bash
pnpm exec vitest run src/daemon/service-env.test.ts
```

Tested manually on Linux (systemd) — gateway starts correctly with the minimal PATH.