### PR TITLE
fix(daemon): enable launchd service before bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Agents: scrub tuple `items` schemas for Gemini tool calls. (#926, fixes #746) — thanks @grp06.
 - Embedded runner: suppress raw API error payloads from replies. (#924) — thanks @grp06.
 - Auth: normalize Claude Code CLI profile mode to oauth and auto-migrate config. (#855) — thanks @sebslight.
+- Daemon: clear persisted launchd disabled state before bootstrap (fixes `daemon install` after uninstall). (#849) — thanks @ndraiman.
 - Logging: tolerate `EIO` from console writes to avoid gateway crashes. (#925, fixes #878) — thanks @grp06.
 - Sandbox: restore `docker.binds` config validation for custom bind mounts. (#873) — thanks @akonyer.
 - Sandbox: preserve configured PATH for `docker exec` so custom tools remain available. (#873) — thanks @akonyer.

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -410,6 +410,7 @@ export async function installLaunchAgent({
 
   await execLaunchctl(["bootout", domain, plistPath]);
   await execLaunchctl(["unload", plistPath]);
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     throw new Error(`launchctl bootstrap failed: ${boot.stderr || boot.stdout}`.trim());

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -410,12 +410,12 @@ export async function installLaunchAgent({
 
   await execLaunchctl(["bootout", domain, plistPath]);
   await execLaunchctl(["unload", plistPath]);
+  // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
   await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     throw new Error(`launchctl bootstrap failed: ${boot.stderr || boot.stdout}`.trim());
   }
-  await execLaunchctl(["enable", `${domain}/${label}`]);
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 
   stdout.write(`${formatLine("Installed LaunchAgent", plistPath)}\n`);


### PR DESCRIPTION
## Summary

Fixes `clawdbot daemon install` failing with `Bootstrap failed: 5: Input/output error` after a previous uninstall.

## Root Cause

When a launchd service is uninstalled via `bootout`, macOS marks it as **disabled** in:
```
/var/db/com.apple.xpc.launchd/disabled.*.plist
```

This disabled state persists across:
- Plist deletions/recreations  
- System reboots
- Process kills

Once disabled, `launchctl bootstrap` refuses to load the service and returns error 5 (I/O error).

## Fix

Call `launchctl enable` **before** `launchctl bootstrap` to clear the disabled state. This matches the fix already applied to the macOS Swift app in `GatewayLaunchAgentManager.swift`.

## Related

- #306 (same error, but fix was only applied to Swift app, not CLI)

## Workaround (before this fix)

```bash
launchctl enable gui/$UID/com.clawdbot.gateway
clawdbot daemon install
```