### PR TITLE
fix: pass --non-interactive to nested doctor in update-runner

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -417,7 +417,7 @@ export async function runGatewayUpdate(
     const doctorStep = await runStep(
       step(
         "clawdbot doctor",
-        managerScriptArgs(manager, "clawdbot", ["doctor"]),
+        managerScriptArgs(manager, "clawdbot", ["doctor", "--non-interactive"]),
         gitRoot,
         { CLAWDBOT_UPDATE_IN_PROGRESS: "1" },
       ),


### PR DESCRIPTION
The nested doctor call during `clawdbot update` hangs on TTY because it prompts for:
- Legacy config migration
- Gateway daemon install/restart
- etc.

`CLAWDBOT_UPDATE_IN_PROGRESS=1` only skips the 'Update from git?' prompt, not these other prompts.

**Fix:** Add `--non-interactive` flag to the nested doctor call.

**Tested:** Ran `clawdbot doctor` → Yes to update → completes without hanging.