### PR TITLE
docs: add dmHistoryLimit and per-DM dms config documentation

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -345,6 +345,30 @@ Group messages default to **require mention** (either metadata mention or regex 
 
 `messages.groupChat.historyLimit` sets the global default for group history context. Providers can override with `<provider>.historyLimit` (or `<provider>.accounts.*.historyLimit` for multi-account). Set `0` to disable history wrapping.
 
+#### DM history limits
+
+DM conversations use session-based history managed by the agent. You can limit the number of user turns retained per DM session:
+
+```json5
+{
+  channels: {
+    telegram: {
+      dmHistoryLimit: 30,  // limit DM sessions to 30 user turns
+      dms: {
+        "123456789": { historyLimit: 50 }  // per-user override (user ID)
+      }
+    }
+  }
+}
+```
+
+Resolution order:
+1. Per-DM override: `<provider>.dms[userId].historyLimit`
+2. Provider default: `<provider>.dmHistoryLimit`
+3. No limit (all history retained)
+
+Supported providers: `telegram`, `whatsapp`, `discord`, `slack`, `signal`, `imessage`, `msteams`.
+
 Per-agent override (takes precedence when set, even `[]`):
 ```json5
 {

--- a/docs/providers/discord.md
+++ b/docs/providers/discord.md
@@ -270,6 +270,7 @@ ack reaction after the bot replies.
 - `maxLinesPerMessage`: soft max line count per message. Default: 17.
 - `mediaMaxMb`: clamp inbound media saved to disk.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20; falls back to `messages.groupChat.historyLimit`; `0` disables).
+- `dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `discord.dms["<user_id>"].historyLimit`.
 - `retry`: retry policy for outbound Discord API calls (attempts, minDelayMs, maxDelayMs, jitter).
 - `actions`: per-action tool gates; omit to allow all (set `false` to disable).
   - `reactions` (covers react + read reactions)

--- a/docs/providers/imessage.md
+++ b/docs/providers/imessage.md
@@ -173,6 +173,7 @@ Provider options:
 - `imessage.groupPolicy`: `open | allowlist | disabled` (default: open).
 - `imessage.groupAllowFrom`: group sender allowlist.
 - `imessage.historyLimit` / `imessage.accounts.*.historyLimit`: max group messages to include as context (0 disables).
+- `imessage.dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `imessage.dms["<handle>"].historyLimit`.
 - `imessage.groups`: per-group defaults + allowlist (use `"*"` for global defaults).
 - `imessage.includeAttachments`: ingest attachments into context.
 - `imessage.mediaMaxMb`: inbound/outbound media cap (MB).

--- a/docs/providers/msteams.md
+++ b/docs/providers/msteams.md
@@ -172,6 +172,7 @@ This is often easier than hand-editing JSON manifests.
 ## History context
 - `msteams.historyLimit` controls how many recent channel/group messages are wrapped into the prompt.
 - Falls back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50).
+- DM history can be limited with `msteams.dmHistoryLimit` (user turns). Per-user overrides: `msteams.dms["<user_id>"].historyLimit`.
 
 ## Current Teams RSC Permissions (Manifest)
 These are the **existing resourceSpecific permissions** in our Teams app manifest. They only apply inside the team/chat where the app is installed.

--- a/docs/providers/signal.md
+++ b/docs/providers/signal.md
@@ -110,6 +110,7 @@ Provider options:
 - `signal.groupPolicy`: `open | allowlist | disabled` (default: open).
 - `signal.groupAllowFrom`: group sender allowlist.
 - `signal.historyLimit`: max group messages to include as context (0 disables).
+- `signal.dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `signal.dms["<phone_or_uuid>"].historyLimit`.
 - `signal.textChunkLimit`: outbound chunk size (chars).
 - `signal.mediaMaxMb`: inbound/outbound media cap (MB).
 

--- a/docs/providers/slack.md
+++ b/docs/providers/slack.md
@@ -61,6 +61,7 @@ Or via config:
 ## History context
 - `slack.historyLimit` (or `slack.accounts.*.historyLimit`) controls how many recent channel/group messages are wrapped into the prompt.
 - Falls back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50).
+- DM history can be limited with `slack.dmHistoryLimit` (user turns). Per-user overrides: `slack.dms["<user_id>"].historyLimit`.
 
 ## Manifest (optional)
 Use this Slack app manifest to create the app quickly (adjust the name/command if you want).

--- a/docs/providers/telegram.md
+++ b/docs/providers/telegram.md
@@ -100,6 +100,7 @@ group messages, so use admin if you need full visibility.
 - Outbound text is chunked to `telegram.textChunkLimit` (default 4000).
 - Media downloads/uploads are capped by `telegram.mediaMaxMb` (default 5).
 - Group history context uses `telegram.historyLimit` (or `telegram.accounts.*.historyLimit`), falling back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50).
+- DM history can be limited with `telegram.dmHistoryLimit` (user turns). Per-user overrides: `telegram.dms["<user_id>"].historyLimit`.
 
 ## Group activation modes
 

--- a/docs/providers/whatsapp.md
+++ b/docs/providers/whatsapp.md
@@ -261,6 +261,7 @@ WhatsApp can automatically send emoji reactions to incoming messages immediately
 - `whatsapp.groupAllowFrom` (group sender allowlist).
 - `whatsapp.groupPolicy` (group policy).
 - `whatsapp.historyLimit` / `whatsapp.accounts.<accountId>.historyLimit` (group history context; `0` disables).
+- `whatsapp.dmHistoryLimit` (DM history limit in user turns). Per-user overrides: `whatsapp.dms["<phone>"].historyLimit`.
 - `whatsapp.groups` (group allowlist + mention gating defaults; use `"*"` to allow all)
 - `whatsapp.actions.reactions` (gate WhatsApp tool reactions).
 - `agents.list[].groupChat.mentionPatterns` (or `messages.groupChat.mentionPatterns`)


### PR DESCRIPTION
Document the DM history limit feature across all provider docs:
- Add DM history limits section to gateway/configuration.md
- Add dmHistoryLimit and dms[userId].historyLimit to each provider doc (telegram, whatsapp, discord, slack, signal, imessage, msteams)

Resolution order: per-DM override > provider dmHistoryLimit > no limit