### PR TITLE
chore: set minimum release age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026.1.11 (Unreleased)
 
 ### Changes
+- Build: set pnpm minimum release age to 2880 minutes (2 days). (#718) — thanks @dan-dr.
 - macOS: prompt to install the global `clawdbot` CLI when missing in local mode; install via `clawd.bot/install-cli.sh` (no onboarding) and use external launchd/CLI instead of the embedded gateway runtime.
 - Docs: add gog calendar event color IDs from `gog calendar colors`. (#715) — thanks @mjrussell.
 - Cron/CLI: trim model overrides on cron edits and document main-session guidance. (#711) — thanks @mjrussell.

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "wireit": "^0.14.12"
   },
   "pnpm": {
+    "minimumReleaseAge": 2880,
     "overrides": {
       "@sinclair/typebox": "0.34.47"
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,5 +19,8 @@
     "playwright": "^1.57.0",
     "typescript": "^5.9.3",
     "vitest": "4.0.16"
+  },
+  "pnpm": {
+    "minimumReleaseAge": 2880
   }
 }


### PR DESCRIPTION
Set pnpm minimumReleaseAge to 2880 minutes (2 days) in root and ui.