### PR TITLE
Auto-Reply: relax regex for reply tags to allow whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Auto-reply: block reply ordering fix (duplicate PR superseded by #503). (#483) — thanks @AbhisekBasu1
 - Auto-reply: avoid splitting outbound chunks inside parentheses. (#499) — thanks @philipp-spiess
 - Auto-reply: preserve spacing when stripping inline directives. (#539) — thanks @joshp123
+- Auto-reply: relax reply tag parsing to allow whitespace. (#560) — thanks @mcinteerj
 - Auto-reply: fix /status usage summary filtering for the active provider.
 - Status: show provider prefix in /status model display. (#506) — thanks @mcinteerj
 - Status: compact /status with session token usage + estimated cost, add `/cost` per-response usage lines (tokens-only for OAuth).

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -162,8 +162,20 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("ok");
   });
 
+  it("extracts reply_to_current tag with whitespace", () => {
+    const res = extractReplyToTag("ok [[ reply_to_current ]]", "msg-1");
+    expect(res.replyToId).toBe("msg-1");
+    expect(res.cleaned).toBe("ok");
+  });
+
   it("extracts reply_to id tag", () => {
     const res = extractReplyToTag("see [[reply_to:12345]] now", "msg-1");
+    expect(res.replyToId).toBe("12345");
+    expect(res.cleaned).toBe("see now");
+  });
+
+  it("extracts reply_to id tag with whitespace", () => {
+    const res = extractReplyToTag("see [[ reply_to : 12345 ]] now", "msg-1");
     expect(res.replyToId).toBe("12345");
     expect(res.cleaned).toBe("see now");
   });

--- a/src/auto-reply/reply/reply-tags.ts
+++ b/src/auto-reply/reply/reply-tags.ts
@@ -11,18 +11,18 @@ export function extractReplyToTag(
   let replyToId: string | undefined;
   let hasTag = false;
 
-  const currentMatch = cleaned.match(/\[\[reply_to_current\]\]/i);
+  const currentMatch = cleaned.match(/\[\[\s*reply_to_current\s*\]\]/i);
   if (currentMatch) {
-    cleaned = cleaned.replace(/\[\[reply_to_current\]\]/gi, " ");
+    cleaned = cleaned.replace(/\[\[\s*reply_to_current\s*\]\]/gi, " ");
     hasTag = true;
     if (currentMessageId?.trim()) {
       replyToId = currentMessageId.trim();
     }
   }
 
-  const idMatch = cleaned.match(/\[\[reply_to:([^\]\n]+)\]\]/i);
+  const idMatch = cleaned.match(/\[\[\s*reply_to\s*:\s*([^\]\n]+)\s*\]\]/i);
   if (idMatch?.[1]) {
-    cleaned = cleaned.replace(/\[\[reply_to:[^\]\n]+\]\]/gi, " ");
+    cleaned = cleaned.replace(/\[\[\s*reply_to\s*:[^\]\n]+\]\]/gi, " ");
     replyToId = idMatch[1].trim();
     hasTag = true;
   }

--- a/src/auto-reply/reply/reply-tags.ts
+++ b/src/auto-reply/reply/reply-tags.ts
@@ -22,7 +22,7 @@ export function extractReplyToTag(
 
   const idMatch = cleaned.match(/\[\[\s*reply_to\s*:\s*([^\]\n]+)\s*\]\]/i);
   if (idMatch?.[1]) {
-    cleaned = cleaned.replace(/\[\[\s*reply_to\s*:[^\]\n]+\]\]/gi, " ");
+    cleaned = cleaned.replace(/\[\[\s*reply_to\s*:\s*[^\]\n]+\s*\]\]/gi, " ");
     replyToId = idMatch[1].trim();
     hasTag = true;
   }


### PR DESCRIPTION
## Overview
Relaxed the regex patterns for `[[reply_to_current]]` and `[[reply_to:...]]` tags to allow for whitespace characters.

## Context
Some models (e.g., `gemini-flash-3-preview`) may output tags with internal spaces, such as `[[ reply_to_current ]]` or `[[ reply_to: ... ]]`. The previous strict regex failed to detect and strip these tags, causing them to appear in the final message sent to users.

## Changes
- Updated `extractReplyToTag` in `src/auto-reply/reply/reply-tags.ts` to use `\s*` in regex patterns.

## Testing
- Validated via `vitest` with reproduction test cases covering:
  - `[[ reply_to_current ]]` (spaces inside)
  - `[[reply_to: 123]]` (spaces around colon)
- Verified standard cases still work.
