### PR TITLE
fix(exec): don't SIGKILL backgrounded processes on abort

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test } from "vitest";
+
+import { createExecTool } from "./bash-tools.exec";
+import { getFinishedSession, getSession, resetProcessRegistryForTests } from "./bash-process-registry";
+import { killProcessTree } from "./shell-utils";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+test("background exec is not killed when tool signal aborts", async () => {
+  const tool = createExecTool({ allowBackground: true, backgroundMs: 0 });
+  const abortController = new AbortController();
+
+  const result = await tool.execute(
+    "toolcall",
+    { command: "node -e \"setTimeout(() => {}, 5000)\"", background: true },
+    abortController.signal,
+  );
+
+  expect(result.details.status).toBe("running");
+  const sessionId = (result.details as { sessionId: string }).sessionId;
+
+  abortController.abort();
+
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  const running = getSession(sessionId);
+  const finished = getFinishedSession(sessionId);
+
+  try {
+    expect(finished).toBeUndefined();
+    expect(running?.exited).toBe(false);
+  } finally {
+    const pid = running?.pid;
+    if (pid) killProcessTree(pid);
+  }
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -263,6 +263,7 @@ export function createExecTool(
       };
 
       const onAbort = () => {
+        if (yielded || session.backgrounded) return;
         killSession(session);
       };
 


### PR DESCRIPTION
Fixes #910.

## Problem
When the `exec` tool is used in background mode, it returns early to the caller. The tool-call `AbortSignal` can then fire shortly after the tool returns (lifecycle cleanup), and Clawdbot treated that abort as a hard-cancel and killed the spawned process tree with SIGKILL.

This makes long-running background commands (notably `claude -p ...` started via the coding-agent skill) die almost immediately with `SIGKILL`, producing no output.

## Fix
Ignore abort events once the command has been yielded/backgrounded, so background sessions are allowed to continue running.

## Tests
- Add regression test to ensure aborting the tool-call signal does not kill a backgrounded exec session.