### PR TITLE
fix(sandbox): restore docker.binds and preserve PATH in exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 - Packaging: include `dist/memory/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/memory/index.js`).
 - Agents: persist sub-agent registry across gateway restarts and resume announce flow safely. (#831) — thanks @roshanasingh4.
+- Sandbox: restore `docker.binds` config field that was accidentally removed (fixes config validation errors for custom bind mounts). — thanks @akonyer.
+- Sandbox: preserve configured PATH when running commands via `docker exec` (login shell sources `/etc/profile` which resets PATH; now prepends custom PATH to preserve both custom tools and system paths). — thanks @akonyer.
 
 ## 2026.1.12-1
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -434,3 +434,8 @@ Example:
 - Container not running: it will auto-create per session on demand.
 - Permission errors in sandbox: set `docker.user` to a UID:GID that matches your
   mounted workspace ownership (or chown the workspace folder).
+- Custom tools not found: if you add tools to a custom image and they're not accessible,
+  ensure PATH is set correctly. Clawdbot runs commands with `sh -lc` (login shell), which
+  sources `/etc/profile` and may reset PATH. Set `docker.env.PATH` in your sandbox config
+  to prepend custom paths (e.g., `/custom/bin:/usr/local/share/npm-global/bin`), or add
+  a script to `/etc/profile.d/` in your Dockerfile.

--- a/src/agents/bash-tools.ts
+++ b/src/agents/bash-tools.ts
@@ -955,7 +955,19 @@ function buildDockerExecArgs(params: {
   for (const [key, value] of Object.entries(params.env)) {
     args.push("-e", `${key}=${value}`);
   }
-  args.push(params.containerName, "sh", "-lc", params.command);
+  // Login shell (-l) sources /etc/profile which resets PATH to a minimal set,
+  // overriding both Docker ENV and -e PATH=... environment variables.
+  // Prepend custom PATH after profile sourcing to ensure custom tools are accessible
+  // while preserving system paths that /etc/profile may have added.
+  const pathExport = params.env.PATH
+    ? `export PATH="${params.env.PATH}:$PATH"; `
+    : "";
+  args.push(
+    params.containerName,
+    "sh",
+    "-lc",
+    `${pathExport}${params.command}`,
+  );
   return args;
 }
 
@@ -1127,3 +1139,6 @@ function pad(str: string, width: number) {
   if (str.length >= width) return str;
   return str + " ".repeat(width - str.length);
 }
+
+// Exported for testing
+export { buildDockerExecArgs };

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -2014,3 +2014,62 @@ describe("config preservation on validation failure", () => {
     });
   });
 });
+
+describe("sandbox docker config", () => {
+  it("accepts binds array in sandbox.docker config", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              binds: [
+                "/var/run/docker.sock:/var/run/docker.sock",
+                "/home/user/source:/source:rw",
+              ],
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                image: "custom-sandbox:latest",
+                binds: ["/home/user/projects:/projects:ro"],
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.docker?.binds).toEqual([
+        "/var/run/docker.sock:/var/run/docker.sock",
+        "/home/user/source:/source:rw",
+      ]);
+      expect(res.config.agents?.list?.[0]?.sandbox?.docker?.binds).toEqual([
+        "/home/user/projects:/projects:ro",
+      ]);
+    }
+  });
+
+  it("rejects non-string values in binds array", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              binds: [123, "/valid/path:/path"],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -930,6 +930,7 @@ const SandboxDockerSchema = z
     apparmorProfile: z.string().optional(),
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
+    binds: z.array(z.string()).optional(),
   })
   .optional();
 


### PR DESCRIPTION
This pull request restores and improves Docker sandbox configuration and command execution, focusing on two main areas: fixing configuration validation for custom bind mounts, and ensuring custom tools are accessible in the Docker sandbox by properly handling the `PATH` environment variable. It also adds comprehensive tests for both features and updates documentation to help users troubleshoot common Docker sandbox issues.

**Sandbox Docker configuration fixes and enhancements:**

* Restored the `docker.binds` config field in the sandbox configuration, fixing validation errors and allowing custom bind mounts to be specified again. Updated the schema and added tests to ensure only arrays of strings are accepted. [[1]](diffhunk://#diff-ef5d76c89c8331b758b6f737bdce10d0f80676698e4df6fa8c7d31ce8fdcc269R933) [[2]](diffhunk://#diff-ab8f98e27442cf4a7f9118076ae4f92c320482f7625bb7c8e3ea948072c80680R2017-R2075)
* Added a changelog entry noting the restoration of `docker.binds` and the fix for config validation errors with custom bind mounts.

**Docker exec command improvements:**

* Modified `buildDockerExecArgs` in `bash-tools.ts` to prepend the configured `PATH` after login shell profile sourcing, ensuring both custom tools and system paths are available when running commands via `docker exec`.
* Added and exported tests for `buildDockerExecArgs` to verify correct `PATH` handling, shell invocation, and support for workdir and TTY options. [[1]](diffhunk://#diff-3d735d36c1ae5549d93e4def92787491a4e2bbbe1b4d41af4fe0485e8717fccfR256-R336) [[2]](diffhunk://#diff-90f2e832e75f6a68b7c56f93d4f042a4c5f16f23ee9594ff13d60ece0a77fa6aR1142-R1144) [[3]](diffhunk://#diff-3d735d36c1ae5549d93e4def92787491a4e2bbbe1b4d41af4fe0485e8717fccfR4)
* Updated documentation to explain how to set up the `PATH` for custom tools in Docker sandboxes, including troubleshooting guidance for users.
* Added a changelog entry describing the preservation of the configured `PATH` when running commands via `docker exec`.


The bind mounts were accidentally removed I believe in this commit, so this is a bug fix/revert for: https://github.com/akonyer/clawdbot/commit/256304037e0200459bc8e0abe33ff69752855c9e