### PR TITLE
feat(whatsapp): add debounceMs for batching rapid messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Agents: add Current Date & Time system prompt section with configurable time format (auto/12/24).
 - Tools: normalize Slack/Discord message timestamps with `timestampMs`/`timestampUtc` while keeping raw provider fields.
 - Docs: add Date & Time guide and update prompt/timezone configuration docs.
+- Messages: debounce rapid inbound messages across channels with per-connector overrides. (#971) — thanks @juanpablodlc.
 - Fix: guard model fallback against undefined provider/model values. (#954) — thanks @roshanasingh4.
 - Memory: make `node-llama-cpp` an optional dependency (avoid Node 25 install failures) and improve local-embeddings fallback/errors.
 - Browser: add `snapshot refs=aria` (Playwright aria-ref ids) for self-resolving refs across `snapshot` → `act`.

--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -33,6 +33,16 @@ Channels can redeliver the same message after reconnects. Clawdbot keeps a
 short-lived cache keyed by channel/account/peer/session/message id so duplicate
 deliveries do not trigger another agent run.
 
+## Inbound debouncing
+
+Rapid consecutive messages from the **same sender** can be batched into a single
+agent turn via `messages.inbound`. Debouncing is scoped per channel + conversation
+and uses the most recent message for reply threading/IDs.
+
+Notes:
+- Debounce applies to **text-only** messages; media/attachments flush immediately.
+- Control commands bypass debouncing so they remain standalone.
+
 ## Sessions and devices
 
 Sessions are owned by the gateway, not by clients.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -822,6 +822,31 @@ Controls how inbound messages behave when an agent run is already active.
 }
 ```
 
+### `messages.inbound`
+
+Debounce rapid inbound messages from the **same sender** so multiple back-to-back
+messages become a single agent turn. Debouncing is scoped per channel + conversation
+and uses the most recent message for reply threading/IDs.
+
+```json5
+{
+  messages: {
+    inbound: {
+      debounceMs: 2000, // 0 disables
+      byChannel: {
+        whatsapp: 5000,
+        slack: 1500,
+        discord: 1500
+      }
+    }
+  }
+}
+```
+
+Notes:
+- Debounce batches **text-only** messages; media/attachments flush immediately.
+- Control commands (e.g. `/queue`, `/new`) bypass debouncing so they stay standalone.
+
 ### `commands` (chat command handling)
 
 Controls how chat commands are enabled across connectors.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -54,11 +54,7 @@ import { buildEmbeddedSystemPrompt, createSystemPromptOverride } from "./system-
 import { splitSdkTools } from "./tool-split.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
-import {
-  describeUnknownError,
-  mapThinkingLevel,
-  resolveExecToolDefaults,
-} from "./utils.js";
+import { describeUnknownError, mapThinkingLevel, resolveExecToolDefaults } from "./utils.js";
 
 export async function compactEmbeddedPiSession(params: {
   sessionId: string;
@@ -227,9 +223,7 @@ export async function compactEmbeddedPiSession(params: {
         const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
         const reasoningTagHint = isReasoningTagProvider(provider);
         const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-        const userTimeFormat = resolveUserTimeFormat(
-          params.config?.agents?.defaults?.timeFormat,
-        );
+        const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
         const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
         const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
           sessionKey: params.sessionKey,

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -138,16 +138,16 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("adds normalized timestamps to readMessages payloads", async () => {
-    readMessagesDiscord.mockResolvedValueOnce([
-      { id: "1", timestamp: "2026-01-15T10:00:00.000Z" },
-    ]);
+    readMessagesDiscord.mockResolvedValueOnce([{ id: "1", timestamp: "2026-01-15T10:00:00.000Z" }]);
 
     const result = await handleDiscordMessagingAction(
       "readMessages",
       { channelId: "C1" },
       enableAllActions,
     );
-    const payload = result.details as { messages: Array<{ timestampMs?: number; timestampUtc?: string }> };
+    const payload = result.details as {
+      messages: Array<{ timestampMs?: number; timestampUtc?: string }>;
+    };
 
     const expectedMs = Date.parse("2026-01-15T10:00:00.000Z");
     expect(payload.messages[0].timestampMs).toBe(expectedMs);
@@ -173,16 +173,16 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("adds normalized timestamps to listPins payloads", async () => {
-    listPinsDiscord.mockResolvedValueOnce([
-      { id: "1", timestamp: "2026-01-15T12:00:00.000Z" },
-    ]);
+    listPinsDiscord.mockResolvedValueOnce([{ id: "1", timestamp: "2026-01-15T12:00:00.000Z" }]);
 
     const result = await handleDiscordMessagingAction(
       "listPins",
       { channelId: "C1" },
       enableAllActions,
     );
-    const payload = result.details as { pins: Array<{ timestampMs?: number; timestampUtc?: string }> };
+    const payload = result.details as {
+      pins: Array<{ timestampMs?: number; timestampUtc?: string }>;
+    };
 
     const expectedMs = Date.parse("2026-01-15T12:00:00.000Z");
     expect(payload.pins[0].timestampMs).toBe(expectedMs);

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -334,7 +334,9 @@ describe("handleSlackAction", () => {
     });
 
     const result = await handleSlackAction({ action: "readMessages", channelId: "C1" }, cfg);
-    const payload = result.details as { messages: Array<{ timestampMs?: number; timestampUtc?: string }> };
+    const payload = result.details as {
+      messages: Array<{ timestampMs?: number; timestampUtc?: string }>;
+    };
 
     const expectedMs = Math.round(1735689600.456 * 1000);
     expect(payload.messages[0].timestampMs).toBe(expectedMs);

--- a/src/auto-reply/inbound-debounce.test.ts
+++ b/src/auto-reply/inbound-debounce.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createInboundDebouncer } from "./inbound-debounce.js";
+
+describe("createInboundDebouncer", () => {
+  it("debounces and combines items", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 10,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    await debouncer.enqueue({ key: "a", id: "2" });
+
+    expect(calls).toEqual([]);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(calls).toEqual([["1", "2"]]);
+
+    vi.useRealTimers();
+  });
+
+  it("flushes buffered items before non-debounced item", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string; debounce: boolean }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      shouldDebounce: (item) => item.debounce,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+    await debouncer.enqueue({ key: "a", id: "2", debounce: false });
+
+    expect(calls).toEqual([["1"], ["2"]]);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -1,0 +1,101 @@
+import type { ClawdbotConfig } from "../config/config.js";
+import type { InboundDebounceByProvider } from "../config/types.messages.js";
+
+const resolveMs = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.trunc(value));
+};
+
+const resolveChannelOverride = (params: {
+  byChannel?: InboundDebounceByProvider;
+  channel: string;
+}): number | undefined => {
+  if (!params.byChannel) return undefined;
+  const channelKey = params.channel as keyof InboundDebounceByProvider;
+  return resolveMs(params.byChannel[channelKey]);
+};
+
+export function resolveInboundDebounceMs(params: {
+  cfg: ClawdbotConfig;
+  channel: string;
+  overrideMs?: number;
+}): number {
+  const inbound = params.cfg.messages?.inbound;
+  const override = resolveMs(params.overrideMs);
+  const byChannel = resolveChannelOverride({
+    byChannel: inbound?.byChannel,
+    channel: params.channel,
+  });
+  const base = resolveMs(inbound?.debounceMs);
+  return override ?? byChannel ?? base ?? 0;
+}
+
+type DebounceBuffer<T> = {
+  items: T[];
+  timeout: ReturnType<typeof setTimeout> | null;
+};
+
+export function createInboundDebouncer<T>(params: {
+  debounceMs: number;
+  buildKey: (item: T) => string | null | undefined;
+  shouldDebounce?: (item: T) => boolean;
+  onFlush: (items: T[]) => Promise<void>;
+  onError?: (err: unknown, items: T[]) => void;
+}) {
+  const buffers = new Map<string, DebounceBuffer<T>>();
+  const debounceMs = Math.max(0, Math.trunc(params.debounceMs));
+
+  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
+    buffers.delete(key);
+    if (buffer.timeout) {
+      clearTimeout(buffer.timeout);
+      buffer.timeout = null;
+    }
+    if (buffer.items.length === 0) return;
+    try {
+      await params.onFlush(buffer.items);
+    } catch (err) {
+      params.onError?.(err, buffer.items);
+    }
+  };
+
+  const flushKey = async (key: string) => {
+    const buffer = buffers.get(key);
+    if (!buffer) return;
+    await flushBuffer(key, buffer);
+  };
+
+  const scheduleFlush = (key: string, buffer: DebounceBuffer<T>) => {
+    if (buffer.timeout) clearTimeout(buffer.timeout);
+    buffer.timeout = setTimeout(() => {
+      void flushBuffer(key, buffer);
+    }, debounceMs);
+    buffer.timeout.unref?.();
+  };
+
+  const enqueue = async (item: T) => {
+    const key = params.buildKey(item);
+    const canDebounce = debounceMs > 0 && (params.shouldDebounce?.(item) ?? true);
+
+    if (!canDebounce || !key) {
+      if (key && buffers.has(key)) {
+        await flushKey(key);
+      }
+      await params.onFlush([item]);
+      return;
+    }
+
+    const existing = buffers.get(key);
+    if (existing) {
+      existing.items.push(item);
+      scheduleFlush(key, existing);
+      return;
+    }
+
+    const buffer: DebounceBuffer<T> = { items: [item], timeout: null };
+    buffers.set(key, buffer);
+    scheduleFlush(key, buffer);
+  };
+
+  return { enqueue, flushKey };
+}

--- a/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.test.ts
@@ -263,9 +263,7 @@ describe("trigger handling", () => {
 
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       // Selecting the default model shows "reset to default" instead of "set to"
-      expect(normalizeTestText(text ?? "")).toContain(
-        "anthropic/claude-opus-4-5",
-      );
+      expect(normalizeTestText(text ?? "")).toContain("anthropic/claude-opus-4-5");
 
       const store = loadSessionStore(cfg.session.store);
       // When selecting the default, overrides are cleared

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -24,6 +24,9 @@ export type MsgContext = {
   AccountId?: string;
   ParentSessionKey?: string;
   MessageSid?: string;
+  MessageSids?: string[];
+  MessageSidFirst?: string;
+  MessageSidLast?: string;
   ReplyToId?: string;
   ReplyToBody?: string;
   ReplyToSender?: string;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -168,6 +168,7 @@ const FIELD_LABELS: Record<string, string> = {
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
+  "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
   "talk.apiKey": "Talk API Key",
   "channels.whatsapp": "WhatsApp",
   "channels.telegram": "Telegram",
@@ -328,6 +329,8 @@ const FIELD_HELP: Record<string, string> = {
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.inbound.debounceMs":
+    "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streamMode":

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -189,6 +189,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
   "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",
   "channels.whatsapp.selfChatMode": "WhatsApp Self-Phone Mode",
+  "channels.whatsapp.debounceMs": "WhatsApp Message Debounce (ms)",
   "channels.signal.dmPolicy": "Signal DM Policy",
   "channels.imessage.dmPolicy": "iMessage DM Policy",
   "channels.discord.dm.policy": "Discord DM Policy",
@@ -348,6 +349,8 @@ const FIELD_HELP: Record<string, string> = {
   "channels.whatsapp.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
   "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
+  "channels.whatsapp.debounceMs":
+    "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",
   "channels.signal.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.signal.allowFrom=["*"].',
   "channels.imessage.dmPolicy":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -17,6 +17,22 @@ export type QueueConfig = {
   drop?: QueueDropPolicy;
 };
 
+export type InboundDebounceByProvider = {
+  whatsapp?: number;
+  telegram?: number;
+  discord?: number;
+  slack?: number;
+  signal?: number;
+  imessage?: number;
+  msteams?: number;
+  webchat?: number;
+};
+
+export type InboundDebounceConfig = {
+  debounceMs?: number;
+  byChannel?: InboundDebounceByProvider;
+};
+
 export type BroadcastStrategy = "parallel" | "sequential";
 
 export type BroadcastConfig = {
@@ -64,6 +80,8 @@ export type MessagesConfig = {
   responsePrefix?: string;
   groupChat?: GroupChatConfig;
   queue?: QueueConfig;
+  /** Debounce rapid inbound messages per sender (global + per-channel overrides). */
+  inbound?: InboundDebounceConfig;
   /** Emoji reaction used to acknowledge inbound messages (empty disables). */
   ackReaction?: string;
   /** When to send ack reactions. Default: "group-mentions". */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -75,6 +75,8 @@ export type WhatsAppConfig = {
      */
     group?: "always" | "mentions" | "never";
   };
+  /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
+  debounceMs?: number;
 };
 
 export type WhatsAppAccountConfig = {
@@ -131,4 +133,6 @@ export type WhatsAppAccountConfig = {
      */
     group?: "always" | "mentions" | "never";
   };
+  /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
+  debounceMs?: number;
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -188,6 +188,19 @@ export const QueueModeBySurfaceSchema = z
   })
   .optional();
 
+export const DebounceMsBySurfaceSchema = z
+  .object({
+    whatsapp: z.number().int().nonnegative().optional(),
+    telegram: z.number().int().nonnegative().optional(),
+    discord: z.number().int().nonnegative().optional(),
+    slack: z.number().int().nonnegative().optional(),
+    signal: z.number().int().nonnegative().optional(),
+    imessage: z.number().int().nonnegative().optional(),
+    msteams: z.number().int().nonnegative().optional(),
+    webchat: z.number().int().nonnegative().optional(),
+  })
+  .optional();
+
 export const QueueSchema = z
   .object({
     mode: QueueModeSchema.optional(),
@@ -195,6 +208,13 @@ export const QueueSchema = z
     debounceMs: z.number().int().nonnegative().optional(),
     cap: z.number().int().positive().optional(),
     drop: QueueDropSchema.optional(),
+  })
+  .optional();
+
+export const InboundDebounceSchema = z
+  .object({
+    debounceMs: z.number().int().nonnegative().optional(),
+    byChannel: DebounceMsBySurfaceSchema,
   })
   .optional();
 

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -46,6 +46,7 @@ export const WhatsAppAccountSchema = z
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })
       .optional(),
+    debounceMs: z.number().int().nonnegative().optional().default(0),
   })
   .superRefine((value, ctx) => {
     if (value.dmPolicy !== "open") return;
@@ -101,6 +102,7 @@ export const WhatsAppConfigSchema = z
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })
       .optional(),
+    debounceMs: z.number().int().nonnegative().optional().default(0),
   })
   .superRefine((value, ctx) => {
     if (value.dmPolicy !== "open") return;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-import { GroupChatSchema, NativeCommandsSettingSchema, QueueSchema } from "./zod-schema.core.js";
+import {
+  GroupChatSchema,
+  InboundDebounceSchema,
+  NativeCommandsSettingSchema,
+  QueueSchema,
+} from "./zod-schema.core.js";
 
 export const SessionSchema = z
   .object({
@@ -54,6 +59,7 @@ export const MessagesSchema = z
     responsePrefix: z.string().optional(),
     groupChat: GroupChatSchema,
     queue: QueueSchema,
+    inbound: InboundDebounceSchema,
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -1,11 +1,19 @@
+import type { Client } from "@buape/carbon";
+
+import { hasControlCommand } from "../../auto-reply/command-detection.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../auto-reply/inbound-debounce.js";
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { ReplyToMode } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { DiscordGuildEntryResolved } from "./allow-list.js";
-import type { DiscordMessageHandler } from "./listeners.js";
+import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
 import { processDiscordMessage } from "./message-handler.process.js";
+import { resolveDiscordMessageText } from "./message-utils.js";
 
 type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
 type DiscordConfig = NonNullable<
@@ -32,18 +40,86 @@ export function createDiscordMessageHandler(params: {
 }): DiscordMessageHandler {
   const groupPolicy = params.discordConfig?.groupPolicy ?? "open";
   const ackReactionScope = params.cfg.messages?.ackReactionScope ?? "group-mentions";
+  const debounceMs = resolveInboundDebounceMs({ cfg: params.cfg, channel: "discord" });
 
-  return async (data, client) => {
-    try {
+  const debouncer = createInboundDebouncer<{ data: DiscordMessageEvent; client: Client }>({
+    debounceMs,
+    buildKey: (entry) => {
+      const message = entry.data.message;
+      const authorId = entry.data.author?.id;
+      if (!message || !authorId) return null;
+      const channelId = message.channelId;
+      if (!channelId) return null;
+      return `discord:${params.accountId}:${channelId}:${authorId}`;
+    },
+    shouldDebounce: (entry) => {
+      const message = entry.data.message;
+      if (!message) return false;
+      if (message.attachments && message.attachments.length > 0) return false;
+      const baseText = resolveDiscordMessageText(message, { includeForwarded: false });
+      if (!baseText.trim()) return false;
+      return !hasControlCommand(baseText, params.cfg);
+    },
+    onFlush: async (entries) => {
+      const last = entries.at(-1);
+      if (!last) return;
+      const combinedBaseText =
+        entries.length === 1
+          ? resolveDiscordMessageText(last.data.message, { includeForwarded: false })
+          : entries
+              .map((entry) =>
+                resolveDiscordMessageText(entry.data.message, { includeForwarded: false }),
+              )
+              .filter(Boolean)
+              .join("\n");
+      const syntheticMessage = {
+        ...last.data.message,
+        content: combinedBaseText,
+        attachments: [],
+        message_snapshots: [],
+        messageSnapshots: [],
+        rawData: {
+          ...(last.data.message as { rawData?: Record<string, unknown> }).rawData,
+          message_snapshots: [],
+        },
+      };
+      const syntheticData: DiscordMessageEvent = {
+        ...last.data,
+        message: syntheticMessage,
+      };
       const ctx = await preflightDiscordMessage({
         ...params,
         ackReactionScope,
         groupPolicy,
-        data,
-        client,
+        data: syntheticData,
+        client: last.client,
       });
       if (!ctx) return;
+      if (entries.length > 1) {
+        const ids = entries
+          .map((entry) => entry.data.message?.id)
+          .filter(Boolean) as string[];
+        if (ids.length > 0) {
+          const ctxBatch = ctx as typeof ctx & {
+            MessageSids?: string[];
+            MessageSidFirst?: string;
+            MessageSidLast?: string;
+          };
+          ctxBatch.MessageSids = ids;
+          ctxBatch.MessageSidFirst = ids[0];
+          ctxBatch.MessageSidLast = ids[ids.length - 1];
+        }
+      }
       await processDiscordMessage(ctx);
+    },
+    onError: (err) => {
+      params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));
+    },
+  });
+
+  return async (data, client) => {
+    try {
+      await debouncer.enqueue({ data, client });
     } catch (err) {
       params.runtime.error?.(danger(`handler failed: ${String(err)}`));
     }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -10,6 +10,10 @@ import {
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { formatAgentEnvelope } from "../../auto-reply/envelope.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../auto-reply/inbound-debounce.js";
 import { dispatchReplyFromConfig } from "../../auto-reply/reply/dispatch-from-config.js";
 import {
   buildHistoryContextFromMap,
@@ -73,10 +77,48 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const includeAttachments = opts.includeAttachments ?? imessageCfg.includeAttachments ?? false;
   const mediaMaxBytes = (opts.mediaMaxMb ?? imessageCfg.mediaMaxMb ?? 16) * 1024 * 1024;
 
-  const handleMessage = async (raw: unknown) => {
-    const params = raw as { message?: IMessagePayload | null };
-    const message = params?.message ?? null;
-    if (!message) return;
+  const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "imessage" });
+  const inboundDebouncer = createInboundDebouncer<{ message: IMessagePayload }>({
+    debounceMs: inboundDebounceMs,
+    buildKey: (entry) => {
+      const sender = entry.message.sender?.trim();
+      if (!sender) return null;
+      const conversationId =
+        entry.message.chat_id != null
+          ? `chat:${entry.message.chat_id}`
+          : entry.message.chat_guid ?? entry.message.chat_identifier ?? "unknown";
+      return `imessage:${accountInfo.accountId}:${conversationId}:${sender}`;
+    },
+    shouldDebounce: (entry) => {
+      const text = entry.message.text?.trim() ?? "";
+      if (!text) return false;
+      if (entry.message.attachments && entry.message.attachments.length > 0) return false;
+      return !hasControlCommand(text, cfg);
+    },
+    onFlush: async (entries) => {
+      const last = entries.at(-1);
+      if (!last) return;
+      if (entries.length === 1) {
+        await handleMessageNow(last.message);
+        return;
+      }
+      const combinedText = entries
+        .map((entry) => entry.message.text ?? "")
+        .filter(Boolean)
+        .join("\n");
+      const syntheticMessage: IMessagePayload = {
+        ...last.message,
+        text: combinedText,
+        attachments: null,
+      };
+      await handleMessageNow(syntheticMessage);
+    },
+    onError: (err) => {
+      runtime.error?.(`imessage debounce flush failed: ${String(err)}`);
+    },
+  });
+
+  async function handleMessageNow(message: IMessagePayload) {
 
     const senderRaw = message.sender ?? "";
     const sender = senderRaw.trim();
@@ -403,6 +445,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     if (isGroup && historyKey && historyLimit > 0 && didSendReply) {
       clearHistoryEntries({ historyMap: groupHistories, historyKey });
     }
+  }
+
+  const handleMessage = async (raw: unknown) => {
+    const params = raw as { message?: IMessagePayload | null };
+    const message = params?.message ?? null;
+    if (!message) return;
+    await inboundDebouncer.enqueue({ message });
   };
 
   const client = await createIMessageRpcClient({

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -86,7 +86,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       const conversationId =
         entry.message.chat_id != null
           ? `chat:${entry.message.chat_id}`
-          : entry.message.chat_guid ?? entry.message.chat_identifier ?? "unknown";
+          : (entry.message.chat_guid ?? entry.message.chat_identifier ?? "unknown");
       return `imessage:${accountInfo.accountId}:${conversationId}:${sender}`;
     },
     shouldDebounce: (entry) => {
@@ -119,7 +119,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   async function handleMessageNow(message: IMessagePayload) {
-
     const senderRaw = message.sender ?? "";
     const sender = senderRaw.trim();
     if (!sender) return;

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -109,7 +109,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       Body: combinedBody,
       RawBody: entry.bodyText,
       CommandBody: entry.bodyText,
-      From: entry.isGroup ? `group:${entry.groupId ?? "unknown"}` : `signal:${entry.senderRecipient}`,
+      From: entry.isGroup
+        ? `group:${entry.groupId ?? "unknown"}`
+        : `signal:${entry.senderRecipient}`,
       To: signalTo,
       SessionKey: route.sessionKey,
       AccountId: route.accountId,
@@ -207,7 +209,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const inboundDebouncer = createInboundDebouncer<SignalInboundEntry>({
     debounceMs: inboundDebounceMs,
     buildKey: (entry) => {
-      const conversationId = entry.isGroup ? entry.groupId ?? "unknown" : entry.senderPeerId;
+      const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
       if (!conversationId || !entry.senderPeerId) return null;
       return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
     },

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -7,7 +7,12 @@ import {
   extractShortModelName,
   type ResponsePrefixContext,
 } from "../../auto-reply/reply/response-prefix-template.js";
+import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { formatAgentEnvelope } from "../../auto-reply/envelope.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../auto-reply/inbound-debounce.js";
 import { dispatchReplyFromConfig } from "../../auto-reply/reply/dispatch-from-config.js";
 import { buildHistoryContextFromMap, clearHistoryEntries } from "../../auto-reply/reply/history.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
@@ -36,6 +41,205 @@ import { sendMessageSignal } from "../send.js";
 import type { SignalEventHandlerDeps, SignalReceivePayload } from "./event-handler.types.js";
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
+  const inboundDebounceMs = resolveInboundDebounceMs({ cfg: deps.cfg, channel: "signal" });
+
+  type SignalInboundEntry = {
+    senderName: string;
+    senderDisplay: string;
+    senderRecipient: string;
+    senderPeerId: string;
+    groupId?: string;
+    groupName?: string;
+    isGroup: boolean;
+    bodyText: string;
+    timestamp?: number;
+    messageId?: string;
+    mediaPath?: string;
+    mediaType?: string;
+    commandAuthorized: boolean;
+  };
+
+  async function handleSignalInboundMessage(entry: SignalInboundEntry) {
+    const fromLabel = entry.isGroup
+      ? `${entry.groupName ?? "Signal Group"} id:${entry.groupId}`
+      : `${entry.senderName} id:${entry.senderDisplay}`;
+    const body = formatAgentEnvelope({
+      channel: "Signal",
+      from: fromLabel,
+      timestamp: entry.timestamp ?? undefined,
+      body: entry.bodyText,
+    });
+    let combinedBody = body;
+    const historyKey = entry.isGroup ? String(entry.groupId ?? "unknown") : undefined;
+    if (entry.isGroup && historyKey && deps.historyLimit > 0) {
+      combinedBody = buildHistoryContextFromMap({
+        historyMap: deps.groupHistories,
+        historyKey,
+        limit: deps.historyLimit,
+        entry: {
+          sender: entry.senderName,
+          body: entry.bodyText,
+          timestamp: entry.timestamp ?? undefined,
+          messageId: entry.messageId,
+        },
+        currentMessage: combinedBody,
+        formatEntry: (historyEntry) =>
+          formatAgentEnvelope({
+            channel: "Signal",
+            from: fromLabel,
+            timestamp: historyEntry.timestamp,
+            body: `${historyEntry.sender}: ${historyEntry.body}${
+              historyEntry.messageId ? ` [id:${historyEntry.messageId}]` : ""
+            }`,
+          }),
+      });
+    }
+
+    const route = resolveAgentRoute({
+      cfg: deps.cfg,
+      channel: "signal",
+      accountId: deps.accountId,
+      peer: {
+        kind: entry.isGroup ? "group" : "dm",
+        id: entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId,
+      },
+    });
+    const signalTo = entry.isGroup ? `group:${entry.groupId}` : `signal:${entry.senderRecipient}`;
+    const ctxPayload = {
+      Body: combinedBody,
+      RawBody: entry.bodyText,
+      CommandBody: entry.bodyText,
+      From: entry.isGroup ? `group:${entry.groupId ?? "unknown"}` : `signal:${entry.senderRecipient}`,
+      To: signalTo,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: entry.isGroup ? "group" : "direct",
+      GroupSubject: entry.isGroup ? (entry.groupName ?? undefined) : undefined,
+      SenderName: entry.senderName,
+      SenderId: entry.senderDisplay,
+      Provider: "signal" as const,
+      Surface: "signal" as const,
+      MessageSid: entry.messageId,
+      Timestamp: entry.timestamp ?? undefined,
+      MediaPath: entry.mediaPath,
+      MediaType: entry.mediaType,
+      MediaUrl: entry.mediaPath,
+      CommandAuthorized: entry.commandAuthorized,
+      OriginatingChannel: "signal" as const,
+      OriginatingTo: signalTo,
+    };
+
+    if (!entry.isGroup) {
+      const sessionCfg = deps.cfg.session;
+      const storePath = resolveStorePath(sessionCfg?.store, {
+        agentId: route.agentId,
+      });
+      await updateLastRoute({
+        storePath,
+        sessionKey: route.mainSessionKey,
+        channel: "signal",
+        to: entry.senderRecipient,
+        accountId: route.accountId,
+      });
+    }
+
+    if (shouldLogVerbose()) {
+      const preview = body.slice(0, 200).replace(/\\n/g, "\\\\n");
+      logVerbose(`signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`);
+    }
+
+    let didSendReply = false;
+
+    // Create mutable context for response prefix template interpolation
+    let prefixContext: ResponsePrefixContext = {
+      identityName: resolveIdentityName(deps.cfg, route.agentId),
+    };
+
+    const dispatcher = createReplyDispatcher({
+      responsePrefix: resolveEffectiveMessagesConfig(deps.cfg, route.agentId).responsePrefix,
+      responsePrefixContextProvider: () => prefixContext,
+      humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
+      deliver: async (payload) => {
+        await deps.deliverReplies({
+          replies: [payload],
+          target: ctxPayload.To,
+          baseUrl: deps.baseUrl,
+          account: deps.account,
+          accountId: deps.accountId,
+          runtime: deps.runtime,
+          maxBytes: deps.mediaMaxBytes,
+          textLimit: deps.textLimit,
+        });
+        didSendReply = true;
+      },
+      onError: (err, info) => {
+        deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
+      },
+    });
+
+    const { queuedFinal } = await dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg: deps.cfg,
+      dispatcher,
+      replyOptions: {
+        disableBlockStreaming:
+          typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
+        onModelSelected: (ctx) => {
+          // Mutate the object directly instead of reassigning to ensure the closure sees updates
+          prefixContext.provider = ctx.provider;
+          prefixContext.model = extractShortModelName(ctx.model);
+          prefixContext.modelFull = `${ctx.provider}/${ctx.model}`;
+          prefixContext.thinkingLevel = ctx.thinkLevel ?? "off";
+        },
+      },
+    });
+    if (!queuedFinal) {
+      if (entry.isGroup && historyKey && deps.historyLimit > 0 && didSendReply) {
+        clearHistoryEntries({ historyMap: deps.groupHistories, historyKey });
+      }
+      return;
+    }
+    if (entry.isGroup && historyKey && deps.historyLimit > 0 && didSendReply) {
+      clearHistoryEntries({ historyMap: deps.groupHistories, historyKey });
+    }
+  }
+
+  const inboundDebouncer = createInboundDebouncer<SignalInboundEntry>({
+    debounceMs: inboundDebounceMs,
+    buildKey: (entry) => {
+      const conversationId = entry.isGroup ? entry.groupId ?? "unknown" : entry.senderPeerId;
+      if (!conversationId || !entry.senderPeerId) return null;
+      return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
+    },
+    shouldDebounce: (entry) => {
+      if (!entry.bodyText.trim()) return false;
+      if (entry.mediaPath || entry.mediaType) return false;
+      return !hasControlCommand(entry.bodyText, deps.cfg);
+    },
+    onFlush: async (entries) => {
+      const last = entries.at(-1);
+      if (!last) return;
+      if (entries.length === 1) {
+        await handleSignalInboundMessage(last);
+        return;
+      }
+      const combinedText = entries
+        .map((entry) => entry.bodyText)
+        .filter(Boolean)
+        .join("\\n");
+      if (!combinedText.trim()) return;
+      await handleSignalInboundMessage({
+        ...last,
+        bodyText: combinedText,
+        mediaPath: undefined,
+        mediaType: undefined,
+      });
+    },
+    onError: (err) => {
+      deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
+    },
+  });
+
   return async (event: { event?: string; data?: string }) => {
     if (event.event !== "receive" || !event.data) return;
 
@@ -230,146 +434,23 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const bodyText = messageText || placeholder || dataMessage.quote?.text?.trim() || "";
     if (!bodyText) return;
 
-    const fromLabel = isGroup
-      ? `${groupName ?? "Signal Group"} id:${groupId}`
-      : `${envelope.sourceName ?? senderDisplay} id:${senderDisplay}`;
-    const body = formatAgentEnvelope({
-      channel: "Signal",
-      from: fromLabel,
+    const senderName = envelope.sourceName ?? senderDisplay;
+    const messageId =
+      typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+    await inboundDebouncer.enqueue({
+      senderName,
+      senderDisplay,
+      senderRecipient,
+      senderPeerId,
+      groupId,
+      groupName,
+      isGroup,
+      bodyText,
       timestamp: envelope.timestamp ?? undefined,
-      body: bodyText,
+      messageId,
+      mediaPath,
+      mediaType,
+      commandAuthorized,
     });
-    let combinedBody = body;
-    const historyKey = isGroup ? String(groupId ?? "unknown") : undefined;
-    if (isGroup && historyKey && deps.historyLimit > 0) {
-      combinedBody = buildHistoryContextFromMap({
-        historyMap: deps.groupHistories,
-        historyKey,
-        limit: deps.historyLimit,
-        entry: {
-          sender: envelope.sourceName ?? senderDisplay,
-          body: bodyText,
-          timestamp: envelope.timestamp ?? undefined,
-          messageId:
-            typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined,
-        },
-        currentMessage: combinedBody,
-        formatEntry: (entry) =>
-          formatAgentEnvelope({
-            channel: "Signal",
-            from: fromLabel,
-            timestamp: entry.timestamp,
-            body: `${entry.sender}: ${entry.body}${entry.messageId ? ` [id:${entry.messageId}]` : ""}`,
-          }),
-      });
-    }
-
-    const route = resolveAgentRoute({
-      cfg: deps.cfg,
-      channel: "signal",
-      accountId: deps.accountId,
-      peer: {
-        kind: isGroup ? "group" : "dm",
-        id: isGroup ? (groupId ?? "unknown") : senderPeerId,
-      },
-    });
-    const signalTo = isGroup ? `group:${groupId}` : `signal:${senderRecipient}`;
-    const ctxPayload = {
-      Body: combinedBody,
-      RawBody: bodyText,
-      CommandBody: bodyText,
-      From: isGroup ? `group:${groupId ?? "unknown"}` : `signal:${senderRecipient}`,
-      To: signalTo,
-      SessionKey: route.sessionKey,
-      AccountId: route.accountId,
-      ChatType: isGroup ? "group" : "direct",
-      GroupSubject: isGroup ? (groupName ?? undefined) : undefined,
-      SenderName: envelope.sourceName ?? senderDisplay,
-      SenderId: senderDisplay,
-      Provider: "signal" as const,
-      Surface: "signal" as const,
-      MessageSid: envelope.timestamp ? String(envelope.timestamp) : undefined,
-      Timestamp: envelope.timestamp ?? undefined,
-      MediaPath: mediaPath,
-      MediaType: mediaType,
-      MediaUrl: mediaPath,
-      CommandAuthorized: commandAuthorized,
-      OriginatingChannel: "signal" as const,
-      OriginatingTo: signalTo,
-    };
-
-    if (!isGroup) {
-      const sessionCfg = deps.cfg.session;
-      const storePath = resolveStorePath(sessionCfg?.store, {
-        agentId: route.agentId,
-      });
-      await updateLastRoute({
-        storePath,
-        sessionKey: route.mainSessionKey,
-        channel: "signal",
-        to: senderRecipient,
-        accountId: route.accountId,
-      });
-    }
-
-    if (shouldLogVerbose()) {
-      const preview = body.slice(0, 200).replace(/\n/g, "\\n");
-      logVerbose(`signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`);
-    }
-
-    let didSendReply = false;
-
-    // Create mutable context for response prefix template interpolation
-    let prefixContext: ResponsePrefixContext = {
-      identityName: resolveIdentityName(deps.cfg, route.agentId),
-    };
-
-    const dispatcher = createReplyDispatcher({
-      responsePrefix: resolveEffectiveMessagesConfig(deps.cfg, route.agentId).responsePrefix,
-      responsePrefixContextProvider: () => prefixContext,
-      humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
-      deliver: async (payload) => {
-        await deps.deliverReplies({
-          replies: [payload],
-          target: ctxPayload.To,
-          baseUrl: deps.baseUrl,
-          account: deps.account,
-          accountId: deps.accountId,
-          runtime: deps.runtime,
-          maxBytes: deps.mediaMaxBytes,
-          textLimit: deps.textLimit,
-        });
-        didSendReply = true;
-      },
-      onError: (err, info) => {
-        deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
-      },
-    });
-
-    const { queuedFinal } = await dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg: deps.cfg,
-      dispatcher,
-      replyOptions: {
-        disableBlockStreaming:
-          typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
-        onModelSelected: (ctx) => {
-          // Mutate the object directly instead of reassigning to ensure the closure sees updates
-          prefixContext.provider = ctx.provider;
-          prefixContext.model = extractShortModelName(ctx.model);
-          prefixContext.modelFull = `${ctx.provider}/${ctx.model}`;
-          prefixContext.thinkingLevel = ctx.thinkLevel ?? "off";
-        },
-      },
-    });
-    if (!queuedFinal) {
-      if (isGroup && historyKey && deps.historyLimit > 0 && didSendReply) {
-        clearHistoryEntries({ historyMap: deps.groupHistories, historyKey });
-      }
-      return;
-    }
-    if (isGroup && historyKey && deps.historyLimit > 0 && didSendReply) {
-      clearHistoryEntries({ historyMap: deps.groupHistories, historyKey });
-    }
   };
 }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -45,7 +45,7 @@ export function createSlackMessageHandler(params: {
       if (!last) return;
       const combinedText =
         entries.length === 1
-          ? last.message.text ?? ""
+          ? (last.message.text ?? "")
           : entries
               .map((entry) => entry.message.text ?? "")
               .filter(Boolean)

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -1,3 +1,8 @@
+import { hasControlCommand } from "../../auto-reply/command-detection.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../auto-reply/inbound-debounce.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMessageEvent } from "../types.js";
 import type { SlackMonitorContext } from "./context.js";
@@ -14,6 +19,66 @@ export function createSlackMessageHandler(params: {
   account: ResolvedSlackAccount;
 }): SlackMessageHandler {
   const { ctx, account } = params;
+  const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
+
+  const debouncer = createInboundDebouncer<{
+    message: SlackMessageEvent;
+    opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
+  }>({
+    debounceMs,
+    buildKey: (entry) => {
+      const senderId = entry.message.user ?? entry.message.bot_id;
+      if (!senderId) return null;
+      const threadKey = entry.message.thread_ts
+        ? `${entry.message.channel}:${entry.message.thread_ts}`
+        : entry.message.channel;
+      return `slack:${ctx.accountId}:${threadKey}:${senderId}`;
+    },
+    shouldDebounce: (entry) => {
+      const text = entry.message.text ?? "";
+      if (!text.trim()) return false;
+      if (entry.message.files && entry.message.files.length > 0) return false;
+      return !hasControlCommand(text, ctx.cfg);
+    },
+    onFlush: async (entries) => {
+      const last = entries.at(-1);
+      if (!last) return;
+      const combinedText =
+        entries.length === 1
+          ? last.message.text ?? ""
+          : entries
+              .map((entry) => entry.message.text ?? "")
+              .filter(Boolean)
+              .join("\n");
+      const combinedMentioned = entries.some((entry) => Boolean(entry.opts.wasMentioned));
+      const syntheticMessage: SlackMessageEvent = {
+        ...last.message,
+        text: combinedText,
+      };
+      const prepared = await prepareSlackMessage({
+        ctx,
+        account,
+        message: syntheticMessage,
+        opts: {
+          ...last.opts,
+          wasMentioned: combinedMentioned || last.opts.wasMentioned,
+        },
+      });
+      if (!prepared) return;
+      if (entries.length > 1) {
+        const ids = entries.map((entry) => entry.message.ts).filter(Boolean) as string[];
+        if (ids.length > 0) {
+          prepared.ctxPayload.MessageSids = ids;
+          prepared.ctxPayload.MessageSidFirst = ids[0];
+          prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
+        }
+      }
+      await dispatchPreparedSlackMessage(prepared);
+    },
+    onError: (err) => {
+      ctx.runtime.error?.(`slack inbound debounce flush failed: ${String(err)}`);
+    },
+  });
 
   return async (message, opts) => {
     if (opts.source === "message" && message.type !== "message") return;
@@ -26,8 +91,6 @@ export function createSlackMessageHandler(params: {
       return;
     }
     if (ctx.markMessageSeen(message.channel, message.ts)) return;
-    const prepared = await prepareSlackMessage({ ctx, account, message, opts });
-    if (!prepared) return;
-    await dispatchPreparedSlackMessage(prepared);
+    await debouncer.enqueue({ message, opts });
   };
 }

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -26,6 +26,7 @@ export type ResolvedWhatsAppAccount = {
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
+  debounceMs?: number;
 };
 
 function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
@@ -153,6 +154,7 @@ export function resolveWhatsAppAccount(params: {
     blockStreaming: accountCfg?.blockStreaming ?? rootCfg?.blockStreaming,
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
+    debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
   };
 }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import { getReplyFromConfig } from "../../auto-reply/reply.js";
+import { hasControlCommand } from "../../auto-reply/command-detection.js";
+import { resolveInboundDebounceMs } from "../../auto-reply/inbound-debounce.js";
 import { waitForever } from "../../cli/wait.js";
 import { loadConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
@@ -169,13 +171,22 @@ export async function monitorWebChannel(
       account,
     });
 
+    const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "whatsapp" });
+    const shouldDebounce = (msg: WebInboundMsg) => {
+      if (msg.mediaPath || msg.mediaType) return false;
+      if (msg.location) return false;
+      if (msg.replyToId || msg.replyToBody) return false;
+      return !hasControlCommand(msg.body, cfg);
+    };
+
     const listener = await (listenerFactory ?? monitorWebInbox)({
       verbose,
       accountId: account.accountId,
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
-      debounceMs: tuning.debounceMs ?? account.debounceMs,
+      debounceMs: inboundDebounceMs,
+      shouldDebounce,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;
         lastMessageAt = Date.now();

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -175,6 +175,7 @@ export async function monitorWebChannel(
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
+      debounceMs: tuning.debounceMs ?? account.debounceMs,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;
         lastMessageAt = Date.now();

--- a/src/web/auto-reply/types.ts
+++ b/src/web/auto-reply/types.ts
@@ -30,4 +30,6 @@ export type WebMonitorTuning = {
   statusSink?: (status: WebChannelStatus) => void;
   /** WhatsApp account id. Default: "default". */
   accountId?: string;
+  /** Debounce window (ms) for batching rapid consecutive messages from the same sender. */
+  debounceMs?: number;
 };

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -66,7 +66,7 @@ export async function monitorWebInbox(options: {
     buildKey: (msg) => {
       const senderKey =
         msg.chatType === "group"
-          ? msg.senderJid ?? msg.senderE164 ?? msg.senderName ?? msg.from
+          ? (msg.senderJid ?? msg.senderE164 ?? msg.senderName ?? msg.from)
           : msg.from;
       if (!senderKey) return null;
       const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;


### PR DESCRIPTION
## Summary
Implements message debouncing for WhatsApp to batch rapid consecutive messages from the same sender.

## Changes
- Added \`debounceMs\` configuration option to WhatsApp channel settings
- Implemented message buffering in \`monitorWebInbox\`
- Wired configuration through account resolution and monitor tuning
- Added UI hints and schema documentation

## Usage
\`\`\`json5
{
  "channels": {
    "whatsapp": {
      "debounceMs": 5000  // 5 second window
    }
  }
}
\`\`\`

## Testing
- ✅ Type-check passed (\`pnpm build\`)
- ✅ Lint passed (\`pnpm lint\`)
- ✅ All existing tests passed (3204 tests)
- [ ] Manual integration testing with rapid messages

## AI Assistance
**Marked as AI-assisted** - This PR was implemented with assistance from AI coding tools. I understand what the code does and have verified it works correctly.

Closes #967