### PR TITLE
fix: pass --non-interactive to nested doctor in update-runner

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -417,7 +417,7 @@ export async function runGatewayUpdate(
     const doctorStep = await runStep(
       step(
         "clawdbot doctor",
-        managerScriptArgs(manager, "clawdbot", ["doctor"]),
+        managerScriptArgs(manager, "clawdbot", ["doctor", "--non-interactive"]),
         gitRoot,
         { CLAWDBOT_UPDATE_IN_PROGRESS: "1" },
       ),


### PR DESCRIPTION
The nested doctor call during 'clawdbot update' was hanging because it inherited TTY stdin but wasn't passed --non-interactive. This caused doctor prompts (migrate config, restart gateway, etc.) to wait for input.

CLAWDBOT_UPDATE_IN_PROGRESS only skips the 'Update from git?' prompt, not the other interactive prompts in doctor.