### PR TITLE
docs(showcase): add Adam H's multi-agent swarm

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -98,6 +98,12 @@ Full setup walkthrough (28m) by VelvetShark.
   <img src="/assets/showcase/wienerlinien.png" alt="Wiener Linien skill on ClawdHub" />
 </Card>
 
+<Card title="Multi-Agent Swarm (14+ Agents)" icon="robot" href="https://github.com/adam91holt/clawdspace">
+  **@adam91holt** • `multi-agent` `slack` `orchestration` `swarm`
+
+  14+ Clawdbot agents under one gateway. Opus 4.5 orchestrator delegates to Codex workers. Self-maintaining agents that continuously improve. Open-sourced clawdspace for agent sandboxing.
+</Card>
+
 </CardGroup>
 
 ## 🤖 Automation & Workflows


### PR DESCRIPTION
New showcase entry from Discord #showcase (Jan 10, 2026):

## Added

- **Multi-Agent Swarm** (@adam91holt) - 14+ Clawdbot agents under single gateway
  - Opus 4.5 orchestrator ("Kev") + Codex worker agents
  - Self-maintaining agents that continuously improve
  - Plans to use with clients via Slack Connect
  - Open-sourced [clawdspace](https://github.com/adam91holt/clawdspace) for agent sandboxing
  - Related issue: clawdbot/clawdbot#651

---
*Curated by Ada via showcase-curator skill (cross-channel link from @camerondare)*