### PR TITLE
Prevent onboarding TUI from auto-delivering to lastProvider/lastTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Google: apply patched pi-ai `google-gemini-cli` function call handling (strips ids) after upgrading to pi-ai 0.43.0.
 - Auto-reply: elevated/reasoning toggles now enqueue system events so the model sees the mode change immediately.
 - Tools: keep `image` available in sandbox and fail over when image models return empty output (fixes “(no text returned)”).
+- Onboarding: TUI defaults to `deliver: false` to avoid cross-provider auto-delivery leaks; onboarding spawns the TUI with explicit `deliver: false`. (#791 — thanks @roshanasingh4)
 
 ## 2026.1.11
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -5,12 +5,12 @@ import {
   agentsDeleteCommand,
   agentsListCommand,
 } from "../commands/agents.js";
-import { dashboardCommand } from "../commands/dashboard.js";
 import {
   CONFIGURE_WIZARD_SECTIONS,
   configureCommand,
   configureCommandWithSections,
 } from "../commands/configure.js";
+import { dashboardCommand } from "../commands/dashboard.js";
 import { doctorCommand } from "../commands/doctor.js";
 import { healthCommand } from "../commands/health.js";
 import { messageCommand } from "../commands/message.js";

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { dashboardCommand } from "./dashboard.js";
 
@@ -94,7 +94,10 @@ describe("dashboardCommand", () => {
   it("prints SSH hint when browser cannot open", async () => {
     mockSnapshot("shhhh");
     mocks.copyToClipboard.mockResolvedValue(false);
-    mocks.detectBrowserOpenSupport.mockResolvedValue({ ok: false, reason: "ssh" });
+    mocks.detectBrowserOpenSupport.mockResolvedValue({
+      ok: false,
+      reason: "ssh",
+    });
     mocks.formatControlUiSshHint.mockReturnValue("ssh hint");
 
     await dashboardCommand(runtime);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,6 +1,9 @@
-import { resolveGatewayPort, readConfigFileSnapshot } from "../config/config.js";
-import { defaultRuntime } from "../runtime.js";
+import {
+  readConfigFileSnapshot,
+  resolveGatewayPort,
+} from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
 import {
   copyToClipboard,
   detectBrowserOpenSupport,
@@ -33,7 +36,9 @@ export async function dashboardCommand(
   runtime.log(`Dashboard URL: ${authedUrl}`);
 
   const copied = await copyToClipboard(authedUrl).catch(() => false);
-  runtime.log(copied ? "Copied to clipboard." : "Copy to clipboard unavailable.");
+  runtime.log(
+    copied ? "Copied to clipboard." : "Copy to clipboard unavailable.",
+  );
 
   let opened = false;
   let hint: string | undefined;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -199,7 +199,7 @@ export async function runTui(opts: TuiOptions) {
   let isConnected = false;
   let toolsExpanded = false;
   let showThinking = false;
-  const deliverDefault = opts.deliver ?? true;
+  const deliverDefault = opts.deliver ?? false;
   const autoMessage = opts.message?.trim();
   let autoMessageSent = false;
   let sessionInfo: SessionInfo = {};

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -796,6 +796,8 @@ export async function runOnboardingWizard(
           token: authMode === "token" ? gatewayToken : undefined,
           password:
             authMode === "password" ? baseConfig.gateway?.auth?.password : "",
+          // Safety: onboarding TUI should not auto-deliver to lastProvider/lastTo.
+          deliver: false,
           message: "Wake up, my friend!",
         });
       }


### PR DESCRIPTION
Fixes cross-provider “narration” leaks when the TUI is launched from onboarding.

Problem: `runTui()` defaulted to `deliver=true` when callers omit `deliver`, and onboarding invokes `runTui({ message: "Wake up, my friend!" })` without an explicit `deliver` flag. That means plain-text assistant output can be auto-delivered via the Gateway `agent` route using `sessionEntry.lastProvider/lastTo` (which may point at a different provider/chat), matching reports of cross-surface/cross-provider leakage.

Changes:
- Default `runTui()` delivery to `false` (safe-by-default).
- Explicitly set `deliver: false` in onboarding when spawning the TUI.

Tests/build:
- `pnpm vitest run src/cli/program.test.ts src/wizard/onboarding.test.ts`
- `pnpm build`

Related: #788, #219.

cc @steipete — this makes the routing/delivery layer safe-by-default; it should reduce leaks regardless of thinking token behavior.