### PR TITLE
fix: add 'usage limit' to rate limit detection patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Docker: allow optional home volume + extra bind mounts in `docker-setup.sh`. (#679) — thanks @gabriel-trigo.
 
 ### Fixes
+- Agents: recognize "usage limit" errors as rate limits for failover. (#687) — thanks @evalexpr.
 - CLI: avoid success message when daemon restart is skipped. (#685) — thanks @carlulsoe.
 - Gateway: disable the OpenAI-compatible `/v1/chat/completions` endpoint by default; enable via `gateway.http.endpoints.chatCompletions.enabled=true`.
 - macOS: stabilize bridge tunnels, guard invoke senders on disconnect, and drain stdout/stderr to avoid deadlocks. (#676) — thanks @ngutman.

--- a/src/agents/pi-embedded-helpers.test.ts
+++ b/src/agents/pi-embedded-helpers.test.ts
@@ -272,6 +272,14 @@ describe("classifyFailoverReason", () => {
     );
     expect(classifyFailoverReason("bad request")).toBeNull();
   });
+
+  it("classifies OpenAI usage limit errors as rate_limit", () => {
+    expect(
+      classifyFailoverReason(
+        "You have hit your ChatGPT usage limit (plus plan)",
+      ),
+    ).toBe("rate_limit");
+  });
 });
 
 describe("isCloudCodeAssistFormatError", () => {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -343,6 +343,7 @@ const ERROR_PATTERNS = {
     "resource has been exhausted",
     "quota exceeded",
     "resource_exhausted",
+    "usage limit",
   ],
   timeout: [
     "timeout",


### PR DESCRIPTION
## Summary
- Add "usage limit" to the rate limit error detection patterns in `ERROR_PATTERNS.rateLimit`
- OpenAI/ChatGPT returns "You have hit your ChatGPT usage limit (plus plan)" when users exceed their plan quota
- This error wasn't being recognized as a rate limit, so fallback to alternative models wasn't triggering

## Test plan
- [x] Added test case in `pi-embedded-helpers.test.ts` for the new pattern
- [x] All 50 tests in `pi-embedded-helpers.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)