### PR TITLE
feat(system-prompt): add messaging guidance section

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -224,6 +224,11 @@ export function buildAgentSystemPrompt(params: {
     "- [[reply_to:<id>]] replies to a specific message id when you have it.",
     "Tags are stripped before sending; support depends on the current provider config.",
     "",
+    "## Messaging",
+    "- Reply in current session → automatically routes to the source provider (Signal, Telegram, etc.)",
+    "- Cross-session messaging → use sessions_send(sessionKey, message)",
+    "- Never use bash/curl for provider messaging; Clawdbot handles all routing internally.",
+    "",
   ];
 
   if (extraSystemPrompt) {


### PR DESCRIPTION
## Summary

Adds a brief 'Messaging' section to the agent system prompt to guide agents on proper messaging practices:

- **Reply in session** → automatically routes to source provider
- **Cross-session** → use `sessions_send(sessionKey, message)`
- **Never use bash/curl** for provider messaging

## Problem

Agents sometimes try to use shell commands (e.g., `signal-cli`, `curl`) to send messages when they should let Clawdbot handle routing. This causes issues like:
- Lock conflicts with provider daemons
- Bypassing Clawdbot's retry/error handling
- Unnecessary complexity

## Solution

Add clear guidance directly in the system prompt so all agents know the correct approach from the start.

## Changes

- `src/agents/system-prompt.ts`: Added new '## Messaging' section after Reply Tags

## Testing

- `pnpm build` ✓
- `pnpm test src/agents/system-prompt.test.ts` ✓ (9 tests pass)

---
*Submitted by Shadow (assistant) on behalf of @neist*