### PR TITLE
fix: harden node bridge keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - macOS: add node bridge heartbeat pings to detect half-open sockets and reconnect cleanly. (#572) — thanks @ngutman
+- Node bridge: harden keepalive + heartbeat handling (TCP keepalive, better disconnects, and keepalive config tests). (#577) — thanks @steipete
 - CLI: add `sandbox list` and `sandbox recreate` commands for managing Docker sandbox containers after image/config updates. (#563) — thanks @pasogott
 - Providers: add Microsoft Teams provider with polling, attachments, and CLI send support. (#404) — thanks @onutc
 - Commands: accept /models as an alias for /model.

--- a/src/agents/sandbox-agent-config.test.ts
+++ b/src/agents/sandbox-agent-config.test.ts
@@ -52,11 +52,11 @@ describe("Agent-specific sandbox config", () => {
     spawnCalls.length = 0;
   });
 
-  it(
-    "should use global sandbox config when no agent-specific config exists",
-    { timeout: 15_000 },
-    async () => {
-      const { resolveSandboxContext } = await import("./sandbox.js");
+	  it(
+	    "should use global sandbox config when no agent-specific config exists",
+	    { timeout: 15_000 },
+	    async () => {
+	      const { resolveSandboxContext } = await import("./sandbox.js");
 
       const cfg: ClawdbotConfig = {
         agents: {
@@ -75,19 +75,19 @@ describe("Agent-specific sandbox config", () => {
         },
       };
 
-      const context = await resolveSandboxContext({
-        config: cfg,
-        sessionKey: "agent:main:main",
-        workspaceDir: "/tmp/test",
-      });
+	      const context = await resolveSandboxContext({
+	        config: cfg,
+	        sessionKey: "agent:main:main",
+	        workspaceDir: "/tmp/test",
+	      });
 
-      expect(context).toBeDefined();
-      expect(context?.enabled).toBe(true);
-    },
-  );
+	      expect(context).toBeDefined();
+	      expect(context?.enabled).toBe(true);
+	    },
+	  );
 
-  it("should allow agent-specific docker setupCommand overrides", async () => {
-    const { resolveSandboxContext } = await import("./sandbox.js");
+	  it("should allow agent-specific docker setupCommand overrides", async () => {
+	    const { resolveSandboxContext } = await import("./sandbox.js");
 
     const cfg: ClawdbotConfig = {
       agents: {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -276,28 +276,28 @@ describe("doctor", () => {
         exit: vi.fn(),
       };
 
-      migrateLegacyConfig.mockReturnValue({
-        config: { whatsapp: { allowFrom: ["+15555550123"] } },
-        changes: ["Moved routing.allowFrom → whatsapp.allowFrom."],
-      });
+	      migrateLegacyConfig.mockReturnValue({
+	        config: { whatsapp: { allowFrom: ["+15555550123"] } },
+	        changes: ["Moved routing.allowFrom → whatsapp.allowFrom."],
+	      });
 
-      await doctorCommand(runtime, { nonInteractive: true });
+	      await doctorCommand(runtime, { nonInteractive: true });
 
-      expect(writeConfigFile).toHaveBeenCalledTimes(1);
-      const written = writeConfigFile.mock.calls[0]?.[0] as Record<
-        string,
-        unknown
-      >;
-      expect((written.whatsapp as Record<string, unknown>)?.allowFrom).toEqual([
-        "+15555550123",
-      ]);
-      expect(written.routing).toBeUndefined();
-    },
-  );
+	      expect(writeConfigFile).toHaveBeenCalledTimes(1);
+	      const written = writeConfigFile.mock.calls[0]?.[0] as Record<
+	        string,
+	        unknown
+	      >;
+	      expect((written.whatsapp as Record<string, unknown>)?.allowFrom).toEqual([
+	        "+15555550123",
+	      ]);
+	      expect(written.routing).toBeUndefined();
+	    },
+	  );
 
-  it("migrates legacy Clawdis services", async () => {
-    readConfigFileSnapshot.mockResolvedValue({
-      path: "/tmp/clawdbot.json",
+	  it("migrates legacy Clawdis services", async () => {
+	    readConfigFileSnapshot.mockResolvedValue({
+	      path: "/tmp/clawdbot.json",
       exists: true,
       raw: "{}",
       parsed: {},

--- a/src/infra/bridge/server.ts
+++ b/src/infra/bridge/server.ts
@@ -160,6 +160,14 @@ function isTestEnv() {
   return process.env.NODE_ENV === "test" || Boolean(process.env.VITEST);
 }
 
+export function configureNodeBridgeSocket(socket: {
+  setNoDelay: (noDelay?: boolean) => void;
+  setKeepAlive: (enable?: boolean, initialDelay?: number) => void;
+}) {
+  socket.setNoDelay(true);
+  socket.setKeepAlive(true, 15_000);
+}
+
 function encodeLine(frame: AnyBridgeFrame) {
   return `${JSON.stringify(frame)}\n`;
 }
@@ -228,7 +236,7 @@ export async function startNodeBridgeServer(
   const loopbackHost = "127.0.0.1";
 
   const onConnection = (socket: net.Socket) => {
-    socket.setNoDelay(true);
+    configureNodeBridgeSocket(socket);
 
     let buffer = "";
     let isAuthenticated = false;


### PR DESCRIPTION
Follow-up to #572.

- macOS: use TCP keepalive + ContinuousClock heartbeat loop; log + disconnect on failed/cancelled NWConnection.
- Gateway node bridge: configure TCP keepalive (15s) and cover with unit test.
- Minor lint/test-stability cleanups (remove oxlint warning; bump a couple of slow-test timeouts to avoid cascading failures).