### PR TITLE
fix(ui): default to relative paths for control UI assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
           - runtime: node
             task: lint
             command: pnpm lint
-          - runtime: node
-            task: test
-            command: pnpm test
-          - runtime: node
-            task: build
-            command: pnpm build
+	          - runtime: node
+	            task: test
+	            command: node scripts/ci-sanitize-output.mjs pnpm test
+	          - runtime: node
+	            task: build
+	            command: pnpm build
           - runtime: node
             task: protocol
             command: pnpm protocol:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
           - runtime: node
             task: lint
             command: pnpm lint
-	          - runtime: node
-	            task: test
-	            command: node scripts/ci-sanitize-output.mjs pnpm test
-	          - runtime: node
-	            task: build
-	            command: pnpm build
+          - runtime: node
+            task: test
+            command: node scripts/ci-sanitize-output.mjs pnpm test
+          - runtime: node
+            task: build
+            command: pnpm build
           - runtime: node
             task: protocol
             command: pnpm protocol:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             command: pnpm lint
           - runtime: node
             task: test
-            command: pnpm test
+            command: node scripts/ci-sanitize-output.mjs pnpm test
           - runtime: node
             task: build
             command: pnpm build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - WhatsApp: group `/model list` output by provider for scannability. (#456) - thanks @mcinteerj
 - Hooks: allow per-hook model overrides for webhook/Gmail runs (e.g. GPT 5 Mini).
 - Control UI: logs tab opens at the newest entries (bottom).
+- Control UI: default to relative paths for control UI assets. (#569) — thanks @bjesuiter
 - Control UI: add Docs link, remove chat composer divider, and add New session button.
 - Control UI: link sessions list to chat view. (#471) — thanks @HazAT
 - Control UI: show/patch per-session reasoning level and render extracted reasoning in chat.

--- a/scripts/ci-sanitize-output.mjs
+++ b/scripts/ci-sanitize-output.mjs
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+
+function sanitizeBuffer(input) {
+  const out = Buffer.allocUnsafe(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const b = input[i];
+    // Keep: tab/newline/carriage return + printable ASCII; replace everything else.
+    out[i] = b === 9 || b === 10 || b === 13 || (b >= 32 && b <= 126) ? b : 63;
+  }
+  return out;
+}
+
+const [command, ...args] = process.argv.slice(2);
+if (!command) {
+  process.stderr.write(
+    "Usage: node scripts/ci-sanitize-output.mjs <cmd> [args...]\n",
+  );
+  process.exit(2);
+}
+
+const child = spawn(command, args, {
+  stdio: ["ignore", "pipe", "pipe"],
+  shell: process.platform === "win32",
+});
+
+child.stdout.on("data", (chunk) => {
+  process.stdout.write(sanitizeBuffer(Buffer.from(chunk)));
+});
+
+child.stderr.on("data", (chunk) => {
+  process.stderr.write(sanitizeBuffer(Buffer.from(chunk)));
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) process.exit(1);
+  process.exit(code ?? 1);
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -718,9 +718,7 @@ export async function setAuthProfileOrder(params: {
   const providerKey = normalizeProviderId(params.provider);
   const sanitized =
     params.order && Array.isArray(params.order)
-      ? params.order
-          .map((entry) => String(entry).trim())
-          .filter(Boolean)
+      ? params.order.map((entry) => String(entry).trim()).filter(Boolean)
       : [];
 
   const deduped: string[] = [];

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -582,6 +582,7 @@ export async function getReplyFromConfig(
     directives,
     effectiveModelDirective,
     cfg,
+    agentDir,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -88,7 +88,9 @@ const resolveAuthLabel = async (
   mode: ModelAuthDetailMode = "compact",
 ): Promise<{ label: string; source: string }> => {
   const formatPath = (value: string) => shortenHomePath(value);
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const order = resolveAuthProfileOrder({ cfg, store, provider });
   const providerKey = normalizeProviderId(provider);
   const lastGood = (() => {
@@ -121,7 +123,8 @@ const resolveAuthLabel = async (
       const configProfile = cfg.auth?.profiles?.[profileId];
       const missing =
         !profile ||
-        (configProfile?.provider && configProfile.provider !== profile.provider) ||
+        (configProfile?.provider &&
+          configProfile.provider !== profile.provider) ||
         (configProfile?.mode &&
           configProfile.mode !== profile.type &&
           !(configProfile.mode === "oauth" && profile.type === "token"));
@@ -170,7 +173,11 @@ const resolveAuthLabel = async (
       if (lastGood && profileId === lastGood) flags.push("lastGood");
       if (isProfileInCooldown(store, profileId)) {
         const until = store.usageStats?.[profileId]?.cooldownUntil;
-        if (typeof until === "number" && Number.isFinite(until) && until > now) {
+        if (
+          typeof until === "number" &&
+          Number.isFinite(until) &&
+          until > now
+        ) {
           flags.push(`cooldown ${formatUntil(until)}`);
         } else {
           flags.push("cooldown");
@@ -197,7 +204,11 @@ const resolveAuthLabel = async (
           Number.isFinite(profile.expires) &&
           profile.expires > 0
         ) {
-          flags.push(profile.expires <= now ? "expired" : `exp ${formatUntil(profile.expires)}`);
+          flags.push(
+            profile.expires <= now
+              ? "expired"
+              : `exp ${formatUntil(profile.expires)}`,
+          );
         }
         const suffix = flags.length > 0 ? ` (${flags.join(", ")})` : "";
         return `${profileId}=token:${maskApiKey(profile.token)}${suffix}`;
@@ -218,7 +229,11 @@ const resolveAuthLabel = async (
         Number.isFinite(profile.expires) &&
         profile.expires > 0
       ) {
-        flags.push(profile.expires <= now ? "expired" : `exp ${formatUntil(profile.expires)}`);
+        flags.push(
+          profile.expires <= now
+            ? "expired"
+            : `exp ${formatUntil(profile.expires)}`,
+        );
       }
       const suffixLabel = suffix ? ` ${suffix}` : "";
       const suffixFlags = flags.length > 0 ? ` (${flags.join(", ")})` : "";
@@ -242,7 +257,8 @@ const resolveAuthLabel = async (
   if (customKey) {
     return {
       label: maskApiKey(customKey),
-      source: mode === "verbose" ? `models.json: ${formatPath(modelsPath)}` : "",
+      source:
+        mode === "verbose" ? `models.json: ${formatPath(modelsPath)}` : "",
     };
   }
   return { label: "missing", source: "missing" };
@@ -803,16 +819,16 @@ export async function handleDirectiveOnly(params: {
     }
     modelSelection = resolved.selection;
     if (modelSelection) {
-        if (directives.rawModelProfile) {
-          const profileResolved = resolveProfileOverride({
-            rawProfile: directives.rawModelProfile,
-            provider: modelSelection.provider,
-            cfg: params.cfg,
-            agentDir,
-          });
-          if (profileResolved.error) {
-            return { text: profileResolved.error };
-          }
+      if (directives.rawModelProfile) {
+        const profileResolved = resolveProfileOverride({
+          rawProfile: directives.rawModelProfile,
+          provider: modelSelection.provider,
+          cfg: params.cfg,
+          agentDir,
+        });
+        if (profileResolved.error) {
+          return { text: profileResolved.error };
+        }
         profileOverride = profileResolved.profileId;
       }
       const nextLabel = `${modelSelection.provider}/${modelSelection.model}`;
@@ -960,6 +976,7 @@ export async function persistInlineDirectives(params: {
   directives: InlineDirectives;
   effectiveModelDirective?: string;
   cfg: ClawdbotConfig;
+  agentDir?: string;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -993,6 +1010,7 @@ export async function persistInlineDirectives(params: {
     formatModelSwitchEvent,
     agentCfg,
   } = params;
+  const { agentDir } = params;
   let { provider, model } = params;
 
   if (sessionEntry && sessionStore && sessionKey) {

--- a/src/cli/gateway-cli.ts
+++ b/src/cli/gateway-cli.ts
@@ -180,7 +180,10 @@ async function ensureDevWorkspace(dir: string) {
     path.join(resolvedDir, "TOOLS.md"),
     DEV_TOOLS_TEMPLATE,
   );
-  await writeFileIfMissing(path.join(resolvedDir, "USER.md"), DEV_USER_TEMPLATE);
+  await writeFileIfMissing(
+    path.join(resolvedDir, "USER.md"),
+    DEV_USER_TEMPLATE,
+  );
   await writeFileIfMissing(
     path.join(resolvedDir, "HEARTBEAT.md"),
     DEV_HEARTBEAT_TEMPLATE,

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -392,7 +392,9 @@ export function registerModelsCli(program: Command) {
 
   order
     .command("set")
-    .description("Set per-agent auth order override (locks rotation to this list)")
+    .description(
+      "Set per-agent auth order override (locks rotation to this list)",
+    )
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .argument("<profileIds...>", "Auth profile ids (e.g. anthropic:claude-cli)")
@@ -414,7 +416,9 @@ export function registerModelsCli(program: Command) {
 
   order
     .command("clear")
-    .description("Clear per-agent auth order override (fall back to config/round-robin)")
+    .description(
+      "Clear per-agent auth order override (fall back to config/round-robin)",
+    )
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .action(async (opts) => {

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -23,12 +23,7 @@ describe("parseCliProfileArgs", () => {
   });
 
   it("still accepts global --dev before subcommand", () => {
-    const res = parseCliProfileArgs([
-      "node",
-      "clawdbot",
-      "--dev",
-      "gateway",
-    ]);
+    const res = parseCliProfileArgs(["node", "clawdbot", "--dev", "gateway"]);
     if (!res.ok) throw new Error(res.error);
     expect(res.profile).toBe("dev");
     expect(res.argv).toEqual(["node", "clawdbot", "gateway"]);

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -80,6 +80,7 @@ import {
   DEFAULT_WORKSPACE,
   ensureWorkspaceAndSessions,
   guardCancel,
+  openUrl,
   printWizardHeader,
   probeGatewayReachable,
   randomToken,

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -1,16 +1,22 @@
-import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
+  resolveAgentDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
+import {
+  type AuthProfileStore,
   ensureAuthProfileStore,
   setAuthProfileOrder,
-  type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
 
-function resolveTargetAgent(cfg: ReturnType<typeof loadConfig>, raw?: string): {
+function resolveTargetAgent(
+  cfg: ReturnType<typeof loadConfig>,
+  raw?: string,
+): {
   agentId: string;
   agentDir: string;
 } {
@@ -37,7 +43,9 @@ export async function modelsAuthOrderGetCommand(
 
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const order = describeOrder(store, provider);
 
   if (opts.json) {
@@ -59,9 +67,13 @@ export async function modelsAuthOrderGetCommand(
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
-  runtime.log(`Auth file: ${shortenHomePath(`${agentDir}/auth-profiles.json`)}`);
   runtime.log(
-    order.length > 0 ? `Order override: ${order.join(", ")}` : "Order override: (none)",
+    `Auth file: ${shortenHomePath(`${agentDir}/auth-profiles.json`)}`,
+  );
+  runtime.log(
+    order.length > 0
+      ? `Order override: ${order.join(", ")}`
+      : "Order override: (none)",
   );
 }
 
@@ -75,8 +87,13 @@ export async function modelsAuthOrderClearCommand(
 
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
-  const updated = await setAuthProfileOrder({ agentDir, provider, order: null });
-  if (!updated) throw new Error("Failed to update auth-profiles.json (lock busy?).");
+  const updated = await setAuthProfileOrder({
+    agentDir,
+    provider,
+    order: null,
+  });
+  if (!updated)
+    throw new Error("Failed to update auth-profiles.json (lock busy?).");
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
@@ -94,7 +111,9 @@ export async function modelsAuthOrderSetCommand(
   const cfg = loadConfig();
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
 
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
   const providerKey = normalizeProviderId(provider);
   const requested = (opts.order ?? [])
     .map((entry) => String(entry).trim())
@@ -120,10 +139,10 @@ export async function modelsAuthOrderSetCommand(
     provider,
     order: requested,
   });
-  if (!updated) throw new Error("Failed to update auth-profiles.json (lock busy?).");
+  if (!updated)
+    throw new Error("Failed to update auth-profiles.json (lock busy?).");
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Order override: ${describeOrder(updated, provider).join(", ")}`);
 }
-

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,7 +14,7 @@ function normalizeBase(input: string): string {
 
 export default defineConfig(({ command }) => {
   const envBase = process.env.CLAWDBOT_CONTROL_UI_BASE_PATH?.trim();
-  const base = envBase ? normalizeBase(envBase) : "/";
+  const base = envBase ? normalizeBase(envBase) : "./";
   return {
     base,
     publicDir: path.resolve(here, "public"),


### PR DESCRIPTION
Changes the default base path from \`/\` to \`./\` so the control UI works correctly when served under a custom basePath (e.g., \`/jbclawd/\`).

## Problem
Previously, assets were referenced with absolute paths like \`/assets/...\`, which failed when the UI was served under a subpath. The browser would try to fetch \`/assets/index.js\` instead of \`/jbclawd/assets/index.js\`.

## Solution
With relative paths (\`./assets/...\`), the browser resolves them relative to the HTML location, making the UI work regardless of the configured \`basePath\`.

## Testing
Tested locally with \`basePath: /jbclawd\` - UI now loads correctly.