### PR TITLE
feat(telegram): add deleteMessage action

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -148,7 +148,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     label: "Message",
     name: "message",
     description:
-      "Send messages and channel actions (polls, reactions, pins, threads, etc.) via configured channel plugins.",
+      "Send, delete, and manage messages via channel plugins. Supports actions: send, delete, react, poll, pin, threads, and more.",
     parameters: schema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -35,6 +35,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     const gate = createActionGate(cfg.channels?.telegram?.actions);
     const actions = new Set<ChannelMessageActionName>(["send"]);
     if (gate("reactions")) actions.add("react");
+    if (gate("deleteMessage")) actions.add("delete");
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => hasTelegramInlineButtons(cfg),
@@ -86,6 +87,22 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           messageId,
           emoji,
           remove,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "delete") {
+      const chatId = readStringParam(params, "chatId", { required: true });
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+      });
+      return await handleTelegramAction(
+        {
+          action: "deleteMessage",
+          chatId,
+          messageId: Number(messageId),
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -11,6 +11,7 @@ import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 export type TelegramActionConfig = {
   reactions?: boolean;
   sendMessage?: boolean;
+  deleteMessage?: boolean;
 };
 
 export type TelegramAccountConfig = {


### PR DESCRIPTION
## Summary
- Adds deleteMessage action for Telegram via the message tool
- Allows bots to delete messages in chats where they have permission

## Changes
- `src/telegram/send.ts` - Add `deleteMessageTelegram` function
- `src/agents/tools/telegram-actions.ts` - Add deleteMessage action handler
- `src/channels/plugins/actions/telegram.ts` - Add delete action to message plugin
- `src/config/types.telegram.ts` - Add `deleteMessage` to TelegramActionConfig
- `src/agents/tools/message-tool.ts` - Update description to mention delete

## Usage
```json
{
  "tool": "message",
  "action": "delete",
  "chatId": "-1001234567890",
  "messageId": "12345"
}
```

Can be disabled via config:
```json
{
  "channels": {
    "telegram": {
      "actions": {
        "deleteMessage": false
      }
    }
  }
}
```

## Telegram API Limitations
- Bot can delete its own messages in any chat
- Bot can delete others' messages only if admin with "Delete Messages" permission
- Messages older than 48h in groups may fail to delete

## Test plan
- [ ] Delete bot's own message in DM
- [ ] Delete bot's own message in group
- [ ] Verify error when trying to delete others' message without admin rights
- [ ] Verify action can be disabled via config