### PR TITLE
fix: regenerate @buape/carbon patch for beta-20260109194934

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,10 +183,10 @@
       "@sinclair/typebox": "0.34.47"
     },
     "patchedDependencies": {
-      "@buape/carbon": "patches/@buape__carbon.patch",
       "@mariozechner/pi-agent-core": "patches/@mariozechner__pi-agent-core.patch",
       "@mariozechner/pi-coding-agent": "patches/@mariozechner__pi-coding-agent.patch",
-      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch",
+      "@buape/carbon@0.0.0-beta-20260109194934": "patches/@buape__carbon@0.0.0-beta-20260109194934.patch"
     }
   },
   "vitest": {
@@ -222,7 +222,7 @@
     ]
   },
   "patchedDependencies": {
-    "@buape/carbon": "patches/@buape__carbon.patch",
+    "@buape/carbon@0.0.0-beta-20260109194934": "patches/@buape__carbon@0.0.0-beta-20260109194934.patch",
     "@mariozechner/pi-agent-core": "patches/@mariozechner__pi-agent-core.patch",
     "@mariozechner/pi-coding-agent": "patches/@mariozechner__pi-coding-agent.patch",
     "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch",

--- a/patches/@buape__carbon@0.0.0-beta-20260109194934.patch
+++ b/patches/@buape__carbon@0.0.0-beta-20260109194934.patch
@@ -1,6 +1,8 @@
+diff --git a/dist/src/classes/RequestClient.js b/dist/src/classes/RequestClient.js
+index 4a3357a3a71e993e49dbf4511be7f39aeec03755..1cd3130df8b2cd71a240f8b028a71680628cf0fd 100644
 --- a/dist/src/classes/RequestClient.js
 +++ b/dist/src/classes/RequestClient.js
-@@ -118,6 +118,9 @@
+@@ -118,6 +118,9 @@ export class RequestClient {
              }
          }
          this.abortController = new AbortController();
@@ -10,7 +12,7 @@
          let body;
          if (data?.body &&
              typeof data.body === "object" &&
-@@ -178,12 +181,26 @@
+@@ -178,12 +181,26 @@ export class RequestClient {
                  body = JSON.stringify(data.body);
              }
          }
@@ -43,11 +45,3 @@
          let rawBody = "";
          let parsedBody;
          try {
-@@ -405,4 +422,4 @@
-     }
- }
- const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, Math.max(ms, 0)));
--//# sourceMappingURL=RequestClient.js.map
-\ No newline at end of file
-+//# sourceMappingURL=RequestClient.js.map
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   '@sinclair/typebox': 0.34.47
 
 patchedDependencies:
+  '@buape/carbon@0.0.0-beta-20260109194934':
+    hash: 4d2a2b9a295eb91a8f9febc76d64728f4093bbbddff344cfc88aa14423debe49
+    path: patches/@buape__carbon@0.0.0-beta-20260109194934.patch
   '@mariozechner/pi-agent-core':
     hash: 01312ceb1f6be7e42822c24c9a7a4f7db56b24ae114a364855bd3819779d1cf4
     path: patches/@mariozechner__pi-agent-core.patch
@@ -24,7 +27,7 @@ importers:
     dependencies:
       '@buape/carbon':
         specifier: 0.0.0-beta-20260109194934
-        version: 0.0.0-beta-20260109194934(hono@4.11.3)
+        version: 0.0.0-beta-20260109194934(patch_hash=4d2a2b9a295eb91a8f9febc76d64728f4093bbbddff344cfc88aa14423debe49)(hono@4.11.3)
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -3374,7 +3377,7 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260109194934(hono@4.11.3)':
+  '@buape/carbon@0.0.0-beta-20260109194934(patch_hash=4d2a2b9a295eb91a8f9febc76d64728f4093bbbddff344cfc88aa14423debe49)(hono@4.11.3)':
     dependencies:
       '@types/node': 24.10.4
       discord-api-types: 0.38.36


### PR DESCRIPTION
## Summary
- Regenerate stale `@buape/carbon` patch that failed with `ERR_PNPM_INVALID_PATCH`
- Use versioned patch filename per pnpm conventions
- Patch adds timeout implementation to `RequestClient` (upstream has `timeout` option but doesn't implement it)

## Test plan
- [x] `pnpm install` completes without errors
- [x] `pnpm build` passes
- [x] Verified patch applied correctly (timeout logic present in node_modules)