### PR TITLE
fix(telegram): reply to General forum topic without message_thread_id

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1593,9 +1593,12 @@ async function deliverReplies(params: {
 }
 
 function buildTelegramThreadParams(messageThreadId?: number) {
-  return messageThreadId != null
-    ? { message_thread_id: messageThreadId }
-    : undefined;
+  // General topic (ID 1) should not have message_thread_id set when sending
+  // Telegram routes messages to General by NOT specifying the thread ID
+  if (messageThreadId == null || messageThreadId === 1) {
+    return undefined;
+  }
+  return { message_thread_id: messageThreadId };
 }
 
 function resolveTelegramStreamMode(


### PR DESCRIPTION
## Summary

Fixes replies to the General topic in Telegram forum groups by not sending `message_thread_id` parameter when replying to messages in the General topic (thread ID 1).

Closes #727

## Root Cause

When Clawdbot receives a message from the General topic in a Telegram forum group, it correctly identifies it with `message_thread_id=1`. However, when attempting to reply by sending a message with `message_thread_id=1`, the Telegram Bot API rejects it with:

```
Bad Request: message thread not found
```

This is a known limitation in the Telegram Bot API (see https://github.com/tdlib/telegram-bot-api/issues/798). The General topic must be accessed by **omitting** the `message_thread_id` parameter entirely, not by setting it to 1.

## Fix

Modified `buildTelegramThreadParams()` to return `undefined` when `messageThreadId === 1`, ensuring no `message_thread_id` parameter is sent when replying to General topic messages.

## Testing

Tested with a Telegram forum group where:
1. Messages in General topic were received with `message_thread_id=1`
2. Before fix: Replies failed with "Bad Request: message thread not found"
3. After fix: Replies successfully appear in the General topic

## Files Changed

- `src/telegram/bot.ts`: Updated `buildTelegramThreadParams()` to handle General topic (ID 1) specially