### PR TITLE
Docker: cache deps layer for faster rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,14 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY . .
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
 
 RUN pnpm install --frozen-lockfile
+
+COPY . .
 RUN pnpm build
 RUN pnpm ui:install
 RUN pnpm ui:build

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -61,6 +61,40 @@ docker compose run --rm clawdbot-cli onboard
 docker compose up -d clawdbot-gateway
 ```
 
+### Faster rebuilds (recommended)
+
+To speed up rebuilds, order your Dockerfile so dependency layers are cached.
+This avoids re-running `pnpm install` unless lockfiles change:
+
+```dockerfile
+FROM node:22-bookworm
+
+# Install Bun (required for build scripts)
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN corepack enable
+
+WORKDIR /app
+
+# Cache dependencies unless package metadata changes
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+RUN pnpm ui:install
+RUN pnpm ui:build
+
+ENV NODE_ENV=production
+
+CMD ["node","dist/index.js"]
+```
+
 ### Provider setup (optional)
 
 Use the CLI container to configure providers, then restart the gateway if needed.

--- a/docs/platforms/hetzner.md
+++ b/docs/platforms/hetzner.md
@@ -214,9 +214,15 @@ RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Lin
 # Add more binaries below using the same pattern
 
 WORKDIR /app
-COPY . .
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+
 RUN corepack enable
 RUN pnpm install --frozen-lockfile
+
+COPY . .
 RUN pnpm build
 RUN pnpm ui:install
 RUN pnpm ui:build


### PR DESCRIPTION
## Summary
Docker builds after a fresh pull were slower than local builds because the container cache was invalidated on any source change (pnpm had to re-install all dependencies every time). This change reorders Dockerfile COPY/install steps so dependencies are cached unless lockfiles or install inputs change.

## Timing
- Baseline Dockerfile: `docker build -t clawdbot:local -f Dockerfile .` → 1m25s
- Optimized Dockerfile: first build → 45.5s; cache-hit rebuild → 0.29s

## AI Assistance
Change was assisted by Codex
