### PR TITLE
Adjust UI install for offline pnpm fetch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.1
+      vite:
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.0.16
@@ -243,9 +246,6 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      vite:
-        specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 4.0.16
         version: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(@vitest/browser-preview@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -74,11 +74,16 @@ function runSync(cmd, args, envOverride) {
   if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
 }
 
-function depsInstalled() {
+function depsInstalled(kind) {
   try {
     const require = createRequire(path.join(uiDir, "package.json"));
     require.resolve("vite");
     require.resolve("dompurify");
+    if (kind === "test") {
+      require.resolve("vitest");
+      require.resolve("@vitest/browser-playwright");
+      require.resolve("playwright");
+    }
     return true;
   } catch {
     return false;
@@ -118,7 +123,7 @@ if (action !== "install" && !script) {
 if (runner.kind === "bun") {
   if (action === "install") run(runner.cmd, ["install", ...rest]);
   else {
-    if (!depsInstalled()) {
+    if (!depsInstalled(action === "test" ? "test" : "build")) {
       const installEnv =
         action === "build"
           ? { ...process.env, NODE_ENV: "production" }
@@ -132,7 +137,7 @@ if (runner.kind === "bun") {
 } else {
   if (action === "install") run(runner.cmd, ["install", ...rest]);
   else {
-    if (!depsInstalled()) {
+    if (!depsInstalled(action === "test" ? "test" : "build")) {
       const installEnv =
         action === "build"
           ? { ...process.env, NODE_ENV: "production" }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -64,11 +64,11 @@ function run(cmd, args) {
   });
 }
 
-function runSync(cmd, args) {
+function runSync(cmd, args, envOverride) {
   const result = spawnSync(cmd, args, {
     cwd: uiDir,
     stdio: "inherit",
-    env: process.env,
+    env: envOverride ?? process.env,
   });
   if (result.signal) process.exit(1);
   if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
@@ -118,13 +118,29 @@ if (action !== "install" && !script) {
 if (runner.kind === "bun") {
   if (action === "install") run(runner.cmd, ["install", ...rest]);
   else {
-    if (!depsInstalled()) runSync(runner.cmd, ["install"]);
+    if (!depsInstalled()) {
+      const installEnv =
+        action === "build"
+          ? { ...process.env, NODE_ENV: "production" }
+          : process.env;
+      const installArgs =
+        action === "build" ? ["install", "--production"] : ["install"];
+      runSync(runner.cmd, installArgs, installEnv);
+    }
     run(runner.cmd, ["run", script, ...rest]);
   }
 } else {
   if (action === "install") run(runner.cmd, ["install", ...rest]);
   else {
-    if (!depsInstalled()) runSync(runner.cmd, ["install"]);
+    if (!depsInstalled()) {
+      const installEnv =
+        action === "build"
+          ? { ...process.env, NODE_ENV: "production" }
+          : process.env;
+      const installArgs =
+        action === "build" ? ["install", "--prod"] : ["install"];
+      runSync(runner.cmd, installArgs, installEnv);
+    }
     run(runner.cmd, ["run", script, ...rest]);
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "dompurify": "^3.3.1",
     "lit": "^3.3.2",
-    "marked": "^17.0.1"
+    "marked": "^17.0.1",
+    "vite": "7.3.1"
   },
   "devDependencies": {
     "@vitest/browser-playwright": "4.0.16",
     "playwright": "^1.57.0",
     "typescript": "^5.9.3",
-    "vite": "7.3.1",
     "vitest": "4.0.16"
   }
 }


### PR DESCRIPTION
## Human written summary
Nix builds are failing because of some caching bullshit.

Specifically:
  Failure:
    ERR_PNPM_NO_OFFLINE_TARBALL for @lit-labs/ssr-dom-shim-1.5.1.tgz

Codex thinks it should be fixed in this repo, basically slicing/dicing the pnpm builds to properly separate between prod/dev. When specifically asked on this topic, it replied:
"This is the right fix upstream. We could add a downstream workaround in nix-clawdbot, but
  that would be a policy deviation and likely brittle. My recommendation: land PR #568
  upstream, then re-run the yolo updater." I'm not 100% sure of the impact here, so I'm hoping you can guide me.

## Summary
- Move `vite` into UI runtime deps so prod-only fetches include build tooling.
- Ensure UI build installs with production env/flags when deps are missing.
- Make `ui:test` self-heal by requiring dev-only test deps.
- Refresh `pnpm-lock.yaml` accordingly.

## Context
Downstream Nix build (`pnpm fetch --prod` → offline install) fails with missing tarballs (e.g. `@lit-labs/ssr-dom-shim`). Root cause is prod-only pnpm store + UI install path pulling dev deps/tools, which are not present in prod fetches.

## What changed
- `ui/package.json`: move `vite` to `dependencies`.
- `scripts/ui.js`: when action is `build`, install with `NODE_ENV=production` + `--prod` (pnpm) / `--production` (bun) to avoid pulling dev deps from the offline store.
- `scripts/ui.js`: `ui:test` now checks for dev test deps (`vitest`, `@vitest/browser-playwright`, `playwright`) and installs if missing.

## Testing
- `corepack pnpm install`
- `corepack pnpm fetch --prod --store-dir "$tmp"`
- `NODE_ENV=production corepack pnpm --dir ui install --offline --frozen-lockfile --prod --store-dir "$tmp"`

## Notes
- I reproduced offline failure by running `pnpm fetch --prod` + offline install; the missing package shifted to dev-only UI deps. This change is intended to keep build tooling available while avoiding dev-only tarballs in prod-only stores.


## Docs check
- README and control UI docs still describe `pnpm ui:build` auto-installs UI deps on first run; behavior remains correct.
- No doc edits required; see note below about UI tests after build.

## Behavior note
- `pnpm ui:build` (via `scripts/ui.js`) now auto-installs **production** UI deps only when missing.
- `pnpm ui:test` will auto-install dev test deps if they are missing.

## Risks / Unknowns
- Future UI build tooling added as dev deps would regress prod-only offline builds unless kept in `dependencies`.

## Upstream analysis (uncertain)
- The nix-clawdbot compare range (0220107… → ee70a64) only changes the yolo updater scripts; it does **not** change the clawdbot source pin.
- The pinned upstream rev in nix-clawdbot is currently `58a9e352…`, which already includes `fix(ui): self-heal ui builds` (Jan 6, 2026).
- That commit auto-installs UI deps when missing. In a prod-only pnpm store (`pnpm fetch --prod`), this can trigger offline failures if the store is cold.
- **Uncertainty**: because caches can mask missing tarballs, we can’t prove this is the *only* cause without reproducing in a cold store on CI. This PR is the minimal fix that makes prod-only offline builds deterministic.

## Prompts (recorded by Codex)
- [2026-01-09T12:27:45+01:00]
> ok cool. check out latest main and do this:
>
> • Heads-up from downstream (nix-clawdbot):
>
>   We pin upstream clawdbot main in our Nix repo at:
>     /Users/josh/code/nix/nix-clawdbot
>   and our “yolo” updater currently pins main SHA:
>     ae6f26898789235c1f6ec5da367bd35edeb649a7
>
>   Repro (local):
>     cd /Users/josh/code/nix/nix-clawdbot
>     nix build .#clawdbot-gateway
>
>   Failure:
>     ERR_PNPM_NO_OFFLINE_TARBALL for @lit-labs/ssr-dom-shim-1.5.1.tgz
>
>   This means the lockfile/offline pnpm artifacts don’t include that tarball, so Nix can’t build
>     in offline mode. Likely a dep changed without a lockfile refresh suitable for offline fetch.
>
>   Request:
>   - Re-run pnpm install / update lockfile so `pnpm fetch` works offline.
>   - Verify offline install/build (or `nix build .#clawdbot-gateway` if you can).
>
>   Once fixed, our auto-pin job will pass again.
- [2026-01-09T12:27:45+01:00]
> are we sure this won't break any other install workflows btw?
- [2026-01-09T12:27:45+01:00]
> check the clawdbot docs and make sure we are not breaking anything. ensure that the PR documents this properly. do a brutal self review. ensure our prompts are always included in the PR
- [2026-01-09T12:27:45+01:00]
> ensurre risks are documented in PR
- [2026-01-09T12:27:45+01:00]
> user prompts need to be full






- [2026-01-09T13:20:22+01:00]
> yes do that. also give me a handover prompt that i can get agetns to put in our global agents prompts to tell them to actually go find github comments
- [2026-01-09T13:20:22+01:00]
> add following "human written summary". write it verbatim with only typos/punctuation cleanups, no rewording.
>
>
> nix builds are failing because of some caching bullshit. 
>
> Specifically:
>   Failure:
>     ERR_PNPM_NO_OFFLINE_TARBALL for @lit-labs/ssr-dom-shim-1.5.1.tgz
>
> Codex thinks it should be fixed in this repo, basically slicing/dicing the pnpm builds to properly separate between prod/dev. When specifically asked on this topic, it replied. 
> "This is the right fix upstream. We could add a downstream workaround in nix-clawdbot, but
>   that would be a policy deviation and likely brittle. My recommendation: land PR #568
>   upstream, then re-run the yolo updater.". I'm not 100% sure of the impact here so I'm hoping you can guide me.
- [2026-01-09T13:20:22+01:00]
> put human written summary at top of pr. mark pr as ready
- [2026-01-09T13:20:22+01:00]
> pr comments. take a look
- [2026-01-09T13:20:22+01:00]
> check inline comments
- [2026-01-09T13:20:22+01:00]
> fake news check harder
- [2026-01-09T13:20:22+01:00]
> add following "human written summary". write it verbatim with only typos/punctuation cleanups, no rewording.
- [2026-01-09T13:20:22+01:00]
> prompts dont wrap
- [2026-01-09T13:20:22+01:00]
> update the PR to explain this and say that we're still not certain.


- [2026-01-09T13:30:14+01:00]
> tag codex for re-review?
- [2026-01-09T13:30:14+01:00]
> check again
- [2026-01-09T13:30:14+01:00]
> fake news check harder


- [2026-01-09T13:31:58+01:00]
> ok now check again. you think we get any review comments now?


- [2026-01-09T13:34:04+01:00]
> well resolve the comments and add comment explaining what you did. then re-tag codex. check if the comments are actually useful before following blindly
