### PR TITLE
fix(whatsapp): enable reactions in group chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Auto-reply: prefer `RawBody` for command/directive parsing (WhatsApp + Discord) and prevent fallback runs from clobbering concurrent session updates. (#643) — thanks @mcinteerj.
+- WhatsApp: fix group reactions by preserving message IDs and sender JIDs in history; normalize participant phone numbers to JIDs in outbound reactions. (#640) — thanks @mcinteerj.
 - Cron: `wakeMode: "now"` waits for heartbeat completion (and retries when the main lane is busy). (#666) — thanks @roshanasingh4.
 - Agents/OpenAI: fix Responses tool-only → follow-up turn handling (avoid standalone `reasoning` items that trigger 400 “required following item”).
 - Sandbox: add `clawdbot sandbox explain` (effective policy inspector + fix-it keys); improve “sandbox jail” tool-policy/elevated errors with actionable config key paths; link to docs.
@@ -41,7 +42,6 @@
 - Telegram: serialize media-group processing to avoid missed albums under load.
 - Signal: handle `dataMessage.reaction` events (signal-cli SSE) to avoid broken attachment errors. (#637) — thanks @neist.
 - Docs: showcase entries for ParentPay, R2 Upload, iOS TestFlight, and Oura Health. (#650) — thanks @henrino3.
-
 ## 2026.1.9
 
 ### Highlights

--- a/src/web/auto-reply.test.ts
+++ b/src/web/auto-reply.test.ts
@@ -1127,7 +1127,8 @@ describe("web auto-reply", () => {
     expect(resolver).toHaveBeenCalledTimes(1);
     const payload = resolver.mock.calls[0][0];
     expect(payload.Body).toContain("Chat messages since your last reply");
-    expect(payload.Body).toContain("Alice: hello group");
+    expect(payload.Body).toContain("Alice (+111): hello group");
+    expect(payload.Body).toContain("[message_id: g1]");
     expect(payload.Body).toContain("@bot ping");
     expect(payload.Body).toContain("[from: Bob (+222)]");
   });
@@ -1483,7 +1484,8 @@ describe("web auto-reply", () => {
     expect(resolver).toHaveBeenCalledTimes(2);
     const payload = resolver.mock.calls[1][0];
     expect(payload.Body).toContain("Chat messages since your last reply");
-    expect(payload.Body).toContain("Alice: first");
+    expect(payload.Body).toContain("Alice (+111): first");
+    expect(payload.Body).toContain("[message_id: g-always-1]");
     expect(payload.Body).toContain("Bob: second");
     expect(reply).toHaveBeenCalledTimes(1);
 
@@ -2213,7 +2215,8 @@ describe("broadcast groups", () => {
     for (const call of resolver.mock.calls.slice(0, 2)) {
       const payload = call[0] as { Body: string };
       expect(payload.Body).toContain("Chat messages since your last reply");
-      expect(payload.Body).toContain("Alice: hello group");
+      expect(payload.Body).toContain("Alice (+111): hello group");
+      expect(payload.Body).toContain("[message_id: g1]");
       expect(payload.Body).toContain("@bot ping");
       expect(payload.Body).toContain("[from: Bob (+222)]");
     }
@@ -2239,7 +2242,7 @@ describe("broadcast groups", () => {
     expect(resolver).toHaveBeenCalledTimes(4);
     for (const call of resolver.mock.calls.slice(2, 4)) {
       const payload = call[0] as { Body: string };
-      expect(payload.Body).not.toContain("Alice: hello group");
+      expect(payload.Body).not.toContain("Alice (+111): hello group");
       expect(payload.Body).not.toContain("Chat messages since your last reply");
     }
 

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -620,7 +620,7 @@ export async function monitorWebInbox(options: {
             remoteJid: jid,
             id: messageId,
             fromMe,
-            participant,
+            participant: participant ? toWhatsappJid(participant) : undefined,
           },
         },
       });

--- a/src/web/monitor-inbox.test.ts
+++ b/src/web/monitor-inbox.test.ts
@@ -1402,4 +1402,36 @@ describe("web monitor inbox", () => {
 
     await listener.close();
   });
+
+  it("normalizes participant phone numbers to JIDs in sendReaction", async () => {
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage: vi.fn(),
+      accountId: ACCOUNT_ID,
+      authDir,
+    });
+    const sock = await createWaSocket();
+
+    await listener.sendReaction(
+      "12345@g.us",
+      "msg123",
+      "👍",
+      false,
+      "+6421000000",
+    );
+
+    expect(sock.sendMessage).toHaveBeenCalledWith("12345@g.us", {
+      react: {
+        text: "👍",
+        key: {
+          remoteJid: "12345@g.us",
+          id: "msg123",
+          fromMe: false,
+          participant: "6421000000@s.whatsapp.net",
+        },
+      },
+    });
+
+    await listener.close();
+  });
 });


### PR DESCRIPTION
## Summary

This PR enables the agent to successfully send reactions in WhatsApp group chats by solving two critical issues:
1. **Metadata Preservation**: Group history now stores uid=501(jakemc) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),33(_appstore),98(_lpadmin),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae),701(com.apple.sharepoint.group.1) (message ID) and  for historical messages. These are injected into the group context sandwich as `[message_id: ...]` hints so the agent can reference them.
2. **JID Normalization**: The WhatsApp reaction tool now correctly normalizes participant phone numbers (e.g., `+6421...`) to JIDs (`6421...@s.whatsapp.net`) before sending to the server.

## Related

- Build on top of #639 (Fixes command detection in groups via `RawBody`).
- Addresses a specific metadata requirement discussed in #638 (RFC: Structured MsgContext).

## Changes

- `src/web/auto-reply.ts`: 
    - Updated `groupHistories` map to store `id` and `senderJid`.
    - Injected `[message_id: ID]` into stringified group history context.
- `src/web/inbound.ts`: Normalizes the `participant` JID in `sendReaction` using `toWhatsappJid`.
- `src/web/monitor-inbox.test.ts`: Added unit test for JID normalization in reactions.

## Testing

Verified that `sendReaction` now receives a correctly formatted JID. Tested group history injection logic.