### PR TITLE
feat(agent): improve system prompt date/time context

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -55,6 +55,7 @@ import { splitSdkTools } from "./tool-split.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
 import {
   describeUnknownError,
+  detectUse24Hour,
   formatUserTime,
   mapThinkingLevel,
   resolveExecToolDefaults,
@@ -228,7 +229,8 @@ export async function compactEmbeddedPiSession(params: {
         const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
         const reasoningTagHint = isReasoningTagProvider(provider);
         const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-        const userTime = formatUserTime(new Date(), userTimezone);
+        const use24Hour = params.config?.agents?.defaults?.use24HourTime ?? detectUse24Hour();
+        const userTime = formatUserTime(new Date(), userTimezone, use24Hour);
         const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
           sessionKey: params.sessionKey,
           config: params.config,
@@ -251,6 +253,7 @@ export async function compactEmbeddedPiSession(params: {
           modelAliasLines: buildModelAliasLines(params.config),
           userTimezone,
           userTime,
+          use24HourTime: use24Hour,
           contextFiles,
         });
         const systemPrompt = createSystemPromptOverride(appendPrompt);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -58,6 +58,7 @@ import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { buildEmbeddedSystemPrompt, createSystemPromptOverride } from "../system-prompt.js";
 import { splitSdkTools } from "../tool-split.js";
 import {
+  detectUse24Hour,
   formatUserTime,
   mapThinkingLevel,
   resolveExecToolDefaults,
@@ -174,7 +175,8 @@ export async function runEmbeddedAttempt(
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
     const reasoningTagHint = isReasoningTagProvider(params.provider);
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-    const userTime = formatUserTime(new Date(), userTimezone);
+    const use24Hour = params.config?.agents?.defaults?.use24HourTime ?? detectUse24Hour();
+    const userTime = formatUserTime(new Date(), userTimezone, use24Hour);
     const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
       sessionKey: params.sessionKey,
       config: params.config,
@@ -198,6 +200,7 @@ export async function runEmbeddedAttempt(
       modelAliasLines: buildModelAliasLines(params.config),
       userTimezone,
       userTime,
+      use24HourTime: use24Hour,
       contextFiles,
     });
     const systemPromptReport = buildSystemPromptReport({

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -29,6 +29,7 @@ export function buildEmbeddedSystemPrompt(params: {
   modelAliasLines: string[];
   userTimezone: string;
   userTime?: string;
+  use24HourTime?: boolean;
   contextFiles?: EmbeddedContextFile[];
 }): string {
   return buildAgentSystemPrompt({
@@ -47,6 +48,7 @@ export function buildEmbeddedSystemPrompt(params: {
     modelAliasLines: params.modelAliasLines,
     userTimezone: params.userTimezone,
     userTime: params.userTime,
+    use24HourTime: params.use24HourTime,
     contextFiles: params.contextFiles,
   });
 }

--- a/src/agents/pi-embedded-runner/utils.ts
+++ b/src/agents/pi-embedded-runner/utils.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ClawdbotConfig } from "../../config/config.js";
@@ -31,17 +32,75 @@ export function resolveUserTimezone(configured?: string): string {
   return host?.trim() || "UTC";
 }
 
-export function formatUserTime(date: Date, timeZone: string): string | undefined {
+/** Auto-detect if system uses 24-hour time. Checks OS-specific prefs, then falls back to locale. */
+export function detectUse24Hour(): boolean {
+  // macOS: check system preference
+  if (process.platform === "darwin") {
+    try {
+      const result = execSync("defaults read -g AppleICUForce24HourTime 2>/dev/null", {
+        encoding: "utf8",
+        timeout: 500,
+      }).trim();
+      if (result === "1") return true;
+      if (result === "0") return false;
+    } catch {
+      // Not set, fall through
+    }
+  }
+
+  // Windows: check registry time format
+  if (process.platform === "win32") {
+    try {
+      const result = execSync(
+        'powershell -Command "(Get-Culture).DateTimeFormat.ShortTimePattern"',
+        { encoding: "utf8", timeout: 1000 },
+      ).trim();
+      if (result.startsWith("H")) return true;
+      if (result.startsWith("h")) return false;
+    } catch {
+      // Fall through
+    }
+  }
+
+  // Fallback: check locale formatting (works well on Linux)
   try {
-    const parts = new Intl.DateTimeFormat("en-CA", {
+    const sample = new Date(2000, 0, 1, 13, 0);
+    const formatted = new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(sample);
+    return formatted.includes("13");
+  } catch {
+    return false;
+  }
+}
+
+function ordinalSuffix(day: number): string {
+  if (day >= 11 && day <= 13) return "th";
+  switch (day % 10) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+}
+
+export function formatUserTime(
+  date: Date,
+  timeZone: string,
+  use24Hour = false,
+): string | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
       timeZone,
       weekday: "long",
       year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
+      month: "long",
+      day: "numeric",
+      hour: use24Hour ? "2-digit" : "numeric",
       minute: "2-digit",
-      hourCycle: "h23",
+      hourCycle: use24Hour ? "h23" : "h12",
     }).formatToParts(date);
     const map: Record<string, string> = {};
     for (const part of parts) {
@@ -50,7 +109,13 @@ export function formatUserTime(date: Date, timeZone: string): string | undefined
     if (!map.weekday || !map.year || !map.month || !map.day || !map.hour || !map.minute) {
       return undefined;
     }
-    return `${map.weekday} ${map.year}-${map.month}-${map.day} ${map.hour}:${map.minute}`;
+    const dayNum = parseInt(map.day, 10);
+    const suffix = ordinalSuffix(dayNum);
+    const timePart = use24Hour
+      ? `${map.hour}:${map.minute}`
+      : `${map.hour}:${map.minute} ${map.dayPeriod ?? ""}`.trim();
+    // "Thursday, January 15th, 2026 — 14:38" or "Thursday, January 15th, 2026 — 2:38 PM"
+    return `${map.weekday}, ${map.month} ${dayNum}${suffix}, ${map.year} — ${timePart}`;
   } catch {
     return undefined;
   }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -61,16 +61,41 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
-  it("includes user time when provided", () => {
+  it("includes user time when provided (12h format)", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/clawd",
       userTimezone: "America/Chicago",
-      userTime: "Monday 2026-01-05 15:26",
+      userTime: "Monday, January 5th, 2026 — 3:26 PM",
+      use24HourTime: false,
     });
 
-    expect(prompt).toContain(
-      "Time: assume UTC unless stated. User time zone: America/Chicago. Current user time (local, 24-hour): Monday 2026-01-05 15:26 (America/Chicago).",
-    );
+    expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Monday, January 5th, 2026 — 3:26 PM (America/Chicago)");
+    expect(prompt).toContain("Time format: 12-hour");
+  });
+
+  it("includes user time when provided (24h format)", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      userTimezone: "America/Chicago",
+      userTime: "Monday, January 5th, 2026 — 15:26",
+      use24HourTime: true,
+    });
+
+    expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Monday, January 5th, 2026 — 15:26 (America/Chicago)");
+    expect(prompt).toContain("Time format: 24-hour");
+  });
+
+  it("shows UTC fallback when only timezone is provided", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      userTimezone: "America/Chicago",
+    });
+
+    expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Time zone: America/Chicago");
+    expect(prompt).toContain("assume UTC");
   });
 
   it("includes model alias guidance when aliases are provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -15,6 +15,7 @@ export function buildAgentSystemPrompt(params: {
   modelAliasLines?: string[];
   userTimezone?: string;
   userTime?: string;
+  use24HourTime?: boolean;
   contextFiles?: EmbeddedContextFile[];
   skillsPrompt?: string;
   heartbeatPrompt?: string;
@@ -298,17 +299,20 @@ export function buildAgentSystemPrompt(params: {
     ownerLine ? "## User Identity" : "",
     ownerLine ?? "",
     ownerLine ? "" : "",
+    // Date/time context - prominent section so model reliably knows current date
+    ...(userTimezone || userTime
+      ? [
+          "## Current Date & Time",
+          userTime
+            ? `${userTime} (${userTimezone ?? "unknown"})`
+            : `Time zone: ${userTimezone}. Current time unknown; assume UTC for date/time references.`,
+          `Time format: ${params.use24HourTime ? "24-hour" : "12-hour"}`,
+          "",
+        ]
+      : []),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Clawdbot and included below in Project Context.",
     "",
-    userTimezone || userTime
-      ? `Time: assume UTC unless stated. User time zone: ${
-          userTimezone ?? "unknown"
-        }. Current user time (local, 24-hour): ${userTime ?? "unknown"} (${
-          userTimezone ?? "unknown"
-        }).`
-      : "",
-    userTimezone || userTime ? "" : "",
     "## Reply Tags",
     "To request a native reply/quote on supported surfaces, include one tag in your reply:",
     "- [[reply_to_current]] replies to the triggering message.",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -103,6 +103,8 @@ export type AgentDefaultsConfig = {
   bootstrapMaxChars?: number;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
+  /** Use 24-hour time format in system prompt (default: auto-detect from OS). */
+  use24HourTime?: boolean;
   /** Optional display-only context window override (used for % in status UIs). */
   contextTokens?: number;
   /** Optional CLI backends for text-only fallback (claude-cli, etc.). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -41,6 +41,7 @@ export const AgentDefaultsSchema = z
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     userTimezone: z.string().optional(),
+    use24HourTime: z.boolean().optional(),
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,


### PR DESCRIPTION
## Problem

The model would sometimes hallucinate or miscalculate the current date. While the day of week was technically included, the old format buried it in a dense inline sentence with an ISO-style date that was hard to parse:

```
Time: assume UTC unless stated. User time zone: America/Chicago. Current user time (local, 24-hour): Monday 2026-01-05 15:26 (America/Chicago).
```

The ISO format `2026-01-05` requires the model to calculate what month/day that represents, and the whole thing was a single run-on line easy to skim past.

## Solution

Add a dedicated `## Current Date & Time` section with clear, human-readable formatting:

```
## Current Date & Time
Monday, January 5th, 2026 — 3:26 PM (America/Chicago)
Time format: 12-hour
```

Key improvements:
- **Dedicated section header** makes it impossible to miss
- **Human-readable date** (`January 5th` vs `01-05`) - no calculation needed
- **Day of week first** - most prominent position
- **Respects user's time format preference** (12h vs 24h)

## Changes

- Add dedicated `## Current Date & Time` section with human-readable date format
- Format dates as "Thursday, January 15th, 2026 — 03:07" (day of week first, with ordinal suffix)
- Auto-detect 12h/24h time preference from OS settings:
  - macOS: `defaults read -g AppleICUForce24HourTime`
  - Windows: PowerShell `(Get-Culture).DateTimeFormat.ShortTimePattern`
  - Linux: `Intl.DateTimeFormat` locale fallback
- Add `agents.defaults.use24HourTime` config option for manual override
- Include user's time format preference in system prompt
- Only show UTC fallback when time is unknown

## Test plan
- [x] Tests pass (`pnpm test src/agents/system-prompt.test.ts`)
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Manually verified date format in system prompt
- [x] Verified 24h detection works on macOS

🤖 Generated with [Claude Code](https://claude.ai/code)