### PR TITLE
fix(macos): check config file mode for gateway token/password resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Fix: keep background exec aborts from killing backgrounded sessions while honoring timeouts.
 - Fix: use local auth for gateway security probe unless remote mode has a URL. (#1011) — thanks @ivanrvpereira.
 - Discord: truncate skill command descriptions for slash command limits. (#1018) — thanks @evalexpr.
+- macOS: resolve gateway token/password using config mode/remote URL, and warn when `launchctl setenv` overrides config. (#1022, #1021) — thanks @kkarimi.
 
 ## 2026.1.14-1
 

--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -257,30 +257,8 @@ final class AppState {
 
         let configRoot = ClawdbotConfigFile.loadDict()
         let configGateway = configRoot["gateway"] as? [String: Any]
-        let configModeRaw = (configGateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let configMode: ConnectionMode? = switch configModeRaw {
-        case "local":
-            .local
-        case "remote":
-            .remote
-        default:
-            nil
-        }
         let configRemoteUrl = (configGateway?["remote"] as? [String: Any])?["url"] as? String
-        let configHasRemoteUrl = !(configRemoteUrl?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty ?? true)
-
-        let storedMode = UserDefaults.standard.string(forKey: connectionModeKey)
-        let resolvedConnectionMode: ConnectionMode = if let configMode {
-            configMode
-        } else if configHasRemoteUrl {
-            .remote
-        } else if let storedMode {
-            ConnectionMode(rawValue: storedMode) ?? .local
-        } else {
-            onboardingSeen ? .local : .unconfigured
-        }
+        let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
         self.connectionMode = resolvedConnectionMode
 
         let storedRemoteTarget = UserDefaults.standard.string(forKey: remoteTargetKey) ?? ""

--- a/apps/macos/Sources/Clawdbot/CommandResolver.swift
+++ b/apps/macos/Sources/Clawdbot/CommandResolver.swift
@@ -385,14 +385,8 @@ enum CommandResolver {
     }
 
     static func connectionSettings(defaults: UserDefaults = .standard) -> RemoteSettings {
-        let modeRaw = defaults.string(forKey: connectionModeKey)
-        let mode: AppState.ConnectionMode
-        if let modeRaw {
-            mode = AppState.ConnectionMode(rawValue: modeRaw) ?? .local
-        } else {
-            let seen = defaults.bool(forKey: "clawdbot.onboardingSeen")
-            mode = seen ? .local : .unconfigured
-        }
+        let root = ClawdbotConfigFile.loadDict()
+        let mode = ConnectionModeResolver.resolve(root: root, defaults: defaults).mode
         let target = defaults.string(forKey: remoteTargetKey) ?? ""
         let identity = defaults.string(forKey: remoteIdentityKey) ?? ""
         let projectRoot = defaults.string(forKey: remoteProjectRootKey) ?? ""

--- a/apps/macos/Sources/Clawdbot/ConnectionModeResolver.swift
+++ b/apps/macos/Sources/Clawdbot/ConnectionModeResolver.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum EffectiveConnectionModeSource: Sendable, Equatable {
+    case configMode
+    case configRemoteURL
+    case userDefaults
+    case onboarding
+}
+
+struct EffectiveConnectionMode: Sendable, Equatable {
+    let mode: AppState.ConnectionMode
+    let source: EffectiveConnectionModeSource
+}
+
+enum ConnectionModeResolver {
+    static func resolve(
+        root: [String: Any],
+        defaults: UserDefaults = .standard) -> EffectiveConnectionMode
+    {
+        let gateway = root["gateway"] as? [String: Any]
+        let configModeRaw = (gateway?["mode"] as? String) ?? ""
+        let configMode = configModeRaw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch configMode {
+        case "local":
+            return EffectiveConnectionMode(mode: .local, source: .configMode)
+        case "remote":
+            return EffectiveConnectionMode(mode: .remote, source: .configMode)
+        default:
+            break
+        }
+
+        let remoteURLRaw = ((gateway?["remote"] as? [String: Any])?["url"] as? String) ?? ""
+        let remoteURL = remoteURLRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !remoteURL.isEmpty {
+            return EffectiveConnectionMode(mode: .remote, source: .configRemoteURL)
+        }
+
+        if let storedModeRaw = defaults.string(forKey: connectionModeKey) {
+            let storedMode = AppState.ConnectionMode(rawValue: storedModeRaw) ?? .local
+            return EffectiveConnectionMode(mode: storedMode, source: .userDefaults)
+        }
+
+        let seen = defaults.bool(forKey: "clawdbot.onboardingSeen")
+        return EffectiveConnectionMode(mode: seen ? .local : .unconfigured, source: .onboarding)
+    }
+}
+

--- a/apps/macos/Tests/ClawdbotIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/GatewayEndpointStoreTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import Clawdbot
 
 @Suite struct GatewayEndpointStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "GatewayEndpointStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
     @Test func resolveGatewayTokenPrefersEnvAndFallsBackToLaunchd() {
         let snapshot = LaunchAgentPlistSnapshot(
             programArguments: [],
@@ -65,5 +72,71 @@ import Testing
             env: [:],
             launchdSnapshot: snapshot)
         #expect(password == "launchd-pass")
+    }
+
+    @Test func connectionModeResolverPrefersConfigModeOverDefaults() {
+        let defaults = self.makeDefaults()
+        defaults.set("remote", forKey: connectionModeKey)
+
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": " local ",
+            ],
+        ]
+
+        let resolved = ConnectionModeResolver.resolve(root: root, defaults: defaults)
+        #expect(resolved.mode == .local)
+    }
+
+    @Test func connectionModeResolverTrimsConfigMode() {
+        let defaults = self.makeDefaults()
+        defaults.set("local", forKey: connectionModeKey)
+
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": " remote ",
+            ],
+        ]
+
+        let resolved = ConnectionModeResolver.resolve(root: root, defaults: defaults)
+        #expect(resolved.mode == .remote)
+    }
+
+    @Test func connectionModeResolverFallsBackToDefaultsWhenMissingConfig() {
+        let defaults = self.makeDefaults()
+        defaults.set("remote", forKey: connectionModeKey)
+
+        let resolved = ConnectionModeResolver.resolve(root: [:], defaults: defaults)
+        #expect(resolved.mode == .remote)
+    }
+
+    @Test func connectionModeResolverFallsBackToDefaultsOnUnknownConfig() {
+        let defaults = self.makeDefaults()
+        defaults.set("local", forKey: connectionModeKey)
+
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "staging",
+            ],
+        ]
+
+        let resolved = ConnectionModeResolver.resolve(root: root, defaults: defaults)
+        #expect(resolved.mode == .local)
+    }
+
+    @Test func connectionModeResolverPrefersRemoteURLWhenModeMissing() {
+        let defaults = self.makeDefaults()
+        defaults.set("local", forKey: connectionModeKey)
+
+        let root: [String: Any] = [
+            "gateway": [
+                "remote": [
+                    "url": " ws://umbrel:18789 ",
+                ],
+            ],
+        ]
+
+        let resolved = ConnectionModeResolver.resolve(root: root, defaults: defaults)
+        #expect(resolved.mode == .remote)
     }
 }

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -21,3 +21,14 @@ clawdbot doctor --repair
 clawdbot doctor --deep
 ```
 
+## macOS: `launchctl` env overrides
+
+If you previously ran `launchctl setenv CLAWDBOT_GATEWAY_TOKEN ...` (or `...PASSWORD`), that value overrides your config file and can cause persistent “unauthorized” errors.
+
+```bash
+launchctl getenv CLAWDBOT_GATEWAY_TOKEN
+launchctl getenv CLAWDBOT_GATEWAY_PASSWORD
+
+launchctl unsetenv CLAWDBOT_GATEWAY_TOKEN
+launchctl unsetenv CLAWDBOT_GATEWAY_PASSWORD
+```

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -1,8 +1,13 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
+import type { ClawdbotConfig } from "../config/config.js";
 import { note } from "../terminal/note.js";
+
+const execFileAsync = promisify(execFile);
 
 function resolveHomeDir(): string {
   return process.env.HOME ?? os.homedir();
@@ -19,5 +24,46 @@ export async function noteMacLaunchAgentOverrides() {
     "- To restore default behavior:",
     `  rm ${markerPath}`,
   ].filter((line): line is string => Boolean(line));
+  note(lines.join("\n"), "Gateway (macOS)");
+}
+
+async function launchctlGetenv(name: string): Promise<string | undefined> {
+  try {
+    const result = await execFileAsync("/bin/launchctl", ["getenv", name], { encoding: "utf8" });
+    const value = String(result.stdout ?? "").trim();
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasConfigGatewayCreds(cfg: ClawdbotConfig): boolean {
+  const localToken = typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway?.auth?.token.trim() : "";
+  const localPassword =
+    typeof cfg.gateway?.auth?.password === "string" ? cfg.gateway?.auth?.password.trim() : "";
+  const remoteToken =
+    typeof cfg.gateway?.remote?.token === "string" ? cfg.gateway?.remote?.token.trim() : "";
+  const remotePassword =
+    typeof cfg.gateway?.remote?.password === "string" ? cfg.gateway?.remote?.password.trim() : "";
+  return Boolean(localToken || localPassword || remoteToken || remotePassword);
+}
+
+export async function noteMacLaunchctlGatewayEnvOverrides(cfg: ClawdbotConfig) {
+  if (process.platform !== "darwin") return;
+  if (!hasConfigGatewayCreds(cfg)) return;
+
+  const envToken = await launchctlGetenv("CLAWDBOT_GATEWAY_TOKEN");
+  const envPassword = await launchctlGetenv("CLAWDBOT_GATEWAY_PASSWORD");
+  if (!envToken && !envPassword) return;
+
+  const lines = [
+    "- launchctl environment overrides detected (can cause confusing unauthorized errors).",
+    envToken ? "- `CLAWDBOT_GATEWAY_TOKEN` is set; it overrides config tokens." : undefined,
+    envPassword ? "- `CLAWDBOT_GATEWAY_PASSWORD` is set; it overrides config passwords." : undefined,
+    "- Clear overrides and restart the app/gateway:",
+    envToken ? "  launchctl unsetenv CLAWDBOT_GATEWAY_TOKEN" : undefined,
+    envPassword ? "  launchctl unsetenv CLAWDBOT_GATEWAY_PASSWORD" : undefined,
+  ].filter((line): line is string => Boolean(line));
+
   note(lines.join("\n"), "Gateway (macOS)");
 }

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -38,7 +38,8 @@ async function launchctlGetenv(name: string): Promise<string | undefined> {
 }
 
 function hasConfigGatewayCreds(cfg: ClawdbotConfig): boolean {
-  const localToken = typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway?.auth?.token.trim() : "";
+  const localToken =
+    typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway?.auth?.token.trim() : "";
   const localPassword =
     typeof cfg.gateway?.auth?.password === "string" ? cfg.gateway?.auth?.password.trim() : "";
   const remoteToken =
@@ -59,7 +60,9 @@ export async function noteMacLaunchctlGatewayEnvOverrides(cfg: ClawdbotConfig) {
   const lines = [
     "- launchctl environment overrides detected (can cause confusing unauthorized errors).",
     envToken ? "- `CLAWDBOT_GATEWAY_TOKEN` is set; it overrides config tokens." : undefined,
-    envPassword ? "- `CLAWDBOT_GATEWAY_PASSWORD` is set; it overrides config passwords." : undefined,
+    envPassword
+      ? "- `CLAWDBOT_GATEWAY_PASSWORD` is set; it overrides config passwords."
+      : undefined,
     "- Clear overrides and restart the app/gateway:",
     envToken ? "  launchctl unsetenv CLAWDBOT_GATEWAY_TOKEN" : undefined,
     envPassword ? "  launchctl unsetenv CLAWDBOT_GATEWAY_PASSWORD" : undefined,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -26,7 +26,7 @@ import {
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
-import { noteMacLaunchAgentOverrides } from "./doctor-platform-notes.js";
+import { noteMacLaunchAgentOverrides, noteMacLaunchctlGatewayEnvOverrides } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
@@ -160,6 +160,7 @@ export async function doctorCommand(
   await maybeScanExtraGatewayServices(options);
   await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
   await noteMacLaunchAgentOverrides();
+  await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
   await noteSecurityWarnings(cfg);
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -26,7 +26,10 @@ import {
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
-import { noteMacLaunchAgentOverrides, noteMacLaunchctlGatewayEnvOverrides } from "./doctor-platform-notes.js";
+import {
+  noteMacLaunchAgentOverrides,
+  noteMacLaunchctlGatewayEnvOverrides,
+} from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";


### PR DESCRIPTION
## Summary

- Fixes token/password resolution to check config file's `gateway.mode` directly
- Prevents wrong token path being used when UserDefaults is out of sync with config file

Closes #1021

## Changes

The `GatewayEndpointStore.Deps.live` token and password closures now check the config file's `gateway.mode` value directly, in addition to `CommandResolver.connectionModeIsRemote()` (which reads from UserDefaults).

This ensures that when the config file has `gateway.mode = "remote"`, the app will correctly read from `gateway.remote.token` even if UserDefaults hasn't been synchronized.

```swift
let configMode = (root["gateway"] as? [String: Any])?["mode"] as? String
let isRemote = configMode?.lowercased() == "remote" || CommandResolver.connectionModeIsRemote()
```

## Test plan

- [x] Build succeeds (`swift build --package-path apps/macos`)
- [x] Configure remote mode in config file with remote token
- [x] Verify "Test remote" connects successfully
- [x] Verify local mode still works when configured

🤖 Generated with [Claude Code](https://claude.ai/code)