### PR TITLE
refactor: centralize test path containment checks

### DIFF
--- a/src/web/logout.test.ts
+++ b/src/web/logout.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { isPathWithinBase } from "../../test/helpers/paths.js";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 
 const runtime = {
@@ -28,26 +29,7 @@ describe("web logout", () => {
         vi.resetModules();
         const { logoutWeb, WA_WEB_AUTH_DIR } = await import("./session.js");
 
-        if (process.platform === "win32") {
-          const normalizedHome = path.win32.normalize(home).toLowerCase();
-          const normalizedAuthDir = path.win32
-            .normalize(WA_WEB_AUTH_DIR)
-            .toLowerCase();
-          const rel = path.win32.relative(normalizedHome, normalizedAuthDir);
-          const isWithinHome =
-            rel.length > 0 &&
-            !rel.startsWith("..") &&
-            !path.win32.isAbsolute(rel);
-          expect(isWithinHome).toBe(true);
-        } else {
-          const rel = path.relative(
-            path.resolve(home),
-            path.resolve(WA_WEB_AUTH_DIR),
-          );
-          expect(rel && !rel.startsWith("..") && !path.isAbsolute(rel)).toBe(
-            true,
-          );
-        }
+        expect(isPathWithinBase(home, WA_WEB_AUTH_DIR)).toBe(true);
 
         fs.mkdirSync(WA_WEB_AUTH_DIR, { recursive: true });
         fs.writeFileSync(path.join(WA_WEB_AUTH_DIR, "creds.json"), "{}");

--- a/test/helpers/paths.ts
+++ b/test/helpers/paths.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+export function isPathWithinBase(base: string, target: string): boolean {
+  if (process.platform === "win32") {
+    const normalizedBase = path.win32.normalize(path.win32.resolve(base));
+    const normalizedTarget = path.win32.normalize(path.win32.resolve(target));
+
+    const rel = path.win32.relative(
+      normalizedBase.toLowerCase(),
+      normalizedTarget.toLowerCase(),
+    );
+    return rel === "" || (!rel.startsWith("..") && !path.win32.isAbsolute(rel));
+  }
+
+  const normalizedBase = path.resolve(base);
+  const normalizedTarget = path.resolve(target);
+  const rel = path.relative(normalizedBase, normalizedTarget);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}


### PR DESCRIPTION
Refactor-only.

- Add test helper test/helpers/paths.ts for cross-platform isPathWithinBase().
- Simplify src/web/logout.test.ts and de-dupe src/media/store.test.ts setup.

Gate: pnpm lint && pnpm build && pnpm test