### PR TITLE
fix: use underscores in dock command names for Telegram compatibility

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -241,9 +241,9 @@ export const CHAT_COMMANDS: ChatCommandDefinition[] = (() => {
       .map((dock) =>
         defineChatCommand({
           key: `dock:${dock.id}`,
-          nativeName: `dock-${dock.id}`,
+          nativeName: `dock_${dock.id}`,
           description: `Switch to ${dock.id} for replies.`,
-          textAlias: `/dock-${dock.id}`,
+          textAlias: `/dock_${dock.id}`,
           acceptsArgs: false,
         }),
       ),


### PR DESCRIPTION
## Summary
- Changed dock command names from `dock-{channel}` to `dock_{channel}` (e.g., `dock_telegram`, `dock_discord`, `dock_slack`)
- Telegram Bot API only allows lowercase letters, digits, and underscores in command names — hyphens cause `BOT_COMMAND_INVALID` errors
- Underscores work on all platforms with native commands (Telegram, Discord, Slack)

## Test plan
- [x] Verified fix resolves `setMyCommands` 400 error on Telegram
- [x] Confirmed Discord and Slack allow underscores in slash command names

🤖 Generated with [Claude Code](https://claude.com/claude-code)