### PR TITLE
docs(showcase): add Kev's Dream Team Architecture articles

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -141,10 +141,10 @@ Full setup walkthrough (28m) by VelvetShark.
 
   <img src="/assets/showcase/oura-health.png" alt="Oura ring health assistant" />
 </Card>
-<Card title="Multi-Agent Swarm (14+ Agents)" icon="robot" href="https://github.com/adam91holt/clawdspace">
-  **@adam91holt** • `multi-agent` `slack` `orchestration` `swarm`
+<Card title="Kev's Dream Team (14+ Agents)" icon="robot" href="https://github.com/adam91holt/orchestrated-ai-articles">
+  **@adam91holt** • `multi-agent` `orchestration` `architecture` `manifesto`
 
-  14+ Clawdbot agents under one gateway. Opus 4.5 orchestrator delegates to Codex workers. Self-maintaining agents that continuously improve. Open-sourced clawdspace for agent sandboxing.
+  14+ agents under one gateway with Opus 4.5 orchestrator delegating to Codex workers. Comprehensive [technical write-up](https://github.com/adam91holt/orchestrated-ai-articles) covering the Dream Team roster, model selection, sandboxing, webhooks, heartbeats, and delegation flows. [Clawdspace](https://github.com/adam91holt/clawdspace) for agent sandboxing. [Blog post](https://adams-ai-journey.ghost.io/2026-the-year-of-the-orchestrator/).
 </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Summary
- Update existing Multi-Agent Swarm showcase card to include technical write-ups
- Now links to orchestrated-ai-articles repo (manifesto + architecture deep dive)
- Keeps clawdspace link for agent sandboxing
- Adds blog post link

## Links
- Articles repo: https://github.com/adam91holt/orchestrated-ai-articles
- Clawdspace: https://github.com/adam91holt/clawdspace
- Blog post: https://adams-ai-journey.ghost.io/2026-the-year-of-the-orchestrator/

## Test plan
- [ ] Preview showcase page on Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)