### PR TITLE
fix: handle WhatsApp contact cards inbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - WhatsApp: improve "no active web listener" errors (include account + relink hint). (#612) — thanks @YuriNachos
 - WhatsApp: add broadcast groups for multi-agent replies. (#547) — thanks @pasogott
 - WhatsApp: resolve @lid inbound senders via auth-dir mapping fallback + shared resolver. (#365)
+- WhatsApp: treat shared contact cards as inbound messages. (#622) — thanks @mahmoudashraf93
 - iMessage: isolate group-ish threads by chat_id. (#535) — thanks @mdahmann
 - Models: add OAuth expiry checks in doctor, expanded `models status` auth output (missing auth + `--check` exit codes). (#538) — thanks @latitudeki5223
 - Deps: bump Pi to 0.40.0 and drop pi-ai patch (upstream 429 fix). (#543) — thanks @mcinteerj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - WhatsApp: improve "no active web listener" errors (include account + relink hint). (#612) — thanks @YuriNachos
 - WhatsApp: add broadcast groups for multi-agent replies. (#547) — thanks @pasogott
 - WhatsApp: resolve @lid inbound senders via auth-dir mapping fallback + shared resolver. (#365)
-- WhatsApp: treat shared contact cards as inbound messages. (#622) — thanks @mahmoudashraf93
+- WhatsApp: treat shared contact cards as inbound messages (prefer vCard FN). (#622) — thanks @mahmoudashraf93
 - iMessage: isolate group-ish threads by chat_id. (#535) — thanks @mdahmann
 - Models: add OAuth expiry checks in doctor, expanded `models status` auth output (missing auth + `--check` exit codes). (#538) — thanks @latitudeki5223
 - Deps: bump Pi to 0.40.0 and drop pi-ai patch (upstream 429 fix). (#543) — thanks @mcinteerj

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -28,6 +28,36 @@ describe("web inbound helpers", () => {
     expect(body).toBe("doc");
   });
 
+  it("extracts WhatsApp contact cards", () => {
+    const body = extractText({
+      contactMessage: {
+        displayName: "Ada Lovelace",
+        vcard: [
+          "BEGIN:VCARD",
+          "VERSION:3.0",
+          "FN:Ada Lovelace",
+          "TEL;TYPE=CELL:+15555550123",
+          "END:VCARD",
+        ].join("\n"),
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contact: Ada Lovelace, +15555550123>");
+  });
+
+  it("extracts multiple WhatsApp contact cards", () => {
+    const body = extractText({
+      contactsArrayMessage: {
+        contacts: [
+          { displayName: "Alice" },
+          { displayName: "Bob" },
+          { displayName: "Charlie" },
+          { displayName: "Dana" },
+        ],
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contacts: Alice, Bob, Charlie +1 more>");
+  });
+
   it("unwraps view-once v2 extension messages", () => {
     const body = extractText({
       viewOnceMessageV2Extension: {

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -44,6 +44,22 @@ describe("web inbound helpers", () => {
     expect(body).toBe("<contact: Ada Lovelace, +15555550123>");
   });
 
+  it("prefers FN over N in WhatsApp vcards", () => {
+    const body = extractText({
+      contactMessage: {
+        vcard: [
+          "BEGIN:VCARD",
+          "VERSION:3.0",
+          "N:Lovelace;Ada;;;",
+          "FN:Ada Lovelace",
+          "TEL;TYPE=CELL:+15555550123",
+          "END:VCARD",
+        ].join("\n"),
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contact: Ada Lovelace, +15555550123>");
+  });
+
   it("extracts multiple WhatsApp contact cards", () => {
     const body = extractText({
       contactsArrayMessage: {


### PR DESCRIPTION
## Problem

WhatsApp contact cards (especially sent from iOS) arrive as contactMessage/contactsArrayMessage and currently get dropped, so the gateway never detects the inbound message when a chat only contains a contact card.

## Root Causes

1. **Inbound extraction only accepts text/location/media** — the handler requires extractText or a media placeholder to proceed.
2. **No contact-card parsing** — contactMessage/contactsArrayMessage are not turned into a body, so the message is skipped.

## Changes

• src/web/inbound.ts: parse contact cards and emit a placeholder body with best-effort name/phone.
• src/web/inbound.test.ts: add coverage for single and multi-contact cards.

## Testing

`pnpm exec vitest run src/web/inbound.test.ts`

--------

*Fixed by @mahmoudashraf93 with help from Codex*