### PR TITLE
Add Deepgram transcription support

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   "dependencies": {
     "@buape/carbon": "0.0.0-beta-20260110172854",
     "@clack/prompts": "^0.11.0",
+    "@deepgram/sdk": "^4.11.3",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@deepgram/sdk':
+        specifier: ^4.11.3
+        version: 4.11.3
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.39.2)
@@ -528,6 +531,14 @@ packages:
 
   '@cloudflare/workers-types@4.20251205.0':
     resolution: {integrity: sha512-7pup7fYkuQW5XD8RUS/vkxF9SXlrGyCXuZ4ro3uVQvca/GTeSa+8bZ8T4wbq1Aea5lmLIGSlKbhl2msME7bRBA==}
+
+  '@deepgram/captions@1.2.0':
+    resolution: {integrity: sha512-8B1C/oTxTxyHlSFubAhNRgCbQ2SQ5wwvtlByn8sDYZvdDtdn/VE2yEPZ4BvUnrKWmsbTQY6/ooLV+9Ka2qmDSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@deepgram/sdk@4.11.3':
+    resolution: {integrity: sha512-7NujHlAX6ciBeYAkxkhE7LCZWy0JK3nvFsV2VwVZIUiFR40ykhep5fxYd7ZovM+PbNyCoM8GKNMHu9MeQ5/wTQ==}
+    engines: {node: '>=18.0.0'}
 
   '@discordjs/voice@0.19.0':
     resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
@@ -2010,6 +2021,9 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@24.10.7':
     resolution: {integrity: sha512-+054pVMzVTmRQV8BhpGv3UyfZ2Llgl8rdpDTon+cUH9+na0ncBVXj3wTUKh14+Kiz18ziM3b4ikpP5/Pc0rQEQ==}
 
@@ -2447,6 +2461,9 @@ packages:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
@@ -2471,6 +2488,9 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2483,6 +2503,10 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -4083,6 +4107,9 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -4861,6 +4888,23 @@ snapshots:
 
   '@cloudflare/workers-types@4.20251205.0':
     optional: true
+
+  '@deepgram/captions@1.2.0':
+    dependencies:
+      dayjs: 1.11.19
+
+  '@deepgram/sdk@4.11.3':
+    dependencies:
+      '@deepgram/captions': 1.2.0
+      '@types/node': 18.19.130
+      cross-fetch: 3.2.0
+      deepmerge: 4.3.1
+      events: 3.3.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
 
   '@discordjs/voice@0.19.0':
     dependencies:
@@ -6344,6 +6388,10 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@24.10.7':
     dependencies:
       undici-types: 7.16.0
@@ -6861,6 +6909,12 @@ snapshots:
 
   croner@9.1.0: {}
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-fetch@4.1.0:
     dependencies:
       node-fetch: 2.7.0
@@ -6889,12 +6943,16 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  dayjs@1.11.19: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-extend@0.6.0:
     optional: true
+
+  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -8721,6 +8779,8 @@ snapshots:
   uhyphen@0.2.0: {}
 
   uint8array-extras@1.5.0: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
 

--- a/src/auto-reply/transcription-deepgram.ts
+++ b/src/auto-reply/transcription-deepgram.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import { createClient } from "@deepgram/sdk";
+import type { DeepgramTranscriptionConfig } from "../config/types.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+
+export async function transcribeWithDeepgram(
+  mediaPath: string,
+  config: DeepgramTranscriptionConfig | undefined,
+  timeoutMs: number,
+): Promise<{ text: string } | undefined> {
+  const apiKey = config?.apiKey ?? process.env.DEEPGRAM_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Deepgram API key required: set tools.audio.transcription.deepgram.apiKey or DEEPGRAM_API_KEY env",
+    );
+  }
+
+  const deepgram = createClient(apiKey);
+  const audioBuffer = await fs.readFile(mediaPath);
+
+  if (shouldLogVerbose()) {
+    logVerbose(
+      `Transcribing ${(audioBuffer.length / 1024).toFixed(1)}KB audio with Deepgram (model: ${config?.model ?? "nova-3"})`,
+    );
+  }
+
+  const transcribePromise = deepgram.listen.prerecorded.transcribeFile(audioBuffer, {
+    model: config?.model ?? "nova-3",
+    language: config?.detectLanguage ? undefined : (config?.language ?? "en"),
+    detect_language: config?.detectLanguage ?? false,
+    punctuate: config?.punctuate ?? true,
+    smart_format: config?.smartFormat ?? true,
+  });
+
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("Deepgram transcription timed out")), timeoutMs),
+  );
+
+  const { result, error } = await Promise.race([transcribePromise, timeoutPromise]);
+
+  if (error) {
+    throw new Error(`Deepgram API error: ${error.message}`);
+  }
+
+  const transcript = result?.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? "";
+
+  if (!transcript.trim()) {
+    return undefined;
+  }
+
+  if (shouldLogVerbose()) {
+    logVerbose(
+      `Deepgram transcript: "${transcript.slice(0, 100)}${transcript.length > 100 ? "..." : ""}"`,
+    );
+  }
+
+  return { text: transcript };
+}

