### PR TITLE
fix(agent): strip leaked tool call text and thinking tags from messages

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -358,4 +358,84 @@ File contents here`,
     const result = extractAssistantText(msg);
     expect(result).toBe("Here's what I found:\nDone checking.");
   });
+
+  it("strips thinking tags from text content", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<think>El usuario quiere retomar una tarea...</think>Aquí está tu respuesta.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Aquí está tu respuesta.");
+  });
+
+  it("strips thinking tags without closing tag", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<think>Pensando sobre el problema...",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("");
+  });
+
+  it("strips thinking tags with various formats", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Before<thinking>internal reasoning</thinking>After",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("BeforeAfter");
+  });
+
+  it("strips antthinking tags", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<antthinking>Some reasoning</antthinking>The actual answer.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("The actual answer.");
+  });
+
+  it("handles nested or multiple thinking blocks", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Start<think>first thought</think>Middle<think>second thought</think>End",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("StartMiddleEnd");
+  });
 });

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -423,6 +423,22 @@ File contents here`,
     expect(result).toBe("The actual answer.");
   });
 
+  it("strips thought tags", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<thought>Internal deliberation</thought>Final response.",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Final response.");
+  });
+
   it("handles nested or multiple thinking blocks", () => {
     const msg: AssistantMessage = {
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -47,6 +47,44 @@ function stripDowngradedToolCallText(text: string): string {
   return cleaned.trim();
 }
 
+/**
+ * Strip thinking tags and their content from text.
+ * This is a safety net for cases where the model outputs <think> tags
+ * that slip through other filtering mechanisms.
+ */
+function stripThinkingTagsFromText(text: string): string {
+  if (!text) return text;
+  // Quick check to avoid regex overhead when no tags present.
+  if (!/(?:think(?:ing)?|thought|antthinking)/i.test(text)) return text;
+
+  const tagRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  let result = "";
+  let lastIndex = 0;
+  let inThinking = false;
+
+  for (const match of text.matchAll(tagRe)) {
+    const idx = match.index ?? 0;
+    const isClose = match[1] === "/";
+
+    if (!inThinking && !isClose) {
+      // Opening tag - save text before it.
+      result += text.slice(lastIndex, idx);
+      inThinking = true;
+    } else if (inThinking && isClose) {
+      // Closing tag - skip content inside.
+      inThinking = false;
+    }
+    lastIndex = idx + match[0].length;
+  }
+
+  // Append remaining text if we're not inside thinking.
+  if (!inThinking) {
+    result += text.slice(lastIndex);
+  }
+
+  return result.trim();
+}
+
 export function extractAssistantText(msg: AssistantMessage): string {
   const isTextBlock = (
     block: unknown,
@@ -60,7 +98,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     ? msg.content
         .filter(isTextBlock)
         .map((c) =>
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(c.text)).trim(),
+          stripThinkingTagsFromText(
+            stripDowngradedToolCallText(stripMinimaxToolCallXml(c.text)),
+          ).trim(),
         )
         .filter(Boolean)
     : [];

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -21,6 +21,32 @@ function stripMinimaxToolCallXml(text: string): string {
   return cleaned;
 }
 
+/**
+ * Strip downgraded tool call text representations that leak into text content.
+ * When replaying history to Gemini, tool calls without `thought_signature` are
+ * downgraded to text blocks like `[Tool Call: name (ID: ...)]`. These should
+ * not be shown to users.
+ */
+function stripDowngradedToolCallText(text: string): string {
+  if (!text) return text;
+  if (!/\[Tool (?:Call|Result)/i.test(text)) return text;
+
+  // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
+  // Match until the next [Tool marker or end of string.
+  let cleaned = text.replace(
+    /\[Tool Call:[^\]]*\]\n?(?:Arguments:[\s\S]*?)?(?=\n*\[Tool |\n*$)/gi,
+    "",
+  );
+
+  // Remove [Tool Result for ID ...] blocks and their content.
+  cleaned = cleaned.replace(
+    /\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi,
+    "",
+  );
+
+  return cleaned.trim();
+}
+
 export function extractAssistantText(msg: AssistantMessage): string {
   const isTextBlock = (
     block: unknown,
@@ -33,7 +59,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
   const blocks = Array.isArray(msg.content)
     ? msg.content
         .filter(isTextBlock)
-        .map((c) => stripMinimaxToolCallXml(c.text).trim())
+        .map((c) =>
+          stripDowngradedToolCallText(stripMinimaxToolCallXml(c.text)).trim(),
+        )
         .filter(Boolean)
     : [];
   return blocks.join("\n").trim();


### PR DESCRIPTION
## Summary
- Strip `[Tool Call: ...]` and `[Tool Result for ID ...]` text blocks that leak into assistant messages when Gemini history downgrading converts tool calls without `thought_signature` to text
- Strip `<think>`, `<thinking>`, `<thought>`, and `<antthinking>` tags from text content as a safety net for models that emit thinking tags in text blocks

## Changes
- Added `stripDowngradedToolCallText()` function to filter downgraded tool call representations
- Added `stripThinkingTagsFromText()` function to filter thinking tag leaks
- Updated `extractAssistantText()` to chain all three filters (Minimax XML, downgraded tool calls, thinking tags)
- Added comprehensive test coverage (25 tests total for the module)

## Test Plan
- [x] Unit tests added for all new filter functions
- [x] All 25 tests in `pi-embedded-utils.test.ts` pass
- [x] Full test suite passes (2872 tests)
- [x] Lint and type-check pass
- [x] Local security review passed (no new vulnerabilities)
- [x] Local code review passed

## Context
When using Gemini models via the google-antigravity provider, tool calls that lack a `thought_signature` are downgraded to text blocks during history replay. This caused raw tool invocation syntax to leak into user-facing messages on Telegram and other surfaces.

Similarly, some models emit thinking/reasoning content wrapped in `<think>` tags which should not appear in final responses.

## Related
- Closes #893
- Related to #894 (alternative fix that excludes `google-antigravity` from `downgradeGeminiHistory` entirely). Both PRs can coexist - #894 prevents the leak at the source for google-antigravity, while this PR adds defense-in-depth filtering that catches leaks from any provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)