### PR TITLE
fix: Discord eventQueue + WhatsApp provider activity accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 - Config: fix Minimax hosted onboarding to write `agents.defaults` and allow `msteams` as a heartbeat target. — thanks @steipete
 - Discord: add channel/category management actions (create/edit/move/delete + category removal). (#487) - thanks @NicholasSpisak
 - Docs: split CLI install commands into separate code blocks. (#601) — thanks @martinpucik
+- WhatsApp: record outbound provider activity using the active account id. (#537) — thanks @Nachx639
 
 ## 2026.1.8
 

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
+  accountId?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -587,7 +587,7 @@ export async function monitorWebInbox(options: {
       const result = await sock.sendMessage(jid, payload);
       recordProviderActivity({
         provider: "whatsapp",
-        accountId: options.accountId,
+        accountId: options?.accountId,
         direction: "outbound",
       });
       return { messageId: result?.key?.id ?? "unknown" };
@@ -610,7 +610,7 @@ export async function monitorWebInbox(options: {
       });
       recordProviderActivity({
         provider: "whatsapp",
-        accountId: options.accountId,
+        accountId: options?.accountId,
         direction: "outbound",
       });
       return { messageId: result?.key?.id ?? "unknown" };

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -585,9 +585,10 @@ export async function monitorWebInbox(options: {
         payload = { text };
       }
       const result = await sock.sendMessage(jid, payload);
+      const accountId = sendOptions?.accountId ?? options.accountId;
       recordProviderActivity({
         provider: "whatsapp",
-        accountId: options?.accountId,
+        accountId,
         direction: "outbound",
       });
       return { messageId: result?.key?.id ?? "unknown" };
@@ -610,7 +611,7 @@ export async function monitorWebInbox(options: {
       });
       recordProviderActivity({
         provider: "whatsapp",
-        accountId: options?.accountId,
+        accountId: options.accountId,
         direction: "outbound",
       });
       return { messageId: result?.key?.id ?? "unknown" };

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -69,9 +69,13 @@ export async function sendMessageWhatsApp(
     );
     if (!active) throw new Error("Active web listener missing");
     await active.sendComposingTo(to);
-    const sendOptions: ActiveWebSendOptions | undefined = options.gifPlayback
-      ? { gifPlayback: true }
-      : undefined;
+    const sendOptions: ActiveWebSendOptions | undefined =
+      options.gifPlayback || options.accountId
+        ? {
+            ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            accountId: options.accountId,
+          }
+        : undefined;
     const result = sendOptions
       ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
       : await active.sendMessage(to, text, mediaBuffer, mediaType);


### PR DESCRIPTION
## Summary

Fixes two compatibility issues introduced in recent commits:

1. **Discord**: Removes unsupported `eventQueue` client option that was added in commit 9f8336c9 but is incompatible with @buape/carbon 0.13.0, causing TypeScript compilation errors.

2. **WhatsApp**: Adds missing `accountId` field to `ActiveWebSendOptions` type and uses optional chaining when accessing it, fixing TypeScript errors where `recordProviderActivity` expects `accountId` but the type didn't define it.

## Test plan

- [x] TypeScript build passes without errors
- [x] Both Discord and WhatsApp providers initialize without errors
- [x] macOS app launches and connects to gateway successfully