### PR TITLE
feat(commands): add /commands to list available commands

### DIFF
--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -22,6 +22,12 @@ const CHAT_COMMANDS: ChatCommandDefinition[] = [
     textAliases: ["/help"],
   },
   {
+    key: "commands",
+    nativeName: "commands",
+    description: "List all available commands.",
+    textAliases: ["/commands"],
+  },
+  {
     key: "status",
     nativeName: "status",
     description: "Show current status.",

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -43,6 +43,7 @@ import {
 } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
 import {
+  buildCommandsMessage,
   buildHelpMessage,
   buildStatusMessage,
   formatContextUsageShort,
@@ -402,6 +403,17 @@ export async function handleCommands(params: {
       return { shouldContinue: false };
     }
     return { shouldContinue: false, reply: { text: buildHelpMessage() } };
+  }
+
+  const commandsRequested = command.commandBodyNormalized === "/commands";
+  if (allowTextCommands && commandsRequested) {
+    if (!command.isAuthorizedSender) {
+      logVerbose(
+        `Ignoring /commands from unauthorized sender: ${command.senderE164 || "<unknown>"}`,
+      );
+      return { shouldContinue: false };
+    }
+    return { shouldContinue: false, reply: { text: buildCommandsMessage() } };
   }
 
   const statusRequested =

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -21,6 +21,7 @@ import {
 } from "../config/sessions.js";
 import { resolveCommitHash } from "../infra/git-commit.js";
 import { VERSION } from "../version.js";
+import { listChatCommands } from "./commands-registry.js";
 import type {
   ElevatedLevel,
   ReasoningLevel,
@@ -303,4 +304,14 @@ export function buildHelpMessage(): string {
     "Shortcuts: /new reset | /compact [instructions] | /restart relink",
     "Options: /think <level> | /verbose on|off | /reasoning on|off | /elevated on|off | /model <id>",
   ].join("\n");
+}
+
+export function buildCommandsMessage(): string {
+  const commands = listChatCommands();
+  const lines = ["ℹ️ Available Commands:", ""];
+  for (const cmd of commands) {
+    const aliases = cmd.textAliases.join(", ");
+    lines.push(`${aliases} - ${cmd.description}`);
+  }
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
Implement issue #500: Add `/commands` command to list all available commands with descriptions.

## Changes
- **commands-registry.ts**: Add "commands" command definition to CHAT_COMMANDS array
- **reply/commands.ts**: Add handler for `/commands` command with authorization check
- **status.ts**: Add `buildCommandsMessage()` function that formats command list

## Test plan
- [x] Build passes (`npm run build`)
- [x] Linter passes (`npx @biomejs/biome check`)
- [x] No test regressions in related modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)