### PR TITLE
Allow sending voice notes on telegram without text attached

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -113,8 +113,12 @@ export async function handleTelegramAction(
       throw new Error("Telegram sendMessage is disabled.");
     }
     const to = readStringParam(params, "to", { required: true });
-    const content = readStringParam(params, "content", { required: true });
     const mediaUrl = readStringParam(params, "mediaUrl");
+    // Allow content to be omitted when sending media-only (e.g., voice notes)
+    const content = readStringParam(params, "content", {
+      required: !mediaUrl,
+      allowEmpty: true,
+    }) ?? "";
     const buttons = readTelegramButtons(params);
     if (buttons && !hasInlineButtonsCapability({ cfg, accountId: accountId ?? undefined })) {
       throw new Error(

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -42,7 +42,10 @@ export function applyReplyTagsToPayload(
 
 export function isRenderablePayload(payload: ReplyPayload): boolean {
   return Boolean(
-    payload.text || payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0),
+    payload.text ||
+      payload.mediaUrl ||
+      (payload.mediaUrls && payload.mediaUrls.length > 0) ||
+      payload.audioAsVoice,
   );
 }
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -208,10 +208,12 @@ export async function runMessageAction(
 
   if (action === "send") {
     const to = readStringParam(params, "to", { required: true });
+    // Allow message to be omitted when sending media-only (e.g., voice notes)
+    const mediaHint = readStringParam(params, "media", { trim: false });
     let message = readStringParam(params, "message", {
-      required: true,
+      required: !mediaHint, // Only require message if no media hint
       allowEmpty: true,
-    });
+    }) ?? "";
 
     const parsed = parseReplyDirectives(message);
     message = parsed.text;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -98,6 +98,18 @@ export const buildTelegramMessageContext = async ({
     }
   };
 
+  const sendRecordVoice = async () => {
+    try {
+      await bot.api.sendChatAction(
+        chatId,
+        "record_voice",
+        buildTelegramThreadParams(resolvedThreadId),
+      );
+    } catch (err) {
+      logVerbose(`telegram record_voice cue failed for chat ${chatId}: ${String(err)}`);
+    }
+  };
+
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled"
   if (!isGroup) {
     if (dmPolicy === "disabled") return null;
@@ -408,6 +420,7 @@ export const buildTelegramMessageContext = async ({
     route,
     skillFilter,
     sendTyping,
+    sendRecordVoice,
     ackReactionPromise,
     reactionApi,
     removeAckAfterReply,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -33,6 +33,7 @@ export const dispatchTelegramMessage = async ({
     route,
     skillFilter,
     sendTyping,
+    sendRecordVoice,
     ackReactionPromise,
     reactionApi,
     removeAckAfterReply,
@@ -134,6 +135,7 @@ export const dispatchTelegramMessage = async ({
           replyToMode,
           textLimit,
           messageThreadId: resolvedThreadId,
+          onVoiceRecording: sendRecordVoice,
         });
         didSendReply = true;
       },

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -26,6 +26,8 @@ export async function deliverReplies(params: {
   replyToMode: ReplyToMode;
   textLimit: number;
   messageThreadId?: number;
+  /** Callback invoked before sending a voice message to switch typing indicator. */
+  onVoiceRecording?: () => Promise<void> | void;
 }) {
   const { replies, chatId, runtime, bot, replyToMode, textLimit, messageThreadId } = params;
   const threadParams = buildTelegramThreadParams(messageThreadId);
@@ -97,6 +99,11 @@ export async function deliverReplies(params: {
         });
         if (useVoice) {
           // Voice message - displays as round playable bubble (opt-in via [[audio_as_voice]])
+          // Switch typing indicator to record_voice before sending
+          logVerbose(
+            `telegram voice delivery: invoking onVoiceRecording callback=${typeof params.onVoiceRecording}`,
+          );
+          await params.onVoiceRecording?.();
           await bot.api.sendVoice(chatId, file, {
             ...mediaParams,
           });


### PR DESCRIPTION
Makes it so clawd can send just voice messages, without forcing a text addition which a human user can't do anyway and it feels super weird. Previously if clawd attempted to send a voice note, it would be hit with a validation error requiring to add text. Now it works as lord intended