### PR TITLE
fix: enable block streaming for all major messaging providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Gateway: add OpenAI-compatible `/v1/chat/completions` HTTP endpoint (auth, SSE streaming, per-agent routing). (#680) — thanks @steipete.
 
 ### Fixes
+- Block Streaming: enable for all providers, not just Telegram. (#684) — thanks @rubyrunsstuff.
 - Agents/System: clarify sandboxed runtime in system prompt and surface elevated availability when sandboxed.
 - Auto-reply: prefer `RawBody` for command/directive parsing (WhatsApp + Discord) and prevent fallback runs from clobbering concurrent session updates. (#643) — thanks @mcinteerj.
 - WhatsApp: fix group reactions by preserving message IDs and sender JIDs in history; normalize participant phone numbers to JIDs in outbound reactions. (#640) — thanks @mcinteerj.

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -590,7 +590,6 @@ export async function getReplyFromConfig(
       "on")
     : "off";
   const providerKey = sessionCtx.Provider?.trim().toLowerCase();
-  const explicitBlockStreamingEnable = opts?.disableBlockStreaming === false;
   const resolvedBlockStreaming =
     opts?.disableBlockStreaming === true
       ? "off"
@@ -603,12 +602,7 @@ export async function getReplyFromConfig(
     agentCfg?.blockStreamingBreak === "message_end"
       ? "message_end"
       : "text_end";
-  const allowBlockStreaming =
-    providerKey === "telegram" || explicitBlockStreamingEnable;
-  const blockStreamingEnabled =
-    resolvedBlockStreaming === "on" &&
-    opts?.disableBlockStreaming !== true &&
-    allowBlockStreaming;
+  const blockStreamingEnabled = resolvedBlockStreaming === "on";
   const blockReplyChunking = blockStreamingEnabled
     ? resolveBlockStreamingChunking(
         cfg,


### PR DESCRIPTION
## What this does

Enables block streaming for all providers, not just Telegram.

## The problem

Messages were batching at the end instead of streaming incrementally for iMessage and other non-Telegram providers.

## The fix

```diff
- const explicitBlockStreamingEnable = opts?.disableBlockStreaming === false;
- // ...
- const allowBlockStreaming =
-     providerKey === "telegram" || explicitBlockStreamingEnable;
- const blockStreamingEnabled =
-     resolvedBlockStreaming === "on" &&
-     opts?.disableBlockStreaming !== true &&
-     allowBlockStreaming;
+ const blockStreamingEnabled = resolvedBlockStreaming === "on";
```

`resolvedBlockStreaming` already handles the `disableBlockStreaming` config, so the extra checks were redundant.

---
*Submitted by Ruby 🐱*