### PR TITLE
refactor: extract vcard parsing helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- WhatsApp: refactor vCard parsing helper and improve empty contact card summaries. (#624) — thanks @steipete
 - Pairing: cap pending DM pairing requests at 3 per provider and avoid pairing replies for outbound DMs. — thanks @steipete
 - macOS: replace relay smoke test with version check in packaging script. (#615) — thanks @YuriNachos
 - macOS: avoid clearing Launch at Login during app initialization. (#607) — thanks @wes-davis

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -74,6 +74,15 @@ describe("web inbound helpers", () => {
     expect(body).toBe("<contacts: Alice, Bob, Charlie +1 more>");
   });
 
+  it("summarizes empty WhatsApp contact cards with a count", () => {
+    const body = extractText({
+      contactsArrayMessage: {
+        contacts: [{}, {}],
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contacts: 2 contacts>");
+  });
+
   it("unwraps view-once v2 extension messages", () => {
     const body = extractText({
       viewOnceMessageV2Extension: {

--- a/src/web/vcard.ts
+++ b/src/web/vcard.ts
@@ -1,0 +1,58 @@
+type ParsedVcard = {
+  name?: string;
+  phones: string[];
+};
+
+const ALLOWED_VCARD_KEYS = new Set(["FN", "N", "TEL"]);
+
+export function parseVcard(vcard?: string): ParsedVcard {
+  if (!vcard) return { phones: [] };
+  const lines = vcard.split(/\r?\n/);
+  let nameFromN: string | undefined;
+  let nameFromFn: string | undefined;
+  const phones: string[] = [];
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).toUpperCase();
+    const rawValue = line.slice(colonIndex + 1).trim();
+    if (!rawValue) continue;
+    const baseKey = normalizeVcardKey(key);
+    if (!baseKey || !ALLOWED_VCARD_KEYS.has(baseKey)) continue;
+    const value = cleanVcardValue(rawValue);
+    if (!value) continue;
+    if (baseKey === "FN" && !nameFromFn) {
+      nameFromFn = normalizeVcardName(value);
+      continue;
+    }
+    if (baseKey === "N" && !nameFromN) {
+      nameFromN = normalizeVcardName(value);
+      continue;
+    }
+    if (baseKey === "TEL") {
+      phones.push(value);
+    }
+  }
+  return { name: nameFromFn ?? nameFromN, phones };
+}
+
+function normalizeVcardKey(key: string): string | undefined {
+  const [primary] = key.split(";");
+  if (!primary) return undefined;
+  const segments = primary.split(".");
+  return segments[segments.length - 1] || undefined;
+}
+
+function cleanVcardValue(value: string): string {
+  return value
+    .replace(/\\n/gi, " ")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .trim();
+}
+
+function normalizeVcardName(value: string): string {
+  return value.replace(/;/g, " ").replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## Summary\n- move vCard parsing into a dedicated helper with a small key allowlist\n- return a count-based placeholder when contact cards lack labels\n- cover empty contact-card arrays in inbound tests\n\n## Testing\n- pnpm exec vitest run src/web/inbound.test.ts