### PR TITLE
Use "Brave" browser by default.

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -785,7 +785,7 @@ Location:
 
 ## Browser
 
-Browser control CLI (dedicated Chrome/Chromium). See [`clawdbot browser`](/cli/browser) and the [Browser tool](/tools/browser).
+Browser control CLI (dedicated Brave/Chrome/Chromium). See [`clawdbot browser`](/cli/browser) and the [Browser tool](/tools/browser).
 
 Common options:
 - `--url <controlUrl>`

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2371,9 +2371,9 @@ Example:
 }
 ```
 
-### `browser` (clawd-managed Chrome)
+### `browser` (clawd-managed browser)
 
-Clawdbot can start a **dedicated, isolated** Chrome/Chromium instance for clawd and expose a small loopback control server.
+Clawdbot can start a **dedicated, isolated** Brave/Chrome/Chromium instance for clawd and expose a small loopback control server.
 Profiles can point at a **remote** Chrome via `profiles.<name>.cdpUrl`. Remote
 profiles are attach-only (start/stop/reset are disabled).
 

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-summary: "Fix Chrome/Chromium CDP startup issues for Clawdbot browser control on Linux"
+summary: "Fix Brave/Chrome/Chromium CDP startup issues for Clawdbot browser control on Linux"
 read_when: "Browser control fails on Linux, especially with snap Chromium"
 ---
 
@@ -7,7 +7,7 @@ read_when: "Browser control fails on Linux, especially with snap Chromium"
 
 ## Problem: "Failed to start Chrome CDP on port 18800"
 
-Clawdbot's browser control server fails to launch Chrome/Chromium with the error:
+Clawdbot's browser control server fails to launch Brave/Chrome/Chromium with the error:
 ```
 {"error":"Error: Failed to start Chrome CDP on port 18800 for profile \"clawd\"."}
 ```
@@ -107,7 +107,7 @@ curl -s http://127.0.0.1:18791/tabs
 | Option | Description | Default |
 |--------|-------------|---------|
 | `browser.enabled` | Enable browser control | `true` |
-| `browser.executablePath` | Path to Chrome/Chromium binary | auto-detected |
+| `browser.executablePath` | Path to Brave/Chrome/Chromium binary | auto-detected |
 | `browser.headless` | Run without GUI | `false` |
 | `browser.noSandbox` | Add `--no-sandbox` flag (needed for some Linux setups) | `false` |
 | `browser.attachOnly` | Don't launch browser, only attach to existing | `false` |

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -8,7 +8,7 @@ read_when:
 
 # Browser (clawd-managed)
 
-Clawdbot can run a **dedicated Chrome/Chromium profile** that the agent controls.
+Clawdbot can run a **dedicated Brave/Chrome/Chromium profile** that the agent controls.
 It is isolated from your personal browser and is managed through a small local
 control server.
 
@@ -69,17 +69,17 @@ Notes:
 - If you override the Gateway port (`gateway.port` or `CLAWDBOT_GATEWAY_PORT`),
   the default browser ports shift to stay in the same “family” (control = gateway + 2).
 - `cdpUrl` defaults to `controlUrl + 1` when unset.
-- `attachOnly: true` means “never launch Chrome; only attach if it is already running.”
+- `attachOnly: true` means “never launch a local browser; only attach if it is already running.”
 - `color` + per-profile `color` tint the browser UI so you can see which profile is active.
 
 ## Local vs remote control
 
 - **Local control (default):** `controlUrl` is loopback (`127.0.0.1`/`localhost`).
-  The Gateway starts the control server and can launch Chrome.
+  The Gateway starts the control server and can launch a local browser.
 - **Remote control:** `controlUrl` is non-loopback. The Gateway **does not** start
   a local server; it assumes you are pointing at an existing server elsewhere.
 - **Remote CDP:** set `browser.profiles.<name>.cdpUrl` (or `browser.cdpUrl`) to
-  attach to a remote Chrome. In this case, Clawdbot will not launch a local browser.
+  attach to a remote Brave/Chrome/Chromium. In this case, Clawdbot will not launch a local browser.
 
 ## Remote browser (control server)
 
@@ -88,7 +88,7 @@ Gateway at it with a remote `controlUrl`. This lets the agent drive a browser
 outside the host (lab box, VM, remote desktop, etc.).
 
 Key points:
-- The **control server** speaks to Chrome/Chromium via **CDP**.
+- The **control server** speaks to Brave/Chrome/Chromium via **CDP**.
 - The **Gateway** only needs the HTTP control URL.
 - Profiles are resolved on the **control server** side.
 
@@ -104,7 +104,7 @@ Example:
 ```
 
 Use `profiles.<name>.cdpUrl` for **remote CDP** if you want the Gateway to talk
