### PR TITLE
Persist subagent run registry to survive gateway restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Packaging: include `dist/memory/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/memory/index.js`).
+- Agents: persist sub-agent registry across gateway restarts and resume announce flow safely. (#831) — thanks @roshanasingh4.
 
 ## 2026.1.12-1
 

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => ({
+    status: "ok",
+    startedAt: 111,
+    endedAt: 222,
+  })),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn(() => noop),
+}));
+
+const announceSpy = vi.fn(async () => {});
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+}));
+
+describe("subagent registry persistence", () => {
+  const previousStateDir = process.env.CLAWDBOT_STATE_DIR;
+  let tempStateDir: string | null = null;
+
+  afterEach(async () => {
+    announceSpy.mockClear();
+    vi.resetModules();
+    if (tempStateDir) {
+      await fs.rm(tempStateDir, { recursive: true, force: true });
+      tempStateDir = null;
+    }
+    if (previousStateDir === undefined) {
+      delete process.env.CLAWDBOT_STATE_DIR;
+    } else {
+      process.env.CLAWDBOT_STATE_DIR = previousStateDir;
+    }
+  });
+
+  it("persists runs to disk and resumes after restart", async () => {
+    tempStateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-subagent-"),
+    );
+    process.env.CLAWDBOT_STATE_DIR = tempStateDir;
+
+    vi.resetModules();
+    const mod1 = await import("./subagent-registry.js");
+
+    mod1.registerSubagentRun({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do the thing",
+      cleanup: "keep",
+    });
+
+    const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+    const raw = await fs.readFile(registryPath, "utf8");
+    const parsed = JSON.parse(raw) as { runs?: Record<string, unknown> };
+    expect(parsed.runs && Object.keys(parsed.runs)).toContain("run-1");
+
+    // Simulate a process restart: module re-import should load persisted runs
+    // and trigger the announce flow once the run resolves.
+    vi.resetModules();
+    await import("./subagent-registry.js");
+
+    // allow queued async wait/announce to execute
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(announceSpy).toHaveBeenCalled();
+
+    type AnnounceParams = {
+      childRunId: string;
+      childSessionKey: string;
+    };
+    const first = announceSpy.mock.calls[0]?.[0] as unknown as AnnounceParams;
+    expect(first.childRunId).toBe("run-1");
+    expect(first.childSessionKey).toBe("agent:main:subagent:test");
+  });
+});

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -18,7 +18,7 @@ vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: vi.fn(() => noop),
 }));
 
-const announceSpy = vi.fn(async () => {});
+const announceSpy = vi.fn(async () => true);
 vi.mock("./subagent-announce.js", () => ({
   runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
 }));
@@ -67,7 +67,8 @@ describe("subagent registry persistence", () => {
     // Simulate a process restart: module re-import should load persisted runs
     // and trigger the announce flow once the run resolves.
     vi.resetModules();
-    await import("./subagent-registry.js");
+    const mod2 = await import("./subagent-registry.js");
+    mod2.initSubagentRegistry();
 
     // allow queued async wait/announce to execute
     await new Promise((r) => setTimeout(r, 0));
@@ -81,5 +82,45 @@ describe("subagent registry persistence", () => {
     const first = announceSpy.mock.calls[0]?.[0] as unknown as AnnounceParams;
     expect(first.childRunId).toBe("run-1");
     expect(first.childSessionKey).toBe("agent:main:subagent:test");
+  });
+
+  it("retries announce even when announceHandled was persisted", async () => {
+    tempStateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-subagent-"),
+    );
+    process.env.CLAWDBOT_STATE_DIR = tempStateDir;
+
+    const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+    const persisted = {
+      version: 1,
+      runs: {
+        "run-2": {
+          runId: "run-2",
+          childSessionKey: "agent:main:subagent:two",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "do the other thing",
+          cleanup: "keep",
+          createdAt: 1,
+          startedAt: 1,
+          endedAt: 2,
+          announceHandled: true,
+        },
+      },
+    };
+    await fs.mkdir(path.dirname(registryPath), { recursive: true });
+    await fs.writeFile(registryPath, `${JSON.stringify(persisted)}\n`, "utf8");
+
+    vi.resetModules();
+    const mod = await import("./subagent-registry.js");
+    mod.initSubagentRegistry();
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const calls = announceSpy.mock.calls.map((call) => call[0]);
+    const match = calls.find(
+      (params) => (params as { childRunId?: string }).childRunId === "run-2",
+    );
+    expect(match).toBeTruthy();
   });
 });

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+
+import { STATE_DIR_CLAWDBOT } from "../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+import type { SubagentRunRecord } from "./subagent-registry.js";
+
+export type PersistedSubagentRegistryVersion = 1;
+
+type PersistedSubagentRegistry = {
+  version: 1;
+  runs: Record<string, SubagentRunRecord>;
+};
+
+const REGISTRY_VERSION = 1 as const;
+
+export function resolveSubagentRegistryPath(): string {
+  return path.join(STATE_DIR_CLAWDBOT, "subagents", "runs.json");
+}
+
+export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
+  const pathname = resolveSubagentRegistryPath();
+  const raw = loadJsonFile(pathname);
+  if (!raw || typeof raw !== "object") return new Map();
+  const record = raw as Partial<PersistedSubagentRegistry>;
+  if (record.version !== REGISTRY_VERSION) return new Map();
+  const runsRaw = record.runs;
+  if (!runsRaw || typeof runsRaw !== "object") return new Map();
+  const out = new Map<string, SubagentRunRecord>();
+  for (const [runId, entry] of Object.entries(runsRaw)) {
+    if (!entry || typeof entry !== "object") continue;
+    const typed = entry as SubagentRunRecord;
+    if (!typed.runId || typeof typed.runId !== "string") continue;
+    out.set(runId, typed);
+  }
+  return out;
+}
+
+export function saveSubagentRegistryToDisk(
+  runs: Map<string, SubagentRunRecord>,
+) {
+  const pathname = resolveSubagentRegistryPath();
+  const out: PersistedSubagentRegistry = {
+    version: REGISTRY_VERSION,
+    runs: Object.fromEntries(runs.entries()),
+  };
+  saveJsonFile(pathname, out);
+}

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -8,10 +8,12 @@ export type PersistedSubagentRegistryVersion = 1;
 
 type PersistedSubagentRegistry = {
   version: 1;
-  runs: Record<string, SubagentRunRecord>;
+  runs: Record<string, PersistedSubagentRunRecord>;
 };
 
 const REGISTRY_VERSION = 1 as const;
