### PR TITLE
fix: resolve WhatsApp accountId for single-account multi-agent setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026.1.12-4
 
 ### Fixes
+- WhatsApp: pass resolved accountId to active listener check so heartbeat/webhook delivery works with custom account names (not just `default`); add single-listener fallback for single-account multi-agent setups. (#776)
 - Onboarding/Configure: refuse to proceed with invalid configs; run `clawdbot doctor` first to avoid wiping custom fields. (#764 — thanks @mukhtharcm)
 - Anthropic: merge consecutive user turns (preserve newest metadata) before validation to avoid “Incorrect role information” errors. (#804 — thanks @ThomsenDrake)
 - Discord/Slack: centralize reply-thread planning so auto-thread replies stay in the created thread without parent reply refs.

--- a/src/providers/plugins/whatsapp.ts
+++ b/src/providers/plugins/whatsapp.ts
@@ -367,7 +367,7 @@ export const whatsappPlugin: ProviderPlugin<ResolvedWhatsAppAccount> = {
       }
       const listenerActive = deps?.hasActiveWebListener
         ? deps.hasActiveWebListener()
-        : Boolean(getActiveWebListener());
+        : Boolean(getActiveWebListener(account.accountId));
       if (!listenerActive) {
         return { ok: false, reason: "whatsapp-not-running" };
       }

--- a/src/web/active-listener.test.ts
+++ b/src/web/active-listener.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getActiveWebListener,
+  requireActiveWebListener,
+  setActiveWebListener,
+} from "./active-listener.js";
+
+describe("active-listener", () => {
+  const mockListener = {
+    sendComposingTo: vi.fn(async () => {}),
+    sendMessage: vi.fn(async () => ({ messageId: "msg123" })),
+    sendPoll: vi.fn(async () => ({ messageId: "poll123" })),
+    sendReaction: vi.fn(async () => {}),
+  };
+
+  afterEach(() => {
+    setActiveWebListener(null);
+    setActiveWebListener("kev", null);
+    setActiveWebListener("other", null);
+  });
+
+  describe("getActiveWebListener", () => {
+    it("returns null when no listeners registered", () => {
+      expect(getActiveWebListener()).toBeNull();
+      expect(getActiveWebListener("kev")).toBeNull();
+    });
+
+    it("returns listener for matching accountId", () => {
+      setActiveWebListener("kev", mockListener);
+      expect(getActiveWebListener("kev")).toBe(mockListener);
+    });
+
+    it("returns listener when account is named default", () => {
+      setActiveWebListener("default", mockListener);
+      expect(getActiveWebListener()).toBe(mockListener);
+      expect(getActiveWebListener("default")).toBe(mockListener);
+    });
+
+    it("falls back to single listener when accountId not found", () => {
+      setActiveWebListener("kev", mockListener);
+      expect(getActiveWebListener()).toBe(mockListener);
+      expect(getActiveWebListener("default")).toBe(mockListener);
+      expect(getActiveWebListener("nonexistent")).toBe(mockListener);
+    });
+
+    it("does not fall back when multiple listeners exist", () => {
+      const otherListener = { ...mockListener };
+      setActiveWebListener("kev", mockListener);
+      setActiveWebListener("other", otherListener);
+      expect(getActiveWebListener("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("requireActiveWebListener", () => {
+    it("throws when no listeners registered", () => {
+      expect(() => requireActiveWebListener()).toThrow(
+        /No active WhatsApp Web listener/,
+      );
+    });
+
+    it("returns listener and accountId for matching accountId", () => {
+      setActiveWebListener("kev", mockListener);
+      const result = requireActiveWebListener("kev");
+      expect(result.accountId).toBe("kev");
+      expect(result.listener).toBe(mockListener);
+    });
+
+    it("returns listener when account is named default", () => {
+      setActiveWebListener("default", mockListener);
+      const result = requireActiveWebListener();
+      expect(result.accountId).toBe("default");
+      expect(result.listener).toBe(mockListener);
+    });
+
+    it("throws for non-matching accountId when multiple listeners", () => {
+      const otherListener = { ...mockListener };
+      setActiveWebListener("kev", mockListener);
+      setActiveWebListener("other", otherListener);
+      expect(() => requireActiveWebListener("nonexistent")).toThrow(
+        /No active WhatsApp Web listener/,
+      );
+    });
+
+    it("falls back to single listener and returns correct accountId", () => {
+      setActiveWebListener("kev", mockListener);
+      const result = requireActiveWebListener();
+      expect(result.accountId).toBe("kev");
+      expect(result.listener).toBe(mockListener);
+    });
+
+    it("falls back when requesting default but only custom account exists", () => {
+      setActiveWebListener("kev", mockListener);
+      const result = requireActiveWebListener("default");
+      expect(result.accountId).toBe("kev");
+      expect(result.listener).toBe(mockListener);
+    });
+  });
+
+  describe("setActiveWebListener", () => {
+    it("registers listener with accountId", () => {
+      setActiveWebListener("kev", mockListener);
+      expect(getActiveWebListener("kev")).toBe(mockListener);
+    });
+
+    it("registers listener without accountId as default", () => {
+      setActiveWebListener(mockListener);
+      expect(getActiveWebListener("default")).toBe(mockListener);
+    });
+
+    it("removes listener when set to null", () => {
+      setActiveWebListener("kev", mockListener);
+      expect(getActiveWebListener("kev")).toBe(mockListener);
+      setActiveWebListener("kev", null);
+      expect(getActiveWebListener("kev")).toBeNull();
+    });
+  });
+});

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -40,6 +40,10 @@ export function requireActiveWebListener(accountId?: string | null): {
 } {
   const id = resolveWebAccountId(accountId);
   const listener = listeners.get(id) ?? null;
+  if (!listener && listeners.size === 1) {
+    const [singleId, singleListener] = [...listeners.entries()][0];
+    return { accountId: singleId, listener: singleListener };
+  }
   if (!listener) {
     throw new Error(
       `No active WhatsApp Web listener (account: ${id}). Start the gateway, then link WhatsApp with: clawdbot providers login --provider whatsapp --account ${id}.`,
@@ -80,5 +84,9 @@ export function getActiveWebListener(
   accountId?: string | null,
 ): ActiveWebListener | null {
   const id = resolveWebAccountId(accountId);
-  return listeners.get(id) ?? null;
+  const listener = listeners.get(id) ?? null;
+  if (!listener && listeners.size === 1) {
+    return [...listeners.values()][0];
+  }
+  return listener;
 }


### PR DESCRIPTION
## Summary

Fixes WhatsApp heartbeat and webhook delivery failing when a user has a single WhatsApp account with a custom name (not `default`).

**The Problem:**
- In multi-agent setups, accounts are named consistently (e.g., `kev`, `rex`, `forge`)
- WhatsApp heartbeat check called `getActiveWebListener()` without passing the resolved `accountId`
- This caused it to look for `default` even when the account was named `kev`
- Result: "heartbeat: provider not ready" / "No active WhatsApp Web listener (account: default)"

**The Fix:**
1. **`whatsapp.ts:370`**: Pass `account.accountId` to `getActiveWebListener()` - the accountId was already correctly resolved but wasn't being used
2. **`active-listener.ts`**: Add single-listener fallback - if only one listener exists and the requested accountId isn't found, use that listener

**Why not just use `default`?**
- Users with multi-agent architectures have consistent naming across providers (Slack, WhatsApp, agents)
- Forcing `default` as the account name breaks this consistency
- The `resolveDefaultWhatsAppAccountId()` function exists to handle this - it returns the first configured account if `default` doesn't exist

## Test plan
- [x] Added 14 unit tests for `active-listener.ts` covering:
  - Single listener fallback for both `getActiveWebListener` and `requireActiveWebListener`
  - Default account name behavior
  - Multiple listener scenarios (no fallback)
- [x] Manual testing with webhook delivery to WhatsApp (DM and group)
- [x] Existing `outbound.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)