### PR TITLE
Hooks: default agent delivery to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Agent: add claude-cli/opus-4.5 runner via Claude CLI with resume support (tools disabled).
 - CLI: move `clawdbot message` to subcommands (`message send|poll|…`), fold Discord/Slack/Telegram/WhatsApp tools into `message`, and require `--provider` unless only one provider is configured.
 - CLI: improve `logs` output (pretty/plain/JSONL), add gateway unreachable hint, and document logging.
+- Hooks: default hook agent delivery to true. (#533) — thanks @mcinteerj
 - WhatsApp: route queued replies to the original sender instead of the bot's own number. (#534) — thanks @mcinteerj
 - Models: add OAuth expiry checks in doctor, expanded `models status` auth output (missing auth + `--check` exit codes). (#538) — thanks @latitudeki5223
 - Deps: bump Pi to 0.40.0 and drop pi-ai patch (upstream 429 fix). (#543) — thanks @mcinteerj

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -57,7 +57,7 @@ Payload:
   "name": "Email",
   "sessionKey": "hook:email:msg-123",
   "wakeMode": "now",
-  "deliver": false,
+  "deliver": true,
   "provider": "last",
   "to": "+15551234567",
   "model": "openai/gpt-5.2-mini",
@@ -70,7 +70,7 @@ Payload:
 - `name` optional (string): Human-readable name for the hook (e.g., "GitHub"), used as a prefix in session summaries.
 - `sessionKey` optional (string): The key used to identify the agent's session. Defaults to a random `hook:<uuid>`. Using a consistent key allows for a multi-turn conversation within the hook context.
 - `wakeMode` optional (`now` | `next-heartbeat`): Whether to trigger an immediate heartbeat (default `now`) or wait for the next periodic check.
-- `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging provider. Defaults to `false`. Responses that are only heartbeat acknowledgments are automatically skipped.
+- `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging provider. Defaults to `true`. Responses that are only heartbeat acknowledgments are automatically skipped.
 - `provider` optional (string): The messaging service for delivery. One of: `last`, `whatsapp`, `telegram`, `discord`, `slack`, `signal`, `imessage`. Defaults to `last`.
 - `to` optional (string): The recipient identifier for the provider (e.g., phone number for WhatsApp/Signal, chat ID for Telegram, channel ID for Discord/Slack). Defaults to the last recipient in the main session.
 - `model` optional (string): Model override (e.g., `anthropic/claude-3-5-sonnet` or an alias). Must be in the allowed model list if restricted.

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -66,6 +66,16 @@ describe("gateway hooks helpers", () => {
       expect(ok.value.sessionKey).toBe("hook:fixed");
       expect(ok.value.provider).toBe("last");
       expect(ok.value.name).toBe("Hook");
+      expect(ok.value.deliver).toBe(true);
+    }
+
+    const explicitNoDeliver = normalizeAgentPayload(
+      { message: "hello", deliver: false },
+      { idFactory: () => "fixed" },
+    );
+    expect(explicitNoDeliver.ok).toBe(true);
+    if (explicitNoDeliver.ok) {
+      expect(explicitNoDeliver.value.deliver).toBe(false);
     }
 
     const imsg = normalizeAgentPayload(

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -210,7 +210,7 @@ export function normalizeAgentPayload(
   if (modelRaw !== undefined && !model) {
     return { ok: false, error: "model required" };
   }
-  const deliver = payload.deliver === true;
+  const deliver = payload.deliver !== false;
   const thinkingRaw = payload.thinking;
   const thinking =
     typeof thinkingRaw === "string" && thinkingRaw.trim()

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -176,7 +176,7 @@ export function createHooksRequestHandler(
             name: mapped.action.name ?? "Hook",
             wakeMode: mapped.action.wakeMode,
             sessionKey: mapped.action.sessionKey ?? "",
-            deliver: mapped.action.deliver === true,
+            deliver: mapped.action.deliver !== false,
             provider: mapped.action.provider ?? "last",
             to: mapped.action.to,
             model: mapped.action.model,


### PR DESCRIPTION
Follow-up to #532. Defaults hook/agent to deliver:true as in general you'd want it to be possible for agent to message the user. even with deliver:true, agent can still choose to just send heartbeat and no message would send. Updated documentation to reflect the new default.