### PR TITLE
fix(agent): use session key agentId for transcript path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixes
 - CLI/Update: preserve base environment when passing overrides to update subprocesses. (#713) — thanks @danielz1z.
 - Agents: treat message tool errors as failures so fallback replies still send; require `to` + `message` for `action=send`. (#717) — thanks @theglove44.
+- Agents: route subagent transcripts to the target agent sessions directory and add regression coverage. (#708) — thanks @xMikeMickelson.
+- Agents/Tools: preserve action enums when flattening tool schemas. (#708) — thanks @xMikeMickelson.
 
 ## 2026.1.10
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -127,6 +127,18 @@ function extractEnumValues(schema: unknown): unknown[] | undefined {
   const record = schema as Record<string, unknown>;
   if (Array.isArray(record.enum)) return record.enum;
   if ("const" in record) return [record.const];
+  const variants = Array.isArray(record.anyOf)
+    ? record.anyOf
+    : Array.isArray(record.oneOf)
+      ? record.oneOf
+      : null;
+  if (variants) {
+    const values = variants.flatMap((variant) => {
+      const extracted = extractEnumValues(variant);
+      return extracted ?? [];
+    });
+    return values.length > 0 ? values : undefined;
+  }
   return undefined;
 }
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -62,7 +62,6 @@ const AllMessageActions = [
   "ban",
 ];
 
-
 const MessageToolCommonSchema = {
   provider: Type.Optional(Type.String()),
   media: Type.Optional(Type.String()),
@@ -379,8 +378,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         const mediaUrl =
           readStringParam(params, "media", { trim: false }) ??
           (parsed.mediaUrls?.[0] || parsed.mediaUrl);
-        const replyTo =
-          readStringParam(params, "replyTo") ?? parsed.replyToId;
+        const replyTo = readStringParam(params, "replyTo") ?? parsed.replyToId;
         const threadId = readStringParam(params, "threadId");
         const buttons = params.buttons;
         const gifPlayback =
@@ -844,8 +842,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         const mediaUrl =
           readStringParam(params, "media", { trim: false }) ??
           (parsed.mediaUrls?.[0] || parsed.mediaUrl);
-        const replyTo =
-          readStringParam(params, "replyTo") ?? parsed.replyToId;
+        const replyTo = readStringParam(params, "replyTo") ?? parsed.replyToId;
         return await handleDiscordAction(
           {
             action: "threadReply",

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -416,7 +416,9 @@ export async function agentCommand(
       catalog: catalogForThinking,
     });
   }
-  const sessionFile = resolveSessionFilePath(sessionId, sessionEntry);
+  const sessionFile = resolveSessionFilePath(sessionId, sessionEntry, {
+    agentId: sessionAgentId,
+  });
 
   const startedAt = Date.now();
   let lifecycleEnded = false;

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -7,6 +7,7 @@ import {
   buildGroupDisplayName,
   deriveSessionKey,
   loadSessionStore,
+  resolveSessionFilePath,
   resolveSessionKey,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptsDir,
@@ -178,6 +179,31 @@ describe("sessions", () => {
           "main",
           "sessions",
           "sess-1-topic-123.jsonl",
+        ),
+      );
+    } finally {
+      if (prev === undefined) {
+        delete process.env.CLAWDBOT_STATE_DIR;
+      } else {
+        process.env.CLAWDBOT_STATE_DIR = prev;
+      }
+    }
+  });
+
+  it("uses agent id when resolving session file fallback paths", () => {
+    const prev = process.env.CLAWDBOT_STATE_DIR;
+    process.env.CLAWDBOT_STATE_DIR = "/custom/state";
+    try {
+      const sessionFile = resolveSessionFilePath("sess-2", undefined, {
+        agentId: "codex",
+      });
+      expect(sessionFile).toBe(
+        path.join(
+          path.resolve("/custom/state"),
+          "agents",
+          "codex",
+          "sessions",
+          "sess-2.jsonl",
         ),
       );
     } finally {


### PR DESCRIPTION
## Summary
- Fix cross-agent subagent transcript path resolution
- Transcripts were written to spawner's agent directory instead of target agent's directory

## Problem
When agent A spawns a subagent targeting agent B (e.g., main spawning codex), the transcript was written to agent A's directory instead of agent B's:
- Session key: `agent:codex:subagent:...`
- Transcript written to: `agents/main/sessions/` ❌
- Expected location: `agents/codex/sessions/` ✓

This caused `chat.history` to fail finding subagent responses since it looked in the wrong directory.

## Fix
Pass `sessionAgentId` (extracted from session key) to `resolveSessionFilePath` so transcripts are written to the correct agent's session directory.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All tests pass (`pnpm test` - 2399 tests)
- [x] Manual test: agent-to-agent spawn now writes transcripts to correct directory

🤖 Generated with [Claude Code](https://claude.ai/code)