### PR TITLE
Docs: link Hetzner guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Control UI: improve mobile responsiveness. (#558) — thanks @carlulsoe
 - CLI: add `sandbox list` and `sandbox recreate` commands for managing Docker sandbox containers after image/config updates. (#563) — thanks @pasogott
 - Docs: add Hetzner Docker VPS guide. (#556) — thanks @Iamadig
+- Docs: link Hetzner guide from install + platforms docs. (#592) — thanks @steipete
 - Providers: add Microsoft Teams provider with polling, attachments, and CLI send support. (#404) — thanks @onutc
 - Slack: honor reply tags + replyToMode while keeping threaded replies in-thread. (#574) — thanks @bolismauro
 - Discord: avoid category parent overrides for channel allowlists and refactor thread context helpers. (#588) — thanks @steipete

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -51,6 +51,8 @@ It writes config/workspace on the host:
 - `~/.clawdbot/`
 - `~/clawd`
 
+Running on a VPS? See [Hetzner (Docker VPS)](/platforms/hetzner).
+
 ### Manual flow (compose)
 
 ```bash

--- a/docs/platforms/hetzner.md
+++ b/docs/platforms/hetzner.md
@@ -17,6 +17,7 @@ The Gateway can be accessed via:
 
 This guide assumes Ubuntu or Debian on Hetzner.  
 If you are on another Linux VPS, map packages accordingly.
+For the generic Docker flow, see [Docker](/install/docker).
 
 ---
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -20,6 +20,11 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 - Windows: [Windows](/platforms/windows)
 - Linux: [Linux](/platforms/linux)
 
+## VPS & hosting
+
+- Hetzner (Docker): [Hetzner](/platforms/hetzner)
+- exe.dev (VM + HTTPS proxy): [exe.dev](/platforms/exe-dev)
+
 ## Common links
 
 - Install guide: [Getting Started](/start/getting-started)


### PR DESCRIPTION
## Summary
- link Hetzner VPS guide from Docker + Platforms docs
- add cross-links in Hetzner guide
- note follow-up in changelog

## Testing
- pnpm lint
- pnpm build
- pnpm test