### PR TITLE
fix(tools): flatten gateway tool schema for Vertex AI compatibility

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -5,44 +5,37 @@ import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 
-const GatewayToolSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("restart"),
-    delayMs: Type.Optional(Type.Number()),
-    reason: Type.Optional(Type.String()),
+const GATEWAY_ACTIONS = [
+  "restart",
+  "config.get",
+  "config.schema",
+  "config.apply",
+  "update.run",
+] as const;
+
+type GatewayAction = (typeof GATEWAY_ACTIONS)[number];
+
+// NOTE: Using a flattened object schema instead of Type.Union([Type.Object(...), ...])
+// because Claude API on Vertex AI rejects nested anyOf schemas as invalid JSON Schema.
+// The discriminator (action) determines which properties are relevant; runtime validates.
+const GatewayToolSchema = Type.Object({
+  action: Type.Unsafe<GatewayAction>({
+    type: "string",
+    enum: [...GATEWAY_ACTIONS],
   }),
-  Type.Object({
-    action: Type.Literal("config.get"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-  }),
-  Type.Object({
-    action: Type.Literal("config.schema"),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-  }),
-  Type.Object({
-    action: Type.Literal("config.apply"),
-    raw: Type.String(),
-    sessionKey: Type.Optional(Type.String()),
-    note: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Number()),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Number()),
-  }),
-  Type.Object({
-    action: Type.Literal("update.run"),
-    sessionKey: Type.Optional(Type.String()),
-    note: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Number()),
-    timeoutMs: Type.Optional(Type.Number()),
-    gatewayUrl: Type.Optional(Type.String()),
-    gatewayToken: Type.Optional(Type.String()),
-  }),
-]);
+  // restart
+  delayMs: Type.Optional(Type.Number()),
+  reason: Type.Optional(Type.String()),
+  // config.get, config.schema, config.apply, update.run
+  gatewayUrl: Type.Optional(Type.String()),
+  gatewayToken: Type.Optional(Type.String()),
+  timeoutMs: Type.Optional(Type.Number()),
+  // config.apply, update.run
+  raw: Type.Optional(Type.String()),
+  sessionKey: Type.Optional(Type.String()),
+  note: Type.Optional(Type.String()),
+  restartDelayMs: Type.Optional(Type.Number()),
+});
 
 export function createGatewayTool(opts?: {
   agentSessionKey?: string;


### PR DESCRIPTION
## Summary

Flattens the gateway tool schema to resolve Vertex AI compatibility issues, bringing it inline with other tool definitions. The tool now uses a single `Type.Object` with an `action` discriminator instead of `Type.Union([...])`, bringing it in line with JSON Schema 2020-12 requirements.

## Problem

When using Claude models via Google Cloud Code Assist (Antigravity), requests fail with:

```
Cloud Code Assist API error (400): {
  "message": "tools.11.custom.input_schema: JSON schema is invalid.
  It must match JSON Schema draft 2020-12"
}
```

**Root Cause:**

The gateway tool uses `Type.Union([...])` which compiles to a root-level `anyOf` schema:

```json
{
  "anyOf": [
    { "type": "object", "properties": { "action": { "const": "restart" }, ... } },
    { "type": "object", "properties": { "action": { "const": "config.get" }, ... } },
    ...
  ]
}
```

- **Anthropic's direct API:** Accepts this schema 
- **Vertex AI / Cloud Code Assist:** Enforces strict JSON Schema 2020-12 and rejects root-level `anyOf` without a top-level `type` field 

## Fix

Flatten the schema to a single `Type.Object` with an `action` enum, following the same pattern established in #409 for `browser-tool.ts`:

**Before:**
```typescript
const GatewayToolSchema = Type.Union([
  Type.Object({ action: Type.Literal("restart"), ... }),
  Type.Object({ action: Type.Literal("config.get"), ... }),
  ...
]);
```

**After:**
```typescript
const GatewayToolSchema = Type.Object({
  action: Type.Unsafe<GatewayAction>({
    type: "string",
    enum: ["restart", "config.get", "config.schema", "config.apply", "update.run"],
  }),
  // restart
  delayMs: Type.Optional(Type.Number()),
  reason: Type.Optional(Type.String()),
  // config.get, config.schema, config.apply, update.run
  gatewayUrl: Type.Optional(Type.String()),
  ...
});
```

## Related

- #409 — Same fix for other tools, such as `browser-tool.ts`

## Testing

- Tested with `google-antigravity/claude-opus-4-5-thinking`

