### PR TITLE
Avoid splitting outbound chunks inside parentheses

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -170,4 +170,29 @@ describe("chunkMarkdownText", () => {
       expect(nonFenceLines.join("\n").trim()).not.toBe("");
     }
   });
+
+  it("keeps parenthetical phrases together", () => {
+    const text = "Heads up now (Though now I'm curious)ok";
+    const chunks = chunkMarkdownText(text, 35);
+    expect(chunks).toEqual(["Heads up now", "(Though now I'm curious)ok"]);
+  });
+
+  it("handles nested parentheses", () => {
+    const text = "Hello (outer (inner) end) world";
+    const chunks = chunkMarkdownText(text, 26);
+    expect(chunks).toEqual(["Hello (outer (inner) end)", "world"]);
+  });
+
+  it("hard-breaks when a parenthetical exceeds the limit", () => {
+    const text = `(${"a".repeat(80)})`;
+    const chunks = chunkMarkdownText(text, 20);
+    expect(chunks[0]?.length).toBe(20);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("ignores unmatched closing parentheses", () => {
+    const text = "Hello) world (ok)";
+    const chunks = chunkMarkdownText(text, 12);
+    expect(chunks).toEqual(["Hello)", "world (ok)"]);
+  });
 });

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -60,18 +60,27 @@ export function chunkText(text: string, limit: number): string[] {
   while (remaining.length > limit) {
     const window = remaining.slice(0, limit);
 
-    // 1) Prefer a newline break inside the window.
-    let breakIdx = window.lastIndexOf("\n");
+    // 1) Prefer a newline break inside the window (outside parentheses).
+    let lastNewline = -1;
+    let lastWhitespace = -1;
+    let depth = 0;
+    for (let i = 0; i < window.length; i++) {
+      const char = window[i];
+      if (char === "(") {
+        depth += 1;
+        continue;
+      }
+      if (char === ")" && depth > 0) {
+        depth -= 1;
+        continue;
+      }
+      if (depth !== 0) continue;
+      if (char === "\n") lastNewline = i;
+      else if (/\s/.test(char)) lastWhitespace = i;
+    }
 
     // 2) Otherwise prefer the last whitespace (word boundary) inside the window.
-    if (breakIdx <= 0) {
-      for (let i = window.length - 1; i >= 0; i--) {
-        if (/\s/.test(window[i])) {
-          breakIdx = i;
-          break;
-        }
-      }
-    }
+    let breakIdx = lastNewline > 0 ? lastNewline : lastWhitespace;
 
     // 3) Fallback: hard break exactly at the limit.
     if (breakIdx <= 0) breakIdx = limit;
@@ -204,15 +213,27 @@ function pickSafeBreakIndex(
   window: string,
   spans: ReturnType<typeof parseFenceSpans>,
 ): number {
-  let newlineIdx = window.lastIndexOf("\n");
-  while (newlineIdx > 0) {
-    if (isSafeFenceBreak(spans, newlineIdx)) return newlineIdx;
-    newlineIdx = window.lastIndexOf("\n", newlineIdx - 1);
+  let lastNewline = -1;
+  let lastWhitespace = -1;
+  let depth = 0;
+
+  for (let i = 0; i < window.length; i++) {
+    if (!isSafeFenceBreak(spans, i)) continue;
+    const char = window[i];
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")" && depth > 0) {
+      depth -= 1;
+      continue;
+    }
+    if (depth !== 0) continue;
+    if (char === "\n") lastNewline = i;
+    else if (/\s/.test(char)) lastWhitespace = i;
   }
 
-  for (let i = window.length - 1; i > 0; i--) {
-    if (/\s/.test(window[i]) && isSafeFenceBreak(spans, i)) return i;
-  }
-
+  if (lastNewline > 0) return lastNewline;
+  if (lastWhitespace > 0) return lastWhitespace;
   return -1;
 }


### PR DESCRIPTION
## Summary
- avoid choosing newline/whitespace breakpoints inside parentheses when chunking text
- add regression tests for parenthetical splits, nested parens, over-limit fallback, and unmatched closing parens

## Problem
Outbound chunking (notably Telegram, but also other chunked providers) can split inside parenthetical phrases, producing awkward fragments. Example reported from Telegram UI:
- "(Though now I'm curious what model it is..."
- "👀)"

<img width="778" height="180" alt="CleanShot 2026-01-08 at 16 32 51@2x" src="https://github.com/user-attachments/assets/519a7ec9-11c1-46cd-92d1-5874e637c0ed" />


## Approach
- while scanning the chunk window, track paren depth and only record newline/whitespace breaks when depth is 0
- keep the existing hard-break fallback if no safe break exists

## Initial Prompt Summary
User report: Telegram messages often split inside parentheses; request was to stop splits until a closing ")" is found again.

## Iterations
- implemented a paren-aware splitter
- tried a lookahead-to-closing-paren approach, then reverted it to avoid extending chunks beyond the limit
- landed the simplest in-window paren-aware breakpoint selection and added regression tests

## Testing
- bunx vitest src/auto-reply/chunk.test.ts
