### PR TITLE
fix(discord): isolate autoThread thread context

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -147,7 +147,10 @@ export async function processDiscordMessage(
     body: text,
   });
   let shouldClearHistory = false;
-  if (!isDirectMessage) {
+  const shouldIncludeChannelHistory =
+    !isDirectMessage &&
+    !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
+  if (shouldIncludeChannelHistory) {
     combinedBody = buildHistoryContextFromMap({
       historyMap: guildHistories,
       historyKey: message.channelId,
@@ -162,10 +165,12 @@ export async function processDiscordMessage(
           body: `${entry.sender}: ${entry.body} [id:${entry.messageId ?? "unknown"} channel:${message.channelId}]`,
         }),
     });
+    shouldClearHistory = true;
+  }
+  if (!isDirectMessage) {
     const name = formatDiscordUserTag(author);
     const id = author.id;
     combinedBody = `${combinedBody}\n[from: ${name} user id:${id}]`;
-    shouldClearHistory = true;
   }
   const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
   if (replyContext) {
@@ -212,7 +217,7 @@ export async function processDiscordMessage(
     parentSessionKey,
     useSuffix: false,
   });
-  const ctxPayload = {
+  let ctxPayload = {
     Body: combinedBody,
     RawBody: baseText,
     CommandBody: baseText,
@@ -272,6 +277,35 @@ export async function processDiscordMessage(
   const deliverTarget = replyPlan.deliverTarget;
   replyTarget = replyPlan.replyTarget;
   const replyReference = replyPlan.replyReference;
+
+  // If autoThread created a new thread, ensure we also isolate session context to that thread.
+  if (createdThreadId && replyTarget === `channel:${createdThreadId}`) {
+    const threadSessionKey = buildAgentSessionKey({
+      agentId: route.agentId,
+      channel: route.channel,
+      peer: { kind: "channel", id: createdThreadId },
+    });
+    const autoParentSessionKey = buildAgentSessionKey({
+      agentId: route.agentId,
+      channel: route.channel,
+      peer: { kind: "channel", id: message.channelId },
+    });
+    const autoThreadKeys = resolveThreadSessionKeys({
+      baseSessionKey: threadSessionKey,
+      threadId: createdThreadId,
+      parentSessionKey: autoParentSessionKey,
+      useSuffix: false,
+    });
+
+    ctxPayload = {
+      ...ctxPayload,
+      From: `group:${createdThreadId}`,
+      To: `channel:${createdThreadId}`,
+      OriginatingTo: `channel:${createdThreadId}`,
+      SessionKey: autoThreadKeys.sessionKey,
+      ParentSessionKey: autoThreadKeys.parentSessionKey,
+    };
+  }
 
   if (isDirectMessage) {
     const sessionCfg = cfg.session;


### PR DESCRIPTION
### What this fixes
Discord `autoThread` previously replied into newly-created threads while keeping the *parent channel* session/context, so concurrent threads polluted each other.

### Changes
- When `autoThread` creates a new thread, re-key `SessionKey` (and `From`/`To`) to the created thread channel so each thread has isolated context.
- In `autoThread` launcher channels, skip parent-channel rolling history for top-level messages (the parent behaves like an index/launcher; rolling history is usually unrelated thread starters).

### Expected behavior
- Thread A and Thread B no longer share conversational context.
- Thread messages still include the thread starter via existing `ThreadStarterBody` handling.
