### PR TITLE
fix(postinstall): update pi-ai patch for 0.45.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 - Packaging: include `dist/memory/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/memory/index.js`).
 - Agents: persist sub-agent registry across gateway restarts and resume announce flow safely. (#831) — thanks @roshanasingh4.
+- Postinstall: fix npm/bun patch context mismatch by pinning `@mariozechner/pi-ai` to `0.45.6` and updating patch. (#861)
 
 ## 2026.1.12-1
 

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.4",
     "@mariozechner/pi-agent-core": "^0.45.3",
-    "@mariozechner/pi-ai": "^0.45.3",
+    "@mariozechner/pi-ai": "0.45.6",
     "@mariozechner/pi-coding-agent": "^0.45.3",
     "@mariozechner/pi-tui": "^0.45.3",
     "@microsoft/agents-hosting": "^1.1.1",
@@ -209,7 +209,7 @@
       "@sinclair/typebox": "0.34.47"
     },
     "patchedDependencies": {
-      "@mariozechner/pi-ai@0.45.3": "patches/@mariozechner__pi-ai@0.45.3.patch"
+      "@mariozechner/pi-ai@0.45.6": "patches/@mariozechner__pi-ai@0.45.6.patch"
     }
   },
   "vitest": {

--- a/patches/@mariozechner__pi-ai@0.45.6.patch
+++ b/patches/@mariozechner__pi-ai@0.45.6.patch
@@ -28,10 +28,10 @@ index 7488c79..4c34587 100644
  }
  function mapStopReason(status) {
 diff --git a/dist/providers/openai-responses.js b/dist/providers/openai-responses.js
-index c4714f4..4d1e6b0 100644
+index fc060fe..df48e54 100644
 --- a/dist/providers/openai-responses.js
 +++ b/dist/providers/openai-responses.js
-@@ -400,10 +400,16 @@ function convertMessages(model, context) {
+@@ -401,10 +401,16 @@ function convertMessages(model, context) {
          }
          else if (msg.role === "assistant") {
              const output = [];
@@ -48,7 +48,7 @@ index c4714f4..4d1e6b0 100644
                          const reasoningItem = JSON.parse(block.thinkingSignature);
                          output.push(reasoningItem);
                      }
-@@ -438,6 +444,16 @@ function convertMessages(model, context) {
+@@ -439,6 +445,16 @@ function convertMessages(model, context) {
                      });
                  }
              }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ overrides:
   '@sinclair/typebox': 0.34.47
 
 patchedDependencies:
-  '@mariozechner/pi-ai@0.45.3':
-    hash: c8bf66c9ab4dc6fb8cb630102c7dad4a9c288ee4c9edb9538d69d6a1eadf5f94
-    path: patches/@mariozechner__pi-ai@0.45.3.patch
+  '@mariozechner/pi-ai@0.45.6':
+    hash: 6071f744466fc5eb2312148334ade48fecc8e65845d178c857a29b3b11fa1890
+    path: patches/@mariozechner__pi-ai@0.45.6.patch
 
 importers:
 
@@ -35,8 +35,8 @@ importers:
         specifier: ^0.45.3
         version: 0.45.3(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-ai':
-        specifier: ^0.45.3
-        version: 0.45.3(patch_hash=c8bf66c9ab4dc6fb8cb630102c7dad4a9c288ee4c9edb9538d69d6a1eadf5f94)(ws@8.19.0)(zod@4.3.5)
+        specifier: 0.45.6
+        version: 0.45.6(patch_hash=6071f744466fc5eb2312148334ade48fecc8e65845d178c857a29b3b11fa1890)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-coding-agent':
         specifier: ^0.45.3
         version: 0.45.3(ws@8.19.0)(zod@4.3.5)
@@ -1009,8 +1009,8 @@ packages:
     resolution: {integrity: sha512-yWgIKuhhCOxLdbNUcX5oNELdUSqkvnoYsXWOq6/IDiolvQMag4fWNsabeAd2OqiueH8k9sFx3G5cFR53PtHLEw==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.45.3':
-    resolution: {integrity: sha512-PVL4xrDfP24v86ZZBAw+3HMqqDjq/RyIpQc+0c/QKp2Ldu4SlX7zYqzDDeXR1PWNvxVPdHwIihMnoXOh/361iA==}
+  '@mariozechner/pi-ai@0.45.6':
+    resolution: {integrity: sha512-AtKx0XUjd2cJPucrDTd/GbCNzCYW612SpGanFD5gzFvMBKBlT4Br4tW+E0rOocFO0oydvWyACaKLGamQqUCfdQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -5106,7 +5106,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.45.3(ws@8.19.0)(zod@4.3.5)':
     dependencies:
-      '@mariozechner/pi-ai': 0.45.3(patch_hash=c8bf66c9ab4dc6fb8cb630102c7dad4a9c288ee4c9edb9538d69d6a1eadf5f94)(ws@8.19.0)(zod@4.3.5)
+      '@mariozechner/pi-ai': 0.45.6(patch_hash=6071f744466fc5eb2312148334ade48fecc8e65845d178c857a29b3b11fa1890)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-tui': 0.45.3
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -5117,7 +5117,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.45.3(patch_hash=c8bf66c9ab4dc6fb8cb630102c7dad4a9c288ee4c9edb9538d69d6a1eadf5f94)(ws@8.19.0)(zod@4.3.5)':
+  '@mariozechner/pi-ai@0.45.6(patch_hash=6071f744466fc5eb2312148334ade48fecc8e65845d178c857a29b3b11fa1890)(ws@8.19.0)(zod@4.3.5)':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.5)
       '@aws-sdk/client-bedrock-runtime': 3.967.0
@@ -5144,7 +5144,7 @@ snapshots:
       '@mariozechner/clipboard': 0.3.0
       '@mariozechner/jiti': 2.6.2
       '@mariozechner/pi-agent-core': 0.45.3(ws@8.19.0)(zod@4.3.5)
-      '@mariozechner/pi-ai': 0.45.3(patch_hash=c8bf66c9ab4dc6fb8cb630102c7dad4a9c288ee4c9edb9538d69d6a1eadf5f94)(ws@8.19.0)(zod@4.3.5)
+      '@mariozechner/pi-ai': 0.45.6(patch_hash=6071f744466fc5eb2312148334ade48fecc8e65845d178c857a29b3b11fa1890)(ws@8.19.0)(zod@4.3.5)
       '@mariozechner/pi-tui': 0.45.3
       chalk: 5.6.2
       cli-highlight: 2.1.11


### PR DESCRIPTION
## Summary
Fixes #861 - npm/bun installs were failing with "context mismatch" errors during postinstall patch application.

**Root cause:** `package.json` declared `"@mariozechner/pi-ai": "^0.45.3"` but the patch was written for exactly `0.45.3`. npm resolved the caret range to `0.45.6`, where the code had shifted by a few lines, causing patch context mismatches.

**Fix:**
- Pin `@mariozechner/pi-ai` to exact version `0.45.6` (no caret)
- Create new patch file targeting `0.45.6` line numbers (all 3 original files + timeout fix)
- Remove old `0.45.3` patch

## Test plan
- [x] Reproduced original error with npm install simulation
- [x] Verified patch applies with pnpm (`pnpm install`)
- [x] Verified patch applies with npm postinstall.js fallback
- [x] E2E test: `npm pack` → `npm install` succeeds with all patches applied
- [x] Verified all 4 patch changes present in node_modules
- [x] Build passes
- [x] Existing tests pass (3 pre-existing failures unrelated to this change)