### PR TITLE
✨ Telegram Inline Keyboard Buttons

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -580,6 +580,8 @@ function buildEmbeddedSystemPrompt(params: {
     arch: string;
     node: string;
     model: string;
+    provider?: string;
+    capabilities?: string[];
   };
   sandboxInfo?: EmbeddedSandboxInfo;
   tools: AgentTool[];
@@ -746,6 +748,7 @@ export async function compactEmbeddedPiSession(params: {
   sessionId: string;
   sessionKey?: string;
   messageProvider?: string;
+  messageProviderCapabilities?: string[];
   agentAccountId?: string;
   sessionFile: string;
   workspaceDir: string;
@@ -864,6 +867,8 @@ export async function compactEmbeddedPiSession(params: {
           arch: os.arch(),
           node: process.version,
           model: `${provider}/${modelId}`,
+          provider: params.messageProvider?.trim().toLowerCase(),
+          capabilities: params.messageProviderCapabilities,
         };
         const sandboxInfo = buildEmbeddedSandboxInfo(sandbox);
         const reasoningTagHint = provider === "ollama";
@@ -973,6 +978,7 @@ export async function runEmbeddedPiAgent(params: {
   sessionId: string;
   sessionKey?: string;
   messageProvider?: string;
+  messageProviderCapabilities?: string[];
   agentAccountId?: string;
   sessionFile: string;
   workspaceDir: string;
@@ -1177,6 +1183,8 @@ export async function runEmbeddedPiAgent(params: {
             arch: os.arch(),
             node: process.version,
             model: `${provider}/${modelId}`,
+            provider: params.messageProvider?.trim().toLowerCase(),
+            capabilities: params.messageProviderCapabilities,
           };
           const sandboxInfo = buildEmbeddedSandboxInfo(sandbox);
           const reasoningTagHint = provider === "ollama";

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -19,6 +19,8 @@ export function buildAgentSystemPrompt(params: {
     arch?: string;
     node?: string;
     model?: string;
+    provider?: string;
+    capabilities?: string[];
   };
   sandboxInfo?: {
     enabled: boolean;
@@ -127,6 +129,13 @@ export function buildAgentSystemPrompt(params: {
     ? `Heartbeat prompt: ${heartbeatPrompt}`
     : "Heartbeat prompt: (configured)";
   const runtimeInfo = params.runtimeInfo;
+  const runtimeCapabilities = (runtimeInfo?.capabilities ?? [])
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const runtimeProvider = runtimeInfo?.provider?.trim();
+  const runtimeCapabilitiesLine = runtimeInfo?.capabilities
+    ? `capabilities=${runtimeCapabilities.length > 0 ? runtimeCapabilities.join(",") : "none"}`
+    : "";
 
   const lines = [
     "You are a personal assistant running inside ClaudeBot.",
@@ -264,6 +273,8 @@ export function buildAgentSystemPrompt(params: {
           : "",
       runtimeInfo?.node ? `node=${runtimeInfo.node}` : "",
       runtimeInfo?.model ? `model=${runtimeInfo.model}` : "",
+      runtimeProvider ? `provider=${runtimeProvider}` : "",
+      runtimeCapabilitiesLine,
       `thinking=${params.defaultThinkLevel ?? "off"}`,
     ]
       .filter(Boolean)

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ClawdbotConfig } from "../../config/config.js";
-import { handleTelegramAction } from "./telegram-actions.js";
+import {
+  handleTelegramAction,
+  readTelegramButtons,
+} from "./telegram-actions.js";
 
 const reactMessageTelegram = vi.fn(async () => ({ ok: true }));
 const sendMessageTelegram = vi.fn(async () => ({
@@ -167,5 +170,46 @@ describe("handleTelegramAction", () => {
         cfg,
       ),
     ).rejects.toThrow(/Telegram bot token missing/);
+  });
+});
+
+describe("readTelegramButtons", () => {
+  it("returns trimmed button rows for valid input", () => {
+    const result = readTelegramButtons({
+      buttons: [[{ text: "  Option A ", callback_data: " cmd:a " }]],
+    });
+    expect(result).toEqual([
+      [{ text: "Option A", callback_data: "cmd:a" }],
+    ]);
+  });
+
+  it("rejects non-array inputs", () => {
+    expect(() => readTelegramButtons({ buttons: "nope" })).toThrow(
+      /buttons must be an array/i,
+    );
+  });
+
+  it("rejects non-array rows", () => {
+    expect(() => readTelegramButtons({ buttons: [{}] })).toThrow(
+      /buttons\[0\] must be an array/i,
+    );
+  });
+
+  it("rejects invalid buttons", () => {
+    expect(() =>
+      readTelegramButtons({
+        buttons: [[{ text: "Ok", callback_data: "" }]],
+      }),
+    ).toThrow(/requires text and callback_data/i);
+    expect(() =>
+      readTelegramButtons({
+        buttons: [[{ text: "", callback_data: "cmd:ok" }]],
+      }),
+    ).toThrow(/requires text and callback_data/i);
+    expect(() =>
+      readTelegramButtons({
+        buttons: [[null]],
+      }),
+    ).toThrow(/must be an object/i);
   });
 });

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -95,7 +95,7 @@ type TelegramButton = {
   callback_data: string;
 };
 
-function readTelegramButtons(
+export function readTelegramButtons(
   params: Record<string, unknown>,
 ): TelegramButton[][] | undefined {
   const raw = params.buttons;

--- a/src/agents/tools/telegram-schema.ts
+++ b/src/agents/tools/telegram-schema.ts
@@ -20,6 +20,17 @@ export const TelegramToolSchema = Type.Union([
     mediaUrl: Type.Optional(
       Type.String({ description: "URL of image/video/audio to attach" }),
     ),
+    buttons: Type.Optional(
+      Type.Array(
+        Type.Array(
+          Type.Object({
+            text: Type.String(),
+            callback_data: Type.String(),
+          }),
+        ),
+        { description: "Inline keyboard buttons (array of button rows)" },
+      ),
+    ),
     replyToMessageId: Type.Optional(
       Type.Union([Type.String(), Type.Number()], {
         description: "Message ID to reply to (for threading)",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -14,6 +14,7 @@ import {
   type SessionEntry,
   saveSessionStore,
 } from "../../config/sessions.js";
+import { resolveProviderCapabilities } from "../../config/provider-capabilities.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
@@ -228,6 +229,13 @@ export async function runReplyAgent(params: {
     let fallbackProvider = followupRun.run.provider;
     let fallbackModel = followupRun.run.model;
     try {
+      const messageProvider = sessionCtx.Provider?.trim().toLowerCase();
+      const messageProviderCapabilities =
+        resolveProviderCapabilities({
+          cfg: followupRun.run.config,
+          provider: messageProvider,
+          accountId: sessionCtx.AccountId,
+        }) ?? (messageProvider ? [] : undefined);
       const allowPartialStream = !(
         followupRun.run.reasoningLevel === "stream" && opts?.onReasoningStream
       );
@@ -239,8 +247,8 @@ export async function runReplyAgent(params: {
           runEmbeddedPiAgent({
             sessionId: followupRun.run.sessionId,
             sessionKey,
-            messageProvider:
-              sessionCtx.Provider?.trim().toLowerCase() || undefined,
+            messageProvider: messageProvider || undefined,
+            messageProviderCapabilities,
             agentAccountId: sessionCtx.AccountId,
             sessionFile: followupRun.run.sessionFile,
             workspaceDir: followupRun.run.workspaceDir,

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -19,6 +19,7 @@ import {
   type SessionScope,
   saveSessionStore,
 } from "../../config/sessions.js";
+import { resolveProviderCapabilities } from "../../config/provider-capabilities.js";
 import { logVerbose } from "../../globals.js";
 import {
   formatUsageSummaryLine,
@@ -532,10 +533,18 @@ export async function handleCommands(params: {
       cfg,
       isGroup,
     });
+    const messageProvider = command.provider?.trim().toLowerCase();
+    const messageProviderCapabilities =
+      resolveProviderCapabilities({
+        cfg,
+        provider: messageProvider,
+        accountId: ctx.AccountId,
+      }) ?? (messageProvider ? [] : undefined);
     const result = await compactEmbeddedPiSession({
       sessionId,
       sessionKey,
-      messageProvider: command.provider,
+      messageProvider: messageProvider,
+      messageProviderCapabilities,
       sessionFile: resolveSessionFilePath(sessionId, sessionEntry),
       workspaceDir,
       config: cfg,

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -440,6 +440,11 @@ export async function handleCommands(params: {
       ? (normalizeGroupActivation(sessionEntry?.groupActivation) ??
         defaultGroupActivation())
       : undefined;
+    const statusProviderCapabilities = resolveProviderCapabilities({
+      cfg,
+      provider: command.provider,
+      accountId: ctx.AccountId,
+    });
     const statusText = buildStatusMessage({
       agent: {
         ...cfg.agent,
@@ -472,6 +477,8 @@ export async function handleCommands(params: {
         showDetails: queueOverrides,
       },
       includeTranscriptUsage: false,
+      provider: command.provider,
+      providerCapabilities: statusProviderCapabilities,
     });
     return { shouldContinue: false, reply: { text: statusText } };
   }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -54,6 +54,8 @@ type StatusArgs = {
   queue?: QueueStatus;
   includeTranscriptUsage?: boolean;
   now?: number;
+  provider?: string;
+  providerCapabilities?: string[];
 };
 
 const formatAge = (ms?: number | null) => {
@@ -281,12 +283,20 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelLabel = model ? `${provider}/${model}` : "unknown";
   const authLabel = args.modelAuth ? ` · 🔑 ${args.modelAuth}` : "";
   const modelLine = `🧠 Model: ${modelLabel}${authLabel}`;
+  const capabilitiesLabel =
+    args.providerCapabilities && args.providerCapabilities.length > 0
+      ? args.providerCapabilities.join(", ")
+      : "none";
+  const providerLine = args.provider
+    ? `📡 Provider: ${args.provider} · Capabilities: ${capabilitiesLabel}`
+    : null;
   const commit = resolveCommitHash();
   const versionLine = `🦞 ClawdBot ${VERSION}${commit ? ` (${commit})` : ""}`;
 
   return [
     versionLine,
     modelLine,
+    providerLine,
     `📚 ${contextLine}`,
     args.usageLine,
     `🧵 ${sessionLine}`,

--- a/src/config/provider-capabilities.ts
+++ b/src/config/provider-capabilities.ts
@@ -1,0 +1,55 @@
+import { normalizeAccountId } from "../routing/session-key.js";
+import type { ClawdbotConfig } from "./config.js";
+
+function normalizeCapabilities(
+  capabilities: string[] | undefined,
+): string[] | undefined {
+  if (!capabilities) return undefined;
+  return capabilities.map((entry) => entry.trim()).filter(Boolean);
+}
+
+export function resolveProviderCapabilities(params: {
+  cfg?: ClawdbotConfig;
+  provider?: string | null;
+  accountId?: string | null;
+}): string[] | undefined {
+  const cfg = params.cfg;
+  const provider = params.provider?.trim().toLowerCase();
+  if (!cfg || !provider) return undefined;
+
+  const accountId = normalizeAccountId(params.accountId);
+
+  switch (provider) {
+    case "whatsapp":
+      return normalizeCapabilities(
+        cfg.whatsapp?.accounts?.[accountId]?.capabilities ??
+          cfg.whatsapp?.capabilities,
+      );
+    case "telegram":
+      return normalizeCapabilities(
+        cfg.telegram?.accounts?.[accountId]?.capabilities ??
+          cfg.telegram?.capabilities,
+      );
+    case "discord":
+      return normalizeCapabilities(
+        cfg.discord?.accounts?.[accountId]?.capabilities ??
+          cfg.discord?.capabilities,
+      );
+    case "slack":
+      return normalizeCapabilities(
+        cfg.slack?.accounts?.[accountId]?.capabilities ?? cfg.slack?.capabilities,
+      );
+    case "signal":
+      return normalizeCapabilities(
+        cfg.signal?.accounts?.[accountId]?.capabilities ??
+          cfg.signal?.capabilities,
+      );
+    case "imessage":
+      return normalizeCapabilities(
+        cfg.imessage?.accounts?.[accountId]?.capabilities ??
+          cfg.imessage?.capabilities,
+      );
+    default:
+      return undefined;
+  }
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -98,6 +98,8 @@ export type WhatsAppActionConfig = {
 export type WhatsAppConfig = {
   /** Optional per-account WhatsApp configuration (multi-account). */
   accounts?: Record<string, WhatsAppAccountConfig>;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
   /**
@@ -131,6 +133,8 @@ export type WhatsAppConfig = {
 export type WhatsAppAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** If false, do not start this WhatsApp account provider. Default: true. */
   enabled?: boolean;
   /** Override auth directory (Baileys multi-file auth state). */
@@ -265,6 +269,8 @@ export type TelegramActionConfig = {
 export type TelegramAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /**
    * Controls how Telegram direct chats (DMs) are handled:
    * - "pairing" (default): unknown senders get a pairing code; owner must approve
@@ -401,6 +407,8 @@ export type DiscordActionConfig = {
 export type DiscordAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** If false, do not start this Discord account. Default: true. */
   enabled?: boolean;
   token?: string;
@@ -494,6 +502,8 @@ export type SlackSlashCommandConfig = {
 export type SlackAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** If false, do not start this Slack account. Default: true. */
   enabled?: boolean;
   botToken?: string;
@@ -529,6 +539,8 @@ export type SlackConfig = {
 export type SignalAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** If false, do not start this Signal account. Default: true. */
   enabled?: boolean;
   /** Optional explicit E.164 account for signal-cli. */
@@ -572,6 +584,8 @@ export type SignalConfig = {
 export type IMessageAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional provider capability tags used for runtime metadata. */
+  capabilities?: string[];
   /** If false, do not start this iMessage account. Default: true. */
   enabled?: boolean;
   /** imsg CLI binary path (default: imsg). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -160,6 +160,7 @@ const TelegramGroupSchema = z.object({
 
 const TelegramAccountSchemaBase = z.object({
   name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   botToken: z.string().optional(),
@@ -250,6 +251,7 @@ const DiscordGuildSchema = z.object({
 
 const DiscordAccountSchema = z.object({
   name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   token: z.string().optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
@@ -317,6 +319,7 @@ const SlackChannelSchema = z.object({
 
 const SlackAccountSchema = z.object({
   name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   botToken: z.string().optional(),
   appToken: z.string().optional(),
@@ -357,6 +360,7 @@ const SlackConfigSchema = SlackAccountSchema.extend({
 
 const SignalAccountSchemaBase = z.object({
   name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   account: z.string().optional(),
   httpUrl: z.string().optional(),
@@ -403,6 +407,7 @@ const SignalConfigSchema = SignalAccountSchemaBase.extend({
 
 const IMessageAccountSchemaBase = z.object({
   name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   cliPath: z.string().optional(),
   dbPath: z.string().optional(),
@@ -1120,6 +1125,7 @@ export const ClawdbotSchema = z.object({
           z
             .object({
               name: z.string().optional(),
+              capabilities: z.array(z.string()).optional(),
               enabled: z.boolean().optional(),
               /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
               authDir: z.string().optional(),
@@ -1156,6 +1162,7 @@ export const ClawdbotSchema = z.object({
             .optional(),
         )
         .optional(),
+      capabilities: z.array(z.string()).optional(),
       dmPolicy: DmPolicySchema.optional().default("pairing"),
       selfChatMode: z.boolean().optional(),
       allowFrom: z.array(z.string()).optional(),

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -29,7 +29,51 @@ vi.mock("grammy", () => ({
   InputFile: class {},
 }));
 
-import { reactMessageTelegram, sendMessageTelegram } from "./send.js";
+import {
+  buildInlineKeyboard,
+  reactMessageTelegram,
+  sendMessageTelegram,
+} from "./send.js";
+
+describe("buildInlineKeyboard", () => {
+  it("returns undefined for empty input", () => {
+    expect(buildInlineKeyboard()).toBeUndefined();
+    expect(buildInlineKeyboard([])).toBeUndefined();
+  });
+
+  it("builds inline keyboards for valid input", () => {
+    const result = buildInlineKeyboard([
+      [{ text: "Option A", callback_data: "cmd:a" }],
+      [
+        { text: "Option B", callback_data: "cmd:b" },
+        { text: "Option C", callback_data: "cmd:c" },
+      ],
+    ]);
+    expect(result).toEqual({
+      inline_keyboard: [
+        [{ text: "Option A", callback_data: "cmd:a" }],
+        [
+          { text: "Option B", callback_data: "cmd:b" },
+          { text: "Option C", callback_data: "cmd:c" },
+        ],
+      ],
+    });
+  });
+
+  it("filters invalid buttons and empty rows", () => {
+    const result = buildInlineKeyboard([
+      [
+        { text: "", callback_data: "cmd:skip" },
+        { text: "Ok", callback_data: "cmd:ok" },
+      ],
+      [{ text: "Missing data", callback_data: "" }],
+      [],
+    ]);
+    expect(result).toEqual({
+      inline_keyboard: [[{ text: "Ok", callback_data: "cmd:ok" }]],
+    });
+  });
+});
 
 describe("sendMessageTelegram", () => {
   beforeEach(() => {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -105,7 +105,7 @@ function normalizeMessageId(raw: string | number): number {
   throw new Error("Message id is required for Telegram reactions");
 }
 
-function buildInlineKeyboard(
+export function buildInlineKeyboard(
   buttons?: TelegramSendOpts["buttons"],
 ): InlineKeyboardMarkup | undefined {
   if (!buttons?.length) return undefined;


### PR DESCRIPTION
## What

Two related features for Telegram:

### 1. Inline Keyboard Buttons
Add support for inline keyboard buttons in Telegram messages — enabling interactive UI elements like quick actions and contextual options.

### 2. Provider Capabilities
Allow providers to declare capabilities in config that flow into the agent's system prompt, so the agent knows what features are available for the current session.

---

## Inline Buttons

### Usage

```typescript
await telegram.sendMessage({
  to: chatId,
  content: "Choose wisely:",
  buttons: [
    [
      { text: "👍 Yes", callback_data: "cmd:yes" },
      { text: "👎 No", callback_data: "cmd:no" }
    ]
  ]
});
```

When a user taps a button, the `callback_data` is routed to the agent as if they had typed that text.

### Changes
- `telegram-schema.ts` — `buttons` parameter
- `telegram-actions.ts` — parse and validate buttons
- `send.ts` — build `InlineKeyboardMarkup`
- `bot.ts` — handle `callback_query` events

---

## Provider Capabilities

### Config

```json
{
  "telegram": {
    "capabilities": ["inlineButtons"]
  }
}
```

### Runtime

Capabilities appear in the agent's system prompt Runtime line:
```
Runtime: ... | provider=telegram | capabilities=inlineButtons
```

And in `/status`:
```
📡 Provider: telegram · Capabilities: inlineButtons
```

### Changes
- `types.ts` / `zod-schema.ts` — add `capabilities?: string[]` to all providers
- `provider-capabilities.ts` — new helper to resolve capabilities
- `system-prompt.ts` — display in Runtime line
- `status.ts` / `commands.ts` — display in `/status`

---

## Proof it works

![Telegram inline buttons in action](https://i.imgur.com/FU8KXiJ.jpeg)

---

🐐 *Built with Codex CLI, tested in production*