### PR TITLE
fix: Make timezone and 24 hour clock explicit in system prompt

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -69,7 +69,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "Time: assume UTC unless stated. User TZ=America/Chicago. Current user time (converted)=Monday 2026-01-05 15:26.",
+      "Time: assume UTC unless stated. User time zone: America/Chicago. Current user time (local, 24-hour): Monday 2026-01-05 15:26 (America/Chicago).",
     );
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -314,7 +314,11 @@ export function buildAgentSystemPrompt(params: {
     "These user-editable files are loaded by Clawdbot and included below in Project Context.",
     "",
     userTimezone || userTime
-      ? `Time: assume UTC unless stated. User TZ=${userTimezone ?? "unknown"}. Current user time (converted)=${userTime ?? "unknown"}.`
+      ? `Time: assume UTC unless stated. User time zone: ${
+          userTimezone ?? "unknown"
+        }. Current user time (local, 24-hour): ${userTime ?? "unknown"} (${
+          userTimezone ?? "unknown"
+        }).`
       : "",
     userTimezone || userTime ? "" : "",
     "## Reply Tags",


### PR DESCRIPTION
On heartbeat, bot is getting confused if it is 12 noon, or 12 midnight.