### PR TITLE
fix: normalize telegram command mentions

### DIFF
--- a/src/auto-reply/command-detection.test.ts
+++ b/src/auto-reply/command-detection.test.ts
@@ -71,4 +71,17 @@ describe("control command parsing", () => {
     expect(hasControlCommand("prefix /send on")).toBe(false);
     expect(hasControlCommand("/send on")).toBe(true);
   });
+
+  it("ignores telegram commands addressed to other bots", () => {
+    expect(
+      hasControlCommand("/help@otherbot", undefined, {
+        botUsername: "clawdbot",
+      }),
+    ).toBe(false);
+    expect(
+      hasControlCommand("/help@clawdbot", undefined, {
+        botUsername: "clawdbot",
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/auto-reply/command-detection.ts
+++ b/src/auto-reply/command-detection.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "../config/types.js";
 import {
+  type CommandNormalizeOptions,
   listChatCommands,
   listChatCommandsForConfig,
   normalizeCommandBody,
@@ -8,11 +9,12 @@ import {
 export function hasControlCommand(
   text?: string,
   cfg?: ClawdbotConfig,
+  options?: CommandNormalizeOptions,
 ): boolean {
   if (!text) return false;
   const trimmed = text.trim();
   if (!trimmed) return false;
-  const normalizedBody = normalizeCommandBody(trimmed);
+  const normalizedBody = normalizeCommandBody(trimmed, options);
   if (!normalizedBody) return false;
   const lowered = normalizedBody.toLowerCase();
   const commands = cfg ? listChatCommandsForConfig(cfg) : listChatCommands();

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -7,6 +7,7 @@ import {
   listChatCommandsForConfig,
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
+  normalizeCommandBody,
   shouldHandleTextCommands,
 } from "./commands-registry.js";
 
@@ -91,5 +92,27 @@ describe("commands registry", () => {
         commandSource: "native",
       }),
     ).toBe(true);
+  });
+
+  it("normalizes telegram-style command mentions for the current bot", () => {
+    expect(
+      normalizeCommandBody("/help@clawdbot", { botUsername: "clawdbot" }),
+    ).toBe("/help");
+    expect(
+      normalizeCommandBody("/help@clawdbot args", {
+        botUsername: "clawdbot",
+      }),
+    ).toBe("/help args");
+    expect(
+      normalizeCommandBody("/help@clawdbot: args", {
+        botUsername: "clawdbot",
+      }),
+    ).toBe("/help args");
+  });
+
+  it("keeps telegram-style command mentions for other bots", () => {
+    expect(
+      normalizeCommandBody("/help@otherbot", { botUsername: "clawdbot" }),
+    ).toBe("/help@otherbot");
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -17,6 +17,7 @@ import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   buildCommandText,
   listNativeCommandSpecsForConfig,
+  normalizeCommandBody,
 } from "../auto-reply/commands-registry.js";
 import { formatAgentEnvelope } from "../auto-reply/envelope.js";
 import {
@@ -557,7 +558,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       !wasMentioned &&
       !hasAnyMention &&
       commandAuthorized &&
-      hasControlCommand(msg.text ?? msg.caption ?? "", cfg);
+      hasControlCommand(msg.text ?? msg.caption ?? "", cfg, { botUsername });
     const effectiveWasMentioned = wasMentioned || shouldBypassMention;
     const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
     if (isGroup && requireMention && canDetectMention) {
@@ -682,10 +683,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     ].filter((entry): entry is string => Boolean(entry));
     const groupSystemPrompt =
       systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+    const commandBody = normalizeCommandBody(rawBody, { botUsername });
     const ctxPayload = {
       Body: combinedBody,
       RawBody: rawBody,
-      CommandBody: rawBody,
+      CommandBody: commandBody,
       From: isGroup
         ? buildTelegramGroupFrom(chatId, messageThreadId)
         : `telegram:${chatId}`,


### PR DESCRIPTION
Telegram group commands often arrive as `/cmd@botname`. The text-command parser treated these as unknown, so /help and friends wouldn’t trigger when native commands were off (or registration failed). This change strips the `@botname` suffix during normalization so text commands resolve correctly.

What changed
- Normalize `/cmd@botname` → /cmd before alias/arg parsing.
- Added a regression test for /help@botname with args/colon forms.

Why
- Telegram’s group UX appends @botname.
- Our text command detection didn’t handle that format.

Tests
- Added: commands-registry normalization test (no suite run locally).

Example (Before → After)

Before (text commands in Telegram groups, native off):
/help@peanuttobot
Result: treated as unknown → no /help handler.

After:
/help@peanuttobot
Result: normalized to /help → /help handler runs as expected.