### PR TITLE
fix(discord): treat channels config as overrides list, not allowlist

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -129,7 +129,7 @@ describe("discord guild/channel resolution", () => {
     expect(help?.systemPrompt).toBe("Use short answers.");
   });
 
-  it("denies channel when config present but no match", () => {
+  it("allows unlisted channels by default (overrides list behavior)", () => {
     const guildInfo: DiscordGuildEntryResolved = {
       channels: {
         general: { allow: true },
@@ -141,7 +141,8 @@ describe("discord guild/channel resolution", () => {
       channelName: "random",
       channelSlug: "random",
     });
-    expect(channel?.allowed).toBe(false);
+    // Unlisted channels should return null (allow by default)
+    expect(channel).toBeNull();
   });
 });
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -2259,7 +2259,7 @@ export function resolveDiscordChannelConfig(params: {
       systemPrompt: entry.systemPrompt,
     };
   }
-  return { allowed: false };
+  return null;
 }
 
 export function isDiscordGroupAllowedByPolicy(params: {


### PR DESCRIPTION
## Summary

Fixes Discord guild channel configs treating the `channels` configuration as an implicit allowlist, which blocked all messages from unlisted channels when users configured specific channels for a guild.

## Changes

- **`src/discord/monitor.ts`**: Modified `resolveDiscordChannelConfig()` at line 2262
  - Changed: `return { allowed: false }` → `return null`
  - Effect: Unlisted channels now return `null` (allow by default) instead of being blocked

- **`src/discord/monitor.test.ts`**: Updated test at lines 132-145
  - Changed test name from "denies channel when config present but no match"
  - Changed assertion from `expect(channel?.allowed).toBe(false)` to `expect(channel).toBeNull()`
  - Effect: Test now validates the correct overrides list behavior

## Root Cause

The `resolveDiscordChannelConfig()` function returned `{ allowed: false }` for any channel not explicitly listed in the guild's `channels` config. This treated the config as an **implicit allowlist**:
- Listed channels → allowed (with custom settings)
- Unlisted channels → BLOCKED

This broke message handling when users added per-account guild channel configs - suddenly all unlisted channels stopped working.

## Solution

Changed the function to return `null` for unlisted channels, treating the config as an **explicit overrides list**:
- Listed channels → allowed (with custom settings)
- Unlisted channels → `null` → allow by default (caller's default behavior)

## Testing

- Ran `npm run lint` - passed
- Ran `npm test -- src/discord/monitor.test.ts` - all Discord monitor tests passed (23/23)
- Updated existing test to validate correct behavior

## Related Issues

Fixes #466

## AI-Assisted PR

This PR was created with assistance from Claude Code (Anthropic).
- Testing level: Lightly tested (lint + test suite)
- Prompts/session logs available upon request

---
Co-Authored-By: Claude <noreply@anthropic.com>