### PR TITLE
fix(whatsapp): handle user JID device suffix in sender normalization

### DIFF
--- a/src/auto-reply/reply/session-reset-group.test.ts
+++ b/src/auto-reply/reply/session-reset-group.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../../config/config.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
+import { initSessionState } from "./session.js";
+
+describe("initSessionState reset triggers in WhatsApp groups", () => {
+  it("Reset trigger /new works for authorized sender in WhatsApp group", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-group-reset-"),
+    );
+    const storePath = path.join(root, "sessions.json");
+
+    // Config that matches production: WhatsApp with specific allowFrom
+    const cfg = {
+      session: { store: storePath },
+      whatsapp: {
+        allowFrom: ["+41796666864"],
+        groupPolicy: "open",
+      },
+    } as ClawdbotConfig;
+
+    // Group message context matching what WhatsApp handler creates
+    const groupMessageCtx = {
+      Body: `[Chat messages since your last reply - for context]\\n[WhatsApp 120363406150318674@g.us 2026-01-13T07:45Z] Someone: hello\\n\\n[Current message - respond to this]\\n[WhatsApp 120363406150318674@g.us 2026-01-13T07:45Z] Peschiño: /new\\n[from: Peschiño (+41796666864)]`,
+      RawBody: "/new",
+      CommandBody: "/new",
+      From: "120363406150318674@g.us",
+      To: "+41779241027",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:120363406150318674@g.us",
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      SenderName: "Peschiño",
+      SenderE164: "+41796666864",
+      SenderId: "41796666864:0@s.whatsapp.net",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The reset should be detected
+    expect(result.triggerBodyNormalized).toBe("/new");
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe("");
+  });
+
+  it("Reset trigger /new blocked for unauthorized sender in existing session", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-group-reset-unauth-"),
+    );
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:whatsapp:group:120363406150318674@g.us";
+    const existingSessionId = "existing-session-123";
+
+    // Create an existing session
+    const { saveSessionStore } = await import("../../config/sessions.js");
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 }, // Long idle to prevent auto-reset
+      whatsapp: {
+        allowFrom: ["+41796666864"], // Owner's number
+        groupPolicy: "open",
+      },
+    } as ClawdbotConfig;
+
+    // Group message from different sender (not in allowFrom)
+    const groupMessageCtx = {
+      Body: `[Context]\\n[WhatsApp ...] OtherPerson: /new\\n[from: OtherPerson (+1555123456)]`,
+      RawBody: "/new",
+      CommandBody: "/new",
+      From: "120363406150318674@g.us",
+      To: "+41779241027",
+      ChatType: "group",
+      SessionKey: sessionKey,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      SenderName: "OtherPerson",
+      SenderE164: "+1555123456", // Different sender (not authorized)
+      SenderId: "1555123456:0@s.whatsapp.net",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Reset should NOT be triggered for unauthorized sender - session ID should stay the same
+    expect(result.triggerBodyNormalized).toBe("/new");
+    expect(result.sessionId).toBe(existingSessionId); // Session should NOT change
+    expect(result.isNewSession).toBe(false);
+  });
+
+  it("Debug: resolveCommandAuthorization for WhatsApp group sender", async () => {
+    const cfg = {
+      whatsapp: {
+        allowFrom: ["+41796666864"],
+        groupPolicy: "open",
+      },
+    } as ClawdbotConfig;
+
+    const ctx = {
+      Body: "/new",
+      RawBody: "/new",
+      From: "120363406150318674@g.us",
+      To: "+41779241027",
+      ChatType: "group",
+      Provider: "whatsapp",
+      SenderE164: "+41796666864",
+      SenderId: "41796666864:0@s.whatsapp.net",
+    };
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The authorized sender should be recognized
+    expect(auth.isAuthorizedSender).toBe(true);
+    expect(auth.ownerList).toContain("+41796666864");
+  });
+
+  it("Reset trigger works when RawBody is clean but Body has wrapped context", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "clawdbot-group-rawbody-"),
+    );
+    const storePath = path.join(root, "sessions.json");
+
+    const cfg = {
+      session: { store: storePath },
+      whatsapp: {
+        allowFrom: ["*"], // Allow all
+        groupPolicy: "open",
+      },
+    } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      // Body is wrapped with context prefixes
+      Body: `[WhatsApp 120363406150318674@g.us 2026-01-13T07:45Z] Jake: /new\n[from: Jake (+1222)]`,
+      // RawBody is clean
+      RawBody: "/new",
+      CommandBody: "/new",
+      From: "120363406150318674@g.us",
+      To: "+1111",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+      Provider: "whatsapp",
+      SenderE164: "+1222",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe("/new");
+    expect(result.isNewSession).toBe(true);
+  });
+});

