### PR TITLE
feat: Delivery mirroring - let agents remember what they sent

### DIFF
--- a/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
@@ -347,6 +347,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let sessionkey: String?
     public let idempotencykey: String
 
     public init(
@@ -356,6 +357,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        sessionkey: String?,
         idempotencykey: String
     ) {
         self.to = to
@@ -364,6 +366,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
@@ -373,6 +376,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }
 }

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -100,7 +100,9 @@ Common `agentTurn` fields:
 - `bestEffortDeliver`: avoid failing the job if delivery fails.
 
 Isolation options (only for `session=isolated`):
-- `postToMainPrefix` (CLI: `--post-prefix`): prefix for the summary system event in main.
+- `postToMainPrefix` (CLI: `--post-prefix`): prefix for the system event in main.
+- `postToMainMode`: `summary` (default) or `full`.
+- `postToMainMaxChars`: max chars when `postToMainMode=full` (default 8000).
 
 ### Model and thinking overrides
 Isolated jobs (`agentTurn`) can override the model and thinking level:

--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -78,6 +78,7 @@ export function createClawdbotTools(options?: {
     createCronTool(),
     createMessageTool({
       agentAccountId: options?.agentAccountId,
+      agentSessionKey: options?.agentSessionKey,
       config: options?.config,
       currentChannelId: options?.currentChannelId,
       currentThreadTs: options?.currentThreadTs,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -203,7 +203,10 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       ) {
         const text = typeof params.message === "string" ? params.message : "";
         if (text.trim()) {
-          const agentId = resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg });
+          const agentId = resolveSessionAgentId({
+            sessionKey: options.agentSessionKey,
+            config: cfg,
+          });
           await appendAssistantMessageToSessionTranscript({
             agentId,
             sessionKey: options.agentSessionKey,

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -114,6 +114,18 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       threadId: threadId ?? null,
       abortSignal,
     });
+
+    // Optional: mirror delivered text back into the session transcript so the agent "remembers" it.
+    if (cfg.messages?.deliveryMirror?.enabled && params.sessionKey) {
+      const { appendAssistantMessageToSessionTranscript } = await import("../../config/sessions.js");
+      const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg });
+      await appendAssistantMessageToSessionTranscript({
+        agentId,
+        sessionKey: params.sessionKey,
+        text,
+      });
+    }
+
     const last = results.at(-1);
     return { ok: true, messageId: last?.messageId };
   } catch (err) {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -117,7 +117,8 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
 
     // Optional: mirror delivered text back into the session transcript so the agent "remembers" it.
     if (cfg.messages?.deliveryMirror?.enabled && params.sessionKey) {
-      const { appendAssistantMessageToSessionTranscript } = await import("../../config/sessions.js");
+      const { appendAssistantMessageToSessionTranscript } =
+        await import("../../config/sessions.js");
       const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg });
       await appendAssistantMessageToSessionTranscript({
         agentId,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -184,6 +184,14 @@ export function registerCronAddCommand(cron: Command) {
                     typeof opts.postPrefix === "string" && opts.postPrefix.trim()
                       ? opts.postPrefix.trim()
                       : "Cron",
+                  postToMainMode:
+                    opts.postMode === "full" || opts.postMode === "summary"
+                      ? opts.postMode
+                      : undefined,
+                  postToMainMaxChars:
+                    typeof opts.postMaxChars === "string" && /^\d+$/.test(opts.postMaxChars)
+                      ? Number.parseInt(opts.postMaxChars, 10)
+                      : undefined,
                 }
               : undefined;
 

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -87,7 +87,17 @@ export function registerCronAddCommand(cron: Command) {
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
-      .option("--post-prefix <prefix>", "Prefix for summary system event", "Cron")
+      .option("--post-prefix <prefix>", "Prefix for main-session post", "Cron")
+      .option(
+        "--post-mode <mode>",
+        "What to post back to main for isolated jobs (summary|full)",
+        "summary",
+      )
+      .option(
+        "--post-max-chars <n>",
+        "Max chars when --post-mode=full (default 8000)",
+        "8000",
+      )
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>) => {
         try {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -93,11 +93,7 @@ export function registerCronAddCommand(cron: Command) {
         "What to post back to main for isolated jobs (summary|full)",
         "summary",
       )
-      .option(
-        "--post-max-chars <n>",
-        "Max chars when --post-mode=full (default 8000)",
-        "8000",
-      )
+      .option("--post-max-chars <n>", "Max chars when --post-mode=full (default 8000)", "8000")
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>) => {
         try {

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -4,3 +4,4 @@ export * from "./sessions/paths.js";
 export * from "./sessions/session-key.js";
 export * from "./sessions/store.js";
 export * from "./sessions/types.js";
+export * from "./sessions/transcript.js";

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
+
+describe("appendAssistantMessageToSessionTranscript", () => {
+  let tempDir: string;
+  let storePath: string;
+  let sessionsDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-test-"));
+    sessionsDir = path.join(tempDir, "agents", "main", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    storePath = path.join(sessionsDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns error for missing sessionKey", async () => {
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey: "",
+      text: "test",
+      storePath,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("missing sessionKey");
+    }
+  });
+
+  it("returns error for empty text", async () => {
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey: "test-session",
+      text: "   ",
+      storePath,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("empty text");
+    }
+  });
+
+  it("returns error for unknown sessionKey", async () => {
+    fs.writeFileSync(storePath, JSON.stringify({}), "utf-8");
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey: "nonexistent",
+      text: "test message",
+      storePath,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("unknown sessionKey");
+    }
+  });
+
+  it("creates transcript file and appends message for valid session", async () => {
+    const sessionId = "test-session-id";
+    const sessionKey = "test-session";
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        chatType: "direct",
+        channel: "discord",
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf-8");
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from delivery mirror!",
+      storePath,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(fs.existsSync(result.sessionFile)).toBe(true);
+
+      const lines = fs.readFileSync(result.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(2); // header + message
+
+      const header = JSON.parse(lines[0]);
+      expect(header.type).toBe("session");
+      expect(header.id).toBe(sessionId);
+
+      const messageLine = JSON.parse(lines[1]);
+      expect(messageLine.message.role).toBe("assistant");
+      expect(messageLine.message.content[0].type).toBe("text");
+      expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
+    }
+  });
+
+  it("appends to existing transcript file", async () => {
+    const sessionId = "existing-session";
+    const sessionKey = "existing";
+    const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+
+    // Create existing transcript
+    const existingHeader = { type: "session", version: 3, id: sessionId, timestamp: new Date().toISOString() };
+    const existingMessage = { message: { role: "user", content: [{ type: "text", text: "Hi" }] } };
+    fs.writeFileSync(sessionFile, `${JSON.stringify(existingHeader)}\n${JSON.stringify(existingMessage)}\n`, "utf-8");
+
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        sessionFile,
+        chatType: "direct",
+        channel: "discord",
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf-8");
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Mirrored reply",
+      storePath,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const lines = fs.readFileSync(result.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(3); // header + existing + new
+
+      const newMessage = JSON.parse(lines[2]);
+      expect(newMessage.message.role).toBe("assistant");
+      expect(newMessage.message.content[0].text).toBe("Mirrored reply");
+    }
+  });
+});

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -99,9 +99,18 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
 
     // Create existing transcript
-    const existingHeader = { type: "session", version: 3, id: sessionId, timestamp: new Date().toISOString() };
+    const existingHeader = {
+      type: "session",
+      version: 3,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+    };
     const existingMessage = { message: { role: "user", content: [{ type: "text", text: "Hi" }] } };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(existingHeader)}\n${JSON.stringify(existingMessage)}\n`, "utf-8");
+    fs.writeFileSync(
+      sessionFile,
+      `${JSON.stringify(existingHeader)}\n${JSON.stringify(existingMessage)}\n`,
+      "utf-8",
+    );
 
     const store = {
       [sessionKey]: {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { SessionEntry } from "./types.js";
+import { loadSessionStore, saveSessionStore } from "./store.js";
+import { resolveDefaultSessionStorePath, resolveSessionTranscriptPath } from "./paths.js";
+
+export type MirrorDeliveryMode = "full" | "summary";
+
+export async function appendAssistantMessageToSessionTranscript(params: {
+  agentId?: string;
+  sessionKey: string;
+  text: string;
+  /** Optional override for store path (mostly for tests). */
+  storePath?: string;
+}): Promise<{ ok: true; sessionFile: string } | { ok: false; reason: string }> {
+  const sessionKey = params.sessionKey.trim();
+  const text = params.text;
+  if (!sessionKey) return { ok: false, reason: "missing sessionKey" };
+  if (!text.trim()) return { ok: false, reason: "empty text" };
+
+  const storePath = params.storePath ?? resolveDefaultSessionStorePath(params.agentId);
+  const store = loadSessionStore(storePath);
+  const entry = store[sessionKey] as SessionEntry | undefined;
+  if (!entry?.sessionId) return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
+
+  const sessionFile =
+    entry.sessionFile?.trim() || resolveSessionTranscriptPath(entry.sessionId, params.agentId);
+
+  await fs.promises.mkdir(path.dirname(sessionFile), { recursive: true });
+
+  // If transcript doesn't exist, we still want to create it so the message is persisted.
+  // Use the minimal line format supported by Clawdbot transcript readers.
+  if (!fs.existsSync(sessionFile)) {
+    const header = {
+      type: "session",
+      version: 3,
+      id: entry.sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    await fs.promises.writeFile(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  }
+
+  const message = {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
+
+  await fs.promises.appendFile(sessionFile, `${JSON.stringify({ message })}\n`, "utf-8");
+
+  // Ensure the session store points at the file we just wrote.
+  if (!entry.sessionFile || entry.sessionFile !== sessionFile) {
+    await saveSessionStore(storePath, {
+      ...store,
+      [sessionKey]: {
+        ...entry,
+        sessionFile,
+      },
+    });
+  }
+
+  return { ok: true, sessionFile };
+}

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -40,6 +40,10 @@ export type AudioConfig = {
 };
 
 export type MessagesConfig = {
+  deliveryMirror?: {
+    /** Mirror delivered outbound text back into the session transcript (assistant role). */
+    enabled?: boolean;
+  };
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
   /**

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -52,6 +52,11 @@ export const MessagesSchema = z
   .object({
     messagePrefix: z.string().optional(),
     responsePrefix: z.string().optional(),
+    deliveryMirror: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .optional(),
     groupChat: GroupChatSchema,
     queue: QueueSchema,
     ackReaction: z.string().optional(),

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -25,6 +25,14 @@ export function pickSummaryFromPayloads(payloads: Array<{ text?: string | undefi
   return undefined;
 }
 
+export function pickLastNonEmptyTextFromPayloads(payloads: Array<{ text?: string | undefined }>) {
+  for (let i = payloads.length - 1; i >= 0; i--) {
+    const clean = (payloads[i]?.text ?? "").trim();
+    if (clean) return clean;
+  }
+  return undefined;
+}
+
 /**
  * Check if all payloads are just heartbeat ack responses (HEARTBEAT_OK).
  * Returns true if delivery should be skipped because there's no real content.

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -30,6 +30,8 @@ export type CronServiceDeps = {
   runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<{
     status: "ok" | "error" | "skipped";
     summary?: string;
+    /** Last non-empty agent text output (not truncated). */
+    outputText?: string;
     error?: string;
   }>;
   onEvent?: (evt: CronEvent) => void;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -66,7 +66,12 @@ export async function executeJob(
 
   let deleted = false;
 
-  const finish = async (status: "ok" | "error" | "skipped", err?: string, summary?: string) => {
+  const finish = async (
+    status: "ok" | "error" | "skipped",
+    err?: string,
+    summary?: string,
+    outputText?: string,
+  ) => {
     const endedAt = state.deps.nowMs();
     job.state.runningAtMs = undefined;
     job.state.lastRunAtMs = startedAt;
@@ -108,7 +113,19 @@ export async function executeJob(
 
     if (job.sessionTarget === "isolated") {
       const prefix = job.isolation?.postToMainPrefix?.trim() || "Cron";
-      const body = (summary ?? err ?? status).trim();
+      const mode = job.isolation?.postToMainMode ?? "summary";
+
+      let body = (summary ?? err ?? status).trim();
+      if (mode === "full") {
+        // Prefer full agent output if available; fall back to summary.
+        const maxCharsRaw = job.isolation?.postToMainMaxChars;
+        const maxChars = Number.isFinite(maxCharsRaw) ? Math.max(0, maxCharsRaw as number) : 8000;
+        const fullText = (outputText ?? "").trim();
+        if (fullText) {
+          body = fullText.length > maxChars ? `${fullText.slice(0, maxChars)}…` : fullText;
+        }
+      }
+
       const statusPrefix = status === "ok" ? prefix : `${prefix} (${status})`;
       state.deps.enqueueSystemEvent(`${statusPrefix}: ${body}`, {
         agentId: job.agentId,
@@ -182,9 +199,9 @@ export async function executeJob(
       job,
       message: job.payload.message,
     });
-    if (res.status === "ok") await finish("ok", undefined, res.summary);
-    else if (res.status === "skipped") await finish("skipped", undefined, res.summary);
-    else await finish("error", res.error ?? "cron job failed", res.summary);
+    if (res.status === "ok") await finish("ok", undefined, res.summary, res.outputText);
+    else if (res.status === "skipped") await finish("skipped", undefined, res.summary, res.outputText);
+    else await finish("error", res.error ?? "cron job failed", res.summary, res.outputText);
   } catch (err) {
     await finish("error", String(err));
   } finally {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -200,7 +200,8 @@ export async function executeJob(
       message: job.payload.message,
     });
     if (res.status === "ok") await finish("ok", undefined, res.summary, res.outputText);
-    else if (res.status === "skipped") await finish("skipped", undefined, res.summary, res.outputText);
+    else if (res.status === "skipped")
+      await finish("skipped", undefined, res.summary, res.outputText);
     else await finish("error", res.error ?? "cron job failed", res.summary, res.outputText);
   } catch (err) {
     await finish("error", String(err));

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -27,6 +27,14 @@ export type CronPayload =
 
 export type CronIsolation = {
   postToMainPrefix?: string;
+  /**
+   * What to post back into the main session after an isolated run.
+   * - summary: small status/summary line (default)
+   * - full: the agent's final text output (optionally truncated)
+   */
+  postToMainMode?: "summary" | "full";
+  /** Max chars when postToMainMode="full". Default: 8000. */
+  postToMainMaxChars?: number;
 };
 
 export type CronJobState = {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -21,6 +21,8 @@ export const SendParamsSchema = Type.Object(
     gifPlayback: Type.Optional(Type.Boolean()),
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
+    /** Optional session key for mirroring delivered output back into the transcript. */
+    sessionKey: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -55,6 +55,8 @@ export const CronPayloadSchema = Type.Union([
 export const CronIsolationSchema = Type.Object(
   {
     postToMainPrefix: Type.Optional(Type.String()),
+    postToMainMode: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("full")])),
+    postToMainMaxChars: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## 🦞 The Problem

When Clawdbot sends a message to Discord/Slack/etc., that delivery is a **side-effect that never enters the session transcript**. On the next turn, the agent has no memory of what it sent — unless it fetches channel history or reads a log file.

This is particularly painful for **cron jobs**:
- An isolated cron run generates a digest and sends it to Discord
- The `postToMain` summary is just a truncated line, not the full output
- If you ask "what did you post this morning?", the agent genuinely doesn't know

The agent literally cannot answer "what did I just say?" without extra tooling.

## 💡 The Solution: Delivery Mirroring

Add a first-class `messages.deliveryMirror` config option that **mirrors delivered messages back into the session transcript as assistant messages**.

```json
{
  "messages": {
    "deliveryMirror": {
      "enabled": true
    }
  }
}
```

When enabled, every successful outbound send also appends an `assistant` message to the session transcript with the exact text that was delivered. Future turns naturally include "what I said" in context.

## 🔧 Implementation

Mirroring hooks added at three layers (covers all send paths):

1. **`routeReply`** — normal agent replies after a turn
2. **`message` tool** — when agents use the message tool to send
3. **Gateway `send` API** — raw gateway sends (with optional `sessionKey` param)

Also adds **`isolation.postToMainMode: "full"`** for cron jobs — isolated runs can now post full output (not just summary) back to the main session.

### Files Changed
- `src/config/sessions/transcript.ts` — new `appendAssistantMessageToSessionTranscript()` helper
- `src/auto-reply/reply/route-reply.ts` — mirroring for normal replies
- `src/agents/tools/message-tool.ts` — mirroring for message tool
- `src/gateway/server-methods/send.ts` — mirroring for gateway API
- `src/cron/*` — `postToMainMode` option for isolated cron runs
- Config types + schemas updated

## ✅ Testing

- [x] Unit tests for `appendAssistantMessageToSessionTranscript` (5 tests, all passing)
- [x] Docker build + isolated gateway test
- [x] End-to-end: agent sends via message tool → message appears in transcript
- [x] Linter passes (0 warnings, 0 errors)

## 🤖 AI-Assisted

This PR was built with Claude (Opus). The implementation was tested in a Docker container with an isolated config before committing. I understand what the code does and have verified it works end-to-end.

---

**Why this matters:** Agents that can't remember what they said aren't really agents — they're stateless responders. This makes Clawdbot's cron jobs, scheduled digests, and multi-turn workflows actually coherent.