### PR TITLE
fix(slack): respect top-level requireMention config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Embedded runner: suppress raw API error payloads from replies. (#924) — thanks @grp06.
+- Slack: respect `channels.slack.requireMention` default when resolving channel mention gating. (#850) — thanks @evalexpr.
 
 ## 2026.1.14
 

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -75,6 +75,8 @@ export type SlackAccountConfig = {
   appToken?: string;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
+  /** Default mention requirement for channel messages (default: true). */
+  requireMention?: boolean;
   /**
    * Controls how channel messages are handled:
    * - "open": channels bypass allowlists; mention-gating applies

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -212,6 +212,7 @@ export const SlackAccountSchema = z.object({
   botToken: z.string().optional(),
   appToken: z.string().optional(),
   allowBots: z.boolean().optional(),
+  requireMention: z.boolean().optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),

--- a/src/slack/monitor/channel-config.test.ts
+++ b/src/slack/monitor/channel-config.test.ts
@@ -29,4 +29,3 @@ describe("resolveSlackChannelConfig", () => {
     expect(res).toMatchObject({ requireMention: true });
   });
 });
-

--- a/src/slack/monitor/channel-config.test.ts
+++ b/src/slack/monitor/channel-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSlackChannelConfig } from "./channel-config.js";
+
+describe("resolveSlackChannelConfig", () => {
+  it("uses defaultRequireMention when channels config is empty", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: {},
+      defaultRequireMention: false,
+    });
+    expect(res).toEqual({ allowed: true, requireMention: false });
+  });
+
+  it("defaults defaultRequireMention to true when not provided", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: {},
+    });
+    expect(res).toEqual({ allowed: true, requireMention: true });
+  });
+
+  it("prefers explicit channel/fallback requireMention over defaultRequireMention", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { "*": { requireMention: true } },
+      defaultRequireMention: false,
+    });
+    expect(res).toMatchObject({ requireMention: true });
+  });
+});
+

--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -70,8 +70,9 @@ export function resolveSlackChannelConfig(params: {
       systemPrompt?: string;
     }
   >;
+  defaultRequireMention?: boolean;
 }): SlackChannelConfigResolved | null {
-  const { channelId, channelName, channels } = params;
+  const { channelId, channelName, channels, defaultRequireMention } = params;
   const entries = channels ?? {};
   const keys = Object.keys(entries);
   const normalizedName = channelName ? normalizeSlackSlug(channelName) : "";
@@ -102,11 +103,12 @@ export function resolveSlackChannelConfig(params: {
   }
   const fallback = entries["*"];
 
+  const requireMentionDefault = defaultRequireMention ?? true;
   if (keys.length === 0) {
-    return { allowed: true, requireMention: true };
+    return { allowed: true, requireMention: requireMentionDefault };
   }
   if (!matched && !fallback) {
-    return { allowed: false, requireMention: true };
+    return { allowed: false, requireMention: requireMentionDefault };
   }
 
   const resolved = matched ?? fallback ?? {};
@@ -114,7 +116,8 @@ export function resolveSlackChannelConfig(params: {
     firstDefined(resolved.enabled, resolved.allow, fallback?.enabled, fallback?.allow, true) ??
     true;
   const requireMention =
-    firstDefined(resolved.requireMention, fallback?.requireMention, true) ?? true;
+    firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
+    requireMentionDefault;
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -34,6 +34,7 @@ export type SlackMonitorContext = {
   allowFrom: string[];
   groupDmEnabled: boolean;
   groupDmChannels: string[];
+  defaultRequireMention: boolean;
   channelsConfig?: Record<
     string,
     {
@@ -103,6 +104,7 @@ export function createSlackMonitorContext(params: {
   allowFrom: Array<string | number> | undefined;
   groupDmEnabled: boolean;
   groupDmChannels: Array<string | number> | undefined;
+  defaultRequireMention?: boolean;
   channelsConfig?: SlackMonitorContext["channelsConfig"];
   groupPolicy: SlackMonitorContext["groupPolicy"];
   useAccessGroups: boolean;
@@ -132,6 +134,7 @@ export function createSlackMonitorContext(params: {
 
   const allowFrom = normalizeAllowList(params.allowFrom);
   const groupDmChannels = normalizeAllowList(params.groupDmChannels);
+  const defaultRequireMention = params.defaultRequireMention ?? true;
 
   const markMessageSeen = (channelId: string | undefined, ts?: string) => {
     if (!channelId || !ts) return false;
@@ -274,6 +277,7 @@ export function createSlackMonitorContext(params: {
         channelId: p.channelId,
         channelName: p.channelName,
         channels: params.channelsConfig,
+        defaultRequireMention,
       });
       const channelAllowed = channelConfig?.allowed !== false;
       const channelAllowlistConfigured =
@@ -330,6 +334,7 @@ export function createSlackMonitorContext(params: {
     allowFrom,
     groupDmEnabled: params.groupDmEnabled,
     groupDmChannels,
+    defaultRequireMention,
     channelsConfig: params.channelsConfig,
     groupPolicy: params.groupPolicy,
     useAccessGroups: params.useAccessGroups,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -56,6 +56,7 @@ export async function prepareSlackMessage(params: {
         channelId: message.channel,
         channelName,
         channels: ctx.channelsConfig,
+        defaultRequireMention: ctx.defaultRequireMention,
       })
     : null;
 
@@ -200,7 +201,9 @@ export async function prepareSlackMessage(params: {
     cfg,
     surface: "slack",
   });
-  const shouldRequireMention = isRoom ? (channelConfig?.requireMention ?? true) : false;
+  const shouldRequireMention = isRoom
+    ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
+    : false;
 
   // Allow "control commands" to bypass mention gating if sender is authorized.
   const shouldBypassMention =

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -122,6 +122,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     allowFrom,
     groupDmEnabled,
     groupDmChannels,
+    defaultRequireMention: slackCfg.requireMention,
     channelsConfig,
     groupPolicy,
     useAccessGroups,

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -136,6 +136,7 @@ export function registerSlackMonitorSlashCommands(params: {
           channelId: command.channel_id,
           channelName: channelInfo?.name,
           channels: ctx.channelsConfig,
+          defaultRequireMention: ctx.defaultRequireMention,
         });
         if (ctx.useAccessGroups) {
           const channelAllowlistConfigured =


### PR DESCRIPTION
## Summary
- The `channels.slack.requireMention` setting was defined in the schema but never passed to `resolveSlackChannelConfig()`, which always defaulted to `true`
- This meant setting `requireMention: false` at the top level had no effect—channels still required mentions
- Pass `slackCfg.requireMention` as `defaultRequireMention` to the resolver and use it as the fallback

## Test plan
- [x] Existing tests pass (`pnpm vitest run src/slack/monitor`)
- [ ] Manual test: set `channels.slack.requireMention: false` and verify bot responds without @mention

🤖 Generated with [Claude Code](https://claude.ai/code)