### PR TITLE
fix: strip provider prefix from Google model IDs (#795)

### DIFF
--- a/patches/@mariozechner__pi-ai@0.43.0.patch
+++ b/patches/@mariozechner__pi-ai@0.43.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/providers/google-gemini-cli.js b/dist/providers/google-gemini-cli.js
-index 12540bb1069087a0d0a2967f792008627b9f79d9..f30b525620e6d8e45146b439ec3733e4053c9d2a 100644
+index 12540bb1069087a0d0a2967f792008627b9f79d9..522e560ab79e6fe9358d3cce548fd4919dd856bd 100644
 --- a/dist/providers/google-gemini-cli.js
 +++ b/dist/providers/google-gemini-cli.js
 @@ -248,6 +248,11 @@ export const streamGoogleGeminiCli = (model, context, options) => {
@@ -15,7 +15,7 @@ index 12540bb1069087a0d0a2967f792008627b9f79d9..f30b525620e6d8e45146b439ec3733e4
                      if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
                          // Use server-provided delay or exponential backoff
 diff --git a/dist/providers/google-shared.js b/dist/providers/google-shared.js
-index ae4710b0f134ac4a48f5b7053f454d1068bee71f..b1b5bd94586f68461ccc44e4a9cdf3acb4e0d084 100644
+index ae4710b0f134ac4a48f5b7053f454d1068bee71f..af0dff70dafc92c84eeb5c1c4448f8b95ad20cb9 100644
 --- a/dist/providers/google-shared.js
 +++ b/dist/providers/google-shared.js
 @@ -42,6 +42,8 @@ export function retainThoughtSignature(existing, incoming) {
@@ -47,8 +47,23 @@ index ae4710b0f134ac4a48f5b7053f454d1068bee71f..b1b5bd94586f68461ccc44e4a9cdf3ac
              // Cloud Code Assist API requires all function responses to be in a single user turn.
              // Check if the last content is already a user turn with function responses and merge.
              const lastContent = contents[contents.length - 1];
+diff --git a/dist/providers/google.js b/dist/providers/google.js
+index 18fc906231b103a5b3f58f87559a1602f347dc99..3e162680d81898bd28d83f96d864b7a146a83ed1 100644
+--- a/dist/providers/google.js
++++ b/dist/providers/google.js
+@@ -260,8 +260,9 @@ function buildParams(model, context, options = {}) {
+         }
+         config.abortSignal = options.signal;
+     }
++    const modelName = model.id.includes("/") ? model.id.split("/").pop() : model.id;
+     const params = {
+-        model: model.id,
++        model: modelName,
+         contents,
+         config,
+     };
 diff --git a/dist/providers/openai-codex-responses.js b/dist/providers/openai-codex-responses.js
-index ad0a2aabbe10382cee4e463b68a02864dd235e57..8c001acfd0b4e0743181c246f1bedcf8cd2ffb02 100644
+index ad0a2aabbe10382cee4e463b68a02864dd235e57..62b35a73e42ecc7e2d29e052b6ab2d3b1542eeb6 100644
 --- a/dist/providers/openai-codex-responses.js
 +++ b/dist/providers/openai-codex-responses.js
 @@ -517,7 +517,7 @@ function convertTools(tools) {
@@ -61,7 +76,7 @@ index ad0a2aabbe10382cee4e463b68a02864dd235e57..8c001acfd0b4e0743181c246f1bedcf8
  }
  function mapStopReason(status) {
 diff --git a/dist/providers/openai-responses.js b/dist/providers/openai-responses.js
-index f07085c64390b211340d6a826b28ea9c2e77302f..7f758532246cc7b062df48e9cec4e6c904b76a99 100644
+index f07085c64390b211340d6a826b28ea9c2e77302f..6d7445465c7afc9fb94531eae5d5a740aa5526aa 100644
 --- a/dist/providers/openai-responses.js
 +++ b/dist/providers/openai-responses.js
 @@ -396,10 +396,16 @@ function convertMessages(model, context) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@mariozechner/pi-ai@0.43.0':
-    hash: 3eee8ed34968210911b89dc61e65d651e2be64943933d24ab1de86c7fee9ffdd
+    hash: 946c027f6601937d94460f1d30c7a3b7e70d78411dfeecb1240f72db5517f8ab
     path: patches/@mariozechner__pi-ai@0.43.0.patch
 
 importers:
@@ -36,7 +36,7 @@ importers:
         version: 0.43.0(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-ai':
         specifier: ^0.43.0
-        version: 0.43.0(patch_hash=3eee8ed34968210911b89dc61e65d651e2be64943933d24ab1de86c7fee9ffdd)(ws@8.19.0)(zod@4.3.5)
+        version: 0.43.0(patch_hash=946c027f6601937d94460f1d30c7a3b7e70d78411dfeecb1240f72db5517f8ab)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-coding-agent':
         specifier: ^0.43.0
         version: 0.43.0(ws@8.19.0)(zod@4.3.5)
@@ -4404,7 +4404,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.43.0(ws@8.19.0)(zod@4.3.5)':
     dependencies:
-      '@mariozechner/pi-ai': 0.43.0(patch_hash=3eee8ed34968210911b89dc61e65d651e2be64943933d24ab1de86c7fee9ffdd)(ws@8.19.0)(zod@4.3.5)
+      '@mariozechner/pi-ai': 0.43.0(patch_hash=946c027f6601937d94460f1d30c7a3b7e70d78411dfeecb1240f72db5517f8ab)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-tui': 0.43.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -4414,7 +4414,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.43.0(patch_hash=3eee8ed34968210911b89dc61e65d651e2be64943933d24ab1de86c7fee9ffdd)(ws@8.19.0)(zod@4.3.5)':
+  '@mariozechner/pi-ai@0.43.0(patch_hash=946c027f6601937d94460f1d30c7a3b7e70d78411dfeecb1240f72db5517f8ab)(ws@8.19.0)(zod@4.3.5)':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.5)
       '@google/genai': 1.34.0
@@ -4438,7 +4438,7 @@ snapshots:
     dependencies:
       '@mariozechner/clipboard': 0.3.0
       '@mariozechner/pi-agent-core': 0.43.0(ws@8.19.0)(zod@4.3.5)
-      '@mariozechner/pi-ai': 0.43.0(patch_hash=3eee8ed34968210911b89dc61e65d651e2be64943933d24ab1de86c7fee9ffdd)(ws@8.19.0)(zod@4.3.5)
+      '@mariozechner/pi-ai': 0.43.0(patch_hash=946c027f6601937d94460f1d30c7a3b7e70d78411dfeecb1240f72db5517f8ab)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-tui': 0.43.0
       chalk: 5.6.2
       cli-highlight: 2.1.11

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -5,12 +5,12 @@ import {
   agentsDeleteCommand,
   agentsListCommand,
 } from "../commands/agents.js";
-import { dashboardCommand } from "../commands/dashboard.js";
 import {
   CONFIGURE_WIZARD_SECTIONS,
   configureCommand,
   configureCommandWithSections,
 } from "../commands/configure.js";
+import { dashboardCommand } from "../commands/dashboard.js";
 import { doctorCommand } from "../commands/doctor.js";
 import { healthCommand } from "../commands/health.js";
 import { messageCommand } from "../commands/message.js";

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { dashboardCommand } from "./dashboard.js";
 
@@ -94,7 +94,10 @@ describe("dashboardCommand", () => {
   it("prints SSH hint when browser cannot open", async () => {
     mockSnapshot("shhhh");
     mocks.copyToClipboard.mockResolvedValue(false);
-    mocks.detectBrowserOpenSupport.mockResolvedValue({ ok: false, reason: "ssh" });
+    mocks.detectBrowserOpenSupport.mockResolvedValue({
+      ok: false,
+      reason: "ssh",
+    });
     mocks.formatControlUiSshHint.mockReturnValue("ssh hint");
 
     await dashboardCommand(runtime);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,6 +1,9 @@
-import { resolveGatewayPort, readConfigFileSnapshot } from "../config/config.js";
-import { defaultRuntime } from "../runtime.js";
+import {
+  readConfigFileSnapshot,
+  resolveGatewayPort,
+} from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
 import {
   copyToClipboard,
   detectBrowserOpenSupport,
@@ -33,7 +36,9 @@ export async function dashboardCommand(
   runtime.log(`Dashboard URL: ${authedUrl}`);
 
   const copied = await copyToClipboard(authedUrl).catch(() => false);
-  runtime.log(copied ? "Copied to clipboard." : "Copy to clipboard unavailable.");
+  runtime.log(
+    copied ? "Copied to clipboard." : "Copy to clipboard unavailable.",
+  );
 
   let opened = false;
   let hint: string | undefined;


### PR DESCRIPTION
Fixes #795 reported by @pein1337-jpg

## Problem
Gemini 3 models returned 404 Not Found because the full model ID
(e.g., \`google/gemini-3-flash-preview\`) was being sent to the
Google Generative AI API, which expects only the model name
without the provider prefix.

## Solution
The fix extracts just the model name before sending to the API:
- \`google/gemini-3-flash-preview\` → \`gemini-3-flash-preview\`
- \`gemini-3-flash-preview\` → \`gemini-3-flash-preview\` (unchanged)

This was done by updating \`patches/@mariozechner__pi-ai@0.43.0.patch\`
to include changes to \`dist/providers/google.js\`.

### Changed Files
- \`patches/@mariozechner__pi-ai@0.43.0.patch\` (added google.js model ID stripping)
- \`pnpm-lock.yaml\` (updated patch hash)

### Testing
Verified with:
- clawdbot 2026.1.9-2026.1.11-4
- @mariozechner/pi-ai 0.42.2-0.43.0
- Node.js v22.21.1

## Credit
Fix originally proposed and validated by @pein1337-jpg in #795