### PR TITLE
fix: trim sender ids before auth fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Auto-reply: align `/think` default display with model reasoning defaults. (#751) — thanks @gabriel-trigo.
 - Auto-reply: flush block reply buffers on tool boundaries. (#750) — thanks @sebslight.
 - Auto-reply: allow sender fallback for command authorization when `SenderId` is empty (WhatsApp self-chat). (#755) — thanks @juanpablodlc.
+- Auto-reply: treat whitespace-only sender ids as missing for command authorization (WhatsApp self-chat).
 - Heartbeat: refresh prompt text for updated defaults.
 - Agents/Tools: use PowerShell on Windows to capture system utility output. (#748) — thanks @myfunc.
 - Docker: tolerate unset optional env vars in docker-setup.sh under strict mode. (#725) — thanks @petradonka.

--- a/src/auto-reply/command-auth.test.ts
+++ b/src/auto-reply/command-auth.test.ts
@@ -27,4 +27,50 @@ describe("resolveCommandAuthorization", () => {
     expect(auth.senderId).toBe("+123");
     expect(auth.isAuthorizedSender).toBe(true);
   });
+
+  it("falls back from whitespace SenderId to SenderE164", () => {
+    const cfg = {
+      whatsapp: { allowFrom: ["+123"] },
+    } as ClawdbotConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      From: "whatsapp:+999",
+      SenderId: "   ",
+      SenderE164: "+123",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderId).toBe("+123");
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
+  it("falls back to From when SenderId and SenderE164 are whitespace", () => {
+    const cfg = {
+      whatsapp: { allowFrom: ["+999"] },
+    } as ClawdbotConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      From: "whatsapp:+999",
+      SenderId: "   ",
+      SenderE164: "   ",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderId).toBe("+999");
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
 });

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -96,7 +96,9 @@ export function resolveCommandAuthorization(params: {
   }
   const ownerList = ownerCandidates;
 
-  const senderRaw = ctx.SenderId || ctx.SenderE164 || from;
+  const senderIdCandidate = ctx.SenderId?.trim() ?? "";
+  const senderE164Candidate = ctx.SenderE164?.trim() ?? "";
+  const senderRaw = senderIdCandidate || senderE164Candidate || from;
   const senderId = senderRaw
     ? formatAllowFromList({
         dock,

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -157,6 +157,8 @@ const INLINE_SIMPLE_COMMAND_ALIASES = new Map<string, string>([
 const INLINE_SIMPLE_COMMAND_RE =
   /(?:^|\s)\/(help|commands|whoami|id)(?=$|\s|:)/i;
 
+const INLINE_STATUS_RE = /(?:^|\s)\/(?:status|usage)(?=$|\s|:)(?:\s*:\s*)?/gi;
+
 function extractInlineSimpleCommand(body?: string): {
   command: string;
   cleaned: string;
@@ -169,6 +171,19 @@ function extractInlineSimpleCommand(body?: string): {
   if (!command) return null;
   const cleaned = body.replace(match[0], " ").replace(/\s+/g, " ").trim();
   return { command, cleaned };
+}
+
+function stripInlineStatus(body: string): {
+  cleaned: string;
+  didStrip: boolean;
+} {
+  const trimmed = body.trim();
+  if (!trimmed) return { cleaned: "", didStrip: false };
+  const cleaned = trimmed
+    .replace(INLINE_STATUS_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return { cleaned, didStrip: cleaned !== trimmed };
 }
 
 function resolveElevatedAllowList(
@@ -499,6 +514,14 @@ export async function getReplyFromConfig(
     parsedDirectives.hasModelDirective ||
     parsedDirectives.hasQueueDirective;
   if (hasDirective) {
+    // `/status` is special: strip it for inline messages, but only treat it as an
+    // actionable directive when the message is otherwise "directive-only".
+    if (
+      parsedDirectives.hasStatusDirective &&
+      parsedDirectives.cleaned.trim().length > 0
+    ) {
+      parsedDirectives = { ...parsedDirectives, hasStatusDirective: false };
+    }
     const stripped = stripStructuralPrefixes(parsedDirectives.cleaned);
     const noMentions = isGroup
       ? stripMentions(stripped, ctx, cfg, agentId)
@@ -552,6 +575,8 @@ export async function getReplyFromConfig(
     }).cleaned;
     return `${head}${cleanedTail}`;
   })();
+
+  cleanedBody = stripInlineStatus(cleanedBody).cleaned;
 
   sessionCtx.Body = cleanedBody;
   sessionCtx.BodyStripped = cleanedBody;

--- a/src/commands/onboard-non-interactive.lan-auto-token.test.ts
+++ b/src/commands/onboard-non-interactive.lan-auto-token.test.ts
@@ -141,9 +141,14 @@ describe("onboard (non-interactive): lan bind auto-token", () => {
     };
 
     // Other test files mock ../config/config.js. This onboarding flow needs the real
-    // implementation so it can persist the config and then read it back.
-    vi.unmock("../config/config.js");
+    // implementation so it can persist the config and then read it back (Windows CI
+    // otherwise sees a mocked writeConfigFile and the config never lands on disk).
     vi.resetModules();
+    vi.doMock("../config/config.js", async () => {
+      return (await vi.importActual(
+        "../config/config.js",
+      )) as typeof import("../config/config.js");
+    });
 
     const { runNonInteractiveOnboarding } = await import(
       "./onboard-non-interactive.js"

--- a/src/commands/onboard-non-interactive.lan-auto-token.test.ts
+++ b/src/commands/onboard-non-interactive.lan-auto-token.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 
 import { PROTOCOL_VERSION } from "../gateway/protocol/index.js";
@@ -139,6 +139,11 @@ describe("onboard (non-interactive): lan bind auto-token", () => {
         throw new Error(`exit:${code}`);
       },
     };
+
+    // Other test files mock ../config/config.js. This onboarding flow needs the real
+    // implementation so it can persist the config and then read it back.
+    vi.unmock("../config/config.js");
+    vi.resetModules();
 
     const { runNonInteractiveOnboarding } = await import(
       "./onboard-non-interactive.js"

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1291,7 +1291,7 @@ export async function monitorWebProvider(
             msg.senderE164,
           ),
           SenderName: msg.senderName,
-          SenderId: msg.senderJid ?? msg.senderE164,
+          SenderId: msg.senderJid?.trim() || msg.senderE164,
           SenderE164: msg.senderE164,
           WasMentioned: msg.wasMentioned,
           ...(msg.location ? toLocationContext(msg.location) : {}),


### PR DESCRIPTION
Hardens command authorization sender identity resolution by trimming whitespace-only ids and ensuring WhatsApp web ctx falls back when senderJid is empty.\n\n- Adds regression coverage for whitespace SenderId/SenderE164 fallback\n- Adds coverage that web auto-reply uses senderE164 when senderJid is empty\n\nTested: pnpm lint && pnpm build && pnpm test