### PR TITLE
Feat/zalo channel

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -18,6 +18,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Signal](/channels/signal) — signal-cli; privacy-focused.
 - [iMessage](/channels/imessage) — macOS only; native integration.
 - [Microsoft Teams](/channels/msteams) — Bot Framework; enterprise support.
+- [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (experimental).
 - [WebChat](/web/webchat) — Gateway WebChat UI over WebSocket.
 
 ## Notes

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -1,0 +1,149 @@
+---
+summary: "Zalo bot support status, capabilities, and configuration"
+read_when:
+  - Working on Zalo features or webhooks
+---
+# Zalo (Bot API)
+
+Status: experimental. Direct messages only; groups coming soon per Zalo docs.
+
+## Quick setup (beginner)
+1) Create a bot at **https://bot.zaloplatforms.com** and copy the token.
+2) Set the token:
+   - Env: `ZALO_BOT_TOKEN=...`
+   - Or config: `channels.zalo.botToken: "..."`.
+3) Start the gateway.
+4) DM access is pairing by default; approve the pairing code on first contact.
+
+Minimal config:
+```json5
+{
+  channels: {
+    zalo: {
+      enabled: true,
+      botToken: "12345689:abc-xyz",
+      dmPolicy: "pairing"
+    }
+  }
+}
+```
+
+## What it is
+- A Zalo Bot API channel owned by the Gateway.
+- Deterministic routing: replies go back to Zalo; the model never chooses channels.
+- DMs share the agent's main session.
+- Groups are not yet supported (Zalo docs state "coming soon").
+
+## Setup (fast path)
+
+### 1) Create a bot token (Zalo Bot Platform)
+1) Go to **https://bot.zaloplatforms.com** and sign in.
+2) Create a new bot and configure its settings.
+3) Copy the bot token (format: `12345689:abc-xyz`).
+
+### 2) Configure the token (env or config)
+Example:
+
+```json5
+{
+  channels: {
+    zalo: {
+      enabled: true,
+      botToken: "12345689:abc-xyz",
+      dmPolicy: "pairing"
+    }
+  }
+}
+```
+
+Env option: `ZALO_BOT_TOKEN=...` (works for the default account).
+
+Multi-account support: use `channels.zalo.accounts` with per-account tokens and optional `name`. See [`gateway/configuration`](/gateway/configuration) for the shared pattern.
+
+3) Start the gateway. Zalo starts when a token is resolved (env or config).
+4) DM access defaults to pairing. Approve the code when the bot is first contacted.
+
+## How it works (behavior)
+- Inbound messages are normalized into the shared channel envelope with media placeholders.
+- Replies always route back to the same Zalo chat.
+- Long-polling by default; webhook mode available with `channels.zalo.webhookUrl`.
+
+## Limits
+- Outbound text is chunked to 2000 characters (Zalo API limit).
+- Media downloads/uploads are capped by `channels.zalo.mediaMaxMb` (default 5).
+- Streaming is blocked by default due to the 2000 char limit making streaming less useful.
+
+## Access control (DMs)
+
+### DM access
+- Default: `channels.zalo.dmPolicy = "pairing"`. Unknown senders receive a pairing code; messages are ignored until approved (codes expire after 1 hour).
+- Approve via:
+  - `clawdbot pairing list zalo`
+  - `clawdbot pairing approve zalo <CODE>`
+- Pairing is the default token exchange. Details: [Pairing](/start/pairing)
+- `channels.zalo.allowFrom` accepts numeric user IDs.
+
+## Long-polling vs webhook
+- Default: long-polling (no public URL required).
+- Webhook mode: set `channels.zalo.webhookUrl` and `channels.zalo.webhookSecret`.
+  - The webhook secret must be 8-256 characters.
+  - Webhook URL must use HTTPS.
+  - Zalo sends events with `X-Bot-Api-Secret-Token` header for verification.
+
+**Note:** getUpdates (polling) and webhook are mutually exclusive per Zalo API docs.
+
+## Supported message types
+- **Text messages**: Full support with 2000 character chunking.
+- **Image messages**: Download and process inbound images; send images via `sendPhoto`.
+- **Stickers**: Logged but not fully processed (no agent response).
+- **Unsupported types**: Logged (e.g., messages from protected users).
+
+## Capabilities
+| Feature | Status |
+|---------|--------|
+| Direct messages | ✅ Supported |
+| Groups | ❌ Coming soon (per Zalo docs) |
+| Media (images) | ✅ Supported |
+| Reactions | ❌ Not supported |
+| Threads | ❌ Not supported |
+| Polls | ❌ Not supported |
+| Native commands | ❌ Not supported |
+| Streaming | ⚠️ Blocked (2000 char limit) |
+
+## Delivery targets (CLI/cron)
+- Use a chat id as the target.
+- Example: `clawdbot message send --channel zalo --to 123456789 --message "hi"`.
+
+## Troubleshooting
+
+**Bot doesn't respond:**
+- Check that the token is valid: `clawdbot channels status --probe`
+- Verify the sender is approved (pairing or allowFrom)
+- Check gateway logs: `clawdbot logs --follow`
+
+**Webhook not receiving events:**
+- Ensure webhook URL uses HTTPS
+- Verify secret token is 8-256 characters
+- Check that getUpdates polling is not running (they're mutually exclusive)
+
+## Configuration reference (Zalo)
+Full configuration: [Configuration](/gateway/configuration)
+
+Provider options:
+- `channels.zalo.enabled`: enable/disable channel startup.
+- `channels.zalo.botToken`: bot token from Zalo Bot Platform.
+- `channels.zalo.tokenFile`: read token from file path.
+- `channels.zalo.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
+- `channels.zalo.allowFrom`: DM allowlist (user IDs). `open` requires `"*"`.
+- `channels.zalo.mediaMaxMb`: inbound/outbound media cap (MB, default 5).
+- `channels.zalo.webhookUrl`: enable webhook mode (HTTPS required).
+- `channels.zalo.webhookSecret`: webhook secret (8-256 chars).
+- `channels.zalo.webhookPath`: local webhook path.
+- `channels.zalo.historyLimit`: conversation history limit.
+
+Multi-account options:
+- `channels.zalo.accounts.<id>.botToken`: per-account token.
+- `channels.zalo.accounts.<id>.name`: display name.
+- `channels.zalo.accounts.<id>.enabled`: enable/disable account.
+- `channels.zalo.accounts.<id>.dmPolicy`: per-account DM policy.
+- `channels.zalo.accounts.<id>.allowFrom`: per-account allowlist.

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -7,6 +7,7 @@ import { resolveTelegramAccount } from "../telegram/accounts.js";
 import { normalizeE164 } from "../utils.js";
 import { resolveWhatsAppAccount } from "../web/accounts.js";
 import { normalizeWhatsAppTarget } from "../whatsapp/normalize.js";
+import { resolveZaloAccount } from "../zalo/accounts.js";
 import {
   resolveDiscordGroupRequireMention,
   resolveIMessageGroupRequireMention,
@@ -319,6 +320,33 @@ const DOCKS: Record<ChannelId, ChannelDock> = {
         currentThreadTs: context.ReplyToId,
         hasRepliedRef,
       }),
+    },
+  },
+  zalo: {
+    id: "zalo",
+    capabilities: {
+      chatTypes: ["direct"],
+      media: true,
+      blockStreaming: true,
+    },
+    outbound: { textChunkLimit: 2000 },
+    config: {
+      resolveAllowFrom: ({ cfg, accountId }) =>
+        (resolveZaloAccount({ cfg, accountId }).config.allowFrom ?? []).map(
+          (entry) => String(entry),
+        ),
+      formatAllowFrom: ({ allowFrom }) =>
+        allowFrom
+          .map((entry) => String(entry).trim())
+          .filter(Boolean)
+          .map((entry) => entry.replace(/^(zalo|zl):/i, ""))
+          .map((entry) => entry.toLowerCase()),
+    },
+    groups: {
+      resolveRequireMention: () => true,
+    },
+    threading: {
+      resolveReplyToMode: () => "off",
     },
   },
 };

--- a/src/channels/plugins/actions/zalo.ts
+++ b/src/channels/plugins/actions/zalo.ts
@@ -1,0 +1,77 @@
+import { jsonResult, readStringParam } from "../../../agents/tools/common.js";
+import type { ClawdbotConfig } from "../../../config/config.js";
+import {
+  listZaloAccountIds,
+  resolveZaloAccount,
+} from "../../../zalo/accounts.js";
+import { sendMessageZalo } from "../../../zalo/send.js";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+} from "../types.js";
+
+const providerId = "zalo";
+
+function listEnabledZaloAccounts(cfg: ClawdbotConfig) {
+  return listZaloAccountIds(cfg)
+    .map((accountId) => resolveZaloAccount({ cfg, accountId }))
+    .filter((account) => account.enabled && account.tokenSource !== "none");
+}
+
+export const zaloMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const accounts = listEnabledZaloAccounts(cfg);
+    if (accounts.length === 0) return [];
+    // Zalo only supports sending messages (no reactions)
+    const actions = new Set<ChannelMessageActionName>(["send"]);
+    return Array.from(actions);
+  },
+  supportsButtons: () => false, // Zalo doesn't support inline buttons
+  extractToolSend: ({ args }) => {
+    const action = typeof args.action === "string" ? args.action.trim() : "";
+    if (action !== "sendMessage") return null;
+    const to = typeof args.to === "string" ? args.to : undefined;
+    const content = typeof args.content === "string" ? args.content : "";
+    const mediaUrl = readStringParam(args, "mediaUrl") ?? undefined;
+    if (!to || !content) return null;
+    return {
+      providerId,
+      to,
+      content,
+      mediaUrl,
+    };
+  },
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action === "send") {
+      const to = readStringParam(params, "to", { required: true });
+      const content = readStringParam(params, "message", {
+        required: true,
+        allowEmpty: true,
+      });
+      const mediaUrl = readStringParam(params, "media", { trim: false });
+
+      const result = await sendMessageZalo(to, content ?? "", {
+        accountId: accountId ?? undefined,
+        mediaUrl: mediaUrl ?? undefined,
+        cfg,
+      });
+
+      if (!result.ok) {
+        return jsonResult({
+          ok: false,
+          error: result.error ?? "Failed to send Zalo message",
+        });
+      }
+
+      return jsonResult({
+        ok: true,
+        to,
+        messageId: result.messageId,
+      });
+    }
+
+    throw new Error(
+      `Action ${action} is not supported for provider ${providerId}.`,
+    );
+  },
+};

--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -11,6 +11,7 @@ import { slackPlugin } from "./slack.js";
 import { telegramPlugin } from "./telegram.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 import { whatsappPlugin } from "./whatsapp.js";
+import { zaloPlugin } from "./zalo.js";
 
 // Channel plugins registry (runtime).
 //
@@ -31,6 +32,7 @@ function resolveChannels(): ChannelPlugin[] {
     signalPlugin,
     imessagePlugin,
     msteamsPlugin,
+    zaloPlugin,
   ];
 }
 
@@ -63,5 +65,6 @@ export {
   slackPlugin,
   telegramPlugin,
   whatsappPlugin,
+  zaloPlugin,
 };
 export type { ChannelId, ChannelPlugin } from "./types.js";

--- a/src/channels/plugins/load.ts
+++ b/src/channels/plugins/load.ts
@@ -14,6 +14,7 @@ const LOADERS: Record<ChannelId, PluginLoader> = {
   signal: async () => (await import("./signal.js")).signalPlugin,
   imessage: async () => (await import("./imessage.js")).imessagePlugin,
   msteams: async () => (await import("./msteams.js")).msteamsPlugin,
+  zalo: async () => (await import("./zalo.js")).zaloPlugin,
 };
 
 const cache = new Map<ChannelId, ChannelPlugin>();

--- a/src/channels/plugins/onboarding/zalo.ts
+++ b/src/channels/plugins/onboarding/zalo.ts
@@ -1,0 +1,421 @@
+import type { ClawdbotConfig } from "../../../config/config.js";
+import type { DmPolicy } from "../../../config/types.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+} from "../../../routing/session-key.js";
+import { formatDocsLink } from "../../../terminal/links.js";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import {
+  listZaloAccountIds,
+  resolveDefaultZaloAccountId,
+  resolveZaloAccount,
+} from "../../../zalo/accounts.js";
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+} from "../onboarding-types.js";
+import { addWildcardAllowFrom, promptAccountId } from "./helpers.js";
+
+const channel = "zalo" as const;
+
+type UpdateMode = "polling" | "webhook";
+
+function setZaloDmPolicy(cfg: ClawdbotConfig, dmPolicy: DmPolicy) {
+  const allowFrom =
+    dmPolicy === "open"
+      ? addWildcardAllowFrom(cfg.channels?.zalo?.allowFrom)
+      : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      zalo: {
+        ...cfg.channels?.zalo,
+        dmPolicy,
+        ...(allowFrom ? { allowFrom } : {}),
+      },
+    },
+  };
+}
+
+function setZaloUpdateMode(
+  cfg: ClawdbotConfig,
+  mode: UpdateMode,
+  webhookUrl?: string,
+  webhookSecret?: string,
+): ClawdbotConfig {
+  if (mode === "polling") {
+    // Remove webhook config for polling mode
+    const { webhookUrl: _, webhookSecret: __, ...rest } =
+      cfg.channels?.zalo ?? {};
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        zalo: rest,
+      },
+    };
+  }
+  // Webhook mode
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      zalo: {
+        ...cfg.channels?.zalo,
+        webhookUrl,
+        webhookSecret,
+      },
+    },
+  };
+}
+
+async function noteZaloTokenHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "1) Open Zalo Bot Platform: https://bot.zaloplatforms.com",
+      "2) Create a bot and get the token",
+      "3) Token looks like 12345689:abc-xyz",
+      "Tip: you can also set ZALO_BOT_TOKEN in your env.",
+      `Docs: ${formatDocsLink("/channels/zalo")}`,
+      "Website: https://clawd.bot",
+    ].join("\n"),
+    "Zalo bot token",
+  );
+}
+
+async function promptZaloAllowFrom(params: {
+  cfg: ClawdbotConfig;
+  prompter: WizardPrompter;
+  accountId: string;
+}): Promise<ClawdbotConfig> {
+  const { cfg, prompter, accountId } = params;
+  const resolved = resolveZaloAccount({ cfg, accountId });
+  const existingAllowFrom = resolved.config.allowFrom ?? [];
+  const entry = await prompter.text({
+    message: "Zalo allowFrom (user id)",
+    placeholder: "123456789",
+    initialValue: existingAllowFrom[0]
+      ? String(existingAllowFrom[0])
+      : undefined,
+    validate: (value) => {
+      const raw = String(value ?? "").trim();
+      if (!raw) return "Required";
+      if (!/^\d+$/.test(raw)) return "Use a numeric Zalo user id";
+      return undefined;
+    },
+  });
+  const normalized = String(entry).trim();
+  const merged = [
+    ...existingAllowFrom.map((item) => String(item).trim()).filter(Boolean),
+    normalized,
+  ];
+  const unique = [...new Set(merged)];
+
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        zalo: {
+          ...cfg.channels?.zalo,
+          enabled: true,
+          dmPolicy: "allowlist",
+          allowFrom: unique,
+        },
+      },
+    };
+  }
+
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      zalo: {
+        ...cfg.channels?.zalo,
+        enabled: true,
+        accounts: {
+          ...cfg.channels?.zalo?.accounts,
+          [accountId]: {
+            ...cfg.channels?.zalo?.accounts?.[accountId],
+            enabled: cfg.channels?.zalo?.accounts?.[accountId]?.enabled ?? true,
+            dmPolicy: "allowlist",
+            allowFrom: unique,
+          },
+        },
+      },
+    },
+  };
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "Zalo",
+  channel,
+  policyKey: "channels.zalo.dmPolicy",
+  allowFromKey: "channels.zalo.allowFrom",
+  getCurrent: (cfg) => cfg.channels?.zalo?.dmPolicy ?? "pairing",
+  setPolicy: (cfg, policy) => setZaloDmPolicy(cfg, policy),
+};
+
+export const zaloOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const configured = listZaloAccountIds(cfg).some((accountId) =>
+      Boolean(resolveZaloAccount({ cfg, accountId }).token),
+    );
+    return {
+      channel,
+      configured,
+      statusLines: [`Zalo: ${configured ? "configured" : "needs token"}`],
+      selectionHint: configured
+        ? "recommended · configured"
+        : "recommended · newcomer-friendly",
+      quickstartScore: configured ? 1 : 10,
+    };
+  },
+  configure: async ({
+    cfg,
+    prompter,
+    accountOverrides,
+    shouldPromptAccountIds,
+    forceAllowFrom,
+  }) => {
+    const zaloOverride = accountOverrides.zalo?.trim();
+    const defaultZaloAccountId = resolveDefaultZaloAccountId(cfg);
+    let zaloAccountId = zaloOverride
+      ? normalizeAccountId(zaloOverride)
+      : defaultZaloAccountId;
+    if (shouldPromptAccountIds && !zaloOverride) {
+      zaloAccountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Zalo",
+        currentId: zaloAccountId,
+        listAccountIds: listZaloAccountIds,
+        defaultAccountId: defaultZaloAccountId,
+      });
+    }
+
+    let next = cfg;
+    const resolvedAccount = resolveZaloAccount({
+      cfg: next,
+      accountId: zaloAccountId,
+    });
+    const accountConfigured = Boolean(resolvedAccount.token);
+    const allowEnv = zaloAccountId === DEFAULT_ACCOUNT_ID;
+    const canUseEnv = allowEnv && Boolean(process.env.ZALO_BOT_TOKEN?.trim());
+    const hasConfigToken = Boolean(
+      resolvedAccount.config.botToken || resolvedAccount.config.tokenFile,
+    );
+
+    let token: string | null = null;
+    if (!accountConfigured) {
+      await noteZaloTokenHelp(prompter);
+    }
+    if (canUseEnv && !resolvedAccount.config.botToken) {
+      const keepEnv = await prompter.confirm({
+        message: "ZALO_BOT_TOKEN detected. Use env var?",
+        initialValue: true,
+      });
+      if (keepEnv) {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zalo: {
+              ...next.channels?.zalo,
+              enabled: true,
+            },
+          },
+        };
+      } else {
+        token = String(
+          await prompter.text({
+            message: "Enter Zalo bot token",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+      }
+    } else if (hasConfigToken) {
+      const keep = await prompter.confirm({
+        message: "Zalo token already configured. Keep it?",
+        initialValue: true,
+      });
+      if (!keep) {
+        token = String(
+          await prompter.text({
+            message: "Enter Zalo bot token",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+      }
+    } else {
+      token = String(
+        await prompter.text({
+          message: "Enter Zalo bot token",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+    }
+
+    if (token) {
+      if (zaloAccountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zalo: {
+              ...next.channels?.zalo,
+              enabled: true,
+              botToken: token,
+            },
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zalo: {
+              ...next.channels?.zalo,
+              enabled: true,
+              accounts: {
+                ...next.channels?.zalo?.accounts,
+                [zaloAccountId]: {
+                  ...next.channels?.zalo?.accounts?.[zaloAccountId],
+                  enabled:
+                    next.channels?.zalo?.accounts?.[zaloAccountId]?.enabled ??
+                    true,
+                  botToken: token,
+                },
+              },
+            },
+          },
+        };
+      }
+    }
+
+    // Prompt for DM policy
+    const existingDmPolicy = next.channels?.zalo?.dmPolicy ?? "pairing";
+    await prompter.note(
+      [
+        "Zalo direct chats are gated by `channels.zalo.dmPolicy`.",
+        "- pairing (default): unknown senders get a pairing code; owner approves",
+        "- allowlist: only allow senders in allowFrom list",
+        '- open: allow all DMs (requires allowFrom to include "*")',
+        "- disabled: ignore Zalo DMs",
+        "",
+        `Current: dmPolicy=${existingDmPolicy}`,
+        `Docs: ${formatDocsLink("/channels/zalo")}`,
+      ].join("\n"),
+      "Zalo DM access",
+    );
+
+    const dmPolicyChoice = (await prompter.select({
+      message: "How should Zalo handle new DM senders?",
+      options: [
+        {
+          value: "pairing",
+          label: "Pairing mode (new senders get a code to approve)",
+        },
+        {
+          value: "allowlist",
+          label: "Allowlist mode (only pre-approved senders)",
+        },
+        { value: "open", label: "Open mode (allow all DMs)" },
+        { value: "disabled", label: "Disabled (ignore all DMs)" },
+      ],
+      initialValue: existingDmPolicy,
+    })) as DmPolicy;
+
+    next = setZaloDmPolicy(next, dmPolicyChoice);
+
+    // If allowlist mode, prompt for allowFrom
+    if (dmPolicyChoice === "allowlist" || forceAllowFrom) {
+      next = await promptZaloAllowFrom({
+        cfg: next,
+        prompter,
+        accountId: zaloAccountId,
+      });
+    }
+
+    // Prompt for update mode (polling vs webhook)
+    const existingWebhookUrl = next.channels?.zalo?.webhookUrl;
+    const currentMode: UpdateMode = existingWebhookUrl ? "webhook" : "polling";
+
+    await prompter.note(
+      [
+        "Zalo supports two ways to receive messages:",
+        "- Polling: bot periodically checks for new messages (simpler, good for dev)",
+        "- Webhook: Zalo pushes messages to your server (recommended for production)",
+        "",
+        `Current: ${currentMode}${existingWebhookUrl ? ` (${existingWebhookUrl})` : ""}`,
+        "Note: getUpdates (polling) won't work if webhook is set.",
+      ].join("\n"),
+      "Zalo update mode",
+    );
+
+    const updateModeChoice = (await prompter.select({
+      message: "How should Zalo deliver messages?",
+      options: [
+        {
+          value: "polling",
+          label: "Polling (getUpdates) - simpler, good for development",
+        },
+        {
+          value: "webhook",
+          label: "Webhook - recommended for production",
+        },
+      ],
+      initialValue: currentMode,
+    })) as UpdateMode;
+
+    if (updateModeChoice === "webhook") {
+      const webhookUrl = await prompter.text({
+        message: "Webhook URL (must be HTTPS)",
+        placeholder: "https://your-server.com/zalo/webhook",
+        initialValue: existingWebhookUrl,
+        validate: (value) => {
+          const url = String(value ?? "").trim();
+          if (!url) return "Required";
+          if (!url.startsWith("https://")) return "Must be HTTPS URL";
+          return undefined;
+        },
+      });
+
+      const existingSecret = next.channels?.zalo?.webhookSecret;
+      const webhookSecret = await prompter.text({
+        message: "Webhook secret (8-256 chars, for X-Bot-Api-Secret-Token)",
+        placeholder: "your-secret-token",
+        initialValue: existingSecret,
+        validate: (value) => {
+          const secret = String(value ?? "").trim();
+          if (!secret) return "Required";
+          if (secret.length < 8) return "Must be at least 8 characters";
+          if (secret.length > 256) return "Must be at most 256 characters";
+          return undefined;
+        },
+      });
+
+      next = setZaloUpdateMode(
+        next,
+        "webhook",
+        String(webhookUrl).trim(),
+        String(webhookSecret).trim(),
+      );
+    } else {
+      next = setZaloUpdateMode(next, "polling");
+    }
+
+    return { cfg: next, accountId: zaloAccountId };
+  },
+  dmPolicy,
+  disable: (cfg) => ({
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      zalo: { ...cfg.channels?.zalo, enabled: false },
+    },
+  }),
+};

--- a/src/channels/plugins/onboarding/zalo.ts
+++ b/src/channels/plugins/onboarding/zalo.ts
@@ -47,8 +47,11 @@ function setZaloUpdateMode(
 ): ClawdbotConfig {
   if (mode === "polling") {
     // Remove webhook config for polling mode
-    const { webhookUrl: _, webhookSecret: __, ...rest } =
-      cfg.channels?.zalo ?? {};
+    const {
+      webhookUrl: _,
+      webhookSecret: __,
+      ...rest
+    } = cfg.channels?.zalo ?? {};
     return {
       ...cfg,
       channels: {

--- a/src/channels/plugins/outbound/load.ts
+++ b/src/channels/plugins/outbound/load.ts
@@ -15,6 +15,7 @@ const LOADERS: Record<ChannelId, OutboundLoader> = {
   signal: async () => (await import("./signal.js")).signalOutbound,
   imessage: async () => (await import("./imessage.js")).imessageOutbound,
   msteams: async () => (await import("./msteams.js")).msteamsOutbound,
+  zalo: async () => (await import("./zalo.js")).zaloOutbound,
 };
 
 const cache = new Map<ChannelId, ChannelOutboundAdapter>();

--- a/src/channels/plugins/outbound/zalo.ts
+++ b/src/channels/plugins/outbound/zalo.ts
@@ -1,0 +1,44 @@
+import { chunkMarkdownText } from "../../../auto-reply/chunk.js";
+import { sendMessageZalo } from "../../../zalo/send.js";
+import type { ChannelOutboundAdapter } from "../types.js";
+
+export const zaloOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunker: chunkMarkdownText,
+  textChunkLimit: 2000, // Zalo's message limit
+  resolveTarget: ({ to }) => {
+    const trimmed = to?.trim();
+    if (!trimmed) {
+      return {
+        ok: false,
+        error: new Error("Delivering to Zalo requires --to <chatId>"),
+      };
+    }
+    return { ok: true, to: trimmed };
+  },
+  sendText: async ({ to, text, accountId }) => {
+    const result = await sendMessageZalo(to, text, {
+      verbose: false,
+      accountId: accountId ?? undefined,
+    });
+    return {
+      channel: "zalo",
+      ok: result.ok,
+      messageId: result.messageId ?? "",
+      error: result.error ? new Error(result.error) : undefined,
+    };
+  },
+  sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+    const result = await sendMessageZalo(to, text, {
+      verbose: false,
+      mediaUrl,
+      accountId: accountId ?? undefined,
+    });
+    return {
+      channel: "zalo",
+      ok: result.ok,
+      messageId: result.messageId ?? "",
+      error: result.error ? new Error(result.error) : undefined,
+    };
+  },
+};

--- a/src/channels/plugins/status-issues/zalo.ts
+++ b/src/channels/plugins/status-issues/zalo.ts
@@ -1,0 +1,48 @@
+import type { ChannelAccountSnapshot, ChannelStatusIssue } from "../types.js";
+import { asString, isRecord } from "./shared.js";
+
+type ZaloAccountStatus = {
+  accountId?: unknown;
+  enabled?: unknown;
+  configured?: unknown;
+  dmPolicy?: unknown;
+};
+
+function readZaloAccountStatus(
+  value: ChannelAccountSnapshot,
+): ZaloAccountStatus | null {
+  if (!isRecord(value)) return null;
+  return {
+    accountId: value.accountId,
+    enabled: value.enabled,
+    configured: value.configured,
+    dmPolicy: value.dmPolicy,
+  };
+}
+
+export function collectZaloStatusIssues(
+  accounts: ChannelAccountSnapshot[],
+): ChannelStatusIssue[] {
+  const issues: ChannelStatusIssue[] = [];
+  for (const entry of accounts) {
+    const account = readZaloAccountStatus(entry);
+    if (!account) continue;
+    const accountId = asString(account.accountId) ?? "default";
+    const enabled = account.enabled !== false;
+    const configured = account.configured === true;
+    if (!enabled || !configured) continue;
+
+    // Warn if dmPolicy is "open" - anyone can message the bot
+    if (account.dmPolicy === "open") {
+      issues.push({
+        channel: "zalo",
+        accountId,
+        kind: "config",
+        message:
+          'Zalo dmPolicy is "open", allowing any user to message the bot without pairing.',
+        fix: 'Set channels.zalo.dmPolicy to "pairing" or "allowlist" to restrict access.',
+      });
+    }
+  }
+  return issues;
+}

--- a/src/channels/plugins/zalo.ts
+++ b/src/channels/plugins/zalo.ts
@@ -1,0 +1,342 @@
+/**
+ * Zalo channel plugin
+ * @see https://bot.zaloplatforms.com/docs
+ */
+
+import { chunkMarkdownText } from "../../auto-reply/chunk.js";
+import { shouldLogVerbose } from "../../globals.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+} from "../../routing/session-key.js";
+import {
+  listZaloAccountIds,
+  type ResolvedZaloAccount,
+  resolveDefaultZaloAccountId,
+  resolveZaloAccount,
+} from "../../zalo/accounts.js";
+import { probeZalo } from "../../zalo/probe.js";
+import { sendMessageZalo } from "../../zalo/send.js";
+import { getChatChannelMeta } from "../registry.js";
+import { zaloMessageActions } from "./actions/zalo.js";
+import {
+  deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
+} from "./config-helpers.js";
+import { formatPairingApproveHint } from "./helpers.js";
+import { zaloOnboardingAdapter } from "./onboarding/zalo.js";
+import { PAIRING_APPROVED_MESSAGE } from "./pairing-message.js";
+import {
+  applyAccountNameToChannelSection,
+  migrateBaseNameToDefaultAccount,
+} from "./setup-helpers.js";
+import { collectZaloStatusIssues } from "./status-issues/zalo.js";
+import type { ChannelPlugin } from "./types.js";
+
+const meta = getChatChannelMeta("zalo");
+
+/**
+ * Normalize a Zalo messaging target (strip prefixes like zalo: or zl:)
+ */
+function normalizeZaloMessagingTarget(raw: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  // Strip zalo: or zl: prefix
+  return trimmed.replace(/^(zalo|zl):/i, "");
+}
+
+export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount> = {
+  id: "zalo",
+  meta: {
+    ...meta,
+    quickstartAllowFrom: true,
+  },
+  onboarding: zaloOnboardingAdapter,
+  pairing: {
+    idLabel: "zaloUserId",
+    normalizeAllowEntry: (entry) => entry.replace(/^(zalo|zl):/i, ""),
+    notifyApproval: async ({ cfg, id }) => {
+      const account = resolveZaloAccount({ cfg });
+      if (!account.token) throw new Error("Zalo token not configured");
+      await sendMessageZalo(id, PAIRING_APPROVED_MESSAGE, {
+        token: account.token,
+      });
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct"], // Groups "coming soon" per Zalo docs
+    media: true,
+    reactions: false,
+    threads: false,
+    polls: false,
+    nativeCommands: false,
+    blockStreaming: true, // 2000 char limit makes streaming less useful
+  },
+  reload: { configPrefixes: ["channels.zalo"] },
+  config: {
+    listAccountIds: (cfg) => listZaloAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveZaloAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultZaloAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "zalo",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "zalo",
+        accountId,
+        clearBaseFields: ["botToken", "tokenFile", "name"],
+      }),
+    isConfigured: (account) => Boolean(account.token?.trim()),
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.token?.trim()),
+      tokenSource: account.tokenSource,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveZaloAccount({ cfg, accountId }).config.allowFrom ?? []).map(
+        (entry) => String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => entry.replace(/^(zalo|zl):/i, ""))
+        .map((entry) => entry.toLowerCase()),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId =
+        accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(
+        cfg.channels?.zalo?.accounts?.[resolvedAccountId],
+      );
+      const basePath = useAccountPath
+        ? `channels.zalo.accounts.${resolvedAccountId}.`
+        : "channels.zalo.";
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
+        allowFrom: account.config.allowFrom ?? [],
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        approveHint: formatPairingApproveHint("zalo"),
+        normalizeEntry: (raw) => raw.replace(/^(zalo|zl):/i, ""),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const groupPolicy = account.config.groupPolicy ?? "allowlist";
+      if (groupPolicy !== "open") return [];
+      return [
+        `- Zalo: groupPolicy="open" allows any group to trigger. Set channels.zalo.groupPolicy="allowlist" to restrict.`,
+      ];
+    },
+  },
+  groups: {
+    resolveRequireMention: () => true, // Default to requiring mention in groups
+  },
+  threading: {
+    resolveReplyToMode: () => "off", // Zalo doesn't support reply threading
+  },
+  actions: zaloMessageActions,
+  messaging: {
+    normalizeTarget: normalizeZaloMessagingTarget,
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zalo",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "ZALO_BOT_TOKEN can only be used for the default account.";
+      }
+      if (!input.useEnv && !input.token && !input.tokenFile) {
+        return "Zalo requires --token or --token-file (or --use-env).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zalo",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({
+              cfg: namedConfig,
+              channelKey: "zalo",
+            })
+          : namedConfig;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            zalo: {
+              ...next.channels?.zalo,
+              enabled: true,
+              ...(input.useEnv
+                ? {}
+                : input.tokenFile
+                  ? { tokenFile: input.tokenFile }
+                  : input.token
+                    ? { botToken: input.token }
+                    : {}),
+            },
+          },
+        };
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          zalo: {
+            ...next.channels?.zalo,
+            enabled: true,
+            accounts: {
+              ...next.channels?.zalo?.accounts,
+              [accountId]: {
+                ...next.channels?.zalo?.accounts?.[accountId],
+                enabled: true,
+                ...(input.tokenFile
+                  ? { tokenFile: input.tokenFile }
+                  : input.token
+                    ? { botToken: input.token }
+                    : {}),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: chunkMarkdownText,
+    textChunkLimit: 2000, // Zalo's message limit
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim();
+      if (!trimmed) {
+        return {
+          ok: false,
+          error: new Error("Delivering to Zalo requires --to <chatId>"),
+        };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async ({ to, text, accountId }) => {
+      const result = await sendMessageZalo(to, text, {
+        verbose: false,
+        accountId: accountId ?? undefined,
+      });
+      return {
+        channel: "zalo",
+        ok: result.ok,
+        messageId: result.messageId ?? "",
+        error: result.error ? new Error(result.error) : undefined,
+      };
+    },
+    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const result = await sendMessageZalo(to, text, {
+        verbose: false,
+        mediaUrl,
+        accountId: accountId ?? undefined,
+      });
+      return {
+        channel: "zalo",
+        ok: result.ok,
+        messageId: result.messageId ?? "",
+        error: result.error ? new Error(result.error) : undefined,
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: collectZaloStatusIssues,
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      tokenSource: snapshot.tokenSource ?? "none",
+      running: snapshot.running ?? false,
+      mode: snapshot.mode ?? null,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ account, timeoutMs }) =>
+      probeZalo(account.token, timeoutMs),
+    buildAccountSnapshot: ({ account, runtime }) => {
+      const configured = Boolean(account.token?.trim());
+      return {
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured,
+        tokenSource: account.tokenSource,
+        running: runtime?.running ?? false,
+        lastStartAt: runtime?.lastStartAt ?? null,
+        lastStopAt: runtime?.lastStopAt ?? null,
+        lastError: runtime?.lastError ?? null,
+        mode: account.config.webhookUrl ? "webhook" : "polling",
+        lastInboundAt: runtime?.lastInboundAt ?? null,
+        lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      };
+    },
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      const token = account.token.trim();
+      let zaloBotLabel = "";
+      try {
+        const probe = await probeZalo(token, 2500);
+        const name = probe.ok ? probe.bot?.name?.trim() : null;
+        if (name) zaloBotLabel = ` (${name})`;
+        ctx.setStatus({
+          accountId: account.accountId,
+          bot: probe.bot,
+        });
+      } catch (err) {
+        if (shouldLogVerbose()) {
+          ctx.log?.debug?.(
+            `[${account.accountId}] bot probe failed: ${String(err)}`,
+          );
+        }
+      }
+      ctx.log?.info(`[${account.accountId}] starting provider${zaloBotLabel}`);
+      // Lazy import: the monitor pulls the reply pipeline; avoid ESM init cycles.
+      const { monitorZaloProvider } = await import("../../zalo/monitor.js");
+      return monitorZaloProvider({
+        token,
+        accountId: account.accountId,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        useWebhook: Boolean(account.config.webhookUrl),
+        webhookUrl: account.config.webhookUrl,
+        webhookSecret: account.config.webhookSecret,
+        webhookPath: account.config.webhookPath,
+      });
+    },
+  },
+};

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -8,6 +8,7 @@ export const CHAT_CHANNEL_ORDER = [
   "signal",
   "imessage",
   "msteams",
+  "zalo",
 ] as const;
 
 export type ChatChannelId = (typeof CHAT_CHANNEL_ORDER)[number];
@@ -94,11 +95,20 @@ const CHAT_CHANNEL_META: Record<ChatChannelId, ChatChannelMeta> = {
     docsLabel: "msteams",
     blurb: "supported (Bot Framework).",
   },
+  zalo: {
+    id: "zalo",
+    label: "Zalo",
+    selectionLabel: "Zalo (Bot API)",
+    docsPath: "/channels/zalo",
+    docsLabel: "zalo",
+    blurb: "Vietnam-focused messaging platform with Bot API.",
+  },
 };
 
 export const CHAT_CHANNEL_ALIASES: Record<string, ChatChannelId> = {
   imsg: "imessage",
   teams: "msteams",
+  zl: "zalo",
 };
 
 const normalizeChannelKey = (raw?: string | null): string | undefined => {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -803,6 +803,49 @@ export type MSTeamsConfig = {
   teams?: Record<string, MSTeamsTeamConfig>;
 };
 
+export type ZaloAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** If false, do not start this Zalo account. Default: true. */
+  enabled?: boolean;
+  /** Bot token from Zalo Bot Creator. */
+  botToken?: string;
+  /** Path to file containing the bot token. */
+  tokenFile?: string;
+  /** Webhook URL for receiving updates (HTTPS required). */
+  webhookUrl?: string;
+  /** Webhook secret token (8-256 chars) for request verification. */
+  webhookSecret?: string;
+  /** Webhook path for the gateway HTTP server. */
+  webhookPath?: string;
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /** Allowlist for DM senders (Zalo user IDs). */
+  allowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom; mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Per-group config. Key is group ID. */
+  groups?: Record<string, { requireMention?: boolean }>;
+  /** Max inbound media size in MB. */
+  mediaMaxMb?: number;
+  /** Max messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Proxy URL for API requests. */
+  proxy?: string;
+};
+
+export type ZaloConfig = {
+  /** Optional per-account Zalo configuration (multi-account). */
+  accounts?: Record<string, ZaloAccountConfig>;
+  /** Default account ID when multiple accounts are configured. */
+  defaultAccount?: string;
+} & ZaloAccountConfig;
+
 export type ChannelsConfig = {
   whatsapp?: WhatsAppConfig;
   telegram?: TelegramConfig;
@@ -811,6 +854,7 @@ export type ChannelsConfig = {
   signal?: SignalConfig;
   imessage?: IMessageConfig;
   msteams?: MSTeamsConfig;
+  zalo?: ZaloConfig;
 };
 
 export type IMessageAccountConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -771,6 +771,36 @@ const WhatsAppConfigSchema = z
     });
   });
 
+const ZaloAccountSchema = z.object({
+  name: z.string().optional(),
+  enabled: z.boolean().optional().default(true),
+  botToken: z.string().optional(),
+  tokenFile: z.string().optional(),
+  webhookUrl: z.string().optional(),
+  webhookSecret: z.string().optional(),
+  webhookPath: z.string().optional(),
+  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  groups: z
+    .record(
+      z.string(),
+      z.object({ requireMention: z.boolean().optional() }).optional(),
+    )
+    .optional(),
+  mediaMaxMb: z.number().int().positive().optional(),
+  historyLimit: z.number().int().min(0).optional(),
+  proxy: z.string().optional(),
+});
+
+const ZaloConfigSchema = z
+  .object({
+    accounts: z.record(z.string(), ZaloAccountSchema.optional()).optional(),
+    defaultAccount: z.string().optional(),
+  })
+  .merge(ZaloAccountSchema)
+  .optional();
+
 const ChannelsSchema = z
   .object({
     whatsapp: WhatsAppConfigSchema.optional(),
@@ -780,6 +810,7 @@ const ChannelsSchema = z
     signal: SignalConfigSchema.optional(),
     imessage: IMessageConfigSchema.optional(),
     msteams: MSTeamsConfigSchema.optional(),
+    zalo: ZaloConfigSchema.optional(),
   })
   .optional();
 

--- a/src/zalo/accounts.ts
+++ b/src/zalo/accounts.ts
@@ -1,0 +1,140 @@
+/**
+ * Zalo account resolution and configuration
+ */
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { resolveZaloToken } from "./token.js";
+
+export type ZaloAccountConfig = {
+  enabled?: boolean;
+  botToken?: string;
+  tokenFile?: string;
+  name?: string;
+  webhookUrl?: string;
+  webhookSecret?: string;
+  webhookPath?: string;
+  dmPolicy?: "open" | "allowlist" | "pairing";
+  allowFrom?: Array<string | number>;
+  groupPolicy?: "open" | "allowlist";
+  groups?: Record<string, unknown>;
+  mediaMaxMb?: number;
+  historyLimit?: number;
+  proxy?: string;
+};
+
+export type ResolvedZaloAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  token: string;
+  tokenSource: "env" | "config" | "configFile" | "none";
+  config: ZaloAccountConfig;
+};
+
+/**
+ * List all configured Zalo account IDs
+ */
+export function listZaloAccountIds(cfg: ClawdbotConfig): string[] {
+  const zaloConfig = cfg.channels?.zalo;
+  if (!zaloConfig) return [];
+
+  const accountIds = new Set<string>();
+
+  // Check if base config has a token (default account)
+  const { token: baseToken } = resolveZaloToken(cfg, DEFAULT_ACCOUNT_ID);
+  if (baseToken) {
+    accountIds.add(DEFAULT_ACCOUNT_ID);
+  }
+
+  // Add explicitly configured accounts
+  const accounts = zaloConfig.accounts;
+  if (accounts && typeof accounts === "object") {
+    for (const id of Object.keys(accounts)) {
+      accountIds.add(id);
+    }
+  }
+
+  return Array.from(accountIds);
+}
+
+/**
+ * Resolve the default Zalo account ID
+ */
+export function resolveDefaultZaloAccountId(cfg: ClawdbotConfig): string {
+  const zaloConfig = cfg.channels?.zalo;
+
+  // Check for explicit default
+  if (zaloConfig?.defaultAccount) {
+    return zaloConfig.defaultAccount;
+  }
+
+  // If base config has token, use default
+  const { token: baseToken } = resolveZaloToken(cfg, DEFAULT_ACCOUNT_ID);
+  if (baseToken) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+
+  // Otherwise, use first configured account
+  const accountIds = listZaloAccountIds(cfg);
+  return accountIds[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Resolve a Zalo account by ID
+ */
+export function resolveZaloAccount(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+}): ResolvedZaloAccount {
+  const { cfg, accountId } = params;
+  const resolvedAccountId = accountId ?? resolveDefaultZaloAccountId(cfg);
+  const zaloConfig = cfg.channels?.zalo;
+
+  // Get token
+  const { token, tokenSource } = resolveZaloToken(cfg, resolvedAccountId);
+
+  // Get account-specific config
+  const accountConfig =
+    resolvedAccountId !== DEFAULT_ACCOUNT_ID
+      ? (zaloConfig?.accounts?.[resolvedAccountId] as
+          | ZaloAccountConfig
+          | undefined)
+      : undefined;
+
+  // Merge base config with account config
+  const mergedConfig: ZaloAccountConfig = {
+    enabled: zaloConfig?.enabled,
+    dmPolicy: zaloConfig?.dmPolicy as ZaloAccountConfig["dmPolicy"],
+    allowFrom: zaloConfig?.allowFrom as ZaloAccountConfig["allowFrom"],
+    groupPolicy: zaloConfig?.groupPolicy as ZaloAccountConfig["groupPolicy"],
+    groups: zaloConfig?.groups as ZaloAccountConfig["groups"],
+    webhookUrl: zaloConfig?.webhookUrl,
+    webhookSecret: zaloConfig?.webhookSecret,
+    webhookPath: zaloConfig?.webhookPath,
+    mediaMaxMb: zaloConfig?.mediaMaxMb,
+    historyLimit: zaloConfig?.historyLimit,
+    proxy: zaloConfig?.proxy,
+    ...accountConfig,
+  };
+
+  // Resolve enabled state
+  const enabled =
+    accountConfig?.enabled !== undefined
+      ? accountConfig.enabled
+      : zaloConfig?.enabled !== false;
+
+  // Resolve name
+  const name =
+    accountConfig?.name ??
+    (resolvedAccountId === DEFAULT_ACCOUNT_ID ? zaloConfig?.name : undefined);
+
+  return {
+    accountId: resolvedAccountId,
+    name,
+    enabled,
+    token,
+    tokenSource,
+    config: mergedConfig,
+  };
+}

--- a/src/zalo/api.ts
+++ b/src/zalo/api.ts
@@ -1,0 +1,200 @@
+/**
+ * Zalo Bot API client
+ * @see https://bot.zaloplatforms.com/docs
+ */
+
+const ZALO_API_BASE = "https://bot-api.zaloplatforms.com";
+
+export type ZaloApiResponse<T = unknown> = {
+  ok: boolean;
+  result?: T;
+  error_code?: number;
+  description?: string;
+};
+
+export type ZaloBotInfo = {
+  id: string;
+  name: string;
+  avatar?: string;
+};
+
+export type ZaloMessage = {
+  message_id: string;
+  from: {
+    id: string;
+    name?: string;
+    avatar?: string;
+  };
+  chat: {
+    id: string;
+    chat_type: "PRIVATE" | "GROUP";
+  };
+  date: number;
+  text?: string;
+  photo?: string;
+  caption?: string;
+  sticker?: string;
+};
+
+export type ZaloUpdate = {
+  event_name:
+    | "message.text.received"
+    | "message.image.received"
+    | "message.sticker.received"
+    | "message.unsupported.received";
+  message?: ZaloMessage;
+};
+
+export type ZaloSendMessageParams = {
+  chat_id: string;
+  text: string;
+};
+
+export type ZaloSendPhotoParams = {
+  chat_id: string;
+  photo: string;
+  caption?: string;
+};
+
+export type ZaloSetWebhookParams = {
+  url: string;
+  secret_token: string;
+};
+
+export type ZaloGetUpdatesParams = {
+  /** Timeout in seconds (passed as string to API) */
+  timeout?: number;
+};
+
+export class ZaloApiError extends Error {
+  constructor(
+    message: string,
+    public readonly errorCode?: number,
+    public readonly description?: string,
+  ) {
+    super(message);
+    this.name = "ZaloApiError";
+  }
+
+  /** True if this is a long-polling timeout (no updates available) */
+  get isPollingTimeout(): boolean {
+    return this.errorCode === 408;
+  }
+}
+
+/**
+ * Call the Zalo Bot API
+ */
+export async function callZaloApi<T = unknown>(
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+  options?: { timeoutMs?: number },
+): Promise<ZaloApiResponse<T>> {
+  const url = `${ZALO_API_BASE}/bot${token}/${method}`;
+  const controller = new AbortController();
+  const timeoutId = options?.timeoutMs
+    ? setTimeout(() => controller.abort(), options.timeoutMs)
+    : undefined;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    const data = (await response.json()) as ZaloApiResponse<T>;
+
+    if (!data.ok) {
+      throw new ZaloApiError(
+        data.description ?? `Zalo API error: ${method}`,
+        data.error_code,
+        data.description,
+      );
+    }
+
+    return data;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Validate bot token and get bot info
+ */
+export async function getMe(
+  token: string,
+  timeoutMs?: number,
+): Promise<ZaloApiResponse<ZaloBotInfo>> {
+  return callZaloApi<ZaloBotInfo>("getMe", token, undefined, { timeoutMs });
+}
+
+/**
+ * Send a text message
+ */
+export async function sendMessage(
+  token: string,
+  params: ZaloSendMessageParams,
+): Promise<ZaloApiResponse<ZaloMessage>> {
+  return callZaloApi<ZaloMessage>("sendMessage", token, params);
+}
+
+/**
+ * Send a photo message
+ */
+export async function sendPhoto(
+  token: string,
+  params: ZaloSendPhotoParams,
+): Promise<ZaloApiResponse<ZaloMessage>> {
+  return callZaloApi<ZaloMessage>("sendPhoto", token, params);
+}
+
+/**
+ * Get updates using long polling (dev/testing only)
+ * Note: Zalo returns a single update per call, not an array like Telegram
+ */
+export async function getUpdates(
+  token: string,
+  params?: ZaloGetUpdatesParams,
+): Promise<ZaloApiResponse<ZaloUpdate>> {
+  // Long polling needs longer timeout
+  const pollTimeoutSec = params?.timeout ?? 30;
+  const timeoutMs = (pollTimeoutSec + 5) * 1000;
+  // Zalo expects timeout as string
+  const body = { timeout: String(pollTimeoutSec) };
+  return callZaloApi<ZaloUpdate>("getUpdates", token, body, { timeoutMs });
+}
+
+/**
+ * Set webhook URL for receiving updates
+ */
+export async function setWebhook(
+  token: string,
+  params: ZaloSetWebhookParams,
+): Promise<ZaloApiResponse<boolean>> {
+  return callZaloApi<boolean>("setWebhook", token, params);
+}
+
+/**
+ * Delete webhook configuration
+ */
+export async function deleteWebhook(
+  token: string,
+): Promise<ZaloApiResponse<boolean>> {
+  return callZaloApi<boolean>("deleteWebhook", token);
+}
+
+/**
+ * Get current webhook info
+ */
+export async function getWebhookInfo(
+  token: string,
+): Promise<
+  ZaloApiResponse<{ url?: string; has_custom_certificate?: boolean }>
+> {
+  return callZaloApi("getWebhookInfo", token);
+}

--- a/src/zalo/index.ts
+++ b/src/zalo/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Zalo channel module exports
+ */
+
+export * from "./accounts.js";
+export * from "./api.js";
+export * from "./probe.js";
+export * from "./send.js";
+export * from "./token.js";

--- a/src/zalo/monitor.ts
+++ b/src/zalo/monitor.ts
@@ -1,0 +1,577 @@
+/**
+ * Zalo provider monitor - handles inbound messages via polling or webhook
+ */
+
+import { chunkMarkdownText } from "../auto-reply/chunk.js";
+import { formatAgentEnvelope } from "../auto-reply/envelope.js";
+import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import type { ClawdbotConfig } from "../config/config.js";
+import { shouldLogVerbose } from "../globals.js";
+import { fetchRemoteMedia } from "../media/fetch.js";
+import { saveMediaBuffer } from "../media/store.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import {
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest,
+} from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  deleteWebhook,
+  getUpdates,
+  sendMessage as sendZaloMessage,
+  sendPhoto as sendZaloPhoto,
+  setWebhook,
+  ZaloApiError,
+  type ZaloMessage,
+  type ZaloUpdate,
+} from "./api.js";
+
+export type ZaloMonitorOptions = {
+  token: string;
+  accountId: string;
+  config: ClawdbotConfig;
+  runtime: RuntimeEnv;
+  abortSignal: AbortSignal;
+  useWebhook?: boolean;
+  webhookUrl?: string;
+  webhookSecret?: string;
+  webhookPath?: string;
+  mediaMaxMb?: number;
+  historyLimit?: number;
+};
+
+export type ZaloMonitorResult = {
+  stop: () => void;
+};
+
+/**
+ * Monitor Zalo for incoming messages
+ */
+export async function monitorZaloProvider(
+  options: ZaloMonitorOptions,
+): Promise<ZaloMonitorResult> {
+  const {
+    token,
+    accountId,
+    config,
+    runtime,
+    abortSignal,
+    useWebhook,
+    webhookUrl,
+    webhookSecret,
+    mediaMaxMb,
+  } = options;
+
+  const effectiveMediaMaxMb = mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
+
+  let stopped = false;
+
+  const stop = () => {
+    stopped = true;
+  };
+
+  if (useWebhook && webhookUrl && webhookSecret) {
+    // Webhook mode
+    await setupWebhookMode(token, webhookUrl, webhookSecret);
+  } else {
+    // Polling mode - ensure webhook is cleared
+    try {
+      await deleteWebhook(token);
+    } catch {
+      // Ignore errors when deleting webhook
+    }
+
+    // Start polling loop
+    startPollingLoop(
+      token,
+      accountId,
+      config,
+      runtime,
+      abortSignal,
+      () => stopped,
+      effectiveMediaMaxMb,
+    );
+  }
+
+  return { stop };
+}
+
+/**
+ * Set up webhook mode
+ */
+async function setupWebhookMode(
+  token: string,
+  webhookUrl: string,
+  webhookSecret: string,
+): Promise<void> {
+  // Validate webhook URL is HTTPS
+  if (!webhookUrl.startsWith("https://")) {
+    throw new Error("Zalo webhook URL must use HTTPS");
+  }
+
+  // Validate secret length (8-256 chars)
+  if (webhookSecret.length < 8 || webhookSecret.length > 256) {
+    throw new Error("Zalo webhook secret must be 8-256 characters");
+  }
+
+  await setWebhook(token, {
+    url: webhookUrl,
+    secret_token: webhookSecret,
+  });
+}
+
+/** Zalo message text limit (2000 characters) */
+const ZALO_TEXT_LIMIT = 2000;
+
+/** Default media size limit in MB */
+const DEFAULT_MEDIA_MAX_MB = 5;
+
+/** Verbose logging helper */
+function logVerbose(message: string): void {
+  if (shouldLogVerbose()) {
+    console.log(`[zalo] ${message}`);
+  }
+}
+
+/**
+ * Check if a sender is allowed based on allowFrom list
+ */
+function isSenderAllowed(senderId: string, allowFrom: string[]): boolean {
+  if (allowFrom.includes("*")) return true;
+  const normalizedSenderId = senderId.toLowerCase();
+  return allowFrom.some((entry) => {
+    const normalized = entry.toLowerCase().replace(/^(zalo|zl):/i, "");
+    return normalized === normalizedSenderId;
+  });
+}
+
+/**
+ * Start the long-polling loop for updates
+ * Note: Zalo returns a single update per getUpdates call (not an array)
+ */
+function startPollingLoop(
+  token: string,
+  accountId: string,
+  config: ClawdbotConfig,
+  runtime: RuntimeEnv,
+  abortSignal: AbortSignal,
+  isStopped: () => boolean,
+  mediaMaxMb: number,
+): void {
+  const pollTimeout = 30; // seconds
+
+  const poll = async () => {
+    if (isStopped() || abortSignal.aborted) {
+      return;
+    }
+
+    try {
+      const response = await getUpdates(token, {
+        timeout: pollTimeout,
+      });
+
+      if (response.ok && response.result) {
+        // Zalo returns a single update, not an array
+        await processUpdate(
+          response.result,
+          token,
+          accountId,
+          config,
+          runtime,
+          mediaMaxMb,
+        );
+      }
+    } catch (err) {
+      // 408 timeout is normal for long polling - just means no new messages
+      if (err instanceof ZaloApiError && err.isPollingTimeout) {
+        // Silent - immediately poll again
+      } else if (!isStopped() && !abortSignal.aborted) {
+        // Log actual errors but continue polling
+        console.error(`[${accountId}] Zalo polling error:`, err);
+        // Wait a bit before retrying on error
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+    }
+
+    // Schedule next poll
+    if (!isStopped() && !abortSignal.aborted) {
+      setImmediate(poll);
+    }
+  };
+
+  // Start polling
+  void poll();
+}
+
+/**
+ * Process an incoming Zalo update
+ */
+async function processUpdate(
+  update: ZaloUpdate,
+  token: string,
+  accountId: string,
+  config: ClawdbotConfig,
+  runtime: RuntimeEnv,
+  mediaMaxMb: number,
+): Promise<void> {
+  const { event_name, message } = update;
+
+  if (!message) {
+    return;
+  }
+
+  // Handle different event types
+  switch (event_name) {
+    case "message.text.received":
+      await handleTextMessage(message, token, accountId, config, runtime);
+      break;
+    case "message.image.received":
+      await handleImageMessage(
+        message,
+        token,
+        accountId,
+        config,
+        runtime,
+        mediaMaxMb,
+      );
+      break;
+    case "message.sticker.received":
+      // Stickers are not fully supported yet
+      console.log(`[${accountId}] Received sticker from ${message.from.id}`);
+      break;
+    case "message.unsupported.received":
+      // Unsupported message types (e.g., from protected users)
+      console.log(
+        `[${accountId}] Received unsupported message type from ${message.from.id}`,
+      );
+      break;
+  }
+}
+
+/**
+ * Handle incoming text message
+ */
+async function handleTextMessage(
+  message: ZaloMessage,
+  token: string,
+  accountId: string,
+  config: ClawdbotConfig,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const { text } = message;
+
+  if (!text?.trim()) {
+    return;
+  }
+
+  await processMessageWithPipeline({
+    message,
+    token,
+    accountId,
+    config,
+    runtime,
+    text,
+    mediaPath: undefined,
+    mediaType: undefined,
+  });
+}
+
+/**
+ * Handle incoming image message
+ */
+async function handleImageMessage(
+  message: ZaloMessage,
+  token: string,
+  accountId: string,
+  config: ClawdbotConfig,
+  runtime: RuntimeEnv,
+  mediaMaxMb: number,
+): Promise<void> {
+  const { photo, caption } = message;
+
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
+
+  // Download and save the image if available
+  if (photo) {
+    try {
+      const maxBytes = mediaMaxMb * 1024 * 1024;
+      const fetched = await fetchRemoteMedia({ url: photo });
+      const saved = await saveMediaBuffer(
+        fetched.buffer,
+        fetched.contentType,
+        "inbound",
+        maxBytes,
+      );
+      mediaPath = saved.path;
+      mediaType = saved.contentType;
+    } catch (err) {
+      console.error(`[${accountId}] Failed to download Zalo image:`, err);
+    }
+  }
+
+  await processMessageWithPipeline({
+    message,
+    token,
+    accountId,
+    config,
+    runtime,
+    text: caption,
+    mediaPath,
+    mediaType,
+  });
+}
+
+/**
+ * Process a message through the agent pipeline
+ */
+async function processMessageWithPipeline(params: {
+  message: ZaloMessage;
+  token: string;
+  accountId: string;
+  config: ClawdbotConfig;
+  runtime: RuntimeEnv;
+  text?: string;
+  mediaPath?: string;
+  mediaType?: string;
+}): Promise<void> {
+  const {
+    message,
+    token,
+    accountId,
+    config,
+    runtime,
+    text,
+    mediaPath,
+    mediaType,
+  } = params;
+  const { from, chat, message_id, date } = message;
+
+  const isGroup = chat.chat_type === "GROUP";
+  const chatId = chat.id;
+  const senderId = from.id;
+  const senderName = from.name;
+
+  // Get Zalo config for DM policy
+  const zaloCfg = config.channels?.zalo ?? {};
+  const dmPolicy = zaloCfg.dmPolicy ?? "pairing";
+  const configAllowFrom = (zaloCfg.allowFrom ?? []).map((v) => String(v));
+
+  // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled"
+  if (!isGroup) {
+    if (dmPolicy === "disabled") {
+      logVerbose(`Blocked zalo DM from ${senderId} (dmPolicy=disabled)`);
+      return;
+    }
+
+    if (dmPolicy !== "open") {
+      // Merge config allowFrom with store allowFrom
+      const storeAllowFrom = await readChannelAllowFromStore("zalo").catch(
+        () => [],
+      );
+      const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+      const allowed = isSenderAllowed(senderId, effectiveAllowFrom);
+
+      if (!allowed) {
+        if (dmPolicy === "pairing") {
+          // Create pairing request
+          const { code, created } = await upsertChannelPairingRequest({
+            channel: "zalo",
+            id: senderId,
+            meta: {
+              name: senderName ?? undefined,
+            },
+          });
+
+          if (created) {
+            logVerbose(`zalo pairing request sender=${senderId}`);
+            try {
+              await sendZaloMessage(token, {
+                chat_id: chatId,
+                text: buildPairingReply({
+                  channel: "zalo",
+                  idLine: `Your Zalo user id: ${senderId}`,
+                  code,
+                }),
+              });
+            } catch (err) {
+              logVerbose(
+                `zalo pairing reply failed for ${senderId}: ${String(err)}`,
+              );
+            }
+          }
+        } else {
+          logVerbose(
+            `Blocked unauthorized zalo sender ${senderId} (dmPolicy=${dmPolicy})`,
+          );
+        }
+        return;
+      }
+    }
+  }
+
+  // Resolve the agent route
+  const route = resolveAgentRoute({
+    cfg: config,
+    channel: "zalo",
+    accountId,
+    peer: {
+      kind: isGroup ? "group" : "dm",
+      id: chatId,
+    },
+  });
+
+  // Build the message body with envelope formatting
+  const rawBody = text?.trim() || (mediaPath ? "<media:image>" : "");
+  const fromLabel = isGroup
+    ? `group:${chatId} from ${senderName || senderId}`
+    : senderName || `user:${senderId}`;
+  const body = formatAgentEnvelope({
+    channel: "Zalo",
+    from: fromLabel,
+    timestamp: date ? date * 1000 : undefined,
+    body: rawBody,
+  });
+
+  // Build MsgContext for the agent
+  const ctxPayload: MsgContext = {
+    Body: body,
+    RawBody: rawBody,
+    CommandBody: rawBody,
+    From: isGroup ? `group:${chatId}` : `zalo:${senderId}`,
+    To: `zalo:${chatId}`,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: isGroup ? "group" : "direct",
+    SenderName: senderName || undefined,
+    SenderId: senderId,
+    Provider: "zalo",
+    Surface: "zalo",
+    MessageSid: message_id,
+    MediaPath: mediaPath,
+    MediaType: mediaType,
+    MediaUrl: mediaPath,
+    OriginatingChannel: "zalo" as const,
+    OriginatingTo: `zalo:${chatId}`,
+  };
+
+  // Dispatch to the agent pipeline
+  await dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg: config,
+    dispatcherOptions: {
+      deliver: async (payload: ReplyPayload) => {
+        await deliverZaloReply({
+          payload,
+          token,
+          chatId,
+          runtime,
+        });
+      },
+      onError: (err, info) => {
+        runtime.error?.(
+          `[${accountId}] Zalo ${info.kind} reply failed: ${String(err)}`,
+        );
+      },
+    },
+  });
+}
+
+/**
+ * Deliver a reply payload to Zalo
+ */
+async function deliverZaloReply(params: {
+  payload: ReplyPayload;
+  token: string;
+  chatId: string;
+  runtime: RuntimeEnv;
+}): Promise<void> {
+  const { payload, token, chatId, runtime } = params;
+
+  // Handle media URLs
+  const mediaList = payload.mediaUrls?.length
+    ? payload.mediaUrls
+    : payload.mediaUrl
+      ? [payload.mediaUrl]
+      : [];
+
+  if (mediaList.length > 0) {
+    // Send media with optional caption
+    let first = true;
+    for (const mediaUrl of mediaList) {
+      const caption = first ? payload.text : undefined;
+      first = false;
+      try {
+        await sendZaloPhoto(token, {
+          chat_id: chatId,
+          photo: mediaUrl,
+          caption,
+        });
+      } catch (err) {
+        runtime.error?.(`Zalo photo send failed: ${String(err)}`);
+      }
+    }
+    return;
+  }
+
+  // Send text message, chunked to 2000 char limit
+  if (payload.text) {
+    const chunks = chunkMarkdownText(payload.text, ZALO_TEXT_LIMIT);
+    for (const chunk of chunks) {
+      try {
+        await sendZaloMessage(token, {
+          chat_id: chatId,
+          text: chunk,
+        });
+      } catch (err) {
+        runtime.error?.(`Zalo message send failed: ${String(err)}`);
+      }
+    }
+  }
+}
+
+/**
+ * Handle incoming Zalo webhook request
+ * This can be used by the gateway's HTTP server to process webhook events
+ */
+export function handleZaloWebhook(
+  body: unknown,
+  token: string,
+  secretToken: string,
+  headerToken: string,
+  accountId: string,
+  config: ClawdbotConfig,
+  runtime: RuntimeEnv,
+  mediaMaxMb?: number,
+): { ok: boolean; error?: string } {
+  // Verify the secret token
+  if (headerToken !== secretToken) {
+    return { ok: false, error: "Invalid secret token" };
+  }
+
+  // Parse the webhook payload
+  const payload = body as { ok?: boolean; result?: ZaloUpdate };
+
+  if (!payload.ok || !payload.result) {
+    return { ok: false, error: "Invalid webhook payload" };
+  }
+
+  const effectiveMediaMaxMb = mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
+
+  // Process the update asynchronously
+  processUpdate(
+    payload.result,
+    token,
+    accountId,
+    config,
+    runtime,
+    effectiveMediaMaxMb,
+  ).catch((err) => {
+    console.error(`[${accountId}] Error processing Zalo webhook:`, err);
+  });
+
+  return { ok: true };
+}

--- a/src/zalo/probe.ts
+++ b/src/zalo/probe.ts
@@ -1,0 +1,80 @@
+/**
+ * Zalo bot token validation and probing
+ */
+
+import { getMe, ZaloApiError, type ZaloBotInfo } from "./api.js";
+
+export type ZaloProbeResult = {
+  ok: boolean;
+  bot?: ZaloBotInfo;
+  error?: string;
+  elapsedMs: number;
+};
+
+/**
+ * Probe/validate a Zalo bot token by calling getMe
+ */
+export async function probeZalo(
+  token: string,
+  timeoutMs = 5000,
+): Promise<ZaloProbeResult> {
+  if (!token?.trim()) {
+    return {
+      ok: false,
+      error: "No token provided",
+      elapsedMs: 0,
+    };
+  }
+
+  const startTime = Date.now();
+
+  try {
+    const response = await getMe(token.trim(), timeoutMs);
+    const elapsedMs = Date.now() - startTime;
+
+    if (response.ok && response.result) {
+      return {
+        ok: true,
+        bot: response.result,
+        elapsedMs,
+      };
+    }
+
+    return {
+      ok: false,
+      error: "Invalid response from Zalo API",
+      elapsedMs,
+    };
+  } catch (err) {
+    const elapsedMs = Date.now() - startTime;
+
+    if (err instanceof ZaloApiError) {
+      return {
+        ok: false,
+        error: err.description ?? err.message,
+        elapsedMs,
+      };
+    }
+
+    if (err instanceof Error) {
+      if (err.name === "AbortError") {
+        return {
+          ok: false,
+          error: `Request timed out after ${timeoutMs}ms`,
+          elapsedMs,
+        };
+      }
+      return {
+        ok: false,
+        error: err.message,
+        elapsedMs,
+      };
+    }
+
+    return {
+      ok: false,
+      error: String(err),
+      elapsedMs,
+    };
+  }
+}

--- a/src/zalo/send.ts
+++ b/src/zalo/send.ts
@@ -1,0 +1,154 @@
+/**
+ * Zalo message sending utilities
+ */
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { sendMessage, sendPhoto } from "./api.js";
+import { resolveZaloToken } from "./token.js";
+
+export type ZaloSendOptions = {
+  token?: string;
+  accountId?: string;
+  cfg?: ClawdbotConfig;
+  mediaUrl?: string;
+  caption?: string;
+  verbose?: boolean;
+};
+
+export type ZaloSendResult = {
+  ok: boolean;
+  messageId?: string;
+  error?: string;
+};
+
+/**
+ * Resolve the token to use for sending
+ */
+function resolveToken(options: ZaloSendOptions): string {
+  if (options.token) {
+    return options.token;
+  }
+
+  if (options.cfg) {
+    const { token } = resolveZaloToken(options.cfg, options.accountId);
+    return token;
+  }
+
+  // Fallback to env
+  return process.env.ZALO_BOT_TOKEN?.trim() ?? "";
+}
+
+/**
+ * Send a text message to a Zalo chat
+ */
+export async function sendMessageZalo(
+  chatId: string,
+  text: string,
+  options: ZaloSendOptions = {},
+): Promise<ZaloSendResult> {
+  const token = resolveToken(options);
+
+  if (!token) {
+    return {
+      ok: false,
+      error: "No Zalo bot token configured",
+    };
+  }
+
+  if (!chatId?.trim()) {
+    return {
+      ok: false,
+      error: "No chat_id provided",
+    };
+  }
+
+  // Handle media if provided
+  if (options.mediaUrl) {
+    return sendPhotoZalo(chatId, options.mediaUrl, {
+      ...options,
+      token,
+      caption: text || options.caption,
+    });
+  }
+
+  try {
+    const response = await sendMessage(token, {
+      chat_id: chatId.trim(),
+      text: text.slice(0, 2000), // Enforce 2000 char limit
+    });
+
+    if (response.ok && response.result) {
+      return {
+        ok: true,
+        messageId: response.result.message_id,
+      };
+    }
+
+    return {
+      ok: false,
+      error: "Failed to send message",
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Send a photo message to a Zalo chat
+ */
+export async function sendPhotoZalo(
+  chatId: string,
+  photoUrl: string,
+  options: ZaloSendOptions = {},
+): Promise<ZaloSendResult> {
+  const token = options.token ?? resolveToken(options);
+
+  if (!token) {
+    return {
+      ok: false,
+      error: "No Zalo bot token configured",
+    };
+  }
+
+  if (!chatId?.trim()) {
+    return {
+      ok: false,
+      error: "No chat_id provided",
+    };
+  }
+
+  if (!photoUrl?.trim()) {
+    return {
+      ok: false,
+      error: "No photo URL provided",
+    };
+  }
+
+  try {
+    const response = await sendPhoto(token, {
+      chat_id: chatId.trim(),
+      photo: photoUrl.trim(),
+      caption: options.caption?.slice(0, 2000),
+    });
+
+    if (response.ok && response.result) {
+      return {
+        ok: true,
+        messageId: response.result.message_id,
+      };
+    }
+
+    return {
+      ok: false,
+      error: "Failed to send photo",
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/zalo/token.ts
+++ b/src/zalo/token.ts
@@ -1,0 +1,92 @@
+/**
+ * Zalo token resolution
+ */
+
+import { readFileSync } from "node:fs";
+import type { ClawdbotConfig } from "../config/config.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+
+export type ZaloTokenResolution = {
+  token: string;
+  tokenSource: "env" | "config" | "configFile" | "none";
+};
+
+/**
+ * Resolve the Zalo bot token for an account.
+ *
+ * Resolution precedence:
+ * 1. Account-level config (`channels.zalo.accounts[accountId].botToken`)
+ * 2. Account-level tokenFile (`channels.zalo.accounts[accountId].tokenFile`)
+ * 3. Base config (`channels.zalo.botToken`) - default account only
+ * 4. Base tokenFile (`channels.zalo.tokenFile`) - default account only
+ * 5. Environment variable (`ZALO_BOT_TOKEN`) - default account only
+ */
+export function resolveZaloToken(
+  cfg: ClawdbotConfig,
+  accountId?: string | null,
+): ZaloTokenResolution {
+  const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
+  const isDefaultAccount = resolvedAccountId === DEFAULT_ACCOUNT_ID;
+  const zaloConfig = cfg.channels?.zalo;
+
+  // Check account-level config first
+  if (resolvedAccountId !== DEFAULT_ACCOUNT_ID) {
+    const accountConfig = zaloConfig?.accounts?.[resolvedAccountId];
+    if (accountConfig) {
+      // Account botToken
+      const accountToken =
+        typeof accountConfig === "object"
+          ? (accountConfig as { botToken?: string }).botToken?.trim()
+          : undefined;
+      if (accountToken) {
+        return { token: accountToken, tokenSource: "config" };
+      }
+
+      // Account tokenFile
+      const accountTokenFile =
+        typeof accountConfig === "object"
+          ? (accountConfig as { tokenFile?: string }).tokenFile?.trim()
+          : undefined;
+      if (accountTokenFile) {
+        try {
+          const fileToken = readFileSync(accountTokenFile, "utf-8").trim();
+          if (fileToken) {
+            return { token: fileToken, tokenSource: "configFile" };
+          }
+        } catch {
+          // File not readable, fall through
+        }
+      }
+    }
+  }
+
+  // For default account (or fallback), check base config
+  if (isDefaultAccount) {
+    // Base botToken
+    const baseToken = zaloConfig?.botToken?.trim();
+    if (baseToken) {
+      return { token: baseToken, tokenSource: "config" };
+    }
+
+    // Base tokenFile
+    const baseTokenFile = zaloConfig?.tokenFile?.trim();
+    if (baseTokenFile) {
+      try {
+        const fileToken = readFileSync(baseTokenFile, "utf-8").trim();
+        if (fileToken) {
+          return { token: fileToken, tokenSource: "configFile" };
+        }
+      } catch {
+        // File not readable, fall through
+      }
+    }
+
+    // Environment variable (default account only)
+    const envToken = process.env.ZALO_BOT_TOKEN?.trim();
+    if (envToken) {
+      return { token: envToken, tokenSource: "env" };
+    }
+  }
+
+  return { token: "", tokenSource: "none" };
+}


### PR DESCRIPTION
## Summary

Adding Zalo as a new messaging channel, following the Discord/Telegram patterns.

## What is Zalo?

Zalo is Vietnam's most popular messaging app (~75M users). Their Bot API (https://bot.zaloplatforms.com/docs) provides a Telegram-like interface with polling/webhook support.

## Implementation Overview

- **Authentication**: Bot Token format `12345689:abc-xyz` (no expiry)
- **Delivery**: Supports both long-polling (`getUpdates`) and webhooks
- **DM Security**: Full policy support (pairing/allowlist/open/disabled)
- **Message types**: Text (2000 char limit), photos, stickers

## Files Added

- `src/zalo/` - Core API, token handling, monitor, send logic
- `src/channels/plugins/zalo.ts` - Channel plugin
- `src/channels/plugins/onboarding/zalo.ts` - Setup wizard
- `src/channels/plugins/outbound/zalo.ts` - Outbound adapter
- `docs/channels/zalo.md` - Documentation

## Testing Status

✅ Build + lint pass  
✅ Bot connects via polling  
✅ Pairing flow works (`clawdbot pairing approve zalo <CODE>`)

## Notes

🤖 **AI-assisted implementation** (Claude) - lightly tested on real Zalo bot, I understand what the code does.

Groups support is "coming soon" per Zalo docs, so this is DMs only for now.