### PR TITLE
fix(auto-reply): RawBody command parsing + safer usage save

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2087,6 +2087,7 @@ Template placeholders are expanded in `audio.transcription.command` (and any fut
 | Variable | Description |
 |----------|-------------|
 | `{{Body}}` | Full inbound message body |
+| `{{RawBody}}` | Raw inbound message body (no history/sender wrappers; best for command parsing) |
 | `{{BodyStripped}}` | Body with group mentions stripped (best default for agents) |
 | `{{From}}` | Sender identifier (E.164 for WhatsApp; may differ per provider) |
 | `{{To}}` | Destination identifier |

--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
@@ -10,7 +9,8 @@ vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
   runEmbeddedPiAgent: vi.fn(),
   queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
-  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+  resolveEmbeddedSessionLane: (key: string) =>
+    `session:${key.trim() || "main"}`,
   isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
   isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
 }));

--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { getReplyFromConfig } from "./reply.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(
+    async (home) => {
+      return await fn(home);
+    },
+    {
+      env: {
+        CLAWDBOT_AGENT_DIR: (home) => path.join(home, ".clawdbot", "agent"),
+        PI_CODING_AGENT_DIR: (home) => path.join(home, ".clawdbot", "agent"),
+      },
+      prefix: "clawdbot-rawbody-",
+    },
+  );
+}
+
+describe("RawBody directive parsing", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([
+      { id: "claude-opus-4-5", name: "Opus 4.5", provider: "anthropic" },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("/model, /think, /verbose directives detected from RawBody even when Body has structural wrapper", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Chat messages since your last reply - for context]\\n[WhatsApp ...] Someone: hello\\n\\n[Current message - respond to this]\\n[WhatsApp ...] Jake: /think:high\\n[from: Jake McInteer (+6421807830)]`,
+        RawBody: "/think:high",
+        From: "+1222",
+        To: "+1222",
+        ChatType: "group",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+            },
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("Thinking level set to high.");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("/model status detected from RawBody", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Context]\nJake: /model status\n[from: Jake]`,
+        RawBody: "/model status",
+        From: "+1222",
+        To: "+1222",
+        ChatType: "group",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+              models: {
+                "anthropic/claude-opus-4-5": {},
+              },
+            },
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("anthropic/claude-opus-4-5");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("Integration: WhatsApp group message with structural wrapper and RawBody command", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Chat messages since your last reply - for context]\\n[WhatsApp ...] Someone: hello\\n\\n[Current message - respond to this]\\n[WhatsApp ...] Jake: /status\\n[from: Jake McInteer (+6421807830)]`,
+        RawBody: "/status",
+        ChatType: "group",
+        From: "+1222",
+        To: "+1222",
+        SessionKey: "agent:main:whatsapp:group:G1",
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        SenderE164: "+1222",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+            },
+          },
+          whatsapp: { allowFrom: ["+1222"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("Session: agent:main:whatsapp:group:G1");
+      expect(text).toContain("anthropic/claude-opus-4-5");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -336,7 +336,8 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
   } = sessionState;
 
-  const rawBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
+  // Prefer RawBody (clean message without structural context) for directive parsing.
+  const rawBody = sessionCtx.RawBody ?? sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   const clearInlineDirectives = (cleaned: string): InlineDirectives => ({
     cleaned,
     hasThinkDirective: false,
@@ -750,7 +751,8 @@ export async function getReplyFromConfig(
     .filter(Boolean)
     .join("\n\n");
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
-  const rawBodyTrimmed = (ctx.Body ?? "").trim();
+  // Use RawBody for bare reset detection (clean message without structural context).
+  const rawBodyTrimmed = (ctx.RawBody ?? ctx.Body ?? "").trim();
   const baseBodyTrimmedRaw = baseBody.trim();
   if (
     allowTextCommands &&

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -60,7 +60,11 @@ import {
   defaultGroupActivation,
   resolveGroupRequireMention,
 } from "./reply/groups.js";
-import { stripMentions, stripStructuralPrefixes } from "./reply/mentions.js";
+import {
+  CURRENT_MESSAGE_MARKER,
+  stripMentions,
+  stripStructuralPrefixes,
+} from "./reply/mentions.js";
 import {
   createModelSelectionState,
   resolveContextTokens,
@@ -429,7 +433,6 @@ export async function getReplyFromConfig(
         hasQueueDirective: false,
         queueReset: false,
       };
-  const marker = "[Current message - respond to this]";
   const existingBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   const cleanedBody = (() => {
     if (!existingBody) return parsedDirectives.cleaned;
@@ -439,15 +442,20 @@ export async function getReplyFromConfig(
       }).cleaned;
     }
 
-    const markerIndex = existingBody.indexOf(marker);
+    const markerIndex = existingBody.indexOf(CURRENT_MESSAGE_MARKER);
     if (markerIndex < 0) {
       return parseInlineDirectives(existingBody, {
         modelAliases: configuredAliases,
       }).cleaned;
     }
 
-    const head = existingBody.slice(0, markerIndex + marker.length);
-    const tail = existingBody.slice(markerIndex + marker.length);
+    const head = existingBody.slice(
+      0,
+      markerIndex + CURRENT_MESSAGE_MARKER.length,
+    );
+    const tail = existingBody.slice(
+      markerIndex + CURRENT_MESSAGE_MARKER.length,
+    );
     const cleanedTail = parseInlineDirectives(tail, {
       modelAliases: configuredAliases,
     }).cleaned;

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { isAbortTrigger } from "./abort.js";
-import { initSessionState } from "./session.js";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 import type { ClawdbotConfig } from "../../config/config.js";
+import { isAbortTrigger } from "./abort.js";
+import { initSessionState } from "./session.js";
 
 describe("abort detection", () => {
   it("triggerBodyNormalized extracts /stop from RawBody for abort detection", async () => {

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isAbortTrigger } from "./abort.js";
+import { initSessionState } from "./session.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ClawdbotConfig } from "../../config/config.js";
+
+describe("abort detection", () => {
+  it("triggerBodyNormalized extracts /stop from RawBody for abort detection", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-abort-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Context]\nJake: /stop\n[from: Jake]`,
+      RawBody: "/stop",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // /stop is detected via exact match in handleAbort, not isAbortTrigger
+    expect(result.triggerBodyNormalized).toBe("/stop");
+  });
+
+  it("isAbortTrigger matches bare word triggers (without slash)", () => {
+    expect(isAbortTrigger("stop")).toBe(true);
+    expect(isAbortTrigger("esc")).toBe(true);
+    expect(isAbortTrigger("abort")).toBe(true);
+    expect(isAbortTrigger("wait")).toBe(true);
+    expect(isAbortTrigger("exit")).toBe(true);
+    expect(isAbortTrigger("hello")).toBe(false);
+    // /stop is NOT matched by isAbortTrigger - it's handled separately
+    expect(isAbortTrigger("/stop")).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -81,7 +81,8 @@ export async function tryFastAbortFromMessage(params: {
     sessionKey: targetKey ?? ctx.SessionKey ?? "",
     config: cfg,
   });
-  const raw = stripStructuralPrefixes(ctx.Body ?? "");
+  // Use RawBody for abort detection (clean message without structural context).
+  const raw = stripStructuralPrefixes(ctx.RawBody ?? ctx.Body ?? "");
   const isGroup = ctx.ChatType?.trim().toLowerCase() === "group";
   const stripped = isGroup ? stripMentions(raw, ctx, cfg, agentId) : raw;
   const normalized = normalizeCommandBody(stripped);

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -91,7 +91,7 @@ export function stripStructuralPrefixes(text: string): string {
   const afterMarker = text.includes(marker)
     ? text.slice(text.indexOf(marker) + marker.length).trimStart()
     : text;
-  
+
   return afterMarker
     .replace(/\[[^\]]+\]\s*/g, "")
     .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -89,11 +89,13 @@ export function stripStructuralPrefixes(text: string): string {
   // detection still works in group batches that include history/context.
   const marker = "[Current message - respond to this]";
   const afterMarker = text.includes(marker)
-    ? text.slice(text.indexOf(marker) + marker.length)
+    ? text.slice(text.indexOf(marker) + marker.length).trimStart()
     : text;
+  
   return afterMarker
     .replace(/\[[^\]]+\]\s*/g, "")
     .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")
+    .replace(/\\n/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -105,9 +107,9 @@ export function stripMentions(
   agentId?: string,
 ): string {
   let result = text;
-  const patterns = normalizeMentionPatterns(
-    resolveMentionPatterns(cfg, agentId),
-  );
+  const rawPatterns = resolveMentionPatterns(cfg, agentId);
+  const patterns = normalizeMentionPatterns(rawPatterns);
+
   for (const p of patterns) {
     try {
       const re = new RegExp(p, "gi");

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -23,6 +23,8 @@ function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
 
 const BACKSPACE_CHAR = "\u0008";
 
+export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
+
 function normalizeMentionPattern(pattern: string): string {
   if (!pattern.includes(BACKSPACE_CHAR)) return pattern;
   return pattern.split(BACKSPACE_CHAR).join("\\b");
@@ -87,9 +89,12 @@ export function matchesMentionPatterns(
 export function stripStructuralPrefixes(text: string): string {
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
-  const marker = "[Current message - respond to this]";
-  const afterMarker = text.includes(marker)
-    ? text.slice(text.indexOf(marker) + marker.length).trimStart()
+  const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)
+    ? text
+        .slice(
+          text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length,
+        )
+        .trimStart()
     : text;
 
   return afterMarker

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -110,3 +110,67 @@ describe("initSessionState thread forking", () => {
     );
   });
 });
+
+describe("initSessionState RawBody", () => {
+  it("triggerBodyNormalized correctly extracts commands when Body contains context but RawBody is clean", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Chat messages since your last reply - for context]\n[WhatsApp ...] Someone: hello\n\n[Current message - respond to this]\n[WhatsApp ...] Jake: /status\n[from: Jake McInteer (+6421807830)]`,
+      RawBody: "/status",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe("/status");
+  });
+
+  it("Reset triggers (/new, /reset) work with RawBody", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-reset-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Context]\nJake: /new\n[from: Jake]`,
+      RawBody: "/new",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe("");
+  });
+
+  it("falls back to Body when RawBody is undefined", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-fallback-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const ctx = {
+      Body: "/status",
+      SessionKey: "agent:main:whatsapp:dm:S1",
+    };
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe("/status");
+  });
+});

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -134,7 +134,9 @@ describe("initSessionState RawBody", () => {
   });
 
   it("Reset triggers (/new, /reset) work with RawBody", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-reset-"));
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-rawbody-reset-"),
+    );
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as ClawdbotConfig;
 
@@ -156,7 +158,9 @@ describe("initSessionState RawBody", () => {
   });
 
   it("falls back to Body when RawBody is undefined", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-fallback-"));
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-rawbody-fallback-"),
+    );
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as ClawdbotConfig;
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -277,7 +277,9 @@ export async function initSessionState(params: {
 
   const sessionCtx: TemplateContext = {
     ...ctx,
-    BodyStripped: bodyStripped ?? ctx.RawBody ?? ctx.Body,
+    // Keep BodyStripped aligned with Body (best default for agent prompts).
+    // RawBody is reserved for command/directive parsing and may omit context.
+    BodyStripped: bodyStripped ?? ctx.Body ?? ctx.RawBody,
     SessionId: sessionId,
     IsNewSession: isNewSession ? "true" : "false",
   };

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -11,6 +11,11 @@ export type OriginatingChannelType =
 
 export type MsgContext = {
   Body?: string;
+  /**
+   * Raw message body without structural context (history, sender labels).
+   * Used for command detection. Falls back to Body if not set.
+   */
+  RawBody?: string;
   From?: string;
   To?: string;
   SessionKey?: string;

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -11,6 +11,7 @@ import {
   resolveSessionTranscriptPath,
   resolveSessionTranscriptsDir,
   updateLastRoute,
+  updateSessionStoreEntry,
 } from "./sessions.js";
 
 describe("sessions", () => {
@@ -174,5 +175,53 @@ describe("sessions", () => {
         process.env.CLAWDBOT_STATE_DIR = prev;
       }
     }
+  });
+
+  it("updateSessionStoreEntry merges concurrent patches", async () => {
+    const mainSessionKey = "agent:main:main";
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-sessions-"));
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [mainSessionKey]: {
+            sessionId: "sess-1",
+            updatedAt: 123,
+            thinkingLevel: "low",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    await Promise.all([
+      updateSessionStoreEntry({
+        storePath,
+        sessionKey: mainSessionKey,
+        update: async () => {
+          await sleep(50);
+          return { modelOverride: "anthropic/claude-opus-4-5" };
+        },
+      }),
+      updateSessionStoreEntry({
+        storePath,
+        sessionKey: mainSessionKey,
+        update: async () => {
+          await sleep(10);
+          return { thinkingLevel: "high" };
+        },
+      }),
+    ]);
+
+    const store = loadSessionStore(storePath);
+    expect(store[mainSessionKey]?.modelOverride).toBe(
+      "anthropic/claude-opus-4-5",
+    );
+    expect(store[mainSessionKey]?.thinkingLevel).toBe("high");
+    await expect(fs.stat(`${storePath}.lock`)).rejects.toThrow();
   });
 });

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -133,6 +133,19 @@ export type SessionEntry = {
   skillsSnapshot?: SessionSkillSnapshot;
 };
 
+function mergeSessionEntry(
+  existing: SessionEntry,
+  patch: Partial<SessionEntry>,
+): SessionEntry {
+  const sessionId = patch.sessionId ?? existing.sessionId ?? crypto.randomUUID();
+  const updatedAt = Math.max(
+    existing.updatedAt ?? 0,
+    patch.updatedAt ?? 0,
+    Date.now(),
+  );
+  return { ...existing, ...patch, sessionId, updatedAt };
+}
+
 export type GroupKeyResolution = {
   key: string;
   legacyKey?: string;
@@ -474,6 +487,92 @@ export async function saveSessionStore(
   } finally {
     await fs.promises.rm(tmp, { force: true });
   }
+}
+
+type SessionStoreLockOptions = {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  staleMs?: number;
+};
+
+async function withSessionStoreLock<T>(
+  storePath: string,
+  fn: () => Promise<T>,
+  opts: SessionStoreLockOptions = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 25;
+  const staleMs = opts.staleMs ?? 30_000;
+  const lockPath = `${storePath}.lock`;
+  const startedAt = Date.now();
+
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+
+  while (true) {
+    try {
+      const handle = await fs.promises.open(lockPath, "wx");
+      try {
+        await handle.writeFile(
+          JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+          "utf-8",
+        );
+      } catch {
+        // best-effort
+      }
+      await handle.close();
+      break;
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code?: unknown }).code)
+          : null;
+      if (code !== "EEXIST") throw err;
+
+      const now = Date.now();
+      if (now - startedAt > timeoutMs) {
+        throw new Error(`timeout acquiring session store lock: ${lockPath}`);
+      }
+
+      // Best-effort stale lock eviction (e.g. crashed process).
+      try {
+        const st = await fs.promises.stat(lockPath);
+        const ageMs = now - st.mtimeMs;
+        if (ageMs > staleMs) {
+          await fs.promises.unlink(lockPath);
+          continue;
+        }
+      } catch {
+        // ignore
+      }
+
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await fs.promises.unlink(lockPath).catch(() => undefined);
+  }
+}
+
+export async function updateSessionStoreEntry(params: {
+  storePath: string;
+  sessionKey: string;
+  update: (entry: SessionEntry) => Promise<Partial<SessionEntry> | null>;
+}): Promise<SessionEntry | null> {
+  const { storePath, sessionKey, update } = params;
+  return await withSessionStoreLock(storePath, async () => {
+    const store = loadSessionStore(storePath);
+    const existing = store[sessionKey];
+    if (!existing) return null;
+    const patch = await update(existing);
+    if (!patch) return existing;
+    const next = mergeSessionEntry(existing, patch);
+    store[sessionKey] = next;
+    await saveSessionStore(storePath, store);
+    return next;
+  });
 }
 
 export async function updateLastRoute(params: {

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -1088,6 +1088,7 @@ export function createDiscordMessageHandler(params: {
       });
       const ctxPayload = {
         Body: combinedBody,
+        RawBody: baseText,
         From: isDirectMessage
           ? `discord:${author.id}`
           : `group:${message.channelId}`,

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1221,6 +1221,7 @@ export async function monitorWebProvider(
       const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
         ctx: {
           Body: combinedBody,
+          RawBody: msg.body,
           From: msg.from,
           To: msg.to,
           SessionKey: route.sessionKey,


### PR DESCRIPTION
Fixes two auto-reply reliability issues:\n\n1) WhatsApp group messages: introduce MsgContext.RawBody (clean message text) and prefer it for command/directive/abort/reset parsing. Keep Body/BodyStripped as the best-available prompt text (may include structural context/history).\n\n2) Fallback runs: reload the session store from disk immediately before persisting usage/model info to reduce clobbering concurrent session updates (e.g. /model during a long run).\n\nIncludes tests covering RawBody parsing and abort/reset triggers.