### PR TITLE
feat(discord): expose channel management actions via message tool

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: Use when you need to control Discord from Clawdbot via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
+description: Use when you need to control Discord from Clawdbot via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
 ---
 
 # Discord Actions
@@ -133,6 +133,7 @@ Use `discord.actions.*` to disable action groups:
 - `emojiUploads`, `stickerUploads`
 - `memberInfo`, `roleInfo`, `channelInfo`, `voiceStatus`, `events`
 - `roles` (role add/remove, default `false`)
+- `channels` (channel/category create/edit/delete/move, default `false`)
 - `moderation` (timeout/kick/ban, default `false`)
 ### Read recent messages
 
@@ -291,6 +292,90 @@ Use `discord.actions.*` to disable action groups:
 {
   "action": "channelList",
   "guildId": "999"
+}
+```
+
+### Channel management (disabled by default)
+
+Create, edit, delete, and move channels and categories. Enable via `discord.actions.channels: true`.
+
+**Create a text channel:**
+
+```json
+{
+  "action": "channelCreate",
+  "guildId": "999",
+  "name": "general-chat",
+  "type": 0,
+  "parentId": "888",
+  "topic": "General discussion"
+}
+```
+
+- `type`: 0 = text, 2 = voice, 4 = category (use `categoryCreate` for convenience)
+- `parentId`: category ID to nest under (optional)
+- `topic`, `position`, `nsfw`: optional
+
+**Create a category:**
+
+```json
+{
+  "action": "categoryCreate",
+  "guildId": "999",
+  "name": "Projects"
+}
+```
+
+**Edit a channel:**
+
+```json
+{
+  "action": "channelEdit",
+  "channelId": "123",
+  "name": "new-name",
+  "topic": "Updated topic"
+}
+```
+
+- Supports `name`, `topic`, `position`, `parentId` (null to remove from category), `nsfw`, `rateLimitPerUser`
+
+**Move a channel:**
+
+```json
+{
+  "action": "channelMove",
+  "guildId": "999",
+  "channelId": "123",
+  "parentId": "888",
+  "position": 2
+}
+```
+
+- `parentId`: target category (null to move to top level)
+
+**Delete a channel:**
+
+```json
+{
+  "action": "channelDelete",
+  "channelId": "123"
+}
+```
+
+**Edit/delete a category:**
+
+```json
+{
+  "action": "categoryEdit",
+  "categoryId": "888",
+  "name": "Renamed Category"
+}
+```
+
+```json
+{
+  "action": "categoryDelete",
+  "categoryId": "888"
 }
 ```
 


### PR DESCRIPTION
## Summary

Add channel-create, channel-edit, channel-delete, channel-move, category-create, category-edit, and category-delete actions to the unified message tool. These actions were already implemented in the Discord-specific handler but weren't accessible via the `pi_message` tool.

## Changes

- Add 7 new channel/category management actions to `MessageActionSchema`
- Add parameters: `name`, `type`, `parentId`, `topic`, `position`, `nsfw`, `rateLimitPerUser`, `categoryId`
- Gate actions behind `discord.actions.channels` (disabled by default, like moderation)
- Add execute handlers routing to existing Discord action handlers
- Update Discord skill SKILL.md with documentation

## Channel Types

- 0 = text channel
- 2 = voice channel  
- 4 = category (use `categoryCreate` for convenience)

## Usage Examples

```json
{
  "action": "channel-create",
  "guildId": "999",
  "name": "general-chat",
  "type": 0,
  "parentId": "888",
  "topic": "General discussion"
}
```

## Testing

All 1986 tests pass, including the discord-actions tests.