### PR TITLE
fix: prevent /status command from sending twice

### DIFF
--- a/src/auto-reply/reply/commands.ts
+++ b/src/auto-reply/reply/commands.ts
@@ -637,9 +637,7 @@ export async function handleCommands(params: {
     };
   }
 
-  const statusRequested =
-    directives.hasStatusDirective ||
-    command.commandBodyNormalized === "/status";
+  const statusRequested = directives.hasStatusDirective;
   if (allowTextCommands && statusRequested) {
     if (!command.isAuthorizedSender) {
       logVerbose(


### PR DESCRIPTION
## Problem
The /status command was sending the status message twice.

## Root Cause
In handleCommands(), statusRequested checked both:
1. directives.hasStatusDirective
2. command.commandBodyNormalized === "/status"

When /status is sent:
1. The inline status handler in reply.js sends status and sets directives.hasStatusDirective = false
2. handleCommands() still matches on commandBodyNormalized === "/status" and sends again

## Fix
Remove the redundant commandBodyNormalized check since the directive parsing system already correctly identifies /status commands and sets hasStatusDirective.

## Testing
Tested manually - /status now sends only once.