### PR TITLE
fix(agent): prevent reasoning and tag leaks for Gemini 3/Antigravity models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - CLI/Update: preserve base environment when passing overrides to update subprocesses. (#713) — thanks @danielz1z.
 - Agents: treat message tool errors as failures so fallback replies still send; require `to` + `message` for `action=send`. (#717) — thanks @theglove44.
 - Agents: preserve reasoning items on tool-only turns.
+- Agents: enforce `<final>` gating for reasoning-tag providers to prevent tag/reasoning leaks. (#754) — thanks @mcinteerj.
 - Agents/Subagents: wait for completion before announcing, align wait timeout with run timeout, and make announce prompts more emphatic.
 - Agents: route subagent transcripts to the target agent sessions directory and add regression coverage. (#708) — thanks @xMikeMickelson.
 - Agents/Tools: preserve action enums when flattening tool schemas. (#708) — thanks @xMikeMickelson.

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -183,7 +183,11 @@ export async function sanitizeSessionMessagesImages(
 const GOOGLE_TURN_ORDER_BOOTSTRAP_TEXT = "(session bootstrap)";
 
 export function isGoogleModelApi(api?: string | null): boolean {
-  return api === "google-gemini-cli" || api === "google-generative-ai";
+  return (
+    api === "google-gemini-cli" ||
+    api === "google-generative-ai" ||
+    api === "google-antigravity"
+  );
 }
 
 export function sanitizeGoogleTurnOrdering(

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -43,6 +43,7 @@ import {
   enqueueCommandInLane,
 } from "../process/command-queue.js";
 import { normalizeMessageProvider } from "../utils/message-provider.js";
+import { isReasoningTagProvider } from "../utils/provider-utils.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveClawdbotAgentDir } from "./agent-paths.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
@@ -1141,7 +1142,7 @@ export async function compactEmbeddedPiSession(params: {
           sandbox,
           params.bashElevated,
         );
-        const reasoningTagHint = provider === "ollama";
+        const reasoningTagHint = isReasoningTagProvider(provider);
         const userTimezone = resolveUserTimezone(
           params.config?.agents?.defaults?.userTimezone,
         );
@@ -1547,7 +1548,7 @@ export async function runEmbeddedPiAgent(params: {
             sandbox,
             params.bashElevated,
           );
-          const reasoningTagHint = provider === "ollama";
+          const reasoningTagHint = isReasoningTagProvider(provider);
           const userTimezone = resolveUserTimezone(
             params.config?.agents?.defaults?.userTimezone,
           );

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -1156,9 +1156,6 @@ export async function getReplyFromConfig(
     resolvedQueue.mode === "collect" ||
     resolvedQueue.mode === "steer-backlog";
   const authProfileId = sessionEntry?.authProfileOverride;
-  // DEBUG: Check provider for reasoning tag
-  const shouldEnforce = isReasoningTagProvider(provider);
-  // defaultRuntime.log(`[DEBUG] reply.ts: provider='${provider}', isReasoningTagProvider=${shouldEnforce}`);
 
   const followupRun = {
     prompt: queuedBody,
@@ -1198,15 +1195,7 @@ export async function getReplyFromConfig(
       ownerNumbers:
         command.ownerList.length > 0 ? command.ownerList : undefined,
       extraSystemPrompt: extraSystemPrompt || undefined,
-      ...(isReasoningTagProvider(provider)
-        ? (() => {
-            logVerbose(`[reply] Enforcing final tag for provider: ${provider}`);
-            return { enforceFinalTag: true };
-          })()
-        : (() => {
-            logVerbose(`[reply] NOT enforcing final tag for provider: ${provider}`);
-            return {};
-          })()),
+      ...(isReasoningTagProvider(provider) ? { enforceFinalTag: true } : {}),
     },
   };
 

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -7,10 +7,12 @@
  * (e.g. <think> and <final>) in the text stream, rather than using native
  * API fields for reasoning/thinking.
  */
-export function isReasoningTagProvider(provider: string | undefined | null): boolean {
+export function isReasoningTagProvider(
+  provider: string | undefined | null,
+): boolean {
   if (!provider) return false;
   const normalized = provider.trim().toLowerCase();
-  
+
   // Check for exact matches or known prefixes/substrings for reasoning providers
   if (
     normalized === "ollama" ||
@@ -19,7 +21,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   ) {
     return true;
   }
-  
+
   // Handle google-antigravity and its model variations (e.g. google-antigravity/gemini-3)
   if (normalized.includes("google-antigravity")) {
     return true;
@@ -29,6 +31,6 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (normalized.includes("minimax")) {
     return true;
   }
-  
+
   return false;
 }

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Utility functions for provider-specific logic and capabilities.
+ */
+
+/**
+ * Returns true if the provider requires reasoning to be wrapped in tags
+ * (e.g. <think> and <final>) in the text stream, rather than using native
+ * API fields for reasoning/thinking.
+ */
+export function isReasoningTagProvider(provider: string | undefined | null): boolean {
+  if (!provider) return false;
+  const normalized = provider.trim().toLowerCase();
+  
+  // Check for exact matches or known prefixes/substrings for reasoning providers
+  if (
+    normalized === "ollama" ||
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai"
+  ) {
+    return true;
+  }
+  
+  // Handle google-antigravity and its model variations (e.g. google-antigravity/gemini-3)
+  if (normalized.includes("google-antigravity")) {
+    return true;
+  }
+  
+  return false;
+}

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -24,6 +24,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (normalized.includes("google-antigravity")) {
     return true;
   }
+
+  // Handle Minimax (M2.1 is chatty/reasoning-like)
+  if (normalized.includes("minimax")) {
+    return true;
+  }
   
   return false;
 }


### PR DESCRIPTION
## Problem
1. **Reasoning Leak:** Models like `google-antigravity/gemini-3-flash` were outputting 'thinking out loud' text (e.g., `*Locating Manulife*`) directly to WhatsApp because they weren't always wrapping these thoughts in `<think>` tags.
2. **Tag Leak:** The mechanism to wrap/strip thoughts using `<final>` tags was failing because:
    - The provider check was too strict (exact match only), causing `enforceFinalTag` to default to `false`.
    - Even when enabled, nested or malformed tags (e.g., `<final><final>...`) could leak through regex filters.

## Changes
1. **Strict Buffering:** When `enforceFinalTag` is enabled, the agent now **buffers all streaming output** until it detects a `<final>` tag. This prevents untagged 'planning' steps from leaking as partial messages.
2. **Robust Provider Detection:** Added `src/utils/provider-utils.ts` to correctly identify reasoning providers (including model variations like `gemini-3-pro-low`).
3. **Hardened Stripper:** Updated `pi-embedded-subscribe.ts` to forcibly remove any remaining `<final>` tags from the output, ensuring users never see raw XML tags even if the model hallucinates them.

## Verification
- Confirmed `isReasoningTagProvider` returns `true` for `google-antigravity/gemini-3-flash`.
- Verified logs show `enforceFinalTag is ENABLED`.
- Confirmed via logs that 'Locating Manulife' style streaming leaks are now suppressed by the buffer-until-final logic.