### PR TITLE
Slack: drop Socket Mode events with mismatched api_app_id

### DIFF
--- a/src/slack/monitor.tool-result.part-1.test.ts
+++ b/src/slack/monitor.tool-result.part-1.test.ts
@@ -163,6 +163,46 @@ describe("monitorSlackProvider tool results", () => {
     expect(sendMock.mock.calls[1][1]).toBe("PFX final reply");
   });
 
+  it("drops events with mismatched api_app_id", async () => {
+    const client = getSlackClient();
+    if (!client) throw new Error("Slack client not registered");
+    (client.auth as { test: ReturnType<typeof vi.fn> }).test.mockResolvedValue({
+      user_id: "bot-user",
+      team_id: "T1",
+      api_app_id: "A1",
+    });
+
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      appToken: "xapp-1-A1-abc",
+      abortSignal: controller.signal,
+    });
+
+    await waitForEvent("message");
+    const handler = getSlackHandlers()?.get("message");
+    if (!handler) throw new Error("Slack message handler not registered");
+
+    await handler({
+      body: { api_app_id: "A2", team_id: "T1" },
+      event: {
+        type: "message",
+        user: "U1",
+        text: "hello",
+        ts: "123",
+        channel: "C1",
+        channel_type: "im",
+      },
+    });
+
+    await flush();
+    controller.abort();
+    await run;
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+  });
+
   it("does not derive responsePrefix from routed agent identity when unset", async () => {
     config = {
       agents: {

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -29,6 +29,7 @@ export type SlackMonitorContext = {
 
   botUserId: string;
   teamId: string;
+  apiAppId: string;
 
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
@@ -67,6 +68,7 @@ export type SlackMonitorContext = {
 
   logger: ReturnType<typeof getChildLogger>;
   markMessageSeen: (channelId: string | undefined, ts?: string) => boolean;
+  shouldDropMismatchedSlackEvent: (body: unknown) => boolean;
   resolveSlackSystemEventSessionKey: (params: {
     channelId?: string | null;
     channelType?: string | null;
@@ -99,6 +101,7 @@ export function createSlackMonitorContext(params: {
 
   botUserId: string;
   teamId: string;
+  apiAppId: string;
 
   historyLimit: number;
   sessionScope: SessionScope;
@@ -313,6 +316,28 @@ export function createSlackMonitorContext(params: {
     return true;
   };
 
+  const shouldDropMismatchedSlackEvent = (body: unknown) => {
+    if (!body || typeof body !== "object") return false;
+    const raw = body as { api_app_id?: unknown; team_id?: unknown };
+    const incomingApiAppId =
+      typeof raw.api_app_id === "string" ? raw.api_app_id : "";
+    const incomingTeamId = typeof raw.team_id === "string" ? raw.team_id : "";
+
+    if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
+      logVerbose(
+        `slack: drop event with api_app_id=${incomingApiAppId} (expected ${params.apiAppId})`,
+      );
+      return true;
+    }
+    if (params.teamId && incomingTeamId && incomingTeamId !== params.teamId) {
+      logVerbose(
+        `slack: drop event with team_id=${incomingTeamId} (expected ${params.teamId})`,
+      );
+      return true;
+    }
+    return false;
+  };
+
   return {
     cfg: params.cfg,
     accountId: params.accountId,
@@ -321,6 +346,7 @@ export function createSlackMonitorContext(params: {
     runtime: params.runtime,
     botUserId: params.botUserId,
     teamId: params.teamId,
+    apiAppId: params.apiAppId,
     historyLimit: params.historyLimit,
     channelHistories,
     sessionScope: params.sessionScope,
@@ -343,6 +369,7 @@ export function createSlackMonitorContext(params: {
     removeAckAfterReply: params.removeAckAfterReply,
     logger,
     markMessageSeen,
+    shouldDropMismatchedSlackEvent,
     resolveSlackSystemEventSessionKey,
     isChannelAllowed,
     resolveChannelName,

--- a/src/slack/monitor/events/channels.ts
+++ b/src/slack/monitor/events/channels.ts
@@ -17,9 +17,12 @@ export function registerSlackChannelEvents(params: {
 
   ctx.app.event(
     "channel_created",
-    async ({ event }: SlackEventMiddlewareArgs<"channel_created">) => {
+    async (args: SlackEventMiddlewareArgs<"channel_created">) => {
       try {
-        const payload = event as SlackChannelCreatedEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackChannelCreatedEvent;
         const channelId = payload.channel?.id;
         const channelName = payload.channel?.name;
         if (
@@ -50,9 +53,12 @@ export function registerSlackChannelEvents(params: {
 
   ctx.app.event(
     "channel_rename",
-    async ({ event }: SlackEventMiddlewareArgs<"channel_rename">) => {
+    async (args: SlackEventMiddlewareArgs<"channel_rename">) => {
       try {
-        const payload = event as SlackChannelRenamedEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackChannelRenamedEvent;
         const channelId = payload.channel?.id;
         const channelName =
           payload.channel?.name_normalized ?? payload.channel?.name;

--- a/src/slack/monitor/events/members.ts
+++ b/src/slack/monitor/events/members.ts
@@ -14,9 +14,12 @@ export function registerSlackMemberEvents(params: {
 
   ctx.app.event(
     "member_joined_channel",
-    async ({ event }: SlackEventMiddlewareArgs<"member_joined_channel">) => {
+    async (args: SlackEventMiddlewareArgs<"member_joined_channel">) => {
       try {
-        const payload = event as SlackMemberChannelEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackMemberChannelEvent;
         const channelId = payload.channel;
         const channelInfo = channelId
           ? await ctx.resolveChannelName(channelId)
@@ -57,9 +60,12 @@ export function registerSlackMemberEvents(params: {
 
   ctx.app.event(
     "member_left_channel",
-    async ({ event }: SlackEventMiddlewareArgs<"member_left_channel">) => {
+    async (args: SlackEventMiddlewareArgs<"member_left_channel">) => {
       try {
-        const payload = event as SlackMemberChannelEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackMemberChannelEvent;
         const channelId = payload.channel;
         const channelInfo = channelId
           ? await ctx.resolveChannelName(channelId)

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -21,9 +21,12 @@ export function registerSlackMessageEvents(params: {
 
   ctx.app.event(
     "message",
-    async ({ event }: SlackEventMiddlewareArgs<"message">) => {
+    async (args: SlackEventMiddlewareArgs<"message">) => {
       try {
-        const message = event as SlackMessageEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const message = args.event as SlackMessageEvent;
         if (message.subtype === "message_changed") {
           const changed = event as SlackMessageChangedEvent;
           const channelId = changed.channel;
@@ -125,9 +128,12 @@ export function registerSlackMessageEvents(params: {
 
   ctx.app.event(
     "app_mention",
-    async ({ event }: SlackEventMiddlewareArgs<"app_mention">) => {
+    async (args: SlackEventMiddlewareArgs<"app_mention">) => {
       try {
-        const mention = event as SlackAppMentionEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const mention = args.event as SlackAppMentionEvent;
         await handleSlackMessage(mention as unknown as SlackMessageEvent, {
           source: "app_mention",
           wasMentioned: true,

--- a/src/slack/monitor/events/pins.ts
+++ b/src/slack/monitor/events/pins.ts
@@ -12,9 +12,12 @@ export function registerSlackPinEvents(params: { ctx: SlackMonitorContext }) {
 
   ctx.app.event(
     "pin_added",
-    async ({ event }: SlackEventMiddlewareArgs<"pin_added">) => {
+    async (args: SlackEventMiddlewareArgs<"pin_added">) => {
       try {
-        const payload = event as SlackPinEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackPinEvent;
         const channelId = payload.channel_id;
         const channelInfo = channelId
           ? await ctx.resolveChannelName(channelId)
@@ -59,9 +62,12 @@ export function registerSlackPinEvents(params: { ctx: SlackMonitorContext }) {
 
   ctx.app.event(
     "pin_removed",
-    async ({ event }: SlackEventMiddlewareArgs<"pin_removed">) => {
+    async (args: SlackEventMiddlewareArgs<"pin_removed">) => {
       try {
-        const payload = event as SlackPinEvent;
+        if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+          return;
+        }
+        const payload = args.event as SlackPinEvent;
         const channelId = payload.channel_id;
         const channelInfo = channelId
           ? await ctx.resolveChannelName(channelId)

--- a/src/slack/monitor/events/reactions.ts
+++ b/src/slack/monitor/events/reactions.ts
@@ -90,15 +90,21 @@ export function registerSlackReactionEvents(params: {
 
   ctx.app.event(
     "reaction_added",
-    async ({ event }: SlackEventMiddlewareArgs<"reaction_added">) => {
-      await handleReactionEvent(event as SlackReactionEvent, "added");
+    async (args: SlackEventMiddlewareArgs<"reaction_added">) => {
+      if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+        return;
+      }
+      await handleReactionEvent(args.event as SlackReactionEvent, "added");
     },
   );
 
   ctx.app.event(
     "reaction_removed",
-    async ({ event }: SlackEventMiddlewareArgs<"reaction_removed">) => {
-      await handleReactionEvent(event as SlackReactionEvent, "removed");
+    async (args: SlackEventMiddlewareArgs<"reaction_removed">) => {
+      if (ctx.shouldDropMismatchedSlackEvent((args as { body?: unknown }).body)) {
+        return;
+      }
+      await handleReactionEvent(args.event as SlackReactionEvent, "removed");
     },
   );
 }

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -18,6 +18,13 @@ import { registerSlackMonitorSlashCommands } from "./slash.js";
 
 import type { MonitorSlackOpts } from "./types.js";
 
+function parseApiAppIdFromAppToken(raw?: string) {
+  const token = raw?.trim();
+  if (!token) return undefined;
+  const match = /^xapp-\d-([a-z0-9]+)-/i.exec(token);
+  return match?.[1]?.toUpperCase();
+}
+
 export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const cfg = opts.config ?? loadConfig();
 
@@ -84,12 +91,25 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
   let botUserId = "";
   let teamId = "";
+  let apiAppId = "";
+  const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
   try {
     const auth = await app.client.auth.test({ token: botToken });
     botUserId = auth.user_id ?? "";
     teamId = auth.team_id ?? "";
+    apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
   } catch {
     // auth test failing is non-fatal; message handler falls back to regex mentions.
+  }
+
+  if (
+    apiAppId &&
+    expectedApiAppIdFromAppToken &&
+    apiAppId !== expectedApiAppIdFromAppToken
+  ) {
+    runtime.error?.(
+      `slack token mismatch: bot token api_app_id=${apiAppId} but app token looks like api_app_id=${expectedApiAppIdFromAppToken}`,
+    );
   }
 
   const ctx = createSlackMonitorContext({
@@ -100,6 +120,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     runtime,
     botUserId,
     teamId,
+    apiAppId,
     historyLimit,
     sessionScope,
     mainKey,


### PR DESCRIPTION
Fixes a failure mode where a gateway can process Slack Socket Mode events that belong to a different Slack app (same workspace), if tokens are ever mismatched.

What changed
- Capture bot token identity via auth.test (team_id + api_app_id).
- Drop inbound events when the Socket Mode envelope body.api_app_id or body.team_id does not match.
- Emit a clear error when the bot token api_app_id disagrees with the app token's embedded app id (xapp-…-Axxxx-…).

Tests
- Added a unit test to ensure mismatched events are dropped.

Refs: clawdbot/clawdbot#828