### PR TITLE
fix: externalize playwright-core in Bun build for browser automation

### DIFF
--- a/docs/mac/bun.md
+++ b/docs/mac/bun.md
@@ -42,8 +42,8 @@ Important bundler flags:
 - `--compile`: produces a standalone executable
 - `--bytecode`: reduces startup time / parsing overhead (works here)
 - externals:
-  - `-e electron`
-  - Reason: avoid bundling Electron stubs in the relay binary
+  - `-e electron` – avoid bundling Electron stubs
+  - `-e playwright-core` – load from `node_modules/` at runtime (required for browser automation)
 
 Version injection:
 - `--define "__CLAWDIS_VERSION__=\"<pkg version>\""`

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -112,6 +112,7 @@ if [[ "${SKIP_GATEWAY_PACKAGE:-0}" != "1" ]]; then
 	    --bytecode \
 	    --outfile "$RELAY_OUT" \
 	    -e electron \
+	    -e playwright-core \
 	    --define "__CLAWDIS_VERSION__=\\\"$PKG_VERSION\\\""
 	  chmod +x "$RELAY_OUT"
 
@@ -126,6 +127,25 @@ if [[ "${SKIP_GATEWAY_PACKAGE:-0}" != "1" ]]; then
   echo "🧠 Copying bundled skills"
   rm -rf "$RELAY_DIR/skills"
   cp -R "$ROOT_DIR/skills" "$RELAY_DIR/skills"
+
+  echo "🎭 Bundling playwright-core for browser automation"
+  rm -rf "$RELAY_DIR/node_modules"
+  mkdir -p "$RELAY_DIR/node_modules/playwright-core"
+  if [ -d "$ROOT_DIR/node_modules/playwright-core" ]; then
+    cp -R "$ROOT_DIR/node_modules/playwright-core/"* "$RELAY_DIR/node_modules/playwright-core/"
+    echo "✓ playwright-core bundled successfully"
+  else
+    echo "WARN: playwright-core not found at $ROOT_DIR/node_modules/playwright-core (browser actions will be unavailable)" >&2
+  fi
+
+  echo "🌐 Bundling chromium-bidi for CDP protocol"
+  if [ -d "$ROOT_DIR/node_modules/chromium-bidi" ]; then
+    mkdir -p "$RELAY_DIR/node_modules/chromium-bidi"
+    cp -R "$ROOT_DIR/node_modules/chromium-bidi/"* "$RELAY_DIR/node_modules/chromium-bidi/"
+    echo "✓ chromium-bidi bundled successfully"
+  else
+    echo "WARN: chromium-bidi not found at $ROOT_DIR/node_modules/chromium-bidi (continuing)" >&2
+  fi
 
   echo "📄 Writing embedded runtime package.json (Pi compatibility)"
   cat > "$RELAY_DIR/package.json" <<JSON


### PR DESCRIPTION
## Problem
The `clawdis_browser` tool returns HTTP 501 "Playwright is not available in this gateway build" when trying to use navigate/act actions.

## Root Cause
The Bun build script bundles `playwright-core` into the compiled relay binary. When Bun bundles a module, the dynamic `import("./pw-ai.js")` can't properly load `playwright-core` because the module resolution points to the bundled (incomplete) version.

## Solution
- Add `-e playwright-core` to the Bun build command to externalize the module
- Copy `playwright-core` and `chromium-bidi` to `Relay/node_modules/` at build time
- Bun resolves the external module from the adjacent `node_modules` directory at runtime

## Changes
- `scripts/package-mac-app.sh`: Added `-e playwright-core` and module copy logic
- `docs/mac/bun.md`: Updated documentation

## Testing
After rebuild, browser automation actions (navigate, click, type, etc.) work via Playwright CDP connection on port 18792.