### PR TITLE
Readme Fix: Update section title from 'macOS app' to 'Apps'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Cron/CLI: trim model overrides on cron edits and document main-session guidance. (#711) — thanks @mjrussell.
 - Skills: bundle `skill-creator` to guide creating and packaging skills.
 - Discord: expose channel/category management actions in the message tool. (#730) — thanks @NicholasSpisak
+- Docs: rename README “macOS app” section to “Apps”. (#733) — thanks @AbhisekBasu1.
 
 ### Fixes
 - Doctor: surface plugin diagnostics in the report.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Send these in WhatsApp/Telegram/Slack/WebChat (group commands are owner-only):
 - `/restart` — restart the gateway (owner-only in groups)
 - `/activation mention|always` — group activation toggle (groups only)
 
-## macOS app (optional)
+## Apps (optional)
 
 The Gateway alone delivers a great experience. All apps are optional and add extra features.
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -59,7 +59,7 @@ export function stripHeartbeatToken(
       : maxAckCharsRaw;
   const maxAckChars = Math.max(
     0,
-    Number.isFinite(parsedAckChars)
+    typeof parsedAckChars === "number" && Number.isFinite(parsedAckChars)
       ? parsedAckChars
       : DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   );

--- a/src/infra/heartbeat-runner.test.ts
+++ b/src/infra/heartbeat-runner.test.ts
@@ -2,9 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-
-// Avoid pulling optional runtime deps during isolated runs.
-vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import * as replyModule from "../auto-reply/reply.js";
 import type { ClawdbotConfig } from "../config/config.js";
@@ -19,6 +16,9 @@ import {
   runHeartbeatOnce,
 } from "./heartbeat-runner.js";
 import { resolveHeartbeatDeliveryTarget } from "./outbound/targets.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
 
 describe("resolveHeartbeatIntervalMs", () => {
   it("returns default when unset", () => {


### PR DESCRIPTION
Tiny readme change that makes it less confusing. 

The section title being "macOS app" makes it seem like the app is mandatory, when it is optional. Updated it to just "Apps"