### PR TITLE
WhatsApp: fix routing for queued messages

### DIFF
--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1261,7 +1261,7 @@ export async function monitorWebProvider(
           Provider: "whatsapp",
           Surface: "whatsapp",
           OriginatingChannel: "whatsapp",
-          OriginatingTo: msg.to,
+          OriginatingTo: msg.from,
         },
         cfg,
         dispatcher,


### PR DESCRIPTION
Fixes the routing bug where queued WhatsApp messages were delivered to the bot's own number instead of the original sender. The root cause was 'OriginatingTo' being set to 'msg.to' (self) instead of 'msg.from' (user/group).