### PR TITLE
Fix format parameter conflict and subagent auth inheritance

### DIFF
--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -207,6 +207,19 @@ export function ensureAuthProfileStore(
     return asStore;
   }
 
+  // Fallback: inherit auth-profiles from main agent if subagent has none
+  if (agentDir) {
+    const mainAuthPath = resolveAuthStorePath(); // without agentDir = main
+    const mainRaw = loadJsonFile(mainAuthPath);
+    const mainStore = coerceAuthStore(mainRaw);
+    if (mainStore && Object.keys(mainStore.profiles).length > 0) {
+      // Clone main store to subagent directory for auth inheritance
+      saveJsonFile(authPath, mainStore);
+      log.info("inherited auth-profiles from main agent", { agentDir });
+      return mainStore;
+    }
+  }
+
   const legacyRaw = loadJsonFile(resolveLegacyAuthStorePath(agentDir));
   const legacy = coerceLegacyStore(legacyRaw);
   const store: AuthProfileStore = {

--- a/src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-a.test.ts
+++ b/src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-a.test.ts
@@ -129,16 +129,16 @@ describe("createClawdbotCodingTools", () => {
     expect(Array.isArray(action?.enum)).toBe(true);
     expect(action?.enum).toContain("act");
 
-    const format = parameters.properties?.format as
+    const snapshotFormat = parameters.properties?.snapshotFormat as
       | {
           type?: unknown;
           enum?: unknown[];
           anyOf?: unknown[];
         }
       | undefined;
-    expect(format?.type).toBe("string");
-    expect(format?.anyOf).toBeUndefined();
-    expect(format?.enum).toEqual(["aria", "ai"]);
+    expect(snapshotFormat?.type).toBe("string");
+    expect(snapshotFormat?.anyOf).toBeUndefined();
+    expect(snapshotFormat?.enum).toEqual(["aria", "ai"]);
   });
   it("inlines local $ref before removing unsupported keywords", () => {
     const cleaned = __testing.cleanToolSchemaForGemini({

--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -91,7 +91,7 @@ export const BrowserToolSchema = Type.Object({
   limit: Type.Optional(Type.Number()),
   maxChars: Type.Optional(Type.Number()),
   mode: optionalStringEnum(BROWSER_SNAPSHOT_MODES),
-  format: optionalStringEnum(BROWSER_SNAPSHOT_FORMATS),
+  snapshotFormat: optionalStringEnum(BROWSER_SNAPSHOT_FORMATS),
   refs: optionalStringEnum(BROWSER_SNAPSHOT_REFS),
   interactive: Type.Optional(Type.Boolean()),
   compact: Type.Optional(Type.Boolean()),

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -191,8 +191,8 @@ export function createBrowserTool(opts?: {
         }
         case "snapshot": {
           const format =
-            params.format === "ai" || params.format === "aria"
-              ? (params.format as "ai" | "aria")
+            params.snapshotFormat === "ai" || params.snapshotFormat === "aria"
+              ? (params.snapshotFormat as "ai" | "aria")
               : "ai";
           const mode = params.mode === "efficient" ? "efficient" : undefined;
           const labels = typeof params.labels === "boolean" ? params.labels : undefined;

--- a/src/agents/tools/canvas-tool.ts
+++ b/src/agents/tools/canvas-tool.ts
@@ -40,7 +40,7 @@ const CanvasToolSchema = Type.Object({
   // eval
   javaScript: Type.Optional(Type.String()),
   // snapshot
-  format: optionalStringEnum(CANVAS_SNAPSHOT_FORMATS),
+  outputFormat: optionalStringEnum(CANVAS_SNAPSHOT_FORMATS),
   maxWidth: Type.Optional(Type.Number()),
   quality: Type.Optional(Type.Number()),
   delayMs: Type.Optional(Type.Number()),
@@ -127,7 +127,7 @@ export function createCanvasTool(): AnyAgentTool {
           return jsonResult({ ok: true });
         }
         case "snapshot": {
-          const formatRaw = typeof params.format === "string" ? params.format.toLowerCase() : "png";
+          const formatRaw = typeof params.outputFormat === "string" ? params.outputFormat.toLowerCase() : "png";
           const format = formatRaw === "jpg" || formatRaw === "jpeg" ? "jpeg" : "png";
           const maxWidth =
             typeof params.maxWidth === "number" && Number.isFinite(params.maxWidth)


### PR DESCRIPTION
## Summary

Two bugs fixed that were manually patched on VPC:

### Bug 1: Format Parameter JSON Schema Conflict
- Renamed `format` to `snapshotFormat` in browser-tool schema/implementation
- Renamed `format` to `outputFormat` in canvas-tool schema/implementation
- The parameter name `format` conflicts with JSON Schema keyword, causing Google Cloud Code Assist to reject the schema as invalid

### Bug 2: Auth-Profiles Not Inherited by Subagents
- Added fallback in `ensureAuthProfileStore()` to inherit auth-profiles from main agent when subagent has none
- Ensures subagents can use OAuth tokens without manual file copying

## Test plan
- [ ] Verify logs no longer show `browser.parameters.properties.format` warnings
- [ ] Verify subagent spawn works without manual auth-profiles copy
- [ ] Verify Minimax no longer falls back to Opus due to format errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)