### PR TITLE
feat(signal): add mention gating for groups

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -559,6 +559,14 @@ export type SignalAccountConfig = {
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
    */
   groupPolicy?: GroupPolicy;
+  /** Per-group config (keyed by group ID or "*" for all groups). */
+  groups?: Record<
+    string,
+    {
+      /** If true, bot only responds when mentioned (via @mention, quote-reply, or pattern). */
+      requireMention?: boolean;
+    }
+  >;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   mediaMaxMb?: number;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -355,6 +355,11 @@ const SlackConfigSchema = SlackAccountSchema.extend({
   accounts: z.record(z.string(), SlackAccountSchema.optional()).optional(),
 });
 
+const SignalGroupSchema = z.object({
+  /** If true, bot only responds when mentioned (via @mention, quote-reply, or pattern). */
+  requireMention: z.boolean().optional(),
+});
+
 const SignalAccountSchemaBase = z.object({
   name: z.string().optional(),
   enabled: z.boolean().optional(),
@@ -372,6 +377,7 @@ const SignalAccountSchemaBase = z.object({
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
+  groups: z.record(z.string(), SignalGroupSchema.optional()).optional(),
   textChunkLimit: z.number().int().positive().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
 });


### PR DESCRIPTION
Add opt-in mention gating for Signal groups, consistent with Telegram/WhatsApp behavior.

## Features

When enabled via `signal.groups.<id>.requireMention = true`, the bot only responds to messages where it was:
- **@-mentioned** via Signal's native mention feature
- **Quote-replied** to (replying to a bot message)
- **Matched by a pattern** (via `routing.groupChat.mentionPatterns`)

## Changes

- Add `SignalMention` and `SignalQuote` types for proper typing of Signal's mention/quote structures
- Add `wasBotMentioned()` and `isReplyingToBot()` helper functions for mention detection
- Strip U+FFFC (Object Replacement Character) that Signal inserts at mention positions
- Add `(mentioned)` indicator to message body when bot was mentioned (for context in logs/agent prompts)
- Pass `WasMentioned` in context payload for downstream use
- Control commands bypass mention gating (consistent with Telegram behavior)
- Add `groups` config to Signal schema and types

## Configuration

```yaml
signal:
  groups:
    # Specific group by ID
    "abc123":
      requireMention: true
    # Or wildcard for all groups
    "*":
      requireMention: true
```

## Context

This brings Signal mention gating in line with the existing implementation for Telegram and WhatsApp, allowing users to add the bot to groups without it responding to every message - only when explicitly mentioned or replied to.

---
*Submitted by Shadow (assistant) on behalf of @neist*