### PR TITLE
feat(bash): add host-only /bash slash command

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -743,8 +743,10 @@ Controls how chat commands are enabled across connectors.
 ```json5
 {
   commands: {
-    native: false,          // register native commands when supported
+    native: "auto",         // register native commands when supported (auto)
     text: true,             // parse slash commands in chat messages
+    bash: false,            // allow ! (alias: /bash) (host-only; requires tools.elevated allowlists)
+    bashForegroundMs: 2000, // bash foreground window (0 backgrounds immediately)
     config: false,          // allow /config (writes to disk)
     debug: false,           // allow /debug (runtime-only overrides)
     restart: false,         // allow /restart + gateway restart tool
@@ -758,6 +760,8 @@ Notes:
 - `commands.text: false` disables parsing chat messages for commands.
 - `commands.native: "auto"` (default) turns on native commands for Discord/Telegram and leaves Slack off; unsupported providers stay text-only.
 - Set `commands.native: true|false` to force all, or override per provider with `discord.commands.native`, `telegram.commands.native`, `slack.commands.native` (bool or `"auto"`). `false` clears previously registered commands on Discord/Telegram at startup; Slack commands are managed in the Slack app.
+- `commands.bash: true` enables `! <cmd>` to run host shell commands (`/bash <cmd>` also works as an alias). Requires `tools.elevated.enabled` and allowlisting the sender in `tools.elevated.allowFrom.<provider>`.
+- `commands.bashForegroundMs` controls how long bash waits before backgrounding. While a bash job is running, new `! <cmd>` requests are rejected (one at a time).
 - `commands.config: true` enables `/config` (reads/writes `clawdbot.json`).
 - `commands.debug: true` enables `/debug` (runtime-only overrides).
 - `commands.restart: true` enables `/restart` and the gateway tool restart action.

--- a/docs/tools/elevated.md
+++ b/docs/tools/elevated.md
@@ -7,6 +7,7 @@ read_when:
 
 ## What it does
 - Elevated mode allows the exec tool to run with elevated privileges when the feature is available and the sender is approved.
+- The bash chat command (`!`; `/bash` alias) uses the same `tools.elevated` allowlists because it always runs on the host.
 - **Optional for sandboxed agents**: elevated only changes behavior when the agent is running in a sandbox. If the agent already runs unsandboxed, elevated is effectively a no-op.
 - Directive forms: `/elevated on`, `/elevated off`, `/elev on`, `/elev off`.
 - Only `on|off` are accepted; anything else returns a hint and does not change state.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -7,6 +7,7 @@ read_when:
 # Slash commands
 
 Commands are handled by the Gateway. Most commands must be sent as a **standalone** message that starts with `/`.
+The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 
 There are two related systems:
 
@@ -26,6 +27,8 @@ They run immediately, are stripped before the model sees the message, and the re
   commands: {
     native: "auto",
     text: true,
+    bash: false,
+    bashForegroundMs: 2000,
     config: false,
     debug: false,
     restart: false,
@@ -40,6 +43,8 @@ They run immediately, are stripped before the model sees the message, and the re
   - Auto: on for Discord/Telegram; off for Slack (until you add slash commands); ignored for providers without native support.
   - Set `discord.commands.native`, `telegram.commands.native`, or `slack.commands.native` to override per provider (bool or `"auto"`).
   - `false` clears previously registered commands on Discord/Telegram at startup. Slack commands are managed in the Slack app and are not removed automatically.
+- `commands.bash` (default `false`) enables `! <cmd>` to run host shell commands (`/bash <cmd>` is an alias; requires `tools.elevated` allowlists).
+- `commands.bashForegroundMs` (default `2000`) controls how long bash waits before switching to background mode (`0` backgrounds immediately).
 - `commands.config` (default `false`) enables `/config` (reads/writes `clawdbot.json`).
 - `commands.debug` (default `false`) enables `/debug` (runtime-only overrides).
 - `commands.useAccessGroups` (default `true`) enforces allowlists/policies for commands.
@@ -66,9 +71,13 @@ Text + native (when enabled):
 - `/elevated on|off` (alias: `/elev`)
 - `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
