### PR TITLE
fix(whatsapp): context isolation + config toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Telegram: split long captions into media + follow-up text messages. (#907) - thanks @jalehman.
 - Slack: drop Socket Mode events with mismatched `api_app_id`/`team_id`. (#889) — thanks @roshanasingh4.
 - Discord: isolate autoThread thread context. (#856) — thanks @davidguttman.
+- WhatsApp: fix context isolation using wrong ID (was bot's number, now conversation ID); add `channels.whatsapp.contextIsolation` config to disable. (#911)
 
 ## 2026.1.13
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -31,6 +31,7 @@ export function buildThreadingToolContext(params: {
       accountId: sessionCtx.AccountId,
       context: {
         Channel: sessionCtx.Provider,
+        From: sessionCtx.From,
         To: sessionCtx.To,
         ReplyToId: sessionCtx.ReplyToId,
         ThreadLabel: sessionCtx.ThreadLabel,

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -145,11 +145,15 @@ const DOCKS: Record<ChannelId, ChannelDock> = {
       },
     },
     threading: {
-      buildToolContext: ({ context, hasRepliedRef }) => ({
-        currentChannelId: context.To?.trim() || undefined,
-        currentThreadTs: context.ReplyToId,
-        hasRepliedRef,
-      }),
+      buildToolContext: ({ cfg, accountId, context, hasRepliedRef }) => {
+        const account = resolveWhatsAppAccount({ cfg, accountId });
+        const isolationEnabled = account.contextIsolation !== false;
+        return {
+          currentChannelId: isolationEnabled ? context.From?.trim() || undefined : undefined,
+          currentThreadTs: context.ReplyToId,
+          hasRepliedRef,
+        };
+      },
     },
   },
   discord: {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -189,6 +189,7 @@ export type ChannelThreadingAdapter = {
 
 export type ChannelThreadingContext = {
   Channel?: string;
+  From?: string;
   To?: string;
   ReplyToId?: string;
   ThreadLabel?: string;

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -71,6 +71,12 @@ export type WhatsAppConfig = {
      */
     group?: "always" | "mentions" | "never";
   };
+  /**
+   * Restrict agent sends to the current chat context.
+   * - true (default): agent can only send to the chat it received a message from
+   * - false: agent can send to any chat (DM or group) regardless of context
+   */
+  contextIsolation?: boolean;
 };
 
 export type WhatsAppAccountConfig = {
@@ -123,4 +129,10 @@ export type WhatsAppAccountConfig = {
      */
     group?: "always" | "mentions" | "never";
   };
+  /**
+   * Restrict agent sends to the current chat context.
+   * - true (default): agent can only send to the chat it received a message from
+   * - false: agent can send to any chat (DM or group) regardless of context
+   */
+  contextIsolation?: boolean;
 };

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -44,6 +44,7 @@ export const WhatsAppAccountSchema = z
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })
       .optional(),
+    contextIsolation: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.dmPolicy !== "open") return;
@@ -97,6 +98,7 @@ export const WhatsAppConfigSchema = z
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })
       .optional(),
+    contextIsolation: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.dmPolicy !== "open") return;

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -24,6 +24,7 @@ export type ResolvedWhatsAppAccount = {
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
+  contextIsolation?: boolean;
 };
 
 function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
@@ -124,6 +125,8 @@ export function resolveWhatsAppAccount(params: {
     blockStreaming: accountCfg?.blockStreaming ?? params.cfg.channels?.whatsapp?.blockStreaming,
     ackReaction: accountCfg?.ackReaction ?? params.cfg.channels?.whatsapp?.ackReaction,
     groups: accountCfg?.groups ?? params.cfg.channels?.whatsapp?.groups,
+    contextIsolation:
+      accountCfg?.contextIsolation ?? params.cfg.channels?.whatsapp?.contextIsolation,
   };
 }
 


### PR DESCRIPTION
## Summary
- **Bug fix**: Context isolation was using `context.To` (bot's phone number) instead of `context.From` (conversation ID), blocking all cross-chat WhatsApp sends
- **New config**: Add `channels.whatsapp.contextIsolation` to control the feature

## Changes

### Bug Fix
1. Added `From` field to `ChannelThreadingContext` type
2. Pass `sessionCtx.From` through in `buildThreadingToolContext`
3. Use `context.From` for WhatsApp's `currentChannelId`

### Config Feature
4. Add `contextIsolation` to `WhatsAppConfig` and `WhatsAppAccountConfig` types
5. Add zod validation for the new config
6. Add to `ResolvedWhatsAppAccount` with account→global fallback
7. Update WhatsApp's `buildToolContext` to respect the config

## Config Usage

```json
{
  "channels": {
    "whatsapp": {
      "contextIsolation": false
    }
  }
}
```

- `true` (default): Agent can only send to the chat it received a message from
- `false`: Agent can send to any chat (DM or group) regardless of context

## Test Plan
- [x] Lint passes (`pnpm lint`)
- [x] Build passes (`pnpm build`)
- [x] Tests pass (`pnpm test`)
- [ ] Manual: With `contextIsolation: true` (default), agent in DM cannot send to group
- [ ] Manual: With `contextIsolation: false`, agent in DM can send to group
- [ ] Manual: Message in group, agent replies in same group (both configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)