### PR TITLE
Fix MiniMax onboarding auth storage when CLAWDBOT_AGENT_DIR is set

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -113,8 +113,6 @@ describe("applyAuthChoice", () => {
 
     const authProfilePath = path.join(
       tempStateDir,
-      "agents",
-      "main",
       "agent",
       "auth-profiles.json",
     );
@@ -172,8 +170,6 @@ describe("applyAuthChoice", () => {
 
     const authProfilePath = path.join(
       tempStateDir,
-      "agents",
-      "main",
       "agent",
       "auth-profiles.json",
     );
@@ -339,8 +335,6 @@ describe("applyAuthChoice", () => {
 
     const authProfilePath = path.join(
       tempStateDir,
-      "agents",
-      "main",
       "agent",
       "auth-profiles.json",
     );
@@ -428,8 +422,6 @@ describe("applyAuthChoice", () => {
 
     const authProfilePath = path.join(
       tempStateDir,
-      "agents",
-      "main",
       "agent",
       "auth-profiles.json",
     );

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -16,6 +16,7 @@ import {
   applySyntheticConfig,
   applySyntheticProviderConfig,
   OPENROUTER_DEFAULT_MODEL_REF,
+  setMinimaxApiKey,
   SYNTHETIC_DEFAULT_MODEL_ID,
   SYNTHETIC_DEFAULT_MODEL_REF,
   writeOAuthCredentials,
@@ -50,10 +51,9 @@ describe("writeOAuthCredentials", () => {
     delete process.env.CLAWDBOT_OAUTH_DIR;
   });
 
-  it("writes auth-profiles.json under CLAWDBOT_STATE_DIR/agents/main/agent", async () => {
+  it("writes auth-profiles.json under CLAWDBOT_AGENT_DIR when set", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-oauth-"));
     process.env.CLAWDBOT_STATE_DIR = tempStateDir;
-    // Even if legacy env vars are set, onboarding should write to the multi-agent path.
     process.env.CLAWDBOT_AGENT_DIR = path.join(tempStateDir, "agent");
     process.env.PI_CODING_AGENT_DIR = process.env.CLAWDBOT_AGENT_DIR;
 
@@ -65,11 +65,8 @@ describe("writeOAuthCredentials", () => {
 
     await writeOAuthCredentials("openai-codex", creds);
 
-    // Now writes to the multi-agent path: agents/main/agent
     const authProfilePath = path.join(
       tempStateDir,
-      "agents",
-      "main",
       "agent",
       "auth-profiles.json",
     );
@@ -85,7 +82,67 @@ describe("writeOAuthCredentials", () => {
 
     await expect(
       fs.readFile(
-        path.join(tempStateDir, "agent", "auth-profiles.json"),
+        path.join(tempStateDir, "agents", "main", "agent", "auth-profiles.json"),
+        "utf8",
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe("setMinimaxApiKey", () => {
+  const previousStateDir = process.env.CLAWDBOT_STATE_DIR;
+  const previousAgentDir = process.env.CLAWDBOT_AGENT_DIR;
+  const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+  let tempStateDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempStateDir) {
+      await fs.rm(tempStateDir, { recursive: true, force: true });
+      tempStateDir = null;
+    }
+    if (previousStateDir === undefined) {
+      delete process.env.CLAWDBOT_STATE_DIR;
+    } else {
+      process.env.CLAWDBOT_STATE_DIR = previousStateDir;
+    }
+    if (previousAgentDir === undefined) {
+      delete process.env.CLAWDBOT_AGENT_DIR;
+    } else {
+      process.env.CLAWDBOT_AGENT_DIR = previousAgentDir;
+    }
+    if (previousPiAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+    }
+  });
+
+  it("writes to CLAWDBOT_AGENT_DIR when set", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-minimax-"));
+    process.env.CLAWDBOT_STATE_DIR = tempStateDir;
+    process.env.CLAWDBOT_AGENT_DIR = path.join(tempStateDir, "custom-agent");
+    process.env.PI_CODING_AGENT_DIR = process.env.CLAWDBOT_AGENT_DIR;
+
+    await setMinimaxApiKey("sk-minimax-test");
+
+    const customAuthPath = path.join(
+      tempStateDir,
+      "custom-agent",
+      "auth-profiles.json",
+    );
+    const raw = await fs.readFile(customAuthPath, "utf8");
+    const parsed = JSON.parse(raw) as {
+      profiles?: Record<string, { type?: string; provider?: string; key?: string }>;
+    };
+    expect(parsed.profiles?.["minimax:default"]).toMatchObject({
+      type: "api_key",
+      provider: "minimax",
+      key: "sk-minimax-test",
+    });
+
+    await expect(
+      fs.readFile(
+        path.join(tempStateDir, "agents", "main", "agent", "auth-profiles.json"),
         "utf8",
       ),
     ).rejects.toThrow();

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -1,5 +1,5 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
-import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { resolveClawdbotAgentDir } from "../agents/agent-paths.js";
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
 import { OPENCODE_ZEN_DEFAULT_MODEL_REF } from "../agents/opencode-zen-models.js";
 import {
@@ -115,7 +115,7 @@ export async function writeOAuthCredentials(
       provider,
       ...creds,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -128,7 +128,7 @@ export async function setAnthropicApiKey(key: string, agentDir?: string) {
       provider: "anthropic",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -141,7 +141,7 @@ export async function setGeminiApiKey(key: string, agentDir?: string) {
       provider: "google",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -154,7 +154,7 @@ export async function setMinimaxApiKey(key: string, agentDir?: string) {
       provider: "minimax",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -167,7 +167,7 @@ export async function setMoonshotApiKey(key: string, agentDir?: string) {
       provider: "moonshot",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -180,7 +180,7 @@ export async function setSyntheticApiKey(key: string, agentDir?: string) {
       provider: "synthetic",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -196,7 +196,7 @@ export async function setZaiApiKey(key: string, agentDir?: string) {
       provider: "zai",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -208,7 +208,7 @@ export async function setOpenrouterApiKey(key: string, agentDir?: string) {
       provider: "openrouter",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 
@@ -714,7 +714,7 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
       provider: "opencode",
       key,
     },
-    agentDir: agentDir ?? resolveDefaultAgentDir(),
+    agentDir: agentDir ?? resolveClawdbotAgentDir(),
   });
 }
 


### PR DESCRIPTION
Fixes #827.

Problem: onboarding wrote API keys to the default multi-agent dir even when CLAWDBOT_AGENT_DIR / PI_CODING_AGENT_DIR overrides are used, so model discovery couldn't see MiniMax auth and failed with `Unknown model: minimax/MiniMax-M2.1`.

Resolution: write onboarding auth profiles to `resolveClawdbotAgentDir()` when no explicit agentDir is provided, aligning onboarding with runtime auth/model discovery. Added regression tests covering env override behavior.