### PR TITLE
Fix tool call id length cap (AI-assisted)

### DIFF
--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -26,22 +26,26 @@ function shortHash(text: string): string {
 }
 
 function makeUniqueToolId(params: { id: string; used: Set<string> }): string {
-  const base = sanitizeToolCallId(params.id);
+  const MAX_LEN = 40;
+
+  const base = sanitizeToolCallId(params.id).slice(0, MAX_LEN);
   if (!params.used.has(base)) return base;
 
   const hash = shortHash(params.id);
-  const maxBaseLen = 64 - 1 - hash.length;
+  const maxBaseLen = MAX_LEN - 1 - hash.length;
   const clippedBase =
     base.length > maxBaseLen ? base.slice(0, maxBaseLen) : base;
   const candidate = `${clippedBase}_${hash}`;
   if (!params.used.has(candidate)) return candidate;
 
   for (let i = 2; i < 1000; i += 1) {
-    const next = `${candidate}_${i}`;
+    const suffix = `_${i}`;
+    const next = `${candidate.slice(0, MAX_LEN - suffix.length)}${suffix}`;
     if (!params.used.has(next)) return next;
   }
 
-  return `${candidate}_${Date.now()}`;
+  const ts = `_${Date.now()}`;
+  return `${candidate.slice(0, MAX_LEN - ts.length)}${ts}`;
 }
 
 function rewriteAssistantToolCallIds(params: {


### PR DESCRIPTION
Fix OpenAI/OpenRouter failures where tool_call IDs exceed 40 chars.

Error observed (OpenRouter -> OpenAI):
```
Invalid 'messages[2].tool_calls[0].id': string too long. Expected a string with maximum length 40, but got a string with length 83 instead.
```
I was using codex sub with 5.2 which didn't have this issue. Then I switched to 4o-mini through the subscription and then clawd started mentioning this error. Which is how I as able to get its assistance in fixing it. Now I have switched to openrouter from 4o-mini all the way up to 5.2 pro and can only get this error as a reply with a max of 64 instead of the 40 seen previously.

- Caps generated tool call IDs at 40 chars while preserving uniqueness.
- Tested: `corepack pnpm test` (394 files / 2861 tests passed).

AI-assisted: yes (Codex/Clawdbot).