### PR TITLE
fix: clear gateway auth when set to off

### DIFF
--- a/src/commands/configure.gateway-auth.test.ts
+++ b/src/commands/configure.gateway-auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGatewayAuthConfig } from "./configure.js";
+
+describe("buildGatewayAuthConfig", () => {
+  it("clears token/password when auth is off", () => {
+    const result = buildGatewayAuthConfig({
+      existing: { mode: "token", token: "abc", password: "secret" },
+      mode: "off",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("preserves allowTailscale when auth is off", () => {
+    const result = buildGatewayAuthConfig({
+      existing: {
+        mode: "token",
+        token: "abc",
+        allowTailscale: true,
+      },
+      mode: "off",
+    });
+
+    expect(result).toEqual({ allowTailscale: true });
+  });
+
+  it("drops password when switching to token", () => {
+    const result = buildGatewayAuthConfig({
+      existing: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+      },
+      mode: "token",
+      token: "abc",
+    });
+
+    expect(result).toEqual({
+      mode: "token",
+      token: "abc",
+      allowTailscale: false,
+    });
+  });
+
+  it("drops token when switching to password", () => {
+    const result = buildGatewayAuthConfig({
+      existing: { mode: "token", token: "abc" },
+      mode: "password",
+      password: "secret",
+    });
+
+    expect(result).toEqual({ mode: "password", password: "secret" });
+  });
+});


### PR DESCRIPTION
## Summary
- clear gateway auth when user selects off
- preserve allowTailscale metadata only
- add regression test

## Testing
- pnpm vitest run src/commands/configure.gateway-auth.test.ts
- pnpm lint (fails: existing lint errors in src/agents/models-config.ts, src/agents/models-config.test.ts, src/commands/auth-choice.ts)