### PR TITLE
Add calendar event color documentation to gog skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - macOS: prompt to install the global `clawdbot` CLI when missing in local mode; install via `clawd.bot/install-cli.sh` (no onboarding) and use external launchd/CLI instead of the embedded gateway runtime.
+- Docs: add gog calendar event color IDs from `gog calendar colors`. (#715) — thanks @mjrussell.
 
 ## 2026.1.10
 

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -35,18 +35,18 @@ Common commands
 Calendar Colors
 - Use `gog calendar colors` to see all available event colors (IDs 1-11)
 - Add colors to events with `--event-color <id>` flag
-- Event color IDs:
-  - 1: Lavender (#a4bdfc)
-  - 2: Sage (#7ae7bf)
-  - 3: Grape (#dbadff)
-  - 4: Flamingo (#ff887c)
-  - 5: Banana (#fbd75b)
-  - 6: Tangerine (#ffb878)
-  - 7: Peacock (#46d6db)
-  - 8: Graphite (#e1e1e1)
-  - 9: Blueberry (#5484ed)
-  - 10: Basil (#51b749)
-  - 11: Tomato (#dc2127)
+- Event color IDs (from `gog calendar colors` output):
+  - 1: #a4bdfc
+  - 2: #7ae7bf
+  - 3: #dbadff
+  - 4: #ff887c
+  - 5: #fbd75b
+  - 6: #ffb878
+  - 7: #46d6db
+  - 8: #e1e1e1
+  - 9: #5484ed
+  - 10: #51b749
+  - 11: #dc2127
 
 Notes
 - Set `GOG_ACCOUNT=you@gmail.com` to avoid repeating `--account`.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -17,7 +17,11 @@ Setup (once)
 Common commands
 - Gmail search: `gog gmail search 'newer_than:7d' --max 10`
 - Gmail send: `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
-- Calendar: `gog calendar events <calendarId> --from <iso> --to <iso>`
+- Calendar list events: `gog calendar events <calendarId> --from <iso> --to <iso>`
+- Calendar create event: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>`
+- Calendar create with color: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7`
+- Calendar update event: `gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4`
+- Calendar show colors: `gog calendar colors`
 - Drive search: `gog drive search "query" --max 10`
 - Contacts: `gog contacts list --max 20`
 - Sheets get: `gog sheets get <sheetId> "Tab!A1:D10" --json`
@@ -27,6 +31,22 @@ Common commands
 - Sheets metadata: `gog sheets metadata <sheetId> --json`
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
+
+Calendar Colors
+- Use `gog calendar colors` to see all available event colors (IDs 1-11)
+- Add colors to events with `--event-color <id>` flag
+- Event color IDs:
+  - 1: Lavender (#a4bdfc)
+  - 2: Sage (#7ae7bf)
+  - 3: Grape (#dbadff)
+  - 4: Flamingo (#ff887c)
+  - 5: Banana (#fbd75b)
+  - 6: Tangerine (#ffb878)
+  - 7: Peacock (#46d6db)
+  - 8: Graphite (#e1e1e1)
+  - 9: Blueberry (#5484ed)
+  - 10: Basil (#51b749)
+  - 11: Tomato (#dc2127)
 
 Notes
 - Set `GOG_ACCOUNT=you@gmail.com` to avoid repeating `--account`.


### PR DESCRIPTION
Adds documentation for the `--event-color` flag when creating and updating calendar events.

## Changes
- Added examples of creating and updating events with colors
- Added color ID reference table with color names and hex codes (1-11)
- Updated command list to show color-related flags

## Context
The gog CLI (v0.6.0+) supports setting event colors via the `--event-color` flag, but this wasn't documented in the skill.