+
+type PersistedSubagentRunRecord = Omit<SubagentRunRecord, "announceHandled">;
 
 export function resolveSubagentRegistryPath(): string {
   return path.join(STATE_DIR_CLAWDBOT, "subagents", "runs.json");
@@ -28,9 +30,17 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
   const out = new Map<string, SubagentRunRecord>();
   for (const [runId, entry] of Object.entries(runsRaw)) {
     if (!entry || typeof entry !== "object") continue;
-    const typed = entry as SubagentRunRecord;
+    const typed = entry as PersistedSubagentRunRecord;
     if (!typed.runId || typeof typed.runId !== "string") continue;
-    out.set(runId, typed);
+    const announceCompletedAt =
+      typeof typed.announceCompletedAt === "number"
+        ? typed.announceCompletedAt
+        : undefined;
+    out.set(runId, {
+      ...typed,
+      announceCompletedAt,
+      announceHandled: Boolean(announceCompletedAt),
+    });
   }
   return out;
 }
@@ -39,9 +49,14 @@ export function saveSubagentRegistryToDisk(
   runs: Map<string, SubagentRunRecord>,
 ) {
   const pathname = resolveSubagentRegistryPath();
+  const serialized: Record<string, PersistedSubagentRunRecord> = {};
+  for (const [runId, entry] of runs.entries()) {
+    const { announceHandled: _ignored, ...persisted } = entry;
+    serialized[runId] = persisted;
+  }
   const out: PersistedSubagentRegistry = {
     version: REGISTRY_VERSION,
-    runs: Object.fromEntries(runs.entries()),
+    runs: serialized,
   };
   saveJsonFile(pathname, out);
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -19,6 +19,7 @@ import {
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
+import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
 import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
 import {
@@ -460,6 +461,7 @@ export async function startGatewayServer(
   }
 
   const cfgAtStart = loadConfig();
+  initSubagentRegistry();
   await autoMigrateLegacyState({ cfg: cfgAtStart, log });
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(


### PR DESCRIPTION
Fixes #817 (partial): persist subagent run registry + restart resume.

Problem
- Subagent runs are tracked in-memory only (`subagentRuns` map). If the gateway restarts while a subagent is running (or after it finished but before announce), the registry is lost and announce/cleanup may never happen.

Solution
- Persist `SubagentRunRecord` to `STATE_DIR/subagents/runs.json` on every mutation.
- On process start, load the persisted registry and resume pending runs by re-issuing `agent.wait` and/or triggering the announce flow for already-ended runs.
- Keep existing behavior for archive sweeper + cleanup, but make it survive restarts as well.

Tests
- Adds `src/agents/subagent-registry.persistence.test.ts` which simulates a restart via module reload and asserts persisted runs are resumed + announce flow triggers.

Notes
- Intentionally scoped to persistence + restart resume only (no other subagent UX changes).