### PR TITLE
feat(audio): add voice response automation support to all providers

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -78,7 +78,7 @@ export async function runCliAgent(params: {
     .join("\n");
 
   const bootstrapFiles = filterBootstrapFilesForSession(
-    await loadWorkspaceBootstrapFiles(workspaceDir),
+    await loadWorkspaceBootstrapFiles(workspaceDir, { query: params.prompt }),
     params.sessionKey ?? params.sessionId,
   );
   const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -78,7 +78,7 @@ export async function runCliAgent(params: {
     .join("\n");
 
   const bootstrapFiles = filterBootstrapFilesForSession(
-    await loadWorkspaceBootstrapFiles(workspaceDir, { query: params.prompt }),
+    await loadWorkspaceBootstrapFiles(workspaceDir),
     params.sessionKey ?? params.sessionId,
   );
   const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/auto-reply/audio-reply.ts
+++ b/src/auto-reply/audio-reply.ts
@@ -1,0 +1,77 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { splitMediaFromOutput } from "../media/parse.js";
+import { runExec } from "../process/exec.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { applyTemplate, type TemplateContext } from "./templating.js";
+
+type AudioReplyResult = {
+  mediaUrls: string[];
+  audioAsVoice?: boolean;
+};
+
+async function fileExists(candidate: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(candidate);
+    return stat.isFile() && stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function synthesizeReplyAudio(params: {
+  cfg: ClawdbotConfig;
+  ctx: TemplateContext;
+  replyText: string;
+  runtime: RuntimeEnv;
+}): Promise<AudioReplyResult | undefined> {
+  const { cfg, ctx, replyText, runtime } = params;
+  const replyConfig = cfg.audio?.reply;
+  if (!replyConfig?.command?.length) return undefined;
+
+  const trimmedText = replyText.trim();
+  if (!trimmedText) return undefined;
+
+  const timeoutMs = Math.max((replyConfig.timeoutSeconds ?? 45) * 1000, 1_000);
+  const id = crypto.randomUUID();
+  const textPath = path.join(os.tmpdir(), `clawdbot-reply-${id}.txt`);
+  const audioPath = path.join(os.tmpdir(), `clawdbot-reply-${id}.ogg`);
+
+  try {
+    await fs.writeFile(textPath, trimmedText, "utf8");
+    const templateCtx: TemplateContext = {
+      ...ctx,
+      ReplyText: trimmedText,
+      ReplyTextFile: textPath,
+      ReplyAudioPath: audioPath,
+    };
+    const argv = replyConfig.command.map((part) =>
+      applyTemplate(part, templateCtx),
+    );
+    if (!argv.length || !argv[0]) return undefined;
+    if (shouldLogVerbose()) {
+      logVerbose(`Synthesizing audio via command: ${argv.join(" ")}`);
+    }
+    const { stdout } = await runExec(argv[0], argv.slice(1), {
+      timeoutMs,
+      maxBuffer: 5 * 1024 * 1024,
+    });
+    const parsed = splitMediaFromOutput(stdout);
+    let mediaUrls = parsed.mediaUrls;
+    if (!mediaUrls?.length && (await fileExists(audioPath))) {
+      mediaUrls = [audioPath];
+    }
+    if (!mediaUrls?.length) return undefined;
+    return { mediaUrls, audioAsVoice: parsed.audioAsVoice };
+  } catch (err) {
+    runtime.error?.(`Audio reply failed: ${String(err)}`);
+    return undefined;
+  } finally {
+    void fs.unlink(textPath).catch(() => {});
+  }
+}

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -43,6 +43,8 @@ function createDispatcher(): ReplyDispatcher {
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    getAccumulatedText: vi.fn(() => ""),
+    hasDispatchedMedia: vi.fn(() => false),
   };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,7 +1,10 @@
 import type { ClawdbotConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { synthesizeReplyAudio } from "../audio-reply.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { MsgContext } from "../templating.js";
+import { isAudio } from "../transcription.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { tryFastAbortFromMessage } from "./abort.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
@@ -19,8 +22,10 @@ export async function dispatchReplyFromConfig(params: {
   dispatcher: ReplyDispatcher;
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof getReplyFromConfig;
+  /** Runtime for error logging. Required for voice synthesis. */
+  runtime?: RuntimeEnv;
 }): Promise<DispatchFromConfigResult> {
-  const { ctx, cfg, dispatcher } = params;
+  const { ctx, cfg, dispatcher, runtime } = params;
 
   if (shouldSkipDuplicateInbound(ctx)) {
     return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
@@ -161,6 +166,52 @@ export async function dispatchReplyFromConfig(params: {
     }
   }
   await dispatcher.waitForIdle();
+
+  // Generic voice reply synthesis: if inbound was audio and we have accumulated
+  // text without media, synthesize voice and send it.
+  // This makes voice reply work across all providers (WhatsApp, Telegram, etc.).
+  const accumulatedText = dispatcher.getAccumulatedText().trim();
+  const shouldSynthesizeVoice =
+    runtime &&
+    isAudio(ctx.MediaType) &&
+    accumulatedText &&
+    !dispatcher.hasDispatchedMedia() &&
+    cfg.audio?.reply?.command?.length;
+
+  if (shouldSynthesizeVoice) {
+    const audioReply = await synthesizeReplyAudio({
+      cfg,
+      ctx,
+      replyText: accumulatedText,
+      runtime,
+    });
+    if (audioReply?.mediaUrls?.length) {
+      const voicePayload: ReplyPayload = {
+        mediaUrls: audioReply.mediaUrls,
+        mediaUrl: audioReply.mediaUrls[0],
+        audioAsVoice: audioReply.audioAsVoice ?? true,
+      };
+      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+        const result = await routeReply({
+          payload: voicePayload,
+          channel: originatingChannel,
+          to: originatingTo,
+          sessionKey: ctx.SessionKey,
+          accountId: ctx.AccountId,
+          threadId: ctx.MessageThreadId,
+          cfg,
+        });
+        if (result.ok) {
+          queuedFinal = true;
+          routedFinalCount += 1;
+        }
+      } else {
+        queuedFinal = dispatcher.sendFinalReply(voicePayload) || queuedFinal;
+      }
+      await dispatcher.waitForIdle();
+      logVerbose("dispatch-from-config: synthesized voice reply");
+    }
+  }
 
   const counts = dispatcher.getQueuedCounts();
   counts.final += routedFinalCount;

--- a/src/auto-reply/reply/provider-dispatcher.ts
+++ b/src/auto-reply/reply/provider-dispatcher.ts
@@ -9,6 +9,7 @@ import { dispatchReplyFromConfig } from "./dispatch-from-config.js";
 import {
   createReplyDispatcher,
   createReplyDispatcherWithTyping,
+  shouldSkipTextOnlyDelivery,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
 } from "./reply-dispatcher.js";
@@ -24,12 +25,13 @@ export async function dispatchReplyWithBufferedBlockDispatcher(params: {
 }): Promise<DispatchFromConfigResult> {
   // For voiceOnly mode: skip text delivery when inbound is audio and voiceOnly is enabled.
   // Text is still accumulated for voice synthesis, just not delivered to the user.
-  const inboundIsAudio = isAudio(params.ctx.MediaType);
-  const voiceOnlyEnabled = params.cfg.audio?.reply?.voiceOnly === true;
-  const skipTextOnlyDelivery = inboundIsAudio && voiceOnlyEnabled;
+  const skipTextOnlyDelivery = shouldSkipTextOnlyDelivery(
+    params.cfg,
+    params.ctx.MediaType,
+  );
 
   logVerbose(
-    `voiceOnly check: MediaType=${params.ctx.MediaType} isAudio=${inboundIsAudio} voiceOnly=${voiceOnlyEnabled} skipText=${skipTextOnlyDelivery}`
+    `voiceOnly check: MediaType=${params.ctx.MediaType} isAudio=${isAudio(params.ctx.MediaType)} voiceOnly=${params.cfg.audio?.reply?.voiceOnly === true} skipText=${skipTextOnlyDelivery}`,
   );
 
   const { dispatcher, replyOptions, markDispatchIdle } =

--- a/src/auto-reply/reply/provider-dispatcher.ts
+++ b/src/auto-reply/reply/provider-dispatcher.ts
@@ -9,9 +9,9 @@ import { dispatchReplyFromConfig } from "./dispatch-from-config.js";
 import {
   createReplyDispatcher,
   createReplyDispatcherWithTyping,
-  shouldSkipTextOnlyDelivery,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
+  shouldSkipTextOnlyDelivery,
 } from "./reply-dispatcher.js";
 
 export async function dispatchReplyWithBufferedBlockDispatcher(params: {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,5 +1,6 @@
-import type { HumanDelayConfig } from "../../config/types.js";
+import type { ClawdbotConfig, HumanDelayConfig } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
+import { isAudio } from "../transcription.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import type { TypingController } from "./typing.js";
@@ -37,6 +38,24 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
 
 /** Sleep for a given number of milliseconds. */
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Compute whether to skip text-only delivery for voiceOnly mode.
+ * When the inbound message is audio and voiceOnly is enabled in config,
+ * text replies should be skipped (but still accumulated for voice synthesis).
+ *
+ * @param cfg - The clawdbot config containing audio.reply.voiceOnly setting
+ * @param mediaType - The MediaType of the inbound message (e.g., "audio/ogg")
+ * @returns true if text-only replies should be skipped
+ */
+export function shouldSkipTextOnlyDelivery(
+  cfg: ClawdbotConfig | undefined,
+  mediaType: string | undefined | null,
+): boolean {
+  const inboundIsAudio = isAudio(mediaType);
+  const voiceOnlyEnabled = cfg?.audio?.reply?.voiceOnly === true;
+  return inboundIsAudio && voiceOnlyEnabled;
+}
 
 export type ReplyDispatcherOptions = {
   deliver: ReplyDispatchDeliverer;

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -74,6 +74,9 @@ export type TemplateContext = MsgContext & {
   BodyStripped?: string;
   SessionId?: string;
   IsNewSession?: string;
+  ReplyText?: string;
+  ReplyTextFile?: string;
+  ReplyAudioPath?: string;
 };
 
 // Simple {{Placeholder}} interpolation using inbound message context.

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -41,6 +41,20 @@ export type AudioConfig = {
     command: string[];
     timeoutSeconds?: number;
   };
+  reply?: {
+    // Optional CLI to turn reply text into audio; templated args.
+    // Use {{ReplyText}} or {{ReplyTextFile}} (path with reply text) and {{ReplyAudioPath}}.
+    // Command should print MEDIA:<path> to stdout (or write to ReplyAudioPath).
+    command: string[];
+    timeoutSeconds?: number;
+    /**
+     * When true, suppress text replies and only send synthesized voice.
+     * Text is still accumulated internally for voice synthesis.
+     * Only applies when inbound message is audio.
+     * Default: false (send both text and voice).
+     */
+    voiceOnly?: boolean;
+  };
 };
 
 export type MessagesConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,26 +1,1849 @@
-// Split into focused modules to keep files small and improve edit locality.
+export type ReplyMode = "text" | "command";
+export type TypingMode = "never" | "instant" | "thinking" | "message";
+export type SessionScope = "per-sender" | "global";
+export type ReplyToMode = "off" | "first" | "all";
+export type GroupPolicy = "open" | "disabled" | "allowlist";
+export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
 
-export * from "./types.agent-defaults.js";
-export * from "./types.agents.js";
-export * from "./types.auth.js";
-export * from "./types.base.js";
-export * from "./types.browser.js";
-export * from "./types.channels.js";
-export * from "./types.clawdbot.js";
-export * from "./types.cron.js";
-export * from "./types.discord.js";
-export * from "./types.gateway.js";
-export * from "./types.hooks.js";
-export * from "./types.imessage.js";
-export * from "./types.messages.js";
-export * from "./types.models.js";
-export * from "./types.msteams.js";
-export * from "./types.plugins.js";
-export * from "./types.queue.js";
-export * from "./types.sandbox.js";
-export * from "./types.signal.js";
-export * from "./types.skills.js";
-export * from "./types.slack.js";
-export * from "./types.telegram.js";
-export * from "./types.tools.js";
-export * from "./types.whatsapp.js";
+export type OutboundRetryConfig = {
+  /** Max retry attempts for outbound requests (default: 3). */
+  attempts?: number;
+  /** Minimum retry delay in ms (default: 300-500ms depending on provider). */
+  minDelayMs?: number;
+  /** Maximum retry delay cap in ms (default: 30000). */
+  maxDelayMs?: number;
+  /** Jitter factor (0-1) applied to delays (default: 0.1). */
+  jitter?: number;
+};
+
+export type BlockStreamingCoalesceConfig = {
+  minChars?: number;
+  maxChars?: number;
+  idleMs?: number;
+};
+
+export type BlockStreamingChunkConfig = {
+  minChars?: number;
+  maxChars?: number;
+  breakPreference?: "paragraph" | "newline" | "sentence";
+};
+
+export type HumanDelayConfig = {
+  /** Delay style for block replies (off|natural|custom). */
+  mode?: "off" | "natural" | "custom";
+  /** Minimum delay in milliseconds (default: 800). */
+  minMs?: number;
+  /** Maximum delay in milliseconds (default: 2500). */
+  maxMs?: number;
+};
+
+export type SessionSendPolicyAction = "allow" | "deny";
+export type SessionSendPolicyMatch = {
+  channel?: string;
+  chatType?: "direct" | "group" | "room";
+  keyPrefix?: string;
+};
+export type SessionSendPolicyRule = {
+  action: SessionSendPolicyAction;
+  match?: SessionSendPolicyMatch;
+};
+export type SessionSendPolicyConfig = {
+  default?: SessionSendPolicyAction;
+  rules?: SessionSendPolicyRule[];
+};
+
+export type SessionConfig = {
+  scope?: SessionScope;
+  resetTriggers?: string[];
+  idleMinutes?: number;
+  heartbeatIdleMinutes?: number;
+  store?: string;
+  typingIntervalSeconds?: number;
+  typingMode?: TypingMode;
+  mainKey?: string;
+  sendPolicy?: SessionSendPolicyConfig;
+  agentToAgent?: {
+    /** Max ping-pong turns between requester/target (0–5). Default: 5. */
+    maxPingPongTurns?: number;
+  };
+};
+
+export type LoggingConfig = {
+  level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
+  file?: string;
+  consoleLevel?:
+    | "silent"
+    | "fatal"
+    | "error"
+    | "warn"
+    | "info"
+    | "debug"
+    | "trace";
+  consoleStyle?: "pretty" | "compact" | "json";
+  /** Redact sensitive tokens in tool summaries. Default: "tools". */
+  redactSensitive?: "off" | "tools";
+  /** Regex patterns used to redact sensitive tokens (defaults apply when unset). */
+  redactPatterns?: string[];
+};
+
+export type WebReconnectConfig = {
+  initialMs?: number;
+  maxMs?: number;
+  factor?: number;
+  jitter?: number;
+  maxAttempts?: number; // 0 = unlimited
+};
+
+export type WebConfig = {
+  /** If false, do not start the WhatsApp web provider. Default: true. */
+  enabled?: boolean;
+  heartbeatSeconds?: number;
+  reconnect?: WebReconnectConfig;
+};
+
+// Provider docking: allowlists keyed by provider id (and internal "webchat").
+export type AgentElevatedAllowFromConfig = Partial<
+  Record<string, Array<string | number>>
+>;
+
+export type IdentityConfig = {
+  name?: string;
+  theme?: string;
+  emoji?: string;
+};
+
+export type WhatsAppActionConfig = {
+  reactions?: boolean;
+  sendMessage?: boolean;
+  polls?: boolean;
+};
+
+export type WhatsAppConfig = {
+  /** Optional per-account WhatsApp configuration (multi-account). */
+  accounts?: Record<string, WhatsAppAccountConfig>;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /**
+   * Inbound message prefix (WhatsApp only).
+   * Default: `[{agents.list[].identity.name}]` (or `[clawdbot]`) when allowFrom is empty, else `""`.
+   */
+  messagePrefix?: string;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /**
+   * Same-phone setup (bot uses your personal WhatsApp number).
+   */
+  selfChatMode?: boolean;
+  /** Optional allowlist for WhatsApp direct chats (E.164). */
+  allowFrom?: string[];
+  /** Optional allowlist for WhatsApp group senders (E.164). */
+  groupAllowFrom?: string[];
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom, only mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  /** Maximum media file size in MB. Default: 50. */
+  mediaMaxMb?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Per-action tool gating (default: true for all). */
+  actions?: WhatsAppActionConfig;
+  groups?: Record<
+    string,
+    {
+      requireMention?: boolean;
+    }
+  >;
+  /** Acknowledgment reaction sent immediately upon message receipt. */
+  ackReaction?: {
+    /** Emoji to use for acknowledgment (e.g., "👀"). Empty = disabled. */
+    emoji?: string;
+    /** Send reactions in direct chats. Default: true. */
+    direct?: boolean;
+    /**
+     * Send reactions in group chats:
+     * - "always": react to all group messages
+     * - "mentions": react only when bot is mentioned
+     * - "never": never react in groups
+     * Default: "mentions"
+     */
+    group?: "always" | "mentions" | "never";
+  };
+};
+
+export type WhatsAppAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** If false, do not start this WhatsApp account provider. Default: true. */
+  enabled?: boolean;
+  /** Inbound message prefix override for this account (WhatsApp only). */
+  messagePrefix?: string;
+  /** Override auth directory (Baileys multi-file auth state). */
+  authDir?: string;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /** Same-phone setup for this account (bot uses your personal WhatsApp number). */
+  selfChatMode?: boolean;
+  allowFrom?: string[];
+  groupAllowFrom?: string[];
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  textChunkLimit?: number;
+  mediaMaxMb?: number;
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  groups?: Record<
+    string,
+    {
+      requireMention?: boolean;
+    }
+  >;
+  /** Acknowledgment reaction sent immediately upon message receipt. */
+  ackReaction?: {
+    /** Emoji to use for acknowledgment (e.g., "👀"). Empty = disabled. */
+    emoji?: string;
+    /** Send reactions in direct chats. Default: true. */
+    direct?: boolean;
+    /**
+     * Send reactions in group chats:
+     * - "always": react to all group messages
+     * - "mentions": react only when bot is mentioned
+     * - "never": never react in groups
+     * Default: "mentions"
+     */
+    group?: "always" | "mentions" | "never";
+  };
+};
+
+export type BrowserProfileConfig = {
+  /** CDP port for this profile. Allocated once at creation, persisted permanently. */
+  cdpPort?: number;
+  /** CDP URL for this profile (use for remote Chrome). */
+  cdpUrl?: string;
+  /** Profile color (hex). Auto-assigned at creation. */
+  color: string;
+};
+export type BrowserConfig = {
+  enabled?: boolean;
+  /** Base URL of the clawd browser control server. Default: http://127.0.0.1:18791 */
+  controlUrl?: string;
+  /** Base URL of the CDP endpoint. Default: controlUrl with port + 1. */
+  cdpUrl?: string;
+  /** Accent color for the clawd browser profile (hex). Default: #FF4500 */
+  color?: string;
+  /** Override the browser executable path (macOS/Linux). */
+  executablePath?: string;
+  /** Start Chrome headless (best-effort). Default: false */
+  headless?: boolean;
+  /** Pass --no-sandbox to Chrome (Linux containers). Default: false */
+  noSandbox?: boolean;
+  /** If true: never launch; only attach to an existing browser. Default: false */
+  attachOnly?: boolean;
+  /** Default profile to use when profile param is omitted. Default: "clawd" */
+  defaultProfile?: string;
+  /** Named browser profiles with explicit CDP ports or URLs. */
+  profiles?: Record<string, BrowserProfileConfig>;
+};
+
+export type CronConfig = {
+  enabled?: boolean;
+  store?: string;
+  maxConcurrentRuns?: number;
+};
+
+export type HookMappingMatch = {
+  path?: string;
+  source?: string;
+};
+
+export type HookMappingTransform = {
+  module: string;
+  export?: string;
+};
+
+export type HookMappingConfig = {
+  id?: string;
+  match?: HookMappingMatch;
+  action?: "wake" | "agent";
+  wakeMode?: "now" | "next-heartbeat";
+  name?: string;
+  sessionKey?: string;
+  messageTemplate?: string;
+  textTemplate?: string;
+  deliver?: boolean;
+  channel?:
+    | "last"
+    | "whatsapp"
+    | "telegram"
+    | "discord"
+    | "slack"
+    | "signal"
+    | "imessage"
+    | "msteams";
+  to?: string;
+  /** Override model for this hook (provider/model or alias). */
+  model?: string;
+  thinking?: string;
+  timeoutSeconds?: number;
+  transform?: HookMappingTransform;
+};
+
+export type HooksGmailTailscaleMode = "off" | "serve" | "funnel";
+
+export type HooksGmailConfig = {
+  account?: string;
+  label?: string;
+  topic?: string;
+  subscription?: string;
+  pushToken?: string;
+  hookUrl?: string;
+  includeBody?: boolean;
+  maxBytes?: number;
+  renewEveryMinutes?: number;
+  serve?: {
+    bind?: string;
+    port?: number;
+    path?: string;
+  };
+  tailscale?: {
+    mode?: HooksGmailTailscaleMode;
+    path?: string;
+    /** Optional tailscale serve/funnel target (port, host:port, or full URL). */
+    target?: string;
+  };
+  /** Optional model override for Gmail hook processing (provider/model or alias). */
+  model?: string;
+  /** Optional thinking level override for Gmail hook processing. */
+  thinking?: "off" | "minimal" | "low" | "medium" | "high";
+};
+
+export type HooksConfig = {
+  enabled?: boolean;
+  path?: string;
+  token?: string;
+  maxBodyBytes?: number;
+  presets?: string[];
+  transformsDir?: string;
+  mappings?: HookMappingConfig[];
+  gmail?: HooksGmailConfig;
+};
+
+export type TelegramActionConfig = {
+  reactions?: boolean;
+  sendMessage?: boolean;
+};
+
+export type TelegramAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Override native command registration for Telegram (bool or "auto"). */
+  commands?: ProviderCommandsConfig;
+  /**
+   * Controls how Telegram direct chats (DMs) are handled:
+   * - "pairing" (default): unknown senders get a pairing code; owner must approve
+   * - "allowlist": only allow senders in allowFrom (or paired allow store)
+   * - "open": allow all inbound DMs (requires allowFrom to include "*")
+   * - "disabled": ignore all inbound DMs
+   */
+  dmPolicy?: DmPolicy;
+  /** If false, do not start this Telegram account. Default: true. */
+  enabled?: boolean;
+  botToken?: string;
+  /** Path to file containing bot token (for secret managers like agenix). */
+  tokenFile?: string;
+  /** Control reply threading when reply tags are present (off|first|all). */
+  replyToMode?: ReplyToMode;
+  groups?: Record<string, TelegramGroupConfig>;
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for Telegram group senders (user ids or usernames). */
+  groupAllowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom, only mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
+  /** Chunking config for draft streaming in `streamMode: "block"`. */
+  draftChunk?: BlockStreamingChunkConfig;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Draft streaming mode for Telegram (off|partial|block). Default: partial. */
+  streamMode?: "off" | "partial" | "block";
+  mediaMaxMb?: number;
+  /** Retry policy for outbound Telegram API calls. */
+  retry?: OutboundRetryConfig;
+  proxy?: string;
+  webhookUrl?: string;
+  webhookSecret?: string;
+  webhookPath?: string;
+  /** Per-action tool gating (default: true for all). */
+  actions?: TelegramActionConfig;
+};
+
+export type TelegramTopicConfig = {
+  requireMention?: boolean;
+  /** If specified, only load these skills for this topic. Omit = all skills; empty = no skills. */
+  skills?: string[];
+  /** If false, disable the bot for this topic. */
+  enabled?: boolean;
+  /** Optional allowlist for topic senders (ids or usernames). */
+  allowFrom?: Array<string | number>;
+  /** Optional system prompt snippet for this topic. */
+  systemPrompt?: string;
+};
+
+export type TelegramGroupConfig = {
+  requireMention?: boolean;
+  /** If specified, only load these skills for this group (when no topic). Omit = all skills; empty = no skills. */
+  skills?: string[];
+  /** Per-topic configuration (key is message_thread_id as string) */
+  topics?: Record<string, TelegramTopicConfig>;
+  /** If false, disable the bot for this group (and its topics). */
+  enabled?: boolean;
+  /** Optional allowlist for group senders (ids or usernames). */
+  allowFrom?: Array<string | number>;
+  /** Optional system prompt snippet for this group. */
+  systemPrompt?: string;
+};
+
+export type TelegramConfig = {
+  /** Optional per-account Telegram configuration (multi-account). */
+  accounts?: Record<string, TelegramAccountConfig>;
+} & TelegramAccountConfig;
+
+export type DiscordDmConfig = {
+  /** If false, ignore all incoming Discord DMs. Default: true. */
+  enabled?: boolean;
+  /** Direct message access policy (default: pairing). */
+  policy?: DmPolicy;
+  /** Allowlist for DM senders (ids or names). */
+  allowFrom?: Array<string | number>;
+  /** If true, allow group DMs (default: false). */
+  groupEnabled?: boolean;
+  /** Optional allowlist for group DM channels (ids or slugs). */
+  groupChannels?: Array<string | number>;
+};
+
+export type DiscordGuildChannelConfig = {
+  allow?: boolean;
+  requireMention?: boolean;
+  /** If specified, only load these skills for this channel. Omit = all skills; empty = no skills. */
+  skills?: string[];
+  /** If false, disable the bot for this channel. */
+  enabled?: boolean;
+  /** Optional allowlist for channel senders (ids or names). */
+  users?: Array<string | number>;
+  /** Optional system prompt snippet for this channel. */
+  systemPrompt?: string;
+};
+
+export type DiscordReactionNotificationMode =
+  | "off"
+  | "own"
+  | "all"
+  | "allowlist";
+
+export type DiscordGuildEntry = {
+  slug?: string;
+  requireMention?: boolean;
+  /** Reaction notification mode (off|own|all|allowlist). Default: own. */
+  reactionNotifications?: DiscordReactionNotificationMode;
+  users?: Array<string | number>;
+  channels?: Record<string, DiscordGuildChannelConfig>;
+};
+
+export type DiscordActionConfig = {
+  reactions?: boolean;
+  stickers?: boolean;
+  polls?: boolean;
+  permissions?: boolean;
+  messages?: boolean;
+  threads?: boolean;
+  pins?: boolean;
+  search?: boolean;
+  memberInfo?: boolean;
+  roleInfo?: boolean;
+  roles?: boolean;
+  channelInfo?: boolean;
+  voiceStatus?: boolean;
+  events?: boolean;
+  moderation?: boolean;
+  emojiUploads?: boolean;
+  stickerUploads?: boolean;
+  channels?: boolean;
+};
+
+export type DiscordAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Override native command registration for Discord (bool or "auto"). */
+  commands?: ProviderCommandsConfig;
+  /** If false, do not start this Discord account. Default: true. */
+  enabled?: boolean;
+  token?: string;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
+  /**
+   * Controls how guild channel messages are handled:
+   * - "open": guild channels bypass allowlists; mention-gating applies
+   * - "disabled": block all guild channel messages
+   * - "allowlist": only allow channels present in discord.guilds.*.channels
+   */
+  groupPolicy?: GroupPolicy;
+  /** Outbound text chunk size (chars). Default: 2000. */
+  textChunkLimit?: number;
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /**
+   * Soft max line count per Discord message.
+   * Discord clients can clip/collapse very tall messages; splitting by lines
+   * keeps replies readable in-channel. Default: 17.
+   */
+  maxLinesPerMessage?: number;
+  mediaMaxMb?: number;
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Retry policy for outbound Discord API calls. */
+  retry?: OutboundRetryConfig;
+  /** Per-action tool gating (default: true for all). */
+  actions?: DiscordActionConfig;
+  /** Control reply threading when reply tags are present (off|first|all). */
+  replyToMode?: ReplyToMode;
+  dm?: DiscordDmConfig;
+  /** New per-guild config keyed by guild id or slug. */
+  guilds?: Record<string, DiscordGuildEntry>;
+};
+
+export type DiscordConfig = {
+  /** Optional per-account Discord configuration (multi-account). */
+  accounts?: Record<string, DiscordAccountConfig>;
+} & DiscordAccountConfig;
+
+export type SlackDmConfig = {
+  /** If false, ignore all incoming Slack DMs. Default: true. */
+  enabled?: boolean;
+  /** Direct message access policy (default: pairing). */
+  policy?: DmPolicy;
+  /** Allowlist for DM senders (ids). */
+  allowFrom?: Array<string | number>;
+  /** If true, allow group DMs (default: false). */
+  groupEnabled?: boolean;
+  /** Optional allowlist for group DM channels (ids or slugs). */
+  groupChannels?: Array<string | number>;
+};
+
+export type SlackChannelConfig = {
+  /** If false, disable the bot in this channel. (Alias for allow: false.) */
+  enabled?: boolean;
+  /** Legacy channel allow toggle; prefer enabled. */
+  allow?: boolean;
+  /** Require mentioning the bot to trigger replies. */
+  requireMention?: boolean;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
+  /** Allowlist of users that can invoke the bot in this channel. */
+  users?: Array<string | number>;
+  /** Optional skill filter for this channel. */
+  skills?: string[];
+  /** Optional system prompt for this channel. */
+  systemPrompt?: string;
+};
+
+export type SignalReactionNotificationMode =
+  | "off"
+  | "own"
+  | "all"
+  | "allowlist";
+
+export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+
+export type SlackActionConfig = {
+  reactions?: boolean;
+  messages?: boolean;
+  pins?: boolean;
+  search?: boolean;
+  permissions?: boolean;
+  memberInfo?: boolean;
+  channelInfo?: boolean;
+  emojiList?: boolean;
+};
+
+export type SlackSlashCommandConfig = {
+  /** Enable handling for the configured slash command (default: false). */
+  enabled?: boolean;
+  /** Slash command name (default: "clawd"). */
+  name?: string;
+  /** Session key prefix for slash commands (default: "slack:slash"). */
+  sessionPrefix?: string;
+  /** Reply ephemerally (default: true). */
+  ephemeral?: boolean;
+};
+
+export type SlackAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Override native command registration for Slack (bool or "auto"). */
+  commands?: ProviderCommandsConfig;
+  /** If false, do not start this Slack account. Default: true. */
+  enabled?: boolean;
+  botToken?: string;
+  appToken?: string;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
+  /**
+   * Controls how channel messages are handled:
+   * - "open": channels bypass allowlists; mention-gating applies
+   * - "disabled": block all channel messages
+   * - "allowlist": only allow channels present in channels.slack.channels
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max channel messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  textChunkLimit?: number;
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  mediaMaxMb?: number;
+  /** Reaction notification mode (off|own|all|allowlist). Default: own. */
+  reactionNotifications?: SlackReactionNotificationMode;
+  /** Allowlist for reaction notifications when mode is allowlist. */
+  reactionAllowlist?: Array<string | number>;
+  /** Control reply threading when reply tags are present (off|first|all). */
+  replyToMode?: ReplyToMode;
+  actions?: SlackActionConfig;
+  slashCommand?: SlackSlashCommandConfig;
+  dm?: SlackDmConfig;
+  channels?: Record<string, SlackChannelConfig>;
+};
+
+export type SlackConfig = {
+  /** Optional per-account Slack configuration (multi-account). */
+  accounts?: Record<string, SlackAccountConfig>;
+} & SlackAccountConfig;
+
+export type SignalAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** If false, do not start this Signal account. Default: true. */
+  enabled?: boolean;
+  /** Optional explicit E.164 account for signal-cli. */
+  account?: string;
+  /** Optional full base URL for signal-cli HTTP daemon. */
+  httpUrl?: string;
+  /** HTTP host for signal-cli daemon (default 127.0.0.1). */
+  httpHost?: string;
+  /** HTTP port for signal-cli daemon (default 8080). */
+  httpPort?: number;
+  /** signal-cli binary path (default: signal-cli). */
+  cliPath?: string;
+  /** Auto-start signal-cli daemon (default: true if httpUrl not set). */
+  autoStart?: boolean;
+  receiveMode?: "on-start" | "manual";
+  ignoreAttachments?: boolean;
+  ignoreStories?: boolean;
+  sendReadReceipts?: boolean;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for Signal group senders (E.164). */
+  groupAllowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom, no extra gating
+   * - "disabled": block all group messages
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  mediaMaxMb?: number;
+  /** Reaction notification mode (off|own|all|allowlist). Default: own. */
+  reactionNotifications?: SignalReactionNotificationMode;
+  /** Allowlist for reaction notifications when mode is allowlist. */
+  reactionAllowlist?: Array<string | number>;
+};
+
+export type SignalConfig = {
+  /** Optional per-account Signal configuration (multi-account). */
+  accounts?: Record<string, SignalAccountConfig>;
+} & SignalAccountConfig;
+
+export type MSTeamsWebhookConfig = {
+  /** Port for the webhook server. Default: 3978. */
+  port?: number;
+  /** Path for the messages endpoint. Default: /api/messages. */
+  path?: string;
+};
+
+/** Reply style for MS Teams messages. */
+export type MSTeamsReplyStyle = "thread" | "top-level";
+
+/** Channel-level config for MS Teams. */
+export type MSTeamsChannelConfig = {
+  /** Require @mention to respond. Default: true. */
+  requireMention?: boolean;
+  /** Reply style: "thread" replies to the message, "top-level" posts a new message. */
+  replyStyle?: MSTeamsReplyStyle;
+};
+
+/** Team-level config for MS Teams. */
+export type MSTeamsTeamConfig = {
+  /** Default requireMention for channels in this team. */
+  requireMention?: boolean;
+  /** Default reply style for channels in this team. */
+  replyStyle?: MSTeamsReplyStyle;
+  /** Per-channel overrides. Key is conversation ID (e.g., "19:...@thread.tacv2"). */
+  channels?: Record<string, MSTeamsChannelConfig>;
+};
+
+export type MSTeamsConfig = {
+  /** If false, do not start the MS Teams provider. Default: true. */
+  enabled?: boolean;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Azure Bot App ID (from Azure Bot registration). */
+  appId?: string;
+  /** Azure Bot App Password / Client Secret. */
+  appPassword?: string;
+  /** Azure AD Tenant ID (for single-tenant bots). */
+  tenantId?: string;
+  /** Webhook server configuration. */
+  webhook?: MSTeamsWebhookConfig;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /** Allowlist for DM senders (AAD object IDs or UPNs). */
+  allowFrom?: Array<string>;
+  /** Optional allowlist for group/channel senders (AAD object IDs or UPNs). */
+  groupAllowFrom?: Array<string>;
+  /**
+   * Controls how group/channel messages are handled:
+   * - "open": groups bypass allowFrom; mention-gating applies
+   * - "disabled": block all group messages
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /**
+   * Allowed host suffixes for inbound attachment downloads.
+   * Use ["*"] to allow any host (not recommended).
+   */
+  mediaAllowHosts?: Array<string>;
+  /** Default: require @mention to respond in channels/groups. */
+  requireMention?: boolean;
+  /** Max group/channel messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Default reply style: "thread" replies to the message, "top-level" posts a new message. */
+  replyStyle?: MSTeamsReplyStyle;
+  /** Per-team config. Key is team ID (from the /team/ URL path segment). */
+  teams?: Record<string, MSTeamsTeamConfig>;
+};
+
+export type ChannelsConfig = {
+  whatsapp?: WhatsAppConfig;
+  telegram?: TelegramConfig;
+  discord?: DiscordConfig;
+  slack?: SlackConfig;
+  signal?: SignalConfig;
+  imessage?: IMessageConfig;
+  msteams?: MSTeamsConfig;
+};
+
+export type IMessageAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** If false, do not start this iMessage account. Default: true. */
+  enabled?: boolean;
+  /** imsg CLI binary path (default: imsg). */
+  cliPath?: string;
+  /** Optional Messages db path override. */
+  dbPath?: string;
+  /** Optional default send service (imessage|sms|auto). */
+  service?: "imessage" | "sms" | "auto";
+  /** Optional default region (used when sending SMS). */
+  region?: string;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /** Optional allowlist for inbound handles or chat_id targets. */
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for group senders or chat_id targets. */
+  groupAllowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom; mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Include attachments + reactions in watch payloads. */
+  includeAttachments?: boolean;
+  /** Max outbound media size in MB. */
+  mediaMaxMb?: number;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  groups?: Record<
+    string,
+    {
+      requireMention?: boolean;
+    }
+  >;
+};
+
+export type IMessageConfig = {
+  /** Optional per-account iMessage configuration (multi-account). */
+  accounts?: Record<string, IMessageAccountConfig>;
+} & IMessageAccountConfig;
+
+export type QueueMode =
+  | "steer"
+  | "followup"
+  | "collect"
+  | "steer-backlog"
+  | "steer+backlog"
+  | "queue"
+  | "interrupt";
+export type QueueDropPolicy = "old" | "new" | "summarize";
+
+export type QueueModeByProvider = {
+  whatsapp?: QueueMode;
+  telegram?: QueueMode;
+  discord?: QueueMode;
+  slack?: QueueMode;
+  signal?: QueueMode;
+  imessage?: QueueMode;
+  msteams?: QueueMode;
+  webchat?: QueueMode;
+};
+
+export type SandboxDockerSettings = {
+  /** Docker image to use for sandbox containers. */
+  image?: string;
+  /** Prefix for sandbox container names. */
+  containerPrefix?: string;
+  /** Container workdir mount path (default: /workspace). */
+  workdir?: string;
+  /** Run container rootfs read-only. */
+  readOnlyRoot?: boolean;
+  /** Extra tmpfs mounts for read-only containers. */
+  tmpfs?: string[];
+  /** Container network mode (bridge|none|custom). */
+  network?: string;
+  /** Container user (uid:gid). */
+  user?: string;
+  /** Drop Linux capabilities. */
+  capDrop?: string[];
+  /** Extra environment variables for sandbox exec. */
+  env?: Record<string, string>;
+  /** Optional setup command run once after container creation. */
+  setupCommand?: string;
+  /** Limit container PIDs (0 = Docker default). */
+  pidsLimit?: number;
+  /** Limit container memory (e.g. 512m, 2g, or bytes as number). */
+  memory?: string | number;
+  /** Limit container memory swap (same format as memory). */
+  memorySwap?: string | number;
+  /** Limit container CPU shares (e.g. 0.5, 1, 2). */
+  cpus?: number;
+  /**
+   * Set ulimit values by name (e.g. nofile, nproc).
+   * Use "soft:hard" string, a number, or { soft, hard }.
+   */
+  ulimits?: Record<string, string | number | { soft?: number; hard?: number }>;
+  /** Seccomp profile (path or profile name). */
+  seccompProfile?: string;
+  /** AppArmor profile name. */
+  apparmorProfile?: string;
+  /** DNS servers (e.g. ["1.1.1.1", "8.8.8.8"]). */
+  dns?: string[];
+  /** Extra host mappings (e.g. ["api.local:10.0.0.2"]). */
+  extraHosts?: string[];
+  /** Additional bind mounts (host:container:mode format, e.g. ["/host/path:/container/path:rw"]). */
+  binds?: string[];
+};
+
+export type SandboxBrowserSettings = {
+  enabled?: boolean;
+  image?: string;
+  containerPrefix?: string;
+  cdpPort?: number;
+  vncPort?: number;
+  noVncPort?: number;
+  headless?: boolean;
+  enableNoVnc?: boolean;
+  /**
+   * Allow sandboxed sessions to target the host browser control server.
+   * Default: false.
+   */
+  allowHostControl?: boolean;
+  /**
+   * Allowlist of exact control URLs for target="custom".
+   * When set, any custom controlUrl must match this list.
+   */
+  allowedControlUrls?: string[];
+  /**
+   * Allowlist of hostnames for control URLs (hostname only, no ports).
+   * When set, controlUrl hostname must match.
+   */
+  allowedControlHosts?: string[];
+  /**
+   * Allowlist of ports for control URLs.
+   * When set, controlUrl port must match (defaults: http=80, https=443).
+   */
+  allowedControlPorts?: number[];
+  /**
+   * When true (default), sandboxed browser control will try to start/reattach to
+   * the sandbox browser container when a tool call needs it.
+   */
+  autoStart?: boolean;
+  /** Max time to wait for CDP to become reachable after auto-start (ms). */
+  autoStartTimeoutMs?: number;
+};
+
+export type SandboxPruneSettings = {
+  /** Prune if idle for more than N hours (0 disables). */
+  idleHours?: number;
+  /** Prune if older than N days (0 disables). */
+  maxAgeDays?: number;
+};
+
+export type GroupChatConfig = {
+  mentionPatterns?: string[];
+  historyLimit?: number;
+};
+
+export type DmConfig = {
+  historyLimit?: number;
+};
+
+export type QueueConfig = {
+  mode?: QueueMode;
+  byChannel?: QueueModeByProvider;
+  debounceMs?: number;
+  cap?: number;
+  drop?: QueueDropPolicy;
+};
+
+export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+
+export type AgentToolsConfig = {
+  /** Base tool profile applied before allow/deny lists. */
+  profile?: ToolProfileId;
+  allow?: string[];
+  deny?: string[];
+  /** Per-agent elevated exec gate (can only further restrict global tools.elevated). */
+  elevated?: {
+    /** Enable or disable elevated mode for this agent (default: true). */
+    enabled?: boolean;
+    /** Approved senders for /elevated (per-provider allowlists). */
+    allowFrom?: AgentElevatedAllowFromConfig;
+  };
+  sandbox?: {
+    tools?: {
+      allow?: string[];
+      deny?: string[];
+    };
+  };
+};
+
+export type MemorySearchConfig = {
+  /** Enable vector memory search (default: true). */
+  enabled?: boolean;
+  /** Embedding provider mode. */
+  provider?: "openai" | "local";
+  remote?: {
+    baseUrl?: string;
+    apiKey?: string;
+    headers?: Record<string, string>;
+  };
+  /** Fallback behavior when local embeddings fail. */
+  fallback?: "openai" | "none";
+  /** Embedding model id (remote) or alias (local). */
+  model?: string;
+  /** Local embedding settings (node-llama-cpp). */
+  local?: {
+    /** GGUF model path or hf: URI. */
+    modelPath?: string;
+    /** Optional cache directory for local models. */
+    modelCacheDir?: string;
+  };
+  /** Index storage configuration. */
+  store?: {
+    driver?: "sqlite";
+    path?: string;
+  };
+  /** Chunking configuration. */
+  chunking?: {
+    tokens?: number;
+    overlap?: number;
+  };
+  /** Sync behavior. */
+  sync?: {
+    onSessionStart?: boolean;
+    onSearch?: boolean;
+    watch?: boolean;
+    watchDebounceMs?: number;
+    intervalMinutes?: number;
+  };
+  /** Query behavior. */
+  query?: {
+    maxResults?: number;
+    minScore?: number;
+  };
+};
+
+export type ToolsConfig = {
+  /** Base tool profile applied before allow/deny lists. */
+  profile?: ToolProfileId;
+  allow?: string[];
+  deny?: string[];
+  audio?: {
+    transcription?: {
+      /** CLI args (template-enabled). */
+      args?: string[];
+      timeoutSeconds?: number;
+    };
+  };
+  agentToAgent?: {
+    /** Enable agent-to-agent messaging tools. Default: false. */
+    enabled?: boolean;
+    /** Allowlist of agent ids or patterns (implementation-defined). */
+    allow?: string[];
+  };
+  /** Elevated exec permissions for the host machine. */
+  elevated?: {
+    /** Enable or disable elevated mode (default: true). */
+    enabled?: boolean;
+    /** Approved senders for /elevated (per-provider allowlists). */
+    allowFrom?: AgentElevatedAllowFromConfig;
+  };
+  /** Exec tool defaults. */
+  exec?: {
+    /** Default time (ms) before an exec command auto-backgrounds. */
+    backgroundMs?: number;
+    /** Default timeout (seconds) before auto-killing exec commands. */
+    timeoutSec?: number;
+    /** How long to keep finished sessions in memory (ms). */
+    cleanupMs?: number;
+    /** apply_patch subtool configuration (experimental). */
+    applyPatch?: {
+      /** Enable apply_patch for OpenAI models (default: false). */
+      enabled?: boolean;
+      /**
+       * Optional allowlist of model ids that can use apply_patch.
+       * Accepts either raw ids (e.g. "gpt-5.2") or full ids (e.g. "openai/gpt-5.2").
+       */
+      allowModels?: string[];
+    };
+  };
+  /** @deprecated Use tools.exec. */
+  bash?: {
+    /** Default time (ms) before a bash command auto-backgrounds. */
+    backgroundMs?: number;
+    /** Default timeout (seconds) before auto-killing bash commands. */
+    timeoutSec?: number;
+    /** How long to keep finished sessions in memory (ms). */
+    cleanupMs?: number;
+  };
+  /** Sub-agent tool policy defaults (deny wins). */
+  subagents?: {
+    /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
+    model?: string | { primary?: string; fallbacks?: string[] };
+    tools?: {
+      allow?: string[];
+      deny?: string[];
+    };
+  };
+  /** Sandbox tool policy defaults (deny wins). */
+  sandbox?: {
+    tools?: {
+      allow?: string[];
+      deny?: string[];
+    };
+  };
+};
+
+export type AgentModelConfig =
+  | string
+  | {
+      /** Primary model (provider/model). */
+      primary?: string;
+      /** Per-agent model fallbacks (provider/model). */
+      fallbacks?: string[];
+    };
+
+export type AgentConfig = {
+  id: string;
+  default?: boolean;
+  name?: string;
+  workspace?: string;
+  agentDir?: string;
+  model?: AgentModelConfig;
+  memorySearch?: MemorySearchConfig;
+  /** Human-like delay between block replies for this agent. */
+  humanDelay?: HumanDelayConfig;
+  identity?: IdentityConfig;
+  groupChat?: GroupChatConfig;
+  subagents?: {
+    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
+    allowAgents?: string[];
+    /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
+    model?: string | { primary?: string; fallbacks?: string[] };
+  };
+  sandbox?: {
+    mode?: "off" | "non-main" | "all";
+    /** Agent workspace access inside the sandbox. */
+    workspaceAccess?: "none" | "ro" | "rw";
+    /**
+     * Session tools visibility for sandboxed sessions.
+     * - "spawned": only allow session tools to target sessions spawned from this session (default)
+     * - "all": allow session tools to target any session
+     */
+    sessionToolsVisibility?: "spawned" | "all";
+    /** Container/workspace scope for sandbox isolation. */
+    scope?: "session" | "agent" | "shared";
+    /** Legacy alias for scope ("session" when true, "shared" when false). */
+    perSession?: boolean;
+    workspaceRoot?: string;
+    /** Docker-specific sandbox overrides for this agent. */
+    docker?: SandboxDockerSettings;
+    /** Optional sandboxed browser overrides for this agent. */
+    browser?: SandboxBrowserSettings;
+    /** Auto-prune overrides for this agent. */
+    prune?: SandboxPruneSettings;
+  };
+  tools?: AgentToolsConfig;
+};
+
+export type AgentsConfig = {
+  defaults?: AgentDefaultsConfig;
+  list?: AgentConfig[];
+};
+
+export type AgentBinding = {
+  agentId: string;
+  match: {
+    channel: string;
+    accountId?: string;
+    peer?: { kind: "dm" | "group" | "channel"; id: string };
+    guildId?: string;
+    teamId?: string;
+  };
+};
+
+export type BroadcastStrategy = "parallel" | "sequential";
+
+export type BroadcastConfig = {
+  /** Default processing strategy for broadcast peers. */
+  strategy?: BroadcastStrategy;
+  /**
+   * Map peer IDs to arrays of agent IDs that should ALL process messages.
+   *
+   * Note: the index signature includes `undefined` so `strategy?: ...` remains type-safe.
+   */
+  [peerId: string]: string[] | BroadcastStrategy | undefined;
+};
+
+export type AudioConfig = {
+  /** @deprecated Use tools.audio.transcription instead. */
+  transcription?: {
+    // Optional CLI to turn inbound audio into text; templated args, must output transcript to stdout.
+    command: string[];
+    timeoutSeconds?: number;
+  };
+  reply?: {
+    // Optional CLI to turn reply text into audio; templated args.
+    // Use {{ReplyText}} or {{ReplyTextFile}} (path with reply text) and {{ReplyAudioPath}}.
+    // Command should print MEDIA:<path> to stdout (or write to ReplyAudioPath).
+    command: string[];
+    timeoutSeconds?: number;
+  };
+};
+
+export type MessagesConfig = {
+  /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
+  messagePrefix?: string;
+  /**
+   * Prefix auto-added to all outbound replies.
+   * - string: explicit prefix
+   * - special value: `"auto"` derives `[{agents.list[].identity.name}]` for the routed agent (when set)
+   * Default: none
+   */
+  responsePrefix?: string;
+  groupChat?: GroupChatConfig;
+  queue?: QueueConfig;
+  /** Emoji reaction used to acknowledge inbound messages (empty disables). */
+  ackReaction?: string;
+  /** When to send ack reactions. Default: "group-mentions". */
+  ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
+  /** Remove ack reaction after reply is sent (default: false). */
+  removeAckAfterReply?: boolean;
+};
+
+export type NativeCommandsSetting = boolean | "auto";
+
+export type CommandsConfig = {
+  /** Enable native command registration when supported (default: "auto"). */
+  native?: NativeCommandsSetting;
+  /** Enable text command parsing (default: true). */
+  text?: boolean;
+  /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
+  bash?: boolean;
+  /** How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately). */
+  bashForegroundMs?: number;
+  /** Allow /config command (default: false). */
+  config?: boolean;
+  /** Allow /debug command (default: false). */
+  debug?: boolean;
+  /** Allow restart commands/tools (default: false). */
+  restart?: boolean;
+  /** Enforce access-group allowlists/policies for commands (default: true). */
+  useAccessGroups?: boolean;
+};
+
+export type ProviderCommandsConfig = {
+  /** Override native command registration for this provider (bool or "auto"). */
+  native?: NativeCommandsSetting;
+};
+
+export type BridgeBindMode = "auto" | "lan" | "loopback" | "custom";
+
+export type BridgeConfig = {
+  enabled?: boolean;
+  port?: number;
+  /**
+   * Bind address policy for the node bridge server.
+   * - auto: Tailnet IPv4 if available, else 0.0.0.0 (fallback to all interfaces)
+   * - lan: 0.0.0.0 (all interfaces, no fallback)
+   * - loopback: 127.0.0.1 (local-only)
+   * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable (requires customBindHost on gateway)
+   */
+  bind?: BridgeBindMode;
+};
+
+export type WideAreaDiscoveryConfig = {
+  enabled?: boolean;
+};
+
+export type DiscoveryConfig = {
+  wideArea?: WideAreaDiscoveryConfig;
+};
+
+export type CanvasHostConfig = {
+  enabled?: boolean;
+  /** Directory to serve (default: ~/clawd/canvas). */
+  root?: string;
+  /** HTTP port to listen on (default: 18793). */
+  port?: number;
+  /** Enable live-reload file watching + WS reloads (default: true). */
+  liveReload?: boolean;
+};
+
+export type TalkConfig = {
+  /** Default ElevenLabs voice ID for Talk mode. */
+  voiceId?: string;
+  /** Optional voice name -> ElevenLabs voice ID map. */
+  voiceAliases?: Record<string, string>;
+  /** Default ElevenLabs model ID for Talk mode. */
+  modelId?: string;
+  /** Default ElevenLabs output format (e.g. mp3_44100_128). */
+  outputFormat?: string;
+  /** ElevenLabs API key (optional; falls back to ELEVENLABS_API_KEY). */
+  apiKey?: string;
+  /** Stop speaking when user starts talking (default: true). */
+  interruptOnSpeech?: boolean;
+};
+
+export type GatewayControlUiConfig = {
+  /** If false, the Gateway will not serve the Control UI (default /). */
+  enabled?: boolean;
+  /** Optional base path prefix for the Control UI (e.g. "/clawdbot"). */
+  basePath?: string;
+};
+
+export type GatewayAuthMode = "token" | "password";
+
+export type GatewayAuthConfig = {
+  /** Authentication mode for Gateway connections. Defaults to token when set. */
+  mode?: GatewayAuthMode;
+  /** Shared token for token mode (stored locally for CLI auth). */
+  token?: string;
+  /** Shared password for password mode (consider env instead). */
+  password?: string;
+  /** Allow Tailscale identity headers when serve mode is enabled. */
+  allowTailscale?: boolean;
+};
+
+export type GatewayTailscaleMode = "off" | "serve" | "funnel";
+
+export type GatewayTailscaleConfig = {
+  /** Tailscale exposure mode for the Gateway control UI. */
+  mode?: GatewayTailscaleMode;
+  /** Reset serve/funnel configuration on shutdown. */
+  resetOnExit?: boolean;
+};
+
+export type GatewayRemoteConfig = {
+  /** Remote Gateway WebSocket URL (ws:// or wss://). */
+  url?: string;
+  /** Token for remote auth (when the gateway requires token auth). */
+  token?: string;
+  /** Password for remote auth (when the gateway requires password auth). */
+  password?: string;
+  /** SSH target for tunneling remote Gateway (user@host). */
+  sshTarget?: string;
+  /** SSH identity file path for tunneling remote Gateway. */
+  sshIdentity?: string;
+};
+
+export type GatewayReloadMode = "off" | "restart" | "hot" | "hybrid";
+
+export type GatewayReloadConfig = {
+  /** Reload strategy for config changes (default: hybrid). */
+  mode?: GatewayReloadMode;
+  /** Debounce window for config reloads (ms). Default: 300. */
+  debounceMs?: number;
+};
+
+export type GatewayHttpChatCompletionsConfig = {
+  /**
+   * If false, the Gateway will not serve `POST /v1/chat/completions`.
+   * Default: false when absent.
+   */
+  enabled?: boolean;
+};
+
+export type GatewayHttpEndpointsConfig = {
+  chatCompletions?: GatewayHttpChatCompletionsConfig;
+};
+
+export type GatewayHttpConfig = {
+  endpoints?: GatewayHttpEndpointsConfig;
+};
+
+export type GatewayConfig = {
+  /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
+  port?: number;
+  /**
+   * Explicit gateway mode. When set to "remote", local gateway start is disabled.
+   * When set to "local", the CLI may start the gateway locally.
+   */
+  mode?: "local" | "remote";
+  /**
+   * Bind address policy for the Gateway WebSocket + Control UI HTTP server.
+   * - auto: Tailnet IPv4 if available, else 0.0.0.0 (fallback to all interfaces)
+   * - lan: 0.0.0.0 (all interfaces, no fallback)
+   * - loopback: 127.0.0.1 (local-only)
+   * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable (requires customBindHost)
+   * Default: loopback (127.0.0.1).
+   */
+  bind?: BridgeBindMode;
+  /** Custom IP address for bind="custom" mode. Fallback: 0.0.0.0. */
+  customBindHost?: string;
+  controlUi?: GatewayControlUiConfig;
+  auth?: GatewayAuthConfig;
+  tailscale?: GatewayTailscaleConfig;
+  remote?: GatewayRemoteConfig;
+  reload?: GatewayReloadConfig;
+  http?: GatewayHttpConfig;
+};
+
+export type SkillConfig = {
+  enabled?: boolean;
+  apiKey?: string;
+  env?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+export type SkillsLoadConfig = {
+  /**
+   * Additional skill folders to scan (lowest precedence).
+   * Each directory should contain skill subfolders with `SKILL.md`.
+   */
+  extraDirs?: string[];
+};
+
+export type SkillsInstallConfig = {
+  preferBrew?: boolean;
+  nodeManager?: "npm" | "pnpm" | "yarn" | "bun";
+};
+
+export type SkillsConfig = {
+  /** Optional bundled-skill allowlist (only affects bundled skills). */
+  allowBundled?: string[];
+  load?: SkillsLoadConfig;
+  install?: SkillsInstallConfig;
+  entries?: Record<string, SkillConfig>;
+};
+
+export type PluginEntryConfig = {
+  enabled?: boolean;
+  config?: Record<string, unknown>;
+};
+
+export type PluginsLoadConfig = {
+  /** Additional plugin/extension paths to load. */
+  paths?: string[];
+};
+
+export type PluginsConfig = {
+  /** Enable or disable plugin loading. */
+  enabled?: boolean;
+  /** Optional plugin allowlist (plugin ids). */
+  allow?: string[];
+  /** Optional plugin denylist (plugin ids). */
+  deny?: string[];
+  load?: PluginsLoadConfig;
+  entries?: Record<string, PluginEntryConfig>;
+};
+
+export type ModelApi =
+  | "openai-completions"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-generative-ai"
+  | "github-copilot";
+
+export type ModelCompatConfig = {
+  supportsStore?: boolean;
+  supportsDeveloperRole?: boolean;
+  supportsReasoningEffort?: boolean;
+  maxTokensField?: "max_completion_tokens" | "max_tokens";
+};
+
+export type ModelDefinitionConfig = {
+  id: string;
+  name: string;
+  api?: ModelApi;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+  headers?: Record<string, string>;
+  compat?: ModelCompatConfig;
+};
+
+export type ModelProviderConfig = {
+  baseUrl: string;
+  apiKey?: string;
+  api?: ModelApi;
+  headers?: Record<string, string>;
+  authHeader?: boolean;
+  models: ModelDefinitionConfig[];
+};
+
+export type ModelsConfig = {
+  mode?: "merge" | "replace";
+  providers?: Record<string, ModelProviderConfig>;
+};
+
+export type AuthProfileConfig = {
+  provider: string;
+  /**
+   * Credential type expected in auth-profiles.json for this profile id.
+   * - api_key: static provider API key
+   * - oauth: refreshable OAuth credentials (access+refresh+expires)
+   * - token: static bearer-style token (optionally expiring; no refresh)
+   */
+  mode: "api_key" | "oauth" | "token";
+  email?: string;
+};
+
+export type AuthConfig = {
+  profiles?: Record<string, AuthProfileConfig>;
+  order?: Record<string, string[]>;
+  cooldowns?: {
+    /** Default billing backoff (hours). Default: 5. */
+    billingBackoffHours?: number;
+    /** Optional per-provider billing backoff (hours). */
+    billingBackoffHoursByProvider?: Record<string, number>;
+    /** Billing backoff cap (hours). Default: 24. */
+    billingMaxHours?: number;
+    /**
+     * Failure window for backoff counters (hours). If no failures occur within
+     * this window, counters reset. Default: 24.
+     */
+    failureWindowHours?: number;
+  };
+};
+
+export type AgentModelEntryConfig = {
+  alias?: string;
+  /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
+  params?: Record<string, unknown>;
+};
+
+export type AgentModelListConfig = {
+  primary?: string;
+  fallbacks?: string[];
+};
+
+export type AgentContextPruningConfig = {
+  mode?: "off" | "adaptive" | "aggressive";
+  keepLastAssistants?: number;
+  softTrimRatio?: number;
+  hardClearRatio?: number;
+  minPrunableToolChars?: number;
+  tools?: {
+    allow?: string[];
+    deny?: string[];
+  };
+  softTrim?: {
+    maxChars?: number;
+    headChars?: number;
+    tailChars?: number;
+  };
+  hardClear?: {
+    enabled?: boolean;
+    placeholder?: string;
+  };
+};
+
+export type CliBackendConfig = {
+  /** CLI command to execute (absolute path or on PATH). */
+  command: string;
+  /** Base args applied to every invocation. */
+  args?: string[];
+  /** Output parsing mode (default: json). */
+  output?: "json" | "text" | "jsonl";
+  /** Output parsing mode when resuming a CLI session. */
+  resumeOutput?: "json" | "text" | "jsonl";
+  /** Prompt input mode (default: arg). */
+  input?: "arg" | "stdin";
+  /** Max prompt length for arg mode (if exceeded, stdin is used). */
+  maxPromptArgChars?: number;
+  /** Extra env vars injected for this CLI. */
+  env?: Record<string, string>;
+  /** Env vars to remove before launching this CLI. */
+  clearEnv?: string[];
+  /** Flag used to pass model id (e.g. --model). */
+  modelArg?: string;
+  /** Model aliases mapping (config model id → CLI model id). */
+  modelAliases?: Record<string, string>;
+  /** Flag used to pass session id (e.g. --session-id). */
+  sessionArg?: string;
+  /** Extra args used when resuming a session (use {sessionId} placeholder). */
+  sessionArgs?: string[];
+  /** Alternate args to use when resuming a session (use {sessionId} placeholder). */
+  resumeArgs?: string[];
+  /** When to pass session ids. */
+  sessionMode?: "always" | "existing" | "none";
+  /** JSON fields to read session id from (in order). */
+  sessionIdFields?: string[];
+  /** Flag used to pass system prompt. */
+  systemPromptArg?: string;
+  /** System prompt behavior (append vs replace). */
+  systemPromptMode?: "append" | "replace";
+  /** When to send system prompt. */
+  systemPromptWhen?: "first" | "always" | "never";
+  /** Flag used to pass image paths. */
+  imageArg?: string;
+  /** How to pass multiple images. */
+  imageMode?: "repeat" | "list";
+  /** Serialize runs for this CLI. */
+  serialize?: boolean;
+};
+
+export type AgentDefaultsConfig = {
+  /** Primary model and fallbacks (provider/model). */
+  model?: AgentModelListConfig;
+  /** Optional image-capable model and fallbacks (provider/model). */
+  imageModel?: AgentModelListConfig;
+  /** Model catalog with optional aliases (full provider/model keys). */
+  models?: Record<string, AgentModelEntryConfig>;
+  /** Agent working directory (preferred). Used as the default cwd for agent runs. */
+  workspace?: string;
+  /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
+  skipBootstrap?: boolean;
+  /** Max chars for injected bootstrap files before truncation (default: 20000). */
+  bootstrapMaxChars?: number;
+  /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
+  userTimezone?: string;
+  /** Optional display-only context window override (used for % in status UIs). */
+  contextTokens?: number;
+  /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
+  cliBackends?: Record<string, CliBackendConfig>;
+  /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
+  contextPruning?: AgentContextPruningConfig;
+  /** Compaction tuning and pre-compaction memory flush behavior. */
+  compaction?: AgentCompactionConfig;
+  /** Vector memory search configuration (per-agent overrides supported). */
+  memorySearch?: MemorySearchConfig;
+  /** Default thinking level when no /think directive is present. */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  /** Default verbose level when no /verbose directive is present. */
+  verboseDefault?: "off" | "on";
+  /** Default elevated level when no /elevated directive is present. */
+  elevatedDefault?: "off" | "on";
+  /** Default block streaming level when no override is present. */
+  blockStreamingDefault?: "off" | "on";
+  /**
+   * Block streaming boundary:
+   * - "text_end": end of each assistant text content block (before tool calls)
+   * - "message_end": end of the whole assistant message (may include tool blocks)
+   */
+  blockStreamingBreak?: "text_end" | "message_end";
+  /** Soft block chunking for streamed replies (min/max chars, prefer paragraph/newline). */
+  blockStreamingChunk?: BlockStreamingChunkConfig;
+  /**
+   * Block reply coalescing (merge streamed chunks before send).
+   * idleMs: wait time before flushing when idle.
+   */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Human-like delay between block replies. */
+  humanDelay?: HumanDelayConfig;
+  timeoutSeconds?: number;
+  /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
+  mediaMaxMb?: number;
+  typingIntervalSeconds?: number;
+  /** Typing indicator start mode (never|instant|thinking|message). */
+  typingMode?: TypingMode;
+  /** Periodic background heartbeat runs. */
+  heartbeat?: {
+    /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
+    every?: string;
+    /** Heartbeat model override (provider/model). */
+    model?: string;
+    /** Delivery target (last|whatsapp|telegram|discord|slack|msteams|signal|imessage|none). */
+    target?:
+      | "last"
+      | "whatsapp"
+      | "telegram"
+      | "discord"
+      | "slack"
+      | "msteams"
+      | "signal"
+      | "imessage"
+      | "none";
+    /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). */
+    to?: string;
+    /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if exists. Consider outstanding tasks. Checkup sometimes on your human during (user local) day time."). */
+    prompt?: string;
+    /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
+    ackMaxChars?: number;
+    /**
+     * When enabled, deliver the model's reasoning payload for heartbeat runs (when available)
+     * as a separate message prefixed with `Reasoning:` (same as `/reasoning on`).
+     *
+     * Default: false (only the final heartbeat payload is delivered).
+     */
+    includeReasoning?: boolean;
+  };
+  /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
+  maxConcurrent?: number;
+  /** Sub-agent defaults (spawned via sessions_spawn). */
+  subagents?: {
+    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
+    maxConcurrent?: number;
+    /** Auto-archive sub-agent sessions after N minutes (default: 60). */
+    archiveAfterMinutes?: number;
+    /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
+    model?: string | { primary?: string; fallbacks?: string[] };
+  };
+  /** Optional sandbox settings for non-main sessions. */
+  sandbox?: {
+    /** Enable sandboxing for sessions. */
+    mode?: "off" | "non-main" | "all";
+    /**
+     * Agent workspace access inside the sandbox.
+     * - "none": do not mount the agent workspace into the container; use a sandbox workspace under workspaceRoot
+     * - "ro": mount the agent workspace read-only; disables write/edit tools
+     * - "rw": mount the agent workspace read/write; enables write/edit tools
+     */
+    workspaceAccess?: "none" | "ro" | "rw";
+    /**
+     * Session tools visibility for sandboxed sessions.
+     * - "spawned": only allow session tools to target sessions spawned from this session (default)
+     * - "all": allow session tools to target any session
+     */
+    sessionToolsVisibility?: "spawned" | "all";
+    /** Container/workspace scope for sandbox isolation. */
+    scope?: "session" | "agent" | "shared";
+    /** Legacy alias for scope ("session" when true, "shared" when false). */
+    perSession?: boolean;
+    /** Root directory for sandbox workspaces. */
+    workspaceRoot?: string;
+    /** Docker-specific sandbox settings. */
+    docker?: SandboxDockerSettings;
+    /** Optional sandboxed browser settings. */
+    browser?: SandboxBrowserSettings;
+    /** Auto-prune sandbox containers. */
+    prune?: SandboxPruneSettings;
+  };
+};
+
+export type AgentCompactionMode = "default" | "safeguard";
+
+export type AgentCompactionConfig = {
+  /** Compaction summarization mode. */
+  mode?: AgentCompactionMode;
+  /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
+  reserveTokensFloor?: number;
+  /** Pre-compaction memory flush (agentic turn). Default: enabled. */
+  memoryFlush?: AgentCompactionMemoryFlushConfig;
+};
+
+export type AgentCompactionMemoryFlushConfig = {
+  /** Enable the pre-compaction memory flush (default: true). */
+  enabled?: boolean;
+  /** Run the memory flush when context is within this many tokens of the compaction threshold. */
+  softThresholdTokens?: number;
+  /** User prompt used for the memory flush turn (NO_REPLY is enforced if missing). */
+  prompt?: string;
+  /** System prompt appended for the memory flush turn. */
+  systemPrompt?: string;
+};
+
+export type ClawdbotConfig = {
+  auth?: AuthConfig;
+  env?: {
+    /** Opt-in: import missing secrets from a login shell environment (exec `$SHELL -l -c 'env -0'`). */
+    shellEnv?: {
+      enabled?: boolean;
+      /** Timeout for the login shell exec (ms). Default: 15000. */
+      timeoutMs?: number;
+    };
+    /** Inline env vars to apply when not already present in the process env. */
+    vars?: Record<string, string>;
+    /** Sugar: allow env vars directly under env (string values only). */
+    [key: string]:
+      | string
+      | Record<string, string>
+      | { enabled?: boolean; timeoutMs?: number }
+      | undefined;
+  };
+  wizard?: {
+    lastRunAt?: string;
+    lastRunVersion?: string;
+    lastRunCommit?: string;
+    lastRunCommand?: string;
+    lastRunMode?: "local" | "remote";
+  };
+  logging?: LoggingConfig;
+  browser?: BrowserConfig;
+  ui?: {
+    /** Accent color for Clawdbot UI chrome (hex). */
+    seamColor?: string;
+  };
+  skills?: SkillsConfig;
+  plugins?: PluginsConfig;
+  models?: ModelsConfig;
+  agents?: AgentsConfig;
+  tools?: ToolsConfig;
+  bindings?: AgentBinding[];
+  broadcast?: BroadcastConfig;
+  audio?: AudioConfig;
+  messages?: MessagesConfig;
+  commands?: CommandsConfig;
+  session?: SessionConfig;
+  web?: WebConfig;
+  channels?: ChannelsConfig;
+  cron?: CronConfig;
+  hooks?: HooksConfig;
+  bridge?: BridgeConfig;
+  discovery?: DiscoveryConfig;
+  canvasHost?: CanvasHostConfig;
+  talk?: TalkConfig;
+  gateway?: GatewayConfig;
+};
+
+export type ConfigValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export type LegacyConfigIssue = {
+  path: string;
+  message: string;
+};
+
+export type ConfigFileSnapshot = {
+  path: string;
+  exists: boolean;
+  raw: string | null;
+  parsed: unknown;
+  valid: boolean;
+  config: ClawdbotConfig;
+  issues: ConfigValidationIssue[];
+  legacyIssues: LegacyConfigIssue[];
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1231,6 +1231,13 @@ export type AudioConfig = {
     // Command should print MEDIA:<path> to stdout (or write to ReplyAudioPath).
     command: string[];
     timeoutSeconds?: number;
+    /**
+     * When true, suppress text replies and only send synthesized voice.
+     * Text is still accumulated internally for voice synthesis.
+     * Only applies when inbound message is audio.
+     * Default: false (send both text and voice).
+     */
+    voiceOnly?: boolean;
   };
 };
 

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -43,8 +43,17 @@ export const BroadcastSchema = z
   .catchall(z.array(z.string()))
   .optional();
 
+const AudioReplySchema = z
+  .object({
+    command: z.array(z.string()),
+    timeoutSeconds: z.number().int().positive().optional(),
+    voiceOnly: z.boolean().optional(),
+  })
+  .optional();
+
 export const AudioSchema = z
   .object({
     transcription: TranscribeAudioSchema,
+    reply: AudioReplySchema,
   })
   .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,20 +1,1459 @@
 import { z } from "zod";
-import { ToolsSchema } from "./zod-schema.agent-runtime.js";
-import {
-  AgentsSchema,
-  AudioSchema,
-  BindingsSchema,
-  BroadcastSchema,
-} from "./zod-schema.agents.js";
-import { HexColorSchema, ModelsConfigSchema } from "./zod-schema.core.js";
-import { HookMappingSchema, HooksGmailSchema } from "./zod-schema.hooks.js";
-import { ChannelsSchema } from "./zod-schema.providers.js";
-import {
-  CommandsSchema,
-  MessagesSchema,
-  SessionSchema,
-} from "./zod-schema.session.js";
 
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { isSafeExecutableValue } from "../infra/exec-safety.js";
+
+const ModelApiSchema = z.union([
+  z.literal("openai-completions"),
+  z.literal("openai-responses"),
+  z.literal("anthropic-messages"),
+  z.literal("google-generative-ai"),
+  z.literal("github-copilot"),
+]);
+
+const ModelCompatSchema = z
+  .object({
+    supportsStore: z.boolean().optional(),
+    supportsDeveloperRole: z.boolean().optional(),
+    supportsReasoningEffort: z.boolean().optional(),
+    maxTokensField: z
+      .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
+      .optional(),
+  })
+  .optional();
+
+const ModelDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  api: ModelApiSchema.optional(),
+  reasoning: z.boolean(),
+  input: z.array(z.union([z.literal("text"), z.literal("image")])),
+  cost: z.object({
+    input: z.number(),
+    output: z.number(),
+    cacheRead: z.number(),
+    cacheWrite: z.number(),
+  }),
+  contextWindow: z.number().positive(),
+  maxTokens: z.number().positive(),
+  headers: z.record(z.string(), z.string()).optional(),
+  compat: ModelCompatSchema,
+});
+
+const ModelProviderSchema = z.object({
+  baseUrl: z.string().min(1),
+  apiKey: z.string().optional(),
+  api: ModelApiSchema.optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  authHeader: z.boolean().optional(),
+  models: z.array(ModelDefinitionSchema),
+});
+
+const ModelsConfigSchema = z
+  .object({
+    mode: z.union([z.literal("merge"), z.literal("replace")]).optional(),
+    providers: z.record(z.string(), ModelProviderSchema).optional(),
+  })
+  .optional();
+
+const GroupChatSchema = z
+  .object({
+    mentionPatterns: z.array(z.string()).optional(),
+    historyLimit: z.number().int().positive().optional(),
+  })
+  .optional();
+
+const DmConfigSchema = z.object({
+  historyLimit: z.number().int().min(0).optional(),
+});
+
+const IdentitySchema = z
+  .object({
+    name: z.string().optional(),
+    theme: z.string().optional(),
+    emoji: z.string().optional(),
+  })
+  .optional();
+
+const QueueModeSchema = z.union([
+  z.literal("steer"),
+  z.literal("followup"),
+  z.literal("collect"),
+  z.literal("steer-backlog"),
+  z.literal("steer+backlog"),
+  z.literal("queue"),
+  z.literal("interrupt"),
+]);
+const QueueDropSchema = z.union([
+  z.literal("old"),
+  z.literal("new"),
+  z.literal("summarize"),
+]);
+const ReplyToModeSchema = z.union([
+  z.literal("off"),
+  z.literal("first"),
+  z.literal("all"),
+]);
+
+// GroupPolicySchema: controls how group messages are handled
+// Used with .default("allowlist").optional() pattern:
+//   - .optional() allows field omission in input config
+//   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
+const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
+
+const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
+
+const BlockStreamingCoalesceSchema = z.object({
+  minChars: z.number().int().positive().optional(),
+  maxChars: z.number().int().positive().optional(),
+  idleMs: z.number().int().nonnegative().optional(),
+});
+
+const BlockStreamingChunkSchema = z.object({
+  minChars: z.number().int().positive().optional(),
+  maxChars: z.number().int().positive().optional(),
+  breakPreference: z
+    .union([
+      z.literal("paragraph"),
+      z.literal("newline"),
+      z.literal("sentence"),
+    ])
+    .optional(),
+});
+
+const HumanDelaySchema = z.object({
+  mode: z
+    .union([z.literal("off"), z.literal("natural"), z.literal("custom")])
+    .optional(),
+  minMs: z.number().int().nonnegative().optional(),
+  maxMs: z.number().int().nonnegative().optional(),
+});
+
+const CliBackendSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  output: z
+    .union([z.literal("json"), z.literal("text"), z.literal("jsonl")])
+    .optional(),
+  resumeOutput: z
+    .union([z.literal("json"), z.literal("text"), z.literal("jsonl")])
+    .optional(),
+  input: z.union([z.literal("arg"), z.literal("stdin")]).optional(),
+  maxPromptArgChars: z.number().int().positive().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  clearEnv: z.array(z.string()).optional(),
+  modelArg: z.string().optional(),
+  modelAliases: z.record(z.string(), z.string()).optional(),
+  sessionArg: z.string().optional(),
+  sessionArgs: z.array(z.string()).optional(),
+  resumeArgs: z.array(z.string()).optional(),
+  sessionMode: z
+    .union([z.literal("always"), z.literal("existing"), z.literal("none")])
+    .optional(),
+  sessionIdFields: z.array(z.string()).optional(),
+  systemPromptArg: z.string().optional(),
+  systemPromptMode: z
+    .union([z.literal("append"), z.literal("replace")])
+    .optional(),
+  systemPromptWhen: z
+    .union([z.literal("first"), z.literal("always"), z.literal("never")])
+    .optional(),
+  imageArg: z.string().optional(),
+  imageMode: z.union([z.literal("repeat"), z.literal("list")]).optional(),
+  serialize: z.boolean().optional(),
+});
+
+const normalizeAllowFrom = (values?: Array<string | number>): string[] =>
+  (values ?? []).map((v) => String(v).trim()).filter(Boolean);
+
+const requireOpenAllowFrom = (params: {
+  policy?: string;
+  allowFrom?: Array<string | number>;
+  ctx: z.RefinementCtx;
+  path: Array<string | number>;
+  message: string;
+}) => {
+  if (params.policy !== "open") return;
+  const allow = normalizeAllowFrom(params.allowFrom);
+  if (allow.includes("*")) return;
+  params.ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: params.path,
+    message: params.message,
+  });
+};
+
+const MSTeamsReplyStyleSchema = z.enum(["thread", "top-level"]);
+
+const RetryConfigSchema = z
+  .object({
+    attempts: z.number().int().min(1).optional(),
+    minDelayMs: z.number().int().min(0).optional(),
+    maxDelayMs: z.number().int().min(0).optional(),
+    jitter: z.number().min(0).max(1).optional(),
+  })
+  .optional();
+
+const QueueModeBySurfaceSchema = z
+  .object({
+    whatsapp: QueueModeSchema.optional(),
+    telegram: QueueModeSchema.optional(),
+    discord: QueueModeSchema.optional(),
+    slack: QueueModeSchema.optional(),
+    signal: QueueModeSchema.optional(),
+    imessage: QueueModeSchema.optional(),
+    msteams: QueueModeSchema.optional(),
+    webchat: QueueModeSchema.optional(),
+  })
+  .optional();
+
+const QueueSchema = z
+  .object({
+    mode: QueueModeSchema.optional(),
+    byChannel: QueueModeBySurfaceSchema,
+    debounceMs: z.number().int().nonnegative().optional(),
+    cap: z.number().int().positive().optional(),
+    drop: QueueDropSchema.optional(),
+  })
+  .optional();
+
+const TranscribeAudioSchema = z
+  .object({
+    command: z.array(z.string()).superRefine((value, ctx) => {
+      const executable = value[0];
+      if (!isSafeExecutableValue(executable)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [0],
+          message: "expected safe executable name or path",
+        });
+      }
+    }),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .optional();
+
+const AudioReplySchema = z
+  .object({
+    command: z.array(z.string()),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .optional();
+
+const HexColorSchema = z
+  .string()
+  .regex(/^#?[0-9a-fA-F]{6}$/, "expected hex color (RRGGBB)");
+
+const ExecutableTokenSchema = z
+  .string()
+  .refine(isSafeExecutableValue, "expected safe executable name or path");
+
+const ToolsAudioTranscriptionSchema = z
+  .object({
+    args: z.array(z.string()).optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .optional();
+
+const NativeCommandsSettingSchema = z.union([z.boolean(), z.literal("auto")]);
+
+const ProviderCommandsSchema = z
+  .object({
+    native: NativeCommandsSettingSchema.optional(),
+  })
+  .optional();
+
+const TelegramTopicSchema = z.object({
+  requireMention: z.boolean().optional(),
+  skills: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  systemPrompt: z.string().optional(),
+});
+
+const TelegramGroupSchema = z.object({
+  requireMention: z.boolean().optional(),
+  skills: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  systemPrompt: z.string().optional(),
+  topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
+});
+
+const TelegramAccountSchemaBase = z.object({
+  name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  commands: ProviderCommandsSchema,
+  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  botToken: z.string().optional(),
+  tokenFile: z.string().optional(),
+  replyToMode: ReplyToModeSchema.optional(),
+  groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
+  dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+  textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
+  draftChunk: BlockStreamingChunkSchema.optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
+  mediaMaxMb: z.number().positive().optional(),
+  retry: RetryConfigSchema,
+  proxy: z.string().optional(),
+  webhookUrl: z.string().optional(),
+  webhookSecret: z.string().optional(),
+  webhookPath: z.string().optional(),
+  actions: z
+    .object({
+      reactions: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+const TelegramAccountSchema = TelegramAccountSchemaBase.superRefine(
+  (value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
+    });
+  },
+);
+
+const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
+  accounts: z.record(z.string(), TelegramAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
+  });
+});
+
+const DiscordDmSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    policy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupEnabled: z.boolean().optional(),
+    groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.policy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.discord.dm.policy="open" requires channels.discord.dm.allowFrom to include "*"',
+    });
+  });
+
+const DiscordGuildChannelSchema = z.object({
+  allow: z.boolean().optional(),
+  requireMention: z.boolean().optional(),
+  skills: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  users: z.array(z.union([z.string(), z.number()])).optional(),
+  systemPrompt: z.string().optional(),
+  autoThread: z.boolean().optional(),
+});
+
+const DiscordGuildSchema = z.object({
+  slug: z.string().optional(),
+  requireMention: z.boolean().optional(),
+  reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+  users: z.array(z.union([z.string(), z.number()])).optional(),
+  channels: z
+    .record(z.string(), DiscordGuildChannelSchema.optional())
+    .optional(),
+});
+
+const DiscordAccountSchema = z.object({
+  name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  commands: ProviderCommandsSchema,
+  token: z.string().optional(),
+  allowBots: z.boolean().optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
+  dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+  textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  maxLinesPerMessage: z.number().int().positive().optional(),
+  mediaMaxMb: z.number().positive().optional(),
+  retry: RetryConfigSchema,
+  actions: z
+    .object({
+      reactions: z.boolean().optional(),
+      stickers: z.boolean().optional(),
+      polls: z.boolean().optional(),
+      permissions: z.boolean().optional(),
+      messages: z.boolean().optional(),
+      threads: z.boolean().optional(),
+      pins: z.boolean().optional(),
+      search: z.boolean().optional(),
+      memberInfo: z.boolean().optional(),
+      roleInfo: z.boolean().optional(),
+      roles: z.boolean().optional(),
+      channelInfo: z.boolean().optional(),
+      voiceStatus: z.boolean().optional(),
+      events: z.boolean().optional(),
+      moderation: z.boolean().optional(),
+    })
+    .optional(),
+  replyToMode: ReplyToModeSchema.optional(),
+  dm: DiscordDmSchema.optional(),
+  guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
+});
+
+const DiscordConfigSchema = DiscordAccountSchema.extend({
+  accounts: z.record(z.string(), DiscordAccountSchema.optional()).optional(),
+});
+
+const SlackDmSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    policy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupEnabled: z.boolean().optional(),
+    groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.policy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.slack.dm.policy="open" requires channels.slack.dm.allowFrom to include "*"',
+    });
+  });
+
+const SlackChannelSchema = z.object({
+  enabled: z.boolean().optional(),
+  allow: z.boolean().optional(),
+  requireMention: z.boolean().optional(),
+  allowBots: z.boolean().optional(),
+  users: z.array(z.union([z.string(), z.number()])).optional(),
+  skills: z.array(z.string()).optional(),
+  systemPrompt: z.string().optional(),
+});
+
+const SlackAccountSchema = z.object({
+  name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  commands: ProviderCommandsSchema,
+  botToken: z.string().optional(),
+  appToken: z.string().optional(),
+  allowBots: z.boolean().optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
+  dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+  textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  mediaMaxMb: z.number().positive().optional(),
+  reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+  reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
+  replyToMode: ReplyToModeSchema.optional(),
+  actions: z
+    .object({
+      reactions: z.boolean().optional(),
+      messages: z.boolean().optional(),
+      pins: z.boolean().optional(),
+      search: z.boolean().optional(),
+      permissions: z.boolean().optional(),
+      memberInfo: z.boolean().optional(),
+      channelInfo: z.boolean().optional(),
+      emojiList: z.boolean().optional(),
+    })
+    .optional(),
+  slashCommand: z
+    .object({
+      enabled: z.boolean().optional(),
+      name: z.string().optional(),
+      sessionPrefix: z.string().optional(),
+      ephemeral: z.boolean().optional(),
+    })
+    .optional(),
+  dm: SlackDmSchema.optional(),
+  channels: z.record(z.string(), SlackChannelSchema.optional()).optional(),
+});
+
+const SlackConfigSchema = SlackAccountSchema.extend({
+  accounts: z.record(z.string(), SlackAccountSchema.optional()).optional(),
+});
+
+const SignalAccountSchemaBase = z.object({
+  name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  account: z.string().optional(),
+  httpUrl: z.string().optional(),
+  httpHost: z.string().optional(),
+  httpPort: z.number().int().positive().optional(),
+  cliPath: ExecutableTokenSchema.optional(),
+  autoStart: z.boolean().optional(),
+  receiveMode: z.union([z.literal("on-start"), z.literal("manual")]).optional(),
+  ignoreAttachments: z.boolean().optional(),
+  ignoreStories: z.boolean().optional(),
+  sendReadReceipts: z.boolean().optional(),
+  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
+  dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+  textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  mediaMaxMb: z.number().int().positive().optional(),
+  reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+  reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
+});
+
+const SignalAccountSchema = SignalAccountSchemaBase.superRefine(
+  (value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
+    });
+  },
+);
+
+const SignalConfigSchema = SignalAccountSchemaBase.extend({
+  accounts: z.record(z.string(), SignalAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
+  });
+});
+
+const IMessageAccountSchemaBase = z.object({
+  name: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  cliPath: ExecutableTokenSchema.optional(),
+  dbPath: z.string().optional(),
+  service: z
+    .union([z.literal("imessage"), z.literal("sms"), z.literal("auto")])
+    .optional(),
+  region: z.string().optional(),
+  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
+  dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+  includeAttachments: z.boolean().optional(),
+  mediaMaxMb: z.number().int().positive().optional(),
+  textChunkLimit: z.number().int().positive().optional(),
+  blockStreaming: z.boolean().optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  groups: z
+    .record(
+      z.string(),
+      z
+        .object({
+          requireMention: z.boolean().optional(),
+        })
+        .optional(),
+    )
+    .optional(),
+});
+
+const IMessageAccountSchema = IMessageAccountSchemaBase.superRefine(
+  (value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
+    });
+  },
+);
+
+const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
+  accounts: z.record(z.string(), IMessageAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
+  });
+});
+
+const MSTeamsChannelSchema = z.object({
+  requireMention: z.boolean().optional(),
+  replyStyle: MSTeamsReplyStyleSchema.optional(),
+});
+
+const MSTeamsTeamSchema = z.object({
+  requireMention: z.boolean().optional(),
+  replyStyle: MSTeamsReplyStyleSchema.optional(),
+  channels: z.record(z.string(), MSTeamsChannelSchema.optional()).optional(),
+});
+
+const MSTeamsConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    capabilities: z.array(z.string()).optional(),
+    appId: z.string().optional(),
+    appPassword: z.string().optional(),
+    tenantId: z.string().optional(),
+    webhook: z
+      .object({
+        port: z.number().int().positive().optional(),
+        path: z.string().optional(),
+      })
+      .optional(),
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: z.array(z.string()).optional(),
+    groupAllowFrom: z.array(z.string()).optional(),
+    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    textChunkLimit: z.number().int().positive().optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    mediaAllowHosts: z.array(z.string()).optional(),
+    requireMention: z.boolean().optional(),
+    historyLimit: z.number().int().min(0).optional(),
+    dmHistoryLimit: z.number().int().min(0).optional(),
+    dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+    replyStyle: MSTeamsReplyStyleSchema.optional(),
+    teams: z.record(z.string(), MSTeamsTeamSchema.optional()).optional(),
+  })
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.msteams.dmPolicy="open" requires channels.msteams.allowFrom to include "*"',
+    });
+  });
+
+const WhatsAppAccountSchema = z
+  .object({
+    name: z.string().optional(),
+    capabilities: z.array(z.string()).optional(),
+    enabled: z.boolean().optional(),
+    messagePrefix: z.string().optional(),
+    /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
+    authDir: z.string().optional(),
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    selfChatMode: z.boolean().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    groupAllowFrom: z.array(z.string()).optional(),
+    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    historyLimit: z.number().int().min(0).optional(),
+    dmHistoryLimit: z.number().int().min(0).optional(),
+    dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().positive().optional(),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            requireMention: z.boolean().optional(),
+          })
+          .optional(),
+      )
+      .optional(),
+    ackReaction: z
+      .object({
+        emoji: z.string().optional(),
+        direct: z.boolean().optional().default(true),
+        group: z
+          .enum(["always", "mentions", "never"])
+          .optional()
+          .default("mentions"),
+      })
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dmPolicy !== "open") return;
+    const allow = (value.allowFrom ?? [])
+      .map((v) => String(v).trim())
+      .filter(Boolean);
+    if (allow.includes("*")) return;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["allowFrom"],
+      message:
+        'channels.whatsapp.accounts.*.dmPolicy="open" requires allowFrom to include "*"',
+    });
+  });
+
+const WhatsAppConfigSchema = z
+  .object({
+    accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
+    capabilities: z.array(z.string()).optional(),
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    messagePrefix: z.string().optional(),
+    selfChatMode: z.boolean().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    groupAllowFrom: z.array(z.string()).optional(),
+    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    historyLimit: z.number().int().min(0).optional(),
+    dmHistoryLimit: z.number().int().min(0).optional(),
+    dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().positive().optional().default(50),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    actions: z
+      .object({
+        reactions: z.boolean().optional(),
+        sendMessage: z.boolean().optional(),
+        polls: z.boolean().optional(),
+      })
+      .optional(),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            requireMention: z.boolean().optional(),
+          })
+          .optional(),
+      )
+      .optional(),
+    ackReaction: z
+      .object({
+        emoji: z.string().optional(),
+        direct: z.boolean().optional().default(true),
+        group: z
+          .enum(["always", "mentions", "never"])
+          .optional()
+          .default("mentions"),
+      })
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dmPolicy !== "open") return;
+    const allow = (value.allowFrom ?? [])
+      .map((v) => String(v).trim())
+      .filter(Boolean);
+    if (allow.includes("*")) return;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["allowFrom"],
+      message:
+        'channels.whatsapp.dmPolicy="open" requires channels.whatsapp.allowFrom to include "*"',
+    });
+  });
+
+const ChannelsSchema = z
+  .object({
+    whatsapp: WhatsAppConfigSchema.optional(),
+    telegram: TelegramConfigSchema.optional(),
+    discord: DiscordConfigSchema.optional(),
+    slack: SlackConfigSchema.optional(),
+    signal: SignalConfigSchema.optional(),
+    imessage: IMessageConfigSchema.optional(),
+    msteams: MSTeamsConfigSchema.optional(),
+  })
+  .optional();
+
+const SessionSchema = z
+  .object({
+    scope: z.union([z.literal("per-sender"), z.literal("global")]).optional(),
+    resetTriggers: z.array(z.string()).optional(),
+    idleMinutes: z.number().int().positive().optional(),
+    heartbeatIdleMinutes: z.number().int().positive().optional(),
+    store: z.string().optional(),
+    typingIntervalSeconds: z.number().int().positive().optional(),
+    typingMode: z
+      .union([
+        z.literal("never"),
+        z.literal("instant"),
+        z.literal("thinking"),
+        z.literal("message"),
+      ])
+      .optional(),
+    mainKey: z.string().optional(),
+    sendPolicy: z
+      .object({
+        default: z.union([z.literal("allow"), z.literal("deny")]).optional(),
+        rules: z
+          .array(
+            z.object({
+              action: z.union([z.literal("allow"), z.literal("deny")]),
+              match: z
+                .object({
+                  channel: z.string().optional(),
+                  chatType: z
+                    .union([
+                      z.literal("direct"),
+                      z.literal("group"),
+                      z.literal("room"),
+                    ])
+                    .optional(),
+                  keyPrefix: z.string().optional(),
+                })
+                .optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+    agentToAgent: z
+      .object({
+        maxPingPongTurns: z.number().int().min(0).max(5).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+const MessagesSchema = z
+  .object({
+    messagePrefix: z.string().optional(),
+    responsePrefix: z.string().optional(),
+    groupChat: GroupChatSchema,
+    queue: QueueSchema,
+    ackReaction: z.string().optional(),
+    ackReactionScope: z
+      .enum(["group-mentions", "group-all", "direct", "all"])
+      .optional(),
+    removeAckAfterReply: z.boolean().optional(),
+  })
+  .optional();
+
+const CommandsSchema = z
+  .object({
+    native: NativeCommandsSettingSchema.optional().default("auto"),
+    text: z.boolean().optional(),
+    bash: z.boolean().optional(),
+    bashForegroundMs: z.number().int().min(0).max(30_000).optional(),
+    config: z.boolean().optional(),
+    debug: z.boolean().optional(),
+    restart: z.boolean().optional(),
+    useAccessGroups: z.boolean().optional(),
+  })
+  .optional()
+  .default({ native: "auto" });
+
+const HeartbeatSchema = z
+  .object({
+    every: z.string().optional(),
+    model: z.string().optional(),
+    includeReasoning: z.boolean().optional(),
+    target: z
+      .union([
+        z.literal("last"),
+        z.literal("whatsapp"),
+        z.literal("telegram"),
+        z.literal("discord"),
+        z.literal("slack"),
+        z.literal("msteams"),
+        z.literal("signal"),
+        z.literal("imessage"),
+        z.literal("none"),
+      ])
+      .optional(),
+    to: z.string().optional(),
+    prompt: z.string().optional(),
+    ackMaxChars: z.number().int().nonnegative().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (!val.every) return;
+    try {
+      parseDurationMs(val.every, { defaultUnit: "m" });
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["every"],
+        message: "invalid duration (use ms, s, m, h)",
+      });
+    }
+  })
+  .optional();
+
+const SandboxDockerSchema = z
+  .object({
+    image: z.string().optional(),
+    containerPrefix: z.string().optional(),
+    workdir: z.string().optional(),
+    readOnlyRoot: z.boolean().optional(),
+    tmpfs: z.array(z.string()).optional(),
+    network: z.string().optional(),
+    user: z.string().optional(),
+    capDrop: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    setupCommand: z.string().optional(),
+    pidsLimit: z.number().int().positive().optional(),
+    memory: z.union([z.string(), z.number()]).optional(),
+    memorySwap: z.union([z.string(), z.number()]).optional(),
+    cpus: z.number().positive().optional(),
+    ulimits: z
+      .record(
+        z.string(),
+        z.union([
+          z.string(),
+          z.number(),
+          z.object({
+            soft: z.number().int().nonnegative().optional(),
+            hard: z.number().int().nonnegative().optional(),
+          }),
+        ]),
+      )
+      .optional(),
+    seccompProfile: z.string().optional(),
+    apparmorProfile: z.string().optional(),
+    dns: z.array(z.string()).optional(),
+    extraHosts: z.array(z.string()).optional(),
+  })
+  .optional();
+
+const SandboxBrowserSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    image: z.string().optional(),
+    containerPrefix: z.string().optional(),
+    cdpPort: z.number().int().positive().optional(),
+    vncPort: z.number().int().positive().optional(),
+    noVncPort: z.number().int().positive().optional(),
+    headless: z.boolean().optional(),
+    enableNoVnc: z.boolean().optional(),
+    allowHostControl: z.boolean().optional(),
+    allowedControlUrls: z.array(z.string()).optional(),
+    allowedControlHosts: z.array(z.string()).optional(),
+    allowedControlPorts: z.array(z.number().int().positive()).optional(),
+    autoStart: z.boolean().optional(),
+    autoStartTimeoutMs: z.number().int().positive().optional(),
+  })
+  .optional();
+
+const SandboxPruneSchema = z
+  .object({
+    idleHours: z.number().int().nonnegative().optional(),
+    maxAgeDays: z.number().int().nonnegative().optional(),
+  })
+  .optional();
+
+const ToolPolicySchema = z
+  .object({
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+  })
+  .optional();
+
+const ToolProfileSchema = z
+  .union([
+    z.literal("minimal"),
+    z.literal("coding"),
+    z.literal("messaging"),
+    z.literal("full"),
+  ])
+  .optional();
+
+// Provider docking: allowlists keyed by provider id (no schema updates when adding providers).
+const ElevatedAllowFromSchema = z
+  .record(z.string(), z.array(z.union([z.string(), z.number()])))
+  .optional();
+
+const AgentSandboxSchema = z
+  .object({
+    mode: z
+      .union([z.literal("off"), z.literal("non-main"), z.literal("all")])
+      .optional(),
+    workspaceAccess: z
+      .union([z.literal("none"), z.literal("ro"), z.literal("rw")])
+      .optional(),
+    sessionToolsVisibility: z
+      .union([z.literal("spawned"), z.literal("all")])
+      .optional(),
+    scope: z
+      .union([z.literal("session"), z.literal("agent"), z.literal("shared")])
+      .optional(),
+    perSession: z.boolean().optional(),
+    workspaceRoot: z.string().optional(),
+    docker: SandboxDockerSchema,
+    browser: SandboxBrowserSchema,
+    prune: SandboxPruneSchema,
+  })
+  .optional();
+
+const AgentToolsSchema = z
+  .object({
+    profile: ToolProfileSchema,
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+    elevated: z
+      .object({
+        enabled: z.boolean().optional(),
+        allowFrom: ElevatedAllowFromSchema,
+      })
+      .optional(),
+    sandbox: z
+      .object({
+        tools: ToolPolicySchema,
+      })
+      .optional(),
+  })
+  .optional();
+
+const MemorySearchSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    provider: z.union([z.literal("openai"), z.literal("local")]).optional(),
+    remote: z
+      .object({
+        baseUrl: z.string().optional(),
+        apiKey: z.string().optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+      })
+      .optional(),
+    fallback: z.union([z.literal("openai"), z.literal("none")]).optional(),
+    model: z.string().optional(),
+    local: z
+      .object({
+        modelPath: z.string().optional(),
+        modelCacheDir: z.string().optional(),
+      })
+      .optional(),
+    store: z
+      .object({
+        driver: z.literal("sqlite").optional(),
+        path: z.string().optional(),
+      })
+      .optional(),
+    chunking: z
+      .object({
+        tokens: z.number().int().positive().optional(),
+        overlap: z.number().int().nonnegative().optional(),
+      })
+      .optional(),
+    sync: z
+      .object({
+        onSessionStart: z.boolean().optional(),
+        onSearch: z.boolean().optional(),
+        watch: z.boolean().optional(),
+        watchDebounceMs: z.number().int().nonnegative().optional(),
+        intervalMinutes: z.number().int().nonnegative().optional(),
+      })
+      .optional(),
+    query: z
+      .object({
+        maxResults: z.number().int().positive().optional(),
+        minScore: z.number().min(0).max(1).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+const AgentModelSchema = z.union([
+  z.string(),
+  z.object({
+    primary: z.string().optional(),
+    fallbacks: z.array(z.string()).optional(),
+  }),
+]);
+const AgentEntrySchema = z.object({
+  id: z.string(),
+  default: z.boolean().optional(),
+  name: z.string().optional(),
+  workspace: z.string().optional(),
+  agentDir: z.string().optional(),
+  model: AgentModelSchema.optional(),
+  memorySearch: MemorySearchSchema,
+  humanDelay: HumanDelaySchema.optional(),
+  identity: IdentitySchema,
+  groupChat: GroupChatSchema,
+  subagents: z
+    .object({
+      allowAgents: z.array(z.string()).optional(),
+      model: z
+        .union([
+          z.string(),
+          z.object({
+            primary: z.string().optional(),
+            fallbacks: z.array(z.string()).optional(),
+          }),
+        ])
+        .optional(),
+    })
+    .optional(),
+  sandbox: AgentSandboxSchema,
+  tools: AgentToolsSchema,
+});
+
+const ToolsSchema = z
+  .object({
+    profile: ToolProfileSchema,
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+    audio: z
+      .object({
+        transcription: ToolsAudioTranscriptionSchema,
+      })
+      .optional(),
+    agentToAgent: z
+      .object({
+        enabled: z.boolean().optional(),
+        allow: z.array(z.string()).optional(),
+      })
+      .optional(),
+    elevated: z
+      .object({
+        enabled: z.boolean().optional(),
+        allowFrom: ElevatedAllowFromSchema,
+      })
+      .optional(),
+    exec: z
+      .object({
+        backgroundMs: z.number().int().positive().optional(),
+        timeoutSec: z.number().int().positive().optional(),
+        cleanupMs: z.number().int().positive().optional(),
+        applyPatch: z
+          .object({
+            enabled: z.boolean().optional(),
+            allowModels: z.array(z.string()).optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+    bash: z
+      .object({
+        backgroundMs: z.number().int().positive().optional(),
+        timeoutSec: z.number().int().positive().optional(),
+        cleanupMs: z.number().int().positive().optional(),
+      })
+      .optional(),
+    subagents: z
+      .object({
+        tools: ToolPolicySchema,
+      })
+      .optional(),
+    sandbox: z
+      .object({
+        tools: ToolPolicySchema,
+      })
+      .optional(),
+  })
+  .optional();
+
+const AgentsSchema = z
+  .object({
+    defaults: z.lazy(() => AgentDefaultsSchema).optional(),
+    list: z.array(AgentEntrySchema).optional(),
+  })
+  .optional();
+
+const BindingsSchema = z
+  .array(
+    z.object({
+      agentId: z.string(),
+      match: z.object({
+        channel: z.string(),
+        accountId: z.string().optional(),
+        peer: z
+          .object({
+            kind: z.union([
+              z.literal("dm"),
+              z.literal("group"),
+              z.literal("channel"),
+            ]),
+            id: z.string(),
+          })
+          .optional(),
+        guildId: z.string().optional(),
+        teamId: z.string().optional(),
+      }),
+    }),
+  )
+  .optional();
+
+const BroadcastStrategySchema = z.enum(["parallel", "sequential"]);
+
+const BroadcastSchema = z
+  .object({
+    strategy: BroadcastStrategySchema.optional(),
+  })
+  .catchall(z.array(z.string()))
+  .optional();
+
+const AudioSchema = z
+  .object({
+    transcription: TranscribeAudioSchema,
+    reply: AudioReplySchema,
+  })
+  .optional();
+
+const HookMappingSchema = z
+  .object({
+    id: z.string().optional(),
+    match: z
+      .object({
+        path: z.string().optional(),
+        source: z.string().optional(),
+      })
+      .optional(),
+    action: z.union([z.literal("wake"), z.literal("agent")]).optional(),
+    wakeMode: z
+      .union([z.literal("now"), z.literal("next-heartbeat")])
+      .optional(),
+    name: z.string().optional(),
+    sessionKey: z.string().optional(),
+    messageTemplate: z.string().optional(),
+    textTemplate: z.string().optional(),
+    deliver: z.boolean().optional(),
+    channel: z
+      .union([
+        z.literal("last"),
+        z.literal("whatsapp"),
+        z.literal("telegram"),
+        z.literal("discord"),
+        z.literal("slack"),
+        z.literal("signal"),
+        z.literal("imessage"),
+        z.literal("msteams"),
+      ])
+      .optional(),
+    to: z.string().optional(),
+    model: z.string().optional(),
+    thinking: z.string().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    transform: z
+      .object({
+        module: z.string(),
+        export: z.string().optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+const HooksGmailSchema = z
+  .object({
+    account: z.string().optional(),
+    label: z.string().optional(),
+    topic: z.string().optional(),
+    subscription: z.string().optional(),
+    pushToken: z.string().optional(),
+    hookUrl: z.string().optional(),
+    includeBody: z.boolean().optional(),
+    maxBytes: z.number().int().positive().optional(),
+    renewEveryMinutes: z.number().int().positive().optional(),
+    serve: z
+      .object({
+        bind: z.string().optional(),
+        port: z.number().int().positive().optional(),
+        path: z.string().optional(),
+      })
+      .optional(),
+    tailscale: z
+      .object({
+        mode: z
+          .union([z.literal("off"), z.literal("serve"), z.literal("funnel")])
+          .optional(),
+        path: z.string().optional(),
+        target: z.string().optional(),
+      })
+      .optional(),
+    model: z.string().optional(),
+    thinking: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+      ])
+      .optional(),
+  })
+  .optional();
+
+const AgentDefaultsSchema = z
+  .object({
+    model: z
+      .object({
+        primary: z.string().optional(),
+        fallbacks: z.array(z.string()).optional(),
+      })
+      .optional(),
+    imageModel: z
+      .object({
+        primary: z.string().optional(),
+        fallbacks: z.array(z.string()).optional(),
+      })
+      .optional(),
+    models: z
+      .record(
+        z.string(),
+        z.object({
+          alias: z.string().optional(),
+          /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
+          params: z.record(z.string(), z.unknown()).optional(),
+        }),
+      )
+      .optional(),
+    workspace: z.string().optional(),
+    skipBootstrap: z.boolean().optional(),
+    bootstrapMaxChars: z.number().int().positive().optional(),
+    userTimezone: z.string().optional(),
+    contextTokens: z.number().int().positive().optional(),
+    cliBackends: z.record(z.string(), CliBackendSchema).optional(),
+    memorySearch: MemorySearchSchema,
+    contextPruning: z
+      .object({
+        mode: z
+          .union([
+            z.literal("off"),
+            z.literal("adaptive"),
+            z.literal("aggressive"),
+          ])
+          .optional(),
+        keepLastAssistants: z.number().int().nonnegative().optional(),
+        softTrimRatio: z.number().min(0).max(1).optional(),
+        hardClearRatio: z.number().min(0).max(1).optional(),
+        minPrunableToolChars: z.number().int().nonnegative().optional(),
+        tools: z
+          .object({
+            allow: z.array(z.string()).optional(),
+            deny: z.array(z.string()).optional(),
+          })
+          .optional(),
+        softTrim: z
+          .object({
+            maxChars: z.number().int().nonnegative().optional(),
+            headChars: z.number().int().nonnegative().optional(),
+            tailChars: z.number().int().nonnegative().optional(),
+          })
+          .optional(),
+        hardClear: z
+          .object({
+            enabled: z.boolean().optional(),
+            placeholder: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+    compaction: z
+      .object({
+        mode: z
+          .union([z.literal("default"), z.literal("safeguard")])
+          .optional(),
+        reserveTokensFloor: z.number().int().nonnegative().optional(),
+        memoryFlush: z
+          .object({
+            enabled: z.boolean().optional(),
+            softThresholdTokens: z.number().int().nonnegative().optional(),
+            prompt: z.string().optional(),
+            systemPrompt: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+      ])
+      .optional(),
+    verboseDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    elevatedDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    blockStreamingDefault: z
+      .union([z.literal("off"), z.literal("on")])
+      .optional(),
+    blockStreamingBreak: z
+      .union([z.literal("text_end"), z.literal("message_end")])
+      .optional(),
+    blockStreamingChunk: BlockStreamingChunkSchema.optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    humanDelay: HumanDelaySchema.optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().positive().optional(),
+    typingIntervalSeconds: z.number().int().positive().optional(),
+    typingMode: z
+      .union([
+        z.literal("never"),
+        z.literal("instant"),
+        z.literal("thinking"),
+        z.literal("message"),
+      ])
+      .optional(),
+    heartbeat: HeartbeatSchema,
+    maxConcurrent: z.number().int().positive().optional(),
+    subagents: z
+      .object({
+        maxConcurrent: z.number().int().positive().optional(),
+        archiveAfterMinutes: z.number().int().positive().optional(),
+        model: z
+          .union([
+            z.string(),
+            z.object({
+              primary: z.string().optional(),
+              fallbacks: z.array(z.string()).optional(),
+            }),
+          ])
+          .optional(),
+      })
+      .optional(),
+    sandbox: z
+      .object({
+        mode: z
+          .union([z.literal("off"), z.literal("non-main"), z.literal("all")])
+          .optional(),
+        workspaceAccess: z
+          .union([z.literal("none"), z.literal("ro"), z.literal("rw")])
+          .optional(),
+        sessionToolsVisibility: z
+          .union([z.literal("spawned"), z.literal("all")])
+          .optional(),
+        scope: z
+          .union([
+            z.literal("session"),
+            z.literal("agent"),
+            z.literal("shared"),
+          ])
+          .optional(),
+        perSession: z.boolean().optional(),
+        workspaceRoot: z.string().optional(),
+        docker: SandboxDockerSchema,
+        browser: SandboxBrowserSchema,
+        prune: SandboxPruneSchema,
+      })
+      .optional(),
+  })
+  .optional();
 export const ClawdbotSchema = z
   .object({
     env: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -237,6 +237,7 @@ const AudioReplySchema = z
   .object({
     command: z.array(z.string()),
     timeoutSeconds: z.number().int().positive().optional(),
+    voiceOnly: z.boolean().optional(),
   })
   .optional();
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -47,8 +47,13 @@ import {
   matchesMentionPatterns,
 } from "../auto-reply/reply/mentions.js";
 import { dispatchReplyWithDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
-import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import {
+  createReplyDispatcher,
+  createReplyDispatcherWithTyping,
+  shouldSkipTextOnlyDelivery,
+} from "../auto-reply/reply/reply-dispatcher.js";
 import { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
+import { getReplyFromConfig } from "../auto-reply/reply.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import {
   isNativeCommandsExplicitlyDisabled,
@@ -1338,6 +1343,10 @@ export function createDiscordMessageHandler(params: {
           responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
             .responsePrefix,
           humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+          skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(
+            cfg,
+            mediaPayload.MediaType,
+          ),
           deliver: async (payload) => {
             const replyToId = replyReference.use();
             await deliverDiscordReply({
@@ -1858,6 +1867,8 @@ export function createDiscordNativeCommand(params: {
           responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
             .responsePrefix,
           humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+          // Native commands (slash commands) don't have media, so this is always false.
+          skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(cfg, undefined),
           deliver: async (payload) => {
             await deliverDiscordInteractionReply({
               interaction,

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -1,33 +1,2653 @@
-export type {
-  DiscordAllowList,
-  DiscordChannelConfigResolved,
-  DiscordGuildEntryResolved,
-} from "./monitor/allow-list.js";
-export {
-  allowListMatches,
-  isDiscordGroupAllowedByPolicy,
-  normalizeDiscordAllowList,
-  normalizeDiscordSlug,
-  resolveDiscordChannelConfig,
-  resolveDiscordCommandAuthorized,
-  resolveDiscordGuildEntry,
-  resolveDiscordShouldRequireMention,
-  resolveGroupDmAllow,
-  shouldEmitDiscordReactionNotification,
-} from "./monitor/allow-list.js";
-export type {
-  DiscordMessageEvent,
-  DiscordMessageHandler,
-} from "./monitor/listeners.js";
-export { registerDiscordListener } from "./monitor/listeners.js";
+import {
+  ChannelType,
+  Client,
+  Command,
+  type CommandInteraction,
+  type CommandOptions,
+  type Guild,
+  type Message,
+  MessageCreateListener,
+  MessageReactionAddListener,
+  MessageReactionRemoveListener,
+  MessageType,
+  type RequestClient,
+  type User,
+} from "@buape/carbon";
+import { GatewayIntents, GatewayPlugin } from "@buape/carbon/gateway";
+import {
+  type APIAttachment,
+  ApplicationCommandOptionType,
+  Routes,
+} from "discord-api-types/v10";
 
-export { createDiscordMessageHandler } from "./monitor/message-handler.js";
-export { buildDiscordMediaPayload } from "./monitor/message-utils.js";
-export { createDiscordNativeCommand } from "./monitor/native-command.js";
-export type { MonitorDiscordOpts } from "./monitor/provider.js";
-export { monitorDiscordProvider } from "./monitor/provider.js";
+import {
+  resolveAckReaction,
+  resolveEffectiveMessagesConfig,
+  resolveHumanDelayConfig,
+} from "../agents/identity.js";
+import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import {
+  buildCommandText,
+  listNativeCommandSpecsForConfig,
+  shouldHandleTextCommands,
+} from "../auto-reply/commands-registry.js";
+import {
+  formatAgentEnvelope,
+  formatThreadStarterEnvelope,
+} from "../auto-reply/envelope.js";
+import { dispatchReplyFromConfig } from "../auto-reply/reply/dispatch-from-config.js";
+import {
+  buildHistoryContextFromMap,
+  clearHistoryEntries,
+  type HistoryEntry,
+} from "../auto-reply/reply/history.js";
+import {
+  buildMentionRegexes,
+  matchesMentionPatterns,
+} from "../auto-reply/reply/mentions.js";
+import { dispatchReplyWithDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import {
+  isNativeCommandsExplicitlyDisabled,
+  resolveNativeCommandsEnabled,
+} from "../config/commands.js";
+import type { ClawdbotConfig, ReplyToMode } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import { resolveStorePath, updateLastRoute } from "../config/sessions.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { recordChannelActivity } from "../infra/channel-activity.js";
+import { formatDurationSeconds } from "../infra/format-duration.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { getChildLogger } from "../logging.js";
+import { fetchRemoteMedia } from "../media/fetch.js";
+import { saveMediaBuffer } from "../media/store.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import {
+  buildAgentSessionKey,
+  resolveAgentRoute,
+} from "../routing/resolve-route.js";
+import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
+import { loadWebMedia } from "../web/media.js";
+import { resolveDiscordAccount } from "./accounts.js";
+import { chunkDiscordText } from "./chunk.js";
+import { attachDiscordGatewayLogging } from "./gateway-logging.js";
+import {
+  getDiscordGatewayEmitter,
+  waitForDiscordGatewayStop,
+} from "./monitor.gateway.js";
+import { fetchDiscordApplicationId } from "./probe.js";
+import {
+  reactMessageDiscord,
+  removeReactionDiscord,
+  sendMessageDiscord,
+} from "./send.js";
+import { normalizeDiscordToken } from "./token.js";
 
-export {
-  resolveDiscordReplyTarget,
-  sanitizeDiscordThreadName,
-} from "./monitor/threading.js";
+export type MonitorDiscordOpts = {
+  token?: string;
+  accountId?: string;
+  config?: ClawdbotConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  mediaMaxMb?: number;
+  historyLimit?: number;
+  replyToMode?: ReplyToMode;
+};
+
+type DiscordConfig = NonNullable<ClawdbotConfig["channels"]>["discord"];
+
+type DiscordMediaInfo = {
+  path: string;
+  contentType?: string;
+  placeholder: string;
+};
+
+type DiscordSnapshotAuthor = {
+  id?: string | null;
+  username?: string | null;
+  discriminator?: string | null;
+  global_name?: string | null;
+  name?: string | null;
+};
+
+type DiscordSnapshotMessage = {
+  content?: string | null;
+  embeds?: Array<{ description?: string | null; title?: string | null }> | null;
+  attachments?: APIAttachment[] | null;
+  author?: DiscordSnapshotAuthor | null;
+};
+
+type DiscordMessageSnapshot = {
+  message?: DiscordSnapshotMessage | null;
+};
+type DiscordReactionEvent = Parameters<MessageReactionAddListener["handle"]>[0];
+type DiscordThreadChannel = {
+  id: string;
+  name?: string | null;
+  parentId?: string | null;
+  parent?: { id?: string; name?: string };
+};
+type DiscordThreadStarter = {
+  text: string;
+  author: string;
+  timestamp?: number;
+};
+
+type DiscordChannelInfo = {
+  type: ChannelType;
+  name?: string;
+  topic?: string;
+  parentId?: string;
+};
+
+const DISCORD_THREAD_STARTER_CACHE = new Map<string, DiscordThreadStarter>();
+const DISCORD_CHANNEL_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
+const DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS = 30 * 1000;
+const DISCORD_CHANNEL_INFO_CACHE = new Map<
+  string,
+  { value: DiscordChannelInfo | null; expiresAt: number }
+>();
+const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 1000;
+
+function logSlowDiscordListener(params: {
+  logger: ReturnType<typeof getChildLogger> | undefined;
+  listener: string;
+  event: string;
+  durationMs: number;
+}) {
+  if (params.durationMs < DISCORD_SLOW_LISTENER_THRESHOLD_MS) return;
+  const duration = formatDurationSeconds(params.durationMs, {
+    decimals: 1,
+    unit: "seconds",
+  });
+  const message = `[EventQueue] Slow listener detected: ${params.listener} took ${duration} for event ${params.event}`;
+  if (params.logger?.warn) {
+    params.logger.warn(message);
+  } else {
+    console.warn(message);
+  }
+}
+
+export function registerDiscordListener(
+  listeners: Array<object>,
+  listener: object,
+) {
+  if (
+    listeners.some((existing) => existing.constructor === listener.constructor)
+  ) {
+    return false;
+  }
+  listeners.push(listener);
+  return true;
+}
+
+async function resolveDiscordThreadStarter(params: {
+  channel: DiscordThreadChannel;
+  client: Client;
+  parentId?: string;
+  parentType?: ChannelType;
+}): Promise<DiscordThreadStarter | null> {
+  const cacheKey = params.channel.id;
+  const cached = DISCORD_THREAD_STARTER_CACHE.get(cacheKey);
+  if (cached) return cached;
+  try {
+    const parentType = params.parentType;
+    const isForumParent =
+      parentType === ChannelType.GuildForum ||
+      parentType === ChannelType.GuildMedia;
+    const messageChannelId = isForumParent
+      ? params.channel.id
+      : params.parentId;
+    if (!messageChannelId) return null;
+    const starter = (await params.client.rest.get(
+      Routes.channelMessage(messageChannelId, params.channel.id),
+    )) as {
+      content?: string | null;
+      embeds?: Array<{ description?: string | null }>;
+      member?: { nick?: string | null; displayName?: string | null };
+      author?: {
+        id?: string | null;
+        username?: string | null;
+        discriminator?: string | null;
+      };
+      timestamp?: string | null;
+    };
+    if (!starter) return null;
+    const text =
+      starter.content?.trim() ?? starter.embeds?.[0]?.description?.trim() ?? "";
+    if (!text) return null;
+    const author =
+      starter.member?.nick ??
+      starter.member?.displayName ??
+      (starter.author
+        ? starter.author.discriminator && starter.author.discriminator !== "0"
+          ? `${starter.author.username ?? "Unknown"}#${starter.author.discriminator}`
+          : (starter.author.username ?? starter.author.id ?? "Unknown")
+        : "Unknown");
+    const timestamp = resolveTimestampMs(starter.timestamp);
+    const payload: DiscordThreadStarter = {
+      text,
+      author,
+      timestamp: timestamp ?? undefined,
+    };
+    DISCORD_THREAD_STARTER_CACHE.set(cacheKey, payload);
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export type DiscordAllowList = {
+  allowAll: boolean;
+  ids: Set<string>;
+  names: Set<string>;
+};
+
+export type DiscordGuildEntryResolved = {
+  id?: string;
+  slug?: string;
+  requireMention?: boolean;
+  reactionNotifications?: "off" | "own" | "all" | "allowlist";
+  users?: Array<string | number>;
+  channels?: Record<
+    string,
+    {
+      allow?: boolean;
+      requireMention?: boolean;
+      skills?: string[];
+      enabled?: boolean;
+      users?: Array<string | number>;
+      systemPrompt?: string;
+      autoThread?: boolean;
+    }
+  >;
+};
+
+export type DiscordChannelConfigResolved = {
+  allowed: boolean;
+  requireMention?: boolean;
+  skills?: string[];
+  enabled?: boolean;
+  users?: Array<string | number>;
+  systemPrompt?: string;
+  autoThread?: boolean;
+};
+
+export type DiscordMessageEvent = Parameters<
+  MessageCreateListener["handle"]
+>[0];
+
+export type DiscordMessageHandler = (
+  data: DiscordMessageEvent,
+  client: Client,
+) => Promise<void>;
+
+function isDiscordThreadType(type: ChannelType | undefined): boolean {
+  return (
+    type === ChannelType.PublicThread ||
+    type === ChannelType.PrivateThread ||
+    type === ChannelType.AnnouncementThread
+  );
+}
+
+type DiscordThreadParentInfo = {
+  id?: string;
+  name?: string;
+  type?: ChannelType;
+};
+
+function resolveDiscordThreadChannel(params: {
+  isGuildMessage: boolean;
+  message: DiscordMessageEvent["message"];
+  channelInfo: DiscordChannelInfo | null;
+}): DiscordThreadChannel | null {
+  if (!params.isGuildMessage) return null;
+  const { message, channelInfo } = params;
+  const channel =
+    "channel" in message
+      ? (message as { channel?: unknown }).channel
+      : undefined;
+  const isThreadChannel =
+    channel &&
+    typeof channel === "object" &&
+    "isThread" in channel &&
+    typeof (channel as { isThread?: unknown }).isThread === "function" &&
+    (channel as { isThread: () => boolean }).isThread();
+  if (isThreadChannel) return channel as unknown as DiscordThreadChannel;
+  if (!isDiscordThreadType(channelInfo?.type)) return null;
+  return {
+    id: message.channelId,
+    name: channelInfo?.name ?? undefined,
+    parentId: channelInfo?.parentId ?? undefined,
+    parent: undefined,
+  };
+}
+
+async function resolveDiscordThreadParentInfo(params: {
+  client: Client;
+  threadChannel: DiscordThreadChannel;
+  channelInfo: DiscordChannelInfo | null;
+}): Promise<DiscordThreadParentInfo> {
+  const { threadChannel, channelInfo, client } = params;
+  const parentId =
+    threadChannel.parentId ??
+    threadChannel.parent?.id ??
+    channelInfo?.parentId ??
+    undefined;
+  if (!parentId) return {};
+  let parentName = threadChannel.parent?.name;
+  const parentInfo = await resolveDiscordChannelInfo(client, parentId);
+  parentName = parentName ?? parentInfo?.name;
+  const parentType = parentInfo?.type;
+  return { id: parentId, name: parentName, type: parentType };
+}
+
+export function resolveDiscordReplyTarget(opts: {
+  replyToMode: ReplyToMode;
+  replyToId?: string;
+  hasReplied: boolean;
+}): string | undefined {
+  if (opts.replyToMode === "off") return undefined;
+  const replyToId = opts.replyToId?.trim();
+  if (!replyToId) return undefined;
+  if (opts.replyToMode === "all") return replyToId;
+  return opts.hasReplied ? undefined : replyToId;
+}
+
+export function sanitizeDiscordThreadName(
+  rawName: string,
+  fallbackId: string,
+): string {
+  const cleanedName = rawName
+    .replace(/<@!?\d+>/g, "") // user mentions
+    .replace(/<@&\d+>/g, "") // role mentions
+    .replace(/<#\d+>/g, "") // channel mentions
+    .replace(/\s+/g, " ")
+    .trim();
+  const baseSource = cleanedName || `Thread ${fallbackId}`;
+  const base = truncateUtf16Safe(baseSource, 80);
+  return truncateUtf16Safe(base, 100) || `Thread ${fallbackId}`;
+}
+
+type DiscordReplyDeliveryPlan = {
+  deliverTarget: string;
+  replyTarget: string;
+  replyReference: ReturnType<typeof createReplyReferencePlanner>;
+};
+
+async function maybeCreateDiscordAutoThread(params: {
+  client: Client;
+  message: DiscordMessageEvent["message"];
+  isGuildMessage: boolean;
+  channelConfig?: DiscordChannelConfigResolved | null;
+  threadChannel?: DiscordThreadChannel | null;
+  baseText: string;
+  combinedBody: string;
+}): Promise<string | undefined> {
+  if (!params.isGuildMessage) return undefined;
+  if (!params.channelConfig?.autoThread) return undefined;
+  if (params.threadChannel) return undefined;
+  try {
+    const threadName = sanitizeDiscordThreadName(
+      params.baseText || params.combinedBody || "Thread",
+      params.message.id,
+    );
+    const created = (await params.client.rest.post(
+      `${Routes.channelMessage(params.message.channelId, params.message.id)}/threads`,
+      {
+        body: {
+          name: threadName,
+          auto_archive_duration: 60,
+        },
+      },
+    )) as { id?: string };
+    const createdId = created?.id ? String(created.id) : "";
+    return createdId || undefined;
+  } catch (err) {
+    logVerbose(
+      `discord: autoThread failed for ${params.message.channelId}/${params.message.id}: ${String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+function resolveDiscordReplyDeliveryPlan(params: {
+  replyTarget: string;
+  replyToMode: ReplyToMode;
+  messageId: string;
+  threadChannel?: DiscordThreadChannel | null;
+  createdThreadId?: string | null;
+}): DiscordReplyDeliveryPlan {
+  const originalReplyTarget = params.replyTarget;
+  let deliverTarget = originalReplyTarget;
+  let replyTarget = originalReplyTarget;
+  if (params.createdThreadId) {
+    deliverTarget = `channel:${params.createdThreadId}`;
+    replyTarget = deliverTarget;
+  }
+  const allowReference = deliverTarget === originalReplyTarget;
+  const replyReference = createReplyReferencePlanner({
+    replyToMode: allowReference ? params.replyToMode : "off",
+    existingId: params.threadChannel ? params.messageId : undefined,
+    startId: params.messageId,
+    allowReference,
+  });
+  return { deliverTarget, replyTarget, replyReference };
+}
+
+function summarizeAllowList(list?: Array<string | number>) {
+  if (!list || list.length === 0) return "any";
+  const sample = list.slice(0, 4).map((entry) => String(entry));
+  const suffix =
+    list.length > sample.length ? ` (+${list.length - sample.length})` : "";
+  return `${sample.join(", ")}${suffix}`;
+}
+
+function summarizeGuilds(entries?: Record<string, DiscordGuildEntryResolved>) {
+  if (!entries || Object.keys(entries).length === 0) return "any";
+  const keys = Object.keys(entries);
+  const sample = keys.slice(0, 4);
+  const suffix =
+    keys.length > sample.length ? ` (+${keys.length - sample.length})` : "";
+  return `${sample.join(", ")}${suffix}`;
+}
+
+export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
+  const cfg = opts.config ?? loadConfig();
+  const account = resolveDiscordAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const token = normalizeDiscordToken(opts.token ?? undefined) ?? account.token;
+  if (!token) {
+    throw new Error(
+      `Discord bot token missing for account "${account.accountId}" (set discord.accounts.${account.accountId}.token or DISCORD_BOT_TOKEN for default).`,
+    );
+  }
+
+  const runtime: RuntimeEnv = opts.runtime ?? {
+    log: console.log,
+    error: console.error,
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+
+  const discordCfg = account.config;
+  const dmConfig = discordCfg.dm;
+  const guildEntries = discordCfg.guilds;
+  const groupPolicy = discordCfg.groupPolicy ?? "open";
+  const allowFrom = dmConfig?.allowFrom;
+  const mediaMaxBytes =
+    (opts.mediaMaxMb ?? discordCfg.mediaMaxMb ?? 8) * 1024 * 1024;
+  const textLimit = resolveTextChunkLimit(cfg, "discord", account.accountId, {
+    fallbackLimit: 2000,
+  });
+  const historyLimit = Math.max(
+    0,
+    opts.historyLimit ??
+      discordCfg.historyLimit ??
+      cfg.messages?.groupChat?.historyLimit ??
+      20,
+  );
+  const replyToMode = opts.replyToMode ?? discordCfg.replyToMode ?? "off";
+  const dmEnabled = dmConfig?.enabled ?? true;
+  const dmPolicy = dmConfig?.policy ?? "pairing";
+  const groupDmEnabled = dmConfig?.groupEnabled ?? false;
+  const groupDmChannels = dmConfig?.groupChannels;
+  const nativeEnabled = resolveNativeCommandsEnabled({
+    providerId: "discord",
+    providerSetting: discordCfg.commands?.native,
+    globalSetting: cfg.commands?.native,
+  });
+  const nativeDisabledExplicit = isNativeCommandsExplicitlyDisabled({
+    providerSetting: discordCfg.commands?.native,
+    globalSetting: cfg.commands?.native,
+  });
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const sessionPrefix = "discord:slash";
+  const ephemeralDefault = true;
+
+  if (shouldLogVerbose()) {
+    logVerbose(
+      `discord: config dm=${dmEnabled ? "on" : "off"} dmPolicy=${dmPolicy} allowFrom=${summarizeAllowList(allowFrom)} groupDm=${groupDmEnabled ? "on" : "off"} groupDmChannels=${summarizeAllowList(groupDmChannels)} groupPolicy=${groupPolicy} guilds=${summarizeGuilds(guildEntries)} historyLimit=${historyLimit} mediaMaxMb=${Math.round(mediaMaxBytes / (1024 * 1024))} native=${nativeEnabled ? "on" : "off"} accessGroups=${useAccessGroups ? "on" : "off"}`,
+    );
+  }
+
+  const applicationId = await fetchDiscordApplicationId(token, 4000);
+  if (!applicationId) {
+    throw new Error("Failed to resolve Discord application id");
+  }
+
+  const commandSpecs = nativeEnabled
+    ? listNativeCommandSpecsForConfig(cfg)
+    : [];
+  const commands = commandSpecs.map((spec) =>
+    createDiscordNativeCommand({
+      command: spec,
+      cfg,
+      discordConfig: discordCfg,
+      accountId: account.accountId,
+      sessionPrefix,
+      ephemeralDefault,
+    }),
+  );
+
+  const client = new Client(
+    {
+      baseUrl: "http://localhost",
+      deploySecret: "a",
+      clientId: applicationId,
+      publicKey: "a",
+      token,
+      autoDeploy: nativeEnabled,
+      eventQueue: {
+        // Auto-threading (create thread + generate reply + post) can exceed the default
+        // 30s listener timeout in some environments.
+        listenerTimeout: 120_000,
+      },
+    },
+    {
+      commands,
+      listeners: [],
+    },
+    [
+      new GatewayPlugin({
+        reconnect: {
+          maxAttempts: Number.POSITIVE_INFINITY,
+        },
+        intents:
+          GatewayIntents.Guilds |
+          GatewayIntents.GuildMessages |
+          GatewayIntents.MessageContent |
+          GatewayIntents.DirectMessages |
+          GatewayIntents.GuildMessageReactions |
+          GatewayIntents.DirectMessageReactions,
+        autoInteractions: true,
+      }),
+    ],
+  );
+
+  const logger = getChildLogger({ module: "discord-auto-reply" });
+  const guildHistories = new Map<string, HistoryEntry[]>();
+  let botUserId: string | undefined;
+
+  if (nativeDisabledExplicit) {
+    await clearDiscordNativeCommands({
+      client,
+      applicationId,
+      runtime,
+    });
+  }
+
+  try {
+    const botUser = await client.fetchUser("@me");
+    botUserId = botUser?.id;
+  } catch (err) {
+    runtime.error?.(
+      danger(`discord: failed to fetch bot identity: ${String(err)}`),
+    );
+  }
+
+  const messageHandler = createDiscordMessageHandler({
+    cfg,
+    discordConfig: discordCfg,
+    accountId: account.accountId,
+    token,
+    runtime,
+    botUserId,
+    guildHistories,
+    historyLimit,
+    mediaMaxBytes,
+    textLimit,
+    replyToMode,
+    dmEnabled,
+    groupDmEnabled,
+    groupDmChannels,
+    allowFrom,
+    guildEntries,
+  });
+
+  registerDiscordListener(
+    client.listeners,
+    new DiscordMessageListener(messageHandler, logger),
+  );
+  registerDiscordListener(
+    client.listeners,
+    new DiscordReactionListener({
+      cfg,
+      accountId: account.accountId,
+      runtime,
+      botUserId,
+      guildEntries,
+      logger,
+    }),
+  );
+  registerDiscordListener(
+    client.listeners,
+    new DiscordReactionRemoveListener({
+      cfg,
+      accountId: account.accountId,
+      runtime,
+      botUserId,
+      guildEntries,
+      logger,
+    }),
+  );
+
+  runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
+
+  const gateway = client.getPlugin<GatewayPlugin>("gateway");
+  const gatewayEmitter = getDiscordGatewayEmitter(gateway);
+  const stopGatewayLogging = attachDiscordGatewayLogging({
+    emitter: gatewayEmitter,
+    runtime,
+  });
+  // Timeout to detect zombie connections where HELLO is never received.
+  const HELLO_TIMEOUT_MS = 30000;
+  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  const onGatewayDebug = (msg: unknown) => {
+    const message = String(msg);
+    if (!message.includes("WebSocket connection opened")) return;
+    if (helloTimeoutId) clearTimeout(helloTimeoutId);
+    helloTimeoutId = setTimeout(() => {
+      if (!gateway?.isConnected) {
+        runtime.log?.(
+          danger(
+            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+          ),
+        );
+        gateway?.disconnect();
+        gateway?.connect(false);
+      }
+      helloTimeoutId = undefined;
+    }, HELLO_TIMEOUT_MS);
+  };
+  gatewayEmitter?.on("debug", onGatewayDebug);
+  try {
+    await waitForDiscordGatewayStop({
+      gateway: gateway
+        ? {
+            emitter: gatewayEmitter,
+            disconnect: () => gateway.disconnect(),
+          }
+        : undefined,
+      abortSignal: opts.abortSignal,
+      onGatewayError: (err) => {
+        runtime.error?.(danger(`discord gateway error: ${String(err)}`));
+      },
+      shouldStopOnError: (err) => {
+        const message = String(err);
+        return (
+          message.includes("Max reconnect attempts") ||
+          message.includes("Fatal Gateway error")
+        );
+      },
+    });
+  } finally {
+    stopGatewayLogging();
+    stopGatewayLogging();
+    if (helloTimeoutId) clearTimeout(helloTimeoutId);
+    gatewayEmitter?.removeListener("debug", onGatewayDebug);
+  }
+}
+
+async function clearDiscordNativeCommands(params: {
+  client: Client;
+  applicationId: string;
+  runtime: RuntimeEnv;
+}) {
+  try {
+    await params.client.rest.put(
+      Routes.applicationCommands(params.applicationId),
+      {
+        body: [],
+      },
+    );
+    logVerbose("discord: cleared native commands (commands.native=false)");
+  } catch (err) {
+    params.runtime.error?.(
+      danger(`discord: failed to clear native commands: ${String(err)}`),
+    );
+  }
+}
+
+export function createDiscordMessageHandler(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+  token: string;
+  runtime: RuntimeEnv;
+  botUserId?: string;
+  guildHistories: Map<string, HistoryEntry[]>;
+  historyLimit: number;
+  mediaMaxBytes: number;
+  textLimit: number;
+  replyToMode: ReplyToMode;
+  dmEnabled: boolean;
+  groupDmEnabled: boolean;
+  groupDmChannels?: Array<string | number>;
+  allowFrom?: Array<string | number>;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+}): DiscordMessageHandler {
+  const {
+    cfg,
+    discordConfig,
+    accountId,
+    token,
+    runtime,
+    botUserId,
+    guildHistories,
+    historyLimit,
+    mediaMaxBytes,
+    textLimit,
+    replyToMode,
+    dmEnabled,
+    groupDmEnabled,
+    groupDmChannels,
+    allowFrom,
+    guildEntries,
+  } = params;
+  const logger = getChildLogger({ module: "discord-auto-reply" });
+  const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
+  const groupPolicy = discordConfig?.groupPolicy ?? "open";
+
+  return async (data, client) => {
+    try {
+      const message = data.message;
+      const author = data.author;
+      if (!author) return;
+
+      const allowBots = discordConfig?.allowBots ?? false;
+      if (author.bot) {
+        // Always ignore own messages to prevent self-reply loops
+        if (botUserId && author.id === botUserId) return;
+        if (!allowBots) {
+          logVerbose("discord: drop bot message (allowBots=false)");
+          return;
+        }
+      }
+
+      const isGuildMessage = Boolean(data.guild_id);
+      const channelInfo = await resolveDiscordChannelInfo(
+        client,
+        message.channelId,
+      );
+      const isDirectMessage = channelInfo?.type === ChannelType.DM;
+      const isGroupDm = channelInfo?.type === ChannelType.GroupDM;
+
+      if (isGroupDm && !groupDmEnabled) {
+        logVerbose("discord: drop group dm (group dms disabled)");
+        return;
+      }
+      if (isDirectMessage && !dmEnabled) {
+        logVerbose("discord: drop dm (dms disabled)");
+        return;
+      }
+
+      const dmPolicy = discordConfig?.dm?.policy ?? "pairing";
+      let commandAuthorized = true;
+      if (isDirectMessage) {
+        if (dmPolicy === "disabled") {
+          logVerbose("discord: drop dm (dmPolicy: disabled)");
+          return;
+        }
+        if (dmPolicy !== "open") {
+          const storeAllowFrom = await readChannelAllowFromStore(
+            "discord",
+          ).catch(() => []);
+          const effectiveAllowFrom = [...(allowFrom ?? []), ...storeAllowFrom];
+          const allowList = normalizeDiscordAllowList(effectiveAllowFrom, [
+            "discord:",
+            "user:",
+          ]);
+          const permitted = allowList
+            ? allowListMatches(allowList, {
+                id: author.id,
+                name: author.username,
+                tag: formatDiscordUserTag(author),
+              })
+            : false;
+          if (!permitted) {
+            commandAuthorized = false;
+            if (dmPolicy === "pairing") {
+              const { code, created } = await upsertChannelPairingRequest({
+                channel: "discord",
+                id: author.id,
+                meta: {
+                  tag: formatDiscordUserTag(author),
+                  name: author.username ?? undefined,
+                },
+              });
+              if (created) {
+                logVerbose(
+                  `discord pairing request sender=${author.id} tag=${formatDiscordUserTag(author)}`,
+                );
+                try {
+                  await sendMessageDiscord(
+                    `user:${author.id}`,
+                    buildPairingReply({
+                      channel: "discord",
+                      idLine: `Your Discord user id: ${author.id}`,
+                      code,
+                    }),
+                    { token, rest: client.rest, accountId },
+                  );
+                } catch (err) {
+                  logVerbose(
+                    `discord pairing reply failed for ${author.id}: ${String(err)}`,
+                  );
+                }
+              }
+            } else {
+              logVerbose(
+                `Blocked unauthorized discord sender ${author.id} (dmPolicy=${dmPolicy})`,
+              );
+            }
+            return;
+          }
+          commandAuthorized = true;
+        }
+      }
+      const botId = botUserId;
+      const baseText = resolveDiscordMessageText(message, {
+        includeForwarded: false,
+      });
+      const messageText = resolveDiscordMessageText(message, {
+        includeForwarded: true,
+      });
+      recordChannelActivity({
+        channel: "discord",
+        accountId,
+        direction: "inbound",
+      });
+      const route = resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId,
+        guildId: data.guild_id ?? undefined,
+        peer: {
+          kind: isDirectMessage ? "dm" : isGroupDm ? "group" : "channel",
+          id: isDirectMessage ? author.id : message.channelId,
+        },
+      });
+      const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
+      const wasMentioned =
+        !isDirectMessage &&
+        (Boolean(
+          botId &&
+            message.mentionedUsers?.some((user: User) => user.id === botId),
+        ) ||
+          matchesMentionPatterns(baseText, mentionRegexes));
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `discord: inbound id=${message.id} guild=${message.guild?.id ?? "dm"} channel=${message.channelId} mention=${wasMentioned ? "yes" : "no"} type=${isDirectMessage ? "dm" : isGroupDm ? "group-dm" : "guild"} content=${messageText ? "yes" : "no"}`,
+        );
+      }
+
+      if (
+        isGuildMessage &&
+        (message.type === MessageType.ChatInputCommand ||
+          message.type === MessageType.ContextMenuCommand)
+      ) {
+        logVerbose("discord: drop channel command message");
+        return;
+      }
+
+      const guildInfo = isGuildMessage
+        ? resolveDiscordGuildEntry({
+            guild: data.guild ?? undefined,
+            guildEntries,
+          })
+        : null;
+      if (
+        isGuildMessage &&
+        guildEntries &&
+        Object.keys(guildEntries).length > 0 &&
+        !guildInfo
+      ) {
+        logVerbose(
+          `Blocked discord guild ${data.guild_id ?? "unknown"} (not in discord.guilds)`,
+        );
+        return;
+      }
+
+      const channelName =
+        channelInfo?.name ??
+        ((isGuildMessage || isGroupDm) &&
+        message.channel &&
+        "name" in message.channel
+          ? message.channel.name
+          : undefined);
+      const threadChannel = resolveDiscordThreadChannel({
+        isGuildMessage,
+        message,
+        channelInfo,
+      });
+      let threadParentId: string | undefined;
+      let threadParentName: string | undefined;
+      let threadParentType: ChannelType | undefined;
+      if (threadChannel) {
+        const parentInfo = await resolveDiscordThreadParentInfo({
+          client,
+          threadChannel,
+          channelInfo,
+        });
+        threadParentId = parentInfo.id;
+        threadParentName = parentInfo.name;
+        threadParentType = parentInfo.type;
+      }
+      const threadName = threadChannel?.name;
+      const configChannelName = threadParentName ?? channelName;
+      const configChannelSlug = configChannelName
+        ? normalizeDiscordSlug(configChannelName)
+        : "";
+      const displayChannelName = threadName ?? channelName;
+      const displayChannelSlug = displayChannelName
+        ? normalizeDiscordSlug(displayChannelName)
+        : "";
+      const guildSlug =
+        guildInfo?.slug ||
+        (data.guild?.name ? normalizeDiscordSlug(data.guild.name) : "");
+
+      const baseSessionKey = route.sessionKey;
+      const channelConfig = isGuildMessage
+        ? resolveDiscordChannelConfig({
+            guildInfo,
+            channelId: threadParentId ?? message.channelId,
+            channelName: configChannelName,
+            channelSlug: configChannelSlug,
+          })
+        : null;
+      if (isGuildMessage && channelConfig?.enabled === false) {
+        logVerbose(
+          `Blocked discord channel ${message.channelId} (channel disabled)`,
+        );
+        return;
+      }
+
+      const groupDmAllowed =
+        isGroupDm &&
+        resolveGroupDmAllow({
+          channels: groupDmChannels,
+          channelId: message.channelId,
+          channelName: displayChannelName,
+          channelSlug: displayChannelSlug,
+        });
+      if (isGroupDm && !groupDmAllowed) return;
+
+      const channelAllowlistConfigured =
+        Boolean(guildInfo?.channels) &&
+        Object.keys(guildInfo?.channels ?? {}).length > 0;
+      const channelAllowed = channelConfig?.allowed !== false;
+      if (
+        isGuildMessage &&
+        !isDiscordGroupAllowedByPolicy({
+          groupPolicy,
+          channelAllowlistConfigured,
+          channelAllowed,
+        })
+      ) {
+        if (groupPolicy === "disabled") {
+          logVerbose("discord: drop guild message (groupPolicy: disabled)");
+        } else if (!channelAllowlistConfigured) {
+          logVerbose(
+            "discord: drop guild message (groupPolicy: allowlist, no channel allowlist)",
+          );
+        } else {
+          logVerbose(
+            `Blocked discord channel ${message.channelId} not in guild channel allowlist (groupPolicy: allowlist)`,
+          );
+        }
+        return;
+      }
+
+      if (isGuildMessage && channelConfig?.allowed === false) {
+        logVerbose(
+          `Blocked discord channel ${message.channelId} not in guild channel allowlist`,
+        );
+        return;
+      }
+
+      const textForHistory = resolveDiscordMessageText(message, {
+        includeForwarded: true,
+      });
+      const historyEntry =
+        isGuildMessage && historyLimit > 0 && textForHistory
+          ? {
+              sender:
+                data.member?.nickname ??
+                author.globalName ??
+                author.username ??
+                author.id,
+              body: textForHistory,
+              timestamp: resolveTimestampMs(message.timestamp),
+              messageId: message.id,
+            }
+          : undefined;
+
+      const shouldRequireMention = resolveDiscordShouldRequireMention({
+        isGuildMessage,
+        isThread: Boolean(threadChannel),
+        channelConfig,
+        guildInfo,
+      });
+      const hasAnyMention = Boolean(
+        !isDirectMessage &&
+          (message.mentionedEveryone ||
+            (message.mentionedUsers?.length ?? 0) > 0 ||
+            (message.mentionedRoles?.length ?? 0) > 0),
+      );
+      if (!isDirectMessage) {
+        commandAuthorized = resolveDiscordCommandAuthorized({
+          isDirectMessage,
+          allowFrom,
+          guildInfo,
+          author,
+        });
+      }
+      const allowTextCommands = shouldHandleTextCommands({
+        cfg,
+        surface: "discord",
+      });
+      const shouldBypassMention =
+        allowTextCommands &&
+        isGuildMessage &&
+        shouldRequireMention &&
+        !wasMentioned &&
+        !hasAnyMention &&
+        commandAuthorized &&
+        hasControlCommand(baseText, cfg);
+      const effectiveWasMentioned = wasMentioned || shouldBypassMention;
+      const canDetectMention = Boolean(botId) || mentionRegexes.length > 0;
+      if (isGuildMessage && shouldRequireMention) {
+        if (botId && !wasMentioned && !shouldBypassMention) {
+          logVerbose(
+            `discord: drop guild message (mention required, botId=${botId})`,
+          );
+          logger.info(
+            {
+              channelId: message.channelId,
+              reason: "no-mention",
+            },
+            "discord: skipping guild message",
+          );
+          return;
+        }
+      }
+
+      if (isGuildMessage) {
+        const channelUsers = channelConfig?.users ?? guildInfo?.users;
+        if (Array.isArray(channelUsers) && channelUsers.length > 0) {
+          const userOk = resolveDiscordUserAllowed({
+            allowList: channelUsers,
+            userId: author.id,
+            userName: author.username,
+            userTag: formatDiscordUserTag(author),
+          });
+          if (!userOk) {
+            logVerbose(
+              `Blocked discord guild sender ${author.id} (not in channel users allowlist)`,
+            );
+            return;
+          }
+        }
+      }
+
+      const systemLocation = resolveDiscordSystemLocation({
+        isDirectMessage,
+        isGroupDm,
+        guild: data.guild ?? undefined,
+        channelName: channelName ?? message.channelId,
+      });
+      const systemText = resolveDiscordSystemEvent(message, systemLocation);
+      if (systemText) {
+        enqueueSystemEvent(systemText, {
+          sessionKey: route.sessionKey,
+          contextKey: `discord:system:${message.channelId}:${message.id}`,
+        });
+        return;
+      }
+
+      const mediaList = await resolveMediaList(message, mediaMaxBytes);
+      const text = messageText;
+      if (!text) {
+        logVerbose(`discord: drop message ${message.id} (empty content)`);
+        return;
+      }
+      const ackReaction = resolveAckReaction(cfg, route.agentId);
+      const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+      const shouldAckReaction = () => {
+        if (!ackReaction) return false;
+        if (ackReactionScope === "all") return true;
+        if (ackReactionScope === "direct") return isDirectMessage;
+        const isGroupChat = isGuildMessage || isGroupDm;
+        if (ackReactionScope === "group-all") return isGroupChat;
+        if (ackReactionScope === "group-mentions") {
+          if (!isGuildMessage) return false;
+          if (!shouldRequireMention) return false;
+          if (!canDetectMention) return false;
+          return wasMentioned || shouldBypassMention;
+        }
+        return false;
+      };
+      const ackReactionPromise = shouldAckReaction()
+        ? reactMessageDiscord(message.channelId, message.id, ackReaction, {
+            rest: client.rest,
+          }).then(
+            () => true,
+            (err) => {
+              logVerbose(
+                `discord react failed for channel ${message.channelId}: ${String(err)}`,
+              );
+              return false;
+            },
+          )
+        : null;
+
+      const fromLabel = isDirectMessage
+        ? buildDirectLabel(author)
+        : buildGuildLabel({
+            guild: data.guild ?? undefined,
+            channelName: channelName ?? message.channelId,
+            channelId: message.channelId,
+          });
+      const groupRoom =
+        isGuildMessage && displayChannelSlug
+          ? `#${displayChannelSlug}`
+          : undefined;
+      const groupSubject = isDirectMessage ? undefined : groupRoom;
+      const channelDescription = channelInfo?.topic?.trim();
+      const systemPromptParts = [
+        channelDescription ? `Channel topic: ${channelDescription}` : null,
+        channelConfig?.systemPrompt?.trim() || null,
+      ].filter((entry): entry is string => Boolean(entry));
+      const groupSystemPrompt =
+        systemPromptParts.length > 0
+          ? systemPromptParts.join("\n\n")
+          : undefined;
+      let combinedBody = formatAgentEnvelope({
+        channel: "Discord",
+        from: fromLabel,
+        timestamp: resolveTimestampMs(message.timestamp),
+        body: text,
+      });
+      let shouldClearHistory = false;
+      if (!isDirectMessage) {
+        combinedBody = buildHistoryContextFromMap({
+          historyMap: guildHistories,
+          historyKey: message.channelId,
+          limit: historyLimit,
+          entry: historyEntry,
+          currentMessage: combinedBody,
+          formatEntry: (entry) =>
+            formatAgentEnvelope({
+              channel: "Discord",
+              from: fromLabel,
+              timestamp: entry.timestamp,
+              body: `${entry.sender}: ${entry.body} [id:${entry.messageId ?? "unknown"} channel:${message.channelId}]`,
+            }),
+        });
+        const name = formatDiscordUserTag(author);
+        const id = author.id;
+        combinedBody = `${combinedBody}\n[from: ${name} user id:${id}]`;
+        shouldClearHistory = true;
+      }
+      const replyContext = resolveReplyContext(message);
+      if (replyContext) {
+        combinedBody = `[Replied message - for context]\n${replyContext}\n\n${combinedBody}`;
+      }
+
+      let threadStarterBody: string | undefined;
+      let threadLabel: string | undefined;
+      let parentSessionKey: string | undefined;
+      if (threadChannel) {
+        const starter = await resolveDiscordThreadStarter({
+          channel: threadChannel,
+          client,
+          parentId: threadParentId,
+          parentType: threadParentType,
+        });
+        if (starter?.text) {
+          const starterEnvelope = formatThreadStarterEnvelope({
+            channel: "Discord",
+            author: starter.author,
+            timestamp: starter.timestamp,
+            body: starter.text,
+          });
+          threadStarterBody = starterEnvelope;
+        }
+        const parentName = threadParentName ?? "parent";
+        threadLabel = threadName
+          ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
+          : `Discord thread #${normalizeDiscordSlug(parentName)}`;
+        if (threadParentId) {
+          parentSessionKey = buildAgentSessionKey({
+            agentId: route.agentId,
+            channel: route.channel,
+            peer: { kind: "channel", id: threadParentId },
+          });
+        }
+      }
+      const mediaPayload = buildDiscordMediaPayload(mediaList);
+      const discordTo = `channel:${message.channelId}`;
+      const threadKeys = resolveThreadSessionKeys({
+        baseSessionKey,
+        threadId: threadChannel ? message.channelId : undefined,
+        parentSessionKey,
+        useSuffix: false,
+      });
+      const ctxPayload = {
+        Body: combinedBody,
+        RawBody: baseText,
+        CommandBody: baseText,
+        From: isDirectMessage
+          ? `discord:${author.id}`
+          : `group:${message.channelId}`,
+        To: discordTo,
+        SessionKey: threadKeys.sessionKey,
+        AccountId: route.accountId,
+        ChatType: isDirectMessage ? "direct" : "group",
+        SenderName:
+          data.member?.nickname ?? author.globalName ?? author.username,
+        SenderId: author.id,
+        SenderUsername: author.username,
+        SenderTag: formatDiscordUserTag(author),
+        GroupSubject: groupSubject,
+        GroupRoom: groupRoom,
+        GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
+        GroupSpace: isGuildMessage
+          ? (guildInfo?.id ?? guildSlug) || undefined
+          : undefined,
+        Provider: "discord" as const,
+        Surface: "discord" as const,
+        WasMentioned: effectiveWasMentioned,
+        MessageSid: message.id,
+        ParentSessionKey: threadKeys.parentSessionKey,
+        ThreadStarterBody: threadStarterBody,
+        ThreadLabel: threadLabel,
+        Timestamp: resolveTimestampMs(message.timestamp),
+        ...mediaPayload,
+        CommandAuthorized: commandAuthorized,
+        CommandSource: "text" as const,
+        // Originating channel for reply routing.
+        OriginatingChannel: "discord" as const,
+        OriginatingTo: discordTo,
+      };
+      let replyTarget = ctxPayload.To ?? undefined;
+      if (!replyTarget) {
+        runtime.error?.(danger("discord: missing reply target"));
+        return;
+      }
+      const createdThreadId = await maybeCreateDiscordAutoThread({
+        client,
+        message,
+        isGuildMessage,
+        channelConfig,
+        threadChannel,
+        baseText: baseText ?? "",
+        combinedBody,
+      });
+      const replyPlan = resolveDiscordReplyDeliveryPlan({
+        replyTarget,
+        replyToMode,
+        messageId: message.id,
+        threadChannel,
+        createdThreadId,
+      });
+      const deliverTarget = replyPlan.deliverTarget;
+      replyTarget = replyPlan.replyTarget;
+      const replyReference = replyPlan.replyReference;
+
+      if (isDirectMessage) {
+        const sessionCfg = cfg.session;
+        const storePath = resolveStorePath(sessionCfg?.store, {
+          agentId: route.agentId,
+        });
+        await updateLastRoute({
+          storePath,
+          sessionKey: route.mainSessionKey,
+          channel: "discord",
+          to: `user:${author.id}`,
+          accountId: route.accountId,
+        });
+      }
+
+      if (shouldLogVerbose()) {
+        const preview = truncateUtf16Safe(combinedBody, 200).replace(
+          /\n/g,
+          "\\n",
+        );
+        logVerbose(
+          `discord inbound: channel=${message.channelId} from=${ctxPayload.From} preview="${preview}"`,
+        );
+      }
+
+      let didSendReply = false;
+      const { dispatcher, replyOptions, markDispatchIdle } =
+        createReplyDispatcherWithTyping({
+          responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+            .responsePrefix,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+          deliver: async (payload) => {
+            const replyToId = replyReference.use();
+            await deliverDiscordReply({
+              replies: [payload],
+              target: deliverTarget,
+              token,
+              accountId,
+              rest: client.rest,
+              runtime,
+              replyToId,
+              textLimit,
+              maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+            });
+            didSendReply = true;
+            replyReference.markSent();
+          },
+          onError: (err, info) => {
+            runtime.error?.(
+              danger(`discord ${info.kind} reply failed: ${String(err)}`),
+            );
+          },
+          onReplyStart: () => sendTyping(message),
+        });
+
+      const { queuedFinal, counts } = await dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        runtime,
+        replyOptions: {
+          ...replyOptions,
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined,
+        },
+      });
+      markDispatchIdle();
+      if (!queuedFinal) {
+        if (
+          isGuildMessage &&
+          shouldClearHistory &&
+          historyLimit > 0 &&
+          didSendReply
+        ) {
+          clearHistoryEntries({
+            historyMap: guildHistories,
+            historyKey: message.channelId,
+          });
+        }
+        return;
+      }
+      didSendReply = true;
+      if (shouldLogVerbose()) {
+        const finalCount = counts.final;
+        logVerbose(
+          `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+        );
+      }
+      if (removeAckAfterReply && ackReactionPromise && ackReaction) {
+        const ackReactionValue = ackReaction;
+        void ackReactionPromise.then((didAck) => {
+          if (!didAck) return;
+          removeReactionDiscord(
+            message.channelId,
+            message.id,
+            ackReactionValue,
+            {
+              rest: client.rest,
+            },
+          ).catch((err) => {
+            logVerbose(
+              `discord: failed to remove ack reaction from ${message.channelId}/${message.id}: ${String(err)}`,
+            );
+          });
+        });
+      }
+      if (
+        isGuildMessage &&
+        shouldClearHistory &&
+        historyLimit > 0 &&
+        didSendReply
+      ) {
+        clearHistoryEntries({
+          historyMap: guildHistories,
+          historyKey: message.channelId,
+        });
+      }
+    } catch (err) {
+      runtime.error?.(danger(`handler failed: ${String(err)}`));
+    }
+  };
+}
+
+class DiscordMessageListener extends MessageCreateListener {
+  constructor(
+    private handler: DiscordMessageHandler,
+    private logger?: ReturnType<typeof getChildLogger>,
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordMessageEvent, client: Client) {
+    const startedAt = Date.now();
+    try {
+      await this.handler(data, client);
+    } finally {
+      logSlowDiscordListener({
+        logger: this.logger,
+        listener: this.constructor.name,
+        event: this.type,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+}
+
+class DiscordReactionListener extends MessageReactionAddListener {
+  constructor(
+    private params: {
+      cfg: ReturnType<typeof loadConfig>;
+      accountId: string;
+      runtime: RuntimeEnv;
+      botUserId?: string;
+      guildEntries?: Record<string, DiscordGuildEntryResolved>;
+      logger: ReturnType<typeof getChildLogger>;
+    },
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordReactionEvent, client: Client) {
+    const startedAt = Date.now();
+    try {
+      await handleDiscordReactionEvent({
+        data,
+        client,
+        action: "added",
+        cfg: this.params.cfg,
+        accountId: this.params.accountId,
+        botUserId: this.params.botUserId,
+        guildEntries: this.params.guildEntries,
+        logger: this.params.logger,
+      });
+    } finally {
+      logSlowDiscordListener({
+        logger: this.params.logger,
+        listener: this.constructor.name,
+        event: this.type,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+}
+
+class DiscordReactionRemoveListener extends MessageReactionRemoveListener {
+  constructor(
+    private params: {
+      cfg: ReturnType<typeof loadConfig>;
+      accountId: string;
+      runtime: RuntimeEnv;
+      botUserId?: string;
+      guildEntries?: Record<string, DiscordGuildEntryResolved>;
+      logger: ReturnType<typeof getChildLogger>;
+    },
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordReactionEvent, client: Client) {
+    const startedAt = Date.now();
+    try {
+      await handleDiscordReactionEvent({
+        data,
+        client,
+        action: "removed",
+        cfg: this.params.cfg,
+        accountId: this.params.accountId,
+        botUserId: this.params.botUserId,
+        guildEntries: this.params.guildEntries,
+        logger: this.params.logger,
+      });
+    } finally {
+      logSlowDiscordListener({
+        logger: this.params.logger,
+        listener: this.constructor.name,
+        event: this.type,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+}
+
+async function handleDiscordReactionEvent(params: {
+  data: DiscordReactionEvent;
+  client: Client;
+  action: "added" | "removed";
+  cfg: ReturnType<typeof loadConfig>;
+  accountId: string;
+  botUserId?: string;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+  logger: ReturnType<typeof getChildLogger>;
+}) {
+  try {
+    const { data, client, action, botUserId, guildEntries } = params;
+    if (!("user" in data)) return;
+    const user = data.user;
+    if (!user || user.bot) return;
+    if (!data.guild_id) return;
+
+    const guildInfo = resolveDiscordGuildEntry({
+      guild: data.guild ?? undefined,
+      guildEntries,
+    });
+    if (guildEntries && Object.keys(guildEntries).length > 0 && !guildInfo) {
+      return;
+    }
+
+    const channel = await client.fetchChannel(data.channel_id);
+    if (!channel) return;
+    const channelName =
+      "name" in channel ? (channel.name ?? undefined) : undefined;
+    const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+    const channelConfig = resolveDiscordChannelConfig({
+      guildInfo,
+      channelId: data.channel_id,
+      channelName,
+      channelSlug,
+    });
+    if (channelConfig?.allowed === false) return;
+
+    if (botUserId && user.id === botUserId) return;
+
+    const reactionMode = guildInfo?.reactionNotifications ?? "own";
+    const message = await data.message.fetch().catch(() => null);
+    const messageAuthorId = message?.author?.id ?? undefined;
+    const shouldNotify = shouldEmitDiscordReactionNotification({
+      mode: reactionMode,
+      botId: botUserId,
+      messageAuthorId,
+      userId: user.id,
+      userName: user.username,
+      userTag: formatDiscordUserTag(user),
+      allowlist: guildInfo?.users,
+    });
+    if (!shouldNotify) return;
+
+    const emojiLabel = formatDiscordReactionEmoji(data.emoji);
+    const actorLabel = formatDiscordUserTag(user);
+    const guildSlug =
+      guildInfo?.slug ||
+      (data.guild?.name
+        ? normalizeDiscordSlug(data.guild.name)
+        : data.guild_id);
+    const channelLabel = channelSlug
+      ? `#${channelSlug}`
+      : channelName
+        ? `#${normalizeDiscordSlug(channelName)}`
+        : `#${data.channel_id}`;
+    const authorLabel = message?.author
+      ? formatDiscordUserTag(message.author)
+      : undefined;
+    const baseText = `Discord reaction ${action}: ${emojiLabel} by ${actorLabel} on ${guildSlug} ${channelLabel} msg ${data.message_id}`;
+    const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
+    const route = resolveAgentRoute({
+      cfg: params.cfg,
+      channel: "discord",
+      accountId: params.accountId,
+      guildId: data.guild_id ?? undefined,
+      peer: { kind: "channel", id: data.channel_id },
+    });
+    enqueueSystemEvent(text, {
+      sessionKey: route.sessionKey,
+      contextKey: `discord:reaction:${action}:${data.message_id}:${user.id}:${emojiLabel}`,
+    });
+  } catch (err) {
+    params.logger.error(
+      danger(`discord reaction handler failed: ${String(err)}`),
+    );
+  }
+}
+
+export function createDiscordNativeCommand(params: {
+  command: {
+    name: string;
+    description: string;
+    acceptsArgs: boolean;
+  };
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+  sessionPrefix: string;
+  ephemeralDefault: boolean;
+}) {
+  const {
+    command,
+    cfg,
+    discordConfig,
+    accountId,
+    sessionPrefix,
+    ephemeralDefault,
+  } = params;
+  return new (class extends Command {
+    name = command.name;
+    description = command.description;
+    defer = true;
+    ephemeral = ephemeralDefault;
+    options = command.acceptsArgs
+      ? ([
+          {
+            name: "input",
+            description: "Command input",
+            type: ApplicationCommandOptionType.String,
+            required: false,
+          },
+        ] satisfies CommandOptions)
+      : undefined;
+
+    async run(interaction: CommandInteraction) {
+      const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+      const user = interaction.user;
+      if (!user) return;
+      const channel = interaction.channel;
+      const channelType = channel?.type;
+      const isDirectMessage = channelType === ChannelType.DM;
+      const isGroupDm = channelType === ChannelType.GroupDM;
+      const channelName =
+        channel && "name" in channel ? (channel.name as string) : undefined;
+      const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+      const prompt = buildCommandText(
+        this.name,
+        command.acceptsArgs
+          ? interaction.options.getString("input")
+          : undefined,
+      );
+      const guildInfo = resolveDiscordGuildEntry({
+        guild: interaction.guild ?? undefined,
+        guildEntries: discordConfig?.guilds,
+      });
+      const channelConfig = interaction.guild
+        ? resolveDiscordChannelConfig({
+            guildInfo,
+            channelId: channel?.id ?? "",
+            channelName,
+            channelSlug,
+          })
+        : null;
+      if (channelConfig?.enabled === false) {
+        await interaction.reply({
+          content: "This channel is disabled.",
+        });
+        return;
+      }
+      if (interaction.guild && channelConfig?.allowed === false) {
+        await interaction.reply({
+          content: "This channel is not allowed.",
+        });
+        return;
+      }
+      if (useAccessGroups && interaction.guild) {
+        const channelAllowlistConfigured =
+          Boolean(guildInfo?.channels) &&
+          Object.keys(guildInfo?.channels ?? {}).length > 0;
+        const channelAllowed = channelConfig?.allowed !== false;
+        const allowByPolicy = isDiscordGroupAllowedByPolicy({
+          groupPolicy: discordConfig?.groupPolicy ?? "open",
+          channelAllowlistConfigured,
+          channelAllowed,
+        });
+        if (!allowByPolicy) {
+          await interaction.reply({
+            content: "This channel is not allowed.",
+          });
+          return;
+        }
+      }
+      const dmEnabled = discordConfig?.dm?.enabled ?? true;
+      const dmPolicy = discordConfig?.dm?.policy ?? "pairing";
+      let commandAuthorized = true;
+      if (isDirectMessage) {
+        if (!dmEnabled || dmPolicy === "disabled") {
+          await interaction.reply({ content: "Discord DMs are disabled." });
+          return;
+        }
+        if (dmPolicy !== "open") {
+          const storeAllowFrom = await readChannelAllowFromStore(
+            "discord",
+          ).catch(() => []);
+          const effectiveAllowFrom = [
+            ...(discordConfig?.dm?.allowFrom ?? []),
+            ...storeAllowFrom,
+          ];
+          const allowList = normalizeDiscordAllowList(effectiveAllowFrom, [
+            "discord:",
+            "user:",
+          ]);
+          const permitted = allowList
+            ? allowListMatches(allowList, {
+                id: user.id,
+                name: user.username,
+                tag: formatDiscordUserTag(user),
+              })
+            : false;
+          if (!permitted) {
+            commandAuthorized = false;
+            if (dmPolicy === "pairing") {
+              const { code, created } = await upsertChannelPairingRequest({
+                channel: "discord",
+                id: user.id,
+                meta: {
+                  tag: formatDiscordUserTag(user),
+                  name: user.username ?? undefined,
+                },
+              });
+              if (created) {
+                await interaction.reply({
+                  content: buildPairingReply({
+                    channel: "discord",
+                    idLine: `Your Discord user id: ${user.id}`,
+                    code,
+                  }),
+                  ephemeral: true,
+                });
+              }
+            } else {
+              await interaction.reply({
+                content: "You are not authorized to use this command.",
+                ephemeral: true,
+              });
+            }
+            return;
+          }
+          commandAuthorized = true;
+        }
+      }
+      if (!isDirectMessage) {
+        const channelUsers = channelConfig?.users ?? guildInfo?.users;
+        if (Array.isArray(channelUsers) && channelUsers.length > 0) {
+          const userOk = resolveDiscordUserAllowed({
+            allowList: channelUsers,
+            userId: user.id,
+            userName: user.username,
+            userTag: formatDiscordUserTag(user),
+          });
+          if (!userOk) {
+            await interaction.reply({
+              content: "You are not authorized to use this command.",
+            });
+            return;
+          }
+        }
+      }
+      if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
+        await interaction.reply({ content: "Discord group DMs are disabled." });
+        return;
+      }
+
+      const isGuild = Boolean(interaction.guild);
+      const channelId = channel?.id ?? "unknown";
+      const interactionId = interaction.rawData.id;
+      const route = resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId,
+        guildId: interaction.guild?.id ?? undefined,
+        peer: {
+          kind: isDirectMessage ? "dm" : isGroupDm ? "group" : "channel",
+          id: isDirectMessage ? user.id : channelId,
+        },
+      });
+      const ctxPayload = {
+        Body: prompt,
+        CommandBody: prompt,
+        From: isDirectMessage ? `discord:${user.id}` : `group:${channelId}`,
+        To: `slash:${user.id}`,
+        SessionKey: `agent:${route.agentId}:${sessionPrefix}:${user.id}`,
+        CommandTargetSessionKey: route.sessionKey,
+        AccountId: route.accountId,
+        ChatType: isDirectMessage ? "direct" : "group",
+        GroupSubject: isGuild ? interaction.guild?.name : undefined,
+        GroupSystemPrompt: isGuild
+          ? (() => {
+              const channelTopic =
+                channel && "topic" in channel
+                  ? (channel.topic ?? undefined)
+                  : undefined;
+              const channelDescription = channelTopic?.trim();
+              const systemPromptParts = [
+                channelDescription
+                  ? `Channel topic: ${channelDescription}`
+                  : null,
+                channelConfig?.systemPrompt?.trim() || null,
+              ].filter((entry): entry is string => Boolean(entry));
+              return systemPromptParts.length > 0
+                ? systemPromptParts.join("\n\n")
+                : undefined;
+            })()
+          : undefined,
+        SenderName: user.globalName ?? user.username,
+        SenderId: user.id,
+        SenderUsername: user.username,
+        SenderTag: formatDiscordUserTag(user),
+        Provider: "discord" as const,
+        Surface: "discord" as const,
+        WasMentioned: true,
+        MessageSid: interactionId,
+        Timestamp: Date.now(),
+        CommandAuthorized: commandAuthorized,
+        CommandSource: "native" as const,
+      };
+
+      let didReply = false;
+      await dispatchReplyWithDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+            .responsePrefix,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+          deliver: async (payload) => {
+            await deliverDiscordInteractionReply({
+              interaction,
+              payload,
+              textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
+                fallbackLimit: 2000,
+              }),
+              maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+              preferFollowUp: didReply,
+            });
+            didReply = true;
+          },
+          onError: (err, info) => {
+            console.error(`discord slash ${info.kind} reply failed`, err);
+          },
+        },
+        replyOptions: {
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined,
+        },
+      });
+    }
+  })();
+}
+
+async function deliverDiscordInteractionReply(params: {
+  interaction: CommandInteraction;
+  payload: ReplyPayload;
+  textLimit: number;
+  maxLinesPerMessage?: number;
+  preferFollowUp: boolean;
+}) {
+  const {
+    interaction,
+    payload,
+    textLimit,
+    maxLinesPerMessage,
+    preferFollowUp,
+  } = params;
+  const mediaList =
+    payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+  const text = payload.text ?? "";
+
+  let hasReplied = false;
+  const sendMessage = async (
+    content: string,
+    files?: { name: string; data: Buffer }[],
+  ) => {
+    const payload =
+      files && files.length > 0
+        ? {
+            content,
+            files: files.map((file) => {
+              if (file.data instanceof Blob) {
+                return { name: file.name, data: file.data };
+              }
+              const arrayBuffer = Uint8Array.from(file.data).buffer;
+              return { name: file.name, data: new Blob([arrayBuffer]) };
+            }),
+          }
+        : { content };
+    if (!preferFollowUp && !hasReplied) {
+      await interaction.reply(payload);
+      hasReplied = true;
+      return;
+    }
+    await interaction.followUp(payload);
+    hasReplied = true;
+  };
+
+  if (mediaList.length > 0) {
+    const media = await Promise.all(
+      mediaList.map(async (url) => {
+        const loaded = await loadWebMedia(url);
+        return {
+          name: loaded.fileName ?? "upload",
+          data: loaded.buffer,
+        };
+      }),
+    );
+    const chunks = chunkDiscordText(text, {
+      maxChars: textLimit,
+      maxLines: maxLinesPerMessage,
+    });
+    const caption = chunks[0] ?? "";
+    await sendMessage(caption, media);
+    for (const chunk of chunks.slice(1)) {
+      if (!chunk.trim()) continue;
+      await interaction.followUp({ content: chunk });
+    }
+    return;
+  }
+
+  if (!text.trim()) return;
+  const chunks = chunkDiscordText(text, {
+    maxChars: textLimit,
+    maxLines: maxLinesPerMessage,
+  });
+  for (const chunk of chunks) {
+    if (!chunk.trim()) continue;
+    await sendMessage(chunk);
+  }
+}
+
+async function deliverDiscordReply(params: {
+  replies: ReplyPayload[];
+  target: string;
+  token: string;
+  accountId?: string;
+  rest?: RequestClient;
+  runtime: RuntimeEnv;
+  textLimit: number;
+  maxLinesPerMessage?: number;
+  replyToId?: string;
+}) {
+  const chunkLimit = Math.min(params.textLimit, 2000);
+  for (const payload of params.replies) {
+    const mediaList =
+      payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const text = payload.text ?? "";
+    if (!text && mediaList.length === 0) continue;
+    const replyTo = params.replyToId?.trim() || undefined;
+
+    if (mediaList.length === 0) {
+      let isFirstChunk = true;
+      for (const chunk of chunkDiscordText(text, {
+        maxChars: chunkLimit,
+        maxLines: params.maxLinesPerMessage,
+      })) {
+        const trimmed = chunk.trim();
+        if (!trimmed) continue;
+        await sendMessageDiscord(params.target, trimmed, {
+          token: params.token,
+          rest: params.rest,
+          accountId: params.accountId,
+          replyTo: isFirstChunk ? replyTo : undefined,
+        });
+        isFirstChunk = false;
+      }
+      continue;
+    }
+
+    const firstMedia = mediaList[0];
+    if (!firstMedia) continue;
+    await sendMessageDiscord(params.target, text, {
+      token: params.token,
+      rest: params.rest,
+      mediaUrl: firstMedia,
+      accountId: params.accountId,
+      replyTo,
+    });
+    for (const extra of mediaList.slice(1)) {
+      await sendMessageDiscord(params.target, "", {
+        token: params.token,
+        rest: params.rest,
+        mediaUrl: extra,
+        accountId: params.accountId,
+      });
+    }
+  }
+}
+
+async function resolveDiscordChannelInfo(
+  client: Client,
+  channelId: string,
+): Promise<DiscordChannelInfo | null> {
+  const cached = DISCORD_CHANNEL_INFO_CACHE.get(channelId);
+  if (cached) {
+    if (cached.expiresAt > Date.now()) return cached.value;
+    DISCORD_CHANNEL_INFO_CACHE.delete(channelId);
+  }
+  try {
+    const channel = await client.fetchChannel(channelId);
+    if (!channel) {
+      DISCORD_CHANNEL_INFO_CACHE.set(channelId, {
+        value: null,
+        expiresAt: Date.now() + DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS,
+      });
+      return null;
+    }
+    const name = "name" in channel ? (channel.name ?? undefined) : undefined;
+    const topic = "topic" in channel ? (channel.topic ?? undefined) : undefined;
+    const parentId =
+      "parentId" in channel ? (channel.parentId ?? undefined) : undefined;
+    const payload: DiscordChannelInfo = {
+      type: channel.type,
+      name,
+      topic,
+      parentId,
+    };
+    DISCORD_CHANNEL_INFO_CACHE.set(channelId, {
+      value: payload,
+      expiresAt: Date.now() + DISCORD_CHANNEL_INFO_CACHE_TTL_MS,
+    });
+    return payload;
+  } catch (err) {
+    logVerbose(`discord: failed to fetch channel ${channelId}: ${String(err)}`);
+    DISCORD_CHANNEL_INFO_CACHE.set(channelId, {
+      value: null,
+      expiresAt: Date.now() + DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS,
+    });
+    return null;
+  }
+}
+
+async function resolveMediaList(
+  message: Message,
+  maxBytes: number,
+): Promise<DiscordMediaInfo[]> {
+  const attachments = message.attachments ?? [];
+  if (attachments.length === 0) return [];
+  const out: DiscordMediaInfo[] = [];
+  for (const attachment of attachments) {
+    try {
+      const fetched = await fetchRemoteMedia({
+        url: attachment.url,
+        filePathHint: attachment.filename ?? attachment.url,
+      });
+      const saved = await saveMediaBuffer(
+        fetched.buffer,
+        fetched.contentType ?? attachment.content_type,
+        "inbound",
+        maxBytes,
+      );
+      out.push({
+        path: saved.path,
+        contentType: saved.contentType,
+        placeholder: inferPlaceholder(attachment),
+      });
+    } catch (err) {
+      const id = attachment.id ?? attachment.url;
+      logVerbose(
+        `discord: failed to download attachment ${id}: ${String(err)}`,
+      );
+    }
+  }
+  return out;
+}
+
+function inferPlaceholder(attachment: APIAttachment): string {
+  const mime = attachment.content_type ?? "";
+  if (mime.startsWith("image/")) return "<media:image>";
+  if (mime.startsWith("video/")) return "<media:video>";
+  if (mime.startsWith("audio/")) return "<media:audio>";
+  return "<media:document>";
+}
+
+function isImageAttachment(attachment: APIAttachment): boolean {
+  const mime = attachment.content_type ?? "";
+  if (mime.startsWith("image/")) return true;
+  const name = attachment.filename?.toLowerCase() ?? "";
+  if (!name) return false;
+  return /\.(avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)$/.test(name);
+}
+
+function buildDiscordAttachmentPlaceholder(
+  attachments?: APIAttachment[],
+): string {
+  if (!attachments || attachments.length === 0) return "";
+  const count = attachments.length;
+  const allImages = attachments.every(isImageAttachment);
+  const label = allImages ? "image" : "file";
+  const suffix = count === 1 ? label : `${label}s`;
+  const tag = allImages ? "<media:image>" : "<media:document>";
+  return `${tag} (${count} ${suffix})`;
+}
+
+function resolveDiscordMessageText(
+  message: Message,
+  options?: { fallbackText?: string; includeForwarded?: boolean },
+): string {
+  const baseText =
+    message.content?.trim() ||
+    buildDiscordAttachmentPlaceholder(message.attachments) ||
+    message.embeds?.[0]?.description ||
+    options?.fallbackText?.trim() ||
+    "";
+  if (!options?.includeForwarded) return baseText;
+  const forwardedText = resolveDiscordForwardedMessagesText(message);
+  if (!forwardedText) return baseText;
+  if (!baseText) return forwardedText;
+  return `${baseText}\n${forwardedText}`;
+}
+
+function resolveDiscordForwardedMessagesText(message: Message): string {
+  const snapshots = resolveDiscordMessageSnapshots(message);
+  if (snapshots.length === 0) return "";
+  const forwardedBlocks = snapshots
+    .map((snapshot) => {
+      const snapshotMessage = snapshot.message;
+      if (!snapshotMessage) return null;
+      const text = resolveDiscordSnapshotMessageText(snapshotMessage);
+      if (!text) return null;
+      const authorLabel = formatDiscordSnapshotAuthor(snapshotMessage.author);
+      const heading = authorLabel
+        ? `[Forwarded message from ${authorLabel}]`
+        : "[Forwarded message]";
+      return `${heading}\n${text}`;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+  if (forwardedBlocks.length === 0) return "";
+  return forwardedBlocks.join("\n\n");
+}
+
+function resolveDiscordMessageSnapshots(
+  message: Message,
+): DiscordMessageSnapshot[] {
+  const rawData = (message as { rawData?: { message_snapshots?: unknown } })
+    .rawData;
+  const snapshots =
+    rawData?.message_snapshots ??
+    (message as { message_snapshots?: unknown }).message_snapshots ??
+    (message as { messageSnapshots?: unknown }).messageSnapshots;
+  if (!Array.isArray(snapshots)) return [];
+  return snapshots.filter(
+    (entry): entry is DiscordMessageSnapshot =>
+      Boolean(entry) && typeof entry === "object",
+  );
+}
+
+function resolveDiscordSnapshotMessageText(
+  snapshot: DiscordSnapshotMessage,
+): string {
+  const content = snapshot.content?.trim() ?? "";
+  const attachmentText = buildDiscordAttachmentPlaceholder(
+    snapshot.attachments ?? undefined,
+  );
+  const embed = snapshot.embeds?.[0];
+  const embedText = embed?.description?.trim() || embed?.title?.trim() || "";
+  return content || attachmentText || embedText || "";
+}
+
+function formatDiscordSnapshotAuthor(
+  author: DiscordSnapshotAuthor | null | undefined,
+): string | undefined {
+  if (!author) return undefined;
+  const globalName = author.global_name ?? undefined;
+  const username = author.username ?? undefined;
+  const name = author.name ?? undefined;
+  const discriminator = author.discriminator ?? undefined;
+  const base = globalName || username || name;
+  if (username && discriminator && discriminator !== "0") {
+    return `@${username}#${discriminator}`;
+  }
+  if (base) return `@${base}`;
+  if (author.id) return `@${author.id}`;
+  return undefined;
+}
+
+export function buildDiscordMediaPayload(
+  mediaList: Array<{ path: string; contentType?: string }>,
+): {
+  MediaPath?: string;
+  MediaType?: string;
+  MediaUrl?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+} {
+  const first = mediaList[0];
+  const mediaPaths = mediaList.map((media) => media.path);
+  const mediaTypes = mediaList
+    .map((media) => media.contentType)
+    .filter(Boolean) as string[];
+  return {
+    MediaPath: first?.path,
+    MediaType: first?.contentType,
+    MediaUrl: first?.path,
+    MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+  };
+}
+
+function resolveReplyContext(message: Message): string | null {
+  const referenced = message.referencedMessage;
+  if (!referenced?.author) return null;
+  const referencedText = resolveDiscordMessageText(referenced, {
+    includeForwarded: true,
+  });
+  if (!referencedText) return null;
+  const fromLabel = referenced.author
+    ? buildDirectLabel(referenced.author)
+    : "Unknown";
+  const body = `${referencedText}\n[discord message id: ${referenced.id} channel: ${referenced.channelId} from: ${formatDiscordUserTag(referenced.author)} user id:${referenced.author?.id ?? "unknown"}]`;
+  return formatAgentEnvelope({
+    channel: "Discord",
+    from: fromLabel,
+    timestamp: resolveTimestampMs(referenced.timestamp),
+    body,
+  });
+}
+
+function buildDirectLabel(author: User) {
+  const username = formatDiscordUserTag(author);
+  return `${username} user id:${author.id}`;
+}
+
+function buildGuildLabel(params: {
+  guild?: Guild;
+  channelName: string;
+  channelId: string;
+}) {
+  const { guild, channelName, channelId } = params;
+  return `${guild?.name ?? "Guild"} #${channelName} channel id:${channelId}`;
+}
+
+function resolveDiscordSystemEvent(
+  message: Message,
+  location: string,
+): string | null {
+  switch (message.type) {
+    case MessageType.ChannelPinnedMessage:
+      return buildDiscordSystemEvent(message, location, "pinned a message");
+    case MessageType.RecipientAdd:
+      return buildDiscordSystemEvent(message, location, "added a recipient");
+    case MessageType.RecipientRemove:
+      return buildDiscordSystemEvent(message, location, "removed a recipient");
+    case MessageType.UserJoin:
+      return buildDiscordSystemEvent(message, location, "user joined");
+    case MessageType.GuildBoost:
+      return buildDiscordSystemEvent(message, location, "boosted the server");
+    case MessageType.GuildBoostTier1:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "boosted the server (Tier 1 reached)",
+      );
+    case MessageType.GuildBoostTier2:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "boosted the server (Tier 2 reached)",
+      );
+    case MessageType.GuildBoostTier3:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "boosted the server (Tier 3 reached)",
+      );
+    case MessageType.ThreadCreated:
+      return buildDiscordSystemEvent(message, location, "created a thread");
+    case MessageType.AutoModerationAction:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "auto moderation action",
+      );
+    case MessageType.GuildIncidentAlertModeEnabled:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "raid protection enabled",
+      );
+    case MessageType.GuildIncidentAlertModeDisabled:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "raid protection disabled",
+      );
+    case MessageType.GuildIncidentReportRaid:
+      return buildDiscordSystemEvent(message, location, "raid reported");
+    case MessageType.GuildIncidentReportFalseAlarm:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "raid report marked false alarm",
+      );
+    case MessageType.StageStart:
+      return buildDiscordSystemEvent(message, location, "stage started");
+    case MessageType.StageEnd:
+      return buildDiscordSystemEvent(message, location, "stage ended");
+    case MessageType.StageSpeaker:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "stage speaker updated",
+      );
+    case MessageType.StageTopic:
+      return buildDiscordSystemEvent(message, location, "stage topic updated");
+    case MessageType.PollResult:
+      return buildDiscordSystemEvent(message, location, "poll results posted");
+    case MessageType.PurchaseNotification:
+      return buildDiscordSystemEvent(
+        message,
+        location,
+        "purchase notification",
+      );
+    default:
+      return null;
+  }
+}
+
+function buildDiscordSystemEvent(
+  message: Message,
+  location: string,
+  action: string,
+) {
+  const authorLabel = message.author
+    ? formatDiscordUserTag(message.author)
+    : "";
+  const actor = authorLabel ? `${authorLabel} ` : "";
+  return `Discord system: ${actor}${action} in ${location}`;
+}
+
+function resolveDiscordSystemLocation(params: {
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+  guild?: Guild;
+  channelName: string;
+}) {
+  const { isDirectMessage, isGroupDm, guild, channelName } = params;
+  if (isDirectMessage) return "DM";
+  if (isGroupDm) return `Group DM #${channelName}`;
+  return guild?.name ? `${guild.name} #${channelName}` : `#${channelName}`;
+}
+
+function formatDiscordReactionEmoji(emoji: {
+  id?: string | null;
+  name?: string | null;
+}) {
+  if (emoji.id && emoji.name) {
+    return `${emoji.name}:${emoji.id}`;
+  }
+  return emoji.name ?? "emoji";
+}
+
+function formatDiscordUserTag(user: User) {
+  const discriminator = (user.discriminator ?? "").trim();
+  if (discriminator && discriminator !== "0") {
+    return `${user.username}#${discriminator}`;
+  }
+  return user.username ?? user.id;
+}
+
+function resolveTimestampMs(timestamp?: string | null) {
+  if (!timestamp) return undefined;
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+export function normalizeDiscordAllowList(
+  raw: Array<string | number> | undefined,
+  prefixes: string[],
+) {
+  if (!raw || raw.length === 0) return null;
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  const allowAll = raw.some((entry) => String(entry).trim() === "*");
+  for (const entry of raw) {
+    const text = String(entry).trim();
+    if (!text || text === "*") continue;
+    const normalized = normalizeDiscordSlug(text);
+    const maybeId = text.replace(/^<@!?/, "").replace(/>$/, "");
+    if (/^\d+$/.test(maybeId)) {
+      ids.add(maybeId);
+      continue;
+    }
+    const prefix = prefixes.find((entry) => text.startsWith(entry));
+    if (prefix) {
+      const candidate = text.slice(prefix.length);
+      if (candidate) ids.add(candidate);
+      continue;
+    }
+    if (normalized) {
+      names.add(normalized);
+    }
+  }
+  return { allowAll, ids, names } satisfies DiscordAllowList;
+}
+
+export function normalizeDiscordSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^#/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function allowListMatches(
+  list: DiscordAllowList,
+  candidate: { id?: string; name?: string; tag?: string },
+) {
+  if (list.allowAll) return true;
+  if (candidate.id && list.ids.has(candidate.id)) return true;
+  const slug = candidate.name ? normalizeDiscordSlug(candidate.name) : "";
+  if (slug && list.names.has(slug)) return true;
+  if (candidate.tag && list.names.has(normalizeDiscordSlug(candidate.tag)))
+    return true;
+  return false;
+}
+
+function resolveDiscordUserAllowed(params: {
+  allowList?: Array<string | number>;
+  userId: string;
+  userName?: string;
+  userTag?: string;
+}) {
+  const allowList = normalizeDiscordAllowList(params.allowList, [
+    "discord:",
+    "user:",
+  ]);
+  if (!allowList) return true;
+  return allowListMatches(allowList, {
+    id: params.userId,
+    name: params.userName,
+    tag: params.userTag,
+  });
+}
+
+export function resolveDiscordCommandAuthorized(params: {
+  isDirectMessage: boolean;
+  allowFrom?: Array<string | number>;
+  guildInfo?: DiscordGuildEntryResolved | null;
+  author: User;
+}) {
+  if (!params.isDirectMessage) return true;
+  const allowList = normalizeDiscordAllowList(params.allowFrom, [
+    "discord:",
+    "user:",
+  ]);
+  if (!allowList) return true;
+  return allowListMatches(allowList, {
+    id: params.author.id,
+    name: params.author.username,
+    tag: formatDiscordUserTag(params.author),
+  });
+}
+
+export function resolveDiscordGuildEntry(params: {
+  guild?: Guild<true> | Guild<false> | null;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+}): DiscordGuildEntryResolved | null {
+  const guild = params.guild;
+  const entries = params.guildEntries;
+  if (!guild || !entries) return null;
+  const byId = entries[guild.id];
+  if (byId) return { ...byId, id: guild.id };
+  const slug = normalizeDiscordSlug(guild.name ?? "");
+  const bySlug = entries[slug];
+  if (bySlug) return { ...bySlug, id: guild.id, slug: slug || bySlug.slug };
+  const wildcard = entries["*"];
+  if (wildcard)
+    return { ...wildcard, id: guild.id, slug: slug || wildcard.slug };
+  return null;
+}
+
+export function resolveDiscordChannelConfig(params: {
+  guildInfo?: DiscordGuildEntryResolved | null;
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+}): DiscordChannelConfigResolved | null {
+  const { guildInfo, channelId, channelName, channelSlug } = params;
+  const channels = guildInfo?.channels;
+  if (!channels) return null;
+  const byId = channels[channelId];
+  if (byId)
+    return {
+      allowed: byId.allow !== false,
+      requireMention: byId.requireMention,
+      skills: byId.skills,
+      enabled: byId.enabled,
+      users: byId.users,
+      systemPrompt: byId.systemPrompt,
+      autoThread: byId.autoThread,
+    };
+  if (channelSlug && channels[channelSlug]) {
+    const entry = channels[channelSlug];
+    return {
+      allowed: entry.allow !== false,
+      requireMention: entry.requireMention,
+      skills: entry.skills,
+      enabled: entry.enabled,
+      users: entry.users,
+      systemPrompt: entry.systemPrompt,
+      autoThread: entry.autoThread,
+    };
+  }
+  if (channelName && channels[channelName]) {
+    const entry = channels[channelName];
+    return {
+      allowed: entry.allow !== false,
+      requireMention: entry.requireMention,
+      skills: entry.skills,
+      enabled: entry.enabled,
+      users: entry.users,
+      systemPrompt: entry.systemPrompt,
+      autoThread: entry.autoThread,
+    };
+  }
+  return { allowed: false };
+}
+
+export function resolveDiscordShouldRequireMention(params: {
+  isGuildMessage: boolean;
+  isThread: boolean;
+  channelConfig?: DiscordChannelConfigResolved | null;
+  guildInfo?: DiscordGuildEntryResolved | null;
+}): boolean {
+  if (!params.isGuildMessage) return false;
+  if (params.isThread && params.channelConfig?.autoThread) return false;
+  return (
+    params.channelConfig?.requireMention ??
+    params.guildInfo?.requireMention ??
+    true
+  );
+}
+
+export function isDiscordGroupAllowedByPolicy(params: {
+  groupPolicy: "open" | "disabled" | "allowlist";
+  channelAllowlistConfigured: boolean;
+  channelAllowed: boolean;
+}): boolean {
+  const { groupPolicy, channelAllowlistConfigured, channelAllowed } = params;
+  if (groupPolicy === "disabled") return false;
+  if (groupPolicy === "open") return true;
+  if (!channelAllowlistConfigured) return false;
+  return channelAllowed;
+}
+
+export function resolveGroupDmAllow(params: {
+  channels?: Array<string | number>;
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+}) {
+  const { channels, channelId, channelName, channelSlug } = params;
+  if (!channels || channels.length === 0) return true;
+  const allowList = channels.map((entry) =>
+    normalizeDiscordSlug(String(entry)),
+  );
+  const candidates = [
+    normalizeDiscordSlug(channelId),
+    channelSlug,
+    channelName ? normalizeDiscordSlug(channelName) : "",
+  ].filter(Boolean);
+  return (
+    allowList.includes("*") ||
+    candidates.some((candidate) => allowList.includes(candidate))
+  );
+}
+
+export function shouldEmitDiscordReactionNotification(params: {
+  mode?: "off" | "own" | "all" | "allowlist";
+  botId?: string;
+  messageAuthorId?: string;
+  userId: string;
+  userName?: string;
+  userTag?: string;
+  allowlist?: Array<string | number>;
+}) {
+  const mode = params.mode ?? "own";
+  if (mode === "off") return false;
+  if (mode === "all") return true;
+  if (mode === "own") {
+    return Boolean(params.botId && params.messageAuthorId === params.botId);
+  }
+  if (mode === "allowlist") {
+    const list = normalizeDiscordAllowList(params.allowlist, [
+      "discord:",
+      "user:",
+    ]);
+    if (!list) return false;
+    return allowListMatches(list, {
+      id: params.userId,
+      name: params.userName,
+      tag: params.userTag,
+    });
+  }
+  return false;
+}
+
+async function sendTyping(params: { client: Client; channelId: string }) {
+  try {
+    const channel = await params.client.fetchChannel(params.channelId);
+    if (!channel) return;
+    if (
+      "triggerTyping" in channel &&
+      typeof channel.triggerTyping === "function"
+    ) {
+      await channel.triggerTyping();
+    }
+  } catch (err) {
+    logVerbose(
+      `discord typing cue failed for channel ${params.channelId}: ${String(err)}`,
+    );
+  }
+}

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -48,12 +48,10 @@ import {
 } from "../auto-reply/reply/mentions.js";
 import { dispatchReplyWithDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import {
-  createReplyDispatcher,
   createReplyDispatcherWithTyping,
   shouldSkipTextOnlyDelivery,
 } from "../auto-reply/reply/reply-dispatcher.js";
 import { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
-import { getReplyFromConfig } from "../auto-reply/reply.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import {
   isNativeCommandsExplicitlyDisabled,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -328,6 +328,7 @@ export async function processDiscordMessage(
     ctx: ctxPayload,
     cfg,
     dispatcher,
+    runtime,
     replyOptions: {
       ...replyOptions,
       skillFilter: channelConfig?.skills,

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -16,7 +16,10 @@ import {
   buildMentionRegexes,
   matchesMentionPatterns,
 } from "../auto-reply/reply/mentions.js";
-import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import {
+  createReplyDispatcher,
+  shouldSkipTextOnlyDelivery,
+} from "../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -491,6 +494,10 @@ export async function monitorIMessageProvider(
       responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
         .responsePrefix,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(
+        cfg,
+        ctxPayload.MediaType,
+      ),
       deliver: async (payload) => {
         await deliverReplies({
           replies: [payload],

--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -1,2 +1,584 @@
-export { monitorIMessageProvider } from "./monitor/monitor-provider.js";
-export type { MonitorIMessageOpts } from "./monitor/types.js";
+import {
+  resolveEffectiveMessagesConfig,
+  resolveHumanDelayConfig,
+} from "../agents/identity.js";
+import { chunkText, resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import { dispatchReplyFromConfig } from "../auto-reply/reply/dispatch-from-config.js";
+import {
+  buildHistoryContextFromMap,
+  clearHistoryEntries,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  type HistoryEntry,
+} from "../auto-reply/reply/history.js";
+import {
+  buildMentionRegexes,
+  matchesMentionPatterns,
+} from "../auto-reply/reply/mentions.js";
+import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import type { ClawdbotConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupRequireMention,
+} from "../config/group-policy.js";
+import { resolveStorePath, updateLastRoute } from "../config/sessions.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { mediaKindFromMime } from "../media/constants.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
+import { resolveIMessageAccount } from "./accounts.js";
+import { createIMessageRpcClient } from "./client.js";
+import { sendMessageIMessage } from "./send.js";
+import {
+  formatIMessageChatTarget,
+  isAllowedIMessageSender,
+  normalizeIMessageHandle,
+} from "./targets.js";
+
+type IMessageAttachment = {
+  original_path?: string | null;
+  mime_type?: string | null;
+  missing?: boolean | null;
+};
+
+type IMessagePayload = {
+  id?: number | null;
+  chat_id?: number | null;
+  sender?: string | null;
+  is_from_me?: boolean | null;
+  text?: string | null;
+  created_at?: string | null;
+  attachments?: IMessageAttachment[] | null;
+  chat_identifier?: string | null;
+  chat_guid?: string | null;
+  chat_name?: string | null;
+  participants?: string[] | null;
+  is_group?: boolean | null;
+};
+
+export type MonitorIMessageOpts = {
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  cliPath?: string;
+  dbPath?: string;
+  accountId?: string;
+  config?: ClawdbotConfig;
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  includeAttachments?: boolean;
+  mediaMaxMb?: number;
+  requireMention?: boolean;
+};
+
+function resolveRuntime(opts: MonitorIMessageOpts): RuntimeEnv {
+  return (
+    opts.runtime ?? {
+      log: console.log,
+      error: console.error,
+      exit: (code: number): never => {
+        throw new Error(`exit ${code}`);
+      },
+    }
+  );
+}
+
+function normalizeAllowList(list?: Array<string | number>) {
+  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+async function deliverReplies(params: {
+  replies: ReplyPayload[];
+  target: string;
+  client: Awaited<ReturnType<typeof createIMessageRpcClient>>;
+  accountId?: string;
+  runtime: RuntimeEnv;
+  maxBytes: number;
+  textLimit: number;
+}) {
+  const { replies, target, client, runtime, maxBytes, textLimit, accountId } =
+    params;
+  for (const payload of replies) {
+    const mediaList =
+      payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const text = payload.text ?? "";
+    if (!text && mediaList.length === 0) continue;
+    if (mediaList.length === 0) {
+      for (const chunk of chunkText(text, textLimit)) {
+        await sendMessageIMessage(target, chunk, {
+          maxBytes,
+          client,
+          accountId,
+        });
+      }
+    } else {
+      let first = true;
+      for (const url of mediaList) {
+        const caption = first ? text : "";
+        first = false;
+        await sendMessageIMessage(target, caption, {
+          mediaUrl: url,
+          maxBytes,
+          client,
+          accountId,
+        });
+      }
+    }
+    runtime.log?.(`imessage: delivered reply to ${target}`);
+  }
+}
+
+export async function monitorIMessageProvider(
+  opts: MonitorIMessageOpts = {},
+): Promise<void> {
+  const runtime = resolveRuntime(opts);
+  const cfg = opts.config ?? loadConfig();
+  const accountInfo = resolveIMessageAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const imessageCfg = accountInfo.config;
+  const historyLimit = Math.max(
+    0,
+    imessageCfg.historyLimit ??
+      cfg.messages?.groupChat?.historyLimit ??
+      DEFAULT_GROUP_HISTORY_LIMIT,
+  );
+  const groupHistories = new Map<string, HistoryEntry[]>();
+  const textLimit = resolveTextChunkLimit(
+    cfg,
+    "imessage",
+    accountInfo.accountId,
+  );
+  const allowFrom = normalizeAllowList(opts.allowFrom ?? imessageCfg.allowFrom);
+  const groupAllowFrom = normalizeAllowList(
+    opts.groupAllowFrom ??
+      imessageCfg.groupAllowFrom ??
+      (imessageCfg.allowFrom && imessageCfg.allowFrom.length > 0
+        ? imessageCfg.allowFrom
+        : []),
+  );
+  const groupPolicy = imessageCfg.groupPolicy ?? "open";
+  const dmPolicy = imessageCfg.dmPolicy ?? "pairing";
+  const includeAttachments =
+    opts.includeAttachments ?? imessageCfg.includeAttachments ?? false;
+  const mediaMaxBytes =
+    (opts.mediaMaxMb ?? imessageCfg.mediaMaxMb ?? 16) * 1024 * 1024;
+
+  const handleMessage = async (raw: unknown) => {
+    const params = raw as { message?: IMessagePayload | null };
+    const message = params?.message ?? null;
+    if (!message) return;
+
+    const senderRaw = message.sender ?? "";
+    const sender = senderRaw.trim();
+    if (!sender) return;
+    if (message.is_from_me) return;
+
+    const chatId = message.chat_id ?? undefined;
+    const chatGuid = message.chat_guid ?? undefined;
+    const chatIdentifier = message.chat_identifier ?? undefined;
+
+    const groupIdCandidate = chatId !== undefined ? String(chatId) : undefined;
+    const groupListPolicy = groupIdCandidate
+      ? resolveChannelGroupPolicy({
+          cfg,
+          channel: "imessage",
+          accountId: accountInfo.accountId,
+          groupId: groupIdCandidate,
+        })
+      : {
+          allowlistEnabled: false,
+          allowed: true,
+          groupConfig: undefined,
+          defaultConfig: undefined,
+        };
+
+    // Some iMessage threads can have multiple participants but still report
+    // is_group=false depending on how Messages stores the identifier.
+    // If the owner explicitly configures a chat_id under imessage.groups, treat
+    // that thread as a "group" for permission gating and session isolation.
+    const treatAsGroupByConfig = Boolean(
+      groupIdCandidate &&
+        groupListPolicy.allowlistEnabled &&
+        groupListPolicy.groupConfig,
+    );
+
+    const isGroup = Boolean(message.is_group) || treatAsGroupByConfig;
+    if (isGroup && !chatId) return;
+
+    const groupId = isGroup ? groupIdCandidate : undefined;
+    const storeAllowFrom = await readChannelAllowFromStore("imessage").catch(
+      () => [],
+    );
+    const effectiveDmAllowFrom = Array.from(
+      new Set([...allowFrom, ...storeAllowFrom]),
+    )
+      .map((v) => String(v).trim())
+      .filter(Boolean);
+    const effectiveGroupAllowFrom = Array.from(
+      new Set([...groupAllowFrom, ...storeAllowFrom]),
+    )
+      .map((v) => String(v).trim())
+      .filter(Boolean);
+
+    if (isGroup) {
+      if (groupPolicy === "disabled") {
+        logVerbose("Blocked iMessage group message (groupPolicy: disabled)");
+        return;
+      }
+      if (groupPolicy === "allowlist") {
+        if (effectiveGroupAllowFrom.length === 0) {
+          logVerbose(
+            "Blocked iMessage group message (groupPolicy: allowlist, no groupAllowFrom)",
+          );
+          return;
+        }
+        const allowed = isAllowedIMessageSender({
+          allowFrom: effectiveGroupAllowFrom,
+          sender,
+          chatId: chatId ?? undefined,
+          chatGuid,
+          chatIdentifier,
+        });
+        if (!allowed) {
+          logVerbose(
+            `Blocked iMessage sender ${sender} (not in groupAllowFrom)`,
+          );
+          return;
+        }
+      }
+      if (groupListPolicy.allowlistEnabled && !groupListPolicy.allowed) {
+        logVerbose(
+          `imessage: skipping group message (${groupId ?? "unknown"}) not in allowlist`,
+        );
+        return;
+      }
+    }
+
+    const dmHasWildcard = effectiveDmAllowFrom.includes("*");
+    const dmAuthorized =
+      dmPolicy === "open"
+        ? true
+        : dmHasWildcard ||
+          (effectiveDmAllowFrom.length > 0 &&
+            isAllowedIMessageSender({
+              allowFrom: effectiveDmAllowFrom,
+              sender,
+              chatId: chatId ?? undefined,
+              chatGuid,
+              chatIdentifier,
+            }));
+    if (!isGroup) {
+      if (dmPolicy === "disabled") return;
+      if (!dmAuthorized) {
+        if (dmPolicy === "pairing") {
+          const senderId = normalizeIMessageHandle(sender);
+          const { code, created } = await upsertChannelPairingRequest({
+            channel: "imessage",
+            id: senderId,
+            meta: {
+              sender: senderId,
+              chatId: chatId ? String(chatId) : undefined,
+            },
+          });
+          if (created) {
+            logVerbose(`imessage pairing request sender=${senderId}`);
+            try {
+              await sendMessageIMessage(
+                sender,
+                buildPairingReply({
+                  channel: "imessage",
+                  idLine: `Your iMessage sender id: ${senderId}`,
+                  code,
+                }),
+                {
+                  client,
+                  maxBytes: mediaMaxBytes,
+                  accountId: accountInfo.accountId,
+                  ...(chatId ? { chatId } : {}),
+                },
+              );
+            } catch (err) {
+              logVerbose(
+                `imessage pairing reply failed for ${senderId}: ${String(err)}`,
+              );
+            }
+          }
+        } else {
+          logVerbose(
+            `Blocked iMessage sender ${sender} (dmPolicy=${dmPolicy})`,
+          );
+        }
+        return;
+      }
+    }
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "imessage",
+      accountId: accountInfo.accountId,
+      peer: {
+        kind: isGroup ? "group" : "dm",
+        id: isGroup
+          ? String(chatId ?? "unknown")
+          : normalizeIMessageHandle(sender),
+      },
+    });
+    const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
+    const messageText = (message.text ?? "").trim();
+    const mentioned = isGroup
+      ? matchesMentionPatterns(messageText, mentionRegexes)
+      : true;
+    const requireMention = resolveChannelGroupRequireMention({
+      cfg,
+      channel: "imessage",
+      accountId: accountInfo.accountId,
+      groupId,
+      requireMentionOverride: opts.requireMention,
+      overrideOrder: "before-config",
+    });
+    const canDetectMention = mentionRegexes.length > 0;
+    const commandAuthorized = isGroup
+      ? effectiveGroupAllowFrom.length > 0
+        ? isAllowedIMessageSender({
+            allowFrom: effectiveGroupAllowFrom,
+            sender,
+            chatId: chatId ?? undefined,
+            chatGuid,
+            chatIdentifier,
+          })
+        : true
+      : dmAuthorized;
+    const shouldBypassMention =
+      isGroup &&
+      requireMention &&
+      !mentioned &&
+      commandAuthorized &&
+      hasControlCommand(messageText);
+    const effectiveWasMentioned = mentioned || shouldBypassMention;
+    if (
+      isGroup &&
+      requireMention &&
+      canDetectMention &&
+      !mentioned &&
+      !shouldBypassMention
+    ) {
+      logVerbose(`imessage: skipping group message (no mention)`);
+      return;
+    }
+
+    const attachments = includeAttachments ? (message.attachments ?? []) : [];
+    const firstAttachment = attachments?.find(
+      (entry) => entry?.original_path && !entry?.missing,
+    );
+    const mediaPath = firstAttachment?.original_path ?? undefined;
+    const mediaType = firstAttachment?.mime_type ?? undefined;
+    const kind = mediaKindFromMime(mediaType ?? undefined);
+    const placeholder = kind
+      ? `<media:${kind}>`
+      : attachments?.length
+        ? "<media:attachment>"
+        : "";
+    const bodyText = messageText || placeholder;
+    if (!bodyText) return;
+
+    const chatTarget = formatIMessageChatTarget(chatId);
+    const fromLabel = isGroup
+      ? `${message.chat_name || "iMessage Group"} id:${chatId ?? "unknown"}`
+      : `${normalizeIMessageHandle(sender)} id:${sender}`;
+    const createdAt = message.created_at
+      ? Date.parse(message.created_at)
+      : undefined;
+    const body = formatAgentEnvelope({
+      channel: "iMessage",
+      from: fromLabel,
+      timestamp: createdAt,
+      body: bodyText,
+    });
+    let combinedBody = body;
+    const historyKey = isGroup
+      ? String(chatId ?? chatGuid ?? chatIdentifier ?? "unknown")
+      : undefined;
+    if (isGroup && historyKey && historyLimit > 0) {
+      combinedBody = buildHistoryContextFromMap({
+        historyMap: groupHistories,
+        historyKey,
+        limit: historyLimit,
+        entry: {
+          sender: normalizeIMessageHandle(sender),
+          body: bodyText,
+          timestamp: createdAt,
+          messageId: message.id ? String(message.id) : undefined,
+        },
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatAgentEnvelope({
+            channel: "iMessage",
+            from: fromLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.sender}: ${entry.body}${
+              entry.messageId ? ` [id:${entry.messageId}]` : ""
+            }`,
+          }),
+      });
+    }
+
+    const imessageTo = chatTarget || `imessage:${sender}`;
+    const ctxPayload = {
+      Body: combinedBody,
+      RawBody: bodyText,
+      CommandBody: bodyText,
+      From: isGroup ? `group:${chatId}` : `imessage:${sender}`,
+      To: imessageTo,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isGroup ? "group" : "direct",
+      GroupSubject: isGroup ? (message.chat_name ?? undefined) : undefined,
+      GroupMembers: isGroup
+        ? (message.participants ?? []).filter(Boolean).join(", ")
+        : undefined,
+      SenderName: sender,
+      SenderId: sender,
+      Provider: "imessage",
+      Surface: "imessage",
+      MessageSid: message.id ? String(message.id) : undefined,
+      Timestamp: createdAt,
+      MediaPath: mediaPath,
+      MediaType: mediaType,
+      MediaUrl: mediaPath,
+      WasMentioned: effectiveWasMentioned,
+      CommandAuthorized: commandAuthorized,
+      // Originating channel for reply routing.
+      OriginatingChannel: "imessage" as const,
+      OriginatingTo: imessageTo,
+    };
+
+    if (!isGroup) {
+      const sessionCfg = cfg.session;
+      const storePath = resolveStorePath(sessionCfg?.store, {
+        agentId: route.agentId,
+      });
+      const to = chatTarget || sender;
+      if (to) {
+        await updateLastRoute({
+          storePath,
+          sessionKey: route.mainSessionKey,
+          channel: "imessage",
+          to,
+          accountId: route.accountId,
+        });
+      }
+    }
+
+    if (shouldLogVerbose()) {
+      const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+      logVerbose(
+        `imessage inbound: chatId=${chatId ?? "unknown"} from=${ctxPayload.From} len=${body.length} preview="${preview}"`,
+      );
+    }
+
+    let didSendReply = false;
+    const dispatcher = createReplyDispatcher({
+      responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+        .responsePrefix,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      deliver: async (payload) => {
+        await deliverReplies({
+          replies: [payload],
+          target: ctxPayload.To,
+          client,
+          accountId: accountInfo.accountId,
+          runtime,
+          maxBytes: mediaMaxBytes,
+          textLimit,
+        });
+        didSendReply = true;
+      },
+      onError: (err, info) => {
+        runtime.error?.(
+          danger(`imessage ${info.kind} reply failed: ${String(err)}`),
+        );
+      },
+    });
+
+    const { queuedFinal } = await dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
+      dispatcher,
+      runtime,
+      replyOptions: {
+        disableBlockStreaming:
+          typeof accountInfo.config.blockStreaming === "boolean"
+            ? !accountInfo.config.blockStreaming
+            : undefined,
+      },
+    });
+    if (!queuedFinal) {
+      if (isGroup && historyKey && historyLimit > 0 && didSendReply) {
+        clearHistoryEntries({ historyMap: groupHistories, historyKey });
+      }
+      return;
+    }
+    if (isGroup && historyKey && historyLimit > 0 && didSendReply) {
+      clearHistoryEntries({ historyMap: groupHistories, historyKey });
+    }
+  };
+
+  const client = await createIMessageRpcClient({
+    cliPath: opts.cliPath ?? imessageCfg.cliPath,
+    dbPath: opts.dbPath ?? imessageCfg.dbPath,
+    runtime,
+    onNotification: (msg) => {
+      if (msg.method === "message") {
+        void handleMessage(msg.params).catch((err) => {
+          runtime.error?.(`imessage: handler failed: ${String(err)}`);
+        });
+      } else if (msg.method === "error") {
+        runtime.error?.(`imessage: watch error ${JSON.stringify(msg.params)}`);
+      }
+    },
+  });
+
+  let subscriptionId: number | null = null;
+  const abort = opts.abortSignal;
+  const onAbort = () => {
+    if (subscriptionId) {
+      void client
+        .request("watch.unsubscribe", {
+          subscription: subscriptionId,
+        })
+        .catch(() => {
+          // Ignore disconnect errors during shutdown.
+        });
+    }
+    void client.stop().catch(() => {
+      // Ignore disconnect errors during shutdown.
+    });
+  };
+  abort?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    const result = await client.request<{ subscription?: number }>(
+      "watch.subscribe",
+      { attachments: includeAttachments },
+    );
+    subscriptionId = result?.subscription ?? null;
+    await client.waitForClose();
+  } catch (err) {
+    if (abort?.aborted) return;
+    runtime.error?.(danger(`imessage: monitor failed: ${String(err)}`));
+    throw err;
+  } finally {
+    abort?.removeEventListener("abort", onAbort);
+    await client.stop();
+  }
+}

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -422,6 +422,7 @@ export async function monitorIMessageProvider(
       ctx: ctxPayload,
       cfg,
       dispatcher,
+      runtime,
       replyOptions: {
         disableBlockStreaming:
           typeof accountInfo.config.blockStreaming === "boolean"

--- a/src/msteams/monitor-handler.ts
+++ b/src/msteams/monitor-handler.ts
@@ -544,6 +544,7 @@ function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         context,
         replyStyle,
         textLimit,
+        mediaType: ctxPayload.MediaType,
       });
 
     // Dispatch to agent

--- a/src/msteams/monitor-handler.ts
+++ b/src/msteams/monitor-handler.ts
@@ -1,11 +1,50 @@
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import { dispatchReplyFromConfig } from "../auto-reply/reply/dispatch-from-config.js";
+import {
+  buildHistoryContextFromMap,
+  clearHistoryEntries,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  type HistoryEntry,
+} from "../auto-reply/reply/history.js";
 import type { ClawdbotConfig } from "../config/types.js";
-import { danger } from "../globals.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
 import type { RuntimeEnv } from "../runtime.js";
-import type { MSTeamsConversationStore } from "./conversation-store.js";
+import {
+  buildMSTeamsAttachmentPlaceholder,
+  buildMSTeamsGraphMessageUrls,
+  buildMSTeamsMediaPayload,
+  downloadMSTeamsGraphMedia,
+  downloadMSTeamsImageAttachments,
+  type MSTeamsAttachmentLike,
+  summarizeMSTeamsHtmlAttachments,
+} from "./attachments.js";
+import type {
+  MSTeamsConversationStore,
+  StoredConversationReference,
+} from "./conversation-store.js";
+import { formatUnknownError } from "./errors.js";
+import {
+  extractMSTeamsConversationMessageId,
+  normalizeMSTeamsConversationId,
+  parseMSTeamsActivityTimestamp,
+  stripMSTeamsMentionTags,
+  wasMSTeamsBotMentioned,
+} from "./inbound.js";
 import type { MSTeamsAdapter } from "./messenger.js";
-import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
-import type { MSTeamsPollStore } from "./polls.js";
+import {
+  isMSTeamsGroupAllowed,
+  resolveMSTeamsReplyPolicy,
+  resolveMSTeamsRouteConfig,
+} from "./policy.js";
+import { extractMSTeamsPollVote, type MSTeamsPollStore } from "./polls.js";
+import { createMSTeamsReplyDispatcher } from "./reply-dispatcher.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 export type MSTeamsAccessTokenProvider = {
@@ -63,4 +102,497 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   });
 
   return handler;
+}
+
+function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
+  const {
+    cfg,
+    runtime,
+    appId,
+    adapter,
+    tokenProvider,
+    textLimit,
+    mediaMaxBytes,
+    conversationStore,
+    pollStore,
+    log,
+  } = deps;
+  const msteamsCfg = cfg.channels?.msteams;
+  const historyLimit = Math.max(
+    0,
+    msteamsCfg?.historyLimit ??
+      cfg.messages?.groupChat?.historyLimit ??
+      DEFAULT_GROUP_HISTORY_LIMIT,
+  );
+  const conversationHistories = new Map<string, HistoryEntry[]>();
+
+  return async function handleTeamsMessage(context: MSTeamsTurnContext) {
+    const activity = context.activity;
+    const rawText = activity.text?.trim() ?? "";
+    const text = stripMSTeamsMentionTags(rawText);
+    const attachments = Array.isArray(activity.attachments)
+      ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
+      : [];
+    const attachmentPlaceholder =
+      buildMSTeamsAttachmentPlaceholder(attachments);
+    const rawBody = text || attachmentPlaceholder;
+    const from = activity.from;
+    const conversation = activity.conversation;
+
+    const attachmentTypes = attachments
+      .map((att) =>
+        typeof att.contentType === "string" ? att.contentType : undefined,
+      )
+      .filter(Boolean)
+      .slice(0, 3);
+    const htmlSummary = summarizeMSTeamsHtmlAttachments(attachments);
+
+    log.info("received message", {
+      rawText: rawText.slice(0, 50),
+      text: text.slice(0, 50),
+      attachments: attachments.length,
+      attachmentTypes,
+      from: from?.id,
+      conversation: conversation?.id,
+    });
+    if (htmlSummary) {
+      log.debug("html attachment summary", htmlSummary);
+    }
+
+    if (!from?.id) {
+      log.debug("skipping message without from.id");
+      return;
+    }
+
+    // Teams conversation.id may include ";messageid=..." suffix - strip it for session key
+    const rawConversationId = conversation?.id ?? "";
+    const conversationId = normalizeMSTeamsConversationId(rawConversationId);
+    const conversationMessageId =
+      extractMSTeamsConversationMessageId(rawConversationId);
+    const conversationType = conversation?.conversationType ?? "personal";
+    const isGroupChat =
+      conversationType === "groupChat" || conversation?.isGroup === true;
+    const isChannel = conversationType === "channel";
+    const isDirectMessage = !isGroupChat && !isChannel;
+
+    const senderName = from.name ?? from.id;
+    const senderId = from.aadObjectId ?? from.id;
+    const storedAllowFrom = await readChannelAllowFromStore("msteams").catch(
+      () => [],
+    );
+
+    // Check DM policy for direct messages
+    if (isDirectMessage && msteamsCfg) {
+      const dmPolicy = msteamsCfg.dmPolicy ?? "pairing";
+      const allowFrom = msteamsCfg.allowFrom ?? [];
+
+      if (dmPolicy === "disabled") {
+        log.debug("dropping dm (dms disabled)");
+        return;
+      }
+
+      if (dmPolicy !== "open") {
+        // Check allowlist - look up from config and pairing store
+        const effectiveAllowFrom = [
+          ...allowFrom.map((v) => String(v).toLowerCase()),
+          ...storedAllowFrom,
+        ];
+
+        const senderLower = senderId.toLowerCase();
+        const senderNameLower = senderName.toLowerCase();
+        const allowed =
+          effectiveAllowFrom.includes("*") ||
+          effectiveAllowFrom.includes(senderLower) ||
+          effectiveAllowFrom.includes(senderNameLower);
+
+        if (!allowed) {
+          if (dmPolicy === "pairing") {
+            const request = await upsertChannelPairingRequest({
+              channel: "msteams",
+              id: senderId,
+              meta: { name: senderName },
+            });
+            if (request) {
+              log.info("msteams pairing request created", {
+                sender: senderId,
+                label: senderName,
+              });
+            }
+          }
+          log.debug("dropping dm (not allowlisted)", {
+            sender: senderId,
+            label: senderName,
+          });
+          return;
+        }
+      }
+    }
+
+    if (!isDirectMessage && msteamsCfg) {
+      const groupPolicy = msteamsCfg.groupPolicy ?? "allowlist";
+      const groupAllowFrom =
+        msteamsCfg.groupAllowFrom ??
+        (msteamsCfg.allowFrom && msteamsCfg.allowFrom.length > 0
+          ? msteamsCfg.allowFrom
+          : []);
+      const effectiveGroupAllowFrom = [
+        ...groupAllowFrom.map((v) => String(v)),
+        ...storedAllowFrom,
+      ];
+
+      if (groupPolicy === "disabled") {
+        log.debug("dropping group message (groupPolicy: disabled)", {
+          conversationId,
+        });
+        return;
+      }
+
+      if (groupPolicy === "allowlist") {
+        if (effectiveGroupAllowFrom.length === 0) {
+          log.debug(
+            "dropping group message (groupPolicy: allowlist, no groupAllowFrom)",
+            { conversationId },
+          );
+          return;
+        }
+        const allowed = isMSTeamsGroupAllowed({
+          groupPolicy,
+          allowFrom: effectiveGroupAllowFrom,
+          senderId,
+          senderName,
+        });
+        if (!allowed) {
+          log.debug("dropping group message (not in groupAllowFrom)", {
+            sender: senderId,
+            label: senderName,
+          });
+          return;
+        }
+      }
+    }
+
+    // Build conversation reference for proactive replies
+    const agent = activity.recipient;
+    const teamId = activity.channelData?.team?.id;
+    const conversationRef: StoredConversationReference = {
+      activityId: activity.id,
+      user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
+      agent,
+      bot: agent ? { id: agent.id, name: agent.name } : undefined,
+      conversation: {
+        id: conversationId,
+        conversationType,
+        tenantId: conversation?.tenantId,
+      },
+      teamId,
+      channelId: activity.channelId,
+      serviceUrl: activity.serviceUrl,
+      locale: activity.locale,
+    };
+    conversationStore.upsert(conversationId, conversationRef).catch((err) => {
+      log.debug("failed to save conversation reference", {
+        error: formatUnknownError(err),
+      });
+    });
+
+    const pollVote = extractMSTeamsPollVote(activity);
+    if (pollVote) {
+      try {
+        const poll = await pollStore.recordVote({
+          pollId: pollVote.pollId,
+          voterId: senderId,
+          selections: pollVote.selections,
+        });
+        if (!poll) {
+          log.debug("poll vote ignored (poll not found)", {
+            pollId: pollVote.pollId,
+          });
+        } else {
+          log.info("recorded poll vote", {
+            pollId: pollVote.pollId,
+            voter: senderId,
+            selections: pollVote.selections,
+          });
+        }
+      } catch (err) {
+        log.error("failed to record poll vote", {
+          pollId: pollVote.pollId,
+          error: formatUnknownError(err),
+        });
+      }
+      return;
+    }
+
+    if (!rawBody) {
+      log.debug("skipping empty message after stripping mentions");
+      return;
+    }
+
+    // Build Teams-specific identifiers
+    const teamsFrom = isDirectMessage
+      ? `msteams:${senderId}`
+      : isChannel
+        ? `msteams:channel:${conversationId}`
+        : `msteams:group:${conversationId}`;
+    const teamsTo = isDirectMessage
+      ? `user:${senderId}`
+      : `conversation:${conversationId}`;
+
+    // Resolve routing
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "msteams",
+      peer: {
+        kind: isDirectMessage ? "dm" : isChannel ? "channel" : "group",
+        id: isDirectMessage ? senderId : conversationId,
+      },
+    });
+
+    const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
+    const inboundLabel = isDirectMessage
+      ? `Teams DM from ${senderName}`
+      : `Teams message in ${conversationType} from ${senderName}`;
+
+    enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      sessionKey: route.sessionKey,
+      contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
+    });
+
+    // Resolve team/channel config for channels and group chats
+    const channelId = conversationId;
+    const { teamConfig, channelConfig } = resolveMSTeamsRouteConfig({
+      cfg: msteamsCfg,
+      teamId,
+      conversationId: channelId,
+    });
+    const { requireMention, replyStyle } = resolveMSTeamsReplyPolicy({
+      isDirectMessage,
+      globalConfig: msteamsCfg,
+      teamConfig,
+      channelConfig,
+    });
+
+    // Check requireMention for channels and group chats
+    if (!isDirectMessage) {
+      const mentioned = wasMSTeamsBotMentioned(activity);
+
+      if (requireMention && !mentioned) {
+        log.debug("skipping message (mention required)", {
+          teamId,
+          channelId,
+          requireMention,
+          mentioned,
+        });
+        return;
+      }
+    }
+
+    // Format the message body with envelope
+    const timestamp = parseMSTeamsActivityTimestamp(activity.timestamp);
+    let mediaList = await downloadMSTeamsImageAttachments({
+      attachments,
+      maxBytes: mediaMaxBytes,
+      tokenProvider: {
+        getAccessToken: (scope) => tokenProvider.getAccessToken(scope),
+      },
+      allowHosts: msteamsCfg?.mediaAllowHosts,
+    });
+    if (mediaList.length === 0) {
+      const onlyHtmlAttachments =
+        attachments.length > 0 &&
+        attachments.every((att) =>
+          String(att.contentType ?? "").startsWith("text/html"),
+        );
+      if (onlyHtmlAttachments) {
+        const messageUrls = buildMSTeamsGraphMessageUrls({
+          conversationType,
+          conversationId,
+          messageId: activity.id ?? undefined,
+          replyToId: activity.replyToId ?? undefined,
+          conversationMessageId,
+          channelData: activity.channelData,
+        });
+        if (messageUrls.length === 0) {
+          log.debug("graph message url unavailable", {
+            conversationType,
+            hasChannelData: Boolean(activity.channelData),
+            messageId: activity.id ?? undefined,
+            replyToId: activity.replyToId ?? undefined,
+          });
+        } else {
+          const attempts: Array<{
+            url: string;
+            hostedStatus?: number;
+            attachmentStatus?: number;
+            hostedCount?: number;
+            attachmentCount?: number;
+            tokenError?: boolean;
+          }> = [];
+          for (const messageUrl of messageUrls) {
+            const graphMedia = await downloadMSTeamsGraphMedia({
+              messageUrl,
+              tokenProvider: {
+                getAccessToken: (scope) => tokenProvider.getAccessToken(scope),
+              },
+              maxBytes: mediaMaxBytes,
+              allowHosts: msteamsCfg?.mediaAllowHosts,
+            });
+            attempts.push({
+              url: messageUrl,
+              hostedStatus: graphMedia.hostedStatus,
+              attachmentStatus: graphMedia.attachmentStatus,
+              hostedCount: graphMedia.hostedCount,
+              attachmentCount: graphMedia.attachmentCount,
+              tokenError: graphMedia.tokenError,
+            });
+            if (graphMedia.media.length > 0) {
+              mediaList = graphMedia.media;
+              break;
+            }
+            if (graphMedia.tokenError) break;
+          }
+          if (mediaList.length === 0) {
+            log.debug("graph media fetch empty", { attempts });
+          }
+        }
+      }
+    }
+    if (mediaList.length > 0) {
+      log.debug("downloaded image attachments", { count: mediaList.length });
+    } else if (htmlSummary?.imgTags) {
+      log.debug("inline images detected but none downloaded", {
+        imgTags: htmlSummary.imgTags,
+        srcHosts: htmlSummary.srcHosts,
+        dataImages: htmlSummary.dataImages,
+        cidImages: htmlSummary.cidImages,
+      });
+    }
+    const mediaPayload = buildMSTeamsMediaPayload(mediaList);
+    const body = formatAgentEnvelope({
+      channel: "Teams",
+      from: senderName,
+      timestamp,
+      body: rawBody,
+    });
+    let combinedBody = body;
+    const isRoomish = !isDirectMessage;
+    const historyKey = isRoomish ? conversationId : undefined;
+    if (isRoomish && historyKey && historyLimit > 0) {
+      combinedBody = buildHistoryContextFromMap({
+        historyMap: conversationHistories,
+        historyKey,
+        limit: historyLimit,
+        entry: {
+          sender: senderName,
+          body: rawBody,
+          timestamp: timestamp?.getTime(),
+          messageId: activity.id ?? undefined,
+        },
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatAgentEnvelope({
+            channel: "Teams",
+            from: conversationType,
+            timestamp: entry.timestamp,
+            body: `${entry.sender}: ${entry.body}${
+              entry.messageId ? ` [id:${entry.messageId}]` : ""
+            }`,
+          }),
+      });
+    }
+
+    // Build context payload for agent
+    const ctxPayload = {
+      Body: combinedBody,
+      RawBody: rawBody,
+      CommandBody: rawBody,
+      From: teamsFrom,
+      To: teamsTo,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isDirectMessage ? "direct" : isChannel ? "room" : "group",
+      GroupSubject: !isDirectMessage ? conversationType : undefined,
+      SenderName: senderName,
+      SenderId: senderId,
+      Provider: "msteams" as const,
+      Surface: "msteams" as const,
+      MessageSid: activity.id,
+      Timestamp: timestamp?.getTime() ?? Date.now(),
+      WasMentioned: isDirectMessage || wasMSTeamsBotMentioned(activity),
+      CommandAuthorized: true,
+      OriginatingChannel: "msteams" as const,
+      OriginatingTo: teamsTo,
+      ...mediaPayload,
+    };
+
+    if (shouldLogVerbose()) {
+      logVerbose(
+        `msteams inbound: from=${ctxPayload.From} preview="${preview}"`,
+      );
+    }
+
+    // Create reply dispatcher
+    const { dispatcher, replyOptions, markDispatchIdle } =
+      createMSTeamsReplyDispatcher({
+        cfg,
+        agentId: route.agentId,
+        runtime,
+        log,
+        adapter,
+        appId,
+        conversationRef,
+        context,
+        replyStyle,
+        textLimit,
+      });
+
+    // Dispatch to agent
+    log.info("dispatching to agent", { sessionKey: route.sessionKey });
+    try {
+      const { queuedFinal, counts } = await dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        runtime,
+        replyOptions,
+      });
+
+      markDispatchIdle();
+      log.info("dispatch complete", { queuedFinal, counts });
+
+      const didSendReply = counts.final + counts.tool + counts.block > 0;
+      if (!queuedFinal) {
+        if (isRoomish && historyKey && historyLimit > 0 && didSendReply) {
+          clearHistoryEntries({
+            historyMap: conversationHistories,
+            historyKey,
+          });
+        }
+        return;
+      }
+      if (shouldLogVerbose()) {
+        const finalCount = counts.final;
+        logVerbose(
+          `msteams: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${teamsTo}`,
+        );
+      }
+      if (isRoomish && historyKey && historyLimit > 0 && didSendReply) {
+        clearHistoryEntries({
+          historyMap: conversationHistories,
+          historyKey,
+        });
+      }
+    } catch (err) {
+      log.error("dispatch failed", { error: String(err) });
+      runtime.error?.(danger(`msteams dispatch failed: ${String(err)}`));
+      // Try to send error message back to Teams.
+      try {
+        await context.sendActivity(
+          `⚠️ Agent failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } catch {
+        // Best effort.
+      }
+    }
+  };
 }

--- a/src/msteams/monitor-handler/message-handler.ts
+++ b/src/msteams/monitor-handler/message-handler.ts
@@ -416,6 +416,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         ctx: ctxPayload,
         cfg,
         dispatcher,
+        runtime,
         replyOptions,
       });
 

--- a/src/msteams/reply-dispatcher.ts
+++ b/src/msteams/reply-dispatcher.ts
@@ -2,7 +2,10 @@ import {
   resolveEffectiveMessagesConfig,
   resolveHumanDelayConfig,
 } from "../agents/identity.js";
-import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import {
+  createReplyDispatcherWithTyping,
+  shouldSkipTextOnlyDelivery,
+} from "../auto-reply/reply/reply-dispatcher.js";
 import type { ClawdbotConfig, MSTeamsReplyStyle } from "../config/types.js";
 import { danger } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -31,6 +34,8 @@ export function createMSTeamsReplyDispatcher(params: {
   context: MSTeamsTurnContext;
   replyStyle: MSTeamsReplyStyle;
   textLimit: number;
+  /** Media type of inbound message (for voiceOnly mode). */
+  mediaType?: string;
 }) {
   const sendTypingIndicator = async () => {
     try {
@@ -44,6 +49,10 @@ export function createMSTeamsReplyDispatcher(params: {
     responsePrefix: resolveEffectiveMessagesConfig(params.cfg, params.agentId)
       .responsePrefix,
     humanDelay: resolveHumanDelayConfig(params.cfg, params.agentId),
+    skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(
+      params.cfg,
+      params.mediaType,
+    ),
     deliver: async (payload) => {
       const messages = renderReplyPayloadsToMessages([payload], {
         textChunkLimit: params.textLimit,

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -11,7 +11,10 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
 } from "../auto-reply/reply/history.js";
-import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import {
+  createReplyDispatcher,
+  shouldSkipTextOnlyDelivery,
+} from "../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -726,6 +729,10 @@ export async function monitorSignalProvider(
         responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
           .responsePrefix,
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+        skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(
+          cfg,
+          ctxPayload.MediaType,
+        ),
         deliver: async (payload) => {
           await deliverReplies({
             replies: [payload],

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -1,23 +1,59 @@
-import { chunkText, resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import {
+  resolveEffectiveMessagesConfig,
+  resolveHumanDelayConfig,
+} from "../agents/identity.js";
+import { chunkText, resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import { dispatchReplyFromConfig } from "../auto-reply/reply/dispatch-from-config.js";
+import {
+  buildHistoryContextFromMap,
+  clearHistoryEntries,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
 } from "../auto-reply/reply/history.js";
+import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { resolveStorePath, updateLastRoute } from "../config/sessions.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
-import { danger } from "../globals.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { mediaKindFromMime } from "../media/constants.js";
 import { saveMediaBuffer } from "../media/store.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeE164 } from "../utils.js";
 import { resolveSignalAccount } from "./accounts.js";
 import { signalCheck, signalRpcRequest } from "./client.js";
 import { spawnSignalDaemon } from "./daemon.js";
-import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
-import { createSignalEventHandler } from "./monitor/event-handler.js";
+import {
+  formatSignalPairingIdLine,
+  formatSignalSenderDisplay,
+  formatSignalSenderId,
+  isSignalSenderAllowed,
+  resolveSignalPeerId,
+  resolveSignalRecipient,
+  resolveSignalSender,
+} from "./identity.js";
 import { sendMessageSignal } from "./send.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
+
+type SignalEnvelope = {
+  sourceNumber?: string | null;
+  sourceUuid?: string | null;
+  sourceName?: string | null;
+  timestamp?: number | null;
+  dataMessage?: SignalDataMessage | null;
+  editMessage?: { dataMessage?: SignalDataMessage | null } | null;
+  syncMessage?: unknown;
+  reactionMessage?: SignalReactionMessage | null;
+};
 
 type SignalReactionMessage = {
   emoji?: string | null;
@@ -29,6 +65,18 @@ type SignalReactionMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
+};
+
+type SignalDataMessage = {
+  timestamp?: number;
+  message?: string | null;
+  attachments?: Array<SignalAttachment>;
+  groupInfo?: {
+    groupId?: string | null;
+    groupName?: string | null;
+  } | null;
+  quote?: { text?: string | null } | null;
+  reaction?: SignalReactionMessage | null;
 };
 
 type SignalAttachment = {
@@ -56,6 +104,12 @@ export type MonitorSignalOpts = {
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
   mediaMaxMb?: number;
+};
+
+type SignalReceivePayload = {
+  account?: string;
+  envelope?: SignalEnvelope | null;
+  exception?: { message?: string } | null;
 };
 
 function resolveRuntime(opts: MonitorSignalOpts): RuntimeEnv {
@@ -352,31 +406,368 @@ export async function monitorSignalProvider(
       });
     }
 
-    const handleEvent = createSignalEventHandler({
-      runtime,
-      cfg,
-      baseUrl,
-      account,
-      accountId: accountInfo.accountId,
-      blockStreaming: accountInfo.config.blockStreaming,
-      historyLimit,
-      groupHistories,
-      textLimit,
-      dmPolicy,
-      allowFrom,
-      groupAllowFrom,
-      groupPolicy,
-      reactionMode,
-      reactionAllowlist,
-      mediaMaxBytes,
-      ignoreAttachments,
-      fetchAttachment,
-      deliverReplies,
-      resolveSignalReactionTargets,
-      isSignalReactionMessage,
-      shouldEmitSignalReactionNotification,
-      buildSignalReactionSystemEventText,
-    });
+    const handleEvent = async (event: { event?: string; data?: string }) => {
+      if (event.event !== "receive" || !event.data) return;
+      let payload: SignalReceivePayload | null = null;
+      try {
+        payload = JSON.parse(event.data) as SignalReceivePayload;
+      } catch (err) {
+        runtime.error?.(`failed to parse event: ${String(err)}`);
+        return;
+      }
+      if (payload?.exception?.message) {
+        runtime.error?.(`receive exception: ${payload.exception.message}`);
+      }
+      const envelope = payload?.envelope;
+      if (!envelope) return;
+      if (envelope.syncMessage) return;
+
+      const sender = resolveSignalSender(envelope);
+      if (!sender) return;
+      if (account && sender.kind === "phone") {
+        if (sender.e164 === normalizeE164(account)) {
+          return;
+        }
+      }
+      const dataMessage =
+        envelope.dataMessage ?? envelope.editMessage?.dataMessage;
+      const reaction = isSignalReactionMessage(envelope.reactionMessage)
+        ? envelope.reactionMessage
+        : isSignalReactionMessage(dataMessage?.reaction)
+          ? dataMessage?.reaction
+          : null;
+      const messageText = (dataMessage?.message ?? "").trim();
+      const quoteText = dataMessage?.quote?.text?.trim() ?? "";
+      const hasBodyContent =
+        Boolean(messageText || quoteText) ||
+        Boolean(!reaction && dataMessage?.attachments?.length);
+      if (reaction && !hasBodyContent) {
+        if (reaction.isRemove) return; // Ignore reaction removals
+        const emojiLabel = reaction.emoji?.trim() || "emoji";
+        const senderDisplay = formatSignalSenderDisplay(sender);
+        const senderName = envelope.sourceName ?? senderDisplay;
+        logVerbose(`signal reaction: ${emojiLabel} from ${senderName}`);
+        const targets = resolveSignalReactionTargets(reaction);
+        const shouldNotify = shouldEmitSignalReactionNotification({
+          mode: reactionMode,
+          account,
+          targets,
+          sender,
+          allowlist: reactionAllowlist,
+        });
+        if (!shouldNotify) return;
+        const groupId = reaction.groupInfo?.groupId ?? undefined;
+        const groupName = reaction.groupInfo?.groupName ?? undefined;
+        const isGroup = Boolean(groupId);
+        const senderPeerId = resolveSignalPeerId(sender);
+        const route = resolveAgentRoute({
+          cfg,
+          channel: "signal",
+          accountId: accountInfo.accountId,
+          peer: {
+            kind: isGroup ? "group" : "dm",
+            id: isGroup ? (groupId ?? "unknown") : senderPeerId,
+          },
+        });
+        const groupLabel = isGroup
+          ? `${groupName ?? "Signal Group"} id:${groupId}`
+          : undefined;
+        const messageId = reaction.targetSentTimestamp
+          ? String(reaction.targetSentTimestamp)
+          : "unknown";
+        const text = buildSignalReactionSystemEventText({
+          emojiLabel,
+          actorLabel: senderName,
+          messageId,
+          targetLabel: targets[0]?.display,
+          groupLabel,
+        });
+        const senderId = formatSignalSenderId(sender);
+        const contextKey = [
+          "signal",
+          "reaction",
+          "added",
+          messageId,
+          senderId,
+          emojiLabel,
+          groupId ?? "",
+        ]
+          .filter(Boolean)
+          .join(":");
+        enqueueSystemEvent(text, {
+          sessionKey: route.sessionKey,
+          contextKey,
+        });
+        return;
+      }
+      if (!dataMessage) return;
+      const senderDisplay = formatSignalSenderDisplay(sender);
+      const senderRecipient = resolveSignalRecipient(sender);
+      const senderPeerId = resolveSignalPeerId(sender);
+      const senderAllowId = formatSignalSenderId(sender);
+      if (!senderRecipient) return;
+      const senderIdLine = formatSignalPairingIdLine(sender);
+      const groupId = dataMessage.groupInfo?.groupId ?? undefined;
+      const groupName = dataMessage.groupInfo?.groupName ?? undefined;
+      const isGroup = Boolean(groupId);
+      const storeAllowFrom = await readChannelAllowFromStore("signal").catch(
+        () => [],
+      );
+      const effectiveDmAllow = [...allowFrom, ...storeAllowFrom];
+      const effectiveGroupAllow = [...groupAllowFrom, ...storeAllowFrom];
+      const dmAllowed =
+        dmPolicy === "open"
+          ? true
+          : isSignalSenderAllowed(sender, effectiveDmAllow);
+
+      if (!isGroup) {
+        if (dmPolicy === "disabled") return;
+        if (!dmAllowed) {
+          if (dmPolicy === "pairing") {
+            const senderId = senderAllowId;
+            const { code, created } = await upsertChannelPairingRequest({
+              channel: "signal",
+              id: senderId,
+              meta: {
+                name: envelope.sourceName ?? undefined,
+              },
+            });
+            if (created) {
+              logVerbose(`signal pairing request sender=${senderId}`);
+              try {
+                await sendMessageSignal(
+                  `signal:${senderRecipient}`,
+                  buildPairingReply({
+                    channel: "signal",
+                    idLine: senderIdLine,
+                    code,
+                  }),
+                  {
+                    baseUrl,
+                    account,
+                    maxBytes: mediaMaxBytes,
+                    accountId: accountInfo.accountId,
+                  },
+                );
+              } catch (err) {
+                logVerbose(
+                  `signal pairing reply failed for ${senderId}: ${String(err)}`,
+                );
+              }
+            }
+          } else {
+            logVerbose(
+              `Blocked signal sender ${senderDisplay} (dmPolicy=${dmPolicy})`,
+            );
+          }
+          return;
+        }
+      }
+      if (isGroup && groupPolicy === "disabled") {
+        logVerbose("Blocked signal group message (groupPolicy: disabled)");
+        return;
+      }
+      if (isGroup && groupPolicy === "allowlist") {
+        if (effectiveGroupAllow.length === 0) {
+          logVerbose(
+            "Blocked signal group message (groupPolicy: allowlist, no groupAllowFrom)",
+          );
+          return;
+        }
+        if (!isSignalSenderAllowed(sender, effectiveGroupAllow)) {
+          logVerbose(
+            `Blocked signal group sender ${senderDisplay} (not in groupAllowFrom)`,
+          );
+          return;
+        }
+      }
+
+      const commandAuthorized = isGroup
+        ? effectiveGroupAllow.length > 0
+          ? isSignalSenderAllowed(sender, effectiveGroupAllow)
+          : true
+        : dmAllowed;
+
+      let mediaPath: string | undefined;
+      let mediaType: string | undefined;
+      let placeholder = "";
+      const firstAttachment = dataMessage.attachments?.[0];
+      if (firstAttachment?.id && !ignoreAttachments) {
+        try {
+          const fetched = await fetchAttachment({
+            baseUrl,
+            account,
+            attachment: firstAttachment,
+            sender: senderRecipient,
+            groupId,
+            maxBytes: mediaMaxBytes,
+          });
+          if (fetched) {
+            mediaPath = fetched.path;
+            mediaType =
+              fetched.contentType ?? firstAttachment.contentType ?? undefined;
+          }
+        } catch (err) {
+          runtime.error?.(danger(`attachment fetch failed: ${String(err)}`));
+        }
+      }
+
+      const kind = mediaKindFromMime(mediaType ?? undefined);
+      if (kind) {
+        placeholder = `<media:${kind}>`;
+      } else if (dataMessage.attachments?.length) {
+        placeholder = "<media:attachment>";
+      }
+
+      const bodyText =
+        messageText || placeholder || dataMessage.quote?.text?.trim() || "";
+      if (!bodyText) return;
+
+      const fromLabel = isGroup
+        ? `${groupName ?? "Signal Group"} id:${groupId}`
+        : `${envelope.sourceName ?? senderDisplay} id:${senderDisplay}`;
+      const body = formatAgentEnvelope({
+        channel: "Signal",
+        from: fromLabel,
+        timestamp: envelope.timestamp ?? undefined,
+        body: bodyText,
+      });
+      let combinedBody = body;
+      const historyKey = isGroup ? String(groupId ?? "unknown") : undefined;
+      if (isGroup && historyKey && historyLimit > 0) {
+        combinedBody = buildHistoryContextFromMap({
+          historyMap: groupHistories,
+          historyKey,
+          limit: historyLimit,
+          entry: {
+            sender: envelope.sourceName ?? senderDisplay,
+            body: bodyText,
+            timestamp: envelope.timestamp ?? undefined,
+            messageId:
+              typeof envelope.timestamp === "number"
+                ? String(envelope.timestamp)
+                : undefined,
+          },
+          currentMessage: combinedBody,
+          formatEntry: (entry) =>
+            formatAgentEnvelope({
+              channel: "Signal",
+              from: fromLabel,
+              timestamp: entry.timestamp,
+              body: `${entry.sender}: ${entry.body}${
+                entry.messageId ? ` [id:${entry.messageId}]` : ""
+              }`,
+            }),
+        });
+      }
+
+      const route = resolveAgentRoute({
+        cfg,
+        channel: "signal",
+        accountId: accountInfo.accountId,
+        peer: {
+          kind: isGroup ? "group" : "dm",
+          id: isGroup ? (groupId ?? "unknown") : senderPeerId,
+        },
+      });
+      const signalTo = isGroup
+        ? `group:${groupId}`
+        : `signal:${senderRecipient}`;
+      const ctxPayload = {
+        Body: combinedBody,
+        RawBody: bodyText,
+        CommandBody: bodyText,
+        From: isGroup
+          ? `group:${groupId ?? "unknown"}`
+          : `signal:${senderRecipient}`,
+        To: signalTo,
+        SessionKey: route.sessionKey,
+        AccountId: route.accountId,
+        ChatType: isGroup ? "group" : "direct",
+        GroupSubject: isGroup ? (groupName ?? undefined) : undefined,
+        SenderName: envelope.sourceName ?? senderDisplay,
+        SenderId: senderDisplay,
+        Provider: "signal" as const,
+        Surface: "signal" as const,
+        MessageSid: envelope.timestamp ? String(envelope.timestamp) : undefined,
+        Timestamp: envelope.timestamp ?? undefined,
+        MediaPath: mediaPath,
+        MediaType: mediaType,
+        MediaUrl: mediaPath,
+        CommandAuthorized: commandAuthorized,
+        // Originating channel for reply routing.
+        OriginatingChannel: "signal" as const,
+        OriginatingTo: signalTo,
+      };
+
+      if (!isGroup) {
+        const sessionCfg = cfg.session;
+        const storePath = resolveStorePath(sessionCfg?.store, {
+          agentId: route.agentId,
+        });
+        await updateLastRoute({
+          storePath,
+          sessionKey: route.mainSessionKey,
+          channel: "signal",
+          to: senderRecipient,
+          accountId: route.accountId,
+        });
+      }
+
+      if (shouldLogVerbose()) {
+        const preview = body.slice(0, 200).replace(/\n/g, "\\n");
+        logVerbose(
+          `signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`,
+        );
+      }
+
+      let didSendReply = false;
+      const dispatcher = createReplyDispatcher({
+        responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+          .responsePrefix,
+        humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+        deliver: async (payload) => {
+          await deliverReplies({
+            replies: [payload],
+            target: ctxPayload.To,
+            baseUrl,
+            account,
+            accountId: accountInfo.accountId,
+            runtime,
+            maxBytes: mediaMaxBytes,
+            textLimit,
+          });
+          didSendReply = true;
+        },
+        onError: (err, info) => {
+          runtime.error?.(
+            danger(`signal ${info.kind} reply failed: ${String(err)}`),
+          );
+        },
+      });
+
+      const { queuedFinal } = await dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        runtime,
+        replyOptions: {
+          disableBlockStreaming:
+            typeof accountInfo.config.blockStreaming === "boolean"
+              ? !accountInfo.config.blockStreaming
+              : undefined,
+        },
+      });
+      if (!queuedFinal) {
+        if (isGroup && historyKey && historyLimit > 0 && didSendReply) {
+          clearHistoryEntries({ historyMap: groupHistories, historyKey });
+        }
+        return;
+      }
+      if (isGroup && historyKey && historyLimit > 0 && didSendReply) {
+        clearHistoryEntries({ historyMap: groupHistories, historyKey });
+      }
+    };
 
     await runSignalSseLoop({
       baseUrl,

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -372,6 +372,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ctx: ctxPayload,
       cfg: deps.cfg,
       dispatcher,
+      runtime: deps.runtime,
       replyOptions: {
         disableBlockStreaming:
           typeof deps.blockStreaming === "boolean"

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -35,7 +35,10 @@ import {
   matchesMentionPatterns,
 } from "../auto-reply/reply/mentions.js";
 import { dispatchReplyWithDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
-import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import {
+  createReplyDispatcherWithTyping,
+  shouldSkipTextOnlyDelivery,
+} from "../auto-reply/reply/reply-dispatcher.js";
 import { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -1169,6 +1172,10 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
           .responsePrefix,
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+        skipTextOnlyDelivery: shouldSkipTextOnlyDelivery(
+          cfg,
+          ctxPayload.MediaType,
+        ),
         deliver: async (payload) => {
           const replyThreadTs = replyPlan.nextThreadTs();
           await deliverReplies({

--- a/src/slack/monitor.ts
+++ b/src/slack/monitor.ts
@@ -1,5 +1,2192 @@
-export { buildSlackSlashCommandMatcher } from "./monitor/commands.js";
-export { isSlackRoomAllowedByPolicy } from "./monitor/policy.js";
-export { monitorSlackProvider } from "./monitor/provider.js";
-export { resolveSlackThreadTs } from "./monitor/replies.js";
-export type { MonitorSlackOpts } from "./monitor/types.js";
+import {
+  App,
+  type SlackCommandMiddlewareArgs,
+  type SlackEventMiddlewareArgs,
+} from "@slack/bolt";
+import type { WebClient as SlackWebClient } from "@slack/web-api";
+import {
+  resolveAckReaction,
+  resolveEffectiveMessagesConfig,
+  resolveHumanDelayConfig,
+} from "../agents/identity.js";
+import {
+  chunkMarkdownText,
+  resolveTextChunkLimit,
+} from "../auto-reply/chunk.js";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import {
+  buildCommandText,
+  listNativeCommandSpecsForConfig,
+  shouldHandleTextCommands,
+} from "../auto-reply/commands-registry.js";
+import {
+  formatAgentEnvelope,
+  formatThreadStarterEnvelope,
+} from "../auto-reply/envelope.js";
+import { dispatchReplyFromConfig } from "../auto-reply/reply/dispatch-from-config.js";
+import {
+  buildHistoryContextFromMap,
+  clearHistoryEntries,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  type HistoryEntry,
+} from "../auto-reply/reply/history.js";
+import {
+  buildMentionRegexes,
+  matchesMentionPatterns,
+} from "../auto-reply/reply/mentions.js";
+import { dispatchReplyWithDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { resolveNativeCommandsEnabled } from "../config/commands.js";
+import type {
+  ClawdbotConfig,
+  SlackReactionNotificationMode,
+  SlackSlashCommandConfig,
+} from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import {
+  resolveSessionKey,
+  resolveStorePath,
+  updateLastRoute,
+} from "../config/sessions.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { createDedupeCache } from "../infra/dedupe.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { getChildLogger } from "../logging.js";
+import { type FetchLike, fetchRemoteMedia } from "../media/fetch.js";
+import { saveMediaBuffer } from "../media/store.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+import {
+  normalizeMainKey,
+  resolveThreadSessionKeys,
+} from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveSlackAccount } from "./accounts.js";
+import { reactSlackMessage, removeSlackReaction } from "./actions.js";
+import { sendMessageSlack } from "./send.js";
+import { resolveSlackThreadTargets } from "./threading.js";
+import { resolveSlackAppToken, resolveSlackBotToken } from "./token.js";
+import type {
+  SlackAppMentionEvent,
+  SlackFile,
+  SlackMessageEvent,
+} from "./types.js";
+
+export type MonitorSlackOpts = {
+  botToken?: string;
+  appToken?: string;
+  accountId?: string;
+  config?: ClawdbotConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  mediaMaxMb?: number;
+  slashCommand?: SlackSlashCommandConfig;
+};
+
+type SlackReactionEvent = {
+  type: "reaction_added" | "reaction_removed";
+  user?: string;
+  reaction?: string;
+  item?: {
+    type?: string;
+    channel?: string;
+    ts?: string;
+  };
+  item_user?: string;
+  event_ts?: string;
+};
+
+type SlackMemberChannelEvent = {
+  type: "member_joined_channel" | "member_left_channel";
+  user?: string;
+  channel?: string;
+  channel_type?: SlackMessageEvent["channel_type"];
+  event_ts?: string;
+};
+
+type SlackChannelCreatedEvent = {
+  type: "channel_created";
+  channel?: { id?: string; name?: string };
+  event_ts?: string;
+};
+
+type SlackChannelRenamedEvent = {
+  type: "channel_rename";
+  channel?: { id?: string; name?: string; name_normalized?: string };
+  event_ts?: string;
+};
+
+type SlackPinEvent = {
+  type: "pin_added" | "pin_removed";
+  channel_id?: string;
+  user?: string;
+  item?: { type?: string; message?: { ts?: string } };
+  event_ts?: string;
+};
+
+type SlackMessageChangedEvent = {
+  type: "message";
+  subtype: "message_changed";
+  channel?: string;
+  message?: { ts?: string };
+  previous_message?: { ts?: string };
+  event_ts?: string;
+};
+
+type SlackMessageDeletedEvent = {
+  type: "message";
+  subtype: "message_deleted";
+  channel?: string;
+  deleted_ts?: string;
+  event_ts?: string;
+};
+
+type SlackThreadBroadcastEvent = {
+  type: "message";
+  subtype: "thread_broadcast";
+  channel?: string;
+  message?: { ts?: string };
+  event_ts?: string;
+};
+
+type SlackChannelConfigResolved = {
+  allowed: boolean;
+  requireMention: boolean;
+  allowBots?: boolean;
+  users?: Array<string | number>;
+  skills?: string[];
+  systemPrompt?: string;
+};
+
+function normalizeSlackSlug(raw?: string) {
+  const trimmed = raw?.trim().toLowerCase() ?? "";
+  if (!trimmed) return "";
+  const dashed = trimmed.replace(/\s+/g, "-");
+  const cleaned = dashed.replace(/[^a-z0-9#@._+-]+/g, "-");
+  return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
+}
+
+function normalizeSlackSlashCommandName(raw: string) {
+  return raw.replace(/^\/+/, "");
+}
+
+export function buildSlackSlashCommandMatcher(name: string) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^/?${escaped}$`);
+}
+
+function normalizeAllowList(list?: Array<string | number>) {
+  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function normalizeAllowListLower(list?: Array<string | number>) {
+  return normalizeAllowList(list).map((entry) => entry.toLowerCase());
+}
+
+function firstDefined<T>(...values: Array<T | undefined>) {
+  for (const value of values) {
+    if (typeof value !== "undefined") return value;
+  }
+  return undefined;
+}
+
+function allowListMatches(params: {
+  allowList: string[];
+  id?: string;
+  name?: string;
+}) {
+  const allowList = params.allowList;
+  if (allowList.length === 0) return false;
+  if (allowList.includes("*")) return true;
+  const id = params.id?.toLowerCase();
+  const name = params.name?.toLowerCase();
+  const slug = normalizeSlackSlug(name);
+  const candidates = [
+    id,
+    id ? `slack:${id}` : undefined,
+    id ? `user:${id}` : undefined,
+    name,
+    name ? `slack:${name}` : undefined,
+    slug,
+  ].filter(Boolean) as string[];
+  return candidates.some((value) => allowList.includes(value));
+}
+
+function resolveSlackUserAllowed(params: {
+  allowList?: Array<string | number>;
+  userId?: string;
+  userName?: string;
+}) {
+  const allowList = normalizeAllowListLower(params.allowList);
+  if (allowList.length === 0) return true;
+  return allowListMatches({
+    allowList,
+    id: params.userId,
+    name: params.userName,
+  });
+}
+
+function resolveSlackSlashCommandConfig(
+  raw?: SlackSlashCommandConfig,
+): Required<SlackSlashCommandConfig> {
+  const normalizedName = normalizeSlackSlashCommandName(
+    raw?.name?.trim() || "clawd",
+  );
+  const name = normalizedName || "clawd";
+  return {
+    enabled: raw?.enabled === true,
+    name,
+    sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
+    ephemeral: raw?.ephemeral !== false,
+  };
+}
+
+function shouldEmitSlackReactionNotification(params: {
+  mode: SlackReactionNotificationMode | undefined;
+  botId?: string | null;
+  messageAuthorId?: string | null;
+  userId: string;
+  userName?: string | null;
+  allowlist?: Array<string | number> | null;
+}) {
+  const { mode, botId, messageAuthorId, userId, userName, allowlist } = params;
+  const effectiveMode = mode ?? "own";
+  if (effectiveMode === "off") return false;
+  if (effectiveMode === "own") {
+    if (!botId || !messageAuthorId) return false;
+    return messageAuthorId === botId;
+  }
+  if (effectiveMode === "allowlist") {
+    if (!Array.isArray(allowlist) || allowlist.length === 0) return false;
+    const users = normalizeAllowListLower(allowlist);
+    return allowListMatches({
+      allowList: users,
+      id: userId,
+      name: userName ?? undefined,
+    });
+  }
+  return true;
+}
+
+function resolveSlackChannelLabel(params: {
+  channelId?: string;
+  channelName?: string;
+}) {
+  const channelName = params.channelName?.trim();
+  if (channelName) {
+    const slug = normalizeSlackSlug(channelName);
+    return `#${slug || channelName}`;
+  }
+  const channelId = params.channelId?.trim();
+  return channelId ? `#${channelId}` : "unknown channel";
+}
+
+function resolveSlackChannelConfig(params: {
+  channelId: string;
+  channelName?: string;
+  channels?: Record<
+    string,
+    {
+      enabled?: boolean;
+      allow?: boolean;
+      requireMention?: boolean;
+      allowBots?: boolean;
+      users?: Array<string | number>;
+      skills?: string[];
+      systemPrompt?: string;
+    }
+  >;
+}): SlackChannelConfigResolved | null {
+  const { channelId, channelName, channels } = params;
+  const entries = channels ?? {};
+  const keys = Object.keys(entries);
+  const normalizedName = channelName ? normalizeSlackSlug(channelName) : "";
+  const directName = channelName ? channelName.trim() : "";
+  const candidates = [
+    channelId,
+    channelName ? `#${directName}` : "",
+    directName,
+    normalizedName,
+  ].filter(Boolean);
+
+  let matched:
+    | {
+        enabled?: boolean;
+        allow?: boolean;
+        requireMention?: boolean;
+        allowBots?: boolean;
+        users?: Array<string | number>;
+        skills?: string[];
+        systemPrompt?: string;
+      }
+    | undefined;
+  for (const candidate of candidates) {
+    if (candidate && entries[candidate]) {
+      matched = entries[candidate];
+      break;
+    }
+  }
+  const fallback = entries["*"];
+
+  if (keys.length === 0) {
+    return { allowed: true, requireMention: true };
+  }
+  if (!matched && !fallback) {
+    return { allowed: false, requireMention: true };
+  }
+
+  const resolved = matched ?? fallback ?? {};
+  const allowed =
+    firstDefined(
+      resolved.enabled,
+      resolved.allow,
+      fallback?.enabled,
+      fallback?.allow,
+      true,
+    ) ?? true;
+  const requireMention =
+    firstDefined(resolved.requireMention, fallback?.requireMention, true) ??
+    true;
+  const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
+  const users = firstDefined(resolved.users, fallback?.users);
+  const skills = firstDefined(resolved.skills, fallback?.skills);
+  const systemPrompt = firstDefined(
+    resolved.systemPrompt,
+    fallback?.systemPrompt,
+  );
+  return { allowed, requireMention, allowBots, users, skills, systemPrompt };
+}
+
+async function resolveSlackMedia(params: {
+  files?: SlackFile[];
+  token: string;
+  maxBytes: number;
+}): Promise<{
+  path: string;
+  contentType?: string;
+  placeholder: string;
+} | null> {
+  const files = params.files ?? [];
+  for (const file of files) {
+    const url = file.url_private_download ?? file.url_private;
+    if (!url) continue;
+    try {
+      const fetchImpl: FetchLike = (input, init) => {
+        const headers = new Headers(init?.headers);
+        headers.set("Authorization", `Bearer ${params.token}`);
+        return fetch(input, { ...init, headers });
+      };
+      const fetched = await fetchRemoteMedia({
+        url,
+        fetchImpl,
+        filePathHint: file.name,
+      });
+      if (fetched.buffer.byteLength > params.maxBytes) continue;
+      const saved = await saveMediaBuffer(
+        fetched.buffer,
+        fetched.contentType ?? file.mimetype,
+        "inbound",
+        params.maxBytes,
+      );
+      const label = fetched.fileName ?? file.name;
+      return {
+        path: saved.path,
+        contentType: saved.contentType,
+        placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
+      };
+    } catch {
+      // Ignore download failures and fall through to the next file.
+    }
+  }
+  return null;
+}
+
+type SlackThreadStarter = {
+  text: string;
+  userId?: string;
+  ts?: string;
+};
+
+const THREAD_STARTER_CACHE = new Map<string, SlackThreadStarter>();
+
+async function resolveSlackThreadStarter(params: {
+  channelId: string;
+  threadTs: string;
+  client: SlackWebClient;
+}): Promise<SlackThreadStarter | null> {
+  const cacheKey = `${params.channelId}:${params.threadTs}`;
+  const cached = THREAD_STARTER_CACHE.get(cacheKey);
+  if (cached) return cached;
+  try {
+    const response = (await params.client.conversations.replies({
+      channel: params.channelId,
+      ts: params.threadTs,
+      limit: 1,
+      inclusive: true,
+    })) as { messages?: Array<{ text?: string; user?: string; ts?: string }> };
+    const message = response?.messages?.[0];
+    const text = (message?.text ?? "").trim();
+    if (!message || !text) return null;
+    const starter: SlackThreadStarter = {
+      text,
+      userId: message.user,
+      ts: message.ts,
+    };
+    THREAD_STARTER_CACHE.set(cacheKey, starter);
+    return starter;
+  } catch {
+    return null;
+  }
+}
+
+export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
+  const cfg = opts.config ?? loadConfig();
+  const account = resolveSlackAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const historyLimit = Math.max(
+    0,
+    account.config.historyLimit ??
+      cfg.messages?.groupChat?.historyLimit ??
+      DEFAULT_GROUP_HISTORY_LIMIT,
+  );
+  const channelHistories = new Map<string, HistoryEntry[]>();
+  const sessionCfg = cfg.session;
+  const sessionScope = sessionCfg?.scope ?? "per-sender";
+  const mainKey = normalizeMainKey(sessionCfg?.mainKey);
+
+  const resolveSlackSystemEventSessionKey = (params: {
+    channelId?: string | null;
+    channelType?: string | null;
+  }) => {
+    const channelId = params.channelId?.trim() ?? "";
+    if (!channelId) return mainKey;
+    const channelType = params.channelType?.trim().toLowerCase() ?? "";
+    const isRoom = channelType === "channel" || channelType === "group";
+    const isGroup = channelType === "mpim";
+    const from = isRoom
+      ? `slack:channel:${channelId}`
+      : isGroup
+        ? `slack:group:${channelId}`
+        : `slack:${channelId}`;
+    const chatType = isRoom ? "room" : isGroup ? "group" : "direct";
+    return resolveSessionKey(
+      sessionScope,
+      { From: from, ChatType: chatType, Provider: "slack" },
+      mainKey,
+    );
+  };
+  const botToken = resolveSlackBotToken(opts.botToken ?? account.botToken);
+  const appToken = resolveSlackAppToken(opts.appToken ?? account.appToken);
+  if (!botToken || !appToken) {
+    throw new Error(
+      `Slack bot + app tokens missing for account "${account.accountId}" (set channels.slack.accounts.${account.accountId}.botToken/appToken or SLACK_BOT_TOKEN/SLACK_APP_TOKEN for default).`,
+    );
+  }
+
+  const runtime: RuntimeEnv = opts.runtime ?? {
+    log: console.log,
+    error: console.error,
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+
+  const slackCfg = account.config;
+  const dmConfig = slackCfg.dm;
+  const dmPolicy = dmConfig?.policy ?? "pairing";
+  const allowFrom = normalizeAllowList(dmConfig?.allowFrom);
+  const groupDmEnabled = dmConfig?.groupEnabled ?? false;
+  const groupDmChannels = normalizeAllowList(dmConfig?.groupChannels);
+  const channelsConfig = slackCfg.channels;
+  const dmEnabled = dmConfig?.enabled ?? true;
+  const groupPolicy = slackCfg.groupPolicy ?? "open";
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const reactionMode = slackCfg.reactionNotifications ?? "own";
+  const reactionAllowlist = slackCfg.reactionAllowlist ?? [];
+  const replyToMode = slackCfg.replyToMode ?? "off";
+  const slashCommand = resolveSlackSlashCommandConfig(
+    opts.slashCommand ?? slackCfg.slashCommand,
+  );
+  const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
+  const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
+  const mediaMaxBytes =
+    (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
+
+  const logger = getChildLogger({ module: "slack-auto-reply" });
+  const channelCache = new Map<
+    string,
+    {
+      name?: string;
+      type?: SlackMessageEvent["channel_type"];
+      topic?: string;
+      purpose?: string;
+    }
+  >();
+  const userCache = new Map<string, { name?: string }>();
+  const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
+
+  const markMessageSeen = (channelId: string | undefined, ts?: string) => {
+    if (!channelId || !ts) return false;
+    return seenMessages.check(`${channelId}:${ts}`);
+  };
+
+  const app = new App({
+    token: botToken,
+    appToken,
+    socketMode: true,
+  });
+
+  let botUserId = "";
+  let teamId = "";
+  try {
+    const auth = await app.client.auth.test({ token: botToken });
+    botUserId = auth.user_id ?? "";
+    teamId = auth.team_id ?? "";
+  } catch (err) {
+    runtime.error?.(danger(`slack auth failed: ${String(err)}`));
+  }
+
+  const resolveChannelName = async (channelId: string) => {
+    const cached = channelCache.get(channelId);
+    if (cached) return cached;
+    try {
+      const info = await app.client.conversations.info({
+        token: botToken,
+        channel: channelId,
+      });
+      const name =
+        info.channel && "name" in info.channel ? info.channel.name : undefined;
+      const channel = info.channel ?? undefined;
+      const type: SlackMessageEvent["channel_type"] | undefined = channel?.is_im
+        ? "im"
+        : channel?.is_mpim
+          ? "mpim"
+          : channel?.is_channel
+            ? "channel"
+            : channel?.is_group
+              ? "group"
+              : undefined;
+      const topic =
+        channel && "topic" in channel
+          ? (channel.topic?.value ?? undefined)
+          : undefined;
+      const purpose =
+        channel && "purpose" in channel
+          ? (channel.purpose?.value ?? undefined)
+          : undefined;
+      const entry = { name, type, topic, purpose };
+      channelCache.set(channelId, entry);
+      return entry;
+    } catch {
+      return {};
+    }
+  };
+
+  const resolveUserName = async (userId: string) => {
+    const cached = userCache.get(userId);
+    if (cached) return cached;
+    try {
+      const info = await app.client.users.info({
+        token: botToken,
+        user: userId,
+      });
+      const profile = info.user?.profile;
+      const name =
+        profile?.display_name ||
+        profile?.real_name ||
+        info.user?.name ||
+        undefined;
+      const entry = { name };
+      userCache.set(userId, entry);
+      return entry;
+    } catch {
+      return {};
+    }
+  };
+
+  const setSlackThreadStatus = async (params: {
+    channelId: string;
+    threadTs?: string;
+    status: string;
+  }) => {
+    if (!params.threadTs) return;
+    const payload = {
+      token: botToken,
+      channel_id: params.channelId,
+      thread_ts: params.threadTs,
+      status: params.status,
+    };
+    const client = app.client as unknown as {
+      assistant?: {
+        threads?: {
+          setStatus?: (args: typeof payload) => Promise<unknown>;
+        };
+      };
+      apiCall?: (method: string, args: typeof payload) => Promise<unknown>;
+    };
+    try {
+      if (client.assistant?.threads?.setStatus) {
+        await client.assistant.threads.setStatus(payload);
+        return;
+      }
+      if (typeof client.apiCall === "function") {
+        await client.apiCall("assistant.threads.setStatus", payload);
+      }
+    } catch (err) {
+      logVerbose(
+        `slack status update failed for channel ${params.channelId}: ${String(err)}`,
+      );
+    }
+  };
+
+  const isChannelAllowed = (params: {
+    channelId?: string;
+    channelName?: string;
+    channelType?: SlackMessageEvent["channel_type"];
+  }) => {
+    const channelType = params.channelType;
+    const isDirectMessage = channelType === "im";
+    const isGroupDm = channelType === "mpim";
+    const isRoom = channelType === "channel" || channelType === "group";
+
+    if (isDirectMessage && !dmEnabled) return false;
+    if (isGroupDm && !groupDmEnabled) return false;
+
+    if (isGroupDm && groupDmChannels.length > 0) {
+      const allowList = normalizeAllowListLower(groupDmChannels);
+      const candidates = [
+        params.channelId,
+        params.channelName ? `#${params.channelName}` : undefined,
+        params.channelName,
+        params.channelName ? normalizeSlackSlug(params.channelName) : undefined,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .map((value) => value.toLowerCase());
+      const permitted =
+        allowList.includes("*") ||
+        candidates.some((candidate) => allowList.includes(candidate));
+      if (!permitted) return false;
+    }
+
+    if (isRoom && params.channelId) {
+      const channelConfig = resolveSlackChannelConfig({
+        channelId: params.channelId,
+        channelName: params.channelName,
+        channels: channelsConfig,
+      });
+      const channelAllowed = channelConfig?.allowed !== false;
+      const channelAllowlistConfigured =
+        Boolean(channelsConfig) && Object.keys(channelsConfig ?? {}).length > 0;
+      if (
+        !isSlackRoomAllowedByPolicy({
+          groupPolicy,
+          channelAllowlistConfigured,
+          channelAllowed,
+        })
+      ) {
+        return false;
+      }
+      if (!channelAllowed) return false;
+    }
+
+    return true;
+  };
+
+  const handleSlackMessage = async (
+    message: SlackMessageEvent,
+    opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
+  ) => {
+    if (opts.source === "message" && message.type !== "message") return;
+    if (
+      opts.source === "message" &&
+      message.subtype &&
+      message.subtype !== "file_share" &&
+      message.subtype !== "bot_message"
+    ) {
+      return;
+    }
+    if (markMessageSeen(message.channel, message.ts)) return;
+
+    let channelInfo: {
+      name?: string;
+      type?: SlackMessageEvent["channel_type"];
+      topic?: string;
+      purpose?: string;
+    } = {};
+    let channelType = message.channel_type;
+    if (!channelType || channelType !== "im") {
+      channelInfo = await resolveChannelName(message.channel);
+      channelType = channelType ?? channelInfo.type;
+    }
+    const channelName = channelInfo?.name;
+    const resolvedChannelType = channelType;
+    const isDirectMessage = resolvedChannelType === "im";
+    const isGroupDm = resolvedChannelType === "mpim";
+    const isRoom =
+      resolvedChannelType === "channel" || resolvedChannelType === "group";
+
+    const channelConfig = isRoom
+      ? resolveSlackChannelConfig({
+          channelId: message.channel,
+          channelName,
+          channels: channelsConfig,
+        })
+      : null;
+
+    const allowBots =
+      channelConfig?.allowBots ??
+      account.config?.allowBots ??
+      cfg.channels?.slack?.allowBots ??
+      false;
+    const isBotMessage = Boolean(message.bot_id);
+    if (isBotMessage) {
+      if (message.user && botUserId && message.user === botUserId) return;
+      if (!allowBots) {
+        logVerbose(
+          `slack: drop bot message ${message.bot_id ?? "unknown"} (allowBots=false)`,
+        );
+        return;
+      }
+    }
+    if (isDirectMessage && !message.user) {
+      logVerbose("slack: drop dm message (missing user id)");
+      return;
+    }
+    const senderId =
+      message.user ?? (isBotMessage ? message.bot_id : undefined);
+    if (!senderId) {
+      logVerbose("slack: drop message (missing sender id)");
+      return;
+    }
+
+    if (
+      !isChannelAllowed({
+        channelId: message.channel,
+        channelName,
+        channelType: resolvedChannelType,
+      })
+    ) {
+      logVerbose("slack: drop message (channel not allowed)");
+      return;
+    }
+
+    const storeAllowFrom = await readChannelAllowFromStore("slack").catch(
+      () => [],
+    );
+    const effectiveAllowFrom = normalizeAllowList([
+      ...allowFrom,
+      ...storeAllowFrom,
+    ]);
+    const effectiveAllowFromLower = normalizeAllowListLower(effectiveAllowFrom);
+
+    if (isDirectMessage) {
+      const directUserId = message.user;
+      if (!directUserId) {
+        logVerbose("slack: drop dm message (missing user id)");
+        return;
+      }
+      if (!dmEnabled || dmPolicy === "disabled") {
+        logVerbose("slack: drop dm (dms disabled)");
+        return;
+      }
+      if (dmPolicy !== "open") {
+        const permitted = allowListMatches({
+          allowList: effectiveAllowFromLower,
+          id: directUserId,
+        });
+        if (!permitted) {
+          if (dmPolicy === "pairing") {
+            const sender = await resolveUserName(directUserId);
+            const senderName = sender?.name ?? undefined;
+            const { code, created } = await upsertChannelPairingRequest({
+              channel: "slack",
+              id: directUserId,
+              meta: { name: senderName },
+            });
+            if (created) {
+              logVerbose(
+                `slack pairing request sender=${directUserId} name=${senderName ?? "unknown"}`,
+              );
+              try {
+                await sendMessageSlack(
+                  message.channel,
+                  buildPairingReply({
+                    channel: "slack",
+                    idLine: `Your Slack user id: ${directUserId}`,
+                    code,
+                  }),
+                  {
+                    token: botToken,
+                    client: app.client,
+                    accountId: account.accountId,
+                  },
+                );
+              } catch (err) {
+                logVerbose(
+                  `slack pairing reply failed for ${message.user}: ${String(err)}`,
+                );
+              }
+            }
+          } else {
+            logVerbose(
+              `Blocked unauthorized slack sender ${message.user} (dmPolicy=${dmPolicy})`,
+            );
+          }
+          return;
+        }
+      }
+    }
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: account.accountId,
+      teamId: teamId || undefined,
+      peer: {
+        kind: isDirectMessage ? "dm" : isRoom ? "channel" : "group",
+        id: isDirectMessage ? (message.user ?? "unknown") : message.channel,
+      },
+    });
+    const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
+    const wasMentioned =
+      opts.wasMentioned ??
+      (!isDirectMessage &&
+        (Boolean(botUserId && message.text?.includes(`<@${botUserId}>`)) ||
+          matchesMentionPatterns(message.text ?? "", mentionRegexes)));
+    const sender = message.user ? await resolveUserName(message.user) : null;
+    const senderName =
+      sender?.name ??
+      message.username?.trim() ??
+      message.user ??
+      message.bot_id ??
+      "unknown";
+    const channelUserAuthorized = isRoom
+      ? resolveSlackUserAllowed({
+          allowList: channelConfig?.users,
+          userId: senderId,
+          userName: senderName,
+        })
+      : true;
+    if (isRoom && !channelUserAuthorized) {
+      logVerbose(
+        `Blocked unauthorized slack sender ${senderId} (not in channel users)`,
+      );
+      return;
+    }
+    const allowList = effectiveAllowFromLower;
+    const commandAuthorized =
+      (allowList.length === 0 ||
+        allowListMatches({
+          allowList,
+          id: senderId,
+          name: senderName,
+        })) &&
+      channelUserAuthorized;
+    const hasAnyMention = /<@[^>]+>/.test(message.text ?? "");
+    const allowTextCommands = shouldHandleTextCommands({
+      cfg,
+      surface: "slack",
+    });
+    const shouldRequireMention = isRoom
+      ? (channelConfig?.requireMention ?? true)
+      : false;
+    const shouldBypassMention =
+      allowTextCommands &&
+      isRoom &&
+      shouldRequireMention &&
+      !wasMentioned &&
+      !hasAnyMention &&
+      commandAuthorized &&
+      hasControlCommand(message.text ?? "", cfg);
+    const effectiveWasMentioned = wasMentioned || shouldBypassMention;
+    const canDetectMention = Boolean(botUserId) || mentionRegexes.length > 0;
+    if (
+      isRoom &&
+      shouldRequireMention &&
+      canDetectMention &&
+      !wasMentioned &&
+      !shouldBypassMention
+    ) {
+      logger.info(
+        { channel: message.channel, reason: "no-mention" },
+        "skipping room message",
+      );
+      return;
+    }
+
+    const media = await resolveSlackMedia({
+      files: message.files,
+      token: botToken,
+      maxBytes: mediaMaxBytes,
+    });
+    const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
+    if (!rawBody) return;
+    const ackReaction = resolveAckReaction(cfg, route.agentId);
+    const ackReactionValue = ackReaction ?? "";
+    const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+    const shouldAckReaction = () => {
+      if (!ackReaction) return false;
+      if (ackReactionScope === "all") return true;
+      if (ackReactionScope === "direct") return isDirectMessage;
+      const isGroupChat = isRoom || isGroupDm;
+      if (ackReactionScope === "group-all") return isGroupChat;
+      if (ackReactionScope === "group-mentions") {
+        if (!isRoom) return false;
+        if (!shouldRequireMention) return false;
+        if (!canDetectMention) return false;
+        return wasMentioned || shouldBypassMention;
+      }
+      return false;
+    };
+    const ackReactionMessageTs = message.ts;
+    const ackReactionPromise =
+      shouldAckReaction() && ackReactionMessageTs && ackReactionValue
+        ? reactSlackMessage(
+            message.channel,
+            ackReactionMessageTs,
+            ackReactionValue,
+            {
+              token: botToken,
+              client: app.client,
+            },
+          ).then(
+            () => true,
+            (err) => {
+              logVerbose(
+                `slack react failed for channel ${message.channel}: ${String(err)}`,
+              );
+              return false;
+            },
+          )
+        : null;
+
+    const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
+    const isRoomish = isRoom || isGroupDm;
+    const historyKey = message.channel;
+    const historyEntry =
+      isRoomish && historyLimit > 0
+        ? {
+            sender: senderName,
+            body: rawBody,
+            timestamp: message.ts
+              ? Math.round(Number(message.ts) * 1000)
+              : undefined,
+            messageId: message.ts,
+          }
+        : undefined;
+
+    const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
+    const inboundLabel = isDirectMessage
+      ? `Slack DM from ${senderName}`
+      : `Slack message in ${roomLabel} from ${senderName}`;
+    const slackFrom = isDirectMessage
+      ? `slack:${message.user}`
+      : isRoom
+        ? `slack:channel:${message.channel}`
+        : `slack:group:${message.channel}`;
+    const baseSessionKey = route.sessionKey;
+    const threadTs = message.thread_ts;
+    const hasThreadTs = typeof threadTs === "string" && threadTs.length > 0;
+    const isThreadReply =
+      hasThreadTs &&
+      (threadTs !== message.ts || Boolean(message.parent_user_id));
+    const threadKeys = resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: isThreadReply ? threadTs : undefined,
+      parentSessionKey: isThreadReply ? baseSessionKey : undefined,
+    });
+    const sessionKey = threadKeys.sessionKey;
+    enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      sessionKey,
+      contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
+    });
+
+    const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}]`;
+    const body = formatAgentEnvelope({
+      channel: "Slack",
+      from: senderName,
+      timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
+      body: textWithId,
+    });
+
+    let combinedBody = body;
+    if (isRoomish && historyLimit > 0) {
+      combinedBody = buildHistoryContextFromMap({
+        historyMap: channelHistories,
+        historyKey,
+        limit: historyLimit,
+        entry: historyEntry,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatAgentEnvelope({
+            channel: "Slack",
+            from: roomLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.sender}: ${entry.body}${
+              entry.messageId
+                ? ` [id:${entry.messageId} channel:${message.channel}]`
+                : ""
+            }`,
+          }),
+      });
+    }
+    const slackTo = isDirectMessage
+      ? `user:${message.user}`
+      : `channel:${message.channel}`;
+    const channelDescription = [channelInfo?.topic, channelInfo?.purpose]
+      .map((entry) => entry?.trim())
+      .filter((entry): entry is string => Boolean(entry))
+      .filter((entry, index, list) => list.indexOf(entry) === index)
+      .join("\n");
+    const systemPromptParts = [
+      channelDescription ? `Channel description: ${channelDescription}` : null,
+      channelConfig?.systemPrompt?.trim() || null,
+    ].filter((entry): entry is string => Boolean(entry));
+    const groupSystemPrompt =
+      systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+    let threadStarterBody: string | undefined;
+    let threadLabel: string | undefined;
+    if (isThreadReply && threadTs) {
+      const starter = await resolveSlackThreadStarter({
+        channelId: message.channel,
+        threadTs,
+        client: app.client,
+      });
+      if (starter?.text) {
+        const starterUser = starter.userId
+          ? await resolveUserName(starter.userId)
+          : null;
+        const starterName = starterUser?.name ?? starter.userId ?? "Unknown";
+        const starterWithId = `${starter.text}\n[slack message id: ${starter.ts ?? threadTs} channel: ${message.channel}]`;
+        threadStarterBody = formatThreadStarterEnvelope({
+          channel: "Slack",
+          author: starterName,
+          timestamp: starter.ts
+            ? Math.round(Number(starter.ts) * 1000)
+            : undefined,
+          body: starterWithId,
+        });
+        const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
+        threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
+      } else {
+        threadLabel = `Slack thread ${roomLabel}`;
+      }
+    }
+    const ctxPayload = {
+      Body: combinedBody,
+      RawBody: rawBody,
+      CommandBody: rawBody,
+      From: slackFrom,
+      To: slackTo,
+      SessionKey: sessionKey,
+      AccountId: route.accountId,
+      ChatType: isDirectMessage ? "direct" : isRoom ? "room" : "group",
+      GroupSubject: isRoomish ? roomLabel : undefined,
+      GroupSystemPrompt: isRoomish ? groupSystemPrompt : undefined,
+      SenderName: senderName,
+      SenderId: senderId,
+      Provider: "slack" as const,
+      Surface: "slack" as const,
+      MessageSid: message.ts,
+      ReplyToId: message.thread_ts ?? message.ts,
+      ParentSessionKey: threadKeys.parentSessionKey,
+      ThreadStarterBody: threadStarterBody,
+      ThreadLabel: threadLabel,
+      Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
+      WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
+      MediaPath: media?.path,
+      MediaType: media?.contentType,
+      MediaUrl: media?.path,
+      CommandAuthorized: commandAuthorized,
+      // Originating channel for reply routing.
+      OriginatingChannel: "slack" as const,
+      OriginatingTo: slackTo,
+    };
+
+    const replyTarget = ctxPayload.To ?? undefined;
+    if (!replyTarget) {
+      runtime.error?.(danger("slack: missing reply target"));
+      return;
+    }
+
+    if (isDirectMessage) {
+      const sessionCfg = cfg.session;
+      const storePath = resolveStorePath(sessionCfg?.store, {
+        agentId: route.agentId,
+      });
+      await updateLastRoute({
+        storePath,
+        sessionKey: route.mainSessionKey,
+        channel: "slack",
+        to: `user:${message.user}`,
+        accountId: route.accountId,
+      });
+    }
+
+    if (shouldLogVerbose()) {
+      logVerbose(
+        `slack inbound: channel=${message.channel} from=${ctxPayload.From} preview="${preview}"`,
+      );
+    }
+
+    // Use helper for status thread; compute baseThreadTs for "first" mode support
+    const { statusThreadTs } = resolveSlackThreadTargets({
+      message,
+      replyToMode,
+    });
+    const messageTs = message.ts ?? message.event_ts;
+    const incomingThreadTs = message.thread_ts;
+    let didSetStatus = false;
+    // Shared mutable ref for tracking if a reply was sent (used by both
+    // auto-reply path and tool path for "first" threading mode).
+    const hasRepliedRef = { value: false };
+    const replyPlan = createSlackReplyDeliveryPlan({
+      replyToMode,
+      incomingThreadTs,
+      messageTs,
+      hasRepliedRef,
+    });
+    const onReplyStart = async () => {
+      didSetStatus = true;
+      await setSlackThreadStatus({
+        channelId: message.channel,
+        threadTs: statusThreadTs,
+        status: "is typing...",
+      });
+    };
+    let didSendReply = false;
+    const { dispatcher, replyOptions, markDispatchIdle } =
+      createReplyDispatcherWithTyping({
+        responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+          .responsePrefix,
+        humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+        deliver: async (payload) => {
+          const replyThreadTs = replyPlan.nextThreadTs();
+          await deliverReplies({
+            replies: [payload],
+            target: replyTarget,
+            token: botToken,
+            accountId: account.accountId,
+            runtime,
+            textLimit,
+            replyThreadTs,
+          });
+          didSendReply = true;
+          replyPlan.markSent();
+        },
+        onError: (err, info) => {
+          runtime.error?.(
+            danger(`slack ${info.kind} reply failed: ${String(err)}`),
+          );
+          if (didSetStatus) {
+            void setSlackThreadStatus({
+              channelId: message.channel,
+              threadTs: statusThreadTs,
+              status: "",
+            });
+          }
+        },
+        onReplyStart,
+      });
+
+    const { queuedFinal, counts } = await dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
+      dispatcher,
+      runtime,
+      replyOptions: {
+        ...replyOptions,
+        skillFilter: channelConfig?.skills,
+        hasRepliedRef,
+        disableBlockStreaming:
+          typeof account.config.blockStreaming === "boolean"
+            ? !account.config.blockStreaming
+            : undefined,
+      },
+    });
+    markDispatchIdle();
+    if (didSetStatus) {
+      await setSlackThreadStatus({
+        channelId: message.channel,
+        threadTs: statusThreadTs,
+        status: "",
+      });
+    }
+    if (!queuedFinal) {
+      if (isRoomish && historyLimit > 0 && didSendReply) {
+        clearHistoryEntries({ historyMap: channelHistories, historyKey });
+      }
+      return;
+    }
+    if (shouldLogVerbose()) {
+      const finalCount = counts.final;
+      logVerbose(
+        `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+      );
+    }
+    if (removeAckAfterReply && ackReactionPromise && ackReactionMessageTs) {
+      const messageTs = ackReactionMessageTs;
+      void ackReactionPromise.then((didAck) => {
+        if (!didAck) return;
+        removeSlackReaction(message.channel, messageTs, ackReactionValue, {
+          token: botToken,
+          client: app.client,
+        }).catch((err) => {
+          logVerbose(
+            `slack: failed to remove ack reaction from ${message.channel}/${message.ts}: ${String(err)}`,
+          );
+        });
+      });
+    }
+    if (isRoomish && historyLimit > 0 && didSendReply) {
+      clearHistoryEntries({ historyMap: channelHistories, historyKey });
+    }
+  };
+
+  app.event(
+    "message",
+    async ({ event }: SlackEventMiddlewareArgs<"message">) => {
+      try {
+        const message = event as SlackMessageEvent;
+        if (message.subtype === "message_changed") {
+          const changed = event as SlackMessageChangedEvent;
+          const channelId = changed.channel;
+          const channelInfo = channelId
+            ? await resolveChannelName(channelId)
+            : {};
+          const channelType = channelInfo?.type;
+          if (
+            !isChannelAllowed({
+              channelId,
+              channelName: channelInfo?.name,
+              channelType,
+            })
+          ) {
+            return;
+          }
+          const messageId = changed.message?.ts ?? changed.previous_message?.ts;
+          const label = resolveSlackChannelLabel({
+            channelId,
+            channelName: channelInfo?.name,
+          });
+          const sessionKey = resolveSlackSystemEventSessionKey({
+            channelId,
+            channelType,
+          });
+          enqueueSystemEvent(`Slack message edited in ${label}.`, {
+            sessionKey,
+            contextKey: `slack:message:changed:${channelId ?? "unknown"}:${messageId ?? changed.event_ts ?? "unknown"}`,
+          });
+          return;
+        }
+        if (message.subtype === "message_deleted") {
+          const deleted = event as SlackMessageDeletedEvent;
+          const channelId = deleted.channel;
+          const channelInfo = channelId
+            ? await resolveChannelName(channelId)
+            : {};
+          const channelType = channelInfo?.type;
+          if (
+            !isChannelAllowed({
+              channelId,
+              channelName: channelInfo?.name,
+              channelType,
+            })
+          ) {
+            return;
+          }
+          const label = resolveSlackChannelLabel({
+            channelId,
+            channelName: channelInfo?.name,
+          });
+          const sessionKey = resolveSlackSystemEventSessionKey({
+            channelId,
+            channelType,
+          });
+          enqueueSystemEvent(`Slack message deleted in ${label}.`, {
+            sessionKey,
+            contextKey: `slack:message:deleted:${channelId ?? "unknown"}:${deleted.deleted_ts ?? deleted.event_ts ?? "unknown"}`,
+          });
+          return;
+        }
+        if (message.subtype === "thread_broadcast") {
+          const thread = event as SlackThreadBroadcastEvent;
+          const channelId = thread.channel;
+          const channelInfo = channelId
+            ? await resolveChannelName(channelId)
+            : {};
+          const channelType = channelInfo?.type;
+          if (
+            !isChannelAllowed({
+              channelId,
+              channelName: channelInfo?.name,
+              channelType,
+            })
+          ) {
+            return;
+          }
+          const label = resolveSlackChannelLabel({
+            channelId,
+            channelName: channelInfo?.name,
+          });
+          const messageId = thread.message?.ts ?? thread.event_ts;
+          const sessionKey = resolveSlackSystemEventSessionKey({
+            channelId,
+            channelType,
+          });
+          enqueueSystemEvent(`Slack thread reply broadcast in ${label}.`, {
+            sessionKey,
+            contextKey: `slack:thread:broadcast:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+          });
+          return;
+        }
+        await handleSlackMessage(message, { source: "message" });
+      } catch (err) {
+        runtime.error?.(danger(`slack handler failed: ${String(err)}`));
+      }
+    },
+  );
+
+  app.event(
+    "app_mention",
+    async ({ event }: SlackEventMiddlewareArgs<"app_mention">) => {
+      try {
+        const mention = event as SlackAppMentionEvent;
+        await handleSlackMessage(mention as unknown as SlackMessageEvent, {
+          source: "app_mention",
+          wasMentioned: true,
+        });
+      } catch (err) {
+        runtime.error?.(danger(`slack mention handler failed: ${String(err)}`));
+      }
+    },
+  );
+
+  const handleReactionEvent = async (
+    event: SlackReactionEvent,
+    action: "added" | "removed",
+  ) => {
+    try {
+      const item = event.item;
+      if (!event.user) return;
+      if (!item?.channel || !item?.ts) return;
+      if (item.type && item.type !== "message") return;
+      if (botUserId && event.user === botUserId) return;
+
+      const channelInfo = await resolveChannelName(item.channel);
+      const channelType = channelInfo?.type;
+      const isDirectMessage = channelType === "im";
+      const isGroupDm = channelType === "mpim";
+      const isRoom = channelType === "channel" || channelType === "group";
+      const channelName = channelInfo?.name;
+
+      if (isDirectMessage && !dmEnabled) return;
+      if (isGroupDm && !groupDmEnabled) return;
+      if (isGroupDm && groupDmChannels.length > 0) {
+        const allowList = normalizeAllowListLower(groupDmChannels);
+        const candidates = [
+          item.channel,
+          channelName ? `#${channelName}` : undefined,
+          channelName,
+          channelName ? normalizeSlackSlug(channelName) : undefined,
+        ]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => value.toLowerCase());
+        const permitted =
+          allowList.includes("*") ||
+          candidates.some((candidate) => allowList.includes(candidate));
+        if (!permitted) return;
+      }
+
+      if (isRoom) {
+        const channelConfig = resolveSlackChannelConfig({
+          channelId: item.channel,
+          channelName,
+          channels: channelsConfig,
+        });
+        if (channelConfig?.allowed === false) return;
+      }
+
+      const actor = await resolveUserName(event.user);
+      const shouldNotify = shouldEmitSlackReactionNotification({
+        mode: reactionMode,
+        botId: botUserId,
+        messageAuthorId: event.item_user ?? undefined,
+        userId: event.user,
+        userName: actor?.name ?? undefined,
+        allowlist: reactionAllowlist,
+      });
+      if (!shouldNotify) return;
+
+      const emojiLabel = event.reaction ?? "emoji";
+      const actorLabel = actor?.name ?? event.user;
+      const channelLabel = channelName
+        ? `#${normalizeSlackSlug(channelName) || channelName}`
+        : `#${item.channel}`;
+      const authorInfo = event.item_user
+        ? await resolveUserName(event.item_user)
+        : undefined;
+      const authorLabel = authorInfo?.name ?? event.item_user;
+      const baseText = `Slack reaction ${action}: :${emojiLabel}: by ${actorLabel} in ${channelLabel} msg ${item.ts}`;
+      const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
+      const sessionKey = resolveSlackSystemEventSessionKey({
+        channelId: item.channel,
+        channelType,
+      });
+      enqueueSystemEvent(text, {
+        sessionKey,
+        contextKey: `slack:reaction:${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}`,
+      });
+    } catch (err) {
+      runtime.error?.(danger(`slack reaction handler failed: ${String(err)}`));
+    }
+  };
+
+  app.event(
+    "reaction_added",
+    async ({ event }: SlackEventMiddlewareArgs<"reaction_added">) => {
+      await handleReactionEvent(event as SlackReactionEvent, "added");
+    },
+  );
+
+  app.event(
+    "reaction_removed",
+    async ({ event }: SlackEventMiddlewareArgs<"reaction_removed">) => {
+      await handleReactionEvent(event as SlackReactionEvent, "removed");
+    },
+  );
+
+  app.event(
+    "member_joined_channel",
+    async ({ event }: SlackEventMiddlewareArgs<"member_joined_channel">) => {
+      try {
+        const payload = event as SlackMemberChannelEvent;
+        const channelId = payload.channel;
+        const channelInfo = channelId
+          ? await resolveChannelName(channelId)
+          : {};
+        const channelType = payload.channel_type ?? channelInfo?.type;
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName: channelInfo?.name,
+            channelType,
+          })
+        ) {
+          return;
+        }
+        const userInfo = payload.user
+          ? await resolveUserName(payload.user)
+          : {};
+        const userLabel = userInfo?.name ?? payload.user ?? "someone";
+        const label = resolveSlackChannelLabel({
+          channelId,
+          channelName: channelInfo?.name,
+        });
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType,
+        });
+        enqueueSystemEvent(`Slack: ${userLabel} joined ${label}.`, {
+          sessionKey,
+          contextKey: `slack:member:joined:${channelId ?? "unknown"}:${payload.user ?? "unknown"}`,
+        });
+      } catch (err) {
+        runtime.error?.(danger(`slack join handler failed: ${String(err)}`));
+      }
+    },
+  );
+
+  app.event(
+    "member_left_channel",
+    async ({ event }: SlackEventMiddlewareArgs<"member_left_channel">) => {
+      try {
+        const payload = event as SlackMemberChannelEvent;
+        const channelId = payload.channel;
+        const channelInfo = channelId
+          ? await resolveChannelName(channelId)
+          : {};
+        const channelType = payload.channel_type ?? channelInfo?.type;
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName: channelInfo?.name,
+            channelType,
+          })
+        ) {
+          return;
+        }
+        const userInfo = payload.user
+          ? await resolveUserName(payload.user)
+          : {};
+        const userLabel = userInfo?.name ?? payload.user ?? "someone";
+        const label = resolveSlackChannelLabel({
+          channelId,
+          channelName: channelInfo?.name,
+        });
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType,
+        });
+        enqueueSystemEvent(`Slack: ${userLabel} left ${label}.`, {
+          sessionKey,
+          contextKey: `slack:member:left:${channelId ?? "unknown"}:${payload.user ?? "unknown"}`,
+        });
+      } catch (err) {
+        runtime.error?.(danger(`slack leave handler failed: ${String(err)}`));
+      }
+    },
+  );
+
+  app.event(
+    "channel_created",
+    async ({ event }: SlackEventMiddlewareArgs<"channel_created">) => {
+      try {
+        const payload = event as SlackChannelCreatedEvent;
+        const channelId = payload.channel?.id;
+        const channelName = payload.channel?.name;
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName,
+            channelType: "channel",
+          })
+        ) {
+          return;
+        }
+        const label = resolveSlackChannelLabel({ channelId, channelName });
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType: "channel",
+        });
+        enqueueSystemEvent(`Slack channel created: ${label}.`, {
+          sessionKey,
+          contextKey: `slack:channel:created:${channelId ?? channelName ?? "unknown"}`,
+        });
+      } catch (err) {
+        runtime.error?.(
+          danger(`slack channel created handler failed: ${String(err)}`),
+        );
+      }
+    },
+  );
+
+  app.event(
+    "channel_rename",
+    async ({ event }: SlackEventMiddlewareArgs<"channel_rename">) => {
+      try {
+        const payload = event as SlackChannelRenamedEvent;
+        const channelId = payload.channel?.id;
+        const channelName =
+          payload.channel?.name_normalized ?? payload.channel?.name;
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName,
+            channelType: "channel",
+          })
+        ) {
+          return;
+        }
+        const label = resolveSlackChannelLabel({ channelId, channelName });
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType: "channel",
+        });
+        enqueueSystemEvent(`Slack channel renamed: ${label}.`, {
+          sessionKey,
+          contextKey: `slack:channel:renamed:${channelId ?? channelName ?? "unknown"}`,
+        });
+      } catch (err) {
+        runtime.error?.(
+          danger(`slack channel rename handler failed: ${String(err)}`),
+        );
+      }
+    },
+  );
+
+  app.event(
+    "pin_added",
+    async ({ event }: SlackEventMiddlewareArgs<"pin_added">) => {
+      try {
+        const payload = event as SlackPinEvent;
+        const channelId = payload.channel_id;
+        const channelInfo = channelId
+          ? await resolveChannelName(channelId)
+          : {};
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName: channelInfo?.name,
+            channelType: channelInfo?.type,
+          })
+        ) {
+          return;
+        }
+        const label = resolveSlackChannelLabel({
+          channelId,
+          channelName: channelInfo?.name,
+        });
+        const userInfo = payload.user
+          ? await resolveUserName(payload.user)
+          : {};
+        const userLabel = userInfo?.name ?? payload.user ?? "someone";
+        const itemType = payload.item?.type ?? "item";
+        const messageId = payload.item?.message?.ts ?? payload.event_ts;
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType: channelInfo?.type ?? undefined,
+        });
+        enqueueSystemEvent(
+          `Slack: ${userLabel} pinned a ${itemType} in ${label}.`,
+          {
+            sessionKey,
+            contextKey: `slack:pin:added:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+          },
+        );
+      } catch (err) {
+        runtime.error?.(
+          danger(`slack pin added handler failed: ${String(err)}`),
+        );
+      }
+    },
+  );
+
+  app.event(
+    "pin_removed",
+    async ({ event }: SlackEventMiddlewareArgs<"pin_removed">) => {
+      try {
+        const payload = event as SlackPinEvent;
+        const channelId = payload.channel_id;
+        const channelInfo = channelId
+          ? await resolveChannelName(channelId)
+          : {};
+        if (
+          !isChannelAllowed({
+            channelId,
+            channelName: channelInfo?.name,
+            channelType: channelInfo?.type,
+          })
+        ) {
+          return;
+        }
+        const label = resolveSlackChannelLabel({
+          channelId,
+          channelName: channelInfo?.name,
+        });
+        const userInfo = payload.user
+          ? await resolveUserName(payload.user)
+          : {};
+        const userLabel = userInfo?.name ?? payload.user ?? "someone";
+        const itemType = payload.item?.type ?? "item";
+        const messageId = payload.item?.message?.ts ?? payload.event_ts;
+        const sessionKey = resolveSlackSystemEventSessionKey({
+          channelId,
+          channelType: channelInfo?.type ?? undefined,
+        });
+        enqueueSystemEvent(
+          `Slack: ${userLabel} unpinned a ${itemType} in ${label}.`,
+          {
+            sessionKey,
+            contextKey: `slack:pin:removed:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+          },
+        );
+      } catch (err) {
+        runtime.error?.(
+          danger(`slack pin removed handler failed: ${String(err)}`),
+        );
+      }
+    },
+  );
+
+  const handleSlashCommand = async (params: {
+    command: SlackCommandMiddlewareArgs["command"];
+    ack: SlackCommandMiddlewareArgs["ack"];
+    respond: SlackCommandMiddlewareArgs["respond"];
+    prompt: string;
+  }) => {
+    const { command, ack, respond, prompt } = params;
+    try {
+      if (!prompt.trim()) {
+        await ack({
+          text: "Message required.",
+          response_type: "ephemeral",
+        });
+        return;
+      }
+      await ack();
+
+      if (botUserId && command.user_id === botUserId) return;
+
+      const channelInfo = await resolveChannelName(command.channel_id);
+      const channelType =
+        channelInfo?.type ??
+        (command.channel_name === "directmessage" ? "im" : undefined);
+      const isDirectMessage = channelType === "im";
+      const isGroupDm = channelType === "mpim";
+      const isRoom = channelType === "channel" || channelType === "group";
+
+      if (isDirectMessage && !dmEnabled) {
+        await respond({
+          text: "Slack DMs are disabled.",
+          response_type: "ephemeral",
+        });
+        return;
+      }
+      if (isGroupDm && !groupDmEnabled) {
+        await respond({
+          text: "Slack group DMs are disabled.",
+          response_type: "ephemeral",
+        });
+        return;
+      }
+      if (isGroupDm && groupDmChannels.length > 0) {
+        const allowList = normalizeAllowListLower(groupDmChannels);
+        const channelName = channelInfo?.name;
+        const candidates = [
+          command.channel_id,
+          channelName ? `#${channelName}` : undefined,
+          channelName,
+          channelName ? normalizeSlackSlug(channelName) : undefined,
+        ]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => value.toLowerCase());
+        const permitted =
+          allowList.includes("*") ||
+          candidates.some((candidate) => allowList.includes(candidate));
+        if (!permitted) {
+          await respond({
+            text: "This group DM is not allowed.",
+            response_type: "ephemeral",
+          });
+          return;
+        }
+      }
+
+      const storeAllowFrom = await readChannelAllowFromStore("slack").catch(
+        () => [],
+      );
+      const effectiveAllowFrom = normalizeAllowList([
+        ...allowFrom,
+        ...storeAllowFrom,
+      ]);
+      const effectiveAllowFromLower =
+        normalizeAllowListLower(effectiveAllowFrom);
+
+      let commandAuthorized = true;
+      let channelConfig: SlackChannelConfigResolved | null = null;
+      if (isDirectMessage) {
+        if (!dmEnabled || dmPolicy === "disabled") {
+          await respond({
+            text: "Slack DMs are disabled.",
+            response_type: "ephemeral",
+          });
+          return;
+        }
+        if (dmPolicy !== "open") {
+          const sender = await resolveUserName(command.user_id);
+          const senderName = sender?.name ?? undefined;
+          const permitted = allowListMatches({
+            allowList: effectiveAllowFromLower,
+            id: command.user_id,
+            name: senderName,
+          });
+          if (!permitted) {
+            if (dmPolicy === "pairing") {
+              const { code, created } = await upsertChannelPairingRequest({
+                channel: "slack",
+                id: command.user_id,
+                meta: { name: senderName },
+              });
+              if (created) {
+                await respond({
+                  text: buildPairingReply({
+                    channel: "slack",
+                    idLine: `Your Slack user id: ${command.user_id}`,
+                    code,
+                  }),
+                  response_type: "ephemeral",
+                });
+              }
+            } else {
+              await respond({
+                text: "You are not authorized to use this command.",
+                response_type: "ephemeral",
+              });
+            }
+            return;
+          }
+          commandAuthorized = true;
+        }
+      }
+
+      if (isRoom) {
+        channelConfig = resolveSlackChannelConfig({
+          channelId: command.channel_id,
+          channelName: channelInfo?.name,
+          channels: channelsConfig,
+        });
+        if (
+          useAccessGroups &&
+          !isSlackRoomAllowedByPolicy({
+            groupPolicy,
+            channelAllowlistConfigured:
+              Boolean(channelsConfig) &&
+              Object.keys(channelsConfig ?? {}).length > 0,
+            channelAllowed: channelConfig?.allowed !== false,
+          })
+        ) {
+          await respond({
+            text: "This channel is not allowed.",
+            response_type: "ephemeral",
+          });
+          return;
+        }
+        if (useAccessGroups && channelConfig?.allowed === false) {
+          await respond({
+            text: "This channel is not allowed.",
+            response_type: "ephemeral",
+          });
+          return;
+        }
+      }
+
+      const sender = await resolveUserName(command.user_id);
+      const senderName = sender?.name ?? command.user_name ?? command.user_id;
+      const channelUserAllowed = isRoom
+        ? resolveSlackUserAllowed({
+            allowList: channelConfig?.users,
+            userId: command.user_id,
+            userName: senderName,
+          })
+        : true;
+      if (isRoom && !channelUserAllowed) {
+        await respond({
+          text: "You are not authorized to use this command here.",
+          response_type: "ephemeral",
+        });
+        return;
+      }
+      const channelName = channelInfo?.name;
+      const roomLabel = channelName
+        ? `#${channelName}`
+        : `#${command.channel_id}`;
+      const isRoomish = isRoom || isGroupDm;
+      const route = resolveAgentRoute({
+        cfg,
+        channel: "slack",
+        accountId: account.accountId,
+        teamId: teamId || undefined,
+        peer: {
+          kind: isDirectMessage ? "dm" : isRoom ? "channel" : "group",
+          id: isDirectMessage ? command.user_id : command.channel_id,
+        },
+      });
+      const channelDescription = [channelInfo?.topic, channelInfo?.purpose]
+        .map((entry) => entry?.trim())
+        .filter((entry): entry is string => Boolean(entry))
+        .filter((entry, index, list) => list.indexOf(entry) === index)
+        .join("\n");
+      const systemPromptParts = [
+        channelDescription
+          ? `Channel description: ${channelDescription}`
+          : null,
+        channelConfig?.systemPrompt?.trim() || null,
+      ].filter((entry): entry is string => Boolean(entry));
+      const groupSystemPrompt =
+        systemPromptParts.length > 0
+          ? systemPromptParts.join("\n\n")
+          : undefined;
+
+      const ctxPayload = {
+        Body: prompt,
+        From: isDirectMessage
+          ? `slack:${command.user_id}`
+          : isRoom
+            ? `slack:channel:${command.channel_id}`
+            : `slack:group:${command.channel_id}`,
+        To: `slash:${command.user_id}`,
+        ChatType: isDirectMessage ? "direct" : isRoom ? "room" : "group",
+        GroupSubject: isRoomish ? roomLabel : undefined,
+        GroupSystemPrompt: isRoomish ? groupSystemPrompt : undefined,
+        SenderName: senderName,
+        SenderId: command.user_id,
+        Provider: "slack" as const,
+        Surface: "slack" as const,
+        WasMentioned: true,
+        MessageSid: command.trigger_id,
+        Timestamp: Date.now(),
+        SessionKey: `agent:${route.agentId}:${slashCommand.sessionPrefix}:${command.user_id}`,
+        CommandTargetSessionKey: route.sessionKey,
+        AccountId: route.accountId,
+        CommandSource: "native" as const,
+        CommandAuthorized: commandAuthorized,
+        // Originating channel for reply routing.
+        OriginatingChannel: "slack" as const,
+        OriginatingTo: `user:${command.user_id}`,
+      };
+
+      const { counts } = await dispatchReplyWithDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId)
+            .responsePrefix,
+          deliver: async (payload) => {
+            await deliverSlackSlashReplies({
+              replies: [payload],
+              respond,
+              ephemeral: slashCommand.ephemeral,
+              textLimit,
+            });
+          },
+          onError: (err, info) => {
+            runtime.error?.(
+              danger(`slack slash ${info.kind} reply failed: ${String(err)}`),
+            );
+          },
+        },
+        replyOptions: { skillFilter: channelConfig?.skills },
+      });
+      if (counts.final + counts.tool + counts.block === 0) {
+        await deliverSlackSlashReplies({
+          replies: [],
+          respond,
+          ephemeral: slashCommand.ephemeral,
+          textLimit,
+        });
+      }
+    } catch (err) {
+      runtime.error?.(danger(`slack slash handler failed: ${String(err)}`));
+      await respond({
+        text: "Sorry, something went wrong handling that command.",
+        response_type: "ephemeral",
+      });
+    }
+  };
+
+  const nativeEnabled = resolveNativeCommandsEnabled({
+    providerId: "slack",
+    providerSetting: account.config.commands?.native,
+    globalSetting: cfg.commands?.native,
+  });
+  const nativeCommands = nativeEnabled
+    ? listNativeCommandSpecsForConfig(cfg)
+    : [];
+  if (nativeCommands.length > 0) {
+    for (const command of nativeCommands) {
+      app.command(
+        `/${command.name}`,
+        async ({ command: cmd, ack, respond }: SlackCommandMiddlewareArgs) => {
+          const prompt = buildCommandText(command.name, cmd.text);
+          await handleSlashCommand({ command: cmd, ack, respond, prompt });
+        },
+      );
+    }
+  } else if (slashCommand.enabled) {
+    app.command(
+      buildSlackSlashCommandMatcher(slashCommand.name),
+      async ({ command, ack, respond }: SlackCommandMiddlewareArgs) => {
+        await handleSlashCommand({
+          command,
+          ack,
+          respond,
+          prompt: command.text?.trim() ?? "",
+        });
+      },
+    );
+  }
+
+  const stopOnAbort = () => {
+    if (opts.abortSignal?.aborted) void app.stop();
+  };
+  opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+
+  try {
+    await app.start();
+    runtime.log?.("slack socket mode connected");
+    if (opts.abortSignal?.aborted) return;
+    await new Promise<void>((resolve) => {
+      opts.abortSignal?.addEventListener("abort", () => resolve(), {
+        once: true,
+      });
+    });
+  } finally {
+    opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+    await app.stop().catch(() => undefined);
+  }
+}
+
+async function deliverReplies(params: {
+  replies: ReplyPayload[];
+  target: string;
+  token: string;
+  accountId?: string;
+  runtime: RuntimeEnv;
+  textLimit: number;
+  replyThreadTs?: string;
+}) {
+  const chunkLimit = Math.min(params.textLimit, 4000);
+  for (const payload of params.replies) {
+    const threadTs = payload.replyToId ?? params.replyThreadTs;
+    const mediaList =
+      payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const text = payload.text ?? "";
+    if (!text && mediaList.length === 0) continue;
+
+    if (mediaList.length === 0) {
+      for (const chunk of chunkMarkdownText(text, chunkLimit)) {
+        const trimmed = chunk.trim();
+        if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN))
+          continue;
+        await sendMessageSlack(params.target, trimmed, {
+          token: params.token,
+          threadTs,
+          accountId: params.accountId,
+        });
+      }
+    } else {
+      let first = true;
+      for (const mediaUrl of mediaList) {
+        const caption = first ? text : "";
+        first = false;
+        await sendMessageSlack(params.target, caption, {
+          token: params.token,
+          mediaUrl,
+          threadTs,
+          accountId: params.accountId,
+        });
+      }
+    }
+    params.runtime.log?.(`delivered reply to ${params.target}`);
+  }
+}
+
+type SlackRespondFn = (payload: {
+  text: string;
+  response_type?: "ephemeral" | "in_channel";
+}) => Promise<unknown>;
+
+export function isSlackRoomAllowedByPolicy(params: {
+  groupPolicy: "open" | "disabled" | "allowlist";
+  channelAllowlistConfigured: boolean;
+  channelAllowed: boolean;
+}): boolean {
+  const { groupPolicy, channelAllowlistConfigured, channelAllowed } = params;
+  if (groupPolicy === "disabled") return false;
+  if (groupPolicy === "open") return true;
+  if (!channelAllowlistConfigured) return false;
+  return channelAllowed;
+}
+
+/**
+ * Compute effective threadTs for a Slack reply based on replyToMode.
+ * - "off": stay in thread if already in one, otherwise main channel
+ * - "first": first reply goes to thread, subsequent replies to main channel
+ * - "all": all replies go to thread
+ */
+export function resolveSlackThreadTs(params: {
+  replyToMode: "off" | "first" | "all";
+  incomingThreadTs: string | undefined;
+  messageTs: string | undefined;
+  hasReplied: boolean;
+}): string | undefined {
+  const planner = createSlackReplyReferencePlanner({
+    replyToMode: params.replyToMode,
+    incomingThreadTs: params.incomingThreadTs,
+    messageTs: params.messageTs,
+    hasReplied: params.hasReplied,
+  });
+  return planner.use();
+}
+
+type SlackReplyDeliveryPlan = {
+  nextThreadTs: () => string | undefined;
+  markSent: () => void;
+};
+
+function createSlackReplyReferencePlanner(params: {
+  replyToMode: "off" | "first" | "all";
+  incomingThreadTs: string | undefined;
+  messageTs: string | undefined;
+  hasReplied?: boolean;
+}) {
+  return createReplyReferencePlanner({
+    replyToMode: params.replyToMode,
+    existingId: params.incomingThreadTs,
+    startId: params.messageTs,
+    hasReplied: params.hasReplied,
+  });
+}
+
+function createSlackReplyDeliveryPlan(params: {
+  replyToMode: "off" | "first" | "all";
+  incomingThreadTs: string | undefined;
+  messageTs: string | undefined;
+  hasRepliedRef: { value: boolean };
+}): SlackReplyDeliveryPlan {
+  const replyReference = createSlackReplyReferencePlanner({
+    replyToMode: params.replyToMode,
+    incomingThreadTs: params.incomingThreadTs,
+    messageTs: params.messageTs,
+    hasReplied: params.hasRepliedRef.value,
+  });
+  return {
+    nextThreadTs: () => replyReference.use(),
+    markSent: () => {
+      replyReference.markSent();
+      params.hasRepliedRef.value = replyReference.hasReplied();
+    },
+  };
+}
+
+async function deliverSlackSlashReplies(params: {
+  replies: ReplyPayload[];
+  respond: SlackRespondFn;
+  ephemeral: boolean;
+  textLimit: number;
+}) {
+  const messages: string[] = [];
+  const chunkLimit = Math.min(params.textLimit, 4000);
+  for (const payload of params.replies) {
+    const textRaw = payload.text?.trim() ?? "";
+    const text =
+      textRaw && !isSilentReplyText(textRaw, SILENT_REPLY_TOKEN)
+        ? textRaw
+        : undefined;
+    const mediaList =
+      payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const combined = [
+      text ?? "",
+      ...mediaList.map((url) => url.trim()).filter(Boolean),
+    ]
+      .filter(Boolean)
+      .join("\n");
+    if (!combined) continue;
+    for (const chunk of chunkMarkdownText(combined, chunkLimit)) {
+      messages.push(chunk);
+    }
+  }
+
+  if (messages.length === 0) {
+    await params.respond({
+      text: "No response was generated for that command.",
+      response_type: "ephemeral",
+    });
+    return;
+  }
+
+  const responseType = params.ephemeral ? "ephemeral" : "in_channel";
+  for (const message of messages) {
+    await params.respond({ text: message, response_type: responseType });
+  }
+}

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -102,6 +102,7 @@ export async function dispatchPreparedSlackMessage(
     ctx: prepared.ctxPayload,
     cfg,
     dispatcher,
+    runtime,
     replyOptions: {
       ...replyOptions,
       skillFilter: prepared.channelConfig?.skills,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -940,6 +940,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           : undefined,
         disableBlockStreaming,
       },
+      runtime,
     });
     draftStream?.stop();
     if (!queuedFinal) {

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1368,9 +1368,7 @@ export async function monitorWebChannel(
               );
               if (shouldLogVerbose()) {
                 const preview =
-                  payload.text != null
-                    ? elide(payload.text, 400)
-                    : "<media>";
+                  payload.text != null ? elide(payload.text, 400) : "<media>";
                 whatsappOutboundLog.debug(
                   `Reply body: ${preview}${hasMedia ? " (media)" : ""}`,
                 );

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1,1 +1,1963 @@
-export * from "./auto-reply.impl.js";
+import {
+  resolveEffectiveMessagesConfig,
+  resolveMessagePrefix,
+} from "../agents/identity.js";
+import {
+  chunkMarkdownText,
+  resolveTextChunkLimit,
+} from "../auto-reply/chunk.js";
+import { synthesizeReplyAudio } from "../auto-reply/audio-reply.js";
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import {
+  normalizeGroupActivation,
+  parseActivationCommand,
+} from "../auto-reply/group-activation.js";
+import {
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  HEARTBEAT_PROMPT,
+  resolveHeartbeatPrompt,
+  stripHeartbeatToken,
+} from "../auto-reply/heartbeat.js";
+import {
+  buildHistoryContext,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+} from "../auto-reply/reply/history.js";
+import {
+  buildMentionRegexes,
+  normalizeMentionText,
+} from "../auto-reply/reply/mentions.js";
+import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import { getReplyFromConfig } from "../auto-reply/reply.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { isAudio } from "../auto-reply/transcription.js";
+import { toLocationContext } from "../channels/location.js";
+import { resolveWhatsAppHeartbeatRecipients } from "../channels/plugins/whatsapp-heartbeat.js";
+import { waitForever } from "../cli/wait.js";
+import { loadConfig } from "../config/config.js";
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupRequireMention,
+} from "../config/group-policy.js";
+import {
+  DEFAULT_IDLE_MINUTES,
+  loadSessionStore,
+  resolveGroupSessionKey,
+  resolveSessionKey,
+  resolveStorePath,
+  saveSessionStore,
+  updateLastRoute,
+} from "../config/sessions.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { formatDurationMs } from "../infra/format-duration.js";
+import { emitHeartbeatEvent } from "../infra/heartbeat-events.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import { createSubsystemLogger, getChildLogger } from "../logging.js";
+import {
+  buildAgentSessionKey,
+  resolveAgentRoute,
+} from "../routing/resolve-route.js";
+import {
+  buildAgentMainSessionKey,
+  buildGroupHistoryKey,
+  DEFAULT_MAIN_KEY,
+  normalizeAgentId,
+  normalizeMainKey,
+} from "../routing/session-key.js";
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { isSelfChatMode, jidToE164, normalizeE164 } from "../utils.js";
+import { resolveWhatsAppAccount } from "./accounts.js";
+import { setActiveWebListener } from "./active-listener.js";
+import { monitorWebInbox } from "./inbound.js";
+import { loadWebMedia } from "./media.js";
+import { sendMessageWhatsApp, sendReactionWhatsApp } from "./outbound.js";
+import {
+  computeBackoff,
+  newConnectionId,
+  type ReconnectPolicy,
+  resolveHeartbeatSeconds,
+  resolveReconnectPolicy,
+  sleepWithAbort,
+} from "./reconnect.js";
+import { formatError, getWebAuthAgeMs, readWebSelfId } from "./session.js";
+
+const whatsappLog = createSubsystemLogger("gateway/channels/whatsapp");
+const whatsappInboundLog = whatsappLog.child("inbound");
+const whatsappOutboundLog = whatsappLog.child("outbound");
+const whatsappHeartbeatLog = whatsappLog.child("heartbeat");
+
+const isLikelyWhatsAppCryptoError = (reason: unknown) => {
+  const formatReason = (value: unknown): string => {
+    if (value == null) return "";
+    if (typeof value === "string") return value;
+    if (value instanceof Error) {
+      return `${value.message}\n${value.stack ?? ""}`;
+    }
+    if (typeof value === "object") {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return Object.prototype.toString.call(value);
+      }
+    }
+    if (typeof value === "number") return String(value);
+    if (typeof value === "boolean") return String(value);
+    if (typeof value === "bigint") return String(value);
+    if (typeof value === "symbol") return value.description ?? value.toString();
+    if (typeof value === "function")
+      return value.name ? `[function ${value.name}]` : "[function]";
+    return Object.prototype.toString.call(value);
+  };
+  const raw =
+    reason instanceof Error
+      ? `${reason.message}\n${reason.stack ?? ""}`
+      : formatReason(reason);
+  const haystack = raw.toLowerCase();
+  const hasAuthError =
+    haystack.includes("unsupported state or unable to authenticate data") ||
+    haystack.includes("bad mac");
+  if (!hasAuthError) return false;
+  return (
+    haystack.includes("@whiskeysockets/baileys") ||
+    haystack.includes("baileys") ||
+    haystack.includes("noise-handler") ||
+    haystack.includes("aesdecryptgcm")
+  );
+};
+
+// Send via the active gateway-backed listener. The monitor already owns the single
+// Baileys session, so use its send API directly.
+async function sendWithIpcFallback(
+  to: string,
+  message: string,
+  opts: { verbose: boolean; mediaUrl?: string },
+): Promise<{ messageId: string; toJid: string }> {
+  return sendMessageWhatsApp(to, message, opts);
+}
+
+const DEFAULT_WEB_MEDIA_BYTES = 5 * 1024 * 1024;
+type WebInboundMsg = Parameters<
+  typeof monitorWebInbox
+>[0]["onMessage"] extends (msg: infer M) => unknown
+  ? M
+  : never;
+
+export type WebMonitorTuning = {
+  reconnect?: Partial<ReconnectPolicy>;
+  heartbeatSeconds?: number;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  statusSink?: (status: WebChannelStatus) => void;
+  /** WhatsApp account id. Default: "default". */
+  accountId?: string;
+};
+
+export { HEARTBEAT_PROMPT, HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN };
+
+export type WebChannelStatus = {
+  running: boolean;
+  connected: boolean;
+  reconnectAttempts: number;
+  lastConnectedAt?: number | null;
+  lastDisconnect?: {
+    at: number;
+    status?: number;
+    error?: string;
+    loggedOut?: boolean;
+  } | null;
+  lastMessageAt?: number | null;
+  lastEventAt?: number | null;
+  lastError?: string | null;
+};
+
+function elide(text?: string, limit = 400) {
+  if (!text) return text;
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}… (truncated ${text.length - limit} chars)`;
+}
+
+type MentionConfig = {
+  mentionRegexes: RegExp[];
+  allowFrom?: Array<string | number>;
+};
+
+type MentionTargets = {
+  normalizedMentions: string[];
+  selfE164: string | null;
+  selfJid: string | null;
+};
+
+function buildMentionConfig(
+  cfg: ReturnType<typeof loadConfig>,
+  agentId?: string,
+): MentionConfig {
+  const mentionRegexes = buildMentionRegexes(cfg, agentId);
+  return { mentionRegexes, allowFrom: cfg.channels?.whatsapp?.allowFrom };
+}
+
+function resolveMentionTargets(
+  msg: WebInboundMsg,
+  authDir?: string,
+): MentionTargets {
+  const jidOptions = authDir ? { authDir } : undefined;
+  const normalizedMentions = msg.mentionedJids?.length
+    ? msg.mentionedJids
+        .map((jid) => jidToE164(jid, jidOptions) ?? jid)
+        .filter(Boolean)
+    : [];
+  const selfE164 =
+    msg.selfE164 ?? (msg.selfJid ? jidToE164(msg.selfJid, jidOptions) : null);
+  const selfJid = msg.selfJid ? msg.selfJid.replace(/:\\d+/, "") : null;
+  return { normalizedMentions, selfE164, selfJid };
+}
+
+function isBotMentionedFromTargets(
+  msg: WebInboundMsg,
+  mentionCfg: MentionConfig,
+  targets: MentionTargets,
+): boolean {
+  const clean = (text: string) =>
+    // Remove zero-width and directionality markers WhatsApp injects around display names
+    normalizeMentionText(text);
+
+  const isSelfChat = isSelfChatMode(targets.selfE164, mentionCfg.allowFrom);
+
+  if (msg.mentionedJids?.length && !isSelfChat) {
+    if (
+      targets.selfE164 &&
+      targets.normalizedMentions.includes(targets.selfE164)
+    )
+      return true;
+    if (targets.selfJid && targets.selfE164) {
+      // Some mentions use the bare JID; match on E.164 to be safe.
+      if (targets.normalizedMentions.includes(targets.selfJid)) return true;
+    }
+  } else if (msg.mentionedJids?.length && isSelfChat) {
+    // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in group chats triggers the bot.
+  }
+  const bodyClean = clean(msg.body);
+  if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) return true;
+
+  // Fallback: detect body containing our own number (with or without +, spacing)
+  if (targets.selfE164) {
+    const selfDigits = targets.selfE164.replace(/\D/g, "");
+    if (selfDigits) {
+      const bodyDigits = bodyClean.replace(/[^\d]/g, "");
+      if (bodyDigits.includes(selfDigits)) return true;
+      const bodyNoSpace = msg.body.replace(/[\s-]/g, "");
+      const pattern = new RegExp(`\\+?${selfDigits}`, "i");
+      if (pattern.test(bodyNoSpace)) return true;
+    }
+  }
+
+  return false;
+}
+
+function debugMention(
+  msg: WebInboundMsg,
+  mentionCfg: MentionConfig,
+  authDir?: string,
+): { wasMentioned: boolean; details: Record<string, unknown> } {
+  const mentionTargets = resolveMentionTargets(msg, authDir);
+  const result = isBotMentionedFromTargets(msg, mentionCfg, mentionTargets);
+  const details = {
+    from: msg.from,
+    body: msg.body,
+    bodyClean: normalizeMentionText(msg.body),
+    mentionedJids: msg.mentionedJids ?? null,
+    normalizedMentionedJids: mentionTargets.normalizedMentions.length
+      ? mentionTargets.normalizedMentions
+      : null,
+    selfJid: msg.selfJid ?? null,
+    selfJidBare: mentionTargets.selfJid,
+    selfE164: msg.selfE164 ?? null,
+    resolvedSelfE164: mentionTargets.selfE164,
+  };
+  return { wasMentioned: result, details };
+}
+
+export { stripHeartbeatToken };
+
+function resolveHeartbeatReplyPayload(
+  replyResult: ReplyPayload | ReplyPayload[] | undefined,
+): ReplyPayload | undefined {
+  if (!replyResult) return undefined;
+  if (!Array.isArray(replyResult)) return replyResult;
+  for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
+    const payload = replyResult[idx];
+    if (!payload) continue;
+    if (
+      payload.text ||
+      payload.mediaUrl ||
+      (payload.mediaUrls && payload.mediaUrls.length > 0)
+    ) {
+      return payload;
+    }
+  }
+  return undefined;
+}
+
+export async function runWebHeartbeatOnce(opts: {
+  cfg?: ReturnType<typeof loadConfig>;
+  to: string;
+  verbose?: boolean;
+  replyResolver?: typeof getReplyFromConfig;
+  sender?: typeof sendMessageWhatsApp;
+  sessionId?: string;
+  overrideBody?: string;
+  dryRun?: boolean;
+}) {
+  const {
+    cfg: cfgOverride,
+    to,
+    verbose = false,
+    sessionId,
+    overrideBody,
+    dryRun = false,
+  } = opts;
+  const replyResolver = opts.replyResolver ?? getReplyFromConfig;
+  const sender = opts.sender ?? sendWithIpcFallback;
+  const runId = newConnectionId();
+  const heartbeatLogger = getChildLogger({
+    module: "web-heartbeat",
+    runId,
+    to,
+  });
+
+  const cfg = cfgOverride ?? loadConfig();
+  const sessionCfg = cfg.session;
+  const sessionScope = sessionCfg?.scope ?? "per-sender";
+  const mainKey = normalizeMainKey(sessionCfg?.mainKey);
+  const sessionKey = resolveSessionKey(sessionScope, { From: to }, mainKey);
+  if (sessionId) {
+    const storePath = resolveStorePath(cfg.session?.store);
+    const store = loadSessionStore(storePath);
+    const current = store[sessionKey] ?? {};
+    store[sessionKey] = {
+      ...current,
+      sessionId,
+      updatedAt: Date.now(),
+    };
+    await saveSessionStore(storePath, store);
+  }
+  const sessionSnapshot = getSessionSnapshot(cfg, to, true);
+  if (verbose) {
+    heartbeatLogger.info(
+      {
+        to,
+        sessionKey: sessionSnapshot.key,
+        sessionId: sessionId ?? sessionSnapshot.entry?.sessionId ?? null,
+        sessionFresh: sessionSnapshot.fresh,
+        idleMinutes: sessionSnapshot.idleMinutes,
+      },
+      "heartbeat session snapshot",
+    );
+  }
+
+  if (overrideBody && overrideBody.trim().length === 0) {
+    throw new Error("Override body must be non-empty when provided.");
+  }
+
+  try {
+    if (overrideBody) {
+      if (dryRun) {
+        whatsappHeartbeatLog.info(
+          `[dry-run] web send -> ${to}: ${elide(overrideBody.trim(), 200)} (manual message)`,
+        );
+        return;
+      }
+      const sendResult = await sender(to, overrideBody, { verbose });
+      emitHeartbeatEvent({
+        status: "sent",
+        to,
+        preview: overrideBody.slice(0, 160),
+        hasMedia: false,
+      });
+      heartbeatLogger.info(
+        {
+          to,
+          messageId: sendResult.messageId,
+          chars: overrideBody.length,
+          reason: "manual-message",
+        },
+        "manual heartbeat message sent",
+      );
+      whatsappHeartbeatLog.info(
+        `manual heartbeat sent to ${to} (id ${sendResult.messageId})`,
+      );
+      return;
+    }
+
+    const replyResult = await replyResolver(
+      {
+        Body: resolveHeartbeatPrompt(cfg.agents?.defaults?.heartbeat?.prompt),
+        From: to,
+        To: to,
+        MessageSid: sessionId ?? sessionSnapshot.entry?.sessionId,
+      },
+      { isHeartbeat: true },
+      cfg,
+    );
+    const replyPayload = resolveHeartbeatReplyPayload(replyResult);
+
+    if (
+      !replyPayload ||
+      (!replyPayload.text &&
+        !replyPayload.mediaUrl &&
+        !replyPayload.mediaUrls?.length)
+    ) {
+      heartbeatLogger.info(
+        {
+          to,
+          reason: "empty-reply",
+          sessionId: sessionSnapshot.entry?.sessionId ?? null,
+        },
+        "heartbeat skipped",
+      );
+      if (shouldLogVerbose()) {
+        whatsappHeartbeatLog.debug("heartbeat ok (empty reply)");
+      }
+      emitHeartbeatEvent({ status: "ok-empty", to });
+      return;
+    }
+
+    const hasMedia = Boolean(
+      replyPayload.mediaUrl || (replyPayload.mediaUrls?.length ?? 0) > 0,
+    );
+    const ackMaxChars = Math.max(
+      0,
+      cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
+        DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+    );
+    const stripped = stripHeartbeatToken(replyPayload.text, {
+      mode: "heartbeat",
+      maxAckChars: ackMaxChars,
+    });
+    if (stripped.shouldSkip && !hasMedia) {
+      // Don't let heartbeats keep sessions alive: restore previous updatedAt so idle expiry still works.
+      const storePath = resolveStorePath(cfg.session?.store);
+      const store = loadSessionStore(storePath);
+      if (sessionSnapshot.entry && store[sessionSnapshot.key]) {
+        store[sessionSnapshot.key].updatedAt = sessionSnapshot.entry.updatedAt;
+        await saveSessionStore(storePath, store);
+      }
+
+      heartbeatLogger.info(
+        { to, reason: "heartbeat-token", rawLength: replyPayload.text?.length },
+        "heartbeat skipped",
+      );
+      if (shouldLogVerbose()) {
+        whatsappHeartbeatLog.debug("heartbeat ok (HEARTBEAT_OK)");
+      }
+      emitHeartbeatEvent({ status: "ok-token", to });
+      return;
+    }
+
+    if (hasMedia) {
+      heartbeatLogger.warn(
+        { to },
+        "heartbeat reply contained media; sending text only",
+      );
+    }
+
+    const finalText = stripped.text || replyPayload.text || "";
+    if (dryRun) {
+      heartbeatLogger.info(
+        { to, reason: "dry-run", chars: finalText.length },
+        "heartbeat dry-run",
+      );
+      whatsappHeartbeatLog.info(
+        `[dry-run] heartbeat -> ${to}: ${elide(finalText, 200)}`,
+      );
+      return;
+    }
+
+    const sendResult = await sender(to, finalText, { verbose });
+    emitHeartbeatEvent({
+      status: "sent",
+      to,
+      preview: finalText.slice(0, 160),
+      hasMedia,
+    });
+    heartbeatLogger.info(
+      {
+        to,
+        messageId: sendResult.messageId,
+        chars: finalText.length,
+        preview: elide(finalText, 140),
+      },
+      "heartbeat sent",
+    );
+    whatsappHeartbeatLog.info(`heartbeat alert sent to ${to}`);
+  } catch (err) {
+    const reason = formatError(err);
+    heartbeatLogger.warn({ to, error: reason }, "heartbeat failed");
+    whatsappHeartbeatLog.warn(`heartbeat failed (${reason})`);
+    emitHeartbeatEvent({ status: "failed", to, reason });
+    throw err;
+  }
+}
+
+export function resolveHeartbeatRecipients(
+  cfg: ReturnType<typeof loadConfig>,
+  opts: { to?: string; all?: boolean } = {},
+) {
+  return resolveWhatsAppHeartbeatRecipients(cfg, opts);
+}
+
+function getSessionSnapshot(
+  cfg: ReturnType<typeof loadConfig>,
+  from: string,
+  isHeartbeat = false,
+) {
+  const sessionCfg = cfg.session;
+  const scope = sessionCfg?.scope ?? "per-sender";
+  const key = resolveSessionKey(
+    scope,
+    { From: from, To: "", Body: "" },
+    normalizeMainKey(sessionCfg?.mainKey),
+  );
+  const store = loadSessionStore(resolveStorePath(sessionCfg?.store));
+  const entry = store[key];
+  const idleMinutes = Math.max(
+    (isHeartbeat
+      ? (sessionCfg?.heartbeatIdleMinutes ?? sessionCfg?.idleMinutes)
+      : sessionCfg?.idleMinutes) ?? DEFAULT_IDLE_MINUTES,
+    1,
+  );
+  const fresh = !!(
+    entry && Date.now() - entry.updatedAt <= idleMinutes * 60_000
+  );
+  return { key, entry, fresh, idleMinutes };
+}
+
+async function deliverWebReply(params: {
+  replyResult: ReplyPayload;
+  msg: WebInboundMsg;
+  maxMediaBytes: number;
+  textLimit: number;
+  replyLogger: ReturnType<typeof getChildLogger>;
+  connectionId?: string;
+  skipLog?: boolean;
+  sendTextBeforeMedia?: boolean;
+}) {
+  const {
+    replyResult,
+    msg,
+    maxMediaBytes,
+    textLimit,
+    replyLogger,
+    connectionId,
+    skipLog,
+    sendTextBeforeMedia,
+  } = params;
+  const replyStarted = Date.now();
+  const textChunks = chunkMarkdownText(replyResult.text || "", textLimit);
+  const mediaList = replyResult.mediaUrls?.length
+    ? replyResult.mediaUrls
+    : replyResult.mediaUrl
+      ? [replyResult.mediaUrl]
+      : [];
+
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  const sendWithRetry = async (
+    fn: () => Promise<unknown>,
+    label: string,
+    maxAttempts = 3,
+  ) => {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await fn();
+      } catch (err) {
+        lastErr = err;
+        const errText = formatError(err);
+        const isLast = attempt === maxAttempts;
+        const shouldRetry = /closed|reset|timed\s*out|disconnect/i.test(
+          errText,
+        );
+        if (!shouldRetry || isLast) {
+          throw err;
+        }
+        const backoffMs = 500 * attempt;
+        logVerbose(
+          `Retrying ${label} to ${msg.from} after failure (${attempt}/${maxAttempts - 1}) in ${backoffMs}ms: ${errText}`,
+        );
+        await sleep(backoffMs);
+      }
+    }
+    throw lastErr;
+  };
+
+  const sendTextChunks = async () => {
+    const totalChunks = textChunks.length;
+    for (const [index, chunk] of textChunks.entries()) {
+      const chunkStarted = Date.now();
+      await sendWithRetry(() => msg.reply(chunk), "text");
+      if (!skipLog) {
+        const durationMs = Date.now() - chunkStarted;
+        whatsappOutboundLog.debug(
+          `Sent chunk ${index + 1}/${totalChunks} to ${msg.from} (${durationMs.toFixed(0)}ms)`,
+        );
+      }
+    }
+    replyLogger.info(
+      {
+        correlationId: msg.id ?? newConnectionId(),
+        connectionId: connectionId ?? null,
+        to: msg.from,
+        from: msg.to,
+        text: elide(replyResult.text, 240),
+        mediaUrl: null,
+        mediaSizeBytes: null,
+        mediaKind: null,
+        durationMs: Date.now() - replyStarted,
+      },
+      "auto-reply sent (text)",
+    );
+  };
+
+  const hasMedia = mediaList.length > 0;
+  const sendTextFirst = sendTextBeforeMedia === true && textChunks.length > 0;
+
+  if (sendTextFirst) {
+    await sendTextChunks();
+    if (!hasMedia) {
+      return;
+    }
+  } else if (!hasMedia && textChunks.length) {
+    await sendTextChunks();
+    return;
+  } else if (!hasMedia) {
+    return;
+  }
+
+  const remainingText = sendTextFirst ? [] : [...textChunks];
+
+  // Media (with optional caption on first item)
+  for (const [index, mediaUrl] of mediaList.entries()) {
+    const caption =
+      index === 0 ? remainingText.shift() || undefined : undefined;
+    try {
+      const media = await loadWebMedia(mediaUrl, maxMediaBytes);
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `Web auto-reply media size: ${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB`,
+        );
+        logVerbose(
+          `Web auto-reply media source: ${mediaUrl} (kind ${media.kind})`,
+        );
+      }
+      if (media.kind === "image") {
+        await sendWithRetry(
+          () =>
+            msg.sendMedia({
+              image: media.buffer,
+              caption,
+              mimetype: media.contentType,
+            }),
+          "media:image",
+        );
+      } else if (media.kind === "audio") {
+        await sendWithRetry(
+          () =>
+            msg.sendMedia({
+              audio: media.buffer,
+              ptt: true,
+              mimetype: media.contentType,
+              caption,
+            }),
+          "media:audio",
+        );
+      } else if (media.kind === "video") {
+        await sendWithRetry(
+          () =>
+            msg.sendMedia({
+              video: media.buffer,
+              caption,
+              mimetype: media.contentType,
+            }),
+          "media:video",
+        );
+      } else {
+        const fileName = media.fileName ?? mediaUrl.split("/").pop() ?? "file";
+        const mimetype = media.contentType ?? "application/octet-stream";
+        await sendWithRetry(
+          () =>
+            msg.sendMedia({
+              document: media.buffer,
+              fileName,
+              caption,
+              mimetype,
+            }),
+          "media:document",
+        );
+      }
+      whatsappOutboundLog.info(
+        `Sent media reply to ${msg.from} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
+      );
+      replyLogger.info(
+        {
+          correlationId: msg.id ?? newConnectionId(),
+          connectionId: connectionId ?? null,
+          to: msg.from,
+          from: msg.to,
+          text: caption ?? null,
+          mediaUrl,
+          mediaSizeBytes: media.buffer.length,
+          mediaKind: media.kind,
+          durationMs: Date.now() - replyStarted,
+        },
+        "auto-reply sent (media)",
+      );
+    } catch (err) {
+      whatsappOutboundLog.error(
+        `Failed sending web media to ${msg.from}: ${formatError(err)}`,
+      );
+      replyLogger.warn({ err, mediaUrl }, "failed to send web media reply");
+      if (index === 0) {
+        const warning =
+          err instanceof Error
+            ? `⚠️ Media failed: ${err.message}`
+            : "⚠️ Media failed.";
+        const fallbackTextParts = [
+          remainingText.shift() ?? caption ?? "",
+          warning,
+        ].filter(Boolean);
+        const fallbackText = fallbackTextParts.join("\n");
+        if (fallbackText) {
+          whatsappOutboundLog.warn(
+            `Media skipped; sent text-only to ${msg.from}`,
+          );
+          await msg.reply(fallbackText);
+        }
+      }
+    }
+  }
+
+  // Remaining text chunks after media
+  for (const chunk of remainingText) {
+    await msg.reply(chunk);
+  }
+}
+
+export async function monitorWebChannel(
+  verbose: boolean,
+  listenerFactory: typeof monitorWebInbox | undefined = monitorWebInbox,
+  keepAlive = true,
+  replyResolver: typeof getReplyFromConfig | undefined = getReplyFromConfig,
+  runtime: RuntimeEnv = defaultRuntime,
+  abortSignal?: AbortSignal,
+  tuning: WebMonitorTuning = {},
+) {
+  const runId = newConnectionId();
+  const replyLogger = getChildLogger({ module: "web-auto-reply", runId });
+  const heartbeatLogger = getChildLogger({ module: "web-heartbeat", runId });
+  const reconnectLogger = getChildLogger({ module: "web-reconnect", runId });
+  const status: WebChannelStatus = {
+    running: true,
+    connected: false,
+    reconnectAttempts: 0,
+    lastConnectedAt: null,
+    lastDisconnect: null,
+    lastMessageAt: null,
+    lastEventAt: null,
+    lastError: null,
+  };
+  const emitStatus = () => {
+    tuning.statusSink?.({
+      ...status,
+      lastDisconnect: status.lastDisconnect
+        ? { ...status.lastDisconnect }
+        : null,
+    });
+  };
+  emitStatus();
+  const baseCfg = loadConfig();
+  const account = resolveWhatsAppAccount({
+    cfg: baseCfg,
+    accountId: tuning.accountId,
+  });
+  const cfg = {
+    ...baseCfg,
+    channels: {
+      ...baseCfg.channels,
+      whatsapp: {
+        ...baseCfg.channels?.whatsapp,
+        ackReaction: account.ackReaction,
+        messagePrefix: account.messagePrefix,
+        allowFrom: account.allowFrom,
+        groupAllowFrom: account.groupAllowFrom,
+        groupPolicy: account.groupPolicy,
+        textChunkLimit: account.textChunkLimit,
+        mediaMaxMb: account.mediaMaxMb,
+        blockStreaming: account.blockStreaming,
+        groups: account.groups,
+      },
+    },
+  } satisfies ReturnType<typeof loadConfig>;
+  const configuredMaxMb = cfg.agents?.defaults?.mediaMaxMb;
+  const maxMediaBytes =
+    typeof configuredMaxMb === "number" && configuredMaxMb > 0
+      ? configuredMaxMb * 1024 * 1024
+      : DEFAULT_WEB_MEDIA_BYTES;
+  const heartbeatSeconds = resolveHeartbeatSeconds(
+    cfg,
+    tuning.heartbeatSeconds,
+  );
+  const reconnectPolicy = resolveReconnectPolicy(cfg, tuning.reconnect);
+  const resolveMentionConfig = (agentId?: string) =>
+    buildMentionConfig(cfg, agentId);
+  const baseMentionConfig = resolveMentionConfig();
+  const groupHistoryLimit =
+    cfg.channels?.whatsapp?.accounts?.[tuning.accountId ?? ""]?.historyLimit ??
+    cfg.channels?.whatsapp?.historyLimit ??
+    cfg.messages?.groupChat?.historyLimit ??
+    DEFAULT_GROUP_HISTORY_LIMIT;
+  const groupHistories = new Map<
+    string,
+    Array<{
+      sender: string;
+      body: string;
+      timestamp?: number;
+      id?: string;
+      senderJid?: string;
+    }>
+  >();
+  const groupMemberNames = new Map<string, Map<string, string>>();
+  const sleep =
+    tuning.sleep ??
+    ((ms: number, signal?: AbortSignal) =>
+      sleepWithAbort(ms, signal ?? abortSignal));
+  const stopRequested = () => abortSignal?.aborted === true;
+  const abortPromise =
+    abortSignal &&
+    new Promise<"aborted">((resolve) =>
+      abortSignal.addEventListener("abort", () => resolve("aborted"), {
+        once: true,
+      }),
+    );
+
+  const noteGroupMember = (
+    conversationId: string,
+    e164?: string,
+    name?: string,
+  ) => {
+    if (!e164 || !name) return;
+    const normalized = normalizeE164(e164);
+    const key = normalized ?? e164;
+    if (!key) return;
+    let roster = groupMemberNames.get(conversationId);
+    if (!roster) {
+      roster = new Map();
+      groupMemberNames.set(conversationId, roster);
+    }
+    roster.set(key, name);
+  };
+
+  const formatGroupMembers = (
+    participants: string[] | undefined,
+    roster: Map<string, string> | undefined,
+    fallbackE164?: string,
+  ) => {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    if (participants?.length) {
+      for (const entry of participants) {
+        if (!entry) continue;
+        const normalized = normalizeE164(entry) ?? entry;
+        if (!normalized || seen.has(normalized)) continue;
+        seen.add(normalized);
+        ordered.push(normalized);
+      }
+    }
+    if (roster) {
+      for (const entry of roster.keys()) {
+        const normalized = normalizeE164(entry) ?? entry;
+        if (!normalized || seen.has(normalized)) continue;
+        seen.add(normalized);
+        ordered.push(normalized);
+      }
+    }
+    if (ordered.length === 0 && fallbackE164) {
+      const normalized = normalizeE164(fallbackE164) ?? fallbackE164;
+      if (normalized) ordered.push(normalized);
+    }
+    if (ordered.length === 0) return undefined;
+    return ordered
+      .map((entry) => {
+        const name = roster?.get(entry);
+        return name ? `${name} (${entry})` : entry;
+      })
+      .join(", ");
+  };
+
+  const resolveGroupResolution = (conversationId: string) =>
+    resolveGroupSessionKey({
+      From: conversationId,
+      ChatType: "group",
+      Provider: "whatsapp",
+    });
+
+  const resolveGroupPolicyFor = (conversationId: string) => {
+    const groupId =
+      resolveGroupResolution(conversationId)?.id ?? conversationId;
+    return resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId,
+    });
+  };
+
+  const resolveGroupRequireMentionFor = (conversationId: string) => {
+    const groupId =
+      resolveGroupResolution(conversationId)?.id ?? conversationId;
+    return resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId,
+    });
+  };
+
+  const resolveGroupActivationFor = (params: {
+    agentId: string;
+    sessionKey: string;
+    conversationId: string;
+  }) => {
+    const storePath = resolveStorePath(cfg.session?.store, {
+      agentId: params.agentId,
+    });
+    const store = loadSessionStore(storePath);
+    const entry = store[params.sessionKey];
+    const requireMention = resolveGroupRequireMentionFor(params.conversationId);
+    const defaultActivation = requireMention === false ? "always" : "mention";
+    return (
+      normalizeGroupActivation(entry?.groupActivation) ?? defaultActivation
+    );
+  };
+
+  const resolveOwnerList = (selfE164?: string | null) => {
+    const allowFrom = baseMentionConfig.allowFrom;
+    const raw =
+      Array.isArray(allowFrom) && allowFrom.length > 0
+        ? allowFrom
+        : selfE164
+          ? [selfE164]
+          : [];
+    return raw
+      .filter((entry): entry is string => Boolean(entry && entry !== "*"))
+      .map((entry) => normalizeE164(entry))
+      .filter((entry): entry is string => Boolean(entry));
+  };
+
+  const isOwnerSender = (msg: WebInboundMsg) => {
+    const sender = normalizeE164(msg.senderE164 ?? "");
+    if (!sender) return false;
+    const owners = resolveOwnerList(msg.selfE164 ?? undefined);
+    return owners.includes(sender);
+  };
+
+  const isStatusCommand = (body: string) => {
+    const trimmed = body.trim().toLowerCase();
+    if (!trimmed) return false;
+    return (
+      trimmed === "/status" ||
+      trimmed === "status" ||
+      trimmed.startsWith("/status ")
+    );
+  };
+
+  const stripMentionsForCommand = (
+    text: string,
+    mentionRegexes: RegExp[],
+    selfE164?: string | null,
+  ) => {
+    let result = text;
+    for (const re of mentionRegexes) {
+      result = result.replace(re, " ");
+    }
+    if (selfE164) {
+      const digits = selfE164.replace(/\D/g, "");
+      if (digits) {
+        const pattern = new RegExp(`\\+?${digits}`, "g");
+        result = result.replace(pattern, " ");
+      }
+    }
+    return result.replace(/\s+/g, " ").trim();
+  };
+
+  // Avoid noisy MaxListenersExceeded warnings in test environments where
+  // multiple gateway instances may be constructed.
+  const currentMaxListeners = process.getMaxListeners?.() ?? 10;
+  if (process.setMaxListeners && currentMaxListeners < 50) {
+    process.setMaxListeners(50);
+  }
+
+  let sigintStop = false;
+  const handleSigint = () => {
+    sigintStop = true;
+  };
+  process.once("SIGINT", handleSigint);
+
+  let reconnectAttempts = 0;
+
+  // Track recently sent messages to prevent echo loops
+  const recentlySent = new Set<string>();
+  const MAX_RECENT_MESSAGES = 100;
+  const buildCombinedEchoKey = (params: {
+    sessionKey: string;
+    combinedBody: string;
+  }) => `combined:${params.sessionKey}:${params.combinedBody}`;
+  const rememberSentText = (
+    text: string | undefined,
+    opts: {
+      combinedBody?: string;
+      combinedBodySessionKey?: string;
+      logVerboseMessage?: boolean;
+    },
+  ) => {
+    if (!text) return;
+    recentlySent.add(text);
+    if (opts.combinedBody && opts.combinedBodySessionKey) {
+      recentlySent.add(
+        buildCombinedEchoKey({
+          sessionKey: opts.combinedBodySessionKey,
+          combinedBody: opts.combinedBody,
+        }),
+      );
+    }
+    if (opts.logVerboseMessage) {
+      logVerbose(
+        `Added to echo detection set (size now: ${recentlySent.size}): ${text.substring(0, 50)}...`,
+      );
+    }
+    if (recentlySent.size > MAX_RECENT_MESSAGES) {
+      const firstKey = recentlySent.values().next().value;
+      if (firstKey) recentlySent.delete(firstKey);
+    }
+  };
+
+  while (true) {
+    if (stopRequested()) break;
+
+    const connectionId = newConnectionId();
+    const startedAt = Date.now();
+    let heartbeat: NodeJS.Timeout | null = null;
+    let watchdogTimer: NodeJS.Timeout | null = null;
+    let lastMessageAt: number | null = null;
+    let handledMessages = 0;
+    let _lastInboundMsg: WebInboundMsg | null = null;
+    let unregisterUnhandled: (() => void) | null = null;
+
+    // Watchdog to detect stuck message processing (e.g., event emitter died)
+    // Should be significantly longer than the reply heartbeat interval to avoid false positives
+    const MESSAGE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes without any messages
+    const WATCHDOG_CHECK_MS = 60 * 1000; // Check every minute
+
+    const backgroundTasks = new Set<Promise<unknown>>();
+
+    const formatReplyContext = (msg: WebInboundMsg) => {
+      if (!msg.replyToBody) return null;
+      const sender = msg.replyToSender ?? "unknown sender";
+      const idPart = msg.replyToId ? ` id:${msg.replyToId}` : "";
+      return `[Replying to ${sender}${idPart}]\n${msg.replyToBody}\n[/Replying]`;
+    };
+
+    const buildLine = (msg: WebInboundMsg, agentId: string) => {
+      // WhatsApp inbound prefix: channels.whatsapp.messagePrefix > legacy messages.messagePrefix > identity/defaults
+      const messagePrefix = resolveMessagePrefix(cfg, agentId, {
+        configured: cfg.channels?.whatsapp?.messagePrefix,
+        hasAllowFrom: (cfg.channels?.whatsapp?.allowFrom?.length ?? 0) > 0,
+      });
+      const prefixStr = messagePrefix ? `${messagePrefix} ` : "";
+      const senderLabel =
+        msg.chatType === "group"
+          ? `${msg.senderName ?? msg.senderE164 ?? "Someone"}: `
+          : "";
+      const replyContext = formatReplyContext(msg);
+      const baseLine = `${prefixStr}${senderLabel}${msg.body}${
+        replyContext ? `\n\n${replyContext}` : ""
+      }`;
+
+      // Wrap with standardized envelope for the agent.
+      return formatAgentEnvelope({
+        channel: "WhatsApp",
+        from:
+          msg.chatType === "group"
+            ? msg.from
+            : msg.from?.replace(/^whatsapp:/, ""),
+        timestamp: msg.timestamp,
+        body: baseLine,
+      });
+    };
+
+    const processMessage = async (
+      msg: WebInboundMsg,
+      route: ReturnType<typeof resolveAgentRoute>,
+      groupHistoryKey: string,
+      opts?: {
+        groupHistory?: Array<{
+          sender: string;
+          body: string;
+          timestamp?: number;
+          id?: string;
+          senderJid?: string;
+        }>;
+        suppressGroupHistoryClear?: boolean;
+      },
+    ): Promise<boolean> => {
+      status.lastMessageAt = Date.now();
+      status.lastEventAt = status.lastMessageAt;
+      emitStatus();
+      const conversationId = msg.conversationId ?? msg.from;
+      let combinedBody = buildLine(msg, route.agentId);
+      let shouldClearGroupHistory = false;
+
+      if (msg.chatType === "group") {
+        const history =
+          opts?.groupHistory ?? groupHistories.get(groupHistoryKey) ?? [];
+        const historyWithoutCurrent =
+          history.length > 0 ? history.slice(0, -1) : [];
+        if (historyWithoutCurrent.length > 0) {
+          const lineBreak = "\\n";
+          const historyText = historyWithoutCurrent
+            .map((m) => {
+              const bodyWithId = m.id
+                ? `${m.body}\n[message_id: ${m.id}]`
+                : m.body;
+              return formatAgentEnvelope({
+                channel: "WhatsApp",
+                from: conversationId,
+                timestamp: m.timestamp,
+                body: `${m.sender}: ${bodyWithId}`,
+              });
+            })
+            .join(lineBreak);
+          combinedBody = buildHistoryContext({
+            historyText,
+            currentMessage: buildLine(msg, route.agentId),
+            lineBreak,
+          });
+        }
+        // Always surface who sent the triggering message so the agent can address them.
+        const senderLabel =
+          msg.senderName && msg.senderE164
+            ? `${msg.senderName} (${msg.senderE164})`
+            : (msg.senderName ?? msg.senderE164 ?? "Unknown");
+        combinedBody = `${combinedBody}\\n[from: ${senderLabel}]`;
+        shouldClearGroupHistory = !(opts?.suppressGroupHistoryClear ?? false);
+      }
+
+      // Echo detection uses combined body so we don't respond twice.
+      const combinedEchoKey = buildCombinedEchoKey({
+        sessionKey: route.sessionKey,
+        combinedBody,
+      });
+      if (recentlySent.has(combinedEchoKey)) {
+        logVerbose(`Skipping auto-reply: detected echo for combined message`);
+        recentlySent.delete(combinedEchoKey);
+        return false;
+      }
+
+      // Send ack reaction immediately upon message receipt (post-gating)
+      if (msg.id) {
+        const ackConfig = cfg.channels?.whatsapp?.ackReaction;
+        const emoji = (ackConfig?.emoji ?? "").trim();
+        const directEnabled = ackConfig?.direct ?? true;
+        const groupMode = ackConfig?.group ?? "mentions";
+        const conversationIdForCheck = msg.conversationId ?? msg.from;
+
+        const shouldSendReaction = () => {
+          if (!emoji) return false;
+
+          if (msg.chatType === "direct") {
+            return directEnabled;
+          }
+
+          if (msg.chatType === "group") {
+            if (groupMode === "never") return false;
+            if (groupMode === "always") return true;
+            if (groupMode === "mentions") {
+              const activation = resolveGroupActivationFor({
+                agentId: route.agentId,
+                sessionKey: route.sessionKey,
+                conversationId: conversationIdForCheck,
+              });
+              if (activation === "always") return true;
+              return msg.wasMentioned === true;
+            }
+          }
+
+          return false;
+        };
+
+        if (shouldSendReaction()) {
+          replyLogger.info(
+            { chatId: msg.chatId, messageId: msg.id, emoji },
+            "sending ack reaction",
+          );
+          sendReactionWhatsApp(msg.chatId, msg.id, emoji, {
+            verbose,
+            fromMe: false,
+            participant: msg.senderJid,
+            accountId: route.accountId,
+          }).catch((err) => {
+            replyLogger.warn(
+              {
+                error: formatError(err),
+                chatId: msg.chatId,
+                messageId: msg.id,
+              },
+              "failed to send ack reaction",
+            );
+            logVerbose(
+              `WhatsApp ack reaction failed for chat ${msg.chatId}: ${formatError(err)}`,
+            );
+          });
+        }
+      }
+
+      const correlationId = msg.id ?? newConnectionId();
+      replyLogger.info(
+        {
+          connectionId,
+          correlationId,
+          from: msg.chatType === "group" ? conversationId : msg.from,
+          to: msg.to,
+          body: elide(combinedBody, 240),
+          mediaType: msg.mediaType ?? null,
+          mediaPath: msg.mediaPath ?? null,
+        },
+        "inbound web message",
+      );
+
+      const fromDisplay = msg.chatType === "group" ? conversationId : msg.from;
+      const kindLabel = msg.mediaType ? `, ${msg.mediaType}` : "";
+      whatsappInboundLog.info(
+        `Inbound message ${fromDisplay} -> ${msg.to} (${msg.chatType}${kindLabel}, ${combinedBody.length} chars)`,
+      );
+      if (shouldLogVerbose()) {
+        whatsappInboundLog.debug(`Inbound body: ${elide(combinedBody, 400)}`);
+      }
+
+      if (msg.chatType !== "group") {
+        const sessionCfg = cfg.session;
+        const storePath = resolveStorePath(sessionCfg?.store, {
+          agentId: route.agentId,
+        });
+        const to = (() => {
+          if (msg.senderE164) return normalizeE164(msg.senderE164);
+          // In direct chats, `msg.from` is already the canonical conversation id,
+          // which is an E.164 string (e.g. "+1555"). Only fall back to JID parsing
+          // when we were handed a JID-like string.
+          if (msg.from.includes("@")) return jidToE164(msg.from);
+          return normalizeE164(msg.from);
+        })();
+        if (to) {
+          const task = updateLastRoute({
+            storePath,
+            sessionKey: route.mainSessionKey,
+            channel: "whatsapp",
+            to,
+            accountId: route.accountId,
+          }).catch((err) => {
+            replyLogger.warn(
+              {
+                error: formatError(err),
+                storePath,
+                sessionKey: route.mainSessionKey,
+                to,
+              },
+              "failed updating last route",
+            );
+          });
+          backgroundTasks.add(task);
+          void task.finally(() => {
+            backgroundTasks.delete(task);
+          });
+        }
+      }
+
+      const textLimit = resolveTextChunkLimit(cfg, "whatsapp");
+      let didLogHeartbeatStrip = false;
+      let didSendReply = false;
+      let didSendVoiceReply = false;
+      const responsePrefix = resolveEffectiveMessagesConfig(
+        cfg,
+        route.agentId,
+      ).responsePrefix;
+      const dispatchCtx = {
+        Body: combinedBody,
+        RawBody: msg.body,
+        CommandBody: msg.body,
+        From: msg.from,
+        To: msg.to,
+        SessionKey: route.sessionKey,
+        AccountId: route.accountId,
+        MessageSid: msg.id,
+        ReplyToId: msg.replyToId,
+        ReplyToBody: msg.replyToBody,
+        ReplyToSender: msg.replyToSender,
+        MediaPath: msg.mediaPath,
+        MediaUrl: msg.mediaUrl,
+        MediaType: msg.mediaType,
+        ChatType: msg.chatType,
+        GroupSubject: msg.groupSubject,
+        GroupMembers: formatGroupMembers(
+          msg.groupParticipants,
+          groupMemberNames.get(groupHistoryKey),
+          msg.senderE164,
+        ),
+        SenderName: msg.senderName,
+        SenderId: msg.senderJid?.trim() || msg.senderE164,
+        SenderE164: msg.senderE164,
+        WasMentioned: msg.wasMentioned,
+        ...(msg.location ? toLocationContext(msg.location) : {}),
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        OriginatingChannel: "whatsapp",
+        OriginatingTo: msg.from,
+      } satisfies MsgContext;
+      const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
+        ctx: dispatchCtx,
+        cfg,
+        replyResolver,
+        dispatcherOptions: {
+          responsePrefix,
+          onHeartbeatStrip: () => {
+            if (!didLogHeartbeatStrip) {
+              didLogHeartbeatStrip = true;
+              logVerbose("Stripped stray HEARTBEAT_OK token from web reply");
+            }
+          },
+          deliver: async (payload, info) => {
+            let replyPayload = payload;
+            let sendTextBeforeMedia = false;
+            const replyText = replyPayload.text?.trim();
+            if (
+              info.kind === "final" &&
+              !didSendVoiceReply &&
+              isAudio(msg.mediaType) &&
+              !replyPayload.mediaUrl &&
+              (replyPayload.mediaUrls?.length ?? 0) === 0 &&
+              replyText &&
+              cfg.audio?.reply?.command?.length
+            ) {
+              const audioReply = await synthesizeReplyAudio({
+                cfg,
+                ctx: dispatchCtx,
+                replyText,
+                runtime: defaultRuntime,
+              });
+              if (audioReply?.mediaUrls?.length) {
+                replyPayload = {
+                  ...replyPayload,
+                  mediaUrls: audioReply.mediaUrls,
+                  mediaUrl: audioReply.mediaUrls[0],
+                  audioAsVoice:
+                    audioReply.audioAsVoice ?? replyPayload.audioAsVoice,
+                };
+                sendTextBeforeMedia = true;
+                didSendVoiceReply = true;
+              }
+            }
+            await deliverWebReply({
+              replyResult: replyPayload,
+              msg,
+              maxMediaBytes,
+              textLimit,
+              replyLogger,
+              connectionId,
+              sendTextBeforeMedia,
+              // Tool + block updates are noisy; skip their log lines.
+              skipLog: info.kind !== "final",
+            });
+            didSendReply = true;
+            if (info.kind === "tool") {
+              rememberSentText(replyPayload.text, {});
+              return;
+            }
+            const shouldLog =
+              info.kind === "final" && replyPayload.text ? true : undefined;
+            rememberSentText(replyPayload.text, {
+              combinedBody,
+              combinedBodySessionKey: route.sessionKey,
+              logVerboseMessage: shouldLog,
+            });
+            if (info.kind === "final") {
+              const fromDisplay =
+                msg.chatType === "group"
+                  ? conversationId
+                  : (msg.from ?? "unknown");
+              const hasMedia = Boolean(
+                replyPayload.mediaUrl || replyPayload.mediaUrls?.length,
+              );
+              whatsappOutboundLog.info(
+                `Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`,
+              );
+              if (shouldLogVerbose()) {
+                const preview =
+                  replyPayload.text != null
+                    ? elide(replyPayload.text, 400)
+                    : "<media>";
+                whatsappOutboundLog.debug(
+                  `Reply body: ${preview}${hasMedia ? " (media)" : ""}`,
+                );
+              }
+            }
+          },
+          onError: (err, info) => {
+            const label =
+              info.kind === "tool"
+                ? "tool update"
+                : info.kind === "block"
+                  ? "block update"
+                  : "auto-reply";
+            whatsappOutboundLog.error(
+              `Failed sending web ${label} to ${msg.from ?? conversationId}: ${formatError(err)}`,
+            );
+          },
+          onReplyStart: msg.sendComposing,
+        },
+        replyOptions: {
+          disableBlockStreaming:
+            typeof cfg.channels?.whatsapp?.blockStreaming === "boolean"
+              ? !cfg.channels.whatsapp.blockStreaming
+              : undefined,
+        },
+      });
+      if (!queuedFinal) {
+        if (shouldClearGroupHistory && didSendReply) {
+          groupHistories.set(groupHistoryKey, []);
+        }
+        logVerbose(
+          "Skipping auto-reply: silent token or no text/media returned from resolver",
+        );
+        return false;
+      }
+
+      if (shouldClearGroupHistory && didSendReply) {
+        groupHistories.set(groupHistoryKey, []);
+      }
+
+      return didSendReply;
+    };
+
+    const maybeBroadcastMessage = async (params: {
+      msg: WebInboundMsg;
+      peerId: string;
+      route: ReturnType<typeof resolveAgentRoute>;
+      groupHistoryKey: string;
+    }): Promise<boolean> => {
+      const { msg, peerId, route, groupHistoryKey } = params;
+      const broadcastAgents = cfg.broadcast?.[peerId];
+      if (!broadcastAgents || !Array.isArray(broadcastAgents)) return false;
+      if (broadcastAgents.length === 0) return false;
+
+      const strategy = cfg.broadcast?.strategy || "parallel";
+      whatsappInboundLog.info(
+        `Broadcasting message to ${broadcastAgents.length} agents (${strategy})`,
+      );
+
+      const agentIds = cfg.agents?.list?.map((agent) =>
+        normalizeAgentId(agent.id),
+      );
+      const hasKnownAgents = (agentIds?.length ?? 0) > 0;
+      const groupHistorySnapshot =
+        msg.chatType === "group"
+          ? (groupHistories.get(groupHistoryKey) ?? [])
+          : undefined;
+
+      const processForAgent = async (agentId: string): Promise<boolean> => {
+        const normalizedAgentId = normalizeAgentId(agentId);
+        if (hasKnownAgents && !agentIds?.includes(normalizedAgentId)) {
+          whatsappInboundLog.warn(
+            `Broadcast agent ${agentId} not found in agents.list; skipping`,
+          );
+          return false;
+        }
+        const agentRoute = {
+          ...route,
+          agentId: normalizedAgentId,
+          sessionKey: buildAgentSessionKey({
+            agentId: normalizedAgentId,
+            channel: "whatsapp",
+            peer: {
+              kind: msg.chatType === "group" ? "group" : "dm",
+              id: peerId,
+            },
+          }),
+          mainSessionKey: buildAgentMainSessionKey({
+            agentId: normalizedAgentId,
+            mainKey: DEFAULT_MAIN_KEY,
+          }),
+        };
+
+        try {
+          return await processMessage(msg, agentRoute, groupHistoryKey, {
+            groupHistory: groupHistorySnapshot,
+            suppressGroupHistoryClear: true,
+          });
+        } catch (err) {
+          whatsappInboundLog.error(
+            `Broadcast agent ${agentId} failed: ${formatError(err)}`,
+          );
+          return false;
+        }
+      };
+
+      let didSendReply = false;
+      if (strategy === "sequential") {
+        for (const agentId of broadcastAgents) {
+          if (await processForAgent(agentId)) didSendReply = true;
+        }
+      } else {
+        const results = await Promise.allSettled(
+          broadcastAgents.map(processForAgent),
+        );
+        didSendReply = results.some(
+          (result) => result.status === "fulfilled" && result.value,
+        );
+      }
+
+      if (msg.chatType === "group" && didSendReply) {
+        groupHistories.set(groupHistoryKey, []);
+      }
+
+      return true;
+    };
+
+    const listener = await (listenerFactory ?? monitorWebInbox)({
+      verbose,
+      accountId: account.accountId,
+      authDir: account.authDir,
+      mediaMaxMb: account.mediaMaxMb,
+      onMessage: async (msg) => {
+        handledMessages += 1;
+        lastMessageAt = Date.now();
+        status.lastMessageAt = lastMessageAt;
+        status.lastEventAt = lastMessageAt;
+        emitStatus();
+        _lastInboundMsg = msg;
+        const conversationId = msg.conversationId ?? msg.from;
+        const peerId =
+          msg.chatType === "group"
+            ? conversationId
+            : (() => {
+                if (msg.senderE164) {
+                  return normalizeE164(msg.senderE164) ?? msg.senderE164;
+                }
+                if (msg.from.includes("@")) {
+                  return jidToE164(msg.from) ?? msg.from;
+                }
+                return normalizeE164(msg.from) ?? msg.from;
+              })();
+        const route = resolveAgentRoute({
+          cfg,
+          channel: "whatsapp",
+          accountId: msg.accountId,
+          peer: {
+            kind: msg.chatType === "group" ? "group" : "dm",
+            id: peerId,
+          },
+        });
+        const groupHistoryKey =
+          msg.chatType === "group"
+            ? buildGroupHistoryKey({
+                channel: "whatsapp",
+                accountId: route.accountId,
+                peerKind: "group",
+                peerId,
+              })
+            : route.sessionKey;
+
+        // Same-phone mode logging retained
+        if (msg.from === msg.to) {
+          logVerbose(`📱 Same-phone mode detected (from === to: ${msg.from})`);
+        }
+
+        // Skip if this is a message we just sent (echo detection)
+        if (recentlySent.has(msg.body)) {
+          whatsappInboundLog.debug(
+            "Skipping echo: detected recently sent message",
+          );
+          logVerbose(
+            `Skipping auto-reply: detected echo (message matches recently sent text)`,
+          );
+          recentlySent.delete(msg.body);
+          return;
+        }
+
+        if (msg.chatType === "group") {
+          const groupPolicy = resolveGroupPolicyFor(conversationId);
+          if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
+            logVerbose(
+              `Skipping group message ${conversationId} (not in allowlist)`,
+            );
+            return;
+          }
+          {
+            const storePath = resolveStorePath(cfg.session?.store, {
+              agentId: route.agentId,
+            });
+            const task = updateLastRoute({
+              storePath,
+              sessionKey: route.sessionKey,
+              channel: "whatsapp",
+              to: conversationId,
+              accountId: route.accountId,
+            }).catch((err) => {
+              replyLogger.warn(
+                {
+                  error: formatError(err),
+                  storePath,
+                  sessionKey: route.sessionKey,
+                  to: conversationId,
+                },
+                "failed updating last route",
+              );
+            });
+            backgroundTasks.add(task);
+            void task.finally(() => {
+              backgroundTasks.delete(task);
+            });
+          }
+          noteGroupMember(groupHistoryKey, msg.senderE164, msg.senderName);
+          const mentionConfig = resolveMentionConfig(route.agentId);
+          const commandBody = stripMentionsForCommand(
+            msg.body,
+            mentionConfig.mentionRegexes,
+            msg.selfE164,
+          );
+          const activationCommand = parseActivationCommand(commandBody);
+          const isOwner = isOwnerSender(msg);
+          const statusCommand = isStatusCommand(commandBody);
+          const shouldBypassMention =
+            isOwner && (activationCommand.hasCommand || statusCommand);
+
+          if (activationCommand.hasCommand && !isOwner) {
+            logVerbose(
+              `Ignoring /activation from non-owner in group ${conversationId}`,
+            );
+            return;
+          }
+
+          if (!shouldBypassMention) {
+            const history =
+              groupHistories.get(groupHistoryKey) ??
+              ([] as Array<{
+                sender: string;
+                body: string;
+                timestamp?: number;
+                id?: string;
+                senderJid?: string;
+              }>);
+            const sender =
+              msg.senderName && msg.senderE164
+                ? `${msg.senderName} (${msg.senderE164})`
+                : (msg.senderName ?? msg.senderE164 ?? "Unknown");
+            history.push({
+              sender,
+              body: msg.body,
+              timestamp: msg.timestamp,
+              id: msg.id,
+              senderJid: msg.senderJid,
+            });
+            while (history.length > groupHistoryLimit) history.shift();
+            groupHistories.set(groupHistoryKey, history);
+          }
+
+          const mentionDebug = debugMention(
+            msg,
+            mentionConfig,
+            account.authDir,
+          );
+          replyLogger.debug(
+            {
+              conversationId,
+              wasMentioned: mentionDebug.wasMentioned,
+              ...mentionDebug.details,
+            },
+            "group mention debug",
+          );
+          const wasMentioned = mentionDebug.wasMentioned;
+          msg.wasMentioned = wasMentioned;
+          const activation = resolveGroupActivationFor({
+            agentId: route.agentId,
+            sessionKey: route.sessionKey,
+            conversationId,
+          });
+          const requireMention = activation !== "always";
+          if (!shouldBypassMention && requireMention && !wasMentioned) {
+            logVerbose(
+              `Group message stored for context (no mention detected) in ${conversationId}: ${msg.body}`,
+            );
+            return;
+          }
+        }
+
+        // Broadcast groups: when we'd reply anyway, run multiple agents.
+        // Does not bypass group mention/activation gating above (Option A).
+        if (
+          await maybeBroadcastMessage({ msg, peerId, route, groupHistoryKey })
+        ) {
+          return;
+        }
+
+        await processMessage(msg, route, groupHistoryKey);
+      },
+    });
+
+    status.connected = true;
+    status.lastConnectedAt = Date.now();
+    status.lastEventAt = status.lastConnectedAt;
+    status.lastError = null;
+    emitStatus();
+
+    // Surface a concise connection event for the next main-session turn/heartbeat.
+    const { e164: selfE164 } = readWebSelfId(account.authDir);
+    const connectRoute = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: account.accountId,
+    });
+    enqueueSystemEvent(
+      `WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`,
+      { sessionKey: connectRoute.sessionKey },
+    );
+
+    setActiveWebListener(account.accountId, listener);
+    unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
+      if (!isLikelyWhatsAppCryptoError(reason)) return false;
+      const errorStr = formatError(reason);
+      reconnectLogger.warn(
+        { connectionId, error: errorStr },
+        "web reconnect: unhandled rejection from WhatsApp socket; forcing reconnect",
+      );
+      listener.signalClose?.({
+        status: 499,
+        isLoggedOut: false,
+        error: reason,
+      });
+      return true;
+    });
+
+    const closeListener = async () => {
+      setActiveWebListener(account.accountId, null);
+      if (unregisterUnhandled) {
+        unregisterUnhandled();
+        unregisterUnhandled = null;
+      }
+      if (heartbeat) clearInterval(heartbeat);
+      if (watchdogTimer) clearInterval(watchdogTimer);
+      if (backgroundTasks.size > 0) {
+        await Promise.allSettled(backgroundTasks);
+        backgroundTasks.clear();
+      }
+      try {
+        await listener.close();
+      } catch (err) {
+        logVerbose(`Socket close failed: ${formatError(err)}`);
+      }
+    };
+
+    if (keepAlive) {
+      heartbeat = setInterval(() => {
+        const authAgeMs = getWebAuthAgeMs(account.authDir);
+        const minutesSinceLastMessage = lastMessageAt
+          ? Math.floor((Date.now() - lastMessageAt) / 60000)
+          : null;
+
+        const logData = {
+          connectionId,
+          reconnectAttempts,
+          messagesHandled: handledMessages,
+          lastMessageAt,
+          authAgeMs,
+          uptimeMs: Date.now() - startedAt,
+          ...(minutesSinceLastMessage !== null && minutesSinceLastMessage > 30
+            ? { minutesSinceLastMessage }
+            : {}),
+        };
+
+        // Warn if no messages in 30+ minutes
+        if (minutesSinceLastMessage && minutesSinceLastMessage > 30) {
+          heartbeatLogger.warn(
+            logData,
+            "⚠️ web gateway heartbeat - no messages in 30+ minutes",
+          );
+        } else {
+          heartbeatLogger.info(logData, "web gateway heartbeat");
+        }
+      }, heartbeatSeconds * 1000);
+
+      // Watchdog: Auto-restart if no messages received for MESSAGE_TIMEOUT_MS
+      watchdogTimer = setInterval(() => {
+        if (lastMessageAt) {
+          const timeSinceLastMessage = Date.now() - lastMessageAt;
+          if (timeSinceLastMessage > MESSAGE_TIMEOUT_MS) {
+            const minutesSinceLastMessage = Math.floor(
+              timeSinceLastMessage / 60000,
+            );
+            heartbeatLogger.warn(
+              {
+                connectionId,
+                minutesSinceLastMessage,
+                lastMessageAt: new Date(lastMessageAt),
+                messagesHandled: handledMessages,
+              },
+              "Message timeout detected - forcing reconnect",
+            );
+            whatsappHeartbeatLog.warn(
+              `No messages received in ${minutesSinceLastMessage}m - restarting connection`,
+            );
+            void closeListener().catch((err) => {
+              logVerbose(`Close listener failed: ${formatError(err)}`);
+            }); // Trigger reconnect
+            listener.signalClose?.({
+              status: 499,
+              isLoggedOut: false,
+              error: "watchdog-timeout",
+            });
+          }
+        }
+      }, WATCHDOG_CHECK_MS);
+    }
+
+    whatsappLog.info("Listening for personal WhatsApp inbound messages.");
+    if (process.stdout.isTTY || process.stderr.isTTY) {
+      whatsappLog.raw("Ctrl+C to stop.");
+    }
+
+    if (!keepAlive) {
+      await closeListener();
+      return;
+    }
+
+    const reason = await Promise.race([
+      listener.onClose?.catch((err) => {
+        reconnectLogger.error(
+          { error: formatError(err) },
+          "listener.onClose rejected",
+        );
+        return { status: 500, isLoggedOut: false, error: err };
+      }) ?? waitForever(),
+      abortPromise ?? waitForever(),
+    ]);
+
+    const uptimeMs = Date.now() - startedAt;
+    if (uptimeMs > heartbeatSeconds * 1000) {
+      reconnectAttempts = 0; // Healthy stretch; reset the backoff.
+    }
+    status.reconnectAttempts = reconnectAttempts;
+    emitStatus();
+
+    if (stopRequested() || sigintStop || reason === "aborted") {
+      await closeListener();
+      break;
+    }
+
+    const statusCode =
+      (typeof reason === "object" && reason && "status" in reason
+        ? (reason as { status?: number }).status
+        : undefined) ?? "unknown";
+    const loggedOut =
+      typeof reason === "object" &&
+      reason &&
+      "isLoggedOut" in reason &&
+      (reason as { isLoggedOut?: boolean }).isLoggedOut;
+
+    const errorStr = formatError(reason);
+    status.connected = false;
+    status.lastEventAt = Date.now();
+    status.lastDisconnect = {
+      at: status.lastEventAt,
+      status: typeof statusCode === "number" ? statusCode : undefined,
+      error: errorStr,
+      loggedOut: Boolean(loggedOut),
+    };
+    status.lastError = errorStr;
+    status.reconnectAttempts = reconnectAttempts;
+    emitStatus();
+
+    reconnectLogger.info(
+      {
+        connectionId,
+        status: statusCode,
+        loggedOut,
+        reconnectAttempts,
+        error: errorStr,
+      },
+      "web reconnect: connection closed",
+    );
+
+    enqueueSystemEvent(
+      `WhatsApp gateway disconnected (status ${statusCode ?? "unknown"})`,
+      { sessionKey: connectRoute.sessionKey },
+    );
+
+    if (loggedOut) {
+      runtime.error(
+        "WhatsApp session logged out. Run `clawdbot channels login --channel web` to relink.",
+      );
+      await closeListener();
+      break;
+    }
+
+    reconnectAttempts += 1;
+    status.reconnectAttempts = reconnectAttempts;
+    emitStatus();
+    if (
+      reconnectPolicy.maxAttempts > 0 &&
+      reconnectAttempts >= reconnectPolicy.maxAttempts
+    ) {
+      reconnectLogger.warn(
+        {
+          connectionId,
+          status: statusCode,
+          reconnectAttempts,
+          maxAttempts: reconnectPolicy.maxAttempts,
+        },
+        "web reconnect: max attempts reached; continuing in degraded mode",
+      );
+      runtime.error(
+        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+      );
+      await closeListener();
+      break;
+    }
+
+    const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+    reconnectLogger.info(
+      {
+        connectionId,
+        status: statusCode,
+        reconnectAttempts,
+        maxAttempts: reconnectPolicy.maxAttempts || "unlimited",
+        delayMs: delay,
+      },
+      "web reconnect: scheduling retry",
+    );
+    runtime.error(
+      `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationMs(delay)}… (${errorStr})`,
+    );
+    await closeListener();
+    try {
+      await sleep(delay, abortSignal);
+    } catch {
+      break;
+    }
+  }
+
+  status.running = false;
+  status.connected = false;
+  status.lastEventAt = Date.now();
+  emitStatus();
+
+  process.removeListener("SIGINT", handleSigint);
+}
+
+export { DEFAULT_WEB_MEDIA_BYTES };

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -2,11 +2,11 @@ import {
   resolveEffectiveMessagesConfig,
   resolveMessagePrefix,
 } from "../agents/identity.js";
+import { synthesizeReplyAudio } from "../auto-reply/audio-reply.js";
 import {
   chunkMarkdownText,
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
-import { synthesizeReplyAudio } from "../auto-reply/audio-reply.js";
 import { formatAgentEnvelope } from "../auto-reply/envelope.js";
 import {
   normalizeGroupActivation,
@@ -30,8 +30,8 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import type { ReplyPayload } from "../auto-reply/types.js";
 import { isAudio } from "../auto-reply/transcription.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
 import { toLocationContext } from "../channels/location.js";
 import { resolveWhatsAppHeartbeatRecipients } from "../channels/plugins/whatsapp-heartbeat.js";
 import { waitForever } from "../cli/wait.js";


### PR DESCRIPTION
 ## Summary

  ### Voice Response Automation
  Add voice response automation to all messaging providers using the configured audio reply command (sag skill/ElevenLabs).

  When a user sends a voice message, the bot synthesizes a voice reply:
  - `voiceOnly: false` (default) - Sends both text AND voice reply
  - `voiceOnly: true` - Sends only voice reply, no text
  - Needs Audio config to clawdconfig json


  ## Changes

  **Voice:**
  - Add `shouldSkipTextOnlyDelivery` helper for voiceOnly logic
  - Add voice reply to Whatsapp, Telegram, Discord, Slack, Signal, MS Teams, iMessage

  ## Test Plan
  - [x] Tested voice reply on WhatsApp
  - [x] Tested voice reply on Telegram
  - [x] Tested voice reply on Discord(individual)