### PR TITLE
Browser: filter AI snapshot noise

### DIFF
--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -183,12 +183,14 @@ async function promptConfigureSections(
       break;
     }
 
-    addMore = guardCancel(
-      await confirm({
-        message: "Configure another section?",
-        initialValue: false,
-      }),
-      runtime,
+    addMore = Boolean(
+      guardCancel(
+        await confirm({
+          message: "Configure another section?",
+          initialValue: false,
+        }),
+        runtime,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- Filter Playwright _snapshotForAI_ output to drop /url: lines and empty generic/none nodes; keeps aria refs intact.
- Add unit coverage for the filter.
- Note in AGENTS.md: rebuild + restart gateway after code changes.

## Evidence (CLI snapshots)
- Tech gadget gifts for dad: 678.3 KB → 150.1 KB (−~528 KB, −~135k tokens; /url: 573 → 0)
- Blue water bottle: 828.4 KB → 194.2 KB (−~634 KB, −~162k tokens; /url: 920 → 0)
- Wireless earbuds: 520.7 KB → 139.8 KB (−~381 KB, −~97k tokens; /url: 571 → 0)

Commands used:
- corepack pnpm clawdbot browser open <url>
- corepack pnpm clawdbot browser snapshot --format ai --target-id <id> --out /tmp/ai-snapshot-*.txt
- Token estimate ≈ len(text)/4; /url: counts via simple grep/Python.