### PR TITLE
Heartbeat: add configurable context filtering for heartbeat runs

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1677,6 +1677,9 @@ Z.AI models are available as `zai/<model>` (e.g. `zai/glm-4.7`) and require
 - `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp, chat id for Telegram).
 - `prompt`: optional override for the heartbeat body (default: `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`). Overrides are sent verbatim; include a `Read HEARTBEAT.md` line if you still want the file read.
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery (default: 300).
+- `contextMode`: heartbeat context mode (`all`, `recent-messages`, `summarize-tools`). Default: `all`.
+- `contextMaxMessages`: max messages to keep when `contextMode` is `recent-messages`.
+- `toolSummaryMaxChars`: max tool result chars before replacement when `contextMode` is `summarize-tools`.
 
 Per-agent heartbeats:
 - Set `agents.list[].heartbeat` to enable or override heartbeat settings for a specific agent.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -130,6 +130,9 @@ Example: two agents, only the second agent runs heartbeats.
 - `to`: optional recipient override (E.164 for WhatsApp, chat id for Telegram, etc.).
 - `prompt`: overrides the default prompt body (not merged).
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
+- `contextMode`: heartbeat context mode (`all`, `recent-messages`, `summarize-tools`).
+- `contextMaxMessages`: max messages to keep when `contextMode` is `recent-messages`.
+- `toolSummaryMaxChars`: max tool result chars before replacement when `contextMode` is `summarize-tools`.
 
 ## Delivery behavior
 

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -70,7 +70,10 @@ export function buildEmbeddedExtensionPaths(params: {
   modelId: string;
   model: Model<Api> | undefined;
 }): string[] {
-  const paths = [resolvePiExtensionPath("transcript-sanitize")];
+  const paths = [
+    resolvePiExtensionPath("heartbeat-context"),
+    resolvePiExtensionPath("transcript-sanitize"),
+  ];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -186,6 +186,7 @@ export async function runEmbeddedPiAgent(
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
+            isHeartbeat: params.isHeartbeat,
             messageChannel: params.messageChannel,
             messageProvider: params.messageProvider,
             agentAccountId: params.agentAccountId,
@@ -225,6 +226,7 @@ export async function runEmbeddedPiAgent(
             extraSystemPrompt: params.extraSystemPrompt,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            heartbeatContext: params.heartbeatContext,
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -62,6 +62,7 @@ import { splitSdkTools } from "../tool-split.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../../date-time.js";
 import { mapThinkingLevel, resolveExecToolDefaults } from "../utils.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
+import { setHeartbeatContextRuntime } from "../../pi-extensions/heartbeat-context/runtime.js";
 
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
@@ -261,6 +262,17 @@ export async function runEmbeddedAttempt(
         sessionId: params.sessionId,
         cwd: effectiveWorkspace,
       });
+
+      if (params.isHeartbeat) {
+        setHeartbeatContextRuntime(sessionManager, {
+          isHeartbeat: true,
+          mode: params.heartbeatContext?.mode,
+          maxMessages: params.heartbeatContext?.maxMessages,
+          toolSummaryMaxChars: params.heartbeatContext?.toolSummaryMaxChars,
+        });
+      } else {
+        setHeartbeatContextRuntime(sessionManager, null);
+      }
 
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
       ensurePiCompactionReserveTokens({

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -9,6 +9,7 @@ import type { SkillSnapshot } from "../../skills.js";
 export type RunEmbeddedPiAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  isHeartbeat?: boolean;
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
@@ -56,4 +57,9 @@ export type RunEmbeddedPiAgentParams = {
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  heartbeatContext?: {
+    mode?: "all" | "recent-messages" | "summarize-tools";
+    maxMessages?: number;
+    toolSummaryMaxChars?: number;
+  };
 };

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -16,6 +16,7 @@ type ModelRegistry = ReturnType<typeof discoverModels>;
 export type EmbeddedRunAttemptParams = {
   sessionId: string;
   sessionKey?: string;
+  isHeartbeat?: boolean;
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
@@ -59,6 +60,11 @@ export type EmbeddedRunAttemptParams = {
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  heartbeatContext?: {
+    mode?: "all" | "recent-messages" | "summarize-tools";
+    maxMessages?: number;
+    toolSummaryMaxChars?: number;
+  };
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/agents/pi-extensions/heartbeat-context.test.ts
+++ b/src/agents/pi-extensions/heartbeat-context.test.ts
@@ -1,0 +1,99 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+
+import { applyHeartbeatContext } from "./heartbeat-context.js";
+
+function makeToolResult(params: {
+  toolCallId: string;
+  toolName: string;
+  text: string;
+}): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: params.toolCallId,
+    toolName: params.toolName,
+    content: [{ type: "text", text: params.text }],
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+function toolText(msg: AgentMessage): string {
+  if (msg.role !== "toolResult") throw new Error("expected toolResult");
+  const first = msg.content.find((b) => b.type === "text");
+  if (!first || first.type !== "text") return "";
+  return first.text;
+}
+
+function makeAssistant(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function makeUser(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+describe("heartbeat-context", () => {
+  it("summarizes large tool results", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistant("a1"),
+      makeToolResult({ toolCallId: "t1", toolName: "browser", text: "x".repeat(100) }),
+    ];
+
+    const next = applyHeartbeatContext(messages, {
+      mode: "summarize-tools",
+      toolSummaryMaxChars: 50,
+    });
+
+    expect(toolText(next[2])).toContain("tool result omitted");
+    expect(toolText(next[2])).toContain("browser");
+  });
+
+  it("keeps small tool results when under the limit", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: "ok" }),
+    ];
+
+    const next = applyHeartbeatContext(messages, {
+      mode: "summarize-tools",
+      toolSummaryMaxChars: 10,
+    });
+
+    expect(toolText(next[0])).toBe("ok");
+  });
+
+  it("keeps only the last N messages", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistant("a1"),
+      makeUser("u2"),
+      makeAssistant("a2"),
+      makeUser("u3"),
+    ];
+
+    const next = applyHeartbeatContext(messages, {
+      mode: "recent-messages",
+      maxMessages: 2,
+    });
+
+    expect(next).toHaveLength(2);
+    expect(next[0]?.role).toBe("assistant");
+    expect(next[1]?.role).toBe("user");
+  });
+
+  it("returns original messages when mode is all", () => {
+    const messages: AgentMessage[] = [makeUser("u1")];
+    const next = applyHeartbeatContext(messages, { mode: "all" });
+    expect(next).toBe(messages);
+  });
+});

--- a/src/agents/pi-extensions/heartbeat-context.ts
+++ b/src/agents/pi-extensions/heartbeat-context.ts
@@ -1,0 +1,126 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import type { ContextEvent, ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+import { getHeartbeatContextRuntime } from "./heartbeat-context/runtime.js";
+
+const DEFAULT_MAX_MESSAGES = 20;
+const DEFAULT_TOOL_SUMMARY_MAX_CHARS = 1_000;
+const IMAGE_CHAR_ESTIMATE = 8_000;
+
+type HeartbeatContextMode = "all" | "recent-messages" | "summarize-tools";
+
+type HeartbeatContextSettings = {
+  mode?: HeartbeatContextMode;
+  maxMessages?: number;
+  toolSummaryMaxChars?: number;
+};
+
+function normalizeMode(mode?: HeartbeatContextMode): HeartbeatContextMode {
+  if (mode === "recent-messages" || mode === "summarize-tools" || mode === "all") return mode;
+  return "all";
+}
+
+function resolveMaxMessages(value?: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return DEFAULT_MAX_MESSAGES;
+}
+
+function resolveToolSummaryMaxChars(value?: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return DEFAULT_TOOL_SUMMARY_MAX_CHARS;
+}
+
+function estimateToolResultChars(message: ToolResultMessage): { chars: number; imageCount: number } {
+  let chars = 0;
+  let imageCount = 0;
+  for (const block of message.content) {
+    if (block.type === "text") {
+      chars += block.text.length;
+      continue;
+    }
+    if (block.type === "image") {
+      imageCount += 1;
+      chars += IMAGE_CHAR_ESTIMATE;
+    }
+  }
+  return { chars, imageCount };
+}
+
+function formatToolResultPlaceholder(params: {
+  toolName?: string;
+  chars: number;
+  imageCount: number;
+}): string {
+  const name = params.toolName?.trim() ? params.toolName.trim() : "unknown";
+  const imageSuffix = params.imageCount > 0 ? `, ${params.imageCount} image(s)` : "";
+  return `[tool result omitted: ${name}, ${params.chars} chars${imageSuffix}]`;
+}
+
+function summarizeToolResults(
+  messages: AgentMessage[],
+  maxChars: number,
+): AgentMessage[] {
+  let next: AgentMessage[] | null = null;
+  for (let i = 0; i < messages.length; i += 1) {
+    const msg = messages[i];
+    if (!msg || msg.role !== "toolResult") continue;
+
+    const toolMsg = msg as ToolResultMessage;
+    const { chars, imageCount } = estimateToolResultChars(toolMsg);
+    if (chars <= maxChars) continue;
+
+    const placeholder = formatToolResultPlaceholder({
+      toolName: toolMsg.toolName,
+      chars,
+      imageCount,
+    });
+    const updated: ToolResultMessage = {
+      ...toolMsg,
+      content: [{ type: "text", text: placeholder }],
+    };
+    if (!next) next = messages.slice();
+    next[i] = updated as unknown as AgentMessage;
+  }
+  return next ?? messages;
+}
+
+function keepRecentMessages(messages: AgentMessage[], maxMessages: number): AgentMessage[] {
+  if (messages.length <= maxMessages) return messages;
+  return messages.slice(-maxMessages);
+}
+
+export function applyHeartbeatContext(
+  messages: AgentMessage[],
+  settings: HeartbeatContextSettings,
+): AgentMessage[] {
+  const mode = normalizeMode(settings.mode);
+  if (mode === "all") return messages;
+
+  if (mode === "recent-messages") {
+    const maxMessages = resolveMaxMessages(settings.maxMessages);
+    return keepRecentMessages(messages, maxMessages);
+  }
+
+  const maxChars = resolveToolSummaryMaxChars(settings.toolSummaryMaxChars);
+  return summarizeToolResults(messages, maxChars);
+}
+
+export default function heartbeatContextExtension(api: ExtensionAPI): void {
+  api.on("context", (event: ContextEvent, ctx) => {
+    const runtime = getHeartbeatContextRuntime(ctx.sessionManager);
+    if (!runtime?.isHeartbeat) return undefined;
+
+    const next = applyHeartbeatContext(event.messages as AgentMessage[], {
+      mode: runtime.mode,
+      maxMessages: runtime.maxMessages,
+      toolSummaryMaxChars: runtime.toolSummaryMaxChars,
+    });
+    if (next === event.messages) return undefined;
+    return { messages: next };
+  });
+}

--- a/src/agents/pi-extensions/heartbeat-context/runtime.ts
+++ b/src/agents/pi-extensions/heartbeat-context/runtime.ts
@@ -1,0 +1,35 @@
+export type HeartbeatContextRuntimeValue = {
+  isHeartbeat: boolean;
+  mode?: "all" | "recent-messages" | "summarize-tools";
+  maxMessages?: number;
+  toolSummaryMaxChars?: number;
+};
+
+const REGISTRY = new WeakMap<object, HeartbeatContextRuntimeValue>();
+
+export function setHeartbeatContextRuntime(
+  sessionManager: unknown,
+  value: HeartbeatContextRuntimeValue | null,
+): void {
+  if (!sessionManager || typeof sessionManager !== "object") {
+    return;
+  }
+
+  const key = sessionManager as object;
+  if (value === null) {
+    REGISTRY.delete(key);
+    return;
+  }
+
+  REGISTRY.set(key, value);
+}
+
+export function getHeartbeatContextRuntime(
+  sessionManager: unknown,
+): HeartbeatContextRuntimeValue | null {
+  if (!sessionManager || typeof sessionManager !== "object") {
+    return null;
+  }
+
+  return REGISTRY.get(sessionManager as object) ?? null;
+}

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -168,6 +168,17 @@ export type AgentDefaultsConfig = {
     /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
     ackMaxChars?: number;
     /**
+     * Heartbeat context mode.
+     * - "all": use full session context (default).
+     * - "recent-messages": keep only the last N messages.
+     * - "summarize-tools": replace large tool results with placeholders.
+     */
+    contextMode?: "all" | "recent-messages" | "summarize-tools";
+    /** Max messages to keep when contextMode = "recent-messages". */
+    contextMaxMessages?: number;
+    /** Max tool result chars before replacing with a placeholder (contextMode = "summarize-tools"). */
+    toolSummaryMaxChars?: number;
+    /**
      * When enabled, deliver the model's reasoning payload for heartbeat runs (when available)
      * as a separate message prefixed with `Reasoning:` (same as `/reasoning on`).
      *

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -13,6 +13,15 @@ export const HeartbeatSchema = z
     every: z.string().optional(),
     model: z.string().optional(),
     includeReasoning: z.boolean().optional(),
+    contextMode: z
+      .union([
+        z.literal("all"),
+        z.literal("recent-messages"),
+        z.literal("summarize-tools"),
+      ])
+      .optional(),
+    contextMaxMessages: z.number().int().positive().optional(),
+    toolSummaryMaxChars: z.number().int().positive().optional(),
     target: z
       .union([
         z.literal("last"),


### PR DESCRIPTION
## Summary
- Add heartbeat-only context filtering (ephemeral) to reduce token usage during heartbeats.
- Support contextMode: "recent-messages" and contextMode: "summarize-tools" with per-agent overrides.
- Document new heartbeat config options.

## Changes
- New heartbeat context extension wired into embedded run pipeline.
- Pass heartbeat context settings through run params; no session transcript mutation.
- Added tests for heartbeat context behavior.
- Docs updated under Gateway configuration + heartbeat docs.

## Testing
- pnpm lint (Node 22) — warnings only (duplicate keys pre-existing)
- pnpm test (Node 22) — 2 failing tests unrelated to this change:
  - src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.test.ts
  - src/auto-reply/reply/session-updates.test.ts

## Config Example
```json5
agents: {
  defaults: {
    heartbeat: {
      contextMode: "summarize-tools",
      toolSummaryMaxChars: 500
      // or: contextMode: "recent-messages", contextMaxMessages: 10
    }
  }
}
```
