### PR TITLE
fix: only inject heartbeat prompt for default agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Agents: gate heartbeat prompt to default agent sessions (including non-agent session keys). (#630) — thanks @adam91holt
 - Agent: fast abort on /stop and cancel tool calls between tool boundaries. (#617)
 - Models/Auth: add OpenCode Zen (multi-model proxy) onboarding. (#623) — thanks @magimetal
 - WhatsApp: refactor vCard parsing helper and improve empty contact card summaries. (#624) — thanks @steipete


### PR DESCRIPTION
## Summary
- Fixed bug where heartbeat prompt from `agents.defaults.heartbeat.prompt` was injected into ALL agents' system prompts
- Non-default agents were reading the default agent's identity files and adopting its persona
- Now heartbeat prompt is only included when the session's agent ID matches the configured default agent

## Test plan
- [x] All 2082 tests pass
- [x] Verified non-default agents no longer receive heartbeat section in system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)