### PR TITLE
fix(telegram): resolve fetch type errors with grammY Bot constructor

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,4 +1,5 @@
 import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
+import type { ApiClientOptions } from "grammy";
 import { Bot, InputFile } from "grammy";
 import { loadConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -113,10 +114,10 @@ export async function sendMessageTelegram(
   // Use provided api or create a new Bot instance. The nullish coalescing
   // operator ensures api is always defined (Bot.api is always non-null).
   const fetchImpl = resolveTelegramFetch();
-  const api =
-    opts.api ??
-    new Bot(token, fetchImpl ? { client: { fetch: fetchImpl } } : undefined)
-      .api;
+  const client: ApiClientOptions | undefined = fetchImpl
+    ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
+    : undefined;
+  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
   const mediaUrl = opts.mediaUrl?.trim();
 
   // Build optional params for forum topics and reply threading.
@@ -271,10 +272,10 @@ export async function reactMessageTelegram(
   const chatId = normalizeChatId(String(chatIdInput));
   const messageId = normalizeMessageId(messageIdInput);
   const fetchImpl = resolveTelegramFetch();
-  const api =
-    opts.api ??
-    new Bot(token, fetchImpl ? { client: { fetch: fetchImpl } } : undefined)
-      .api;
+  const client: ApiClientOptions | undefined = fetchImpl
+    ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
+    : undefined;
+  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
   const request = createTelegramRetryRunner({
     retry: opts.retry,
     configRetry: account.config.retry,

--- a/src/telegram/webhook-set.ts
+++ b/src/telegram/webhook-set.ts
@@ -1,3 +1,4 @@
+import type { ApiClientOptions } from "grammy";
 import { Bot } from "grammy";
 import { resolveTelegramFetch } from "./fetch.js";
 
@@ -8,10 +9,10 @@ export async function setTelegramWebhook(opts: {
   dropPendingUpdates?: boolean;
 }) {
   const fetchImpl = resolveTelegramFetch();
-  const bot = new Bot(
-    opts.token,
-    fetchImpl ? { client: { fetch: fetchImpl } } : undefined,
-  );
+  const client: ApiClientOptions | undefined = fetchImpl
+    ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
+    : undefined;
+  const bot = new Bot(opts.token, client ? { client } : undefined);
   await bot.api.setWebhook(opts.url, {
     secret_token: opts.secret,
     drop_pending_updates: opts.dropPendingUpdates ?? false,
@@ -20,9 +21,9 @@ export async function setTelegramWebhook(opts: {
 
 export async function deleteTelegramWebhook(opts: { token: string }) {
   const fetchImpl = resolveTelegramFetch();
-  const bot = new Bot(
-    opts.token,
-    fetchImpl ? { client: { fetch: fetchImpl } } : undefined,
-  );
+  const client: ApiClientOptions | undefined = fetchImpl
+    ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
+    : undefined;
+  const bot = new Bot(opts.token, client ? { client } : undefined);
   await bot.api.deleteWebhook();
 }


### PR DESCRIPTION
## Description
This PR fixes TypeScript compilation errors caused by type incompatibility between the global \`fetch\` type and grammY's expected \`ApiClientOptions["fetch"]\` type.

## Changes
- Added \`ApiClientOptions\` import from "grammy" in \`src/telegram/send.ts\` and \`src/telegram/webhook-set.ts\`
- Applied proper type assertion (\`as unknown as ApiClientOptions["fetch"]\`) when creating the client object
- Updated 4 locations across 2 files where \`new Bot()\` is called

## Impact
- Resolves TypeScript errors TS2345 in \`src/telegram/send.ts\` (lines 118, 276)
- Resolves TypeScript errors TS2345 in \`src/telegram/webhook-set.ts\` (lines 11, 21)
- Follows the same pattern already used in \`src/telegram/bot.ts\` (lines 155-157)
- Allows the project to build successfully with \`npm run build\`

## Testing
- [x] Verified build passes with \`npm run build\`
- [x] Verified lint passes with \`npm run lint\`
- [x] Verified all telegram module tests pass (93 tests)
- [x] Follows existing code patterns in \`bot.ts\`

Fixes #465

---
**AI-assisted PR**: This PR was created with assistance from Claude Code. The fix follows the existing type assertion pattern already used in the codebase.