### PR TITLE
Fix: avoid duplicate replies when message tool sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CLI: `clawdbot sessions` now includes `elev:*` + `usage:*` flags in the table output.
 - Branding: normalize user-facing “ClawdBot”/“CLAWDBOT” → “Clawdbot” (CLI, status, docs).
 - Models/Auth: allow MiniMax API configs without `models.providers.minimax.apiKey` (auth profiles / `MINIMAX_API_KEY`). (#656) — thanks @mneves75.
+- Agents: avoid duplicate replies when the message tool sends. (#659) — thanks @mickahouan.
 
 ## 2026.1.9
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -558,7 +558,9 @@ export function subscribeEmbeddedPiSession(params: {
               ? (args as Record<string, unknown>)
               : {};
           const action =
-            typeof argsRecord.action === "string" ? argsRecord.action : "";
+            typeof argsRecord.action === "string"
+              ? argsRecord.action.trim()
+              : "";
           // Track send actions: sendMessage/threadReply for Discord/Slack, sessions_send (no action field),
           // and message/send or message/thread-reply for the generic message tool.
           const isMessagingSend =


### PR DESCRIPTION
## What\n- Avoid duplicate replies when responses are delivered via the internal message tool by treating it as a messaging tool (dedupe + pending send tracking).\n\n## Why\n- The gateway already disabled streaming/draft chunking, but duplicates still occurred because message-tool sends weren’t deduped.\n\n## Testing\n- pnpm build