### PR TITLE
fix(ios): add Swift 6 strict concurrency compatibility

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -288,9 +288,8 @@ final class TalkModeManager: NSObject {
             self.chatSubscribedSessionKeys.insert(key)
             self.logger.info("chat.subscribe ok sessionKey=\(key, privacy: .public)")
         } catch {
-            self.logger.warning(
-                "chat.subscribe failed sessionKey=\(key, privacy: .public) " +
-                    "err=\(error.localizedDescription, privacy: .public)")
+            let err = error.localizedDescription
+            self.logger.warning("chat.subscribe failed key=\(key, privacy: .public) err=\(err, privacy: .public)")
         }
     }
 
@@ -528,9 +527,8 @@ final class TalkModeManager: NSObject {
                     self.lastPlaybackWasPCM = false
                     result = await self.mp3Player.play(stream: stream)
                 }
-                self.logger.info(
-                    "elevenlabs stream finished=\(result.finished, privacy: .public) " +
-                        "dur=\(Date().timeIntervalSince(started), privacy: .public)s")
+                let duration = Date().timeIntervalSince(started)
+                self.logger.info("elevenlabs stream finished=\(result.finished, privacy: .public) dur=\(duration, privacy: .public)s")
                 if !result.finished, let interruptedAt = result.interruptedAt {
                     self.lastInterruptedAtSeconds = interruptedAt
                 }


### PR DESCRIPTION
## Summary

Applies the same Swift 6 compatibility patterns from PR #166 (macOS) to the iOS app. These changes are forward-compatible and don't affect behavior on current Swift versions.

**Changes:**

1. **LocationService.swift**: Added `Sendable` constraint to `withTimeout<T>` generic, made `CLLocationManagerDelegate` methods `nonisolated` with `Task { @MainActor in }` pattern to safely access MainActor state from protocol requirements

2. **TalkModeManager.swift**: Fixed OSLog string interpolation to avoid operator overload issues with `OSLogMessage` in Swift 6 (cannot use `+` operator to concatenate interpolated log strings)

## Related Issue

Addresses #164 (Swift 6 / Xcode 26 compatibility) - iOS app changes

## Test Plan

- [x] Verified code compiles on Xcode 26 with Swift 6
- [x] Verified archive and IPA export succeeds
- [x] No SwiftLint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)