### PR TITLE
docs(showcase): add Jan 8 community projects

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -98,6 +98,60 @@ Full setup walkthrough (28m) by VelvetShark.
   <img src="/assets/showcase/wienerlinien.png" alt="Wiener Linien skill on ClawdHub" />
 </Card>
 
+<Card title="Telos Protocol (Self-Improving Agent)" icon="infinity">
+  **@Cash Williams** • `todoist` `self-improvement` `heartbeats`
+
+  Agent manages its own task queue in Todoist. During heartbeats, it generates improvement tasks, gets approval, then executes. Over 20 self-improvement tasks completed.
+</Card>
+
+<Card title="Media Manager (Sonarr/Radarr)" icon="film">
+  **@coard** • `media` `automation` `api`
+
+  Add TV shows and movies by name using Sonarr/Radarr APIs. Just give it a title and it handles the rest.
+</Card>
+
+<Card title="TradingView Analysis" icon="chart-line">
+  **@Bheem** • `trading` `browser` `analysis`
+
+  Logs into TradingView, grabs stock screenshots, and performs technical analysis on demand.
+</Card>
+
+<Card title="Knowledge Classification" icon="folder-tree">
+  **@jhillock** • `obsidian` `knowledge` `automation`
+
+  Automated pipeline that pulls notes, documents, files, and bookmarks, moves them into Obsidian vault, then classifies, organizes, tags, and relates them.
+</Card>
+
+<Card title="Self-Hosted Whisper (3090)" icon="server">
+  **@SweetAsDeals** • `transcription` `self-hosted` `gpu`
+
+  Clawd SSH'd into a garage server with a 3090 GPU, set up Whisper, and created its own API for fast local transcription.
+</Card>
+
+<Card title="iMessage Typing Indicator" icon="message">
+  **@svj** • `imessage` `bluebubbles` `ux`
+
+  Shows typing indicator in iMessage when Clawd is composing a reply. Works in group chats and DMs. Requires SIP disabled.
+</Card>
+
+<Card title="Multi-Instance Setup" icon="users">
+  **@dodeja_terminal49** • `multi-user` `deployment` `family`
+
+  Running multiple Clawdbot instances on the same machine. "Gave my wife her own clawd and they are scheming."
+</Card>
+
+<Card title="TastyTrade Options" icon="chart-candlestick">
+  **@Thoth** • `trading` `options` `tastytrade`
+
+  Generates trade ideas from watchlists using IVR and builds options strategies with Greeks analysis via TastyTrade OpenAPI.
+</Card>
+
+<Card title="Image-to-Video (Replicate)" icon="video">
+  **@Joscha Hoche** • `video` `replicate` `wan-2.5`
+
+  Clawd figured out how to use Replicate API to turn images into videos using Wan-2.5 model.
+</Card>
+
 </CardGroup>
 
 ## 🤖 Automation & Workflows


### PR DESCRIPTION
New showcase entries from Discord #showcase (Jan 7-8, 2026):

## Added

- **Telos Protocol** (@Cash Williams) - Self-improving agent with Todoist task queue
- **Media Manager** (@coard) - Sonarr/Radarr API integration
- **TradingView Analysis** (@Bheem) - Browser-based stock analysis
- **Knowledge Classification** (@jhillock) - Obsidian vault automation
- **Self-Hosted Whisper** (@SweetAsDeals) - 3090 GPU transcription server
- **iMessage Typing Indicator** (@svj) - BlueBubbles typing indicator
- **Multi-Instance Setup** (@dodeja_terminal49) - Family Clawdbot deployment
- **TastyTrade Options** (@Thoth) - Options trading with Greeks
- **Image-to-Video** (@Joscha Hoche) - Replicate Wan-2.5 integration

---
*Curated by Ada via showcase-curator skill*