--- a/src/whatsapp/normalize.test.ts
+++ b/src/whatsapp/normalize.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize.js";
+import {
+  isWhatsAppGroupJid,
+  isWhatsAppUserJid,
+  normalizeWhatsAppTarget,
+} from "./normalize.js";
 
 describe("normalizeWhatsAppTarget", () => {
   it("preserves group JIDs", () => {
@@ -28,6 +32,25 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("1555123@s.whatsapp.net")).toBe("+1555123");
   });
 
+  it("normalizes user JIDs with device suffix to E.164", () => {
+    // This is the bug fix: JIDs like "41796666864:0@s.whatsapp.net" should
+    // normalize to "+41796666864", not "+417966668640" (extra digit from ":0")
+    expect(normalizeWhatsAppTarget("41796666864:0@s.whatsapp.net")).toBe(
+      "+41796666864",
+    );
+    expect(normalizeWhatsAppTarget("1234567890:123@s.whatsapp.net")).toBe(
+      "+1234567890",
+    );
+    // Without device suffix still works
+    expect(normalizeWhatsAppTarget("41796666864@s.whatsapp.net")).toBe(
+      "+41796666864",
+    );
+  });
+
+  it("normalizes LID JIDs to E.164", () => {
+    expect(normalizeWhatsAppTarget("123456789@lid")).toBe("+123456789");
+  });
+
   it("rejects invalid targets", () => {
     expect(normalizeWhatsAppTarget("wat")).toBeNull();
     expect(normalizeWhatsAppTarget("whatsapp:")).toBeNull();
@@ -38,6 +61,16 @@ describe("normalizeWhatsAppTarget", () => {
   it("handles repeated prefixes", () => {
     expect(normalizeWhatsAppTarget("whatsapp:whatsapp:+1555")).toBe("+1555");
     expect(normalizeWhatsAppTarget("group:group:120@g.us")).toBe("120@g.us");
+  });
+});
+
+describe("isWhatsAppUserJid", () => {
+  it("detects user JIDs with various formats", () => {
+    expect(isWhatsAppUserJid("41796666864:0@s.whatsapp.net")).toBe(true);
+    expect(isWhatsAppUserJid("1234567890@s.whatsapp.net")).toBe(true);
+    expect(isWhatsAppUserJid("123456789@lid")).toBe(true);
+    expect(isWhatsAppUserJid("123456789-987654321@g.us")).toBe(false);
+    expect(isWhatsAppUserJid("+1555123")).toBe(false);
   });
 });
 

--- a/src/whatsapp/normalize.ts
+++ b/src/whatsapp/normalize.ts
@@ -21,12 +21,41 @@ export function isWhatsAppGroupJid(value: string): boolean {
   return /^[0-9]+(-[0-9]+)*$/.test(localPart);
 }
 
+/**
+ * Check if value looks like a WhatsApp user JID (e.g. "41796666864:0@s.whatsapp.net" or "123@lid").
+ */
+export function isWhatsAppUserJid(value: string): boolean {
+  const candidate = stripWhatsAppTargetPrefixes(value);
+  const lower = candidate.toLowerCase();
+  // User JIDs: 123456:0@s.whatsapp.net or 123456@s.whatsapp.net or 123@lid
+  return lower.endsWith("@s.whatsapp.net") || lower.endsWith("@lid");
+}
+
+/**
+ * Extract the phone number from a WhatsApp user JID.
+ * "41796666864:0@s.whatsapp.net" -> "41796666864"
+ * "123456@lid" -> "123456"
+ */
+function extractUserJidPhone(jid: string): string {
+  // Remove @s.whatsapp.net or @lid suffix
+  let localPart = jid.replace(/@s\.whatsapp\.net$/i, "").replace(/@lid$/i, "");
+  // Remove device suffix like ":0" or ":123"
+  localPart = localPart.replace(/:\d+$/, "");
+  return localPart;
+}
+
 export function normalizeWhatsAppTarget(value: string): string | null {
   const candidate = stripWhatsAppTargetPrefixes(value);
   if (!candidate) return null;
   if (isWhatsAppGroupJid(candidate)) {
     const localPart = candidate.slice(0, candidate.length - "@g.us".length);
     return `${localPart}@g.us`;
+  }
+  // Handle user JIDs (e.g. "41796666864:0@s.whatsapp.net")
+  if (isWhatsAppUserJid(candidate)) {
+    const phone = extractUserJidPhone(candidate);
+    const normalized = normalizeE164(phone);
+    return normalized.length > 1 ? normalized : null;
   }
   const normalized = normalizeE164(candidate);
   return normalized.length > 1 ? normalized : null;


### PR DESCRIPTION
When resolving command authorization for WhatsApp group messages, user JIDs like '41796666864:0@s.whatsapp.net' were being normalized incorrectly. The ':0' device suffix was being included in the digit extraction, resulting in senderId='+417966668640' instead of '+41796666864'.

This caused reset triggers (/new, /reset) to fail for authorized senders in WhatsApp groups because the sender ID didn't match the allowFrom list.

The fix adds proper handling for WhatsApp user JIDs:
- Detect user JIDs (@s.whatsapp.net and @lid suffixes)
- Strip the device suffix (:0, :123, etc.) before E164 normalization

Fixes: #833 