### PR TITLE
fix(telegram): skip message_thread_id for General topic messages

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -18,6 +18,7 @@ import {
   buildTelegramGroupFrom,
   buildTelegramGroupPeerId,
   buildTelegramThreadParams,
+  buildTypingThreadParams,
   describeReplyTarget,
   extractTelegramLocation,
   hasBotMention,
@@ -92,7 +93,7 @@ export const buildTelegramMessageContext = async ({
 
   const sendTyping = async () => {
     try {
-      await bot.api.sendChatAction(chatId, "typing", buildTelegramThreadParams(resolvedThreadId));
+      await bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(resolvedThreadId));
     } catch (err) {
       logVerbose(`telegram typing cue failed for chat ${chatId}: ${String(err)}`);
     }

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -19,8 +19,27 @@ export function resolveTelegramForumThreadId(params: {
   return params.messageThreadId ?? undefined;
 }
 
+/**
+ * Build thread params for Telegram API calls (messages, media).
+ * Excludes General topic (id=1) as Telegram rejects explicit message_thread_id=1
+ * for sendMessage calls in forum supergroups ("message thread not found" error).
+ */
 export function buildTelegramThreadParams(messageThreadId?: number) {
-  return messageThreadId != null ? { message_thread_id: messageThreadId } : undefined;
+  if (messageThreadId == null || messageThreadId === TELEGRAM_GENERAL_TOPIC_ID) {
+    return undefined;
+  }
+  return { message_thread_id: messageThreadId };
+}
+
+/**
+ * Build thread params for typing indicators (sendChatAction).
+ * Unlike sendMessage, sendChatAction accepts message_thread_id=1 for General topic.
+ */
+export function buildTypingThreadParams(messageThreadId?: number) {
+  if (messageThreadId == null) {
+    return undefined;
+  }
+  return { message_thread_id: messageThreadId };
 }
 
 export function resolveTelegramStreamMode(

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -20,6 +20,7 @@ import { markdownToTelegramHtml } from "./format.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { parseTelegramTarget, stripTelegramInternalPrefixes } from "./targets.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
+import { buildTelegramThreadParams } from "./bot/helpers.js";
 
 type TelegramSendOpts = {
   token?: string;
@@ -166,12 +167,10 @@ export async function sendMessageTelegram(
 
   // Build optional params for forum topics and reply threading.
   // Only include these if actually provided to keep API calls clean.
-  const threadParams: Record<string, number> = {};
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
-  if (messageThreadId != null) {
-    threadParams.message_thread_id = Math.trunc(messageThreadId);
-  }
+  const threadIdParams = buildTelegramThreadParams(messageThreadId);
+  const threadParams: Record<string, number> = threadIdParams ? { ...threadIdParams } : {};
   if (opts.replyToMessageId != null) {
     threadParams.reply_to_message_id = Math.trunc(opts.replyToMessageId);
   }


### PR DESCRIPTION
## Problem

In Telegram forum groups, the General topic uses `thread_id=1`. The Telegram Bot API has inconsistent behavior for this topic:

- **`sendMessage`** with `message_thread_id=1` → ❌ **Rejected** ("message thread not found")
- **`sendChatAction`** (typing) without `message_thread_id` → ❌ **No typing shown**

After the channels rename refactor, Clawdbot started explicitly sending `message_thread_id=1` for messages in the General topic, triggering this error:

```
GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message thread not found)
```

## Investigation

We tested the Telegram Bot API behavior for the General topic:

| API Call | Without thread_id | With thread_id=1 |
|----------|-------------------|------------------|
| `sendMessage` | ✅ Routes to General | ❌ Error: thread not found |
| `sendChatAction` | ❌ No typing shown | ✅ Typing appears |

**This is an inconsistency in the Telegram Bot API** — it requires opposite handling for messages vs typing indicators.

## Solution

Refactored thread handling into two distinct functions to work around the API inconsistency:

### `buildTelegramThreadParams()`
For sending messages. **Omits** `message_thread_id` for General topic (1) — Telegram routes automatically.

### `buildTypingActionParams()`
For typing indicators (`sendChatAction`). **Includes** `message_thread_id=1` — required by the API for typing to appear.

## Testing

Tested in a Telegram forum group:
- ✅ Messages delivered successfully to General
- ✅ Typing indicator appears in General
- ✅ Messages and typing work in other topics