### PR TITLE
Delete session from web ui

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -537,7 +537,7 @@
 .table-head,
 .table-row {
   display: grid;
-  grid-template-columns: 1.4fr 0.8fr 0.8fr 0.7fr 0.8fr 0.8fr;
+  grid-template-columns: 1.4fr 0.9fr 0.8fr 0.7fr 0.8fr 0.8fr 0.8fr 0.8fr 0.6fr;
   gap: 12px;
   align-items: center;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -57,7 +57,7 @@ import {
   updateTelegramForm,
 } from "./controllers/connections";
 import { loadPresence } from "./controllers/presence";
-import { loadSessions, patchSession } from "./controllers/sessions";
+import { loadSessions, patchSession, deleteSession } from "./controllers/sessions";
 import {
   installSkill,
   loadSkills,
@@ -280,6 +280,7 @@ export function renderApp(state: AppViewState) {
               },
               onRefresh: () => loadSessions(state),
               onPatch: (key, patch) => patchSession(state, key, patch),
+              onDelete: (key) => deleteSession(state, key),
             })
           : nothing}
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -60,3 +60,24 @@ export async function patchSession(
     state.sessionsError = String(err);
   }
 }
+
+export async function deleteSession(state: SessionsState, key: string) {
+  if (!state.client || !state.connected) return;
+  if (state.sessionsLoading) return;
+  const confirmed = window.confirm(
+    `Delete session "${key}"?\n\nDeletes the session entry and archives its transcript.`,
+  );
+  if (!confirmed) return;
+  state.sessionsLoading = true;
+  state.sessionsError = null;
+  let deleted = false;
+  try {
+    await state.client.request("sessions.delete", { key, deleteTranscript: true });
+    deleted = true;
+  } catch (err) {
+    state.sessionsError = String(err);
+  } finally {
+    state.sessionsLoading = false;
+  }
+  if (deleted) await loadSessions(state);
+}

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -29,6 +29,7 @@ export type SessionsProps = {
       reasoningLevel?: string | null;
     },
   ) => void;
+  onDelete: (key: string) => void;
 };
 
 const THINK_LEVELS = ["", "off", "minimal", "low", "medium", "high"] as const;
@@ -128,10 +129,13 @@ export function renderSessions(props: SessionsProps) {
           <div>Thinking</div>
           <div>Verbose</div>
           <div>Reasoning</div>
+          <div>Actions</div>
         </div>
         ${rows.length === 0
           ? html`<div class="muted">No sessions found.</div>`
-          : rows.map((row) => renderRow(row, props.basePath, props.onPatch))}
+          : rows.map((row) =>
+              renderRow(row, props.basePath, props.onPatch, props.onDelete),
+            )}
       </div>
     </section>
   `;
@@ -141,6 +145,7 @@ function renderRow(
   row: GatewaySessionRow,
   basePath: string,
   onPatch: SessionsProps["onPatch"],
+  onDelete: SessionsProps["onDelete"],
 ) {
   const updated = row.updatedAt ? formatAgo(row.updatedAt) : "n/a";
   const thinking = row.thinkingLevel ?? "";
@@ -199,6 +204,9 @@ function renderRow(
             html`<option value=${level}>${level || "inherit"}</option>`,
           )}
         </select>
+      </div>
+      <div>
+        <button class="btn danger" @click=${() => onDelete(row.key)}>Delete</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
This pull request adds the ability to delete session entries from the sessions view, including archiving their transcripts, and updates the UI to reflect this new functionality. The main changes are the addition of a `Delete` action for each session and the necessary updates to the UI and controller logic to support session deletion.

**Session management improvements:**

* Added a new `deleteSession` function to `sessions.ts` that confirms user intent, requests session deletion from the backend, and refreshes the session list.
* Updated `app-render.ts` to pass the new `onDelete` handler to the sessions view, enabling session deletion from the UI. 

**UI updates:**

* Modified the sessions table in `sessions.ts` to include an "Actions" column and render a `Delete` button for each session. 
* Updated the table layout in `components.css` to accommodate the new columns for actions.
* Updated the `SessionsProps` type to include the new `onDelete` callback.