### PR TITLE
fix(queue): deduplicate followup queue entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Auto-reply: relax reply tag parsing to allow whitespace. (#560) — thanks @mcinteerj
 - Auto-reply: add per-provider block streaming toggles and coalesce streamed blocks to reduce line spam. (#536) — thanks @mcinteerj
 - Auto-reply: fix /status usage summary filtering for the active provider.
+- Auto-reply: deduplicate followup queue entries using message id/routing to avoid duplicate replies. (#600) — thanks @samratjha96
 - Status: show provider prefix in /status model display. (#506) — thanks @mcinteerj
 - Status: compact /status with session token usage + estimated cost, add `/cost` per-response usage lines (tokens-only for OAuth).
 - Status: show active auth profile and key snippet in /status.

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -846,6 +846,7 @@ export async function getReplyFromConfig(
   const authProfileId = sessionEntry?.authProfileOverride;
   const followupRun = {
     prompt: queuedBody,
+    messageId: sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
     // Originating channel for reply routing.

--- a/src/auto-reply/reply/queue.collect-routing.test.ts
+++ b/src/auto-reply/reply/queue.collect-routing.test.ts
@@ -29,6 +29,111 @@ function createRun(params: {
   };
 }
 
+describe("followup queue deduplication", () => {
+  it("deduplicates messages with same Discord message_id", async () => {
+    const key = `test-dedup-message-id-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    // First enqueue should succeed
+    const first = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "[Discord Guild #test channel id:123] Hello",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(first).toBe(true);
+
+    // Second enqueue with same prompt should be deduplicated
+    const second = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "[Discord Guild #test channel id:123] Hello",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(second).toBe(false);
+
+    // Third enqueue with different prompt should succeed
+    const third = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "[Discord Guild #test channel id:123] World",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(third).toBe(true);
+
+    scheduleFollowupDrain(key, runFollowup);
+    await expect.poll(() => calls.length).toBe(1);
+    // Should collect both unique messages
+    expect(calls[0]?.prompt).toContain(
+      "[Queued messages while agent was busy]",
+    );
+  });
+
+  it("deduplicates across different providers using exact prompt match", async () => {
+    const key = `test-dedup-whatsapp-${Date.now()}`;
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    // First enqueue should succeed
+    const first = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "Hello world",
+        originatingChannel: "whatsapp",
+        originatingTo: "+1234567890",
+      }),
+      settings,
+    );
+    expect(first).toBe(true);
+
+    // Second enqueue with same prompt should be deduplicated
+    const second = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "Hello world",
+        originatingChannel: "whatsapp",
+        originatingTo: "+1234567890",
+      }),
+      settings,
+    );
+    expect(second).toBe(false);
+
+    // Third enqueue with different prompt should succeed
+    const third = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "Hello world 2",
+        originatingChannel: "whatsapp",
+        originatingTo: "+1234567890",
+      }),
+      settings,
+    );
+    expect(third).toBe(true);
+  });
+});
+
 describe("followup queue collect routing", () => {
   it("does not collect when destinations differ", async () => {
     const key = `test-collect-diff-to-${Date.now()}`;

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -27,6 +27,8 @@ export type QueueSettings = {
 };
 export type FollowupRun = {
   prompt: string;
+  /** Provider message ID, when available (for deduplication). */
+  messageId?: string;
   summaryLine?: string;
   enqueuedAt: number;
   /**
@@ -338,13 +340,27 @@ function getFollowupQueue(
   return created;
 }
 /**
- * Check if a prompt is already queued using exact match.
+ * Check if a run is already queued using a stable dedup key.
  */
-function isPromptAlreadyQueued(
-  prompt: string,
+function isRunAlreadyQueued(
+  run: FollowupRun,
   queue: FollowupQueueState,
 ): boolean {
-  return queue.items.some((item) => item.prompt === prompt);
+  const hasSameRouting = (item: FollowupRun) =>
+    item.originatingChannel === run.originatingChannel &&
+    item.originatingTo === run.originatingTo &&
+    item.originatingAccountId === run.originatingAccountId &&
+    item.originatingThreadId === run.originatingThreadId;
+
+  const messageId = run.messageId?.trim();
+  if (messageId) {
+    return queue.items.some(
+      (item) => item.messageId?.trim() === messageId && hasSameRouting(item),
+    );
+  }
+  return queue.items.some(
+    (item) => item.prompt === run.prompt && hasSameRouting(item),
+  );
 }
 
 export function enqueueFollowupRun(
@@ -353,13 +369,14 @@ export function enqueueFollowupRun(
   settings: QueueSettings,
 ): boolean {
   const queue = getFollowupQueue(key, settings);
-  queue.lastEnqueuedAt = Date.now();
-  queue.lastRun = run.run;
 
-  // Deduplicate: skip if the same prompt is already queued.
-  if (isPromptAlreadyQueued(run.prompt, queue)) {
+  // Deduplicate: skip if the same message is already queued.
+  if (isRunAlreadyQueued(run, queue)) {
     return false;
   }
+
+  queue.lastEnqueuedAt = Date.now();
+  queue.lastRun = run.run;
 
   const cap = queue.cap;
   if (cap > 0 && queue.items.length >= cap) {


### PR DESCRIPTION
Was facing some issues with multiple responses to my questions on Discord. Did some digging with Claude and it's because Discord seems to fire off multiple events if the previous one took a while to get processed. 

I think this is a safe assumption to always drop the EXACT same message from being enqueued if it's already in the queue. Didn't test with other providers tbf but seems like the right behavior

## Summary

- Add exact-match deduplication to the followup queue to prevent duplicate responses
- Extracted `isPromptAlreadyQueued()` helper for clarity

## Problem

When messages arrived while the agent was busy processing, the same message could be enqueued multiple times into the followup queue. This caused the bot to respond to the same user message 2-4+ times.

**Root cause:** Discord's event system can emit the same message multiple times (e.g., during reconnects or slow listener processing), and the followup queue had no deduplication logic.

## Solution

Add simple exact-match deduplication in `enqueueFollowupRun()`: if a prompt is already in the queue, skip adding it again.

**Changes:**
- `src/auto-reply/reply/queue.ts` - Added `isPromptAlreadyQueued()` helper
- `src/auto-reply/reply/queue.collect-routing.test.ts` - Added test coverage

## Testing

- pnpm lint
- pnpm build
- pnpm test
- Manually verified on Discord: single response per message even when multiple events fire


Closes: https://github.com/clawdbot/clawdbot/pull/598
