### PR TITLE
feat: add broadcast groups for multi-agent responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Hooks: default hook agent delivery to true. (#533) — thanks @mcinteerj
 - Hooks: normalize hook agent providers (aliases + msteams support).
 - WhatsApp: route queued replies to the original sender instead of the bot's own number. (#534) — thanks @mcinteerj
+- WhatsApp: add broadcast groups for multi-agent replies. (#547) — thanks @pasogott
 - iMessage: isolate group-ish threads by chat_id. (#535) — thanks @mdahmann
 - Models: add OAuth expiry checks in doctor, expanded `models status` auth output (missing auth + `--check` exit codes). (#538) — thanks @latitudeki5223
 - Deps: bump Pi to 0.40.0 and drop pi-ai patch (upstream 429 fix). (#543) — thanks @mcinteerj

--- a/docs/broadcast-groups.md
+++ b/docs/broadcast-groups.md
@@ -1,0 +1,414 @@
+# Broadcast Groups
+
+**Status:** Experimental  
+**Version:** Added in 2026.1.9
+
+## Overview
+
+Broadcast Groups enable multiple agents to process and respond to the same message simultaneously. This allows you to create specialized agent teams that work together in a single WhatsApp group, DM, or channel - all using one phone number.
+
+## Use Cases
+
+### 1. Specialized Agent Teams
+Deploy multiple agents with atomic, focused responsibilities:
+```
+Group: "Development Team"
+Agents:
+  - CodeReviewer (reviews code snippets)
+  - DocumentationBot (generates docs)
+  - SecurityAuditor (checks for vulnerabilities)
+  - TestGenerator (suggests test cases)
+```
+
+Each agent processes the same message and provides its specialized perspective.
+
+### 2. Multi-Language Support
+```
+Group: "International Support"
+Agents:
+  - Agent_EN (responds in English)
+  - Agent_DE (responds in German)
+  - Agent_ES (responds in Spanish)
+```
+
+### 3. Quality Assurance Workflows
+```
+Group: "Customer Support"
+Agents:
+  - SupportAgent (provides answer)
+  - QAAgent (reviews quality, only responds if issues found)
+```
+
+### 4. Task Automation
+```
+Group: "Project Management"
+Agents:
+  - TaskTracker (updates task database)
+  - TimeLogger (logs time spent)
+  - ReportGenerator (creates summaries)
+```
+
+## Configuration
+
+### Basic Setup
+
+Add a `broadcast` section to your routing config:
+
+```json
+{
+  "routing": {
+    "broadcast": {
+      "120363403215116621@g.us": ["alfred", "baerbel", "assistant3"]
+    }
+  }
+}
+```
+
+**Result:** All three agents process every message in this WhatsApp group.
+
+### Processing Strategy
+
+Control how agents process messages:
+
+#### Parallel (Default)
+All agents process simultaneously:
+```json
+{
+  "routing": {
+    "broadcast": {
+      "strategy": "parallel",
+      "120363403215116621@g.us": ["alfred", "baerbel"]
+    }
+  }
+}
+```
+
+#### Sequential
+Agents process in order (one waits for previous to finish):
+```json
+{
+  "routing": {
+    "broadcast": {
+      "strategy": "sequential",
+      "120363403215116621@g.us": ["alfred", "baerbel"]
+    }
+  }
+}
+```
+
+### Complete Example
+
+```json
+{
+  "routing": {
+    "defaultAgentId": "main",
+    "broadcast": {
+      "strategy": "parallel",
+      "120363403215116621@g.us": ["code-reviewer", "security-auditor", "docs-generator"],
+      "120363424282127706@g.us": ["support-en", "support-de"],
+      "+15555550123": ["assistant", "logger"]
+    },
+    "agents": {
+      "code-reviewer": {
+        "name": "Code Reviewer",
+        "workspace": "/path/to/code-reviewer",
+        "sandbox": { "mode": "all" }
+      },
+      "security-auditor": {
+        "name": "Security Auditor", 
+        "workspace": "/path/to/security-auditor",
+        "sandbox": { "mode": "all" }
+      },
+      "docs-generator": {
+        "name": "Documentation Generator",
+        "workspace": "/path/to/docs-generator",
+        "sandbox": { "mode": "all" }
+      }
+    }
+  }
+}
+```
+
+## How It Works
+
+### Message Flow
+
+1. **Incoming message** arrives in a WhatsApp group
+2. **Routing check**: System checks if peer ID is in `routing.broadcast`
+3. **If in broadcast list**:
+   - All listed agents process the message
+   - Each agent has its own session key and isolated context
+   - Agents process in parallel (default) or sequentially
+4. **If not in broadcast list**:
+   - Normal routing applies (first matching binding)
+
+### Session Isolation
+
+Each agent in a broadcast group maintains completely separate:
+
+- **Session keys** (`agent:alfred:whatsapp:group:120363...` vs `agent:baerbel:whatsapp:group:120363...`)
+- **Conversation history** (agent doesn't see other agents' messages)
+- **Workspace** (separate sandboxes if configured)
+- **Tool access** (different allow/deny lists)
+- **Memory/context** (separate IDENTITY.md, SOUL.md, etc.)
+
+This allows each agent to have:
+- Different personalities
+- Different tool access (e.g., read-only vs. read-write)
+- Different models (e.g., opus vs. sonnet)
+- Different skills installed
+
+### Example: Isolated Sessions
+
+In group `120363403215116621@g.us` with agents `["alfred", "baerbel"]`:
+
+**Alfred's context:**
+```
+Session: agent:alfred:whatsapp:group:120363403215116621@g.us
+History: [user message, alfred's previous responses]
+Workspace: /Users/pascal/clawd-alfred/
+Tools: read, write, bash
+```
+
+**Bärbel's context:**
+```
+Session: agent:baerbel:whatsapp:group:120363403215116621@g.us  
+History: [user message, baerbel's previous responses]
+Workspace: /Users/pascal/clawd-baerbel/
+Tools: read only
+```
+
+## Best Practices
+
+### 1. Keep Agents Focused
+
+Design each agent with a single, clear responsibility:
+
+```json
+{
+  "broadcast": {
+    "DEV_GROUP": ["formatter", "linter", "tester"]
+  }
+}
+```
+
+✅ **Good:** Each agent has one job  
+❌ **Bad:** One generic "dev-helper" agent
+
+### 2. Use Descriptive Names
+
+Make it clear what each agent does:
+
+```json
+{
+  "agents": {
+    "security-scanner": { "name": "Security Scanner" },
+    "code-formatter": { "name": "Code Formatter" },
+    "test-generator": { "name": "Test Generator" }
+  }
+}
+```
+
+### 3. Configure Different Tool Access
+
+Give agents only the tools they need:
+
+```json
+{
+  "agents": {
+    "reviewer": {
+      "tools": { "allow": ["read", "bash"] }  // Read-only
+    },
+    "fixer": {
+      "tools": { "allow": ["read", "write", "edit", "bash"] }  // Read-write
+    }
+  }
+}
+```
+
+### 4. Monitor Performance
+
+With many agents, consider:
+- Using `"strategy": "parallel"` (default) for speed
+- Limiting broadcast groups to 5-10 agents
+- Using faster models for simpler agents
+
+### 5. Handle Failures Gracefully
+
+Agents fail independently. One agent's error doesn't block others:
+
+```
+Message → [Agent A ✓, Agent B ✗ error, Agent C ✓]
+Result: Agent A and C respond, Agent B logs error
+```
+
+## Compatibility
+
+### Providers
+
+Broadcast groups currently work with:
+- ✅ WhatsApp (implemented)
+- 🚧 Telegram (planned)
+- 🚧 Discord (planned)
+- 🚧 Slack (planned)
+
+### Routing
+
+Broadcast groups work alongside existing routing:
+
+```json
+{
+  "routing": {
+    "bindings": [
+      { "agentId": "alfred", "match": { "peer": { "id": "GROUP_A" } } }
+    ],
+    "broadcast": {
+      "GROUP_B": ["agent1", "agent2"]
+    }
+  }
+}
+```
+
+- `GROUP_A`: Only alfred responds (normal routing)
+- `GROUP_B`: agent1 AND agent2 respond (broadcast)
+
+**Precedence:** `broadcast` takes priority over `bindings`.
+
+## Troubleshooting
+
+### Agents Not Responding
+
+**Check:**
+1. Agent IDs exist in `routing.agents`
+2. Peer ID format is correct (e.g., `120363403215116621@g.us`)
+3. Agents are not in deny lists
+
+**Debug:**
+```bash
+tail -f ~/.clawdbot/logs/gateway.log | grep broadcast
+```
+
+### Only One Agent Responding
+
+**Cause:** Peer ID might be in `bindings` but not `broadcast`.
+
+**Fix:** Add to broadcast config or remove from bindings.
+
+### Performance Issues
+
+**If slow with many agents:**
+- Reduce number of agents per group
+- Use lighter models (sonnet instead of opus)
+- Check sandbox startup time
+
+## Examples
+
+### Example 1: Code Review Team
+
+```json
+{
+  "routing": {
+    "broadcast": {
+      "strategy": "parallel",
+      "120363403215116621@g.us": [
+        "code-formatter",
+        "security-scanner", 
+        "test-coverage",
+        "docs-checker"
+      ]
+    },
+    "agents": {
+      "code-formatter": {
+        "workspace": "~/agents/formatter",
+        "tools": { "allow": ["read", "write"] }
+      },
+      "security-scanner": {
+        "workspace": "~/agents/security",
+        "tools": { "allow": ["read", "bash"] }
+      },
+      "test-coverage": {
+        "workspace": "~/agents/testing",
+        "tools": { "allow": ["read", "bash"] }
+      },
+      "docs-checker": {
+        "workspace": "~/agents/docs",
+        "tools": { "allow": ["read"] }
+      }
+    }
+  }
+}
+```
+
+**User sends:** Code snippet  
+**Responses:**
+- code-formatter: "Fixed indentation and added type hints"
+- security-scanner: "⚠️ SQL injection vulnerability in line 12"
+- test-coverage: "Coverage is 45%, missing tests for error cases"
+- docs-checker: "Missing docstring for function `process_data`"
+
+### Example 2: Multi-Language Support
+
+```json
+{
+  "routing": {
+    "broadcast": {
+      "strategy": "sequential",
+      "+15555550123": ["detect-language", "translator-en", "translator-de"]
+    },
+    "agents": {
+      "detect-language": {
+        "workspace": "~/agents/lang-detect"
+      },
+      "translator-en": {
+        "workspace": "~/agents/translate-en"
+      },
+      "translator-de": {
+        "workspace": "~/agents/translate-de"
+      }
+    }
+  }
+}
+```
+
+## API Reference
+
+### Config Schema
+
+```typescript
+interface RoutingConfig {
+  broadcast?: {
+    strategy?: "parallel" | "sequential";
+    [peerId: string]: string[] | "parallel" | "sequential";
+  };
+}
+```
+
+### Fields
+
+- `strategy` (optional): How to process agents
+  - `"parallel"` (default): All agents process simultaneously
+  - `"sequential"`: Agents process in array order
+  
+- `[peerId]`: WhatsApp group JID, E.164 number, or other peer ID
+  - Value: Array of agent IDs that should process messages
+
+## Limitations
+
+1. **Max agents:** No hard limit, but 10+ agents may be slow
+2. **Shared context:** Agents don't see each other's responses (by design)
+3. **Message ordering:** Parallel responses may arrive in any order
+4. **Rate limits:** All agents count toward WhatsApp rate limits
+
+## Future Enhancements
+
+Planned features:
+- [ ] Shared context mode (agents see each other's responses)
+- [ ] Agent coordination (agents can signal each other)
+- [ ] Dynamic agent selection (choose agents based on message content)
+- [ ] Agent priorities (some agents respond before others)
+
+## See Also
+
+- [Multi-Agent Configuration](multi-agent-sandbox-tools.md)
+- [Routing Configuration](routing.md)
+- [Session Management](sessions.md)

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -808,6 +808,41 @@ describe("talk.voiceAliases", () => {
   });
 });
 
+describe("broadcast", () => {
+  it("accepts a broadcast peer map with strategy", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "parallel",
+        "120363403215116621@g.us": ["alfred", "baerbel"],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid broadcast strategy", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      broadcast: { strategy: "nope" },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects non-array broadcast entries", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      broadcast: { "120363403215116621@g.us": 123 },
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+
 describe("legacy config detection", () => {
   it("rejects routing.allowFrom", async () => {
     vi.resetModules();

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -946,6 +946,19 @@ export type AgentBinding = {
   };
 };
 
+export type BroadcastStrategy = "parallel" | "sequential";
+
+export type BroadcastConfig = {
+  /** Default processing strategy for broadcast peers. */
+  strategy?: BroadcastStrategy;
+  /**
+   * Map peer IDs to arrays of agent IDs that should ALL process messages.
+   *
+   * Note: the index signature includes `undefined` so `strategy?: ...` remains type-safe.
+   */
+  [peerId: string]: string[] | BroadcastStrategy | undefined;
+};
+
 export type AudioConfig = {
   transcription?: {
     // Optional CLI to turn inbound audio into text; templated args, must output transcript to stdout.
@@ -1373,6 +1386,7 @@ export type ClawdbotConfig = {
   agents?: AgentsConfig;
   tools?: ToolsConfig;
   bindings?: AgentBinding[];
+  broadcast?: BroadcastConfig;
   audio?: AudioConfig;
   messages?: MessagesConfig;
   commands?: CommandsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -842,6 +842,15 @@ const BindingsSchema = z
   )
   .optional();
 
+const BroadcastStrategySchema = z.enum(["parallel", "sequential"]);
+
+const BroadcastSchema = z
+  .object({
+    strategy: BroadcastStrategySchema.optional(),
+  })
+  .catchall(z.array(z.string()))
+  .optional();
+
 const AudioSchema = z
   .object({
     transcription: TranscribeAudioSchema,
@@ -1188,6 +1197,7 @@ export const ClawdbotSchema = z.object({
   agents: AgentsSchema,
   tools: ToolsSchema,
   bindings: BindingsSchema,
+  broadcast: BroadcastSchema,
   audio: AudioSchema,
   messages: MessagesSchema,
   commands: CommandsSchema,


### PR DESCRIPTION
Fixes #546

## Summary

Enables multiple agents to process and respond to the same message simultaneously, allowing teams of specialized agents with atomic tasks to work together in a single WhatsApp group using one phone number.

## Changes

- **Code:** 63 lines added in `src/web/auto-reply.ts` and `src/config/types.ts`
- **Docs:** Complete feature guide in `docs/broadcast-groups.md`

## Key Features

✅ Configure multiple agents per WhatsApp group via `routing.broadcast`
✅ Parallel (default) or sequential processing strategies
✅ Full session isolation (separate history, workspace, tools per agent)
✅ Minimal code changes (~60 lines)
✅ Backward compatible with existing routing

## Example Config

```json
{
  "routing": {
    "broadcast": {
      "strategy": "parallel",
      "120363403215116621@g.us": ["alfred", "baerbel", "assistant3"]
    }
  }
}
```

**Result:** All three agents process every message in this group with isolated sessions.

## Use Cases

- **Specialized agent teams** (code reviewer + security scanner + docs generator)
- **Multi-language support** (EN + DE + ES agents)
- **Quality assurance workflows** (support + QA agents)
- **Task automation** (tracker + logger + reporter)

This enables scaling to **hundreds of focused micro-agents** on a single phone number, each handling specific atomic tasks.

## Testing

Manual testing performed:
- ✅ Two agents in same WhatsApp group
- ✅ Both agents respond independently
- ✅ Separate session histories confirmed
- ✅ Parallel processing works
- ✅ No existing functionality broken

See #546 for detailed requirements and discussion.