### PR TITLE
Telegram: fix webhook multi-account routing (respect bindings.accountId)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Onboarding/Configure: refuse to proceed with invalid configs; run `clawdbot doctor` first to avoid wiping custom fields. (#764 — thanks @mukhtharcm)
 - Anthropic: merge consecutive user turns (preserve newest metadata) before validation to avoid “Incorrect role information” errors. (#804 — thanks @ThomsenDrake)
 - Discord/Slack: centralize reply-thread planning so auto-thread replies stay in the created thread without parent reply refs.
+- Telegram: respect account-scoped bindings when webhook mode is enabled. (#821 — thanks @gumadeiras)
 - Update: run `clawdbot doctor --non-interactive` during updates to avoid TTY hangs. (#781 — thanks @ronyrus)
 - Browser tools: treat explicit `maxChars: 0` as unlimited while keeping the default limit only when omitted. (#796 — thanks @gabriel-trigo)
 - Tools: allow Claude/Gemini tool param aliases (`file_path`, `old_string`, `new_string`) while enforcing required params at runtime. (#793 — thanks @hsrvc)

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -96,6 +96,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   if (opts.useWebhook) {
     await startTelegramWebhook({
       token,
+      accountId: account.accountId,
+      config: cfg,
       path: opts.webhookPath,
       port: opts.webhookPort,
       secret: opts.webhookSecret,

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -31,15 +31,19 @@ describe("startTelegramWebhook", () => {
   it("starts server, registers webhook, and serves health", async () => {
     createTelegramBotSpy.mockClear();
     const abort = new AbortController();
+    const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
       token: "tok",
       accountId: "opie",
-      config: { bindings: [] },
+      config: cfg,
       port: 0, // random free port
       abortSignal: abort.signal,
     });
     expect(createTelegramBotSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: "opie" }),
+      expect.objectContaining({
+        accountId: "opie",
+        config: expect.objectContaining({ bindings: [] }),
+      }),
     );
     const address = server.address();
     if (!address || typeof address === "string") throw new Error("no address");
@@ -56,14 +60,21 @@ describe("startTelegramWebhook", () => {
     handlerSpy.mockClear();
     createTelegramBotSpy.mockClear();
     const abort = new AbortController();
+    const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
       token: "tok",
       accountId: "opie",
-      config: { bindings: [] },
+      config: cfg,
       port: 0,
       abortSignal: abort.signal,
       path: "/hook",
     });
+    expect(createTelegramBotSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "opie",
+        config: expect.objectContaining({ bindings: [] }),
+      }),
+    );
     const addr = server.address();
     if (!addr || typeof addr === "string") throw new Error("no addr");
     await fetch(`http://127.0.0.1:${addr.port}/hook`, { method: "POST" });

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 
 import { webhookCallback } from "grammy";
+import type { ClawdbotConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -8,6 +9,8 @@ import { createTelegramBot } from "./bot.js";
 
 export async function startTelegramWebhook(opts: {
   token: string;
+  accountId?: string;
+  config?: ClawdbotConfig;
   path?: string;
   port?: number;
   host?: string;
@@ -27,6 +30,8 @@ export async function startTelegramWebhook(opts: {
     token: opts.token,
     runtime,
     proxyFetch: opts.fetch,
+    config: opts.config,
+    accountId: opts.accountId,
   });
   const handler = webhookCallback(bot, "http", {
     secretToken: opts.secret,


### PR DESCRIPTION
Fixes #803 

This PR fixes a routing bug where Telegram inbound messages received via webhook mode were always routed as `accountId=default`, causing bindings like `{ provider: "telegram", accountId: "opie" }` to never match and messages to fall back to the default agent (`main`). The webhook server now passes the configured `accountId` (and loaded config) into `createTelegramBot()`, so `resolveAgentRoute()` evaluates bindings correctly and sessions no longer leak across agents.

**What changed**
- webhook.ts: `startTelegramWebhook()` now accepts `accountId` + `config` and forwards both into `createTelegramBot()`.
- monitor.ts: passes `accountId` + `config` into `startTelegramWebhook()` when webhook mode is enabled.
- webhook.test.ts: regression test to ensure webhook startup forwards `accountId` into `createTelegramBot()`.
- bot.test.ts: regression test that `bindings.match.accountId` routes a DM to the bound agent session.

**Reproduction**
Config:
```json5
{
  telegram: {
    enabled: true,
    accounts: {
      steve: { botToken: "...", dmPolicy: "pairing" },
      opie:  { botToken: "...", dmPolicy: "pairing", webhookUrl: "https://example.com/telegram-webhook" }
    }
  },
  bindings: [
    { agentId: "opie", match: { provider: "telegram", accountId: "opie" } }
  ]
}
```

Before:
- DM to `opie` bot routes to `agent:main:...` (binding doesn’t match because webhook bot runs as `accountId=default`).

After:
- DM to `opie` bot routes to `agent:opie:main` and payload carries `AccountId: "opie"`.

**Validation**
Tested locally with three bots and works as intended.
Sample config:
```json5
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "anthropic/claude-opus-4-5",
        "fallbacks": [
          "google-antigravity/claude-opus-4-5-thinking",
          "anthropic/claude-sonnet-4-5",
          "google-antigravity/gemini-3-pro-high",
          "google-antigravity/gemini-3-flash"
        ]
      },
      "models": {
        "google-antigravity/claude-opus-4-5-thinking": {},
        "anthropic/claude-opus-4-5": {
          "alias": "opus"
        },
        "anthropic/claude-sonnet-4-5": {
          "alias": "sonnet"
        },
        "google-antigravity/gemini-3-flash": {
          "alias": "gemini-3-flash"
        },
        "google-antigravity/gemini-3-pro-high": {
          "alias": "gemini-3-pro"
        },
        "anthropic/claude-haiku-4-5": {
          "alias": "haiku"
        }
      },
      "workspace": "/Users/gumadeiras/clawd",
      "contextPruning": {
        "mode": "adaptive"
      },
      "heartbeat": {
        "every": "60m",
        "model": "google-antigravity/gemini-3-pro-high",
        "target": "last"
      }
    },
    "list": [
      {
        "id": "pinguini",
        "default": true,
        "workspace": "/Users/gumadeiras/clawd-pinguini",
        "model": "anthropic/claude-opus-4-5",
        "subagents": {
          "allowAgents": [
            "*"
          ]
        }
      },
      {
        "id": "poe",
        "workspace": "/Users/gumadeiras/clawd-poe",
        "model": "google-antigravity/gemini-3-pro-high",
        "tools": {
          "deny": [
            "peekaboo"
          ]
        }
      },
      {
        "id": "flurry",
        "workspace": "/Users/username/clawd-flurry",
        "model": "google-antigravity/gemini-3-flash",
        "tools": {
          "deny": [
            "peekaboo"
          ]
        }
      }
    ]
  },
  "bindings": [
    {
      "agentId": "pinguini",
      "match": {
        "provider": "telegram",
        "accountId": "pinguini"
      }
    },
    {
      "agentId": "poe",
      "match": {
        "provider": "telegram",
        "accountId": "poe"
      }
    },
    {
      "agentId": "flurry",
      "match": {
        "provider": "telegram",
        "accountId": "flurry"
      }
    }
  ],
  "telegram": {
    "capabilities": [
      "inlineButtons"
    ],
    "enabled": true,
    "dmPolicy": "pairing",
    "groupPolicy": "open",
    "streamMode": "off",
    "accounts": {
      "pinguini": {
        "dmPolicy": "allowlist",
        "botToken": "82...s",
        "allowFrom": [
          "0123456789"
        ],
        "groupPolicy": "allowlist",
        "streamMode": "partial"
      },
      "poe": {
        "dmPolicy": "allowlist",
        "botToken": "85...k",
        "allowFrom": [
          "0123456789"
        ],
        "groupPolicy": "allowlist",
        "streamMode": "partial"
      },
      "flurry": {
        "dmPolicy": "allowlist",
        "botToken": "85...M",
        "allowFrom": [
          "0123456789"
        ],
        "groupPolicy": "allowlist",
        "streamMode": "partial"
      }
    }
  }
}
```
**Notes / follow-ups**
- MS Teams appears to have a similar limitation: inbound routing currently calls `resolveAgentRoute()` without an `accountId`, so account-scoped bindings can’t work there until a stable account identifier is defined for Teams.