-directly to a Chrome instance without a remote control server.
+directly to a Brave/Chrome/Chromium instance without a remote control server.
 
 ### Running the control server on the browser machine
 
@@ -264,22 +264,23 @@ Notes:
 
 ## Isolation guarantees
 
-- **Dedicated user data dir**: never touches your personal Chrome profile.
+- **Dedicated user data dir**: never touches your personal browser profile.
 - **Dedicated ports**: avoids `9222` to prevent collisions with dev workflows.
 - **Deterministic tab control**: target tabs by `targetId`, not “last tab”.
 
 ## Browser selection
 
 When launching locally, Clawdbot picks the first available:
-1. Chrome Canary
-2. Chromium
-3. Chrome
+1. Brave
+2. Chrome Canary
+3. Chromium
+4. Chrome
 
 You can override with `browser.executablePath`.
 
 Platforms:
 - macOS: checks `/Applications` and `~/Applications`.
-- Linux: looks for `google-chrome`, `chromium`, etc.
+- Linux: looks for `brave`, `google-chrome`, `chromium`, etc.
 - Windows: checks common install locations.
 
 ## Control API (optional)
@@ -313,7 +314,7 @@ For the Chrome extension relay driver, ARIA snapshots and screenshots require Pl
 
 High-level flow:
 - A small **control server** accepts HTTP requests.
-- It connects to Chrome/Chromium via **CDP**.
+- It connects to Brave/Chrome/Chromium via **CDP**.
 - For advanced actions (click/type/snapshot/PDF), it uses **Playwright** on top
   of CDP.
 - When Playwright is missing, only non-Playwright operations are available.

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -54,7 +54,9 @@ describe("subagent announce formatting", () => {
     });
 
     expect(agentSpy).toHaveBeenCalled();
-    const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string; sessionKey?: string } };
+    const call = agentSpy.mock.calls[0]?.[0] as {
+      params?: { message?: string; sessionKey?: string };
+    };
     const msg = call?.params?.message as string;
     expect(call?.params?.sessionKey).toBe("agent:main:main");
     expect(msg).toContain("background task");

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -119,7 +119,8 @@ describe("subagent registry persistence", () => {
     // announce should NOT be called since cleanupHandled was true
     const calls = announceSpy.mock.calls.map((call) => call[0]);
     const match = calls.find(
-      (params) => (params as { childSessionKey?: string }).childSessionKey === "agent:main:subagent:two",
+      (params) =>
+        (params as { childSessionKey?: string }).childSessionKey === "agent:main:subagent:two",
     );
     expect(match).toBeFalsy();
   });

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -38,9 +38,7 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
     const announceCompletedAt =
       typeof typed.announceCompletedAt === "number" ? typed.announceCompletedAt : undefined;
     const cleanupCompletedAt =
-      typeof typed.cleanupCompletedAt === "number"
-        ? typed.cleanupCompletedAt
-        : announceCompletedAt;
+      typeof typed.cleanupCompletedAt === "number" ? typed.cleanupCompletedAt : announceCompletedAt;
     const cleanupHandled =
       typeof typed.cleanupHandled === "boolean"
         ? typed.cleanupHandled

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -214,11 +214,7 @@ function ensureListener() {
   });
 }
 
