### PR TITLE
Auto-reply: add native command flag

### DIFF
--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -6,6 +6,7 @@ export type ChatCommandDefinition = {
   description: string;
   textAliases: string[];
   acceptsArgs?: boolean;
+  supportsNative?: boolean;
 };
 
 export type NativeCommandSpec = {
@@ -134,7 +135,9 @@ export function listChatCommands(): ChatCommandDefinition[] {
 }
 
 export function listNativeCommandSpecs(): NativeCommandSpec[] {
-  return CHAT_COMMANDS.map((command) => ({
+  return CHAT_COMMANDS.filter(
+    (command) => command.supportsNative !== false,
+  ).map((command) => ({
     name: command.nativeName,
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),


### PR DESCRIPTION
## Summary\n- add optional supportsNative flag to chat command definitions\n- filter native command registration when supportsNative is false\n\n## Testing\n- not run (small type/registry change)