--- a/src/auto-reply/transcription.ts
+++ b/src/auto-reply/transcription.ts
@@ -1,0 +1,107 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { runExec } from "../process/exec.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { applyTemplate, type MsgContext } from "./templating.js";
+import { transcribeWithDeepgram } from "./transcription-deepgram.js";
+
+const AUDIO_TRANSCRIPTION_BINARY = "whisper";
+
+export function isAudio(mediaType?: string | null) {
+  return Boolean(mediaType?.startsWith("audio"));
+}
+
+export function hasAudioTranscriptionConfig(cfg: ClawdbotConfig): boolean {
+  const transcription = cfg.tools?.audio?.transcription;
+  if (transcription) {
+    if (transcription.args?.length) return true;
+    if (transcription.provider === "deepgram") {
+      return Boolean(transcription.deepgram?.apiKey || process.env.DEEPGRAM_API_KEY);
+    }
+    if (transcription.provider === "openai") return true;
+  }
+  return Boolean(cfg.audio?.transcription?.command?.length);
+}
+
+export async function transcribeInboundAudio(
+  cfg: ClawdbotConfig,
+  ctx: MsgContext,
+  runtime: RuntimeEnv,
+): Promise<{ text: string } | undefined> {
+  const toolTranscriber = cfg.tools?.audio?.transcription;
+  const legacyTranscriber = cfg.audio?.transcription;
+
+  const provider = toolTranscriber?.provider ?? "command";
+  const hasToolTranscriber =
+    provider === "deepgram" || provider === "openai" || Boolean(toolTranscriber?.args?.length);
+
+  if (!hasToolTranscriber && !legacyTranscriber?.command?.length) {
+    return undefined;
+  }
+
+  const timeoutMs = Math.max(
+    (toolTranscriber?.timeoutSeconds ?? legacyTranscriber?.timeoutSeconds ?? 45) * 1000,
+    1_000,
+  );
+
+  let tmpPath: string | undefined;
+  let mediaPath = ctx.MediaPath;
+
+  try {
+    if (!mediaPath && ctx.MediaUrl) {
+      const res = await fetch(ctx.MediaUrl);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const arrayBuf = await res.arrayBuffer();
+      const buffer = Buffer.from(arrayBuf);
+      tmpPath = path.join(os.tmpdir(), `clawdbot-audio-${crypto.randomUUID()}.ogg`);
+      await fs.writeFile(tmpPath, buffer);
+      mediaPath = tmpPath;
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `Downloaded audio for transcription (${(buffer.length / (1024 * 1024)).toFixed(2)}MB) -> ${tmpPath}`,
+        );
+      }
+    }
+    if (!mediaPath) return undefined;
+
+    switch (provider) {
+      case "deepgram":
+        return await transcribeWithDeepgram(mediaPath, toolTranscriber?.deepgram, timeoutMs);
+
+      case "openai":
+        runtime.error?.("OpenAI transcription provider not yet implemented");
+        return undefined;
+
+      default: {
+        const templCtx: MsgContext = { ...ctx, MediaPath: mediaPath };
+        const argv = toolTranscriber?.args?.length
+          ? [AUDIO_TRANSCRIPTION_BINARY, ...(toolTranscriber.args ?? [])].map((part, index) =>
+              index === 0 ? part : applyTemplate(part, templCtx),
+            )
+          : (legacyTranscriber?.command ?? []).map((part) => applyTemplate(part, templCtx));
+        if (shouldLogVerbose()) {
+          logVerbose(`Transcribing audio via command: ${argv.join(" ")}`);
+        }
+        const { stdout } = await runExec(argv[0], argv.slice(1), {
+          timeoutMs,
+          maxBuffer: 5 * 1024 * 1024,
+        });
+        const text = stdout.trim();
+        if (!text) return undefined;
+        return { text };
+      }
+    }
+  } catch (err) {
+    runtime.error?.(`Audio transcription failed: ${String(err)}`);
+    return undefined;
+  } finally {
+    if (tmpPath) {
+      void fs.unlink(tmpPath).catch(() => {});
+    }
+  }
+}

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -164,6 +164,24 @@ export type MemorySearchConfig = {
   };
 };
 
+export type TranscriptionProvider = "command" | "deepgram" | "openai";
+
+export type DeepgramTranscriptionConfig = {
+  apiKey?: string;
+  model?: string;
+  language?: string;
+  detectLanguage?: boolean;
+  punctuate?: boolean;
+  smartFormat?: boolean;
+};
+
+export type TranscriptionConfig = {
+  provider?: TranscriptionProvider;
+  args?: string[];
+  deepgram?: DeepgramTranscriptionConfig;
+  timeoutSeconds?: number;
+};
+
 export type ToolsConfig = {
   /** Base tool profile applied before allow/deny lists. */
   profile?: ToolProfileId;
@@ -214,6 +232,9 @@ export type ToolsConfig = {
         timeoutSeconds?: number;
       };
     };
+  };
+  audio?: {
+    transcription?: TranscriptionConfig;
   };
   media?: MediaToolsConfig;
   /** Message tool configuration. */


### PR DESCRIPTION
Adds Deepgram as a native transcription provider for voice messages.

**Usage:**
```json
{
  "tools": {
    "audio": {
      "transcription": {
        "provider": "deepgram",
        "deepgram": {
          "model": "nova-3",
          "language": "en"
        }
      }
    }
  }
}
```

Or just set `DEEPGRAM_API_KEY` env var.

Tested with Telegram voice messages.