### PR TITLE
macOS: fix wizard hang when /tmp/clawdbot is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes
 - Browser: add tests for snapshot labels/efficient query params and labeled image responses.
+- macOS: ensure launchd log directory exists with a test-only override. (#909) — thanks @roshanasingh4.
 - Telegram: register dock native commands with underscores to avoid `BOT_COMMAND_INVALID` (#929, fixes #901) — thanks @grp06.
 - Google: downgrade unsigned thinking blocks before send to avoid missing signature errors.
 - Agents: make user time zone and 24-hour time explicit in the system prompt. (#859) — thanks @CashWilliams.

--- a/apps/macos/Sources/Clawdbot/LogLocator.swift
+++ b/apps/macos/Sources/Clawdbot/LogLocator.swift
@@ -1,9 +1,21 @@
 import Foundation
 
 enum LogLocator {
-    private static let logDir = URL(fileURLWithPath: "/tmp/clawdbot")
-    private static let stdoutLog = logDir.appendingPathComponent("clawdbot-stdout.log")
-    private static let gatewayLog = logDir.appendingPathComponent("clawdbot-gateway.log")
+    private static var logDir: URL {
+        if let override = ProcessInfo.processInfo.environment["CLAWDBOT_LOG_DIR"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+
+        return URL(fileURLWithPath: "/tmp/clawdbot")
+    }
+
+    private static var stdoutLog: URL {
+        logDir.appendingPathComponent("clawdbot-stdout.log")
+    }
+
+    private static var gatewayLog: URL {
+        logDir.appendingPathComponent("clawdbot-gateway.log")
+    }
 
     private static func ensureLogDirExists() {
         try? FileManager.default.createDirectory(at: self.logDir, withIntermediateDirectories: true)

--- a/apps/macos/Sources/Clawdbot/LogLocator.swift
+++ b/apps/macos/Sources/Clawdbot/LogLocator.swift
@@ -5,12 +5,17 @@ enum LogLocator {
     private static let stdoutLog = logDir.appendingPathComponent("clawdbot-stdout.log")
     private static let gatewayLog = logDir.appendingPathComponent("clawdbot-gateway.log")
 
+    private static func ensureLogDirExists() {
+        try? FileManager.default.createDirectory(at: self.logDir, withIntermediateDirectories: true)
+    }
+
     private static func modificationDate(for url: URL) -> Date {
         (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
     }
 
     /// Returns the newest log file under /tmp/clawdbot/ (rolling or stdout), or nil if none exist.
     static func bestLogFile() -> URL? {
+        self.ensureLogDirExists()
         let fm = FileManager.default
         let files = (try? fm.contentsOfDirectory(
             at: self.logDir,
@@ -26,11 +31,13 @@ enum LogLocator {
 
     /// Path to use for launchd stdout/err.
     static var launchdLogPath: String {
-        stdoutLog.path
+        self.ensureLogDirExists()
+        return stdoutLog.path
     }
 
     /// Path to use for the Gateway launchd job stdout/err.
     static var launchdGatewayLogPath: String {
-        gatewayLog.path
+        self.ensureLogDirExists()
+        return gatewayLog.path
     }
 }

--- a/apps/macos/Tests/ClawdbotIPCTests/LogLocatorTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/LogLocatorTests.swift
@@ -1,21 +1,24 @@
+import Darwin
 import Foundation
 import Testing
 @testable import Clawdbot
 
 @Suite struct LogLocatorTests {
     @Test func launchdGatewayLogPathEnsuresTmpDirExists() throws {
-        let dirPath = "/tmp/clawdbot"
         let fm = FileManager.default
+        let baseDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let logDir = baseDir.appendingPathComponent("clawdbot-tests-\(UUID().uuidString)")
 
-        // Simulate a clean machine state where /tmp/clawdbot does not exist.
-        if fm.fileExists(atPath: dirPath) {
-            try? fm.removeItem(atPath: dirPath)
+        setenv("CLAWDBOT_LOG_DIR", logDir.path, 1)
+        defer {
+            unsetenv("CLAWDBOT_LOG_DIR")
+            try? fm.removeItem(at: logDir)
         }
 
         _ = LogLocator.launchdGatewayLogPath
 
         var isDir: ObjCBool = false
-        #expect(fm.fileExists(atPath: dirPath, isDirectory: &isDir))
+        #expect(fm.fileExists(atPath: logDir.path, isDirectory: &isDir))
         #expect(isDir.boolValue == true)
     }
 }

--- a/apps/macos/Tests/ClawdbotIPCTests/LogLocatorTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/LogLocatorTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+@testable import Clawdbot
+
+@Suite struct LogLocatorTests {
+    @Test func launchdGatewayLogPathEnsuresTmpDirExists() throws {
+        let dirPath = "/tmp/clawdbot"
+        let fm = FileManager.default
+
+        // Simulate a clean machine state where /tmp/clawdbot does not exist.
+        if fm.fileExists(atPath: dirPath) {
+            try? fm.removeItem(atPath: dirPath)
+        }
+
+        _ = LogLocator.launchdGatewayLogPath
+
+        var isDir: ObjCBool = false
+        #expect(fm.fileExists(atPath: dirPath, isDirectory: &isDir))
+        #expect(isDir.boolValue == true)
+    }
+}


### PR DESCRIPTION
Fixes clawdbot/clawdbot#902.

## What was happening
The macOS app starts the gateway via a `launchd` LaunchAgent and configures `StandardOutPath`/`StandardErrorPath` to `/tmp/clawdbot/clawdbot-gateway.log`. On clean machines, `/tmp/clawdbot` may not exist. `launchd` does not create parent directories for log paths, so the job can fail to start and the onboarding wizard times out waiting for the gateway health endpoint.

## Fix
Ensure `/tmp/clawdbot` exists whenever the macOS app computes launchd log paths (via `LogLocator`). This guarantees the parent directory exists before the LaunchAgent plist is written/loaded.

## Tests
Adds a regression test that deletes `/tmp/clawdbot`, accesses `LogLocator.launchdGatewayLogPath`, and asserts the directory is recreated.