### PR TITLE
fix(gmail): keep tailscale serve path at root

### DIFF
--- a/src/hooks/gmail.test.ts
+++ b/src/hooks/gmail.test.ts
@@ -85,7 +85,30 @@ describe("gmail hook config", () => {
     }
   });
 
-  it("keeps explicit serve path for tailscale when set", () => {
+  it("keeps the default public path when serve path is explicit", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            account: "clawdbot@gmail.com",
+            topic: "projects/demo/topics/gog-gmail-watch",
+            pushToken: "push-token",
+            serve: { path: "/gmail-pubsub" },
+            tailscale: { mode: "funnel" },
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.serve.path).toBe("/");
+      expect(result.value.tailscale.path).toBe("/gmail-pubsub");
+    }
+  });
+
+  it("keeps custom public path when serve path is set", () => {
     const result = resolveGmailHookRuntimeConfig(
       {
         hooks: {
@@ -103,7 +126,7 @@ describe("gmail hook config", () => {
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.serve.path).toBe("/custom");
+      expect(result.value.serve.path).toBe("/");
       expect(result.value.tailscale.path).toBe("/custom");
     }
   });

--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -160,23 +160,22 @@ export function resolveGmailHookRuntimeConfig(
       ? Math.floor(servePortRaw)
       : DEFAULT_GMAIL_SERVE_PORT;
   const servePathRaw = overrides.servePath ?? gmail?.serve?.path;
-  const hasExplicitServePath =
-    typeof servePathRaw === "string" && servePathRaw.trim().length > 0;
+  const normalizedServePathRaw =
+    typeof servePathRaw === "string" && servePathRaw.trim().length > 0
+      ? normalizeServePath(servePathRaw)
+      : DEFAULT_GMAIL_SERVE_PATH;
 
   const tailscaleMode =
     overrides.tailscaleMode ?? gmail?.tailscale?.mode ?? "off";
-  // When exposing the push endpoint via Tailscale, the public path is stripped
-  // before proxying; use "/" internally unless the user set a path explicitly.
+  // Tailscale strips the public path before proxying, so listen on "/" when on.
   const servePath = normalizeServePath(
-    tailscaleMode !== "off" && !hasExplicitServePath ? "/" : servePathRaw,
+    tailscaleMode !== "off" ? "/" : normalizedServePathRaw,
   );
 
   const tailscalePathRaw = overrides.tailscalePath ?? gmail?.tailscale?.path;
   const tailscalePath = normalizeServePath(
-    tailscaleMode !== "off" && !tailscalePathRaw
-      ? hasExplicitServePath
-        ? servePathRaw
-        : DEFAULT_GMAIL_SERVE_PATH
+    tailscaleMode !== "off"
+      ? (tailscalePathRaw ?? normalizedServePathRaw)
       : (tailscalePathRaw ?? servePath),
   );
 


### PR DESCRIPTION
Ran the config again today, and ran again into this issue. Made with Codex:

The default Gmail hook path configured by `clawdbot hooks gmail setup` is `/gmail-pubsub`. Tailscale strips the mount path before proxying, so the request lands on `/` and the hook 404s under the default configuration.

When Tailscale is enabled, always listen on `/` internally and keep the public URL on the configured path (defaulting to `/gmail-pubsub`). This makes default and custom paths work reliably.

Alternative (not implemented here): call tailscale with a full target URL so the backend keeps the path, e.g. `tailscale funnel --set-path /gmail-pubsub http://127.0.0.1:8788/gmail-pubsub`. We did not take this path because it requires changing the CLI invocation to pass URLs (not ports) plus extra validation, which is a larger behavior change.

