### PR TITLE
fix(auth): enable OAuth refresh for Claude CLI credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Dependencies: Pi 0.40.0 bump (#543) — thanks @mcinteerj.
 - Build: Docker build cache layer (#605) — thanks @zknicker.
 
-- Auth: enable OAuth token refresh for Claude CLI credentials (`anthropic:claude-cli`) with bidirectional sync back to Claude Code storage (file on Linux/Windows, Keychain on macOS). This allows long-running agents to operate autonomously without manual re-authentication.
+- Auth: enable OAuth token refresh for Claude CLI credentials (`anthropic:claude-cli`) with bidirectional sync back to Claude Code storage (file on Linux/Windows, Keychain on macOS). This allows long-running agents to operate autonomously without manual re-authentication (#654 — thanks @radek-paclt).
 
 ## 2026.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Dependencies: Pi 0.40.0 bump (#543) — thanks @mcinteerj.
 - Build: Docker build cache layer (#605) — thanks @zknicker.
 
+- Auth: enable OAuth token refresh for Claude CLI credentials (`anthropic:claude-cli`) with bidirectional sync back to Claude Code storage (file on Linux/Windows, Keychain on macOS). This allows long-running agents to operate autonomously without manual re-authentication.
 
 ## 2026.1.8
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -102,7 +102,24 @@ At runtime:
 - if `expires` is in the future → use the stored access token
 - if expired → refresh (under a file lock) and overwrite the stored credentials
 
-The refresh flow is automatic; you generally don’t need to manage tokens manually.
+The refresh flow is automatic; you generally don't need to manage tokens manually.
+
+### Bidirectional sync with Claude Code
+
+When Clawdbot refreshes an Anthropic OAuth token (profile `anthropic:claude-cli`), it **writes the new credentials back** to Claude Code's storage:
+
+- **Linux/Windows**: updates `~/.claude/.credentials.json`
+- **macOS**: updates Keychain item "Claude Code-credentials"
+
+This ensures both tools stay in sync and neither gets "logged out" after the other refreshes.
+
+**Why this matters for long-running agents:**
+
+Anthropic OAuth tokens expire after a few hours. Without bidirectional sync:
+1. Clawdbot refreshes the token → gets new access token
+2. Claude Code still has the old token → gets logged out
+
+With bidirectional sync, both tools always have the latest valid token, enabling autonomous operation for days or weeks without manual intervention.
 
 ## Multiple accounts (profiles) + routing
 

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -716,6 +716,11 @@ function syncExternalCliCredentials(
       }
     }
 
+    // Avoid downgrading from oauth to token-only credentials.
+    if (existing?.type === "oauth" && claudeCreds.type === "token") {
+      shouldUpdate = false;
+    }
+
     if (shouldUpdate && !isEqual) {
       store.profiles[CLAUDE_CLI_PROFILE_ID] = claudeCreds;
       mutated = true;


### PR DESCRIPTION
## Summary

When Claude CLI credentials (`anthropic:claude-cli`) expire, automatically refresh using the stored refresh token instead of failing with "No credentials found" error.

## Changes

- Read `refreshToken` from Claude CLI and store as OAuth credential type
- Implement bidirectional sync: after refresh, write new tokens back to Claude Code storage (file on Linux/Windows, Keychain on macOS)
- Prefer OAuth over Token credentials (enables auto-refresh capability)
- Maintain backward compatibility for credentials without refreshToken

## Why this matters

This enables long-running agents to operate autonomously for days or weeks without manual re-authentication when OAuth tokens expire.

## Test plan

- [x] Unit tests for OAuth credential sync (24 tests passing)
- [x] E2E test: expired token refresh with bidirectional sync
- [x] Verified both ClawdBot and Claude Code receive updated credentials
- [x] Lint and build passing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>