### PR TITLE
Structured subagent announce output + include run outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Browser: add tests for snapshot labels/efficient query params and labeled image responses.
 - Doctor: avoid re-adding WhatsApp config when only legacy ack reactions are set. (#927, fixes #900) — thanks @grp06.
 - Agents: scrub tuple `items` schemas for Gemini tool calls. (#926, fixes #746) — thanks @grp06.
+- Agents: stabilize sub-agent announce status from runtime outcomes and normalize Result/Notes. (#835) — thanks @roshanasingh4.
 - Embedded runner: suppress raw API error payloads from replies. (#924) — thanks @grp06.
 - Auth: normalize Claude Code CLI profile mode to oauth and auto-migrate config. (#855) — thanks @sebslight.
 - Daemon: clear persisted launchd disabled state before bootstrap (fixes `daemon install` after uninstall). (#849) — thanks @ndraiman.

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -145,6 +145,7 @@ Behavior:
 - Always non-blocking: returns `{ status: "accepted", runId, childSessionKey }` immediately.
 - After completion, Clawdbot runs a sub-agent **announce step** and posts the result to the requester chat channel.
 - Reply exactly `ANNOUNCE_SKIP` during the announce step to stay silent.
+- Announce replies are normalized to `Status`/`Result`/`Notes`; `Status` comes from runtime outcome (not model text).
 - Sub-agent sessions are auto-archived after `agents.defaults.subagents.archiveAfterMinutes` (default: 60).
 - Announce replies include a stats line (runtime, tokens, sessionKey/sessionId, transcript path, and optional cost).
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -49,8 +49,13 @@ Sub-agents report back via an announce step:
 - The announce step runs inside the sub-agent session (not the requester session).
 - If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
 - Otherwise the announce reply is posted to the requester chat channel via the gateway `send` method.
+- Announce messages are normalized to a stable template:
+  - `Status:` derived from the run outcome (`success`, `error`, `timeout`, or `unknown`).
+  - `Result:` the summary content from the announce step (or `(not available)` if missing).
+  - `Notes:` error details and other useful context.
+- `Status` is not inferred from model output; it comes from runtime outcome signals.
 
-Announce payloads include a stats line at the end:
+Announce payloads include a stats line at the end (even when wrapped):
 - Runtime (e.g., `runtime 5m12s`)
 - Token usage (input/output/total)
 - Estimated cost when model pricing is configured (`models.providers.*.models[].cost`)

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendSpy = vi.fn(async () => ({}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (req: unknown) => {
+    const typed = req as { method?: string; params?: { message?: string } };
+    if (typed.method === "send") {
+      return await sendSpy(typed);
+    }
+    if (typed.method === "agent.wait") {
+      return { status: "error", startedAt: 10, endedAt: 20, error: "boom" };
+    }
+    if (typed.method === "sessions.patch") return {};
+    if (typed.method === "sessions.delete") return {};
+    return {};
+  }),
+}));
+
+vi.mock("./tools/agent-step.js", () => ({
+  runAgentStep: vi.fn(async () => "did some stuff"),
+  readLatestAssistantReply: vi.fn(async () => "raw subagent reply"),
+}));
+
+vi.mock("./tools/sessions-announce-target.js", () => ({
+  resolveAnnounceTarget: vi.fn(async () => ({
+    provider: "telegram",
+    to: "+15550001111",
+    accountId: "default",
+  })),
+}));
+
+vi.mock("./tools/sessions-send-helpers.js", () => ({
+  isAnnounceSkip: () => false,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(async () => ({ entries: {} })),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveStorePath: () => "/tmp/sessions.json",
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    session: { mainKey: "agent:main:main" },
+  }),
+}));
+
+describe("subagent announce formatting", () => {
+  beforeEach(() => {
+    sendSpy.mockClear();
+  });
+
+  it("wraps unstructured announce into Status/Result/Notes", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-123",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: true,
+      startedAt: 10,
+      endedAt: 20,
+    });
+
+    expect(sendSpy).toHaveBeenCalled();
+    const msg = sendSpy.mock.calls[0]?.[0]?.params?.message as string;
+    expect(msg).toContain("Status:");
+    expect(msg).toContain("Status: error");
+    expect(msg).toContain("Result:");
+    expect(msg).toContain("Notes:");
+    expect(msg).toContain("boom");
+  });
+
+  it("keeps runtime status even when announce reply is structured", async () => {
+    const agentStep = await import("./tools/agent-step.js");
+    vi.mocked(agentStep.runAgentStep).mockResolvedValueOnce(
+      "- **Status:** success\n\n- **Result:** did some stuff\n\n- **Notes:** all good",
+    );
+
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-456",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: true,
+      startedAt: 10,
+      endedAt: 20,
+    });
+
+    const msg = sendSpy.mock.calls[0]?.[0]?.params?.message as string;
+    expect(msg).toContain("Status: error");
+    expect(msg).toContain("Result:");
+    expect(msg).toContain("Notes:");
+  });
+});


### PR DESCRIPTION
Fixes #817 (partial): enforce structured announce output + surface run outcome.

Why
- Subagent announces are currently freeform (generated by an agent step). In practice that makes it hard to scan/debug quickly, and failures can be ambiguous.

What changed
- Wraps subagent announce messages into a stable template: `Status:` / `Result:` / `Notes:` when the agent reply is not already structured.
- Captures `agent.wait` outcome (`ok`/`error`/`timeout`) and includes error text in Notes when available.
- Continues best-effort announce even when `agent.wait` reports `error` or `timeout` so requesters aren’t left hanging.

Tests
- Adds `src/agents/subagent-announce.format.test.ts` to ensure unstructured output is wrapped and error details are included.

Scope
- Intentionally limited to announce formatting + outcome surfacing only.