### PR TITLE
fix: pass --non-interactive to doctor during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 - Anthropic: merge consecutive user turns (preserve newest metadata) before validation to avoid “Incorrect role information” errors. (#804 — thanks @ThomsenDrake)
 - Discord/Slack: centralize reply-thread planning so auto-thread replies stay in the created thread without parent reply refs.
+- Update: run `clawdbot doctor --non-interactive` during updates to avoid TTY hangs. (#781 — thanks @ronyrus)
 
 ## 2026.1.12-3
 

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -417,7 +417,7 @@ export async function runGatewayUpdate(
     const doctorStep = await runStep(
       step(
         "clawdbot doctor",
-        managerScriptArgs(manager, "clawdbot", ["doctor"]),
+        managerScriptArgs(manager, "clawdbot", ["doctor", "--non-interactive"]),
         gitRoot,
         { CLAWDBOT_UPDATE_IN_PROGRESS: "1" },
       ),


### PR DESCRIPTION
Fixes `clawdbot update` hanging when doctor prompts for user input on a TTY.