### PR TITLE
fix(zalo): fix pairing channel detection and webhook payload format

### DIFF
--- a/extensions/zalo/src/core-bridge.ts
+++ b/extensions/zalo/src/core-bridge.ts
@@ -30,6 +30,11 @@ export type CoreChannelDeps = {
     channel: string;
     id: string;
     meta?: { name?: string };
+    pairingAdapter?: {
+      idLabel: string;
+      normalizeAllowEntry?: (entry: string) => string;
+      notifyApproval?: (params: { cfg: unknown; id: string; runtime?: unknown }) => Promise<void>;
+    };
   }) => Promise<{ code: string; created: boolean }>;
   fetchRemoteMedia: (params: { url: string }) => Promise<{ buffer: Buffer; contentType?: string }>;
   saveMediaBuffer: (

--- a/src/channels/plugins/pairing.ts
+++ b/src/channels/plugins/pairing.ts
@@ -53,8 +53,11 @@ export async function notifyPairingApproved(params: {
   id: string;
   cfg: ClawdbotConfig;
   runtime?: RuntimeEnv;
+  /** Extension channels can pass their adapter directly to bypass registry lookup. */
+  pairingAdapter?: ChannelPairingAdapter;
 }): Promise<void> {
-  const adapter = requirePairingAdapter(params.channelId);
+  // Extensions may provide adapter directly to bypass ESM module isolation
+  const adapter = params.pairingAdapter ?? requirePairingAdapter(params.channelId);
   if (!adapter.notifyApproval) return;
   await adapter.notifyApproval({
     cfg: params.cfg,

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -8,11 +8,10 @@ const pairingIdLabels: Record<string, string> = {
   telegram: "telegramUserId",
   discord: "discordUserId",
 };
-const requirePairingAdapter = vi.fn((channel: string) => ({
+const getPairingAdapter = vi.fn((channel: string) => ({
   idLabel: pairingIdLabels[channel] ?? "userId",
 }));
 const listPairingChannels = vi.fn(() => ["telegram", "discord"]);
-const resolvePairingChannel = vi.fn((raw: string) => raw);
 
 vi.mock("../pairing/pairing-store.js", () => ({
   listChannelPairingRequests,
@@ -21,9 +20,8 @@ vi.mock("../pairing/pairing-store.js", () => ({
 
 vi.mock("../channels/plugins/pairing.js", () => ({
   listPairingChannels,
-  resolvePairingChannel,
   notifyPairingApproved,
-  requirePairingAdapter,
+  getPairingAdapter,
 }));
 
 vi.mock("../config/config.js", () => ({

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 import {
   listPairingChannels,
   notifyPairingApproved,
-  resolvePairingChannel,
 } from "../channels/plugins/pairing.js";
 import { loadConfig } from "../config/config.js";
 import { resolvePairingIdLabel } from "../pairing/pairing-labels.js";
@@ -16,8 +15,14 @@ import { theme } from "../terminal/theme.js";
 
 const CHANNELS: PairingChannel[] = listPairingChannels();
 
+/** Parse channel, allowing extension channels not in core registry. */
 function parseChannel(raw: unknown): PairingChannel {
-  return resolvePairingChannel(raw);
+  const value = String(raw ?? "").trim().toLowerCase();
+  if (!value) throw new Error("Channel required");
+  if (CHANNELS.includes(value as PairingChannel)) return value as PairingChannel;
+  // Allow extension channels: validate format but don't require registry
+  if (/^[a-z][a-z0-9_-]{0,63}$/.test(value)) return value as PairingChannel;
+  throw new Error(`Invalid channel: ${value}`);
 }
 
 async function notifyApproved(channel: PairingChannel, id: string) {

--- a/src/pairing/pairing-labels.ts
+++ b/src/pairing/pairing-labels.ts
@@ -1,6 +1,6 @@
-import { requirePairingAdapter } from "../channels/plugins/pairing.js";
+import { getPairingAdapter } from "../channels/plugins/pairing.js";
 import type { PairingChannel } from "./pairing-store.js";
 
 export function resolvePairingIdLabel(channel: PairingChannel): string {
-  return requirePairingAdapter(channel).idLabel;
+  return getPairingAdapter(channel)?.idLabel ?? "userId";
 }


### PR DESCRIPTION
## fix(zalo): fix pairing channel detection and webhook payload format

Fixes #987

### Problem

1. **Pairing flow failed for Zalo** - The pairing system used `requirePairingAdapter()` which threw errors for extension channels like Zalo that aren't in the core registry.

2. **Webhook returned 400 Bad Request** - The webhook handler expected payloads wrapped as `{ ok: true, result: ZaloUpdate }`, but Zalo sends updates directly as `{ event_name, message, ... }`.

### Changes

**Pairing fixes:**
- Replace `requirePairingAdapter()` with `getPairingAdapter()` that returns `undefined` for unknown channels instead of throwing
- Allow extension channels to pass their `pairingAdapter` directly to bypass registry lookup
- Add `safeChannelKey()` to sanitize channel IDs for filenames (prevents path traversal)
- Update `parseChannel()` in CLI to accept valid extension channel names not in core registry

**Webhook fix:**
- Handle both payload formats: direct `{ event_name, message }` and wrapped `{ ok, result }`
- Validate presence of `event_name` instead of `ok` flag

### Files Changed

- `extensions/zalo/src/monitor.ts` - Fix webhook payload parsing, pass pairing adapter
- `extensions/zalo/src/core-bridge.ts` - Add `pairingAdapter` to upsert signature
- `src/channels/plugins/pairing.ts` - Accept optional `pairingAdapter` param
- `src/pairing/pairing-store.ts` - Use `getPairingAdapter()`, add `safeChannelKey()`
- `src/pairing/pairing-labels.ts` - Use `getPairingAdapter()` with fallback
- `src/cli/pairing-cli.ts` - Allow extension channels in `parseChannel()`