### PR TITLE
fix(macos): stabilize bridge tunnels (AI-assisted)

### DIFF
--- a/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
+++ b/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
@@ -41,7 +41,8 @@ final class RemotePortTunnel {
     static func create(
         remotePort: Int,
         preferredLocalPort: UInt16? = nil,
-        allowRemoteUrlOverride: Bool = true) async throws -> RemotePortTunnel
+        allowRemoteUrlOverride: Bool = true,
+        allowRandomLocalPort: Bool = true) async throws -> RemotePortTunnel
     {
         let settings = CommandResolver.connectionSettings()
         guard settings.mode == .remote, let parsed = CommandResolver.parseSSHTarget(settings.target) else {
@@ -51,7 +52,9 @@ final class RemotePortTunnel {
                 userInfo: [NSLocalizedDescriptionKey: "Remote mode is not configured"])
         }
 
-        let localPort = try await Self.findPort(preferred: preferredLocalPort)
+        let localPort = try await Self.findPort(
+            preferred: preferredLocalPort,
+            allowRandom: allowRandomLocalPort)
         let sshHost = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
         let remotePortOverride =
             allowRemoteUrlOverride && remotePort == GatewayEnvironment.gatewayPort()
@@ -172,8 +175,16 @@ final class RemotePortTunnel {
         return trimmed.split(separator: ".").first.map(String.init) ?? trimmed
     }
 
-    private static func findPort(preferred: UInt16?) async throws -> UInt16 {
+    private static func findPort(preferred: UInt16?, allowRandom: Bool) async throws -> UInt16 {
         if let preferred, self.portIsFree(preferred) { return preferred }
+        if let preferred, !allowRandom {
+            throw NSError(
+                domain: "RemotePortTunnel",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Local port \(preferred) is unavailable",
+                ])
+        }
 
         return try await withCheckedThrowingContinuation { cont in
             let queue = DispatchQueue(label: "com.clawdbot.remote.tunnel.port", qos: .utility)

--- a/apps/macos/Sources/Clawdbot/ShellExecutor.swift
+++ b/apps/macos/Sources/Clawdbot/ShellExecutor.swift
@@ -50,10 +50,13 @@ enum ShellExecutor {
                 errorMessage: "failed to start: \(error.localizedDescription)")
         }
 
+        let outTask = Task { stdoutPipe.fileHandleForReading.readToEndSafely() }
+        let errTask = Task { stderrPipe.fileHandleForReading.readToEndSafely() }
+
         let waitTask = Task { () -> ShellResult in
             process.waitUntilExit()
-            let out = stdoutPipe.fileHandleForReading.readToEndSafely()
-            let err = stderrPipe.fileHandleForReading.readToEndSafely()
+            let out = await outTask.value
+            let err = await errTask.value
             let status = Int(process.terminationStatus)
             return ShellResult(
                 stdout: String(bytes: out, encoding: .utf8) ?? "",


### PR DESCRIPTION
## What / Why

- Fix pipe deadlock when commands emit large output by reading stdout/stderr concurrently before waitUntilExit, preventing bridge stalls on heavy commands.
  - apps/macos/Sources/Clawdbot/ShellExecutor.swift

- Make control tunnel binding deterministic by disallowing random local ports for the gateway tunnel, preventing "connected but commands fail" when a random port is chosen.
  - apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
  - apps/macos/Sources/Clawdbot/RemoteTunnelManager.swift

- Add single-flight/backoff around control tunnel restarts to avoid rapid restart loops during flaky health checks.
  - apps/macos/Sources/Clawdbot/RemoteTunnelManager.swift

- Prevent bridge receive loop stalls from long-running invokes by handling invoke responses on a detached task, and add clearer logging/disconnect handling.
  - apps/macos/Sources/Clawdbot/NodeMode/MacNodeBridgeSession.swift
  - apps/macos/Sources/Clawdbot/NodeMode/MacNodeModeCoordinator.swift

## Testing

- ./scripts/restart-mac.sh

## AI Assistance

This PR was generated with help from both Codex and Claude and went through several refinement rounds. I understand what the code does.

(Optional) Prompts / session logs: not available.
