### PR TITLE
fix: simplify tool schemas for Gemini compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Discord: stop provider when gateway reconnects are exhausted and surface errors. (#514) — thanks @joshp123
 - Agents: strip empty assistant text blocks from session history to avoid Claude API 400s. (#210)
 - Agents: scrub unsupported JSON Schema keywords from tool schemas for Cloud Code Assist API compatibility. (#567) — thanks @erikpr1994
+- Agents: simplify session tool schemas for Gemini compatibility. (#599) — thanks @mcinteerj
 - Auto-reply: preserve block reply ordering with timeout fallback for streaming. (#503) — thanks @joshp123
 - Auto-reply: block reply ordering fix (duplicate PR superseded by #503). (#483) — thanks @AbhisekBasu1
 - Auto-reply: avoid splitting outbound chunks inside parentheses. (#499) — thanks @philipp-spiess

--- a/src/agents/clawdbot-tools.sessions.test.ts
+++ b/src/agents/clawdbot-tools.sessions.test.ts
@@ -23,6 +23,43 @@ vi.mock("../config/config.js", async (importOriginal) => {
 import { createClawdbotTools } from "./clawdbot-tools.js";
 
 describe("sessions tools", () => {
+  it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
+    const tools = createClawdbotTools();
+    const byName = (name: string) => {
+      const tool = tools.find((candidate) => candidate.name === name);
+      expect(tool).toBeDefined();
+      if (!tool) throw new Error(`missing ${name} tool`);
+      return tool;
+    };
+
+    const schemaProp = (toolName: string, prop: string) => {
+      const tool = byName(toolName);
+      const schema = tool.parameters as {
+        anyOf?: unknown;
+        oneOf?: unknown;
+        properties?: Record<string, unknown>;
+      };
+      expect(schema.anyOf).toBeUndefined();
+      expect(schema.oneOf).toBeUndefined();
+
+      const properties = schema.properties ?? {};
+      const value = properties[prop] as { type?: unknown } | undefined;
+      expect(value).toBeDefined();
+      if (!value) throw new Error(`missing ${toolName} schema prop: ${prop}`);
+      return value;
+    };
+
+    expect(schemaProp("sessions_history", "limit").type).toBe("number");
+    expect(schemaProp("sessions_list", "limit").type).toBe("number");
+    expect(schemaProp("sessions_list", "activeMinutes").type).toBe("number");
+    expect(schemaProp("sessions_list", "messageLimit").type).toBe("number");
+    expect(schemaProp("sessions_send", "timeoutSeconds").type).toBe("number");
+    expect(schemaProp("sessions_spawn", "runTimeoutSeconds").type).toBe(
+      "number",
+    );
+    expect(schemaProp("sessions_spawn", "timeoutSeconds").type).toBe("number");
+  });
+
   it("sessions_list filters kinds and includes messages", async () => {
     callGatewayMock.mockReset();
     callGatewayMock.mockImplementation(async (opts: unknown) => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -18,7 +18,7 @@ import {
 
 const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
-  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+  limit: Type.Optional(Type.Number({ minimum: 1 })),
   includeTools: Type.Optional(Type.Boolean()),
 });
 

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -46,9 +46,9 @@ type SessionListRow = {
 
 const SessionsListToolSchema = Type.Object({
   kinds: Type.Optional(Type.Array(Type.String())),
-  limit: Type.Optional(Type.Integer({ minimum: 1 })),
-  activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
-  messageLimit: Type.Optional(Type.Integer({ minimum: 0 })),
+  limit: Type.Optional(Type.Number({ minimum: 1 })),
+  activeMinutes: Type.Optional(Type.Number({ minimum: 1 })),
+  messageLimit: Type.Optional(Type.Number({ minimum: 0 })),
 });
 
 function resolveSandboxSessionToolsVisibility(

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -30,25 +30,13 @@ import {
   resolvePingPongTurns,
 } from "./sessions-send-helpers.js";
 
-const SessionsSendToolSchema = Type.Union([
-  Type.Object(
-    {
-      sessionKey: Type.String(),
-      message: Type.String(),
-      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      label: Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH }),
-      agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
-      message: Type.String(),
-      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
-    },
-    { additionalProperties: false },
-  ),
-]);
+const SessionsSendToolSchema = Type.Object({
+  sessionKey: Type.Optional(Type.String()),
+  label: Type.Optional(Type.String()),
+  agentId: Type.Optional(Type.String()),
+  message: Type.String(),
+  timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+});
 
 export function createSessionsSendTool(opts?: {
   agentSessionKey?: string;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -32,8 +32,10 @@ import {
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
-  label: Type.Optional(Type.String()),
-  agentId: Type.Optional(Type.String()),
+  label: Type.Optional(
+    Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH }),
+  ),
+  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -25,9 +25,9 @@ const SessionsSpawnToolSchema = Type.Object({
   label: Type.Optional(Type.String()),
   agentId: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
-  runTimeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+  runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   // Back-compat alias. Prefer runTimeoutSeconds.
-  timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+  timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   cleanup: Type.Optional(
     Type.Union([Type.Literal("delete"), Type.Literal("keep")]),
   ),


### PR DESCRIPTION
I am an AI agent submitting this fix on behalf of the user.

### Original Behavior
When using  with the Google Cloud Code Assist API (Gemini models), the agent would crash with a 400 Bad Request error:


This was caused by the  tool using a  schema (compiling to /) and  constraints, which are not fully supported or are validated strictly by the Vertex AI / Gemini API.

### Fix
*   **Simplified  Schema**: Replaced the  (which required *either*  *or*  via ) with a single flat  where all fields are optional. This removes the nested complexity that caused the validation error.
*   **Relaxed Types**: Replaced  with  across , , and  tools to improve compatibility with models that treat all numbers as floats/doubles in their schema validation.

### Testing
*   **Reproduction**: Confirmed the 400 error occurred consistently on the original  branch when the agent attempted to initialize tools with Gemini.
*   **Verification**: Applied the schema changes, rebuilt the project, and successfully sent/received messages using the agent. The agent is now able to tool-call and reply without crashing.
*   **Regression**: Rebased on latest  (as of Jan 10 2026) and verified the fix persists.