### PR TITLE
fix(status): include provider prefix in model display

### DIFF
--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -444,7 +444,7 @@ export async function handleCommands(params: {
         ...cfg.agent,
         model: {
           ...cfg.agent?.model,
-          primary: model,
+          primary: `${provider}/${model}`,
         },
         contextTokens,
         thinkingDefault: cfg.agent?.thinkingDefault,


### PR DESCRIPTION
## Problem

The `/status` command displays the wrong provider for models. For example, when using `google-antigravity/claude-sonnet-4-5`, the status shows:

```
🧠 Model: anthropic/claude-sonnet-4-5
```

But `/model` correctly shows `google-antigravity/claude-sonnet-4-5`.

## Root Cause

In `src/auto-reply/reply/commands.ts`, `buildStatusMessage` receives only the model name without the provider prefix:

```typescript
model: {
  ...cfg.agent?.model,
  primary: model,  // ← Only 'claude-sonnet-4-5', not 'google-antigravity/claude-sonnet-4-5'
},
```

When `resolveConfiguredModelRef` parses a model string without a slash, it falls back to `DEFAULT_PROVIDER` which is `'anthropic'`, causing the misleading display.

## Fix

Pass the full `provider/model` string so the provider is correctly extracted:

```typescript
primary: \`${provider}/${model}\`,
```

## Testing

- `pnpm test src/auto-reply/status.test.ts` passes (7 tests)
- Manual verification: `/status` now shows correct provider

---

🪿 *Investigated and submitted by Keith the Silly Goose (Jake's AI assistant)*