### PR TITLE
fix(macos): stabilize bridge tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@
 - Gateway: add OpenAI-compatible `/v1/chat/completions` HTTP endpoint (auth, SSE streaming, per-agent routing). (#680) — thanks @steipete.
 
 ### Fixes
-- Block Streaming: enable for all providers, not just Telegram. (#684) — thanks @rubyrunsstuff.
+- macOS: stabilize bridge tunnels, guard invoke senders on disconnect, and drain stdout/stderr to avoid deadlocks. (#676) — thanks @ngutman.
 - Agents/System: clarify sandboxed runtime in system prompt and surface elevated availability when sandboxed.
-- Agents/System: add reasoning visibility hint + /reasoning and /status guidance in system prompt.
 - Auto-reply: prefer `RawBody` for command/directive parsing (WhatsApp + Discord) and prevent fallback runs from clobbering concurrent session updates. (#643) — thanks @mcinteerj.
 - WhatsApp: fix group reactions by preserving message IDs and sender JIDs in history; normalize participant phone numbers to JIDs in outbound reactions. (#640) — thanks @mcinteerj.
 - WhatsApp: expose group participant IDs to the model so reactions can target the right sender.

--- a/apps/macos/Sources/Clawdbot/NodeMode/MacNodeBridgeSession.swift
+++ b/apps/macos/Sources/Clawdbot/NodeMode/MacNodeBridgeSession.swift
@@ -20,6 +20,7 @@ actor MacNodeBridgeSession {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private let clock = ContinuousClock()
+    private var disconnectHandler: (@Sendable (String) async -> Void)?
 
     private var connection: NWConnection?
     private var queue: DispatchQueue?
@@ -35,10 +36,12 @@ actor MacNodeBridgeSession {
         endpoint: NWEndpoint,
         hello: BridgeHello,
         onConnected: (@Sendable (String) async -> Void)? = nil,
+        onDisconnected: (@Sendable (String) async -> Void)? = nil,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse)
         async throws
     {
         await self.disconnect()
+        self.disconnectHandler = onDisconnected
         self.state = .connecting
 
         let params = NWParameters.tcp
@@ -83,6 +86,7 @@ actor MacNodeBridgeSession {
             let data = line.data(using: .utf8),
             let base = try? self.decoder.decode(BridgeBaseFrame.self, from: data)
         else {
+            self.logger.error("node bridge hello failed (unexpected response)")
             await self.disconnect()
             throw NSError(domain: "Bridge", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Unexpected bridge response",
@@ -97,53 +101,69 @@ actor MacNodeBridgeSession {
         } else if base.type == "error" {
             let err = try self.decoder.decode(BridgeErrorFrame.self, from: data)
             self.state = .failed(message: "\(err.code): \(err.message)")
+            self.logger.error("node bridge hello error: \(err.code, privacy: .public)")
             await self.disconnect()
             throw NSError(domain: "Bridge", code: 2, userInfo: [
                 NSLocalizedDescriptionKey: "\(err.code): \(err.message)",
             ])
         } else {
             self.state = .failed(message: "Unexpected bridge response")
+            self.logger.error("node bridge hello failed (unexpected frame)")
             await self.disconnect()
             throw NSError(domain: "Bridge", code: 3, userInfo: [
                 NSLocalizedDescriptionKey: "Unexpected bridge response",
             ])
         }
 
-        while true {
-            guard let next = try await self.receiveLine() else { break }
-            guard let nextData = next.data(using: .utf8) else { continue }
-            guard let nextBase = try? self.decoder.decode(BridgeBaseFrame.self, from: nextData) else { continue }
+        do {
+            while true {
+                guard let next = try await self.receiveLine() else { break }
+                guard let nextData = next.data(using: .utf8) else { continue }
+                guard let nextBase = try? self.decoder.decode(BridgeBaseFrame.self, from: nextData) else { continue }
 
-            switch nextBase.type {
-            case "res":
-                let res = try self.decoder.decode(BridgeRPCResponse.self, from: nextData)
-                if let cont = self.pendingRPC.removeValue(forKey: res.id) {
-                    cont.resume(returning: res)
+                switch nextBase.type {
+                case "res":
+                    let res = try self.decoder.decode(BridgeRPCResponse.self, from: nextData)
+                    if let cont = self.pendingRPC.removeValue(forKey: res.id) {
+                        cont.resume(returning: res)
+                    }
+
+                case "event":
+                    let evt = try self.decoder.decode(BridgeEventFrame.self, from: nextData)
+                    self.broadcastServerEvent(evt)
+
+                case "ping":
+                    let ping = try self.decoder.decode(BridgePing.self, from: nextData)
+                    try await self.send(BridgePong(type: "pong", id: ping.id))
+
+                case "pong":
+                    let pong = try self.decoder.decode(BridgePong.self, from: nextData)
+                    self.notePong(pong)
+
+                case "invoke":
+                    let req = try self.decoder.decode(BridgeInvokeRequest.self, from: nextData)
+                    Task.detached { [weak self] in
+                        let res = await onInvoke(req)
+                        guard let self else { return }
+                        do {
+                            try await self.send(res)
+                        } catch {
+                            await self.logInvokeSendFailure(error)
+                        }
+                    }
+
+                default:
+                    continue
                 }
-
-            case "event":
-                let evt = try self.decoder.decode(BridgeEventFrame.self, from: nextData)
-                self.broadcastServerEvent(evt)
-
-            case "ping":
-                let ping = try self.decoder.decode(BridgePing.self, from: nextData)
-                try await self.send(BridgePong(type: "pong", id: ping.id))
-
-            case "pong":
-                let pong = try self.decoder.decode(BridgePong.self, from: nextData)
-                self.notePong(pong)
-
-            case "invoke":
-                let req = try self.decoder.decode(BridgeInvokeRequest.self, from: nextData)
-                let res = await onInvoke(req)
-                try await self.send(res)
-
-            default:
-                continue
             }
-        }
 
-        await self.disconnect()
+            await self.handleDisconnect(reason: "connection closed")
+        } catch {
+            self.logger.error(
+                "node bridge receive failed: \(error.localizedDescription, privacy: .public)")
+            await self.handleDisconnect(reason: "receive failed")
+            throw error
+        }
     }
 
     func sendEvent(event: String, payloadJSON: String?) async throws {
@@ -205,6 +225,7 @@ actor MacNodeBridgeSession {
         self.pingTask?.cancel()
         self.pingTask = nil
         self.lastPongAt = nil
+        self.disconnectHandler = nil
 
         self.connection?.cancel()
         self.connection = nil
@@ -312,6 +333,7 @@ actor MacNodeBridgeSession {
     private func startPingLoop() {
         self.pingTask?.cancel()
         self.lastPongAt = self.clock.now
+        self.logger.debug("node bridge ping loop started")
         self.pingTask = Task { [weak self] in
             guard let self else { return }
             await self.runPingLoop()
@@ -336,7 +358,7 @@ actor MacNodeBridgeSession {
                         "Node bridge heartbeat timed out; disconnecting " +
                         "(age: \(ageDescription, privacy: .public))."
                     self.logger.warning(message)
-                    await self.disconnect()
+                    await self.handleDisconnect(reason: "ping timeout")
                     return
                 }
             }
@@ -350,7 +372,7 @@ actor MacNodeBridgeSession {
                     "Node bridge ping send failed; disconnecting " +
                     "(error: \(errorDescription, privacy: .public))."
                 self.logger.warning(message)
-                await self.disconnect()
+                await self.handleDisconnect(reason: "ping send failed")
                 return
             }
         }
@@ -369,13 +391,26 @@ actor MacNodeBridgeSession {
                 "Node bridge connection failed; disconnecting " +
                 "(error: \(errorDescription, privacy: .public))."
             self.logger.warning(message)
-            await self.disconnect()
+            await self.handleDisconnect(reason: "connection failed")
         case .cancelled:
             self.logger.warning("Node bridge connection cancelled; disconnecting.")
-            await self.disconnect()
+            await self.handleDisconnect(reason: "connection cancelled")
         default:
             break
         }
+    }
+
+    private func handleDisconnect(reason: String) async {
+        self.logger.info("node bridge disconnect reason=\(reason, privacy: .public)")
+        if let handler = self.disconnectHandler {
+            await handler(reason)
+        }
+        await self.disconnect()
+    }
+
+    private func logInvokeSendFailure(_ error: Error) {
+        self.logger.error(
+            "node bridge invoke response send failed: \(error.localizedDescription, privacy: .public)")
     }
 
     private static func makeStateStream(

--- a/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
+++ b/apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
@@ -41,7 +41,8 @@ final class RemotePortTunnel {
     static func create(
         remotePort: Int,
         preferredLocalPort: UInt16? = nil,
-        allowRemoteUrlOverride: Bool = true) async throws -> RemotePortTunnel
+        allowRemoteUrlOverride: Bool = true,
+        allowRandomLocalPort: Bool = true) async throws -> RemotePortTunnel
     {
         let settings = CommandResolver.connectionSettings()
         guard settings.mode == .remote, let parsed = CommandResolver.parseSSHTarget(settings.target) else {
@@ -51,7 +52,9 @@ final class RemotePortTunnel {
                 userInfo: [NSLocalizedDescriptionKey: "Remote mode is not configured"])
         }
 
-        let localPort = try await Self.findPort(preferred: preferredLocalPort)
+        let localPort = try await Self.findPort(
+            preferred: preferredLocalPort,
+            allowRandom: allowRandomLocalPort)
         let sshHost = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
         let remotePortOverride =
             allowRemoteUrlOverride && remotePort == GatewayEnvironment.gatewayPort()
@@ -172,8 +175,16 @@ final class RemotePortTunnel {
         return trimmed.split(separator: ".").first.map(String.init) ?? trimmed
     }
 
-    private static func findPort(preferred: UInt16?) async throws -> UInt16 {
+    private static func findPort(preferred: UInt16?, allowRandom: Bool) async throws -> UInt16 {
         if let preferred, self.portIsFree(preferred) { return preferred }
+        if let preferred, !allowRandom {
+            throw NSError(
+                domain: "RemotePortTunnel",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Local port \(preferred) is unavailable",
+                ])
+        }
 
         return try await withCheckedThrowingContinuation { cont in
             let queue = DispatchQueue(label: "com.clawdbot.remote.tunnel.port", qos: .utility)

--- a/apps/macos/Sources/Clawdbot/ShellExecutor.swift
+++ b/apps/macos/Sources/Clawdbot/ShellExecutor.swift
@@ -50,10 +50,13 @@ enum ShellExecutor {
                 errorMessage: "failed to start: \(error.localizedDescription)")
         }
 
+        let outTask = Task { stdoutPipe.fileHandleForReading.readToEndSafely() }
+        let errTask = Task { stderrPipe.fileHandleForReading.readToEndSafely() }
+
         let waitTask = Task { () -> ShellResult in
             process.waitUntilExit()
-            let out = stdoutPipe.fileHandleForReading.readToEndSafely()
-            let err = stderrPipe.fileHandleForReading.readToEndSafely()
+            let out = await outTask.value
+            let err = await errTask.value
             let status = Int(process.terminationStatus)
             return ShellResult(
                 stdout: String(bytes: out, encoding: .utf8) ?? "",

--- a/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/LowCoverageHelperTests.swift
@@ -57,6 +57,25 @@ struct LowCoverageHelperTests {
         #expect(result.timedOut == true)
     }
 
+    @Test func shellExecutorDrainsStdoutAndStderr() async {
+        let script = """
+        i=0
+        while [ $i -lt 2000 ]; do
+          echo "stdout-$i"
+          echo "stderr-$i" 1>&2
+          i=$((i+1))
+        done
+        """
+        let result = await ShellExecutor.runDetailed(
+            command: ["/bin/sh", "-c", script],
+            cwd: nil,
+            env: nil,
+            timeout: 2)
+        #expect(result.success == true)
+        #expect(result.stdout.contains("stdout-1999"))
+        #expect(result.stderr.contains("stderr-1999"))
+    }
+
     @Test func pairedNodesStorePersists() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("paired-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## What / Why

- Fix pipe deadlock when commands emit large output by reading stdout/stderr concurrently before waitUntilExit, preventing bridge stalls on heavy commands.
  - apps/macos/Sources/Clawdbot/ShellExecutor.swift

- Make control tunnel binding deterministic by disallowing random local ports for the gateway tunnel, preventing "connected but commands fail" when a random port is chosen.
  - apps/macos/Sources/Clawdbot/RemotePortTunnel.swift
  - apps/macos/Sources/Clawdbot/RemoteTunnelManager.swift

- Add single-flight/backoff around control tunnel restarts to avoid rapid restart loops during flaky health checks.
  - apps/macos/Sources/Clawdbot/RemoteTunnelManager.swift

- Prevent bridge receive loop stalls from long-running invokes by handling invoke responses on a detached task, and add clearer logging/disconnect handling.
  - apps/macos/Sources/Clawdbot/NodeMode/MacNodeBridgeSession.swift
  - apps/macos/Sources/Clawdbot/NodeMode/MacNodeModeCoordinator.swift

## Testing

- ./scripts/restart-mac.sh

## AI Assistance

This PR was generated with help from both Codex and Claude and went through several refinement rounds. I understand what the code does.

(Optional) Prompts / session logs: not available.
