### PR TITLE
fix(discord): auto-join threads after creation to receive gateway events

### DIFF
--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -892,7 +892,12 @@ export async function createThreadDiscord(
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
   const route = Routes.threads(channelId, payload.messageId);
-  return await rest.post(route, { body });
+  const thread = (await rest.post(route, { body })) as { id?: string };
+  // Join the thread to receive MESSAGE_CREATE gateway events
+  if (thread?.id) {
+    await rest.put(Routes.threadMembers(thread.id, "@me"));
+  }
+  return thread;
 }
 
 export async function listThreadsDiscord(


### PR DESCRIPTION
## Problem

When creating a thread via the Discord REST API, the bot becomes the thread "owner" but is **not automatically subscribed** to receive `MESSAGE_CREATE` events through the gateway. This means the bot cannot see messages in threads it creates.

## Solution

After creating a thread, explicitly join it by calling:
```
PUT /channels/{threadId}/thread-members/@me
```

This is a minimal change (4 lines) to `src/discord/send.ts` in the `createThreadDiscord` function.

## Testing

1. Create a thread using the `discord` tool with `threadCreate` action
2. Send messages in the thread
3. Verify the bot receives the messages via the gateway (previously it would not)