### PR TITLE
fix(daemon): align systemd unit with documentation

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -141,10 +141,13 @@ function buildSystemdUnit({
   return [
     "[Unit]",
     "Description=Clawdbot Gateway",
+    "After=network-online.target",
+    "Wants=network-online.target",
     "",
     "[Service]",
     `ExecStart=${execStart}`,
     "Restart=always",
+    "RestartSec=5",
     workingDirLine,
     ...envLines,
     "",


### PR DESCRIPTION
## Summary

Align generated systemd service file with documentation:
https://docs.clawd.bot/gateway#supervision-systemd-user-unit

## Changes

Adds missing directives to the generated `.service` file:

- `After=network-online.target`
- `Wants=network-online.target`
- `RestartSec=5`

## Generated file now matches docs:

```ini
[Unit]
Description=Clawdbot Gateway
After=network-online.target
Wants=network-online.target

[Service]
ExecStart=...
Restart=always
RestartSec=5
WorkingDirectory=...
Environment=PATH=...

[Install]
WantedBy=default.target
```