### PR TITLE
fix(providers): strip unsupported id field from google-gemini-cli function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - System events: include local timestamps when events are injected into prompts. (#245 — thanks @thewilloftheshadow)
 - Cron: accept `jobId` aliases for cron update/run/remove params in gateway validation. (#252 — thanks @thewilloftheshadow)
 - Models/Google: normalize Gemini 3 model ids to preview variants before runtime selection. (#795 — thanks @thewilloftheshadow)
+- Models/Google: strip Gemini CLI tool call/response ids in patched provider handling. (#783 — thanks @ananth-vardhan-cn)
 - TUI: keep the last streamed response instead of replacing it with "(no output)". (#747 — thanks @thewilloftheshadow)
 - Slack: accept slash commands with or without leading `/` for custom command configs. (#798 — thanks @thewilloftheshadow)
 - Onboarding/Configure: refuse to proceed with invalid configs; run `clawdbot doctor` first to avoid wiping custom fields. (#764 — thanks @mukhtharcm)


### PR DESCRIPTION
 Summary
- Fixes #756
- Extends the existing `google-vertex` provider fix to also apply to `google-gemini-cli`
- Strips unsupported `id` field from `functionCall` and `functionResponse` payloads

 Changes
Updated `patches/@mariozechner__pi-ai@0.42.2.patch` to include `google-gemini-cli` in the provider check alongside `google-vertex` at two locations in `google-shared.js`:
- Line 113: `functionCall.id` deletion
- Line 159: `functionResponse.id` deletion

 Testing
- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm test` passes (2392/2398 - 6 pre-existing failures unrelated to this change)