### PR TITLE
fix: docker-setup fails on Synology because of problem with bun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm build
+# Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
+ENV CLAWDBOT_PREFER_PNPM=1
 RUN pnpm ui:install
 RUN pnpm ui:build
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -45,10 +45,19 @@ function which(cmd) {
 }
 
 function resolveRunner() {
-  const bun = which("bun");
-  if (bun) return { cmd: bun, kind: "bun" };
+  // CLAWDBOT_PREFER_PNPM=1 forces pnpm (useful in Docker on architectures where Bun fails)
+  const preferPnpm = process.env.CLAWDBOT_PREFER_PNPM === "1";
+  if (!preferPnpm) {
+    const bun = which("bun");
+    if (bun) return { cmd: bun, kind: "bun" };
+  }
   const pnpm = which("pnpm");
   if (pnpm) return { cmd: pnpm, kind: "pnpm" };
+  if (preferPnpm) {
+    // Fallback to bun if pnpm not found even when preferring pnpm
+    const bun = which("bun");
+    if (bun) return { cmd: bun, kind: "bun" };
+  }
   return null;
 }
 


### PR DESCRIPTION
docker-setup.sh fails on Synology due to issues with bun. New ENV CLAWDBOT_PREFER_PNPM=1 prefers PNPM instead of bun. ui.js modified to check for the ENV.