### PR TITLE
feat: wire up model extraParams (temperature, maxTokens) to pi agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Terminal/Table: ANSI-safe wrapping to prevent table clipping/color loss; add regression coverage.
 - Docker: allow optional apt packages during image build and document the build arg. (#697) — thanks @gabriel-trigo.
 - Gateway/Heartbeat: deliver reasoning even when the main heartbeat reply is `HEARTBEAT_OK`. (#694) — thanks @antons.
+- Agents/Pi: inject config `temperature`/`maxTokens` into streaming without replacing the session streamFn; cover with live maxTokens probe. (#732) — thanks @peschee.
 - macOS: clear unsigned launchd overrides on signed restarts and warn via doctor when attach-only/disable markers are set. (#695) — thanks @jeffersonwarrior.
 - Agents: enforce single-writer session locks and drop orphan tool results to prevent tool-call ID failures (MiniMax/Anthropic-compatible APIs).
 - Docs: make `clawdbot status` the first diagnostic step, clarify `status --deep` behavior, and document `/whoami` + `/id`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1026,6 +1026,27 @@ Each `agents.defaults.models` entry can include:
 - `alias` (optional model shortcut, e.g. `/opus`).
 - `params` (optional provider-specific API params passed through to the model request).
 
+`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`. These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
+
+Example:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "anthropic/claude-sonnet-4-5-20250929": {
+          params: { temperature: 0.6 }
+        },
+        "openai/gpt-5.2": {
+          params: { maxTokens: 8192 }
+        }
+      }
+    }
+  }
+}
+```
+
 Z.AI GLM-4.x models automatically enable thinking mode unless you:
 - set `--thinking off`, or
 - define `agents.defaults.models["zai/<model>"].params.thinking` yourself.

--- a/src/agents/pi-embedded-runner-extraparams.live.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.live.test.ts
@@ -1,0 +1,63 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { getModel, streamSimple } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { ClawdbotConfig } from "../config/config.js";
+import { applyExtraParamsToAgent } from "./pi-embedded-runner.js";
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const LIVE = process.env.OPENAI_LIVE_TEST === "1" || process.env.LIVE === "1";
+
+const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
+
+describeLive("pi embedded extra params (live)", () => {
+  it("applies config maxTokens to openai streamFn", async () => {
+    const model = getModel("openai", "gpt-5.2") as Model<"openai-completions">;
+
+    const cfg: ClawdbotConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.2": {
+              params: {
+                maxTokens: 8,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const agent = { streamFn: streamSimple };
+
+    applyExtraParamsToAgent(agent, cfg, "openai", model.id, "off");
+
+    const stream = agent.streamFn(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content:
+              "Write the alphabet letters A through Z as words separated by commas.",
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      { apiKey: OPENAI_KEY },
+    );
+
+    let stopReason: string | undefined;
+    let outputTokens: number | undefined;
+    for await (const event of stream) {
+      if (event.type === "done") {
+        stopReason = event.reason;
+        outputTokens = event.message.usage.output;
+      }
+    }
+
+    expect(stopReason).toBeDefined();
+    expect(outputTokens).toBeDefined();
+    // Should respect maxTokens from config (8) — allow a small buffer for provider rounding.
+    expect(outputTokens ?? 0).toBeLessThanOrEqual(12);
+  }, 30_000);
+});

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -222,7 +222,9 @@ function createStreamFnWithExtraParams(
     return undefined;
   }
 
-  log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
+  log.debug(
+    `creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`,
+  );
 
   // Return a wrapper that merges our params with any passed options
   const wrappedStreamFn: StreamFn = (model, context, options) => {
@@ -248,7 +250,12 @@ function applyExtraParamsToAgent(
   modelId: string,
   thinkLevel?: string,
 ): void {
-  const extraParams = resolveExtraParams({ cfg, provider, modelId, thinkLevel });
+  const extraParams = resolveExtraParams({
+    cfg,
+    provider,
+    modelId,
+    thinkLevel,
+  });
   const wrappedStreamFn = createStreamFnWithExtraParams(extraParams);
 
   if (wrappedStreamFn) {

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import type {
   AgentMessage,
   AgentTool,
+  StreamFn,
   ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type {
@@ -13,7 +14,9 @@ import type {
   AssistantMessage,
   ImageContent,
   Model,
+  SimpleStreamOptions,
 } from "@mariozechner/pi-ai";
+import { streamSimple } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   discoverAuthStorage,
@@ -187,6 +190,73 @@ export function resolveExtraParams(params: {
   }
 
   return extraParams;
+}
+
+/**
+ * Create a wrapped streamFn that injects extra params (like temperature) from config.
+ *
+ * This wraps the default streamSimple with config-driven params for each model.
+ * Example config:
+ *   agents.defaults.models["anthropic/claude-sonnet-4"].params.temperature = 0.7
+ *
+ * @internal
+ */
+function createStreamFnWithExtraParams(
+  extraParams: Record<string, unknown> | undefined,
+): StreamFn | undefined {
+  if (!extraParams || Object.keys(extraParams).length === 0) {
+    return undefined; // No wrapper needed
+  }
+
+  // Extract stream-related params (temperature, maxTokens, etc.)
+  const streamParams: Partial<SimpleStreamOptions> = {};
+  if (typeof extraParams.temperature === "number") {
+    streamParams.temperature = extraParams.temperature;
+  }
+  if (typeof extraParams.maxTokens === "number") {
+    streamParams.maxTokens = extraParams.maxTokens;
+  }
+
+  // If no stream params to inject, no wrapper needed
+  if (Object.keys(streamParams).length === 0) {
+    return undefined;
+  }
+
+  log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
+
+  // Return a wrapper that merges our params with any passed options
+  const wrappedStreamFn: StreamFn = (model, context, options) => {
+    const mergedOptions: SimpleStreamOptions = {
+      ...streamParams,
+      ...options, // Caller options take precedence
+    };
+    return streamSimple(model, context, mergedOptions);
+  };
+
+  return wrappedStreamFn;
+}
+
+/**
+ * Apply extra params (like temperature) to an agent's streamFn.
+ *
+ * Call this after createAgentSession to wire up config-driven model params.
+ */
+function applyExtraParamsToAgent(
+  agent: { streamFn: StreamFn },
+  cfg: ClawdbotConfig | undefined,
+  provider: string,
+  modelId: string,
+  thinkLevel?: string,
+): void {
+  const extraParams = resolveExtraParams({ cfg, provider, modelId, thinkLevel });
+  const wrappedStreamFn = createStreamFnWithExtraParams(extraParams);
+
+  if (wrappedStreamFn) {
+    log.debug(
+      `applying extraParams to agent streamFn for ${provider}/${modelId}`,
+    );
+    agent.streamFn = wrappedStreamFn;
+  }
 }
 
 // We configure context pruning per-session via a WeakMap registry keyed by the SessionManager instance.
@@ -1125,6 +1195,15 @@ export async function compactEmbeddedPiSession(params: {
             additionalExtensionPaths,
           }));
 
+          // Wire up config-driven model params (e.g., temperature)
+          applyExtraParamsToAgent(
+            session.agent,
+            params.config,
+            provider,
+            modelId,
+            params.thinkLevel,
+          );
+
           try {
             const prior = await sanitizeSessionHistory({
               messages: session.messages,
@@ -1519,6 +1598,15 @@ export async function runEmbeddedPiAgent(params: {
             contextFiles: [],
             additionalExtensionPaths,
           }));
+
+          // Wire up config-driven model params (e.g., temperature)
+          applyExtraParamsToAgent(
+            session.agent,
+            params.config,
+            provider,
+            modelId,
+            params.thinkLevel,
+          );
 
           try {
             const prior = await sanitizeSessionHistory({

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1485,10 +1485,7 @@ export async function startGatewayServer(
                 type: "res",
                 id: req.id,
                 ok: false,
-                error: errorShape(
-                  ErrorCodes.INVALID_REQUEST,
-                  handshakeError,
-                ),
+                error: errorShape(ErrorCodes.INVALID_REQUEST, handshakeError),
               });
             } else {
               logWsControl.warn(

--- a/src/plugins/voice-call.plugin.test.ts
+++ b/src/plugins/voice-call.plugin.test.ts
@@ -203,12 +203,9 @@ describe("voice-call plugin", () => {
       resolvePath: (p: string) => p,
     });
 
-    await program.parseAsync(
-      ["node", "cli", "voicecall", "start", "--to", "+1"],
-      {
-        from: "user",
-      },
-    );
+    await program.parseAsync(["voicecall", "start", "--to", "+1"], {
+      from: "user",
+    });
     expect(logSpy).toHaveBeenCalled();
     logSpy.mockRestore();
   });


### PR DESCRIPTION
- Use `resolveExtraParams()` which was defined but unused
- Create streamFn wrapper that injects config-driven params
- Apply to both compaction and run sessions

Config path: `agents.defaults.models["provider/model"].params.temperature`

Example:
  `agents.defaults.models["anthropic/claude-sonnet-4"].params.temperature = 0.7` 
  `agents.defaults.models["openai/gpt-4"].params.maxTokens = 8192`