+- `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
 
 Text-only:
 - `/compact [instructions]` (see [/concepts/compaction](/concepts/compaction))
+- `! <command>` (host-only; one at a time; use `!poll` + `!stop` for long-running jobs)
+- `!poll` (check output / status; accepts optional `sessionId`; `/bash poll` also works)
+- `!stop` (stop the running bash job; accepts optional `sessionId`; `/bash stop` also works)
 
 Notes:
 - Commands accept an optional `:` between the command and args (e.g. `/think: high`, `/send: on`, `/help:`).

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -251,6 +251,13 @@ export const CHAT_COMMANDS: ChatCommandDefinition[] = (() => {
       textAlias: "/queue",
       acceptsArgs: true,
     }),
+    defineChatCommand({
+      key: "bash",
+      description: "Run host shell commands (host-only).",
+      textAlias: "/bash",
+      scope: "text",
+      acceptsArgs: true,
+    }),
   ];
 
   registerAlias(commands, "status", "/usage");
@@ -314,6 +321,7 @@ export function isCommandEnabled(
 ): boolean {
   if (commandKey === "config") return cfg.commands?.config === true;
   if (commandKey === "debug") return cfg.commands?.debug === true;
+  if (commandKey === "bash") return cfg.commands?.bash === true;
   return true;
 }
 

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -976,6 +976,11 @@ export async function getReplyFromConfig(
       command: inlineCommandContext,
       agentId,
       directives,
+      elevated: {
+        enabled: elevatedEnabled,
+        allowed: elevatedAllowed,
+        failures: elevatedFailures,
+      },
       sessionEntry,
       sessionStore,
       sessionKey,
@@ -1033,6 +1038,11 @@ export async function getReplyFromConfig(
     command,
     agentId,
     directives,
+    elevated: {
+      enabled: elevatedEnabled,
+      allowed: elevatedAllowed,
+      failures: elevatedFailures,
+    },
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -1,0 +1,416 @@
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  getFinishedSession,
+  getSession,
+  markExited,
+} from "../../agents/bash-process-registry.js";
+import { createExecTool } from "../../agents/bash-tools.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
+import { killProcessTree } from "../../agents/shell-utils.js";
+import type { ClawdbotConfig } from "../../config/config.js";
+import { logVerbose } from "../../globals.js";
+import type { MsgContext } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
+import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+
+const CHAT_BASH_SCOPE_KEY = "chat:bash";
+const DEFAULT_FOREGROUND_MS = 2000;
+const MAX_FOREGROUND_MS = 30_000;
+
+type BashRequest =
+  | { action: "help" }
+  | { action: "run"; command: string }
+  | { action: "poll"; sessionId?: string }
+  | { action: "stop"; sessionId?: string };
+
+type ActiveBashJob =
+  | { state: "starting"; startedAt: number; command: string }
+  | {
+      state: "running";
+      sessionId: string;
+      startedAt: number;
+      command: string;
+      watcherAttached: boolean;
+    };
+
+let activeJob: ActiveBashJob | null = null;
+
+function clampNumber(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveForegroundMs(cfg: ClawdbotConfig): number {
+  const raw = cfg.commands?.bashForegroundMs;
+  if (typeof raw !== "number" || Number.isNaN(raw))
+    return DEFAULT_FOREGROUND_MS;
+  return clampNumber(Math.floor(raw), 0, MAX_FOREGROUND_MS);
+}
+
+function formatSessionSnippet(sessionId: string) {
+  const trimmed = sessionId.trim();
+  if (trimmed.length <= 12) return trimmed;
+  return `${trimmed.slice(0, 8)}…`;
+}
+
+function formatOutputBlock(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return "(no output)";
+  return `\`\`\`txt\n${trimmed}\n\`\`\``;
+}
+
+function parseBashRequest(raw: string): BashRequest | null {
+  const trimmed = raw.trimStart();
+  let restSource = "";
+  if (trimmed.toLowerCase().startsWith("/bash")) {
+    const match = trimmed.match(/^\/bash(?:\s*:\s*|\s+|$)([\s\S]*)$/i);
+    if (!match) return null;
+    restSource = match[1] ?? "";
+  } else if (trimmed.startsWith("!")) {
+    restSource = trimmed.slice(1);
+    if (restSource.trimStart().startsWith(":")) {
+      restSource = restSource.trimStart().slice(1);
+    }
+  } else {
+    return null;
+  }
+
+  const rest = restSource.trimStart();
+  if (!rest) return { action: "help" };
+  const tokenMatch = rest.match(/^(\S+)(?:\s+([\s\S]+))?$/);
+  const token = tokenMatch?.[1]?.trim() ?? "";
+  const remainder = tokenMatch?.[2]?.trim() ?? "";
+  const lowered = token.toLowerCase();
+  if (lowered === "poll") {
+    return { action: "poll", sessionId: remainder || undefined };
+  }
+  if (lowered === "stop") {
+    return { action: "stop", sessionId: remainder || undefined };
+  }
+  if (lowered === "help") {
+    return { action: "help" };
+  }
+  return { action: "run", command: rest };
+}
+
+function resolveRawCommandBody(params: {
+  ctx: MsgContext;
+  cfg: ClawdbotConfig;
+  agentId?: string;
+  isGroup: boolean;
+}) {
+  const source =
+    params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body ?? "";
+  const stripped = stripStructuralPrefixes(source);
+  return params.isGroup
+    ? stripMentions(stripped, params.ctx, params.cfg, params.agentId)
+    : stripped;
+}
+
+function getScopedSession(sessionId: string) {
+  const running = getSession(sessionId);
+  if (running && running.scopeKey === CHAT_BASH_SCOPE_KEY) return { running };
+  const finished = getFinishedSession(sessionId);
+  if (finished && finished.scopeKey === CHAT_BASH_SCOPE_KEY)
+    return { finished };
+  return {};
+}
+
+function ensureActiveJobState() {
+  if (!activeJob) return null;
+  if (activeJob.state === "starting") return activeJob;
+  const { running, finished } = getScopedSession(activeJob.sessionId);
+  if (running) return activeJob;
+  if (finished) {
+    activeJob = null;
+    return null;
+  }
+  activeJob = null;
+  return null;
+}
+
+function attachActiveWatcher(sessionId: string) {
+  if (!activeJob || activeJob.state !== "running") return;
+  if (activeJob.sessionId !== sessionId) return;
+  if (activeJob.watcherAttached) return;
+  const { running } = getScopedSession(sessionId);
+  const child = running?.child;
+  if (!child) return;
+  activeJob.watcherAttached = true;
+  child.once("close", () => {
+    if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
+      activeJob = null;
+    }
+  });
+}
+
+function buildUsageReply(): ReplyPayload {
+  return {
+    text: [
+      "⚙️ Usage:",
+      "- ! <command>",
+      "- !poll | ! poll",
+      "- !stop | ! stop",
+      "- /bash ... (alias; same subcommands as !)",
+    ].join("\n"),
+  };
+}
+
+function formatElevatedUnavailableMessage(params: {
+  runtimeSandboxed: boolean;
+  failures: Array<{ gate: string; key: string }>;
+  sessionKey?: string;
+}): string {
+  const lines: string[] = [];
+  lines.push(
+    `elevated is not available right now (runtime=${params.runtimeSandboxed ? "sandboxed" : "direct"}).`,
+  );
+  if (params.failures.length > 0) {
+    lines.push(
+      `Failing gates: ${params.failures
+        .map((f) => `${f.gate} (${f.key})`)
+        .join(", ")}`,
+    );
+  } else {
+    lines.push(
+      "Failing gates: enabled (tools.elevated.enabled / agents.list[].tools.elevated.enabled), allowFrom (tools.elevated.allowFrom.<provider>).",
+    );
+  }
+  lines.push("Fix-it keys:");
+  lines.push("- tools.elevated.enabled");
+  lines.push("- tools.elevated.allowFrom.<provider>");
+  lines.push("- agents.list[].tools.elevated.enabled");
+  lines.push("- agents.list[].tools.elevated.allowFrom.<provider>");
+  if (params.sessionKey) {
+    lines.push(`See: clawdbot sandbox explain --session ${params.sessionKey}`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleBashChatCommand(params: {
+  ctx: MsgContext;
+  cfg: ClawdbotConfig;
+  agentId?: string;
+  sessionKey: string;
+  isGroup: boolean;
+  elevated: {
+    enabled: boolean;
+    allowed: boolean;
+    failures: Array<{ gate: string; key: string }>;
+  };
+}): Promise<ReplyPayload> {
+  if (params.cfg.commands?.bash !== true) {
+    return {
+      text: "⚠️ bash is disabled. Set commands.bash=true to enable.",
+    };
+  }
+
+  const agentId =
+    params.agentId ??
+    resolveSessionAgentId({
+      sessionKey: params.sessionKey,
+      config: params.cfg,
+    });
+
+  if (!params.elevated.enabled || !params.elevated.allowed) {
+    const runtimeSandboxed = resolveSandboxRuntimeStatus({
+      cfg: params.cfg,
+      sessionKey: params.ctx.SessionKey,
+    }).sandboxed;
+    return {
+      text: formatElevatedUnavailableMessage({
+        runtimeSandboxed,
+        failures: params.elevated.failures,
+        sessionKey: params.ctx.SessionKey,
+      }),
+    };
+  }
+
+  const rawBody = resolveRawCommandBody({
+    ctx: params.ctx,
+    cfg: params.cfg,
+    agentId,
+    isGroup: params.isGroup,
+  }).trim();
+  const request = parseBashRequest(rawBody);
+  if (!request) {
+    return { text: "⚠️ Unrecognized bash request." };
+  }
+
+  const liveJob = ensureActiveJobState();
+
+  if (request.action === "help") {
+    return buildUsageReply();
+  }
+
+  if (request.action === "poll") {
+    const sessionId =
+      request.sessionId?.trim() ||
+      (liveJob?.state === "running" ? liveJob.sessionId : "");
+    if (!sessionId) {
+      return { text: "⚙️ No active bash job." };
+    }
+    const { running, finished } = getScopedSession(sessionId);
+    if (running) {
+      attachActiveWatcher(sessionId);
+      const runtimeSec = Math.max(
+        0,
+        Math.floor((Date.now() - running.startedAt) / 1000),
+      );
+      const tail = running.tail || "(no output yet)";
+      return {
+        text: [
+          `⚙️ bash still running (session ${formatSessionSnippet(sessionId)}, ${runtimeSec}s).`,
+          formatOutputBlock(tail),
+          "Hint: !stop (or /bash stop)",
+        ].join("\n"),
+      };
+    }
+    if (finished) {
+      if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
+        activeJob = null;
+      }
+      const exitLabel = finished.exitSignal
+        ? `signal ${String(finished.exitSignal)}`
+        : `code ${String(finished.exitCode ?? 0)}`;
+      const prefix = finished.status === "completed" ? "⚙️" : "⚠️";
+      return {
+        text: [
+          `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,
+          `Exit: ${exitLabel}`,
+          formatOutputBlock(finished.aggregated || finished.tail),
+        ].join("\n"),
+      };
+    }
+    if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
+      activeJob = null;
+    }
+    return {
+      text: `⚙️ No bash session found for ${formatSessionSnippet(sessionId)}.`,
+    };
+  }
+
+  if (request.action === "stop") {
+    const sessionId =
+      request.sessionId?.trim() ||
+      (liveJob?.state === "running" ? liveJob.sessionId : "");
+    if (!sessionId) {
+      return { text: "⚙️ No active bash job." };
+    }
+    const { running } = getScopedSession(sessionId);
+    if (!running) {
+      if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
+        activeJob = null;
+      }
+      return {
+        text: `⚙️ No running bash job found for ${formatSessionSnippet(sessionId)}.`,
+      };
+    }
+    if (!running.backgrounded) {
+      return {
+        text: `⚠️ Session ${formatSessionSnippet(sessionId)} is not backgrounded.`,
+      };
+    }
+    const pid = running.pid ?? running.child?.pid;
+    if (pid) {
+      killProcessTree(pid);
+    }
+    markExited(running, null, "SIGKILL", "failed");
+    if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
+      activeJob = null;
+    }
+    return {
+      text: `⚙️ bash stopped (session ${formatSessionSnippet(sessionId)}).`,
+    };
+  }
+
+  // request.action === "run"
+  if (liveJob) {
+    const label =
+      liveJob.state === "running"
+        ? formatSessionSnippet(liveJob.sessionId)
+        : "starting";
+    return {
+      text: `⚠️ A bash job is already running (${label}). Use !poll / !stop (or /bash poll / /bash stop).`,
+    };
+  }
+
+  const commandText = request.command.trim();
+  if (!commandText) return buildUsageReply();
+
+  activeJob = {
+    state: "starting",
+    startedAt: Date.now(),
+    command: commandText,
+  };
+
+  try {
+    const foregroundMs = resolveForegroundMs(params.cfg);
+    const shouldBackgroundImmediately = foregroundMs <= 0;
+    const timeoutSec =
+      params.cfg.tools?.exec?.timeoutSec ?? params.cfg.tools?.bash?.timeoutSec;
+    const execTool = createExecTool({
+      scopeKey: CHAT_BASH_SCOPE_KEY,
+      allowBackground: true,
+      timeoutSec,
+      elevated: {
+        enabled: params.elevated.enabled,
+        allowed: params.elevated.allowed,
+        defaultLevel: "on",
+      },
+    });
+    const result = await execTool.execute("chat-bash", {
+      command: commandText,
+      background: shouldBackgroundImmediately,
+      yieldMs: shouldBackgroundImmediately ? undefined : foregroundMs,
+      timeout: timeoutSec,
+      elevated: true,
+    });
+
+    if (result.details?.status === "running") {
+      const sessionId = result.details.sessionId;
+      activeJob = {
+        state: "running",
+        sessionId,
+        startedAt: result.details.startedAt,
+        command: commandText,
+        watcherAttached: false,
+      };
+      attachActiveWatcher(sessionId);
+      const snippet = formatSessionSnippet(sessionId);
+      logVerbose(`Started bash session ${snippet}: ${commandText}`);
+      return {
+        text: `⚙️ bash started (session ${sessionId}). Still running; use !poll / !stop (or /bash poll / /bash stop).`,
+      };
+    }
+
+    // Completed in foreground.
+    activeJob = null;
+    const exitCode =
+      result.details?.status === "completed" ? result.details.exitCode : 0;
+    const output =
+      result.details?.status === "completed"
+        ? result.details.aggregated
+        : result.content
+            .map((chunk) => (chunk.type === "text" ? chunk.text : ""))
+            .join("\n");
+    return {
+      text: [
+        `⚙️ bash: ${commandText}`,
+        `Exit: ${exitCode}`,
+        formatOutputBlock(output || "(no output)"),
+      ].join("\n"),
+    };
+  } catch (err) {
+    activeJob = null;
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: [`⚠️ bash failed: ${commandText}`, formatOutputBlock(message)].join(
+        "\n",
+      ),
+    };
+  }
+}
+
+export function resetBashChatCommandForTests() {
+  activeJob = null;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -153,6 +153,8 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.cliBackends": "CLI Backends",
   "commands.native": "Native Commands",
   "commands.text": "Text Commands",
+  "commands.bash": "Allow Bash Chat Command",
+  "commands.bashForegroundMs": "Bash Foreground Window (ms)",
   "commands.config": "Allow /config",
   "commands.debug": "Allow /debug",
   "commands.restart": "Allow Restart",
@@ -287,6 +289,10 @@ const FIELD_HELP: Record<string, string> = {
   "commands.native":
     "Register native commands with connectors that support it (Discord/Slack/Telegram).",
   "commands.text": "Allow text command parsing (slash commands only).",
+  "commands.bash":
+    "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
+  "commands.bashForegroundMs":
+    "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
   "commands.config":
     "Allow /config chat command to read/write config on disk (default: false).",
   "commands.debug":

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1229,6 +1229,10 @@ export type CommandsConfig = {
   native?: NativeCommandsSetting;
   /** Enable text command parsing (default: true). */
   text?: boolean;
+  /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
+  bash?: boolean;
+  /** How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately). */
+  bashForegroundMs?: number;
   /** Allow /config command (default: false). */
   config?: boolean;
   /** Allow /debug command (default: false). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -724,6 +724,8 @@ const CommandsSchema = z
   .object({
     native: NativeCommandsSettingSchema.optional().default("auto"),
     text: z.boolean().optional(),
+    bash: z.boolean().optional(),
+    bashForegroundMs: z.number().int().min(0).max(30_000).optional(),
     config: z.boolean().optional(),
     debug: z.boolean().optional(),
     restart: z.boolean().optional(),


### PR DESCRIPTION
### What
Adds a new chat slash command for trusted operators: `/bash <command>`.

- Runs a host shell command from chat **without** invoking the LLM (command-only; does not interfere with agent runs).
- Long-running commands background after a configurable foreground window and can be controlled via chat.
- Enforces **one /bash job at a time** (global) to keep UX simple; additional `/bash <cmd>` requests return "already running".

### Commands
- `/bash <command>`
- `/bash poll` (optionally `/bash poll <sessionId>`)
- `/bash stop` (optionally `/bash stop <sessionId>`)

### Config / Security
- Feature gate: `commands.bash: true` (default off)
- Foreground window: `commands.bashForegroundMs` (0 backgrounds immediately)
- Host execution is gated by existing elevated allowlists:
  - `tools.elevated.enabled`
  - `tools.elevated.allowFrom.<provider>`

### Docs
- Updates docs for `/bash` and the new config keys.

### Tests
- `pnpm lint`
- `pnpm test src/auto-reply/reply/commands.test.ts src/docs/slash-commands-doc.test.ts`
