### PR TITLE
refactor: centralize model override validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Commands: accept /models as an alias for /model.
 - Commands: add `/usage` as an alias for `/status`. (#492) — thanks @lc0rp
 - Models/Auth: add MiniMax Anthropic-compatible API onboarding (minimax-api). (#590) — thanks @mneves75
+- Models: centralize model override validation + hooks Gmail warnings in doctor. (#602) — thanks @steipete
 - Commands: harden slash command registry and list text-only commands in `/commands`.
 - Models/Auth: show per-agent auth candidates in `/model status`, and add `clawdbot models auth order {get,set,clear}` (per-agent auth rotation overrides). — thanks @steipete
 - Debugging: add raw model stream logging flags and document gateway watch mode.

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -83,7 +83,10 @@ State is stored in `auth-profiles.json` under `usageStats`:
 
 If all profiles for a provider fail, Clawdbot moves to the next model in
 `agents.defaults.model.fallbacks`. This applies to auth failures, rate limits, and
-timeouts that exhausted profile rotation.
+timeouts that exhausted profile rotation (other errors do not advance fallback).
+
+When a run starts with a model override (hooks or CLI), fallbacks still end at
+`agents.defaults.model.primary` after trying any configured fallbacks.
 
 ## Related config
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -10,8 +10,7 @@ import {
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import {
-  buildAllowedModelSet,
-  modelKey,
+  getModelRefStatus,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
@@ -1782,22 +1781,21 @@ export async function startGatewayServer(
           defaultModel: DEFAULT_MODEL,
         });
       const catalog = await loadModelCatalog({ config: cfgAtStart });
-      const key = modelKey(hooksModelRef.provider, hooksModelRef.model);
-      const allowed = buildAllowedModelSet({
+      const status = getModelRefStatus({
         cfg: cfgAtStart,
         catalog,
+        ref: hooksModelRef,
         defaultProvider,
         defaultModel,
       });
-      if (!allowed.allowAny && !allowed.allowedKeys.has(key)) {
+      if (!status.allowed) {
         logHooks.warn(
-          `hooks.gmail.model "${key}" not in agents.defaults.models allowlist (will use primary instead)`,
+          `hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
         );
       }
-      const inCatalog = catalog.some((e) => modelKey(e.provider, e.id) === key);
-      if (!inCatalog) {
+      if (!status.inCatalog) {
         logHooks.warn(
-          `hooks.gmail.model "${key}" not in the model catalog (may fail at runtime)`,
+          `hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
         );
       }
     }


### PR DESCRIPTION
## Summary\n- centralize model override allowlist/catalog validation helpers\n- reuse helpers for cron, session patches, and gateway warnings\n- surface hooks.gmail.model warnings in doctor and document fallback behavior\n\n## Testing\n- pnpm lint\n- pnpm build\n- pnpm test