### PR TITLE
feat(update): add progress spinner during update steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CLI/Status: improve Tailscale reporting in `status --all` and harden parsing of noisy `tailscale status --json` output.
 - CLI/Status: make `status --all` scan progress determinate (OSC progress + spinner).
 - Terminal/Table: ANSI-safe wrapping to prevent table clipping/color loss; add regression coverage.
+- CLI/Update: gate progress spinner on stdout TTY and align clean-check step label. (#701) — thanks @bjesuiter.
 
 ## 2026.1.11-4
 

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -90,7 +90,11 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
     applyState();
   };
 
-  timer = setTimeout(start, delayMs);
+  if (delayMs === 0) {
+    start();
+  } else {
+    timer = setTimeout(start, delayMs);
+  }
 
   const setLabel = (next: string) => {
     label = next;

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -117,6 +117,9 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
   if (result.root) {
     defaultRuntime.log(`  Root: ${theme.muted(result.root)}`);
   }
+  if (result.reason) {
+    defaultRuntime.log(`  Reason: ${theme.muted(result.reason)}`);
+  }
 
   if (result.before?.version || result.before?.sha) {
     const before =

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -19,8 +19,8 @@ export type UpdateCommandOptions = {
 };
 
 const STEP_LABELS: Record<string, string> = {
-  "git status": "Checking for uncommitted changes",
-  "git upstream": "Checking upstream branch",
+  "clean check": "Working directory is clean",
+  "upstream check": "Upstream branch exists",
   "git fetch": "Fetching latest changes",
   "git rebase": "Rebasing onto upstream",
   "deps install": "Installing dependencies",
@@ -60,13 +60,8 @@ function createUpdateProgress(enabled: boolean): ProgressController {
 
       const label = getStepLabel(step);
       const duration = theme.muted(`(${formatDuration(step.durationMs)})`);
-
       const icon =
-        step.status === "success"
-          ? theme.success("\u2713")
-          : step.status === "skipped"
-            ? theme.warn("\u25CB")
-            : theme.error("\u2717");
+        step.exitCode === 0 ? theme.success("\u2713") : theme.error("\u2717");
 
       currentSpinner.stop(`${icon} ${label} ${duration}`);
       currentSpinner = null;

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -64,6 +64,15 @@ function createUpdateProgress(enabled: boolean): ProgressController {
 
       currentSpinner.stop(`${icon} ${label} ${duration}`);
       currentSpinner = null;
+
+      if (step.exitCode !== 0 && step.stderrTail) {
+        const lines = step.stderrTail.split("\n").slice(-10);
+        for (const line of lines) {
+          if (line.trim()) {
+            defaultRuntime.log(`    ${theme.error(line)}`);
+          }
+        }
+      }
     },
   };
 

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -61,11 +61,14 @@ function createUpdateProgress(enabled: boolean): ProgressController {
       const label = getStepLabel(step);
       const duration = theme.muted(`(${formatDuration(step.durationMs)})`);
 
-      if (step.exitCode === 0) {
-        currentSpinner.stop(`${theme.success("\u2713")} ${label} ${duration}`);
-      } else {
-        currentSpinner.stop(`${theme.error("\u2717")} ${label} ${duration}`);
-      }
+      const icon =
+        step.status === "success"
+          ? theme.success("\u2713")
+          : step.status === "skipped"
+            ? theme.warn("\u25CB")
+            : theme.error("\u2717");
+
+      currentSpinner.stop(`${icon} ${label} ${duration}`);
       currentSpinner = null;
     },
   };

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -173,7 +173,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     return;
   }
 
-  const showProgress = !opts.json && process.stderr.isTTY;
+  const showProgress = !opts.json && process.stdout.isTTY;
 
   if (!opts.json) {
     defaultRuntime.log(theme.heading("Updating Clawdbot..."));

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -31,8 +31,7 @@ const STEP_LABELS: Record<string, string> = {
 };
 
 function getStepLabel(step: UpdateStepInfo): string {
-  const friendlyLabel = STEP_LABELS[step.name] ?? step.name;
-  return `${friendlyLabel} (${step.name})`;
+  return STEP_LABELS[step.name] ?? step.name;
 }
 
 type ProgressController = {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -305,15 +305,17 @@ export async function runGatewayUpdate(
     const beforeSha = beforeShaResult.stdout.trim() || null;
     const beforeVersion = await readPackageVersion(gitRoot);
 
-    const cleanCheck = await runStep(
+    const statusCheck = await runStep(
       step(
-        "clean check",
-        ["sh", "-c", `test -z "$(git -C '${gitRoot}' status --porcelain)"`],
+        "Running git status",
+        ["git", "-C", gitRoot, "status", "--porcelain"],
         gitRoot,
       ),
     );
-    steps.push(cleanCheck);
-    if (cleanCheck.exitCode !== 0) {
+    steps.push(statusCheck);
+    const hasUncommittedChanges =
+      statusCheck.stdoutTail && statusCheck.stdoutTail.trim().length > 0;
+    if (hasUncommittedChanges) {
       return {
         status: "skipped",
         mode: "git",

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -307,7 +307,7 @@ export async function runGatewayUpdate(
 
     const statusCheck = await runStep(
       step(
-        "Running git status",
+        "clean check",
         ["git", "-C", gitRoot, "status", "--porcelain"],
         gitRoot,
       ),

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -40,6 +40,7 @@ export type UpdateStepInfo = {
 export type UpdateStepCompletion = UpdateStepInfo & {
   durationMs: number;
   exitCode: number | null;
+  stderrTail?: string | null;
 };
 
 export type UpdateStepProgress = {
@@ -199,10 +200,13 @@ async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
   const result = await runCommand(argv, { cwd, timeoutMs, env });
   const durationMs = Date.now() - started;
 
+  const stderrTail = trimLogTail(result.stderr, MAX_LOG_CHARS);
+
   progress?.onStepComplete?.({
     ...stepInfo,
     durationMs,
     exitCode: result.code,
+    stderrTail,
   });
 
   return {


### PR DESCRIPTION
## Summary
- Add progress spinner that shows each update step (git stash, git pull, pnpm install, etc.) as it runs
- Fix spinner to start immediately when `delayMs` is 0
- Show stderr output for failed steps to aid debugging
- Display skipped status with warning indicator when repo is dirty
- Simplify progress handling with proper exit codes

## Changes
- `src/cli/progress.ts`: Fix spinner immediate start behavior
- `src/cli/update-cli.ts`: Integrate live step progress display
- `src/infra/update-runner.ts`: Refactor to emit step events with proper status tracking