### PR TITLE
fix: treat credential validation failures as auth errors for fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Memory: allow custom OpenAI-compatible embedding endpoints for memory search (remote baseUrl/apiKey/headers). (#819 — thanks @mukhtharcm)
 
 ### Fixes
-- Fallback: treat credential validation failures ("no credentials found", "no API key found") as auth errors that trigger model fallback. (#761 — thanks @pilkster)
+- Fallback: treat credential validation failures ("no credentials found", "no API key found") as auth errors that trigger model fallback. (#822 — thanks @sebslight)
 - Telegram: persist polling update offsets across restarts to avoid duplicate updates. (#739 — thanks @thewilloftheshadow)
 - Discord: avoid duplicate message/reaction listeners on monitor reloads. (#744 — thanks @thewilloftheshadow)
 - System events: include local timestamps when events are injected into prompts. (#245 — thanks @thewilloftheshadow)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
 - Memory: allow custom OpenAI-compatible embedding endpoints for memory search (remote baseUrl/apiKey/headers). (#819 — thanks @mukhtharcm)
 
 ### Fixes
+- Fallback: treat credential validation failures ("no credentials found", "no API key found") as auth errors that trigger model fallback. (#761 — thanks @pilkster)
 - Telegram: persist polling update offsets across restarts to avoid duplicate updates. (#739 — thanks @thewilloftheshadow)
 - Discord: avoid duplicate message/reaction listeners on monitor reloads. (#744 — thanks @thewilloftheshadow)
 - System events: include local timestamps when events are injected into prompts. (#245 — thanks @thewilloftheshadow)
 - Cron: accept `jobId` aliases for cron update/run/remove params in gateway validation. (#252 — thanks @thewilloftheshadow)
 - Models/Google: normalize Gemini 3 model ids to preview variants before runtime selection. (#795 — thanks @thewilloftheshadow)
-- TUI: keep the last streamed response instead of replacing it with “(no output)”. (#747 — thanks @thewilloftheshadow)
+- TUI: keep the last streamed response instead of replacing it with "(no output)". (#747 — thanks @thewilloftheshadow)
 - Slack: accept slash commands with or without leading `/` for custom command configs. (#798 — thanks @thewilloftheshadow)
 - Onboarding/Configure: refuse to proceed with invalid configs; run `clawdbot doctor` first to avoid wiping custom fields. (#764 — thanks @mukhtharcm)
 - Anthropic: merge consecutive user turns (preserve newest metadata) before validation to avoid “Incorrect role information” errors. (#804 — thanks @ThomsenDrake)

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -124,6 +124,26 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
   });
 
+  it("falls back on missing API key errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("No API key found for profile openai."))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
   it("appends the configured primary as a last fallback", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -102,6 +102,28 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
   });
 
+  it("falls back on credential validation errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('No credentials found for profile "anthropic:claude-cli".'),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
   it("appends the configured primary as a last fallback", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -361,6 +361,9 @@ const ERROR_PATTERNS = {
     "token has expired",
     /\b401\b/,
     /\b403\b/,
+    // Credential validation failures should trigger fallback (#761)
+    "no credentials found",
+    "no api key found",
   ],
   format: [
     "invalid_request_error",

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -6,11 +6,11 @@ import { formatDurationMs } from "../infra/format-duration.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { createTelegramBot } from "./bot.js";
+import { makeProxyFetch } from "./proxy.js";
 import {
   readTelegramUpdateOffset,
   writeTelegramUpdateOffset,
 } from "./update-offset-store.js";
-import { makeProxyFetch } from "./proxy.js";
 import { startTelegramWebhook } from "./webhook.js";
 
 export type MonitorTelegramOpts = {

--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -34,9 +34,9 @@ describe("telegram update offset store", () => {
         updateId: 421,
       });
 
-      expect(
-        await readTelegramUpdateOffset({ accountId: "primary" }),
-      ).toBe(421);
+      expect(await readTelegramUpdateOffset({ accountId: "primary" })).toBe(
+        421,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Credential validation failures ("no credentials found", "no API key found") now trigger model fallback instead of failing immediately
- When an auth profile has missing/expired credentials and all profiles for a provider fail, the system now properly falls back to configured fallback models

## Problem
When `anthropic:claude-cli` credentials expired, the error `No credentials found for profile "anthropic:claude-cli"` was thrown. This error message wasn't recognized as an auth error, so:
1. The error was thrown immediately
2. Model fallbacks (e.g., `openai/gpt-4o`) were never attempted
3. User saw error instead of degraded service

## Solution
Added "no credentials found" and "no api key found" to the auth error patterns in `ERROR_PATTERNS.auth`. These patterns are now classified as auth errors, triggering the standard fallback behavior.

## Test plan
- [x] Added test case for credential validation error fallback in `model-fallback.test.ts`
- [x] All 593 agent tests pass
- [x] Lint passes

Closes #761