### PR TITLE
fix: serialize block replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Auto-reply: preserve block reply ordering with timeout fallback for streaming. (#503) — thanks @joshp123
 - WhatsApp: group `/model list` output by provider for scannability. (#456) - thanks @mcinteerj
 - Hooks: allow per-hook model overrides for webhook/Gmail runs (e.g. GPT 5 Mini).
 - Control UI: logs tab opens at the newest entries (bottom).

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -47,6 +47,7 @@ import type { TypingController } from "./typing.js";
 import { createTypingSignaler } from "./typing-mode.js";
 
 const BUN_FETCH_SOCKET_ERROR_RE = /socket connection was closed unexpectedly/i;
+const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 const isBunFetchSocketError = (message?: string) =>
   Boolean(message && BUN_FETCH_SOCKET_ERROR_RE.test(message));
@@ -59,6 +60,23 @@ const formatBunFetchSocketError = (message: string) => {
     trimmed || "Unknown error",
     "```",
   ].join("\n");
+};
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutError: Error,
+): Promise<T> => {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 };
 
 export async function runReplyAgent(params: {
@@ -144,6 +162,9 @@ export async function runReplyAgent(params: {
   const pendingStreamedPayloadKeys = new Set<string>();
   const pendingBlockTasks = new Set<Promise<void>>();
   const pendingToolTasks = new Set<Promise<void>>();
+  let blockReplyChain: Promise<void> = Promise.resolve();
+  let blockReplyAborted = false;
+  let didLogBlockReplyAbort = false;
   let didStreamBlockReply = false;
   const buildPayloadKey = (payload: ReplyPayload) => {
     const text = payload.text?.trim() ?? "";
@@ -367,16 +388,44 @@ export async function runReplyAgent(params: {
                     ) {
                       return;
                     }
+                    if (blockReplyAborted) return;
                     pendingStreamedPayloadKeys.add(payloadKey);
-                    const task = (async () => {
-                      await typingSignals.signalTextDelta(taggedPayload.text);
-                      await opts.onBlockReply?.(blockPayload);
-                    })()
-                      .then(() => {
+                    void typingSignals
+                      .signalTextDelta(taggedPayload.text)
+                      .catch((err) => {
+                        logVerbose(
+                          `block reply typing signal failed: ${String(err)}`,
+                        );
+                      });
+                    const timeoutError = new Error(
+                      `block reply delivery timed out after ${BLOCK_REPLY_SEND_TIMEOUT_MS}ms`,
+                    );
+                    blockReplyChain = blockReplyChain
+                      .then(async () => {
+                        if (blockReplyAborted) return false;
+                        await withTimeout(
+                          opts.onBlockReply?.(blockPayload) ?? Promise.resolve(),
+                          BLOCK_REPLY_SEND_TIMEOUT_MS,
+                          timeoutError,
+                        );
+                        return true;
+                      })
+                      .then((didSend) => {
+                        if (!didSend) return;
                         streamedPayloadKeys.add(payloadKey);
                         didStreamBlockReply = true;
                       })
                       .catch((err) => {
+                        if (err === timeoutError) {
+                          blockReplyAborted = true;
+                          if (!didLogBlockReplyAbort) {
+                            didLogBlockReplyAbort = true;
+                            logVerbose(
+                              `block reply delivery timed out after ${BLOCK_REPLY_SEND_TIMEOUT_MS}ms; skipping remaining block replies to preserve ordering`,
+                            );
+                          }
+                          return;
+                        }
                         logVerbose(
                           `block reply delivery failed: ${String(err)}`,
                         );
@@ -384,6 +433,7 @@ export async function runReplyAgent(params: {
                       .finally(() => {
                         pendingStreamedPayloadKeys.delete(payloadKey);
                       });
+                    const task = blockReplyChain;
                     pendingBlockTasks.add(task);
                     void task.finally(() => pendingBlockTasks.delete(task));
                   }
@@ -546,10 +596,10 @@ export async function runReplyAgent(params: {
       })
       .filter(isRenderablePayload);
 
-    // Drop final payloads if block streaming is enabled and we already streamed
-    // block replies. Tool-sent duplicates are filtered below.
+    // Drop final payloads only when block streaming succeeded end-to-end.
+    // If streaming aborted (e.g., timeout), fall back to final payloads.
     const shouldDropFinalPayloads =
-      blockStreamingEnabled && didStreamBlockReply;
+      blockStreamingEnabled && didStreamBlockReply && !blockReplyAborted;
     const messagingToolSentTexts = runResult.messagingToolSentTexts ?? [];
     const messagingToolSentTargets = runResult.messagingToolSentTargets ?? [];
     const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -41,10 +41,14 @@ export async function dispatchReplyFromConfig(params: {
    * Note: Only called when shouldRouteToOriginating is true, so
    * originatingChannel and originatingTo are guaranteed to be defined.
    */
-  const sendPayloadAsync = async (payload: ReplyPayload): Promise<void> => {
+  const sendPayloadAsync = async (
+    payload: ReplyPayload,
+    abortSignal?: AbortSignal,
+  ): Promise<void> => {
     // TypeScript doesn't narrow these from the shouldRouteToOriginating check,
     // but they're guaranteed non-null when this function is called.
     if (!originatingChannel || !originatingTo) return;
+    if (abortSignal?.aborted) return;
     const result = await routeReply({
       payload,
       channel: originatingChannel,
@@ -52,6 +56,7 @@ export async function dispatchReplyFromConfig(params: {
       accountId: ctx.AccountId,
       threadId: ctx.MessageThreadId,
       cfg,
+      abortSignal,
     });
     if (!result.ok) {
       logVerbose(
@@ -73,10 +78,10 @@ export async function dispatchReplyFromConfig(params: {
           dispatcher.sendToolResult(payload);
         }
       },
-      onBlockReply: (payload: ReplyPayload) => {
+      onBlockReply: (payload: ReplyPayload, context) => {
         if (shouldRouteToOriginating) {
-          // Fire-and-forget for streaming block replies when routing.
-          void sendPayloadAsync(payload);
+          // Await routed sends so upstream can enforce ordering/timeouts.
+          return sendPayloadAsync(payload, context?.abortSignal);
         } else {
           // Synchronous dispatch to preserve callback timing.
           dispatcher.sendBlockReply(payload);

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -31,6 +31,22 @@ vi.mock("../../web/outbound.js", () => ({
 const { routeReply } = await import("./route-reply.js");
 
 describe("routeReply", () => {
+  it("skips sends when abort signal is already aborted", async () => {
+    mocks.sendMessageSlack.mockClear();
+    const controller = new AbortController();
+    controller.abort();
+    const res = await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+      abortSignal: controller.signal,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("aborted");
+    expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
+  });
+
   it("no-ops on empty payload", async () => {
     mocks.sendMessageSlack.mockClear();
     const res = await routeReply({

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -30,6 +30,8 @@ export type RouteReplyParams = {
   threadId?: number;
   /** Config for provider-specific settings. */
   cfg: ClawdbotConfig;
+  /** Optional abort signal for cooperative cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type RouteReplyResult = {
@@ -52,7 +54,7 @@ export type RouteReplyResult = {
 export async function routeReply(
   params: RouteReplyParams,
 ): Promise<RouteReplyResult> {
-  const { payload, channel, to, accountId, threadId } = params;
+  const { payload, channel, to, accountId, threadId, abortSignal } = params;
 
   // Debug: `pnpm test src/auto-reply/reply/route-reply.test.ts`
   const text = payload.text ?? "";
@@ -72,6 +74,9 @@ export async function routeReply(
     text: string;
     mediaUrl?: string;
   }): Promise<RouteReplyResult> => {
+    if (abortSignal?.aborted) {
+      return { ok: false, error: "Reply routing aborted" };
+    }
     const { text, mediaUrl } = params;
     switch (channel) {
       case "telegram": {
@@ -148,12 +153,18 @@ export async function routeReply(
   };
 
   try {
+    if (abortSignal?.aborted) {
+      return { ok: false, error: "Reply routing aborted" };
+    }
     if (mediaUrls.length === 0) {
       return await sendOne({ text });
     }
 
     let last: RouteReplyResult | undefined;
     for (let i = 0; i < mediaUrls.length; i++) {
+      if (abortSignal?.aborted) {
+        return { ok: false, error: "Reply routing aborted" };
+      }
       const mediaUrl = mediaUrls[i];
       const caption = i === 0 ? text : "";
       last = await sendOne({ text: caption, mediaUrl });

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,14 +1,24 @@
 import type { TypingController } from "./reply/typing.js";
 
+export type BlockReplyContext = {
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+};
+
 export type GetReplyOptions = {
   onReplyStart?: () => Promise<void> | void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
-  onBlockReply?: (payload: ReplyPayload) => Promise<void> | void;
+  onBlockReply?: (
+    payload: ReplyPayload,
+    context?: BlockReplyContext,
+  ) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   disableBlockStreaming?: boolean;
+  /** Timeout for block reply delivery (ms). */
+  blockReplyTimeoutMs?: number;
   /** If provided, only load these skills for this session (empty = no skills). */
   skillFilter?: string[];
 };


### PR DESCRIPTION
## Summary
- serialize block reply sends to preserve message ordering under typing delays
- make block reply typing non-blocking and add send timeout with fallback to final payloads
- add regression coverage for ordering under delayed typing

## Details
### reply/agent-runner
- chain block reply sends in creation order
- fire typing signals asynchronously to avoid delaying sends
- timeout block sends and fall back to final payloads if streaming aborts

### tests
- add block-streaming ordering regression test

## Testing
- ./node_modules/.bin/vitest run src/auto-reply/reply.block-streaming.test.ts