-function finalizeSubagentCleanup(
-  runId: string,
-  cleanup: "delete" | "keep",
-  didAnnounce: boolean,
-) {
+function finalizeSubagentCleanup(runId: string, cleanup: "delete" | "keep", didAnnounce: boolean) {
   const entry = subagentRuns.get(runId);
   if (!entry) return;
   if (cleanup === "delete") {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -396,7 +396,8 @@ export function buildAgentSystemPrompt(params: {
 
   if (extraSystemPrompt) {
     // Use "Subagent Context" header for minimal mode (subagents), otherwise "Group Chat Context"
-    const contextHeader = promptMode === "minimal" ? "## Subagent Context" : "## Group Chat Context";
+    const contextHeader =
+      promptMode === "minimal" ? "## Subagent Context" : "## Group Chat Context";
     lines.push(contextHeader, extraSystemPrompt, "");
   }
   if (params.reactionGuidance) {

--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import type { ResolvedBrowserConfig } from "./config.js";
 
 export type BrowserExecutable = {
-  kind: "canary" | "chromium" | "chrome" | "custom";
+  kind: "brave" | "canary" | "chromium" | "chrome" | "custom";
   path: string;
 };
 
@@ -27,6 +27,14 @@ function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecu
 
 export function findChromeExecutableMac(): BrowserExecutable | null {
   const candidates: Array<BrowserExecutable> = [
+    {
+      kind: "brave",
+      path: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    },
+    {
+      kind: "brave",
+      path: path.join(os.homedir(), "Applications/Brave Browser.app/Contents/MacOS/Brave Browser"),
+    },
     {
       kind: "canary",
       path: "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
@@ -61,6 +69,10 @@ export function findChromeExecutableMac(): BrowserExecutable | null {
 
 export function findChromeExecutableLinux(): BrowserExecutable | null {
   const candidates: Array<BrowserExecutable> = [
+    { kind: "brave", path: "/usr/bin/brave-browser" },
+    { kind: "brave", path: "/usr/bin/brave-browser-stable" },
+    { kind: "brave", path: "/usr/bin/brave" },
+    { kind: "brave", path: "/snap/bin/brave" },
     { kind: "chrome", path: "/usr/bin/google-chrome" },
     { kind: "chrome", path: "/usr/bin/google-chrome-stable" },
     { kind: "chromium", path: "/usr/bin/chromium" },
@@ -82,6 +94,11 @@ export function findChromeExecutableWindows(): BrowserExecutable | null {
   const candidates: Array<BrowserExecutable> = [];
 
   if (localAppData) {
+    // Brave (user install)
+    candidates.push({
+      kind: "brave",
+      path: joinWin(localAppData, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+    });
     // Chrome Canary (user install)
     candidates.push({
       kind: "canary",
@@ -108,6 +125,16 @@ export function findChromeExecutableWindows(): BrowserExecutable | null {
   candidates.push({
     kind: "chrome",
     path: joinWin(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+  });
+  // Brave (system install, 64-bit)
+  candidates.push({
+    kind: "brave",
+    path: joinWin(programFiles, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+  });
+  // Brave (system install, 32-bit on 64-bit Windows)
+  candidates.push({
+    kind: "brave",
+    path: joinWin(programFilesX86, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
   });
 
   return findFirstExecutable(candidates);

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -147,7 +147,9 @@ export async function launchClawdChrome(
 
   const exe = resolveBrowserExecutable(resolved);
   if (!exe) {
-    throw new Error("No supported browser found (Chrome/Chromium on macOS, Linux, or Windows).");
+    throw new Error(
+      "No supported browser found (Brave/Chrome/Chromium on macOS, Linux, or Windows).",
+    );
   }
 
   const userDataDir = resolveClawdUserDataDir(profile.name);

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -389,7 +389,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       : path.join(path.dirname(storePath), `${sessionId}.jsonl`);
 
     if (!fs.existsSync(transcriptPath)) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "transcript file not found"));
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "transcript file not found"),
+      );
       return;
     }
 
@@ -416,7 +420,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       fs.appendFileSync(transcriptPath, `${JSON.stringify(transcriptEntry)}\n`, "utf-8");
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : String(err);
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, `failed to write transcript: ${errMessage}`));
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, `failed to write transcript: ${errMessage}`),
+      );
       return;
     }
 


### PR DESCRIPTION
Brave should be a lot faster AND a lot better since it doesn't load ads or show cookie banners which confuse the agent.

Codex Prompt:
> Right now the browser that Clawd uses is Chrome. Is it possible to switch that to Brave since it is probably faster without adblock etc. or does only Chrome have this type of automation? Can we make it so Clawdbot detects Brave automatically and uses it if available, otherwise goes with Chrome/Chromium? Brave is safer, so that would be great.

and:

> Add it to the docs, yes.

I did not try this because I am too scared right now to run clawdbot from source while also running it through an install, so might be good for someone to verify this is how it should work.