### PR TITLE
feat(commands): add /commands slash list

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -32,6 +32,7 @@ Inline text like `hello /status` is ignored.
 
 Text + native (when enabled):
 - `/help`
+- `/commands`
 - `/status`
 - `/stop`
 - `/restart`

--- a/src/auto-reply/command-detection.test.ts
+++ b/src/auto-reply/command-detection.test.ts
@@ -42,9 +42,15 @@ describe("control command parsing", () => {
     expect(hasControlCommand("/help")).toBe(true);
     expect(hasControlCommand("/help:")).toBe(true);
     expect(hasControlCommand("help")).toBe(false);
+    expect(hasControlCommand("/commands")).toBe(true);
+    expect(hasControlCommand("/commands:")).toBe(true);
+    expect(hasControlCommand("commands")).toBe(false);
     expect(hasControlCommand("/status")).toBe(true);
     expect(hasControlCommand("/status:")).toBe(true);
     expect(hasControlCommand("status")).toBe(false);
+    expect(hasControlCommand("/compact")).toBe(true);
+    expect(hasControlCommand("/compact:")).toBe(true);
+    expect(hasControlCommand("compact")).toBe(false);
   });
 
   it("requires commands to be the full message", () => {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -17,13 +17,17 @@ describe("commands registry", () => {
     const specs = listNativeCommandSpecs();
     expect(specs.find((spec) => spec.name === "help")).toBeTruthy();
     expect(specs.find((spec) => spec.name === "stop")).toBeTruthy();
+    expect(specs.find((spec) => spec.name === "compact")).toBeFalsy();
   });
 
   it("detects known text commands", () => {
     const detection = getCommandDetection();
     expect(detection.exact.has("/help")).toBe(true);
+    expect(detection.exact.has("/commands")).toBe(true);
     expect(detection.regex.test("/status")).toBe(true);
     expect(detection.regex.test("/status:")).toBe(true);
+    expect(detection.regex.test("/compact")).toBe(true);
+    expect(detection.regex.test("/compact:")).toBe(true);
     expect(detection.regex.test("/stop")).toBe(true);
     expect(detection.regex.test("/send:")).toBe(true);
     expect(detection.regex.test("try /status")).toBe(false);

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -6,6 +6,7 @@ export type ChatCommandDefinition = {
   description: string;
   textAliases: string[];
   acceptsArgs?: boolean;
+  supportsNative?: boolean;
 };
 
 export type NativeCommandSpec = {
@@ -20,6 +21,12 @@ const CHAT_COMMANDS: ChatCommandDefinition[] = [
     nativeName: "help",
     description: "Show available commands.",
     textAliases: ["/help"],
+  },
+  {
+    key: "commands",
+    nativeName: "commands",
+    description: "List all slash commands.",
+    textAliases: ["/commands"],
   },
   {
     key: "status",
@@ -64,6 +71,14 @@ const CHAT_COMMANDS: ChatCommandDefinition[] = [
     nativeName: "new",
     description: "Start a new session.",
     textAliases: ["/new"],
+  },
+  {
+    key: "compact",
+    nativeName: "compact",
+    description: "Compact the current session context.",
+    textAliases: ["/compact"],
+    acceptsArgs: true,
+    supportsNative: false,
   },
   {
     key: "think",
@@ -127,7 +142,9 @@ export function listChatCommands(): ChatCommandDefinition[] {
 }
 
 export function listNativeCommandSpecs(): NativeCommandSpec[] {
-  return CHAT_COMMANDS.map((command) => ({
+  return CHAT_COMMANDS.filter(
+    (command) => command.supportsNative !== false,
+  ).map((command) => ({
     name: command.nativeName,
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -43,6 +43,7 @@ import {
 } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
 import {
+  buildCommandsMessage,
   buildHelpMessage,
   buildStatusMessage,
   formatContextUsageShort,
@@ -402,6 +403,17 @@ export async function handleCommands(params: {
       return { shouldContinue: false };
     }
     return { shouldContinue: false, reply: { text: buildHelpMessage() } };
+  }
+
+  const commandsRequested = command.commandBodyNormalized === "/commands";
+  if (allowTextCommands && commandsRequested) {
+    if (!command.isAuthorizedSender) {
+      logVerbose(
+        `Ignoring /commands from unauthorized sender: ${command.senderE164 || "<unknown>"}`,
+      );
+      return { shouldContinue: false };
+    }
+    return { shouldContinue: false, reply: { text: buildCommandsMessage() } };
   }
 
   const statusRequested =

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildStatusMessage } from "./status.js";
+import { buildCommandsMessage, buildStatusMessage } from "./status.js";
 
 const HOME_ENV_KEYS = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"] as const;
 type HomeEnvSnapshot = Record<
@@ -232,5 +232,18 @@ describe("buildStatusMessage", () => {
       restoreHomeEnv(previousHome);
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("buildCommandsMessage", () => {
+  it("lists commands with aliases and text-only hints", () => {
+    const text = buildCommandsMessage();
+    expect(text).toContain("/commands - List all slash commands.");
+    expect(text).toContain(
+      "/think (aliases: /thinking, /t) - Set thinking level.",
+    );
+    expect(text).toContain(
+      "/compact (text-only) - Compact the current session context.",
+    );
   });
 });

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -21,6 +21,7 @@ import {
 } from "../config/sessions.js";
 import { resolveCommitHash } from "../infra/git-commit.js";
 import { VERSION } from "../version.js";
+import { listChatCommands } from "./commands-registry.js";
 import type {
   ElevatedLevel,
   ReasoningLevel,
@@ -302,5 +303,30 @@ export function buildHelpMessage(): string {
     "ℹ️ Help",
     "Shortcuts: /new reset | /compact [instructions] | /restart relink",
     "Options: /think <level> | /verbose on|off | /reasoning on|off | /elevated on|off | /model <id>",
+    "More: /commands for all slash commands",
   ].join("\n");
+}
+
+export function buildCommandsMessage(): string {
+  const lines = ["ℹ️ Slash commands"];
+  for (const command of listChatCommands()) {
+    const primary = `/${command.nativeName}`;
+    const seen = new Set<string>();
+    const aliases = command.textAliases
+      .map((alias) => alias.trim())
+      .filter(Boolean)
+      .filter((alias) => alias.toLowerCase() !== primary.toLowerCase())
+      .filter((alias) => {
+        const key = alias.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    const aliasLabel = aliases.length
+      ? ` (aliases: ${aliases.join(", ")})`
+      : "";
+    const scopeLabel = command.supportsNative === false ? " (text-only)" : "";
+    lines.push(`${primary}${aliasLabel}${scopeLabel} - ${command.description}`);
+  }
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Rationale

Improves onboarding, help and discovery 

## Work Done
- add /commands to return a dynamic list of slash commands
- include /commands in /help output and slash command docs
- list text-only commands without registering native commands

## Testing
- pnpm test -- src/auto-reply/command-detection.test.ts