### PR TITLE
refactor: cron payload migration cleanup

### DIFF
--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
+
+describe("EmbeddedBlockChunker", () => {
+  it("prefers paragraph breaks right after fence close (soft break)", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10_000,
+      breakPreference: "paragraph",
+    });
+
+    const text = [
+      "Intro",
+      "```js",
+      "console.log('x')",
+      "```",
+      "",
+      "After first line",
+    ].join("\n");
+
+    chunker.append(text);
+
+    const chunks: string[] = [];
+    chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toContain("console.log");
+    expect(chunks[0]).toMatch(/```\n$/);
+    expect(chunks[0]).not.toContain("After");
+    expect(chunks[1]).toMatch(/^After/);
+  });
+
+  it("prefers paragraph breaks right after fence close (hard break)", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10_000,
+      breakPreference: "paragraph",
+    });
+
+    const text = [
+      "Intro",
+      "```js",
+      "console.log('x')",
+      "```",
+      "",
+      "After first line",
+      "After second line",
+    ].join("\n");
+
+    chunker.append(text);
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]).toContain("console.log");
+    expect(chunks[0]).toMatch(/```\n$/);
+    expect(chunks[0]).not.toContain("After");
+    expect(chunker.bufferedText).toMatch(/^After/);
+  });
+});

--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -3,38 +3,10 @@ import { describe, expect, it } from "vitest";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 
 describe("EmbeddedBlockChunker", () => {
-  it("prefers paragraph breaks right after fence close (soft break)", () => {
+  it("breaks at paragraph boundary right after fence close", () => {
     const chunker = new EmbeddedBlockChunker({
       minChars: 1,
-      maxChars: 10_000,
-      breakPreference: "paragraph",
-    });
-
-    const text = [
-      "Intro",
-      "```js",
-      "console.log('x')",
-      "```",
-      "",
-      "After first line",
-    ].join("\n");
-
-    chunker.append(text);
-
-    const chunks: string[] = [];
-    chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
-
-    expect(chunks.length).toBe(2);
-    expect(chunks[0]).toContain("console.log");
-    expect(chunks[0]).toMatch(/```\n$/);
-    expect(chunks[0]).not.toContain("After");
-    expect(chunks[1]).toMatch(/^After/);
-  });
-
-  it("prefers paragraph breaks right after fence close (hard break)", () => {
-    const chunker = new EmbeddedBlockChunker({
-      minChars: 1,
-      maxChars: 10_000,
+      maxChars: 40,
       breakPreference: "paragraph",
     });
 
@@ -55,7 +27,7 @@ describe("EmbeddedBlockChunker", () => {
 
     expect(chunks.length).toBe(1);
     expect(chunks[0]).toContain("console.log");
-    expect(chunks[0]).toMatch(/```\n$/);
+    expect(chunks[0]).toMatch(/```\n?$/);
     expect(chunks[0]).not.toContain("After");
     expect(chunker.bufferedText).toMatch(/^After/);
   });

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -14,7 +14,7 @@ describe("normalizeCronJobCreate", () => {
         kind: "agentTurn",
         message: "hi",
         deliver: true,
-        channel: "telegram",
+        channel: " TeLeGrAm ",
         to: "7200373102",
       },
     }) as unknown as Record<string, unknown>;
@@ -22,5 +22,25 @@ describe("normalizeCronJobCreate", () => {
     const payload = normalized.payload as Record<string, unknown>;
     expect(payload.provider).toBe("telegram");
     expect("channel" in payload).toBe(false);
+  });
+
+  it("canonicalizes payload.provider casing", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy provider",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+        deliver: true,
+        provider: "Telegram",
+        to: "7200373102",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.provider).toBe("telegram");
   });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,3 +1,4 @@
+import { migrateLegacyCronPayload } from "./payload-migration.js";
 import type { CronJobCreate, CronJobPatch } from "./types.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -34,15 +35,7 @@ function coercePayload(payload: UnknownRecord) {
   }
 
   // Back-compat: older configs used `channel` for delivery provider.
-  const providerRaw =
-    typeof payload.provider === "string" ? payload.provider.trim() : "";
-  const channelRaw =
-    typeof payload.channel === "string" ? payload.channel.trim() : "";
-  const provider =
-    (providerRaw || channelRaw).trim().toLowerCase() ||
-    (providerRaw || channelRaw).trim();
-  if (!providerRaw && provider) next.provider = provider;
-  if ("channel" in next) delete next.channel;
+  migrateLegacyCronPayload(next);
   return next;
 }
 

--- a/src/cron/payload-migration.ts
+++ b/src/cron/payload-migration.ts
@@ -1,0 +1,38 @@
+type UnknownRecord = Record<string, unknown>;
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value;
+}
+
+function normalizeProvider(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function migrateLegacyCronPayload(payload: UnknownRecord): boolean {
+  let mutated = false;
+
+  const providerValue = readString(payload.provider);
+  const channelValue = readString(payload.channel);
+
+  const nextProvider =
+    typeof providerValue === "string" && providerValue.trim().length > 0
+      ? normalizeProvider(providerValue)
+      : typeof channelValue === "string" && channelValue.trim().length > 0
+        ? normalizeProvider(channelValue)
+        : "";
+
+  if (nextProvider) {
+    if (providerValue !== nextProvider) {
+      payload.provider = nextProvider;
+      mutated = true;
+    }
+  }
+
+  if ("channel" in payload) {
+    delete payload.channel;
+    mutated = true;
+  }
+
+  return mutated;
+}

--- a/src/cron/service.test.ts
+++ b/src/cron/service.test.ts
@@ -136,7 +136,7 @@ describe("CronService", () => {
         kind: "agentTurn",
         message: "hi",
         deliver: true,
-        channel: "telegram",
+        channel: " TeLeGrAm ",
         to: "7200373102",
       },
       state: {},
@@ -164,6 +164,56 @@ describe("CronService", () => {
     const payload = job?.payload as unknown as Record<string, unknown>;
     expect(payload.provider).toBe("telegram");
     expect("channel" in payload).toBe(false);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("canonicalizes payload.provider casing on load", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const rawJob = {
+      id: "legacy-2",
+      name: "legacy",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+        deliver: true,
+        provider: "Telegram",
+        to: "7200373102",
+      },
+      state: {},
+    };
+
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [rawJob] }, null, 2),
+      "utf-8",
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === rawJob.id);
+    const payload = job?.payload as unknown as Record<string, unknown>;
+    expect(payload.provider).toBe("telegram");
 
     cron.stop();
     await store.cleanup();


### PR DESCRIPTION
Follow-up refactor after #470/#613.

- Centralize legacy cron payload migration (channel -> provider) + provider canonicalization.
- Stabilize block-streaming test mocks (single hoisted mock for both module ids).
- Add/adjust chunker fence-close regression test.

Tested: pnpm lint && pnpm build && pnpm test