### PR TITLE
fix(codesign): add deep sign to catch missed nested code

### DIFF
--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -253,5 +253,13 @@ fi
 # Finally sign the bundle
 sign_item "$APP_BUNDLE" "$APP_ENTITLEMENTS"
 
+# Deep sign to catch missed nested code - only for non-Apple certs (self-signed, custom)
+# Apple certs (Developer ID, Apple Development/Distribution) have specific entitlements
+# per component that --deep would override, breaking TCC permissions.
+if [[ "$IDENTITY" != *"Developer ID"* && "$IDENTITY" != *"Apple Development"* && "$IDENTITY" != *"Apple Distribution"* ]]; then
+  echo "Non-Apple certificate detected; applying deep sign for consistency"
+  codesign --force --deep ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --sign "$IDENTITY" "$APP_BUNDLE"
+fi
+
 rm -f "$ENT_TMP_BASE" "$ENT_TMP_APP_BASE" "$ENT_TMP_APP" "$ENT_TMP_RUNTIME"
 echo "Codesign complete for $APP_BUNDLE"


### PR DESCRIPTION
## Summary
- Adds a conditional `--deep` codesign pass **only for non-Apple certificates**
- Apple certs (Developer ID, Apple Development/Distribution) are untouched to preserve TCC entitlements

## Problem
When signing with self-signed or custom certificates (like local dev certs without Apple Team ID), Team ID mismatches between the app binary and embedded frameworks (like Sparkle.framework) cause dyld validation failures.

## Solution
Add a conditional deep sign pass at the end that:
- ✅ **Applies** for non-Apple certs (self-signed, custom) → fixes Team ID mismatch
- ❌ **Skips** for Apple certs → preserves specific entitlements per component (TCC, JIT, etc.)

```bash
if [[ "$IDENTITY" != *"Developer ID"* && "$IDENTITY" != *"Apple Development"* && "$IDENTITY" != *"Apple Distribution"* ]]; then
  codesign --force --deep ... "$APP_BUNDLE"
fi
```

## Test plan
- [x] Tested with self-signed cert (ClawdisDev) - deep sign applied, app works
- [x] Logic verified: Apple certs skip the deep sign block

🤖 Generated with [Claude Code](https://claude.com/claude-code)