### PR TITLE
macOS: model picker saves provider/model IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixes
 - Agents: strip `<thought>`/`<antthinking>` tags from hidden reasoning output and cover tag variants in tests. (#688) — thanks @theglove44.
+- macOS: save model picker selections as normalized provider/model IDs and keep manual entries aligned. (#683) — thanks @benithors.
 - Agents: recognize "usage limit" errors as rate limits for failover. (#687) — thanks @evalexpr.
 - CLI: avoid success message when daemon restart is skipped. (#685) — thanks @carlulsoe.
 - Gateway: disable the OpenAI-compatible `/v1/chat/completions` endpoint by default; enable via `gateway.http.endpoints.chatCompletions.enabled=true`.

--- a/apps/macos/Sources/Clawdbot/ConfigSettings.swift
+++ b/apps/macos/Sources/Clawdbot/ConfigSettings.swift
@@ -138,12 +138,13 @@ struct ConfigSettings: View {
         .contentShape(Rectangle())
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(Color(nsColor: .textBackgroundColor))
-        )
+                .fill(
+                    Color(nsColor: .textBackgroundColor)))
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(Color.secondary.opacity(0.25), lineWidth: 1)
-        )
+                .stroke(
+                    Color.secondary.opacity(0.25),
+                    lineWidth: 1))
         .popover(isPresented: self.$isModelPickerOpen, arrowEdge: .bottom) {
             self.modelPickerPopover
         }
@@ -783,8 +784,8 @@ struct ConfigSettings: View {
                 choice.provider,
                 self.modelRef(for: choice),
             ]
-            .joined(separator: " ")
-            .lowercased()
+                .joined(separator: " ")
+                .lowercased()
             return tokens.allSatisfy { haystack.contains($0) }
         }
     }

--- a/apps/macos/Sources/Clawdbot/ConfigSettings.swift
+++ b/apps/macos/Sources/Clawdbot/ConfigSettings.swift
@@ -832,7 +832,7 @@ struct ConfigSettings: View {
         if id.lowercased().hasPrefix("\(normalizedProvider)/") {
             return id
         }
-        return "\(provider)/\(id)"
+        return "\(normalizedProvider)/\(id)"
     }
 
     private func matchesConfigModel(_ choice: ModelChoice) -> Bool {
@@ -875,7 +875,14 @@ struct ConfigSettings: View {
     }
 
     private func selectManualModel(_ value: String) {
-        self.configModel = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let slash = trimmed.firstIndex(of: "/") {
+            let provider = trimmed[..<slash].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let model = trimmed[trimmed.index(after: slash)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            self.configModel = provider.isEmpty ? String(model) : "\(provider)/\(model)"
+        } else {
+            self.configModel = trimmed
+        }
         self.autosaveConfig()
         self.isModelPickerOpen = false
     }

--- a/patches/@mariozechner__pi-ai@0.42.2.patch
+++ b/patches/@mariozechner__pi-ai@0.42.2.patch
@@ -7,7 +7,7 @@ index 93aa26c395e9bd0df64376408a13d15ee9e7cce7..beb585e2f2c13eec3bca98acade76110
                      }
                      const errorText = await response.text();
 +                    // Fail immediately on 429 for Antigravity to let callers rotate accounts.
-+                    // Antigravity rate limits can have very long retry delays (10+ minutes). Repro: LIVE=1 CLAWDBOT_LIVE_GATEWAY=1 CLAWDBOT_LIVE_GATEWAY_ALL_MODELS=1 CLAWDBOT_LIVE_GATEWAY_PROVIDERS=\"google-antigravity\" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts
++                    // Antigravity rate limits can have very long retry delays (10+ minutes).
 +                    if (isAntigravity && response.status === 429) {
 +                        throw new Error(`Cloud Code Assist API error (${response.status}): ${errorText}`);
 +                    }
@@ -56,7 +56,7 @@ index 188a8294f26fe1bfe3fb298a7f58e4d8eaf2a529..a3aeb6a7ff53bc4f7f44362adb950b2c
          description: tool.description,
          parameters: tool.parameters,
 -        strict: null,
-+        strict: false, // Repro: LIVE=1 CLAWDBOT_LIVE_GATEWAY=1 CLAWDBOT_LIVE_GATEWAY_ALL_MODELS=1 CLAWDBOT_LIVE_GATEWAY_MODELS=\"openai-codex/gpt-5.2\" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts
++        strict: false,
      }));
  }
  function mapStopReason(status) {


### PR DESCRIPTION
Fixed the mac companion app’s model picker so it saves the full provider/model ID (not just the model name), preventing wrong-provider configs when selecting a provider+model. Replaced the dropdown + manual field with a searchable popover picker and updated selection matching to use full provider/model refs while keeping model metadata labels in sync.