### PR TITLE
CLI: add support for per-provider blockStreaming override

### DIFF
--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -419,7 +419,13 @@ export async function getReplyFromConfig(
       "on")
     : "off";
   const resolvedBlockStreaming =
-    agentCfg?.blockStreamingDefault === "off" ? "off" : "on";
+    opts?.disableBlockStreaming === true
+      ? "off"
+      : opts?.disableBlockStreaming === false
+        ? "on"
+        : agentCfg?.blockStreamingDefault === "off"
+          ? "off"
+          : "on";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
     agentCfg?.blockStreamingBreak === "message_end"
       ? "message_end"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -118,6 +118,8 @@ export type WhatsAppConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
   /** Per-action tool gating (default: true for all). */
   actions?: WhatsAppActionConfig;
   groups?: Record<
@@ -143,6 +145,7 @@ export type WhatsAppAccountConfig = {
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   textChunkLimit?: number;
+  blockStreaming?: boolean;
   groups?: Record<
     string,
     {
@@ -293,6 +296,8 @@ export type TelegramAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
   /** Draft streaming mode for Telegram (off|partial|block). Default: partial. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
@@ -413,6 +418,8 @@ export type DiscordAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 2000. */
   textChunkLimit?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
   /**
    * Soft max line count per Discord message.
    * Discord clients can clip/collapse very tall messages; splitting by lines
@@ -508,6 +515,7 @@ export type SlackAccountConfig = {
    */
   groupPolicy?: GroupPolicy;
   textChunkLimit?: number;
+  blockStreaming?: boolean;
   mediaMaxMb?: number;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: SlackReactionNotificationMode;
@@ -561,6 +569,7 @@ export type SignalAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  blockStreaming?: boolean;
   mediaMaxMb?: number;
 };
 
@@ -601,6 +610,7 @@ export type IMessageAccountConfig = {
   mediaMaxMb?: number;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  blockStreaming?: boolean;
   groups?: Record<
     string,
     {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -170,6 +170,7 @@ const TelegramAccountSchemaBase = z.object({
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
   textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
   streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
   mediaMaxMb: z.number().positive().optional(),
   retry: RetryConfigSchema,
@@ -254,6 +255,7 @@ const DiscordAccountSchema = z.object({
   token: z.string().optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
   textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
   maxLinesPerMessage: z.number().int().positive().optional(),
   mediaMaxMb: z.number().positive().optional(),
   historyLimit: z.number().int().min(0).optional(),
@@ -323,6 +325,7 @@ const SlackAccountSchema = z.object({
   allowBots: z.boolean().optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
   textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
   mediaMaxMb: z.number().positive().optional(),
   reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
   reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
@@ -373,6 +376,7 @@ const SignalAccountSchemaBase = z.object({
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional().default("open"),
   textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
 });
 
@@ -417,6 +421,7 @@ const IMessageAccountSchemaBase = z.object({
   includeAttachments: z.boolean().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
   textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
   groups: z
     .record(
       z.string(),
@@ -1132,6 +1137,7 @@ export const ClawdbotSchema = z.object({
               groupAllowFrom: z.array(z.string()).optional(),
               groupPolicy: GroupPolicySchema.optional().default("open"),
               textChunkLimit: z.number().int().positive().optional(),
+              blockStreaming: z.boolean().optional(),
               groups: z
                 .record(
                   z.string(),
@@ -1165,6 +1171,7 @@ export const ClawdbotSchema = z.object({
       groupAllowFrom: z.array(z.string()).optional(),
       groupPolicy: GroupPolicySchema.optional().default("open"),
       textChunkLimit: z.number().int().positive().optional(),
+      blockStreaming: z.boolean().optional(),
       actions: z
         .object({
           reactions: z.boolean().optional(),

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -1051,7 +1051,14 @@ export function createDiscordMessageHandler(params: {
         ctx: ctxPayload,
         cfg,
         dispatcher,
-        replyOptions: { ...replyOptions, skillFilter: channelConfig?.skills },
+        replyOptions: {
+          ...replyOptions,
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined,
+        },
       });
       markDispatchIdle();
       if (!queuedFinal) {

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -442,6 +442,12 @@ export async function monitorIMessageProvider(
       ctx: ctxPayload,
       cfg,
       dispatcher,
+      replyOptions: {
+        disableBlockStreaming:
+          typeof accountInfo.config.blockStreaming === "boolean"
+            ? !accountInfo.config.blockStreaming
+            : undefined,
+      },
     });
     if (!queuedFinal) return;
   };

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -531,6 +531,12 @@ export async function monitorSignalProvider(
         ctx: ctxPayload,
         cfg,
         dispatcher,
+        replyOptions: {
+          disableBlockStreaming:
+            typeof accountInfo.config.blockStreaming === "boolean"
+              ? !accountInfo.config.blockStreaming
+              : undefined,
+        },
       });
       if (!queuedFinal) return;
     };

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -1139,7 +1139,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       ctx: ctxPayload,
       cfg,
       dispatcher,
-      replyOptions: { ...replyOptions, skillFilter: channelConfig?.skills },
+      replyOptions: {
+        ...replyOptions,
+        skillFilter: channelConfig?.skills,
+        disableBlockStreaming:
+          typeof account.config.blockStreaming === "boolean"
+            ? !account.config.blockStreaming
+            : undefined,
+      },
     });
     markDispatchIdle();
     if (didSetStatus) {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -759,7 +759,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
               if (payload.text) draftStream.update(payload.text);
             }
           : undefined,
-        disableBlockStreaming: Boolean(draftStream),
+        disableBlockStreaming:
+          Boolean(draftStream) ||
+          (typeof telegramCfg.blockStreaming === "boolean"
+            ? !telegramCfg.blockStreaming
+            : undefined),
       },
     });
     markDispatchIdle();

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -23,6 +23,7 @@ export type ResolvedWhatsAppAccount = {
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
   textChunkLimit?: number;
+  blockStreaming?: boolean;
   groups?: WhatsAppAccountConfig["groups"];
 };
 
@@ -119,6 +120,8 @@ export function resolveWhatsAppAccount(params: {
     groupPolicy: accountCfg?.groupPolicy ?? params.cfg.whatsapp?.groupPolicy,
     textChunkLimit:
       accountCfg?.textChunkLimit ?? params.cfg.whatsapp?.textChunkLimit,
+    blockStreaming:
+      accountCfg?.blockStreaming ?? params.cfg.whatsapp?.blockStreaming,
     groups: accountCfg?.groups ?? params.cfg.whatsapp?.groups,
   };
 }

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -783,6 +783,7 @@ export async function monitorWebProvider(
       groupAllowFrom: account.groupAllowFrom,
       groupPolicy: account.groupPolicy,
       textChunkLimit: account.textChunkLimit,
+      blockStreaming: account.blockStreaming,
       groups: account.groups,
     },
   } satisfies ReturnType<typeof loadConfig>;
@@ -1266,7 +1267,13 @@ export async function monitorWebProvider(
         cfg,
         dispatcher,
         replyResolver,
-        replyOptions,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof cfg.whatsapp?.blockStreaming === "boolean"
+              ? !cfg.whatsapp.blockStreaming
+              : undefined,
+        },
       });
       markDispatchIdle();
       if (!queuedFinal) {


### PR DESCRIPTION
## Description
This PR adds support for disabling block streaming per-provider (specifically for WhatsApp, but extensible to all providers). 

Block streaming is currently a global setting (`agent.blockStreamingDefault`). On WhatsApp, each fragment results in a separate message and notification, which is poor UX. This change allows disabling it for WhatsApp specifically while keeping it enabled globally for other providers.

## Changes
- **Schema Update**: Added `blockStreaming: z.boolean().optional()` to base and account-level configs for WhatsApp, Telegram, Discord, Slack, Signal, and iMessage in `src/config/zod-schema.ts`.
- **Logic Update**: Modified `src/auto-reply/reply.ts` to resolve the `blockStreaming` setting, allowing provider-specific overrides to take precedence over the global default.
- **Provider Update**: Updated `monitorWebProvider` (WhatsApp) and all other provider monitors to resolve and pass the `disableBlockStreaming` option to the reply dispatcher.

## Testing
- Verified schema updates with `pnpm lint`.
- Logic ensures that if `blockStreaming` is set to `false` for a provider, `disableBlockStreaming: true` is passed to the agent runner.