### PR TITLE
Agents: prevent silent message-tool drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - CLI/Update: preserve base environment when passing overrides to update subprocesses. (#713) — thanks @danielz1z.
+- Agents: treat message tool errors as failures so fallback replies still send; require `to` + `message` for `action=send`. (#717) — thanks @theglove44.
 
 ## 2026.1.10
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -313,6 +313,7 @@ export function buildAgentSystemPrompt(params: {
           "",
           "### message tool",
           "- Use `message` for proactive sends + provider actions (polls, reactions, etc.).",
+          "- For `action=send`, include `to` and `message`.",
           "- If multiple providers are configured, pass `provider` (whatsapp|telegram|discord|slack|signal|imessage|msteams).",
           telegramInlineButtonsEnabled
             ? "- Telegram: inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data}]]` (callback_data routes back as a user message)."


### PR DESCRIPTION
## Issue
Discord replies can be silently dropped when the message tool is called without `to`. The tool fails, but the agent suppresses the fallback reply.

## Investigation
Logs show `message failed: to required` followed by `Skipping block reply - already sent via messaging tool`, so the send failure is treated as success.

## Root Cause
The message tool schema + system prompt didn’t require `to` for `action=send`, and tool errors returned `{status:"error"}` without flipping `isError`, so dedupe logic treated failures as successful sends.

## Solution
Treat tool results with `{status:"error"|"timeout"}` as failures to keep fallback replies, and require `to` + `message` for `action=send` in the tool schema; clarify prompt guidance.

## Tests
Not run (not requested).