### PR TITLE
[AI-assisted] fix: /model command should clear session overrides

### DIFF
--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,4 +1,5 @@
 import { CONFIG_PATH_CLAWDBOT } from "../../config/config.js";
+import { resolveStorePath } from "../../config/sessions.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { resolveModelTarget, updateConfig } from "./shared.js";
 
@@ -33,4 +34,28 @@ export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
   runtime.log(
     `Default model: ${updated.agents?.defaults?.model?.primary ?? modelRaw}`,
   );
+
+  // Clear session model/provider overrides so new default takes effect
+  try {
+    const { loadSessionStore, saveSessionStore } = await import(
+      "../../config/sessions.js"
+    );
+    const storePath = resolveStorePath(updated.session?.store, {});
+    const sessionStore = loadSessionStore(storePath);
+    let cleared = 0;
+    for (const [_key, entry] of Object.entries(sessionStore)) {
+      if (entry.modelOverride || entry.providerOverride) {
+        delete entry.modelOverride;
+        delete entry.providerOverride;
+        entry.updatedAt = Date.now();
+        cleared++;
+      }
+    }
+    if (cleared > 0) {
+      await saveSessionStore(storePath, sessionStore);
+      runtime.log(`Cleared model overrides in ${cleared} session(s)`);
+    }
+  } catch (err) {
+    runtime.log(`Warning: Failed to clear session overrides: ${String(err)}`);
+  }
 }


### PR DESCRIPTION
Fixes #646

## Problem
When `/model` command updates the default model, session overrides (`modelOverride`, `providerOverride`) persisted in the session store would continue to take precedence over the new default. This made the `/model` command appear ineffective.

## Root Cause
Sessions store `modelOverride` and `providerOverride` fields. When resolving which model to use, the code checks session overrides first, then falls back to config defaults. Even after `/model` updates the config default, old session overrides remained.

## Fix
After updating the config, the `/model` command now:
1. Loads the session store
2. Clears `modelOverride` and `providerOverride` from all sessions
3. Saves the updated session store
4. Logs how many sessions were cleared

This ensures the new default model takes effect immediately for all active sessions.

---

**[AI-assisted]** - Generated with z.ai GLM-4.7

**Testing:** Lightly tested - Logic reviewed, session store APIs are well-tested. The fix uses try-catch for graceful error handling if session store is unavailable.