### PR TITLE
fix(compaction): default to safeguard mode to handle context overflow

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -16,7 +16,23 @@ Compaction **summarizes older conversation** into a compact summary entry and ke
 Compaction **persists** in the session’s JSONL history.
 
 ## Configuration
-See [Compaction config & modes](/concepts/compaction) for the `agents.defaults.compaction` settings.
+
+Configure compaction via `agents.defaults.compaction`:
+
+```yaml
+agents:
+  defaults:
+    compaction:
+      mode: safeguard          # or "basic"
+      reserveTokensFloor: 20000
+      memoryFlush:
+        enabled: true
+```
+
+### Compaction modes
+
+- **safeguard** (default): Chunks large contexts into smaller pieces before summarizing. Handles cases where context exceeds API limits by summarizing in multiple passes. Falls back to truncation if summarization fails.
+- **basic**: Uses the SDK's built-in single-pass summarization. May fail if context is too large to fit in one API request.
 
 ## Auto-compaction (default on)
 When a session nears or exceeds the model’s context window, Clawdbot triggers auto-compaction and may retry the original request using the compacted context.

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../../config/config.js";
+import { buildEmbeddedExtensionPaths } from "./extensions.js";
+
+function makeMinimalParams(cfg?: ClawdbotConfig) {
+  return {
+    cfg,
+    sessionManager: {} as never,
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-20250514",
+    model: undefined,
+  };
+}
+
+describe("buildEmbeddedExtensionPaths", () => {
+  it("includes compaction-safeguard by default (no config)", () => {
+    const paths = buildEmbeddedExtensionPaths(makeMinimalParams());
+    expect(paths.some((p) => p.includes("compaction-safeguard"))).toBe(true);
+  });
+
+  it("includes compaction-safeguard when mode is undefined", () => {
+    const cfg: ClawdbotConfig = { agents: { defaults: { compaction: {} } } };
+    const paths = buildEmbeddedExtensionPaths(makeMinimalParams(cfg));
+    expect(paths.some((p) => p.includes("compaction-safeguard"))).toBe(true);
+  });
+
+  it("includes compaction-safeguard when mode is explicitly 'safeguard'", () => {
+    const cfg: ClawdbotConfig = {
+      agents: { defaults: { compaction: { mode: "safeguard" } } },
+    };
+    const paths = buildEmbeddedExtensionPaths(makeMinimalParams(cfg));
+    expect(paths.some((p) => p.includes("compaction-safeguard"))).toBe(true);
+  });
+
+  it("excludes compaction-safeguard when mode is 'basic'", () => {
+    const cfg: ClawdbotConfig = {
+      agents: { defaults: { compaction: { mode: "basic" } } },
+    };
+    const paths = buildEmbeddedExtensionPaths(makeMinimalParams(cfg));
+    expect(paths.some((p) => p.includes("compaction-safeguard"))).toBe(false);
+  });
+
+  it("always includes transcript-sanitize extension", () => {
+    const paths = buildEmbeddedExtensionPaths(makeMinimalParams());
+    expect(paths.some((p) => p.includes("transcript-sanitize"))).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -59,8 +59,9 @@ function buildContextPruningExtension(params: {
   };
 }
 
-function resolveCompactionMode(cfg?: ClawdbotConfig): "default" | "safeguard" {
-  return cfg?.agents?.defaults?.compaction?.mode === "safeguard" ? "safeguard" : "default";
+function resolveCompactionMode(cfg?: ClawdbotConfig): "basic" | "safeguard" {
+  // Default to safeguard mode to handle context overflow during compaction (issue #699)
+  return cfg?.agents?.defaults?.compaction?.mode === "basic" ? "basic" : "safeguard";
 }
 
 export function buildEmbeddedExtensionPaths(params: {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -216,7 +216,7 @@ export type AgentDefaultsConfig = {
   };
 };
 
-export type AgentCompactionMode = "default" | "safeguard";
+export type AgentCompactionMode = "basic" | "safeguard";
 
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -76,7 +76,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        mode: z.union([z.literal("basic"), z.literal("safeguard")]).optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         memoryFlush: z
           .object({


### PR DESCRIPTION
> [!NOTE]
> Open to discussion on the actual behavior and naming. This is a starting point.

## Summary
- Default compaction mode to `safeguard` to prevent context overflow during compaction (fixes #699)
- Rename `default` mode to `basic` for clarity (since safeguard is now the default)
- Add tests for compaction mode resolution
- Document compaction modes

## Problem
When context grows beyond the model's context window limit, the SDK's built-in compaction tries to summarize all messages in one API call, which itself exceeds the limit. This causes a "death spiral" where sessions become permanently stuck.

The 200k limit in #699 was Claude-specific; the actual limit varies by model.

## Solution
The `compaction-safeguard` extension already exists and handles this by:
1. Chunking messages into smaller pieces (~40% of the model's context window per chunk)
2. Summarizing each chunk sequentially
3. Falling back to truncation if summarization still fails

This PR makes safeguard mode the default instead of requiring explicit configuration.

## Alternative/additional approach
Another option would be to allow configuring a dedicated model for compaction (e.g., a model with a larger context window or a cheaper model for summarization). This could be combined with the safeguard chunking approach.

## Test plan
- [x] Added unit tests for `buildEmbeddedExtensionPaths` verifying mode resolution
- [x] All existing tests pass
- [x] Build succeeds