### PR TITLE
fix(agents): strip <thought> and <antthinking> tags from output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Docker: allow optional home volume + extra bind mounts in `docker-setup.sh`. (#679) — thanks @gabriel-trigo.
 
 ### Fixes
+- Agents: strip `<thought>`/`<antthinking>` tags from hidden reasoning output and cover tag variants in tests. (#688) — thanks @theglove44.
 - Agents: recognize "usage limit" errors as rate limits for failover. (#687) — thanks @evalexpr.
 - CLI: avoid success message when daemon restart is skipped. (#685) — thanks @carlulsoe.
 - Gateway: disable the OpenAI-compatible `/v1/chat/completions` endpoint by default; enable via `gateway.http.endpoints.chatCompletions.enabled=true`.

--- a/src/agents/clawdbot-gateway-tool.test.ts
+++ b/src/agents/clawdbot-gateway-tool.test.ts
@@ -14,9 +14,7 @@ describe("gateway tool", () => {
     vi.useFakeTimers();
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
     const previousStateDir = process.env.CLAWDBOT_STATE_DIR;
-    const stateDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "clawdbot-test-"),
-    );
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-test-"));
     process.env.CLAWDBOT_STATE_DIR = stateDir;
 
     try {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -35,7 +35,8 @@ import {
 const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
 const THINKING_OPEN_RE = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
 const THINKING_CLOSE_RE = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
-const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+const THINKING_TAG_SCAN_RE =
+  /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
 const TOOL_RESULT_MAX_CHARS = 8000;
 const log = createSubsystemLogger("agent/embedded");
 const RAW_STREAM_ENABLED = process.env.CLAWDBOT_RAW_STREAM === "1";

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -32,10 +32,10 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
-const THINKING_TAG_RE = /<\s*\/?\s*think(?:ing)?\s*>/gi;
-const THINKING_OPEN_RE = /<\s*think(?:ing)?\s*>/i;
-const THINKING_CLOSE_RE = /<\s*\/\s*think(?:ing)?\s*>/i;
-const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*think(?:ing)?\s*>/gi;
+const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+const THINKING_OPEN_RE = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+const THINKING_CLOSE_RE = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
 const TOOL_RESULT_MAX_CHARS = 8000;
 const log = createSubsystemLogger("agent/embedded");
 const RAW_STREAM_ENABLED = process.env.CLAWDBOT_RAW_STREAM === "1";

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -52,12 +52,12 @@ export function splitThinkingTaggedText(
   // with a think tag (common for local/OpenAI-compat providers that emulate
   // reasoning blocks via tags).
   if (!trimmedStart.startsWith("<")) return null;
-  const openRe = /<\s*think(?:ing)?\s*>/i;
-  const closeRe = /<\s*\/\s*think(?:ing)?\s*>/i;
+  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
   if (!openRe.test(trimmedStart)) return null;
   if (!closeRe.test(text)) return null;
 
-  const scanRe = /<\s*(\/?)\s*think(?:ing)?\s*>/gi;
+  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
   let inThinking = false;
   let cursor = 0;
   let thinkingStart = 0;
@@ -136,7 +136,7 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
 
 export function extractThinkingFromTaggedText(text: string): string {
   if (!text) return "";
-  const scanRe = /<\s*(\/?)\s*think(?:ing)?\s*>/gi;
+  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
   let result = "";
   let lastIndex = 0;
   let inThinking = false;
@@ -157,8 +157,8 @@ export function extractThinkingFromTaggedStream(text: string): string {
   const closed = extractThinkingFromTaggedText(text);
   if (closed) return closed;
 
-  const openRe = /<\s*think(?:ing)?\s*>/gi;
-  const closeRe = /<\s*\/\s*think(?:ing)?\s*>/gi;
+  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
   const openMatches = [...text.matchAll(openRe)];
   if (openMatches.length === 0) return "";
   const closeMatches = [...text.matchAll(closeRe)];

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -165,9 +165,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
         try {
           await doctorCommand(defaultRuntime, { nonInteractive: true });
         } catch (err) {
-          defaultRuntime.log(
-            theme.warn(`Doctor failed: ${String(err)}`),
-          );
+          defaultRuntime.log(theme.warn(`Doctor failed: ${String(err)}`));
         } finally {
           delete process.env.CLAWDBOT_UPDATE_IN_PROGRESS;
         }


### PR DESCRIPTION
## Description
This PR updates the regexes used for stripping thinking blocks to include support for `<thought>` and `<antthinking>` tags. This ensures that reasoning traces from models using these tags (like Claude 3.7 / Google internal models) are properly hidden when thinking mode is disabled.

## Changes
- Updated `THINKING_TAG_RE` and related regexes in `src/agents/pi-embedded-subscribe.ts`
- Updated regexes in `src/agents/pi-embedded-utils.ts`

## Motivation
Users reported that thinking blocks were leaking into the output despite being disabled. This was likely due to the model using alternative tags not covered by the previous regex.