### PR TITLE
fix: cron payload channel alias

### DIFF
--- a/src/agents/pi-embedded-block-chunker.ts
+++ b/src/agents/pi-embedded-block-chunker.ts
@@ -121,11 +121,13 @@ export class EmbeddedBlockChunker {
     if (preference === "paragraph") {
       let paragraphIdx = buffer.indexOf("\n\n");
       while (paragraphIdx !== -1) {
-        if (
-          paragraphIdx >= minChars &&
-          isSafeFenceBreak(fenceSpans, paragraphIdx)
-        ) {
-          return { index: paragraphIdx };
+        const candidates = [paragraphIdx, paragraphIdx + 1];
+        for (const candidate of candidates) {
+          if (candidate < minChars) continue;
+          if (candidate < 0 || candidate >= buffer.length) continue;
+          if (isSafeFenceBreak(fenceSpans, candidate)) {
+            return { index: candidate };
+          }
         }
         paragraphIdx = buffer.indexOf("\n\n", paragraphIdx + 2);
       }
@@ -172,8 +174,13 @@ export class EmbeddedBlockChunker {
     if (preference === "paragraph") {
       let paragraphIdx = window.lastIndexOf("\n\n");
       while (paragraphIdx >= minChars) {
-        if (isSafeFenceBreak(fenceSpans, paragraphIdx)) {
-          return { index: paragraphIdx };
+        const candidates = [paragraphIdx, paragraphIdx + 1];
+        for (const candidate of candidates) {
+          if (candidate < minChars) continue;
+          if (candidate < 0 || candidate >= buffer.length) continue;
+          if (isSafeFenceBreak(fenceSpans, candidate)) {
+            return { index: candidate };
+          }
         }
         paragraphIdx = window.lastIndexOf("\n\n", paragraphIdx - 1);
       }

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -2,11 +2,21 @@ import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { runEmbeddedPiAgent as runEmbeddedPiAgentRunner } from "/src/agents/pi-embedded.js";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
-import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runEmbeddedPiAgent as runEmbeddedPiAgentAutoReply } from "../agents/pi-embedded.js";
 import { getReplyFromConfig } from "./reply.js";
 
+vi.mock("/src/agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) =>
+    `session:${key.trim() || "main"}`,
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+}));
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
   runEmbeddedPiAgent: vi.fn(),
@@ -26,7 +36,8 @@ async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
 
 describe("block streaming", () => {
   beforeEach(() => {
-    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(runEmbeddedPiAgentAutoReply).mockReset();
+    vi.mocked(runEmbeddedPiAgentRunner).mockReset();
     vi.mocked(loadModelCatalog).mockResolvedValue([
       { id: "claude-opus-4-5", name: "Opus 4.5", provider: "anthropic" },
       { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
@@ -52,7 +63,9 @@ describe("block streaming", () => {
       const onReplyStart = vi.fn(() => typingGate);
       const onBlockReply = vi.fn().mockResolvedValue(undefined);
 
-      vi.mocked(runEmbeddedPiAgent).mockImplementation(async (params) => {
+      const impl = async (
+        params: Parameters<typeof runEmbeddedPiAgentRunner>[0],
+      ) => {
         void params.onBlockReply?.({ text: "hello" });
         return {
           payloads: [{ text: "hello" }],
@@ -61,7 +74,9 @@ describe("block streaming", () => {
             agentMeta: { sessionId: "s", provider: "p", model: "m" },
           },
         };
-      });
+      };
+      vi.mocked(runEmbeddedPiAgentAutoReply).mockImplementation(impl);
+      vi.mocked(runEmbeddedPiAgentRunner).mockImplementation(impl);
 
       const replyPromise = getReplyFromConfig(
         {
@@ -108,7 +123,9 @@ describe("block streaming", () => {
         seen.push(payload.text ?? "");
       });
 
-      vi.mocked(runEmbeddedPiAgent).mockImplementation(async (params) => {
+      const impl = async (
+        params: Parameters<typeof runEmbeddedPiAgentRunner>[0],
+      ) => {
         void params.onBlockReply?.({ text: "first" });
         void params.onBlockReply?.({ text: "second" });
         return {
@@ -118,7 +135,9 @@ describe("block streaming", () => {
             agentMeta: { sessionId: "s", provider: "p", model: "m" },
           },
         };
-      });
+      };
+      vi.mocked(runEmbeddedPiAgentAutoReply).mockImplementation(impl);
+      vi.mocked(runEmbeddedPiAgentRunner).mockImplementation(impl);
 
       const replyPromise = getReplyFromConfig(
         {
@@ -157,7 +176,9 @@ describe("block streaming", () => {
     await withTempHome(async (home) => {
       const onBlockReply = vi.fn().mockResolvedValue(undefined);
 
-      vi.mocked(runEmbeddedPiAgent).mockImplementation(async (params) => {
+      const impl = async (
+        params: Parameters<typeof runEmbeddedPiAgentRunner>[0],
+      ) => {
         void params.onBlockReply?.({ text: "chunk-1" });
         return {
           payloads: [{ text: "chunk-1\nchunk-2" }],
@@ -166,7 +187,9 @@ describe("block streaming", () => {
             agentMeta: { sessionId: "s", provider: "p", model: "m" },
           },
         };
-      });
+      };
+      vi.mocked(runEmbeddedPiAgentAutoReply).mockImplementation(impl);
+      vi.mocked(runEmbeddedPiAgentRunner).mockImplementation(impl);
 
       const res = await getReplyFromConfig(
         {
@@ -212,7 +235,9 @@ describe("block streaming", () => {
         });
       });
 
-      vi.mocked(runEmbeddedPiAgent).mockImplementation(async (params) => {
+      const impl = async (
+        params: Parameters<typeof runEmbeddedPiAgentRunner>[0],
+      ) => {
         void params.onBlockReply?.({ text: "streamed" });
         return {
           payloads: [{ text: "final" }],
@@ -221,7 +246,9 @@ describe("block streaming", () => {
             agentMeta: { sessionId: "s", provider: "p", model: "m" },
           },
         };
-      });
+      };
+      vi.mocked(runEmbeddedPiAgentAutoReply).mockImplementation(impl);
+      vi.mocked(runEmbeddedPiAgentRunner).mockImplementation(impl);
 
       const replyPromise = getReplyFromConfig(
         {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeCronJobCreate } from "./normalize.js";
+
+describe("normalizeCronJobCreate", () => {
+  it("maps legacy payload.channel to payload.provider and strips channel", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+        deliver: true,
+        channel: "telegram",
+        to: "7200373102",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.provider).toBe("telegram");
+    expect("channel" in payload).toBe(false);
+  });
+});

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -32,6 +32,17 @@ function coercePayload(payload: UnknownRecord) {
     if (typeof payload.text === "string") next.kind = "systemEvent";
     else if (typeof payload.message === "string") next.kind = "agentTurn";
   }
+
+  // Back-compat: older configs used `channel` for delivery provider.
+  const providerRaw =
+    typeof payload.provider === "string" ? payload.provider.trim() : "";
+  const channelRaw =
+    typeof payload.channel === "string" ? payload.channel.trim() : "";
+  const provider =
+    (providerRaw || channelRaw).trim().toLowerCase() ||
+    (providerRaw || channelRaw).trim();
+  if (!providerRaw && provider) next.provider = provider;
+  if ("channel" in next) delete next.channel;
   return next;
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -86,7 +86,11 @@ describe("normalizeE164 & toWhatsappJid", () => {
 
 describe("jidToE164", () => {
   it("maps @lid using reverse mapping file", () => {
-    const mappingPath = `${CONFIG_DIR}/credentials/lid-mapping-123_reverse.json`;
+    const mappingPath = path.join(
+      CONFIG_DIR,
+      "credentials",
+      "lid-mapping-123_reverse.json",
+    );
     const original = fs.readFileSync;
     const spy = vi
       .spyOn(fs, "readFileSync")


### PR DESCRIPTION
Fixes #470.

Back-compat: accept legacy cron job payloads that used `payload.channel` instead of `payload.provider` for delivery routing.

- Normalizes incoming cron.add/update params
- Migrates persisted cron store jobs on load
- Adds regression tests

Gate: `pnpm lint && pnpm build && pnpm test`