### PR TITLE
fix(build): remove duplicate agentDir binding

### DIFF
--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -1010,7 +1010,6 @@ export async function persistInlineDirectives(params: {
     formatModelSwitchEvent,
     agentCfg,
   } = params;
-  const { agentDir } = params;
   let { provider, model } = params;
   const activeAgentId = sessionKey
     ? resolveAgentIdFromSessionKey(sessionKey)


### PR DESCRIPTION
## Summary
- fix `TS2451: Cannot redeclare block-scoped variable 'agentDir'` in `src/auto-reply/reply/directive-handling.ts` to get build working

## Notes
- AI-assisted, build now works locally
