### PR TITLE
Agents: scrub tuple items in Gemini tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Docs: document DM history limits for channel DMs. (#883) — thanks @pkrmf.
 
 ### Fixes
+- Agents: scrub tuple `items` schemas for Gemini tool calls. (#746)
 - Embedded runner: suppress raw API error payloads from replies. (#924) — thanks @grp06.
 - Auth: normalize Claude Code CLI profile mode to oauth and auto-migrate config. (#855) — thanks @sebslight.
 

--- a/src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-a.test.ts
+++ b/src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-a.test.ts
@@ -156,6 +156,30 @@ describe("createClawdbotCodingTools", () => {
       enum: ["a", "b"],
     });
   });
+  it("cleans tuple items schemas", () => {
+    const cleaned = __testing.cleanToolSchemaForGemini({
+      type: "object",
+      properties: {
+        tuples: {
+          type: "array",
+          items: [
+            { type: "string", format: "uuid" },
+            { type: "number", minimum: 1 },
+          ],
+        },
+      },
+    }) as {
+      properties?: Record<string, unknown>;
+    };
+
+    const tuples = cleaned.properties?.tuples as { items?: unknown } | undefined;
+    const items = Array.isArray(tuples?.items) ? tuples?.items : [];
+    const first = items[0] as { format?: unknown } | undefined;
+    const second = items[1] as { minimum?: unknown } | undefined;
+
+    expect(first?.format).toBeUndefined();
+    expect(second?.minimum).toBeUndefined();
+  });
   it("drops null-only union variants without flattening other unions", () => {
     const cleaned = __testing.cleanToolSchemaForGemini({
       type: "object",

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -280,8 +280,16 @@ function cleanSchemaForGeminiWithDefs(
           cleanSchemaForGeminiWithDefs(v, nextDefs, refStack),
         ]),
       );
-    } else if (key === "items" && value && typeof value === "object") {
-      cleaned[key] = cleanSchemaForGeminiWithDefs(value, nextDefs, refStack);
+    } else if (key === "items" && value) {
+      if (Array.isArray(value)) {
+        cleaned[key] = value.map((entry) =>
+          cleanSchemaForGeminiWithDefs(entry, nextDefs, refStack),
+        );
+      } else if (typeof value === "object") {
+        cleaned[key] = cleanSchemaForGeminiWithDefs(value, nextDefs, refStack);
+      } else {
+        cleaned[key] = value;
+      }
     } else if (key === "anyOf" && Array.isArray(value)) {
       cleaned[key] =
         cleanedAnyOf ??


### PR DESCRIPTION
## Summary
- clean tuple-style `items` schemas in the Gemini tool sanitizer
- add a regression test for tuple `items` keyword stripping
- add changelog entry for #746

## Testing
- pnpm test src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-a.test.ts

## Notes
- AI-assisted via Clawdbot