### PR TITLE
Discord: stop provider on gateway error exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Discord: stop provider when gateway reconnects are exhausted and surface errors. (#504)
 - Auto-reply: preserve block reply ordering with timeout fallback for streaming. (#503) — thanks @joshp123
 - WhatsApp: group `/model list` output by provider for scannability. (#456) - thanks @mcinteerj
 - Hooks: allow per-hook model overrides for webhook/Gmail runs (e.g. GPT 5 Mini).

--- a/src/discord/monitor.gateway.test.ts
+++ b/src/discord/monitor.gateway.test.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { waitForDiscordGatewayStop } from "./monitor.js";
+
+describe("waitForDiscordGatewayStop", () => {
+  it("resolves on abort and disconnects gateway", async () => {
+    const emitter = new EventEmitter();
+    const disconnect = vi.fn();
+    const abort = new AbortController();
+
+    const promise = waitForDiscordGatewayStop({
+      gateway: { emitter, disconnect },
+      abortSignal: abort.signal,
+    });
+
+    expect(emitter.listenerCount("error")).toBe(1);
+    abort.abort();
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(emitter.listenerCount("error")).toBe(0);
+  });
+
+  it("rejects on gateway error and disconnects", async () => {
+    const emitter = new EventEmitter();
+    const disconnect = vi.fn();
+    const onGatewayError = vi.fn();
+    const abort = new AbortController();
+    const err = new Error("boom");
+
+    const promise = waitForDiscordGatewayStop({
+      gateway: { emitter, disconnect },
+      abortSignal: abort.signal,
+      onGatewayError,
+    });
+
+    emitter.emit("error", err);
+
+    await expect(promise).rejects.toThrow("boom");
+    expect(onGatewayError).toHaveBeenCalledWith(err);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(emitter.listenerCount("error")).toBe(0);
+
+    abort.abort();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Summary
- Stop Discord provider when Carbon gateway reconnects are exhausted by wiring gateway error events into the monitor lifecycle.
- Surface gateway errors in runtime logs so provider status flips from running to stopped instead of silently stalling.
- Add targeted gateway stop tests for abort + error paths to lock in behavior.
- Operator impact: Discord provider now exits cleanly on gateway error so restart automation can recover.

Details
- Discord monitor: add `waitForDiscordGatewayStop` to subscribe to gateway error events, clean up listeners, and disconnect before resolving/rejecting.
- Provider lifecycle: monitor rejection flows through existing runtime status updates, ensuring `lastError` is set and `running=false`.
- Tests: `monitor.gateway.test.ts` covers abort + error handling and listener cleanup.

Testing
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test` (fails: `src/agents/system-prompt.test.ts` expects “ClaudeBot”, `src/cli/gateway.sigterm.test.ts` fails with `spawn bun ENOENT`, `src/hooks/gmail-setup-utils.test.ts` expects temp python path; unhandled error from missing `bun`)
- `corepack pnpm exec vitest run src/discord/monitor.gateway.test.ts`

Follow-ups
- None.
