### PR TITLE
fix: align /think default with model reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Doctor: surface plugin diagnostics in the report.
 - Plugins: treat `plugins.load.paths` directory entries as package roots when they contain `package.json` + `clawdbot.extensions`.
 - Config: expand `~` in `CLAWDBOT_CONFIG_PATH` and common path-like config fields (including `plugins.load.paths`).
+- Auto-reply: align `/think` default display with model reasoning defaults. (#751) — thanks @gabriel-trigo.
 - Docker: tolerate unset optional env vars in docker-setup.sh under strict mode. (#725) — thanks @petradonka.
 - CLI/Update: preserve base environment when passing overrides to update subprocesses. (#713) — thanks @danielz1z.
 - Agents: treat message tool errors as failures so fallback replies still send; require `to` + `message` for `action=send`. (#717) — thanks @theglove44.

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -673,7 +673,8 @@ export async function getReplyFromConfig(
   ) {
     const currentThinkLevel =
       (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
-      (agentCfg?.thinkingDefault as ThinkLevel | undefined);
+      (agentCfg?.thinkingDefault as ThinkLevel | undefined) ??
+      (await modelState.resolveDefaultThinkingLevel());
     const currentVerboseLevel =
       (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
       (agentCfg?.verboseDefault as VerboseLevel | undefined);


### PR DESCRIPTION
## Summary\n- align /think default resolution with model reasoning defaults\n- cover reasoning vs non-reasoning models in /think tests\n\n## Testing\n- pnpm test\n\nFixes #743