### PR TITLE
fix: honor Slack reply threading + tags

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -260,7 +260,9 @@ export async function runReplyAgent(params: {
     followupRun.run.config,
     replyToChannel,
   );
-  const applyReplyToMode = createReplyToModeFilter(replyToMode);
+  const applyReplyToMode = createReplyToModeFilter(replyToMode, {
+    allowTagsWhenOff: replyToChannel === "slack",
+  });
   const cfg = followupRun.run.config;
 
   if (shouldSteer && isStreaming) {

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -10,7 +10,7 @@ export function applyReplyTagsToPayload(
   currentMessageId?: string,
 ): ReplyPayload {
   if (typeof payload.text !== "string") return payload;
-  const { cleaned, replyToId } = extractReplyToTag(
+  const { cleaned, replyToId, hasTag } = extractReplyToTag(
     payload.text,
     currentMessageId,
   );
@@ -18,6 +18,7 @@ export function applyReplyTagsToPayload(
     ...payload,
     text: cleaned ? cleaned : undefined,
     replyToId: replyToId ?? payload.replyToId,
+    replyToTag: hasTag || payload.replyToTag,
   };
 }
 

--- a/src/auto-reply/reply/reply-threading.test.ts
+++ b/src/auto-reply/reply/reply-threading.test.ts
@@ -40,6 +40,13 @@ describe("createReplyToModeFilter", () => {
     expect(filter({ text: "hi", replyToId: "1" }).replyToId).toBeUndefined();
   });
 
+  it("keeps replyToId when mode is off and reply tags are allowed", () => {
+    const filter = createReplyToModeFilter("off", { allowTagsWhenOff: true });
+    expect(
+      filter({ text: "hi", replyToId: "1", replyToTag: true }).replyToId,
+    ).toBe("1");
+  });
+
   it("keeps replyToId when mode is all", () => {
     const filter = createReplyToModeFilter("all");
     expect(filter({ text: "hi", replyToId: "1" }).replyToId).toBe("1");

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -19,11 +19,15 @@ export function resolveReplyToMode(
   }
 }
 
-export function createReplyToModeFilter(mode: ReplyToMode) {
+export function createReplyToModeFilter(
+  mode: ReplyToMode,
+  opts: { allowTagsWhenOff?: boolean } = {},
+) {
   let hasThreaded = false;
   return (payload: ReplyPayload): ReplyPayload => {
     if (!payload.replyToId) return payload;
     if (mode === "off") {
+      if (opts.allowTagsWhenOff && payload.replyToTag) return payload;
       return { ...payload, replyToId: undefined };
     }
     if (mode === "all") return payload;

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -28,6 +28,7 @@ export type ReplyPayload = {
   mediaUrl?: string;
   mediaUrls?: string[];
   replyToId?: string;
+  replyToTag?: boolean;
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
   isError?: boolean;


### PR DESCRIPTION
## Summary
- honor `slack.replyToMode` (off/first/all) to compute reply/status thread ids in the Slack monitor
- route replies using `payload.replyToId ?? replyThreadTs` so reply tags/ids override default threading
- ensure reply tags can still force Slack threading even when `replyToMode=off` (Slack-only)
- add unit coverage for Slack threading modes + forced replyToId, plus reply-tag override filter

## Implementation details
- Slack monitor derives `replyThreadTs` from mode and uses `statusThreadTs` for typing/status updates
- Reply payloads track when a reply tag was present so filtering can allow Slack tags while mode=off
- Deliverer selects `threadTs` per payload to preserve reply tag overrides

## Tests
- pnpm format
- pnpm lint
- pnpm build
- pnpm test