### PR TITLE
fix: include numbers for WhatsApp contact arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - WhatsApp: refactor vCard parsing helper and improve empty contact card summaries. (#624) — thanks @steipete
+- WhatsApp: include phone numbers when multiple contacts are shared. (#625) — thanks @mahmoudashraf93
 - Pairing: cap pending DM pairing requests at 3 per provider and avoid pairing replies for outbound DMs. — thanks @steipete
 - macOS: replace relay smoke test with version check in packaging script. (#615) — thanks @YuriNachos
 - macOS: avoid clearing Launch at Login during app initialization. (#607) — thanks @wes-davis

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -60,18 +60,72 @@ describe("web inbound helpers", () => {
     expect(body).toBe("<contact: Ada Lovelace, +15555550123>");
   });
 
+  it("normalizes tel: prefixes in WhatsApp vcards", () => {
+    const body = extractText({
+      contactMessage: {
+        vcard: [
+          "BEGIN:VCARD",
+          "VERSION:3.0",
+          "FN:Ada Lovelace",
+          "TEL;TYPE=CELL:tel:+15555550123",
+          "END:VCARD",
+        ].join("\n"),
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contact: Ada Lovelace, +15555550123>");
+  });
+
   it("extracts multiple WhatsApp contact cards", () => {
     const body = extractText({
       contactsArrayMessage: {
         contacts: [
-          { displayName: "Alice" },
-          { displayName: "Bob" },
-          { displayName: "Charlie" },
-          { displayName: "Dana" },
+          {
+            displayName: "Alice",
+            vcard: [
+              "BEGIN:VCARD",
+              "VERSION:3.0",
+              "FN:Alice",
+              "TEL;TYPE=CELL:+15555550101",
+              "END:VCARD",
+            ].join("\n"),
+          },
+          {
+            displayName: "Bob",
+            vcard: [
+              "BEGIN:VCARD",
+              "VERSION:3.0",
+              "FN:Bob",
+              "TEL;TYPE=CELL:+15555550102",
+              "END:VCARD",
+            ].join("\n"),
+          },
+          {
+            displayName: "Charlie",
+            vcard: [
+              "BEGIN:VCARD",
+              "VERSION:3.0",
+              "FN:Charlie",
+              "TEL;TYPE=CELL:+15555550103",
+              "TEL;TYPE=HOME:+15555550104",
+              "END:VCARD",
+            ].join("\n"),
+          },
+          {
+            displayName: "Dana",
+            vcard: [
+              "BEGIN:VCARD",
+              "VERSION:3.0",
+              "FN:Dana",
+              "TEL;TYPE=CELL:+15555550105",
+              "END:VCARD",
+            ].join("\n"),
+          },
         ],
       },
     } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
-    expect(body).toBe("<contacts: Alice, Bob, Charlie +1 more>");
+    expect(body).toBe(
+      "<contacts: Alice, +15555550101, Bob, +15555550102, Charlie, +15555550103 (+1 more) +1 more>",
+    );
   });
 
   it("summarizes empty WhatsApp contact cards with a count", () => {

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -124,7 +124,7 @@ describe("web inbound helpers", () => {
       },
     } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
     expect(body).toBe(
-      "<contacts: Alice, +15555550101, Bob, +15555550102, Charlie, +15555550103 (+1 more) +1 more>",
+      "<contacts: Alice, +15555550101, Bob, +15555550102, Charlie, +15555550103 (+1 more), Dana, +15555550105>",
     );
   });
 

--- a/src/web/inbound.test.ts
+++ b/src/web/inbound.test.ts
@@ -124,8 +124,30 @@ describe("web inbound helpers", () => {
       },
     } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
     expect(body).toBe(
-      "<contacts: Alice, +15555550101, Bob, +15555550102, Charlie, +15555550103 (+1 more), Dana, +15555550105>",
+      "<contacts: Alice, +15555550101, Bob, +15555550102, Charlie, +15555550103 (+1 more) +1 more>",
     );
+  });
+
+  it("counts empty WhatsApp contact cards in array summaries", () => {
+    const body = extractText({
+      contactsArrayMessage: {
+        contacts: [
+          {
+            displayName: "Alice",
+            vcard: [
+              "BEGIN:VCARD",
+              "VERSION:3.0",
+              "FN:Alice",
+              "TEL;TYPE=CELL:+15555550101",
+              "END:VCARD",
+            ].join("\n"),
+          },
+          {},
+          {},
+        ],
+      },
+    } as unknown as import("@whiskeysockets/baileys").proto.IMessage);
+    expect(body).toBe("<contacts: Alice, +15555550101 +2 more>");
   });
 
   it("summarizes empty WhatsApp contact cards with a count", () => {

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -801,7 +801,10 @@ function formatContactsPlaceholder(labels: string[], total: number): string {
     const suffix = total === 1 ? "contact" : "contacts";
     return `<contacts: ${total} ${suffix}>`;
   }
-  return `<contacts: ${cleaned.join(", ")}>`;
+  const shown = cleaned.slice(0, 3);
+  const remaining = Math.max(total - shown.length, 0);
+  const suffix = remaining > 0 ? ` +${remaining} more` : "";
+  return `<contacts: ${shown.join(", ")}${suffix}>`;
 }
 
 function formatContactLabel(

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -820,8 +820,7 @@ function formatContactLabel(
 }
 
 function formatPhoneList(phones?: string[]): string | undefined {
-  const cleaned =
-    phones?.map((phone) => phone.trim()).filter(Boolean) ?? [];
+  const cleaned = phones?.map((phone) => phone.trim()).filter(Boolean) ?? [];
   if (cleaned.length === 0) return undefined;
   const [primary, ...rest] = cleaned;
   if (!primary) return undefined;

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -801,10 +801,7 @@ function formatContactsPlaceholder(labels: string[], total: number): string {
     const suffix = total === 1 ? "contact" : "contacts";
     return `<contacts: ${total} ${suffix}>`;
   }
-  const shown = cleaned.slice(0, 3);
-  const remaining = Math.max(total - shown.length, 0);
-  const suffix = remaining > 0 ? ` +${remaining} more` : "";
-  return `<contacts: ${shown.join(", ")}${suffix}>`;
+  return `<contacts: ${cleaned.join(", ")}>`;
 }
 
 function formatContactLabel(

--- a/src/web/vcard.ts
+++ b/src/web/vcard.ts
@@ -32,7 +32,8 @@ export function parseVcard(vcard?: string): ParsedVcard {
       continue;
     }
     if (baseKey === "TEL") {
-      phones.push(value);
+      const phone = normalizeVcardPhone(value);
+      if (phone) phones.push(phone);
     }
   }
   return { name: nameFromFn ?? nameFromN, phones };
@@ -55,4 +56,13 @@ function cleanVcardValue(value: string): string {
 
 function normalizeVcardName(value: string): string {
   return value.replace(/;/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeVcardPhone(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (trimmed.toLowerCase().startsWith("tel:")) {
+    return trimmed.slice(4).trim();
+  }
+  return trimmed;
 }


### PR DESCRIPTION
## Problem

When multiple contacts are shared, the gateway only surfaces the contact names. Phone numbers in the vCard payloads are ignored, so multi-contact shares lose the actual numbers.

## Root Causes

1. **Contact array labels drop phones** — `contactsArrayMessage` maps each entry to `name ?? phone`, so if a name exists the number is discarded.
2. **TEL values not normalized** — `tel:` prefixes can appear in vCard values, which should be stripped for display.

## Changes

• src/web/inbound.ts: include phone labels for multi-contact cards and surface extra numbers per contact.
• src/web/vcard.ts: normalize `tel:` prefixes when parsing phone values.
• src/web/inbound.test.ts: cover multi-contact numbers and tel: normalization.

## Testing

`pnpm exec vitest run src/web/inbound.test.ts`

--------

*Fixed by @mahmoudashraf93 with help from Codex*