### PR TITLE
Fix docker-setup.sh crash with optional env vars under set -u

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Gateway/WebChat: include handshake validation details in the WebSocket close reason for easier debugging.
 - Gateway/Auth: send invalid connect responses before closing the handshake; stabilize invalid-connect auth test.
 - Doctor: surface plugin diagnostics in the report.
+- Docker: tolerate unset optional env vars in docker-setup.sh under strict mode. (#725) — thanks @petradonka.
 - CLI/Update: preserve base environment when passing overrides to update subprocesses. (#713) — thanks @danielz1z.
 - Agents: treat message tool errors as failures so fallback replies still send; require `to` + `message` for `action=send`. (#717) — thanks @theglove44.
 - Agents: route subagent transcripts to the target agent sessions directory and add regression coverage. (#708) — thanks @xMikeMickelson.

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -132,7 +132,7 @@ upsert_env() {
       local replaced=false
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
-          printf '%s=%s\n' "$k" "${!k}" >>"$tmp"
+          printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
           seen["$k"]=1
           replaced=true
           break
@@ -146,7 +146,7 @@ upsert_env() {
 
   for k in "${keys[@]}"; do
     if [[ -z "${seen[$k]:-}" ]]; then
-      printf '%s=%s\n' "$k" "${!k}" >>"$tmp"
+      printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done
 


### PR DESCRIPTION
## Fix docker-setup.sh crash with optional env vars under `set -u`

### Problem

`docker-setup.sh` runs with `set -euo pipefail` and uses indirect variable expansion (`${!k}`) in `upsert_env()` when writing values to `.env`.

Several variables passed to `upsert_env` are documented as **optional** (e.g. `CLAWDBOT_EXTRA_MOUNTS`, `CLAWDBOT_HOME_VOLUME`, `CLAWDBOT_DOCKER_APT_PACKAGES`). When these variables are **unset** on a clean system, indirect expansion triggers a hard failure under `set -u`, causing the setup script to abort during onboarding.

### Solution

Change indirect expansion from `${!k}` to `${!k-}`.

This preserves strict mode while safely treating **unset optional variables as empty** when serializing to `.env`.

#### Why fix this way

* Keeps `set -u` enabled and meaningful elsewhere in the script
* Preserves documented optionality of environment variables
* Limits the behavior change to the `.env` write path only
* Produces expected `.env` entries (`KEY=`) for optional values

### Reproduction

On a clean system with no optional `CLAWDBOT_*` variables set, which is following the docs, running the Docker setup script fails before onboarding. With this change applied, setup completes successfully.
