### PR TITLE
fix(minimax): strip tool invocation XML from assistant text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
 - Sandbox: support tool-policy groups in `tools.sandbox.tools` (e.g. `group:memory`, `group:fs`) to reduce config churn.
 
 ### Fixes
+- Models/MiniMax: strip malformed tool invocation XML (`<invoke>...</invoke>` and `</minimax:tool_call>`) from assistant text to prevent tool call leaks into user messages.
 - Tools/Models: MiniMax vision now uses the Coding Plan VLM endpoint (`/v1/coding_plan/vlm`) so the `image` tool works with MiniMax keys (also accepts `@/path/to/file.png`-style inputs).
-- Gateway/macOS: reduce noisy loopback WS “closed before connect” logs during tests.
+- Gateway/macOS: reduce noisy loopback WS "closed before connect" logs during tests.
 - Auto-reply: resolve ambiguous `/model` fuzzy matches by picking the best candidate instead of erroring.
 
 ## 2026.1.12-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Sandbox: support tool-policy groups in `tools.sandbox.tools` (e.g. `group:memory`, `group:fs`) to reduce config churn.
 
 ### Fixes
-- Models/MiniMax: strip malformed tool invocation XML (`<invoke>...</invoke>` and `</minimax:tool_call>`) from assistant text to prevent tool call leaks into user messages.
+- Models/MiniMax: strip malformed tool invocation XML (`<invoke>...</invoke>` and `</minimax:tool_call>`) from assistant text to prevent tool call leaks into user messages. (#809 — thanks @latitudeki5223)
 - Tools/Models: MiniMax vision now uses the Coding Plan VLM endpoint (`/v1/coding_plan/vlm`) so the `image` tool works with MiniMax keys (also accepts `@/path/to/file.png`-style inputs).
 - Gateway/macOS: reduce noisy loopback WS "closed before connect" logs during tests.
 - Auto-reply: resolve ambiguous `/model` fuzzy matches by picking the best candidate instead of erroring.

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,6 +1,6 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { extractAssistantText } from "./pi-embedded-utils.js";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 
 describe("extractAssistantText", () => {
   it("strips Minimax tool invocation XML from text", () => {

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -41,6 +41,24 @@ describe("extractAssistantText", () => {
     expect(result).toBe("Let me check that.");
   });
 
+  it("keeps invoke snippets without Minimax markers", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Example:\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(
+      `Example:\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>`,
+    );
+  });
+
   it("preserves normal text without tool invocations", () => {
     const msg: AssistantMessage = {
       role: "assistant",
@@ -55,6 +73,22 @@ describe("extractAssistantText", () => {
 
     const result = extractAssistantText(msg);
     expect(result).toBe("This is a normal response without any tool calls.");
+  });
+
+  it("strips Minimax tool invocations with extra attributes", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Before<invoke name='Bash' data-foo="bar">\n<parameter name="command">ls</parameter>\n</invoke>\n</minimax:tool_call>After`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Before\nAfter");
   });
 
   it("strips tool XML mixed with regular content", () => {

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { extractAssistantText } from "./pi-embedded-utils.js";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+
+describe("extractAssistantText", () => {
+  it("strips Minimax tool invocation XML from text", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">netstat -tlnp | grep 18789</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("");
+  });
+
+  it("strips multiple tool invocations", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Let me check that.<invoke name="Read">
+<parameter name="path">/home/admin/test.txt</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Let me check that.");
+  });
+
+  it("preserves normal text without tool invocations", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "This is a normal response without any tool calls.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("This is a normal response without any tool calls.");
+  });
+
+  it("strips tool XML mixed with regular content", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `I'll help you with that.<invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke>
+</minimax:tool_call>Here are the results.`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("I'll help you with that.\nHere are the results.");
+  });
+
+  it("handles multiple invoke blocks in one message", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `First check.<invoke name="Read">
+<parameter name="path">file1.txt</parameter>
+</invoke>
+</minimax:tool_call>Second check.<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>Done.`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("First check.\nSecond check.\nDone.");
+  });
+
+  it("handles stray closing tags without opening tags", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Some text here.</minimax:tool_call>More text.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Some text here.More text.");
+  });
+
+  it("returns empty string when message is only tool invocations", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">test</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("");
+  });
+
+  it("handles multiple text blocks", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "First block.",
+        },
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+        {
+          type: "text",
+          text: "Third block.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("First block.\nThird block.");
+  });
+});

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -10,14 +10,15 @@ import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
  */
 function stripMinimaxToolCallXml(text: string): string {
   if (!text) return text;
+  if (!/minimax:tool_call/i.test(text)) return text;
 
-  // Remove <invoke name="...">...</invoke> blocks (non-greedy to handle multiple)
-  let cleaned = text.replace(/<invoke\s+name="[^"]*">[\s\S]*?<\/invoke>/gi, "");
+  // Remove <invoke ...>...</invoke> blocks (non-greedy to handle multiple).
+  let cleaned = text.replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, "");
 
-  // Remove stray </minimax:tool_call> tags
-  cleaned = cleaned.replace(/<\/minimax:tool_call>/gi, "");
+  // Remove stray minimax tool tags.
+  cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
 
-  return cleaned.trim();
+  return cleaned;
 }
 
 export function extractAssistantText(msg: AssistantMessage): string {


### PR DESCRIPTION
## Problem

Minimax AI was leaking raw tool invocation XML into user-facing messages on Telegram, Discord, and other messaging platforms. Users were seeing output like:

```xml
<invoke name="Bash">
<parameter name="command">netstat -tlnp | grep 18789</parameter>
</invoke>
</minimax:tool_call>
```

This occurred across all messaging surfaces, including cron jobs and auto-replies.

## Root Cause

Minimax embeds tool calls as XML inside text content blocks instead of using proper structured tool calls. This bypasses Clawdbot's normal tool execution pipeline, causing the raw XML to leak through to `extractAssistantText()` and ultimately to end users.

## Solution

Added `stripMinimaxToolCallXml()` function in `src/agents/pi-embedded-utils.ts` that sanitizes assistant text by removing:
- `<invoke name="...">...</invoke>` blocks (using non-greedy regex to handle multiple invocations)
- `</minimax:tool_call>` closing tags

The function is applied in `extractAssistantText()` which processes all assistant messages before delivery, ensuring XML never reaches users.

## Testing

Created comprehensive test suite (`src/agents/pi-embedded-utils.test.ts`) with 8 test cases covering:
- ✅ Single tool invocation removal
- ✅ Multiple tool invocations in one message  
- ✅ Mixed content (normal text + XML)
- ✅ Stray closing tags
- ✅ Messages containing only XML (returns empty string)
- ✅ Multiple text blocks
- ✅ Normal text preservation (no false positives)

All tests pass.

## Changelog

Updated `CHANGELOG.md` with fix entry for 2026.1.12-2 release.

## Impact

- **Fixes:** Tool call XML leakage to all messaging platforms when using Minimax
- **Scope:** Non-breaking change, only affects Minimax provider
- **Safety:** Conservative regex patterns with test coverage

---

🤖 Generated with Claude Code