### PR TITLE
fix: handle Anthropic overloaded_error gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Agents: auto-recover from compaction context overflow by resetting the session and retrying; propagate overflow details from embedded runs so callers can recover.
 - MiniMax: strip malformed tool invocation XML; include `MiniMax-VL-01` in implicit provider for image pairing.
 - Onboarding/Auth: honor `CLAWDBOT_AGENT_DIR` / `PI_CODING_AGENT_DIR` when writing auth profiles (MiniMax). (#829) — thanks @roshanasingh4.
+- Anthropic: handle `overloaded_error` with a friendly message and failover classification. (#832) — thanks @danielz1z.
 - Anthropic: merge consecutive user turns (preserve newest metadata) before validation to avoid incorrect role errors.
 - Messaging: enforce context isolation for message tool sends; keep typing indicators alive during tool execution.
 - Auto-reply: `/status` allowlist behavior, reasoning-tag enforcement on fallback, and system-event enqueueing for elevated/reasoning toggles.

--- a/src/agents/pi-embedded-helpers.test.ts
+++ b/src/agents/pi-embedded-helpers.test.ts
@@ -209,6 +209,11 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("resource has been exhausted")).toBe(
       "rate_limit",
     );
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      ),
+    ).toBe("rate_limit");
     expect(classifyFailoverReason("invalid request format")).toBe("format");
     expect(classifyFailoverReason("credit balance too low")).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
@@ -263,6 +268,15 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toContain(
       "Message ordering conflict",
+    );
+  });
+
+  it("returns a friendly message for Anthropic overload errors", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_123"}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
     );
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -392,6 +392,11 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  // Check for overloaded errors (Anthropic API capacity)
+  if (isOverloadedErrorMessage(raw)) {
+    return "The AI service is temporarily overloaded. Please try again in a moment.";
+  }
+
   // Keep it short for WhatsApp.
   return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
 }
@@ -414,6 +419,7 @@ const ERROR_PATTERNS = {
     "resource_exhausted",
     "usage limit",
   ],
+  overloaded: [/overloaded_error|"type"\s*:\s*"overloaded"/i, "overloaded"],
   timeout: [
     "timeout",
     "timed out",
@@ -496,6 +502,10 @@ export function isAuthErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.auth);
 }
 
+export function isOverloadedErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
 export function isCloudCodeAssistFormatError(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.format);
 }
@@ -517,6 +527,7 @@ export type FailoverReason =
 
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isRateLimitErrorMessage(raw)) return "rate_limit";
+  if (isOverloadedErrorMessage(raw)) return "rate_limit"; // Treat overloaded as rate limit for failover
   if (isCloudCodeAssistFormatError(raw)) return "format";
   if (isBillingErrorMessage(raw)) return "billing";
   if (isTimeoutErrorMessage(raw)) return "timeout";

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -419,7 +419,10 @@ const ERROR_PATTERNS = {
     "resource_exhausted",
     "usage limit",
   ],
-  overloaded: [/overloaded_error|"type"\s*:\s*"overloaded"/i, "overloaded"],
+  overloaded: [
+    /overloaded_error|"type"\s*:\s*"overloaded_error"/i,
+    "overloaded",
+  ],
   timeout: [
     "timeout",
     "timed out",

--- a/src/auto-reply/reply.triggers.test.ts
+++ b/src/auto-reply/reply.triggers.test.ts
@@ -1456,7 +1456,7 @@ describe("trigger handling", () => {
 
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(text).toBe(
-        "⚠️ Context overflow - conversation too long. Starting fresh might help!",
+        "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model.",
       );
       expect(runEmbeddedPiAgent).toHaveBeenCalledOnce();
     });


### PR DESCRIPTION
## Problem

When Anthropic's API returns an `overloaded_error` (temporary capacity issue), the raw JSON error response is sent directly to the user instead of a friendly message:

```json
{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_..."}
```

This happens because `overloaded_error` isn't recognized by the existing error classification patterns.

## Solution

- Add `overloaded` error pattern detection
- Return user-friendly message: "The AI service is temporarily overloaded. Please try again in a moment."
- Classify overloaded errors as failover-worthy (like rate limits) so retry logic kicks in

## Changes

- `formatAssistantErrorText()`: Add friendly message for overloaded errors
- `ERROR_PATTERNS`: Add `overloaded` pattern
- `isOverloadedErrorMessage()`: New detection function  
- `classifyFailoverReason()`: Treat overloaded as rate_limit for failover