### PR TITLE
fix: use oauth mode for Claude CLI auth profiles

### DIFF
--- a/src/agents/auth-profiles.test.ts
+++ b/src/agents/auth-profiles.test.ts
@@ -512,6 +512,86 @@ describe("resolveAuthProfileOrder", () => {
       "anthropic:cool1",
     ]);
   });
+
+  it("mode: oauth config accepts both oauth and token credentials (issue #559)", () => {
+    const now = Date.now();
+    const storeWithBothTypes: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:oauth-cred": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: now + 60_000,
+        },
+        "anthropic:token-cred": {
+          type: "token",
+          provider: "anthropic",
+          token: "just-a-token",
+          expires: now + 60_000,
+        },
+      },
+    };
+
+    // mode: oauth should accept type: oauth (exact match)
+    const orderOauthCred = resolveAuthProfileOrder({
+      store: storeWithBothTypes,
+      provider: "anthropic",
+      cfg: {
+        auth: {
+          profiles: {
+            "anthropic:oauth-cred": { provider: "anthropic", mode: "oauth" },
+          },
+        },
+      },
+    });
+    expect(orderOauthCred).toContain("anthropic:oauth-cred");
+
+    // mode: oauth should also accept type: token (compatibility rule)
+    const orderTokenCred = resolveAuthProfileOrder({
+      store: storeWithBothTypes,
+      provider: "anthropic",
+      cfg: {
+        auth: {
+          profiles: {
+            "anthropic:token-cred": { provider: "anthropic", mode: "oauth" },
+          },
+        },
+      },
+    });
+    expect(orderTokenCred).toContain("anthropic:token-cred");
+  });
+
+  it("mode: token config rejects oauth credentials (issue #559 root cause)", () => {
+    const now = Date.now();
+    const storeWithOauth: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:oauth-cred": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: now + 60_000,
+        },
+      },
+    };
+
+    // mode: token should reject type: oauth (this was the bug)
+    const order = resolveAuthProfileOrder({
+      store: storeWithOauth,
+      provider: "anthropic",
+      cfg: {
+        auth: {
+          profiles: {
+            "anthropic:oauth-cred": { provider: "anthropic", mode: "token" },
+          },
+        },
+      },
+    });
+    expect(order).not.toContain("anthropic:oauth-cred");
+  });
 });
 
 describe("ensureAuthProfileStore", () => {

--- a/src/commands/auth-choice.ts
+++ b/src/commands/auth-choice.ts
@@ -307,7 +307,7 @@ export async function applyAuthChoice(params: {
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: CLAUDE_CLI_PROFILE_ID,
       provider: "anthropic",
-      mode: "token",
+      mode: "oauth",
     });
   } else if (
     params.authChoice === "setup-token" ||
@@ -368,7 +368,7 @@ export async function applyAuthChoice(params: {
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: CLAUDE_CLI_PROFILE_ID,
       provider: "anthropic",
-      mode: "token",
+      mode: "oauth",
     });
   } else if (params.authChoice === "token") {
     const provider = (await params.prompter.select({


### PR DESCRIPTION
## Summary

Fixes #559 - Claude Code OAuth tokens blocked for external API use

The onboarding wizard was setting `mode: "token"` for `claude-cli` and `setup-token` auth choices, but Claude CLI credentials are typically `type: "oauth"` (with access, refresh, expires fields).

The auth-profiles filter allows `mode: "oauth"` to accept both oauth and token credential types (compatibility rule at `auth-profiles.ts:1088-1090`), but not the reverse. This caused profiles to be filtered out when:
- Config had `mode: "token"`
- Credentials were `type: "oauth"`

### Changes

- `src/commands/auth-choice.ts`: Changed `mode: "token"` to `mode: "oauth"` for both `claude-cli` and `setup-token`/`oauth` auth choices (lines 310 and 371)

### Why `mode: "oauth"` is safe

| Credential `type` | Config `mode: "oauth"` | Result |
|-------------------|------------------------|--------|
| `oauth` | types match | ✅ works |
| `token` | compatibility rule allows it | ✅ works |

Claude CLI can produce either type depending on whether a refresh token exists, so `mode: "oauth"` covers both cases.

### Not affected

- Manual `token` auth choice - explicitly stores `type: "token"` credentials
- `github-copilot` - explicitly stores `type: "token"` credentials  
- All API key providers - use `mode: "api_key"`
- Other OAuth providers (chutes, codex, google-antigravity) - already use `mode: "oauth"`

## Test plan

- [x] Ran `pnpm test` on auth-choice.test.ts, onboard-auth.test.ts, auth-profiles.test.ts - all 67 tests pass
- [ ] Manual test: Users with `mode: "token"` in their config for `anthropic:claude-cli` should update to `mode: "oauth"` or re-run onboarding