### PR TITLE
fix: use resolveStateDir() for node-pairing and voicewake storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Agents/OpenAI: fix Responses tool-only → follow-up turn handling (avoid standalone `reasoning` items that trigger 400 “required following item”).
 - Auth: update Claude Code keychain credentials in-place during refresh sync; share JSON file helpers; add CLI fallback coverage.
 - Auth: throttle external CLI credential syncs (Claude/Codex), reduce Keychain reads, and skip sync when cached credentials are still fresh.
+- CLI: respect `CLAWDBOT_STATE_DIR` for node pairing + voice wake settings storage. (#664) — thanks @azade-c.
 - Onboarding/Gateway: persist non-interactive gateway token auth in config; add WS wizard + gateway tool-calling regression coverage.
 - Gateway/Control UI: make `chat.send` non-blocking, wire Stop to `chat.abort`, and treat `/stop` as an out-of-band abort. (#653)
 - Gateway/Control UI: allow `chat.abort` without `runId` (abort active runs), suppress post-abort chat streaming, and prune stuck chat runs. (#653)

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 
 export type NodePairingPendingRequest = {
   requestId: string;
@@ -48,12 +48,8 @@ type NodePairingStateFile = {
 
 const PENDING_TTL_MS = 5 * 60 * 1000;
 
-function defaultBaseDir() {
-  return path.join(os.homedir(), ".clawdbot");
-}
-
 function resolvePaths(baseDir?: string) {
-  const root = baseDir ?? defaultBaseDir();
+  const root = baseDir ?? resolveStateDir();
   const dir = path.join(root, "nodes");
   return {
     dir,

--- a/src/infra/voicewake.ts
+++ b/src/infra/voicewake.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 
 export type VoiceWakeConfig = {
   triggers: string[];
@@ -10,12 +10,8 @@ export type VoiceWakeConfig = {
 
 const DEFAULT_TRIGGERS = ["clawd", "claude", "computer"];
 
-function defaultBaseDir() {
-  return path.join(os.homedir(), ".clawdbot");
-}
-
 function resolvePath(baseDir?: string) {
-  const root = baseDir ?? defaultBaseDir();
+  const root = baseDir ?? resolveStateDir();
   return path.join(root, "settings", "voicewake.json");
 }
 

--- a/src/telegram/bot.media.test.ts
+++ b/src/telegram/bot.media.test.ts
@@ -45,6 +45,14 @@ vi.mock("../config/config.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    updateLastRoute: vi.fn(async () => undefined),
+  };
+});
+
 vi.mock("./pairing-store.js", () => ({
   readTelegramAllowFromStore: vi.fn(async () => [] as string[]),
   upsertTelegramPairingRequest: vi.fn(async () => ({
@@ -63,7 +71,7 @@ vi.mock("../auto-reply/reply.js", () => {
 
 describe("telegram inbound media", () => {
   const INBOUND_MEDIA_TEST_TIMEOUT_MS =
-    process.platform === "win32" ? 30_000 : 10_000;
+    process.platform === "win32" ? 30_000 : 20_000;
 
   it(
     "downloads media via file_path (no file.download)",


### PR DESCRIPTION
## Problem

Both `node-pairing.ts` and `voicewake.ts` were using a local `defaultBaseDir()` function that hardcoded `~/.clawdbot`, ignoring `CLAWDBOT_STATE_DIR`.

This caused:
- `nodes/paired.json` stored in `~/.clawdbot/nodes/` instead of `$CLAWDBOT_STATE_DIR/nodes/`
- `settings/voicewake.json` stored in `~/.clawdbot/settings/` instead of `$CLAWDBOT_STATE_DIR/settings/`

## Solution

Replace the local `defaultBaseDir()` with the canonical `resolveStateDir()` from `config/paths.ts`, which properly respects `CLAWDBOT_STATE_DIR`.

## Changes

- `src/infra/node-pairing.ts`: Use `resolveStateDir()` instead of hardcoded `~/.clawdbot`
- `src/infra/voicewake.ts`: Same fix

## Testing

- Build passes (`pnpm build`)
- Tested manually: nodes config now stored in `$CLAWDBOT_STATE_DIR/nodes/`