### PR TITLE
fix: strip thought_signature fields for cross-provider compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Auto-reply: re-evaluate reasoning tag enforcement on fallback providers to prevent leaked reasoning. (#810 — thanks @mcinteerj)
 - Tools/Gemini: drop null-only union variants while cleaning tool schemas to avoid Cloud Code Assist schema errors. (#782 — thanks @AbhisekBasu1)
 - Connections UI: polish multi-account account cards in the Connections view. (#816 — thanks @steipete)
+- Gemini: strip Claude `msg_*` thought_signature fields from session history to avoid base64 decode errors. (#805 — thanks @marcmarg)
 
 ## 2026.1.12-3
 

--- a/src/agents/pi-embedded-helpers.test.ts
+++ b/src/agents/pi-embedded-helpers.test.ts
@@ -9,12 +9,13 @@ import {
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
   isContextOverflowError,
+  isMessagingToolDuplicate,
   isFailoverErrorMessage,
+  normalizeTextForComparison,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
   sanitizeToolCallId,
   stripThoughtSignatures,
-  validateGeminiTurns,
 } from "./pi-embedded-helpers.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -591,9 +592,9 @@ describe("sanitizeSessionMessagesImages - thought_signature stripping", () => {
     const content = (out[0] as { content?: unknown[] }).content;
     expect(content).toHaveLength(2);
     expect("thought_signature" in ((content?.[0] ?? {}) as object)).toBe(false);
-    expect((content?.[1] as { thought_signature?: unknown })?.thought_signature).toBe(
-      "AQID",
-    );
+    expect(
+      (content?.[1] as { thought_signature?: unknown })?.thought_signature,
+    ).toBe("AQID");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `stripThoughtSignatures()` function to remove Claude's `thought_signature` fields from content blocks
- Integrates into `sanitizeSessionMessagesImages()` for automatic stripping during session sanitization
- Enables cross-provider session sharing (Claude → Gemini, etc.)

## Problem

Claude's extended thinking feature generates `thought_signature` fields with message IDs like `msg_abc123...`. When session history containing these is sent to Google's Gemini API, it fails with:

```
Invalid value at 'thought_signature' (TYPE_BYTES), Base64 decoding failed for "msg_..."
```

Gemini expects Base64-encoded bytes, not Claude's message ID format.

## Solution

Strip `thought_signature` fields from assistant message content blocks during sanitization, before the history is sent to any provider.

## Test plan

- [x] Unit tests for `stripThoughtSignatures()` function
- [x] Integration test for `sanitizeSessionMessagesImages()` thought_signature stripping
- [x] Manual testing with Claude-thinking → Gemini fallback scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)