### PR TITLE
fix(commands): wire /usage alias to /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Providers: add Microsoft Teams provider with polling, attachments, and CLI send support. (#404) — thanks @onutc
 - Slack: honor reply tags + replyToMode while keeping threaded replies in-thread. (#574) — thanks @bolismauro
 - Commands: accept /models as an alias for /model.
+- Commands: add `/usage` as an alias for `/status`. (#492) — thanks @lc0rp
 - Models/Auth: show per-agent auth candidates in `/model status`, and add `clawdbot models auth order {get,set,clear}` (per-agent auth rotation overrides). — thanks @steipete
 - Debugging: add raw model stream logging flags and document gateway watch mode.
 - Gateway: decode dns-sd escaped UTF-8 in discovery output and show scan progress immediately. — thanks @steipete

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -377,7 +377,7 @@ Options:
 Clawdbot can surface provider usage/quota when OAuth/API creds are available.
 
 Surfaces:
-- `/status` (adds a short usage line when available)
+- `/status` (alias: `/usage`; adds a short usage line when available)
 - `clawdbot status --usage` (prints full provider breakdown)
 - macOS menu bar (Usage section under Context)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -35,8 +35,7 @@ Directives (`/think`, `/verbose`, `/reasoning`, `/elevated`) are parsed even whe
 
 Text + native (when enabled):
 - `/help`
-- `/status`
-- `/debug show|set|unset|reset` (runtime overrides, owner-only)
+- `/status` (alias: `/usage`)
 - `/cost on|off` (toggle per-response usage line)
 - `/stop`
 - `/restart`
@@ -47,7 +46,7 @@ Text + native (when enabled):
 - `/verbose on|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; `stream` = Telegram draft only)
 - `/elevated on|off` (alias: `/elev`)
-- `/model <name>` (or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/model <name>` (or `/<alias>` from `agent.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 
 Text-only:
@@ -59,24 +58,6 @@ Notes:
 - `/restart` is disabled by default; set `commands.restart: true` to enable it.
 - `/verbose` is meant for debugging and extra visibility; keep it **off** in normal use.
 - `/reasoning` (and `/verbose`) are risky in group settings: they may reveal internal reasoning or tool output you did not intend to expose. Prefer leaving them off, especially in group chats.
-
-## Debug overrides
-
-`/debug` lets you set **runtime-only** config overrides (memory, not disk). Owner-only.
-
-Examples:
-
-```
-/debug show
-/debug set messages.responsePrefix="[clawdbot]"
-/debug set whatsapp.allowFrom=["+1555","+4477"]
-/debug unset messages.responsePrefix
-/debug reset
-```
-
-Notes:
-- Overrides apply immediately to new config reads, but do **not** write to `clawdbot.json`.
-- Use `/debug reset` to clear all overrides and return to the on-disk config.
 
 ## Surface notes
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -36,6 +36,7 @@ Directives (`/think`, `/verbose`, `/reasoning`, `/elevated`) are parsed even whe
 Text + native (when enabled):
 - `/help`
 - `/status` (alias: `/usage`)
+- `/debug show|set|unset|reset` (runtime overrides, owner-only)
 - `/cost on|off` (toggle per-response usage line)
 - `/stop`
 - `/restart`
@@ -46,7 +47,7 @@ Text + native (when enabled):
 - `/verbose on|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; `stream` = Telegram draft only)
 - `/elevated on|off` (alias: `/elev`)
-- `/model <name>` (or `/<alias>` from `agent.models.*.alias`)
+- `/model <name>` (or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 
 Text-only:
@@ -58,6 +59,24 @@ Notes:
 - `/restart` is disabled by default; set `commands.restart: true` to enable it.
 - `/verbose` is meant for debugging and extra visibility; keep it **off** in normal use.
 - `/reasoning` (and `/verbose`) are risky in group settings: they may reveal internal reasoning or tool output you did not intend to expose. Prefer leaving them off, especially in group chats.
+
+## Debug overrides
+
+`/debug` lets you set **runtime-only** config overrides (memory, not disk). Owner-only.
+
+Examples:
+
+```
+/debug show
+/debug set messages.responsePrefix="[clawdbot]"
+/debug set whatsapp.allowFrom=["+1555","+4477"]
+/debug unset messages.responsePrefix
+/debug reset
+```
+
+Notes:
+- Overrides apply immediately to new config reads, but do **not** write to `clawdbot.json`.
+- Use `/debug reset` to clear all overrides and return to the on-disk config.
 
 ## Surface notes
 

--- a/src/auto-reply/command-detection.test.ts
+++ b/src/auto-reply/command-detection.test.ts
@@ -44,6 +44,8 @@ describe("control command parsing", () => {
     expect(hasControlCommand("help")).toBe(false);
     expect(hasControlCommand("/status")).toBe(true);
     expect(hasControlCommand("/status:")).toBe(true);
+    expect(hasControlCommand("/usage")).toBe(true);
+    expect(hasControlCommand("/usage:")).toBe(true);
     expect(hasControlCommand("status")).toBe(false);
   });
 

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -24,6 +24,8 @@ describe("commands registry", () => {
     expect(detection.exact.has("/help")).toBe(true);
     expect(detection.regex.test("/status")).toBe(true);
     expect(detection.regex.test("/status:")).toBe(true);
+    expect(detection.regex.test("/usage")).toBe(true);
+    expect(detection.regex.test("/usage:")).toBe(true);
     expect(detection.regex.test("/stop")).toBe(true);
     expect(detection.regex.test("/send:")).toBe(true);
     expect(detection.regex.test("/debug set foo=bar")).toBe(true);

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -25,7 +25,7 @@ const CHAT_COMMANDS: ChatCommandDefinition[] = [
     key: "status",
     nativeName: "status",
     description: "Show current status.",
-    textAliases: ["/status"],
+    textAliases: ["/status", "/usage"],
   },
   {
     key: "debug",

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -144,6 +144,12 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("thats not /tmp/hello");
   });
 
+  it("preserves spacing when stripping usage directives before paths", () => {
+    const res = extractStatusDirective("thats not /usage:/tmp/hello");
+    expect(res.hasDirective).toBe(true);
+    expect(res.cleaned).toBe("thats not /tmp/hello");
+  });
+
   it("parses queue options and modes", () => {
     const res = extractQueueDirective(
       "please /queue steer+backlog debounce:2s cap:5 drop:summarize now",

--- a/src/auto-reply/reply.triggers.test.ts
+++ b/src/auto-reply/reply.triggers.test.ts
@@ -242,6 +242,23 @@ describe("trigger handling", () => {
     });
   });
 
+  it("reports status via /usage without invoking the agent", async () => {
+    await withTempHome(async (home) => {
+      const res = await getReplyFromConfig(
+        {
+          Body: "/usage",
+          From: "+1002",
+          To: "+2000",
+        },
+        {},
+        makeCfg(home),
+      );
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("ClawdBot");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+
   it("reports active auth profile and key snippet in status", async () => {
     await withTempHome(async (home) => {
       const cfg = makeCfg(home);

--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -594,7 +594,8 @@ export async function handleCommands(params: {
 
   const statusRequested =
     directives.hasStatusDirective ||
-    command.commandBodyNormalized === "/status";
+    command.commandBodyNormalized === "/status" ||
+    command.commandBodyNormalized === "/usage";
   if (allowTextCommands && statusRequested) {
     const reply = await buildStatusReply({
       cfg,

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -170,7 +170,7 @@ export function extractStatusDirective(body?: string): {
   hasDirective: boolean;
 } {
   if (!body) return { cleaned: "", hasDirective: false };
-  return extractSimpleDirective(body, ["status"]);
+  return extractSimpleDirective(body, ["status", "usage"]);
 }
 
 export type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel };


### PR DESCRIPTION
Lands clawdbot/clawdbot#492 with maintainer fixes.

- Wire /usage -> /status handler + directive stripping
- Add tests + docs + changelog

Fixes #501. Thanks @lc0rp!