### PR TITLE
Fix model fallback error message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Commands: add `/usage` as an alias for `/status`. (#492) — thanks @lc0rp
 - Models/Auth: add MiniMax Anthropic-compatible API onboarding (minimax-api). (#590) — thanks @mneves75
 - Models: centralize model override validation + hooks Gmail warnings in doctor. (#602) — thanks @steipete
+- Agents: avoid base-to-string error stringification in model fallback. (#604) — thanks @steipete
 - Commands: harden slash command registry and list text-only commands in `/commands`.
 - Models/Auth: show per-agent auth candidates in `/model status`, and add `clawdbot models auth order {get,set,clear}` (per-agent auth rotation overrides). — thanks @steipete
 - Debugging: add raw model stream logging flags and document gateway watch mode.

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -54,7 +54,20 @@ function getErrorCode(err: unknown): string {
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
-  return String(err ?? "");
+  if (typeof err === "string") return err;
+  if (
+    typeof err === "number" ||
+    typeof err === "boolean" ||
+    typeof err === "bigint"
+  ) {
+    return String(err);
+  }
+  if (typeof err === "symbol") return err.description ?? "";
+  if (err && typeof err === "object") {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "";
 }
 
 function isTimeoutErrorMessage(raw: string): boolean {


### PR DESCRIPTION
- Avoid base-to-string lint by narrowing error types.\n\nTests: pnpm lint && pnpm build && pnpm test