### PR TITLE
fix(agents): remove unsupported JSON Schema keywords for Cloud Code Assist API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Heartbeat: resolve Telegram account IDs from config-only tokens; cron tool accepts canonical `jobId` and legacy `id` for job actions. (#516) — thanks @YuriNachos
 - Discord: stop provider when gateway reconnects are exhausted and surface errors. (#514) — thanks @joshp123
 - Agents: strip empty assistant text blocks from session history to avoid Claude API 400s. (#210)
+- Agents: scrub unsupported JSON Schema keywords from tool schemas for Cloud Code Assist API compatibility. (#567) — thanks @erikpr1994
 - Auto-reply: preserve block reply ordering with timeout fallback for streaming. (#503) — thanks @joshp123
 - Auto-reply: block reply ordering fix (duplicate PR superseded by #503). (#483) — thanks @AbhisekBasu1
 - Auto-reply: avoid splitting outbound chunks inside parentheses. (#499) — thanks @philipp-spiess

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -718,9 +718,7 @@ export async function setAuthProfileOrder(params: {
   const providerKey = normalizeProviderId(params.provider);
   const sanitized =
     params.order && Array.isArray(params.order)
-      ? params.order
-          .map((entry) => String(entry).trim())
-          .filter(Boolean)
+      ? params.order.map((entry) => String(entry).trim()).filter(Boolean)
       : [];
 
   const deduped: string[] = [];

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -50,35 +50,40 @@ beforeEach(() => {
 });
 
 describe("bash tool backgrounding", () => {
-  it("backgrounds after yield and can be polled", async () => {
-    const result = await bashTool.execute("call1", {
-      command: joinCommands([yieldDelayCmd, "echo done"]),
-      yieldMs: 10,
-    });
-
-    expect(result.details.status).toBe("running");
-    const sessionId = (result.details as { sessionId: string }).sessionId;
-
-    let status = "running";
-    let output = "";
-    const deadline = Date.now() + (process.platform === "win32" ? 8000 : 2000);
-
-    while (Date.now() < deadline && status === "running") {
-      const poll = await processTool.execute("call2", {
-        action: "poll",
-        sessionId,
+  it(
+    "backgrounds after yield and can be polled",
+    async () => {
+      const result = await bashTool.execute("call1", {
+        command: joinCommands([yieldDelayCmd, "echo done"]),
+        yieldMs: 10,
       });
-      status = (poll.details as { status: string }).status;
-      const textBlock = poll.content.find((c) => c.type === "text");
-      output = textBlock?.text ?? "";
-      if (status === "running") {
-        await sleep(20);
-      }
-    }
 
-    expect(status).toBe("completed");
-    expect(output).toContain("done");
-  });
+      expect(result.details.status).toBe("running");
+      const sessionId = (result.details as { sessionId: string }).sessionId;
+
+      let status = "running";
+      let output = "";
+      const deadline =
+        Date.now() + (process.platform === "win32" ? 8000 : 2000);
+
+      while (Date.now() < deadline && status === "running") {
+        const poll = await processTool.execute("call2", {
+          action: "poll",
+          sessionId,
+        });
+        status = (poll.details as { status: string }).status;
+        const textBlock = poll.content.find((c) => c.type === "text");
+        output = textBlock?.text ?? "";
+        if (status === "running") {
+          await sleep(20);
+        }
+      }
+
+      expect(status).toBe("completed");
+      expect(output).toContain("done");
+    },
+    isWin ? 15_000 : 5_000,
+  );
 
   it("supports explicit background", async () => {
     const result = await bashTool.execute("call1", {

--- a/src/agents/bash-tools.ts
+++ b/src/agents/bash-tools.ts
@@ -8,6 +8,7 @@ import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 
 import { logInfo } from "../logger.js";
+import { sliceUtf16Safe } from "../utils.js";
 import {
   addSession,
   appendOutput,
@@ -1041,7 +1042,7 @@ function chunkString(input: string, limit = CHUNK_LIMIT) {
 function truncateMiddle(str: string, max: number) {
   if (str.length <= max) return str;
   const half = Math.floor((max - 3) / 2);
-  return `${str.slice(0, half)}...${str.slice(str.length - half)}`;
+  return `${sliceUtf16Safe(str, 0, half)}...${sliceUtf16Safe(str, -half)}`;
 }
 
 function sliceLogLines(

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -9,6 +9,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging.js";
 import { splitMediaFromOutput } from "../media/parse.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import { isMessagingToolDuplicate } from "./pi-embedded-helpers.js";
@@ -64,7 +65,7 @@ type MessagingToolSend = {
 
 function truncateToolText(text: string): string {
   if (text.length <= TOOL_RESULT_MAX_CHARS) return text;
-  return `${text.slice(0, TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
+  return `${truncateUtf16Safe(text, TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
 }
 
 function sanitizeToolResult(result: unknown): unknown {

--- a/src/agents/pi-tools.test.ts
+++ b/src/agents/pi-tools.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
-import { createClawdbotCodingTools } from "./pi-tools.js";
+import { __testing, createClawdbotCodingTools } from "./pi-tools.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
 
 describe("createClawdbotCodingTools", () => {
@@ -62,6 +62,28 @@ describe("createClawdbotCodingTools", () => {
     expect(format?.type).toBe("string");
     expect(format?.anyOf).toBeUndefined();
     expect(format?.enum).toEqual(["aria", "ai"]);
+  });
+
+  it("inlines local $ref before removing unsupported keywords", () => {
+    const cleaned = __testing.cleanToolSchemaForGemini({
+      type: "object",
+      properties: {
+        foo: { $ref: "#/$defs/Foo" },
+      },
+      $defs: {
+        Foo: { type: "string", enum: ["a", "b"] },
+      },
+    }) as {
+      $defs?: unknown;
+      properties?: Record<string, unknown>;
+    };
+
+    expect(cleaned.$defs).toBeUndefined();
+    expect(cleaned.properties).toBeDefined();
+    expect(cleaned.properties?.foo).toMatchObject({
+      type: "string",
+      enum: ["a", "b"],
+    });
   });
 
   it("preserves action enums in normalized schemas", () => {

--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -88,7 +88,9 @@ const resolveAuthLabel = async (
   mode: ModelAuthDetailMode = "compact",
 ): Promise<{ label: string; source: string }> => {
   const formatPath = (value: string) => shortenHomePath(value);
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const order = resolveAuthProfileOrder({ cfg, store, provider });
   const providerKey = normalizeProviderId(provider);
   const lastGood = (() => {
@@ -121,7 +123,8 @@ const resolveAuthLabel = async (
       const configProfile = cfg.auth?.profiles?.[profileId];
       const missing =
         !profile ||
-        (configProfile?.provider && configProfile.provider !== profile.provider) ||
+        (configProfile?.provider &&
+          configProfile.provider !== profile.provider) ||
         (configProfile?.mode &&
           configProfile.mode !== profile.type &&
           !(configProfile.mode === "oauth" && profile.type === "token"));
@@ -170,7 +173,11 @@ const resolveAuthLabel = async (
       if (lastGood && profileId === lastGood) flags.push("lastGood");
       if (isProfileInCooldown(store, profileId)) {
         const until = store.usageStats?.[profileId]?.cooldownUntil;
-        if (typeof until === "number" && Number.isFinite(until) && until > now) {
+        if (
+          typeof until === "number" &&
+          Number.isFinite(until) &&
+          until > now
+        ) {
           flags.push(`cooldown ${formatUntil(until)}`);
         } else {
           flags.push("cooldown");
@@ -197,7 +204,11 @@ const resolveAuthLabel = async (
           Number.isFinite(profile.expires) &&
           profile.expires > 0
         ) {
-          flags.push(profile.expires <= now ? "expired" : `exp ${formatUntil(profile.expires)}`);
+          flags.push(
+            profile.expires <= now
+              ? "expired"
+              : `exp ${formatUntil(profile.expires)}`,
+          );
         }
         const suffix = flags.length > 0 ? ` (${flags.join(", ")})` : "";
         return `${profileId}=token:${maskApiKey(profile.token)}${suffix}`;
@@ -218,7 +229,11 @@ const resolveAuthLabel = async (
         Number.isFinite(profile.expires) &&
         profile.expires > 0
       ) {
-        flags.push(profile.expires <= now ? "expired" : `exp ${formatUntil(profile.expires)}`);
+        flags.push(
+          profile.expires <= now
+            ? "expired"
+            : `exp ${formatUntil(profile.expires)}`,
+        );
       }
       const suffixLabel = suffix ? ` ${suffix}` : "";
       const suffixFlags = flags.length > 0 ? ` (${flags.join(", ")})` : "";
@@ -242,7 +257,8 @@ const resolveAuthLabel = async (
   if (customKey) {
     return {
       label: maskApiKey(customKey),
-      source: mode === "verbose" ? `models.json: ${formatPath(modelsPath)}` : "",
+      source:
+        mode === "verbose" ? `models.json: ${formatPath(modelsPath)}` : "",
     };
   }
   return { label: "missing", source: "missing" };
@@ -803,16 +819,16 @@ export async function handleDirectiveOnly(params: {
     }
     modelSelection = resolved.selection;
     if (modelSelection) {
-        if (directives.rawModelProfile) {
-          const profileResolved = resolveProfileOverride({
-            rawProfile: directives.rawModelProfile,
-            provider: modelSelection.provider,
-            cfg: params.cfg,
-            agentDir,
-          });
-          if (profileResolved.error) {
-            return { text: profileResolved.error };
-          }
+      if (directives.rawModelProfile) {
+        const profileResolved = resolveProfileOverride({
+          rawProfile: directives.rawModelProfile,
+          provider: modelSelection.provider,
+          cfg: params.cfg,
+          agentDir,
+        });
+        if (profileResolved.error) {
+          return { text: profileResolved.error };
+        }
         profileOverride = profileResolved.profileId;
       }
       const nextLabel = `${modelSelection.provider}/${modelSelection.model}`;
@@ -994,6 +1010,10 @@ export async function persistInlineDirectives(params: {
     agentCfg,
   } = params;
   let { provider, model } = params;
+  const activeAgentId = sessionKey
+    ? resolveAgentIdFromSessionKey(sessionKey)
+    : resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, activeAgentId);
 
   if (sessionEntry && sessionStore && sessionKey) {
     let updated = false;

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -392,7 +392,9 @@ export function registerModelsCli(program: Command) {
 
   order
     .command("set")
-    .description("Set per-agent auth order override (locks rotation to this list)")
+    .description(
+      "Set per-agent auth order override (locks rotation to this list)",
+    )
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .argument("<profileIds...>", "Auth profile ids (e.g. anthropic:claude-cli)")
@@ -414,7 +416,9 @@ export function registerModelsCli(program: Command) {
 
   order
     .command("clear")
-    .description("Clear per-agent auth order override (fall back to config/round-robin)")
+    .description(
+      "Clear per-agent auth order override (fall back to config/round-robin)",
+    )
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .action(async (opts) => {

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -80,6 +80,7 @@ import {
   DEFAULT_WORKSPACE,
   ensureWorkspaceAndSessions,
   guardCancel,
+  openUrl,
   printWizardHeader,
   probeGatewayReachable,
   randomToken,

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -1,16 +1,22 @@
-import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
+  resolveAgentDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
+import {
+  type AuthProfileStore,
   ensureAuthProfileStore,
   setAuthProfileOrder,
-  type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
 
-function resolveTargetAgent(cfg: ReturnType<typeof loadConfig>, raw?: string): {
+function resolveTargetAgent(
+  cfg: ReturnType<typeof loadConfig>,
+  raw?: string,
+): {
   agentId: string;
   agentDir: string;
 } {
@@ -37,7 +43,9 @@ export async function modelsAuthOrderGetCommand(
 
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const order = describeOrder(store, provider);
 
   if (opts.json) {
@@ -59,9 +67,13 @@ export async function modelsAuthOrderGetCommand(
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
-  runtime.log(`Auth file: ${shortenHomePath(`${agentDir}/auth-profiles.json`)}`);
   runtime.log(
-    order.length > 0 ? `Order override: ${order.join(", ")}` : "Order override: (none)",
+    `Auth file: ${shortenHomePath(`${agentDir}/auth-profiles.json`)}`,
+  );
+  runtime.log(
+    order.length > 0
+      ? `Order override: ${order.join(", ")}`
+      : "Order override: (none)",
   );
 }
 
@@ -75,8 +87,13 @@ export async function modelsAuthOrderClearCommand(
 
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
-  const updated = await setAuthProfileOrder({ agentDir, provider, order: null });
-  if (!updated) throw new Error("Failed to update auth-profiles.json (lock busy?).");
+  const updated = await setAuthProfileOrder({
+    agentDir,
+    provider,
+    order: null,
+  });
+  if (!updated)
+    throw new Error("Failed to update auth-profiles.json (lock busy?).");
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
@@ -94,7 +111,9 @@ export async function modelsAuthOrderSetCommand(
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
 
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const providerKey = normalizeProviderId(provider);
   const requested = (opts.order ?? [])
     .map((entry) => String(entry).trim())
@@ -120,10 +139,10 @@ export async function modelsAuthOrderSetCommand(
     provider,
     order: requested,
   });
-  if (!updated) throw new Error("Failed to update auth-profiles.json (lock busy?).");
+  if (!updated)
+    throw new Error("Failed to update auth-profiles.json (lock busy?).");
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Order override: ${describeOrder(updated, provider).join(", ")}`);
 }
-

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1202,13 +1202,14 @@ export type AgentDefaultsConfig = {
     every?: string;
     /** Heartbeat model override (provider/model). */
     model?: string;
-    /** Delivery target (last|whatsapp|telegram|discord|signal|imessage|none). */
+    /** Delivery target (last|whatsapp|telegram|discord|slack|msteams|signal|imessage|none). */
     target?:
       | "last"
       | "whatsapp"
       | "telegram"
       | "discord"
       | "slack"
+      | "msteams"
       | "signal"
       | "imessage"
       | "msteams"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1212,7 +1212,6 @@ export type AgentDefaultsConfig = {
       | "msteams"
       | "signal"
       | "imessage"
-      | "msteams"
       | "none";
     /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). */
     to?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -601,6 +601,7 @@ const HeartbeatSchema = z
         z.literal("telegram"),
         z.literal("discord"),
         z.literal("slack"),
+        z.literal("msteams"),
         z.literal("signal"),
         z.literal("imessage"),
         z.literal("none"),

--- a/src/cron/isolated-agent.ts
+++ b/src/cron/isolated-agent.ts
@@ -49,7 +49,7 @@ import {
 import { registerAgentRunContext } from "../infra/agent-events.js";
 import { parseTelegramTarget } from "../telegram/targets.js";
 import { resolveTelegramToken } from "../telegram/token.js";
-import { normalizeE164 } from "../utils.js";
+import { normalizeE164, truncateUtf16Safe } from "../utils.js";
 import type { CronJob } from "./types.js";
 
 export type RunCronAgentTurnResult = {
@@ -68,7 +68,7 @@ function pickSummaryFromOutput(text: string | undefined) {
   const clean = (text ?? "").trim();
   if (!clean) return undefined;
   const limit = 2000;
-  return clean.length > limit ? `${clean.slice(0, limit)}…` : clean;
+  return clean.length > limit ? `${truncateUtf16Safe(clean, limit)}…` : clean;
 }
 
 function pickSummaryFromPayloads(

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 
+import { truncateUtf16Safe } from "../utils.js";
 import { computeNextRunAtMs } from "./schedule.js";
 import { loadCronStore, saveCronStore } from "./store.js";
 import type {
@@ -61,7 +62,7 @@ function normalizeOptionalText(raw: unknown) {
 
 function truncateText(input: string, maxLen: number) {
   if (input.length <= maxLen) return input;
-  return `${input.slice(0, Math.max(0, maxLen - 1)).trimEnd()}…`;
+  return `${truncateUtf16Safe(input, Math.max(0, maxLen - 1)).trimEnd()}…`;
 }
 
 function inferLegacyName(job: {

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -61,6 +61,7 @@ import {
 } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
 import { chunkDiscordText } from "./chunk.js";
@@ -1017,7 +1018,10 @@ export function createDiscordMessageHandler(params: {
       }
 
       if (shouldLogVerbose()) {
-        const preview = combinedBody.slice(0, 200).replace(/\n/g, "\\n");
+        const preview = truncateUtf16Safe(combinedBody, 200).replace(
+          /\n/g,
+          "\\n",
+        );
         logVerbose(
           `discord inbound: channel=${message.channelId} from=${ctxPayload.From} preview="${preview}"`,
         );

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -24,6 +24,7 @@ import {
 } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
 import { resolveIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient } from "./client.js";
 import { sendMessageIMessage } from "./send.js";
@@ -413,7 +414,7 @@ export async function monitorIMessageProvider(
     }
 
     if (shouldLogVerbose()) {
-      const preview = body.slice(0, 200).replace(/\n/g, "\\n");
+      const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
       logVerbose(
         `imessage inbound: chatId=${chatId ?? "unknown"} from=${ctxPayload.From} len=${body.length} preview="${preview}"`,
       );

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -503,13 +503,19 @@ function formatConsoleLine(opts: {
 }
 
 function writeConsoleLine(level: Level, line: string) {
+  const sanitized =
+    process.platform === "win32" && process.env.GITHUB_ACTIONS === "true"
+      ? line
+          .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?")
+          .replace(/[\uD800-\uDFFF]/g, "?")
+      : line;
   const sink = rawConsole ?? console;
   if (forceConsoleToStderr || level === "error" || level === "fatal") {
-    (sink.error ?? console.error)(line);
+    (sink.error ?? console.error)(sanitized);
   } else if (level === "warn") {
-    (sink.warn ?? console.warn)(line);
+    (sink.warn ?? console.warn)(sanitized);
   } else {
-    (sink.log ?? console.log)(line);
+    (sink.log ?? console.log)(sanitized);
   }
 }
 

--- a/src/msteams/monitor.ts
+++ b/src/msteams/monitor.ts
@@ -55,10 +55,11 @@ export async function monitorMSTeamsProvider(
   const port = msteamsCfg.webhook?.port ?? 3978;
   const textLimit = resolveTextChunkLimit(cfg, "msteams");
   const MB = 1024 * 1024;
+  const agentDefaults = cfg.agents?.defaults;
   const mediaMaxBytes =
-    typeof cfg.agents?.defaults?.mediaMaxMb === "number" &&
-    cfg.agents.defaults.mediaMaxMb > 0
-      ? Math.floor(cfg.agents.defaults.mediaMaxMb * MB)
+    typeof agentDefaults?.mediaMaxMb === "number" &&
+    agentDefaults.mediaMaxMb > 0
+      ? Math.floor(agentDefaults.mediaMaxMb * MB)
       : 8 * MB;
   const conversationStore =
     opts.conversationStore ?? createMSTeamsConversationStoreFs();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,6 +95,61 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+export function sliceUtf16Safe(
+  input: string,
+  start: number,
+  end?: number,
+): string {
+  const len = input.length;
+
+  let from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
+  let to =
+    end === undefined
+      ? len
+      : end < 0
+        ? Math.max(len + end, 0)
+        : Math.min(end, len);
+
+  if (to < from) {
+    const tmp = from;
+    from = to;
+    to = tmp;
+  }
+
+  if (from > 0 && from < len) {
+    const codeUnit = input.charCodeAt(from);
+    if (
+      isLowSurrogate(codeUnit) &&
+      isHighSurrogate(input.charCodeAt(from - 1))
+    ) {
+      from += 1;
+    }
+  }
+
+  if (to > 0 && to < len) {
+    const codeUnit = input.charCodeAt(to - 1);
+    if (isHighSurrogate(codeUnit) && isLowSurrogate(input.charCodeAt(to))) {
+      to -= 1;
+    }
+  }
+
+  return input.slice(from, to);
+}
+
+export function truncateUtf16Safe(input: string, maxLen: number): string {
+  const limit = Math.max(0, Math.floor(maxLen));
+  if (input.length <= limit) return input;
+  return sliceUtf16Safe(input, 0, limit);
+}
+
 export function resolveUserPath(input: string): string {
   const trimmed = input.trim();
   if (!trimmed) return trimmed;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,12 +12,16 @@ const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
 const originalXdgStateHome = process.env.XDG_STATE_HOME;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalStateDir = process.env.CLAWDBOT_STATE_DIR;
 const originalTestHome = process.env.CLAWDBOT_TEST_HOME;
 
 const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "clawdbot-test-home-"));
 process.env.HOME = tempHome;
 process.env.USERPROFILE = tempHome;
 process.env.CLAWDBOT_TEST_HOME = tempHome;
+if (process.platform === "win32") {
+  process.env.CLAWDBOT_STATE_DIR = path.join(tempHome, ".clawdbot");
+}
 process.env.XDG_CONFIG_HOME = path.join(tempHome, ".config");
 process.env.XDG_DATA_HOME = path.join(tempHome, ".local", "share");
 process.env.XDG_STATE_HOME = path.join(tempHome, ".local", "state");
@@ -35,6 +39,7 @@ process.on("exit", () => {
   restoreEnv("XDG_DATA_HOME", originalXdgDataHome);
   restoreEnv("XDG_STATE_HOME", originalXdgStateHome);
   restoreEnv("XDG_CACHE_HOME", originalXdgCacheHome);
+  restoreEnv("CLAWDBOT_STATE_DIR", originalStateDir);
   restoreEnv("CLAWDBOT_TEST_HOME", originalTestHome);
   try {
     fs.rmSync(tempHome, { recursive: true, force: true });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,58 +2,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-function sanitizeWindowsCIOutput(text: string): string {
-  return text
-    .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?")
-    .replace(/[\uD800-\uDFFF]/g, "?");
-}
+import { installWindowsCIOutputSanitizer } from "./windows-ci-output-sanitizer";
 
-if (process.platform === "win32" && process.env.GITHUB_ACTIONS === "true") {
-  const decodeUtf8Text = (chunk: unknown): string | null => {
-    if (typeof chunk === "string") return chunk;
-    if (Buffer.isBuffer(chunk)) return chunk.toString("utf-8");
-    if (chunk instanceof Uint8Array)
-      return Buffer.from(chunk).toString("utf-8");
-    if (chunk instanceof ArrayBuffer)
-      return Buffer.from(chunk).toString("utf-8");
-    if (ArrayBuffer.isView(chunk)) {
-      return Buffer.from(
-        chunk.buffer,
-        chunk.byteOffset,
-        chunk.byteLength,
-      ).toString("utf-8");
-    }
-    return null;
-  };
-
-  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-  const originalStderrWrite = process.stderr.write.bind(process.stderr);
-
-  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
-    const text = decodeUtf8Text(chunk);
-    if (text !== null)
-      return originalStdoutWrite(sanitizeWindowsCIOutput(text), ...args);
-    return originalStdoutWrite(chunk as never, ...args); // passthrough
-  }) as typeof process.stdout.write;
-
-  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
-    const text = decodeUtf8Text(chunk);
-    if (text !== null)
-      return originalStderrWrite(sanitizeWindowsCIOutput(text), ...args);
-    return originalStderrWrite(chunk as never, ...args); // passthrough
-  }) as typeof process.stderr.write;
-
-  const originalWriteSync = fs.writeSync.bind(fs);
-  fs.writeSync = ((fd: number, data: unknown, ...args: unknown[]) => {
-    if (fd === 1 || fd === 2) {
-      const text = decodeUtf8Text(data);
-      if (text !== null) {
-        return originalWriteSync(fd, sanitizeWindowsCIOutput(text), ...args);
-      }
-    }
-    return originalWriteSync(fd, data as never, ...(args as never[]));
-  }) as typeof fs.writeSync;
-}
+installWindowsCIOutputSanitizer();
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -16,12 +16,24 @@ if (process.platform === "win32" && process.env.GITHUB_ACTIONS === "true") {
     if (typeof chunk === "string") {
       return originalStdoutWrite(sanitizeWindowsCIOutput(chunk), ...args);
     }
+    if (Buffer.isBuffer(chunk)) {
+      return originalStdoutWrite(
+        sanitizeWindowsCIOutput(chunk.toString("utf-8")),
+        ...args,
+      );
+    }
     return originalStdoutWrite(chunk as never, ...args);
   }) as typeof process.stdout.write;
 
   process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
     if (typeof chunk === "string") {
       return originalStderrWrite(sanitizeWindowsCIOutput(chunk), ...args);
+    }
+    if (Buffer.isBuffer(chunk)) {
+      return originalStderrWrite(
+        sanitizeWindowsCIOutput(chunk.toString("utf-8")),
+        ...args,
+      );
     }
     return originalStderrWrite(chunk as never, ...args);
   }) as typeof process.stderr.write;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -9,34 +9,50 @@ function sanitizeWindowsCIOutput(text: string): string {
 }
 
 if (process.platform === "win32" && process.env.GITHUB_ACTIONS === "true") {
+  const decodeUtf8Text = (chunk: unknown): string | null => {
+    if (typeof chunk === "string") return chunk;
+    if (Buffer.isBuffer(chunk)) return chunk.toString("utf-8");
+    if (chunk instanceof Uint8Array)
+      return Buffer.from(chunk).toString("utf-8");
+    if (chunk instanceof ArrayBuffer)
+      return Buffer.from(chunk).toString("utf-8");
+    if (ArrayBuffer.isView(chunk)) {
+      return Buffer.from(
+        chunk.buffer,
+        chunk.byteOffset,
+        chunk.byteLength,
+      ).toString("utf-8");
+    }
+    return null;
+  };
+
   const originalStdoutWrite = process.stdout.write.bind(process.stdout);
   const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
   process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
-    if (typeof chunk === "string") {
-      return originalStdoutWrite(sanitizeWindowsCIOutput(chunk), ...args);
-    }
-    if (Buffer.isBuffer(chunk)) {
-      return originalStdoutWrite(
-        sanitizeWindowsCIOutput(chunk.toString("utf-8")),
-        ...args,
-      );
-    }
-    return originalStdoutWrite(chunk as never, ...args);
+    const text = decodeUtf8Text(chunk);
+    if (text !== null)
+      return originalStdoutWrite(sanitizeWindowsCIOutput(text), ...args);
+    return originalStdoutWrite(chunk as never, ...args); // passthrough
   }) as typeof process.stdout.write;
 
   process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
-    if (typeof chunk === "string") {
-      return originalStderrWrite(sanitizeWindowsCIOutput(chunk), ...args);
-    }
-    if (Buffer.isBuffer(chunk)) {
-      return originalStderrWrite(
-        sanitizeWindowsCIOutput(chunk.toString("utf-8")),
-        ...args,
-      );
-    }
-    return originalStderrWrite(chunk as never, ...args);
+    const text = decodeUtf8Text(chunk);
+    if (text !== null)
+      return originalStderrWrite(sanitizeWindowsCIOutput(text), ...args);
+    return originalStderrWrite(chunk as never, ...args); // passthrough
   }) as typeof process.stderr.write;
+
+  const originalWriteSync = fs.writeSync.bind(fs);
+  fs.writeSync = ((fd: number, data: unknown, ...args: unknown[]) => {
+    if (fd === 1 || fd === 2) {
+      const text = decodeUtf8Text(data);
+      if (text !== null) {
+        return originalWriteSync(fd, sanitizeWindowsCIOutput(text), ...args);
+      }
+    }
+    return originalWriteSync(fd, data as never, ...(args as never[]));
+  }) as typeof fs.writeSync;
 }
 
 const originalHome = process.env.HOME;

--- a/test/vitest-global-setup.ts
+++ b/test/vitest-global-setup.ts
@@ -1,0 +1,5 @@
+import { installWindowsCIOutputSanitizer } from "./windows-ci-output-sanitizer";
+
+export default function globalSetup() {
+  installWindowsCIOutputSanitizer();
+}

--- a/test/windows-ci-output-sanitizer.ts
+++ b/test/windows-ci-output-sanitizer.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+
+function sanitizeWindowsCIOutput(text: string): string {
+  return text
+    .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?")
+    .replace(/[\uD800-\uDFFF]/g, "?");
+}
+
+function decodeUtf8Text(chunk: unknown): string | null {
+  if (typeof chunk === "string") return chunk;
+  if (Buffer.isBuffer(chunk)) return chunk.toString("utf-8");
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString("utf-8");
+  if (chunk instanceof ArrayBuffer) return Buffer.from(chunk).toString("utf-8");
+  if (ArrayBuffer.isView(chunk)) {
+    return Buffer.from(
+      chunk.buffer,
+      chunk.byteOffset,
+      chunk.byteLength,
+    ).toString("utf-8");
+  }
+  return null;
+}
+
+export function installWindowsCIOutputSanitizer(): void {
+  if (process.platform !== "win32") return;
+  if (process.env.GITHUB_ACTIONS !== "true") return;
+
+  const globalKey = "__clawdbotWindowsCIOutputSanitizerInstalled";
+  if ((globalThis as Record<string, unknown>)[globalKey] === true) return;
+  (globalThis as Record<string, unknown>)[globalKey] = true;
+
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    const text = decodeUtf8Text(chunk);
+    if (text !== null)
+      return originalStdoutWrite(sanitizeWindowsCIOutput(text), ...args);
+    return originalStdoutWrite(chunk as never, ...args); // passthrough
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    const text = decodeUtf8Text(chunk);
+    if (text !== null)
+      return originalStderrWrite(sanitizeWindowsCIOutput(text), ...args);
+    return originalStderrWrite(chunk as never, ...args); // passthrough
+  }) as typeof process.stderr.write;
+
+  const originalWriteSync = fs.writeSync.bind(fs);
+  fs.writeSync = ((fd: number, data: unknown, ...args: unknown[]) => {
+    if (fd === 1 || fd === 2) {
+      const text = decodeUtf8Text(data);
+      if (text !== null) {
+        return originalWriteSync(fd, sanitizeWindowsCIOutput(text), ...args);
+      }
+    }
+    return originalWriteSync(fd, data as never, ...(args as never[]));
+  }) as typeof fs.writeSync;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts", "test/format-error.test.ts"],
     setupFiles: ["test/setup.ts"],
+    globalSetup: ["test/vitest-global-setup.ts"],
     exclude: [
       "dist/**",
       "apps/macos/**",


### PR DESCRIPTION
## Summary
- Remove JSON Schema keywords that Cloud Code Assist API rejects (patternProperties, additionalProperties, $schema, $id, $ref, $defs, definitions)
- Add oneOf literal flattening to match existing anyOf behavior
- Add test to verify no unsupported keywords remain in tool schemas

## Problem
When switching from Claude to Gemini mid-session (e.g., when running out of tokens), Claude's tool schemas contain JSON Schema keywords that Google's Cloud Code Assist API rejects as non-compliant with JSON Schema draft 2020-12.

## Solution
Extended `cleanSchemaForGemini()` in `src/agents/pi-tools.ts` to:
1. Remove all unsupported keywords via `UNSUPPORTED_SCHEMA_KEYWORDS` blocklist
2. Flatten `oneOf` literals to enum (matching existing `anyOf` behavior)
3. Remove `additionalProperties` entirely instead of just recursively cleaning it

## Test Plan
- [x] Added test "removes unsupported JSON Schema keywords for Cloud Code Assist API compatibility"
- [x] All 1820 existing tests pass
- [x] Lint clean
- [x] Build successful

## Changes
| Keyword | Before | After |
|---------|--------|-------|
| patternProperties | Removed | Removed ✓ |
| additionalProperties | Recursively cleaned | **Removed entirely** |
| $schema, $id, $ref, $defs, definitions | Kept | **Removed** |
| oneOf literals | Not flattened | **Flattened to enum** |