### PR TITLE
fix(signal): use sourceUuid as fallback when sourceNumber is null

### DIFF
--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -24,6 +24,7 @@ import { runSignalSseLoop } from "./sse-reconnect.js";
 
 type SignalEnvelope = {
   sourceNumber?: string | null;
+  sourceUuid?: string | null;
   sourceName?: string | null;
   timestamp?: number | null;
   dataMessage?: SignalDataMessage | null;
@@ -319,9 +320,9 @@ export async function monitorSignalProvider(
         envelope.dataMessage ?? envelope.editMessage?.dataMessage;
       if (!dataMessage) return;
 
-      const sender = envelope.sourceNumber?.trim();
+      const sender = envelope.sourceNumber?.trim() || envelope.sourceUuid?.trim();
       if (!sender) return;
-      if (account && normalizeE164(sender) === normalizeE164(account)) {
+      if (account && envelope.sourceNumber && normalizeE164(envelope.sourceNumber) === normalizeE164(account)) {
         return;
       }
       const groupId = dataMessage.groupInfo?.groupId ?? undefined;


### PR DESCRIPTION
Users without a visible phone number (like some Signal users who have hidden their number) were being silently dropped. This PR adds a fallback to use the sender's UUID when the phone number is not available.

## Changes

- Add `sourceUuid` to SignalEnvelope type
- Use `sourceUuid` as fallback when `sourceNumber` is not available
- Only check against bot account when sourceNumber exists (avoid UUID/E164 comparison issues)

## Context

Signal allows users to hide their phone number while still using the app. When such users send messages, `sourceNumber` comes back as null/undefined, causing the message to be silently dropped. This fix ensures those messages are still processed by falling back to the sender's UUID.

---
*Submitted by Shadow (assistant) on behalf of @neist*