### PR TITLE
feat: add removeAckAfterReply option (Discord, Slack, Telegram)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Providers: add Microsoft Teams provider with polling, attachments, and CLI send support. (#404) — thanks @onutc
 - Slack: honor reply tags + replyToMode while keeping threaded replies in-thread. (#574) — thanks @bolismauro
 - Slack: configurable reply threading (`slack.replyToMode`) + proper mrkdwn formatting for outbound messages. (#464) — thanks @austinm911
+- Providers: remove ack reactions after reply on Discord/Slack/Telegram. (#633) — thanks @levifig
 - Discord: avoid category parent overrides for channel allowlists and refactor thread context helpers. (#588) — thanks @steipete
 - Discord: fix forum thread starters and cache channel lookups for thread context. (#585) — thanks @thewilloftheshadow
 - Discord: log gateway disconnect/reconnect events at info and add verbose gateway metrics. (#595) — thanks @steipete

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -948,7 +948,8 @@ See [Messages](/concepts/messages) for queueing, sessions, and streaming context
   messages: {
     responsePrefix: "🦞", // or "auto"
     ackReaction: "👀",
-    ackReactionScope: "group-mentions"
+    ackReactionScope: "group-mentions",
+    removeAckAfterReply: false
   }
 }
 ```
@@ -974,6 +975,9 @@ active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` t
 - `group-all`: all group/room messages
 - `direct`: direct messages only
 - `all`: all messages
+
+`removeAckAfterReply` removes the bot’s ack reaction after a reply is sent
+(Slack/Discord/Telegram only). Default: `false`.
 
 ### `talk`
 

--- a/docs/providers/discord.md
+++ b/docs/providers/discord.md
@@ -225,7 +225,8 @@ Outbound Discord API calls retry on rate limits (429) using Discord `retry_after
 ```
 
 Ack reactions are controlled globally via `messages.ackReaction` +
-`messages.ackReactionScope`.
+`messages.ackReactionScope`. Use `messages.removeAckAfterReply` to clear the
+ack reaction after the bot replies.
 
 - `dm.enabled`: set `false` to ignore all DMs (default `true`).
 - `dm.policy`: DM access control (`pairing` recommended). `"open"` requires `dm.allowFrom=["*"]`.

--- a/docs/providers/slack.md
+++ b/docs/providers/slack.md
@@ -192,7 +192,8 @@ Tokens can also be supplied via env vars:
 - `SLACK_APP_TOKEN`
 
 Ack reactions are controlled globally via `messages.ackReaction` +
-`messages.ackReactionScope`.
+`messages.ackReactionScope`. Use `messages.removeAckAfterReply` to clear the
+ack reaction after the bot replies.
 
 ## Limits
 - Outbound text is chunked to `slack.textChunkLimit` (default 4000).

--- a/docs/providers/telegram.md
+++ b/docs/providers/telegram.md
@@ -287,4 +287,4 @@ Related global options:
 - `agents.list[].groupChat.mentionPatterns` (mention gating patterns).
 - `messages.groupChat.mentionPatterns` (global fallback).
 - `commands.native`, `commands.text`, `commands.useAccessGroups` (command behavior).
-- `messages.responsePrefix`, `messages.ackReaction`, `messages.ackReactionScope`.
+- `messages.responsePrefix`, `messages.ackReaction`, `messages.ackReactionScope`, `messages.removeAckAfterReply`.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -999,6 +999,8 @@ export type MessagesConfig = {
   ackReaction?: string;
   /** When to send ack reactions. Default: "group-mentions". */
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
+  /** Remove ack reaction after reply is sent (default: false). */
+  removeAckAfterReply?: boolean;
 };
 
 export type CommandsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -603,6 +603,7 @@ const MessagesSchema = z
     ackReactionScope: z
       .enum(["group-mentions", "group-all", "direct", "all"])
       .optional(),
+    removeAckAfterReply: z.boolean().optional(),
   })
   .optional();
 

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -591,28 +591,31 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
       return false;
     };
-    let didAddAckReaction = false;
-    if (shouldAckReaction() && msg.message_id) {
-      const api = bot.api as unknown as {
-        setMessageReaction?: (
-          chatId: number | string,
-          messageId: number,
-          reactions: Array<{ type: "emoji"; emoji: string }>,
-        ) => Promise<void>;
-      };
-      if (typeof api.setMessageReaction === "function") {
-        api
-          .setMessageReaction(chatId, msg.message_id, [
+    const api = bot.api as unknown as {
+      setMessageReaction?: (
+        chatId: number | string,
+        messageId: number,
+        reactions: Array<{ type: "emoji"; emoji: string }>,
+      ) => Promise<void>;
+    };
+    const reactionApi =
+      typeof api.setMessageReaction === "function"
+        ? api.setMessageReaction.bind(api)
+        : null;
+    const ackReactionPromise =
+      shouldAckReaction() && msg.message_id && reactionApi
+        ? reactionApi(chatId, msg.message_id, [
             { type: "emoji", emoji: ackReaction },
-          ])
-          .catch((err) => {
-            logVerbose(
-              `telegram react failed for chat ${chatId}: ${String(err)}`,
-            );
-          });
-        didAddAckReaction = true;
-      }
-    }
+          ]).then(
+            () => true,
+            (err) => {
+              logVerbose(
+                `telegram react failed for chat ${chatId}: ${String(err)}`,
+              );
+              return false;
+            },
+          )
+        : null;
 
     let placeholder = "";
     if (msg.photo) placeholder = "<media:image>";
@@ -857,21 +860,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     markDispatchIdle();
     draftStream?.stop();
     if (!queuedFinal) return;
-    if (removeAckAfterReply && didAddAckReaction && msg.message_id) {
-      const api = bot.api as unknown as {
-        setMessageReaction?: (
-          chatId: number | string,
-          messageId: number,
-          reactions: Array<{ type: "emoji"; emoji: string }>,
-        ) => Promise<void>;
-      };
-      if (typeof api.setMessageReaction === "function") {
-        api.setMessageReaction(chatId, msg.message_id, []).catch((err) => {
+    if (
+      removeAckAfterReply &&
+      ackReactionPromise &&
+      msg.message_id &&
+      reactionApi
+    ) {
+      void ackReactionPromise.then((didAck) => {
+        if (!didAck) return;
+        reactionApi(chatId, msg.message_id, []).catch((err) => {
           logVerbose(
             `telegram: failed to remove ack reaction from ${chatId}/${msg.message_id}: ${String(err)}`,
           );
         });
-      }
+      });
     }
   };
 


### PR DESCRIPTION
## Summary

Adds `messages.removeAckAfterReply` config option to automatically remove acknowledgment reactions after the bot sends a reply, reducing visual clutter while still providing immediate feedback that messages were received.

**Supported Platforms:** Discord, Slack, and Telegram

## Demo
![CleanShot 2026-01-10 at 00 36 03](https://github.com/user-attachments/assets/28a7136b-f816-46bb-a693-33a84c1014d7)

## Changes

### Configuration
- Added `removeAckAfterReply` boolean field to `MessagesConfig` (default: `false`)
- Added TypeScript type definition and Zod validation schema

### Platform Implementations

**Discord** (`src/discord/monitor.ts`)
- Track ack reaction state in message handler
- Remove reaction after successful reply delivery using `removeReactionDiscord()`
- Fire-and-forget with verbose error logging

**Slack** (`src/slack/monitor.ts`)
- Track ack reaction state in message handler  
- Remove reaction after successful reply delivery using `removeSlackReaction()`
- Fire-and-forget with verbose error logging

**Telegram** (`src/telegram/bot.ts`)
- Track ack reaction state in message handler
- Remove reaction after successful reply delivery using `setMessageReaction([])` (empty array)
- Fire-and-forget with verbose error logging

### Error Handling
- All removal operations are fire-and-forget with `.catch()` handlers
- Failures are logged to verbose but don't block message flow
- Graceful degradation if permissions change or messages are deleted

## Testing

- ✅ Type-check passes (`bun run build`)
- ✅ Lint passes (`bun run lint`)  
- ✅ All tests pass (309 test files, 2093 tests)
- ✅ Manual testing planned on all three platforms

## Configuration Example

```json
{
  "messages": {
    "ackReaction": "👀",
    "ackReactionScope": "group-mentions",
    "removeAckAfterReply": true
  }
}
```

## Behavior

### Before (removeAckAfterReply: false or unset)
1. User sends message
2. Bot adds ack reaction (e.g., 👀)
3. Bot processes and sends reply
4. **Ack reaction remains on message**

### After (removeAckAfterReply: true)  
1. User sends message
2. Bot adds ack reaction (e.g., 👀)
3. Bot processes and sends reply
4. **Bot removes ack reaction automatically**

## Edge Cases Handled

- ✅ No ack added (`shouldAckReaction() === false`): no removal attempted
- ✅ Ack add failed: removal attempt also fails (same API), logged but non-blocking
- ✅ Reply failed: ack stays as visual indicator of error
- ✅ Message deleted: removal fails with 404, logged to verbose
- ✅ Bot loses permissions: removal fails with 403, logged to verbose
- ✅ Telegram API unavailable: gracefully skips if `setMessageReaction` not supported

## Files Changed

- `src/config/types.ts` - Type definition for `removeAckAfterReply`
- `src/config/zod-schema.ts` - Zod validation schema
- `src/discord/monitor.ts` - Discord implementation
- `src/slack/monitor.ts` - Slack implementation  
- `src/telegram/bot.ts` - Telegram implementation

## Closes

Closes #627