### PR TITLE
Skills: load plugin extension skills

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -226,9 +226,11 @@ export default function (api) {
 
 ## Skills
 
-Plugins can ship a skill in the repo (`skills/<name>/SKILL.md`).
-Enable it with `plugins.entries.<id>.enabled` (or other config gates) and ensure
-it’s present in your workspace/managed skills locations.
+Plugins can ship a skill in the repo (`skills/<name>/SKILL.md`). Installed
+plugin extensions are scanned for skills automatically
+(`~/.clawdbot/extensions/*/skills` and `<workspace>/.clawdbot/extensions/*/skills`),
+and you can still override with managed/workspace skills if you need to
+customize the instructions.
 
 ## Distribution (npm)
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -10,18 +10,21 @@ Clawdbot uses **[AgentSkills](https://agentskills.io)-compatible** skill folders
 
 ## Locations and precedence
 
-Skills are loaded from **three** places:
+Skills are loaded from **four** places:
 
 1) **Bundled skills**: shipped with the install (npm package or Clawdbot.app)
 2) **Managed/local skills**: `~/.clawdbot/skills`
 3) **Workspace skills**: `<workspace>/skills`
+4) **Plugin skills**: `~/.clawdbot/extensions/*/skills` and
+   `<workspace>/.clawdbot/extensions/*/skills`
 
 If a skill name conflicts, precedence is:
 
-`<workspace>/skills` (highest) → `~/.clawdbot/skills` → bundled skills (lowest)
+`<workspace>/skills` (highest) → `~/.clawdbot/skills` → bundled skills →
+`skills.load.extraDirs` → plugin skills (lowest)
 
-Additionally, you can configure extra skill folders (lowest precedence) via
-`skills.load.extraDirs` in `~/.clawdbot/clawdbot.json`.
+Additionally, you can configure extra skill folders (below bundled skills,
+above plugins) via `skills.load.extraDirs` in `~/.clawdbot/clawdbot.json`.
 
 ## Per-agent vs shared skills
 


### PR DESCRIPTION
## Summary
- load skills from installed plugin extension directories (global + workspace)
- include plugin load paths from config when resolving skill sources
- document plugin skill discovery + precedence

## Testing
- not run (docs + config logic only)