### PR TITLE
fix: enable block streaming for Telegram when streamMode is 'block'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Auth: default billing disable backoff to 5h (doubling, 24h cap) and surface disabled/cooldown profiles in `models list` + doctor. (#486) — thanks @steipete
 - Commands: harden slash command registry and list text-only commands in `/commands`.
 - Models/Auth: show per-agent auth candidates in `/model status`, and add `clawdbot models auth order {get,set,clear}` (per-agent auth rotation overrides). — thanks @steipete
+- Telegram: keep streamMode draft-only; avoid forcing block streaming. (#619) — thanks @rubyrunsstuff
 - Debugging: add raw model stream logging flags and document gateway watch mode.
 - Gateway: decode dns-sd escaped UTF-8 in discovery output and show scan progress immediately. — thanks @steipete
 - Agent: add claude-cli/opus-4.5 runner via Claude CLI with resume support (tools disabled).

--- a/src/agents/pi-embedded-block-chunker.ts
+++ b/src/agents/pi-embedded-block-chunker.ts
@@ -221,6 +221,10 @@ export class EmbeddedBlockChunker {
       if (sentenceIdx >= minChars) return { index: sentenceIdx };
     }
 
+    if (preference === "newline" && buffer.length < maxChars) {
+      return { index: -1 };
+    }
+
     for (let i = window.length - 1; i >= minChars; i--) {
       if (/\s/.test(window[i]) && isSafeFenceBreak(fenceSpans, i)) {
         return { index: i };

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -109,7 +109,6 @@ import {
 
 // Optional features can be implemented as Pi extensions that run in the same Node process.
 
-
 /**
  * Resolve provider-specific extraParams from model config.
  * Auto-enables thinking mode for GLM-4.x models unless explicitly disabled.

--- a/src/auto-reply/reply/block-streaming.ts
+++ b/src/auto-reply/reply/block-streaming.ts
@@ -58,9 +58,7 @@ export function resolveBlockStreamingChunking(
     Math.floor(chunkCfg?.maxChars ?? DEFAULT_BLOCK_STREAM_MAX),
   );
   const maxChars = Math.max(1, Math.min(maxRequested, textLimit));
-  const telegramBlockStreaming =
-    providerKey === "telegram" && cfg?.telegram?.streamMode === "block";
-  const minFallback = telegramBlockStreaming ? 1 : DEFAULT_BLOCK_STREAM_MIN;
+  const minFallback = DEFAULT_BLOCK_STREAM_MIN;
   const minRequested = Math.max(
     1,
     Math.floor(chunkCfg?.minChars ?? minFallback),
@@ -135,13 +133,6 @@ export function resolveBlockStreamingCoalescing(
   })();
   const coalesceCfg =
     providerCfg ?? cfg?.agents?.defaults?.blockStreamingCoalesce;
-  if (
-    providerKey === "telegram" &&
-    cfg?.telegram?.streamMode === "block" &&
-    !coalesceCfg
-  ) {
-    return undefined;
-  }
   const minRequested = Math.max(
     1,
     Math.floor(

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -826,15 +826,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         onReplyStart: sendTyping,
       });
 
-    const blockStreamingDisabledByConfig =
-      typeof telegramCfg.blockStreaming === "boolean"
-        ? !telegramCfg.blockStreaming
-        : false;
-    const forceBlockStreaming = Boolean(
-      streamMode === "block" && !draftStream && !blockStreamingDisabledByConfig,
-    );
     const disableBlockStreaming =
-      Boolean(draftStream) || blockStreamingDisabledByConfig ? true : undefined;
+      Boolean(draftStream) ||
+      (typeof telegramCfg.blockStreaming === "boolean"
+        ? !telegramCfg.blockStreaming
+        : undefined);
 
     const { queuedFinal } = await dispatchReplyFromConfig({
       ctx: ctxPayload,
@@ -851,9 +847,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
               if (payload.text) draftStream.update(payload.text);
             }
           : undefined,
-        disableBlockStreaming: forceBlockStreaming
-          ? false
-          : disableBlockStreaming,
+        disableBlockStreaming,
       },
     });
     markDispatchIdle();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -826,6 +826,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         onReplyStart: sendTyping,
       });
 
+    const blockStreamingDisabledByConfig =
+      typeof telegramCfg.blockStreaming === "boolean"
+        ? !telegramCfg.blockStreaming
+        : false;
+    const forceBlockStreaming = Boolean(
+      streamMode === "block" && !draftStream && !blockStreamingDisabledByConfig,
+    );
+    const disableBlockStreaming =
+      Boolean(draftStream) || blockStreamingDisabledByConfig ? true : undefined;
+
     const { queuedFinal } = await dispatchReplyFromConfig({
       ctx: ctxPayload,
       cfg,
@@ -841,11 +851,9 @@ export function createTelegramBot(opts: TelegramBotOptions) {
               if (payload.text) draftStream.update(payload.text);
             }
           : undefined,
-        disableBlockStreaming:
-          Boolean(draftStream) ||
-          (typeof telegramCfg.blockStreaming === "boolean"
-            ? !telegramCfg.blockStreaming
-            : undefined),
+        disableBlockStreaming: forceBlockStreaming
+          ? false
+          : disableBlockStreaming,
       },
     });
     markDispatchIdle();


### PR DESCRIPTION
## Problem
When `telegram.streamMode: 'block'` is configured, all messages were still being batched into one message at the end instead of streaming as separate messages during generation.

## Root Causes
1. **disableBlockStreaming logic** - The flag was being set based on `blockStreamingDefault` even when `streamMode: 'block'` was explicitly configured
2. **minChars default too high** - Default of 800 chars meant chunks wouldn't send until accumulating 800 chars, even with newline/sentence break preference
3. **Coalescing delays** - Default coalescing was batching chunks together

## Changes
- `src/telegram/bot.ts`: Fix disableBlockStreaming logic to force-enable block streaming when `streamMode === 'block'`
- `src/auto-reply/reply/block-streaming.ts`: Set minChars default to 1 for Telegram block mode; skip coalescing when not explicitly configured
- `src/agents/pi-embedded-block-chunker.ts`: Fix newline preference to wait for actual newlines instead of breaking on any whitespace

## Testing
Tested on Telegram DM - messages now stream as separate messages during generation instead of batching at the end.

---
*Fixed by Ruby 🐱 with help from Codex*

No need for clawdtributor adding, I'm @thewilloftheshadow's assistant 