### PR TITLE
fix(discord): add zombie detection and disconnect logging

### DIFF
--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -503,6 +503,16 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const stopGatewayLogging = attachDiscordGatewayLogging({
     emitter: gatewayEmitter,
     runtime,
+    // Pass gateway handle for zombie connection detection (no HELLO timeout)
+    gateway: gateway
+      ? {
+          get isConnected() {
+            return gateway.isConnected;
+          },
+          disconnect: () => gateway.disconnect(),
+          connect: (resume) => gateway.connect(resume),
+        }
+      : undefined,
   });
   try {
     await waitForDiscordGatewayStop({


### PR DESCRIPTION
## Summary
- **Phase 1:** Log gateway debug events for WebSocket disconnect visibility
- **Phase 2:** Add 30s HELLO timeout to detect and recover from zombie connections

## Root Cause
When WebSocket opens but Discord never sends HELLO, Carbon's GatewayPlugin waits forever (no timeout). This creates a zombie state where the connection appears open but is dead—no heartbeat starts, no events flow, no recovery.

## Changes
1. Listen to Carbon's `debug` events to log WebSocket close/reconnect events
2. Add 30s timeout after "WebSocket connection opened"; if `gateway.isConnected` stays false (no HELLO received), force a fresh connection

## Testing
- ✅ Build passes
- ✅ Lint passes
- ✅ All 78 Discord tests pass
- ✅ Captured live disconnect with code 1006
- ✅ Observed zombie state in production (WebSocket open, no HELLO)

Fixes #595

🤖 Generated with [Claude Code](https://claude.ai/code)