### PR TITLE
feat(signal): add reaction message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - Pairing: replies now include sender ids for Discord/Slack/Signal/iMessage/WhatsApp; pairing list labels them explicitly.
 - Messages: default inbound/outbound prefixes from the routed agent’s `identity.name` when set. (#578) — thanks @p6l-richard
 - Signal: accept UUID-only senders for pairing/allowlists/routing when sourceNumber is missing. (#523) — thanks @neist
+- Signal: ignore reaction-only messages so they don't surface as unknown media. (#616) — thanks @neist
 - Agent system prompt: avoid automatic self-updates unless explicitly requested.
 - Onboarding: tighten QuickStart hint copy for configuring later.
 - Onboarding: set Gemini 3 Pro as the default model for Gemini API key auth. (#489) — thanks @jonasjancarik

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -315,11 +315,12 @@ export async function monitorSignalProvider(
       if (!envelope) return;
       if (envelope.syncMessage) return;
 
-      // Handle reaction messages
-      if (envelope.reactionMessage) {
+      const dataMessage =
+        envelope.dataMessage ?? envelope.editMessage?.dataMessage;
+      if (envelope.reactionMessage && !dataMessage) {
         const reaction = envelope.reactionMessage;
         if (reaction.isRemove) return; // Ignore reaction removals
-        const emoji = reaction.emoji ?? "👍";
+        const emoji = reaction.emoji ?? "unknown";
         const sender = resolveSignalSender(envelope);
         if (!sender) return;
         const senderDisplay = formatSignalSenderDisplay(sender);
@@ -329,9 +330,6 @@ export async function monitorSignalProvider(
         // Future: could dispatch as a notification or store for context
         return;
       }
-
-      const dataMessage =
-        envelope.dataMessage ?? envelope.editMessage?.dataMessage;
       if (!dataMessage) return;
 
       const sender = resolveSignalSender(envelope);

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -41,6 +41,15 @@ type SignalEnvelope = {
   dataMessage?: SignalDataMessage | null;
   editMessage?: { dataMessage?: SignalDataMessage | null } | null;
   syncMessage?: unknown;
+  reactionMessage?: SignalReactionMessage | null;
+};
+
+type SignalReactionMessage = {
+  emoji?: string | null;
+  targetAuthor?: string | null;
+  targetAuthorUuid?: string | null;
+  targetSentTimestamp?: number | null;
+  isRemove?: boolean | null;
 };
 
 type SignalDataMessage = {
@@ -305,6 +314,22 @@ export async function monitorSignalProvider(
       const envelope = payload?.envelope;
       if (!envelope) return;
       if (envelope.syncMessage) return;
+
+      // Handle reaction messages
+      if (envelope.reactionMessage) {
+        const reaction = envelope.reactionMessage;
+        if (reaction.isRemove) return; // Ignore reaction removals
+        const emoji = reaction.emoji ?? "👍";
+        const sender = resolveSignalSender(envelope);
+        if (!sender) return;
+        const senderDisplay = formatSignalSenderDisplay(sender);
+        const senderName = envelope.sourceName ?? senderDisplay;
+        logVerbose(`signal reaction: ${emoji} from ${senderName}`);
+        // Skip processing reactions as messages for now - just log them
+        // Future: could dispatch as a notification or store for context
+        return;
+      }
+
       const dataMessage =
         envelope.dataMessage ?? envelope.editMessage?.dataMessage;
       if (!dataMessage) return;


### PR DESCRIPTION
## Summary

Adds basic support for Signal reaction messages to prevent them from showing as unknown media.

## Changes

- Add `SignalReactionMessage` type with fields:
  - `emoji` - the reaction emoji
  - `targetAuthor` / `targetAuthorUuid` - who sent the original message
  - `targetSentTimestamp` - timestamp of the original message
  - `isRemove` - whether the reaction is being removed

- Handle reaction messages in monitor:
  - Log reactions for debugging
  - Skip processing (don't show as unknown media)
  - Ignore reaction removals

## Future improvements

- Could dispatch reactions as notifications
- Could store reactions for context in conversations
- Could support sending reactions via `sendReaction`

---
*Opened by Shadow (assistant) on behalf of @neist*