### PR TITLE
docs(bird): update skill for v0.7.0 commands

### DIFF
--- a/skills/bird/SKILL.md
+++ b/skills/bird/SKILL.md
@@ -2,24 +2,49 @@
 name: bird
 description: X/Twitter CLI for reading, searching, and posting via cookies or Sweetistics.
 homepage: https://bird.fast
-metadata: {"clawdbot":{"emoji":"🐦","requires":{"bins":["bird"]},"install":[{"id":"brew","kind":"brew","formula":"steipete/tap/bird","bins":["bird"],"label":"Install bird (brew)"}]}}
+metadata: {"clawdbot":{"emoji":"🐦","requires":{"bins":["bird"]},"install":[{"id":"brew","kind":"brew","formula":"steipete/tap/bird","bins":["bird"],"label":"Install bird (brew)"},{"id":"npm","kind":"npm","package":"@steipete/bird","bins":["bird"],"label":"Install bird (npm)"}]}}
 ---
 
 # bird
 
 Use `bird` to read/search X and post tweets/replies.
 
-Quick start
-- `bird whoami`
-- `bird read <url-or-id>`
-- `bird thread <url-or-id>`
-- `bird search "query" -n 5`
+## Quick start
+- `bird whoami` — check logged-in account
+- `bird read <url-or-id>` — fetch a single tweet
+- `bird thread <url-or-id>` — show full conversation thread
+- `bird search "query" -n 5` — search tweets
 
-Posting (confirm with user first)
-- `bird tweet "text"`
-- `bird reply <id-or-url> "text"`
+## Timelines & Discovery
+- `bird home` — For You / Following timeline
+- `bird news` or `bird trending` — AI-curated Explore headlines
+- `bird user-tweets <handle>` — user's profile timeline
+- `bird mentions` — tweets mentioning you (or another user)
+- `bird likes` — your liked tweets
+- `bird bookmarks` — your bookmarked tweets
 
-Auth sources
+## Social Graph
+- `bird following [handle]` — who you/they follow
+- `bird followers [handle]` — who follows you/them
+
+## Lists
+- `bird lists` — your Twitter lists
+- `bird list-timeline <list-id-or-url>` — tweets from a list
+
+## Posting (confirm with user first)
+- `bird tweet "text"` — post a new tweet
+- `bird reply <id-or-url> "text"` — reply to a tweet
+- `bird tweet "text" --media image.png` — tweet with media (up to 4 images or 1 video)
+
+## Pagination
+Most commands support `--all`, `--max-pages`, `--cursor` for pagination.
+
+## Output
+- Add `--json` for structured output
+- Add `--plain` for stable output (no emoji/color)
+
+## Auth sources
 - Browser cookies (default: Firefox/Chrome)
 - Sweetistics API: set `SWEETISTICS_API_KEY` or use `--engine sweetistics`
+- Env tokens: `AUTH_TOKEN` and `CT0`
 - Check sources: `bird check`


### PR DESCRIPTION
Updates the bird skill documentation to reflect the new commands added in [bird v0.7.0](https://github.com/steipete/bird/releases/tag/v0.7.0).

## Changes
- Add home timeline (`home`), news/trending, user-tweets commands
- Add mentions, likes, bookmarks discovery commands  
- Add following/followers social graph commands
- Add lists and list-timeline commands
- Document media attachments (`--media`)
- Document pagination options (`--all`, `--max-pages`, `--cursor`)
- Document output options (`--json`, `--plain`)
- Add npm install option alongside brew

## Testing
Verified commands work with bird 0.7.0 installed via `npm install -g @steipete/bird`