### PR TITLE
fix: cleanup old suspended claude processes to prevent memory leaks

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -11,7 +11,7 @@ import type { ClawdbotConfig } from "../config/config.js";
 import type { CliBackendConfig } from "../config/types.js";
 import { shouldLogVerbose } from "../globals.js";
 import { createSubsystemLogger } from "../logging.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
@@ -601,6 +601,18 @@ export async function runCliAgent(params: {
         }
         return next;
       })();
+
+      // Clean up old suspended processes with the same sessionId to prevent memory leaks
+      if (useResume && cliSessionIdToSend) {
+        try {
+          await runExec("pkill", [
+            "-f",
+            `claude.*--resume.*${cliSessionIdToSend.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+          ]);
+        } catch {
+          // Ignore if no processes found
+        }
+      }
 
       const result = await runCommandWithTimeout([backend.command, ...args], {
         timeoutMs: params.timeoutMs,


### PR DESCRIPTION
When resuming Claude sessions, old processes with --resume flags were never killed, causing them to accumulate in memory (60+ processes, ~3GB of RAM). 

This fix kills old processes with the same sessionId before launching a new one.

## Changes
- Kill old suspended processes when resuming Claude CLI sessions
- Prevents memory leak from accumulating abandoned processes

## Testing
Tested locally with Claude CLI resume sessions.