### PR TITLE
Rename 'Claude CLI' to 'Claude Code' in auth options

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -42,7 +42,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "anthropic",
     label: "Anthropic",
-    hint: "Claude CLI + API key",
+    hint: "Claude Code + API key",
     choices: ["claude-cli", "setup-token", "token", "apiKey"],
   },
   {
@@ -138,13 +138,13 @@ export function buildAuthChoiceOptions(params: {
   if (claudeCli?.type === "oauth" || claudeCli?.type === "token") {
     options.push({
       value: "claude-cli",
-      label: "Anthropic token (Claude CLI)",
+      label: "Anthropic token (Claude Code)",
       hint: formatOAuthHint(claudeCli.expires),
     });
   } else if (params.includeClaudeCliIfMissing && platform === "darwin") {
     options.push({
       value: "claude-cli",
-      label: "Anthropic token (Claude CLI)",
+      label: "Anthropic token (Claude Code)",
       hint: "requires Keychain access",
     });
   }


### PR DESCRIPTION
## Summary

Anthropic's CLI tool was rebranded from "Claude CLI" to "Claude Code". This PR updates the user-facing labels and hints in the onboarding flow to reflect the current name.

## Changes

- Updated hint text from "Claude CLI + API key" to "Claude Code + API key"
- Updated auth option labels from "Anthropic token (Claude CLI)" to "Anthropic token (Claude Code)"

## Screenshot reference

The text appears during onboarding when selecting the Anthropic auth method.

## Test plan

- [x] Run `clawdbot onboard` and verify the auth option now shows "Claude Code" instead of "Claude CLI"