### PR TITLE
Fix systemd ExecStart whitespace parsing

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSystemdExecStart } from "./systemd-unit.js";
+
+describe("parseSystemdExecStart", () => {
+  it("splits on whitespace outside quotes", () => {
+    const execStart = "/usr/bin/clawdbot gateway start --foo bar";
+    expect(parseSystemdExecStart(execStart)).toEqual([
+      "/usr/bin/clawdbot",
+      "gateway",
+      "start",
+      "--foo",
+      "bar",
+    ]);
+  });
+
+  it("preserves quoted arguments", () => {
+    const execStart = "/usr/bin/clawdbot gateway start --name \"My Bot\"";
+    expect(parseSystemdExecStart(execStart)).toEqual([
+      "/usr/bin/clawdbot",
+      "gateway",
+      "start",
+      "--name",
+      "My Bot",
+    ]);
+  });
+
+  it("supports backslash-escaped characters", () => {
+    const execStart = "/usr/bin/clawdbot gateway start --path \/tmp\/clawdbot";
+    expect(parseSystemdExecStart(execStart)).toEqual([
+      "/usr/bin/clawdbot",
+      "gateway",
+      "start",
+      "--path",
+      "/tmp/clawdbot",
+    ]);
+  });
+});

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -76,7 +76,7 @@ export function parseSystemdExecStart(value: string): string[] {
       inQuotes = !inQuotes;
       continue;
     }
-    if (!inQuotes && /\\s/.test(char)) {
+    if (!inQuotes && /\s/.test(char)) {
       if (current) {
         args.push(current);
         current = "";


### PR DESCRIPTION
Fixes #972.

**Issue**
`clawdbot daemon status --deep` / doctor can warn: "Service command does not include the gateway subcommand" even when the systemd unit's `ExecStart=` includes `gateway`.

**Root cause**
`parseSystemdExecStart` uses `/\\s/` (matches a literal backslash + `s`) instead of `/\s/` (whitespace), so ExecStart is never split into args and `gateway` isn't detected.

**Fix**
Use `/\s/` for whitespace splitting.

**Tests**
Adds `src/daemon/systemd-unit.test.ts` to cover whitespace splitting, quoted args, and backslash escaping.