### PR TITLE
fix(daemon): add KillMode=process to systemd unit for podman compatibility

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -154,6 +154,10 @@ function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
+    // KillMode=process ensures systemd only waits for the main process to exit.
+    // Without this, podman's conmon (container monitor) processes block shutdown
+    // since they run as children of the gateway and stay in the same cgroup.
+    "KillMode=process",
     workingDirLine,
     ...envLines,
     "",


### PR DESCRIPTION
## Summary
- Add `KillMode=process` to generated systemd unit file
- Prevents service restart hanging when using podman for sandbox containers

## Context
With podman (daemonless), sandbox containers spawn `conmon` (container monitor) 
as child processes of the gateway. These stay in the gateway's cgroup, causing 
systemd to wait indefinitely on restart since it waits for all cgroup processes.

With Docker this isn't an issue because containers are managed by the separate 
`dockerd` daemon.

`KillMode=process` tells systemd to only wait for the main process, letting 
containers stay alive (preserving fast restart behavior) while fixing the hang.

## Testing
- Tested on Arch Linux with podman + systemd user service
- Before: `systemctl --user restart clawdbot-gateway` hangs indefinitely
- After: restart completes in ~0.2s, containers stay running

## Notes
- No effect on Docker users (containers aren't children of gateway)
- Containers intentionally kept alive for fast restarts