### PR TITLE
fix Mac app Launch at Login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- macOS: avoid clearing Launch at Login during app initialization. (#607) — thanks @wes-davis
 - macOS: add node bridge heartbeat pings to detect half-open sockets and reconnect cleanly. (#572) — thanks @ngutman
 - Node bridge: harden keepalive + heartbeat handling (TCP keepalive, better disconnects, and keepalive config tests). (#577) — thanks @steipete
 - Control UI: improve mobile responsiveness. (#558) — thanks @carlulsoe

--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -29,7 +29,10 @@ final class AppState {
     }
 
     var launchAtLogin: Bool {
-        didSet { self.ifNotPreview { Task { AppStateStore.updateLaunchAtLogin(enabled: self.launchAtLogin) } } }
+        didSet {
+            guard !self.isInitializing else { return }
+            self.ifNotPreview { Task { AppStateStore.updateLaunchAtLogin(enabled: self.launchAtLogin) } }
+        }
     }
 
     var onboardingSeen: Bool {


### PR DESCRIPTION
## Summary

Commit `73211c90` introduced a bug where the Mac app deleted the Launch at Login plist on every startup. 

The `AppState.init()` sets `launchAtLogin = false`, which triggers `didSet` and deletes `~/Library/LaunchAgents/com.clawdbot.mac.plist` before the async status check can read the actual value.

Fixed by adding `guard !self.isInitializing` to skip the `didSet` side effect during initialization.

## Test plan

1. Enable "Launch at login" in Settings > General
2. Verify plist exists: `cat ~/Library/LaunchAgents/com.clawdbot.mac.plist`
3. Quit and relaunch app
4. Verify checkbox still checked and plist still exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)