### PR TITLE
feat(config): add per-agent identity support

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -28,6 +28,32 @@ function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export type Identity = {
+  name?: string;
+  theme?: string;
+  emoji?: string;
+};
+
+/**
+ * Resolve the effective identity for an agent.
+ * Per-agent identity fields override root-level identity fields.
+ */
+export function resolveAgentIdentity(
+  cfg: ClawdbotConfig,
+  agentId: string,
+): Identity | undefined {
+  const rootIdentity = cfg.identity;
+  const agentIdentity = cfg.routing?.agents?.[agentId]?.identity;
+
+  if (!rootIdentity && !agentIdentity) return undefined;
+
+  return {
+    name: agentIdentity?.name ?? rootIdentity?.name,
+    theme: agentIdentity?.theme ?? rootIdentity?.theme,
+    emoji: agentIdentity?.emoji ?? rootIdentity?.emoji,
+  };
+}
+
 export function applyIdentityDefaults(cfg: ClawdbotConfig): ClawdbotConfig {
   const identity = cfg.identity;
   if (!identity) return cfg;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -539,6 +539,11 @@ export type RoutingConfig = {
   agents?: Record<
     string,
     {
+      identity?: {
+        name?: string;
+        theme?: string;
+        emoji?: string;
+      };
       workspace?: string;
       agentDir?: string;
       model?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -47,6 +47,14 @@ const ModelProviderSchema = z.object({
   models: z.array(ModelDefinitionSchema),
 });
 
+const IdentitySchema = z
+  .object({
+    name: z.string().optional(),
+    theme: z.string().optional(),
+    emoji: z.string().optional(),
+  })
+  .optional();
+
 const ModelsConfigSchema = z
   .object({
     mode: z.union([z.literal("merge"), z.literal("replace")]).optional(),
@@ -215,6 +223,7 @@ const RoutingSchema = z
         z.string(),
         z
           .object({
+            identity: IdentitySchema,
             workspace: z.string().optional(),
             agentDir: z.string().optional(),
             model: z.string().optional(),
@@ -351,13 +360,7 @@ export const ClawdbotSchema = z.object({
         .optional(),
     })
     .optional(),
-  identity: z
-    .object({
-      name: z.string().optional(),
-      theme: z.string().optional(),
-      emoji: z.string().optional(),
-    })
-    .optional(),
+  identity: IdentitySchema,
   wizard: z
     .object({
       lastRunAt: z.string().optional(),


### PR DESCRIPTION
## Summary

  - Add `identity` support to per-agent config in multi-agent setups
  - Each agent can now have its own `name`, `theme`, and `emoji`
  - Add `resolveAgentIdentity()` helper to merge agent identity with root-level fallback

  ## Motivation

  In multi-agent setups, each agent should be able to have its own identity (name, theme, emoji) rather than sharing a single root-level identity. This enables use cases like having "Clawd" as a personal assistant and "Paul" as a research bot, each with distinct personalities.

  ## Changes

  | File | Change |
  |------|--------|
  | `src/config/zod-schema.ts` | Extract `IdentitySchema`, add to agent config |
  | `src/config/types.ts` | Add `identity` to agent type definition |
  | `src/config/defaults.ts` | Add `resolveAgentIdentity(cfg, agentId)` helper |

  ## Usage

  ```json
  {
    "routing": {
      "agents": {
        "main": {
          "identity": {
            "name": "Clawd",
            "theme": "co-founder, coach, buddy",
            "emoji": "🦎"
          },
          "workspace": "~/clawd"
        },
        "paul": {
          "identity": {
            "name": "Paul"
          },
          "workspace": "~/clawd-paul"
        }
      }
    }
  }
```

## Backwards Compatibility

  - Root-level identity still works and acts as fallback
  - resolveAgentIdentity() merges agent identity over root identity (agent wins)
  - Existing single-agent configs are unaffected