### PR TITLE
Allow cross context messaging

### DIFF
--- a/src/config/config.tools-message.test.ts
+++ b/src/config/config.tools-message.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { ClawdbotSchema } from "./zod-schema.js";
+
+describe("tools.message config", () => {
+  it("accepts allowCrossContextSend", () => {
+    const parsed = ClawdbotSchema.safeParse({
+      tools: {
+        message: {
+          allowCrossContextSend: true,
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.tools?.message?.allowCrossContextSend).toBe(true);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -105,6 +105,7 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
   "tools.exec.applyPatch.enabled": "Enable apply_patch",
   "tools.exec.applyPatch.allowModels": "apply_patch Model Allowlist",
+  "tools.message.allowCrossContextSend": "Allow Cross-Context Messaging",
   "tools.web.search.enabled": "Enable Web Search Tool",
   "tools.web.search.provider": "Web Search Provider",
   "tools.web.search.apiKey": "Brave Search API Key",
@@ -249,6 +250,8 @@ const FIELD_HELP: Record<string, string> = {
     "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
   "tools.exec.applyPatch.allowModels":
     'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
+  "tools.message.allowCrossContextSend":
+    "Allow the message tool to send outside the current chat context (default: false).",
   "tools.web.search.enabled": "Enable the web_search tool (requires Brave API key).",
   "tools.web.search.provider": 'Search provider (only "brave" supported today).',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -175,4 +175,9 @@ export type ToolsConfig = {
       deny?: string[];
     };
   };
+  /** Message tool configuration. */
+  message?: {
+    /** Allow sending messages to targets outside the current chat context. Default: false. */
+    allowCrossContextSend?: boolean;
+  };
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -288,6 +288,11 @@ export const ToolsSchema = z
         transcription: ToolsAudioTranscriptionSchema,
       })
       .optional(),
+    message: z
+      .object({
+        allowCrossContextSend: z.boolean().optional(),
+      })
+      .optional(),
     agentToAgent: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -12,7 +12,7 @@ import type {
   ChannelMessageActionName,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
-import type { ClawdbotConfig } from "../../config/config.js";
+import { loadConfig, type ClawdbotConfig } from "../../config/config.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import type { OutboundSendDeps } from "./deliver.js";
@@ -147,6 +147,9 @@ function enforceContextIsolation(params: {
   params: Record<string, unknown>;
   toolContext?: ChannelThreadingToolContext;
 }): void {
+  // Always read fresh config so changes take effect without gateway restart
+  if (loadConfig().tools?.message?.allowCrossContextSend) return;
+
   const currentTarget = params.toolContext?.currentChannelId?.trim();
   if (!currentTarget) return;
   if (!CONTEXT_GUARDED_ACTIONS.has(params.action)) return;


### PR DESCRIPTION
Context from discord:

> 9:08 PM]tinscape: @Peter Steinberger any reason to have disabled cross context posting (e.g. instructing clawdbot to send a message to another group in WhatsApp)? I liked the fact that it was possible
> 9:08 PM]Peter Steinberger: it should be. but idk out of hand. pleaes dig in

---

Coding Agent conversations:

## Claude Code

**User:** I used to be able to have the agent send a WhatsApp message to any conversation. After last git pull, I now get the error: `Cross-context messaging denied`. Verify where this comes from and if there is a configuration parameter to enable it back.

**Assistant:** Found the issue. Commit `ffc465394` ("fix: enforce message context isolation") added context isolation with no config bypass. The check is in `src/infra/outbound/message-action-runner.ts:152`. No config option exists currently. Would you like me to add one? I'd suggest `tools.message.allowCrossContextSend`.

**User:** I just updated repo, 226 new commits from contributors. Check whether the context isolation enforcement is still in place, and still no configuration for it.

**Assistant:** Confirmed: Context isolation still enforced, no config option added. Want me to add a config option to bypass it?

**User:** Yes. Create a new branch, implement the changes, run the tests, and only if all pass, commit.

**Assistant:** Done. Branch `feat/allow-cross-context-messaging` created with commit. Config option: `tools.message.allowCrossContextSend: true`. All tests pass.

**User:** Wait, I have a `clawdbot.json`, not `clawdbot.yaml`.

**Assistant:** Same structure, JSON syntax:
```json
{ "tools": { "message": { "allowCrossContextSend": true } } }
```

**User:** I just updated my ~/.clawdbot/clawdbot.json, rebuilt the gateway, restarted it, and still get the error.

**Assistant:** Found it! In `src/gateway/config-reload.ts:70`, changes to `tools.*` are ignored (no hot-reload). Fixed by making the cross-context check always read fresh config via `loadConfig()`. Updated commit - no rebuild/restart needed now.

*(At this point, still not working, decided to switch to Codex)*

**User:** Write down everything we've discussed in a concise markdown document ./handoff.md

**Assistant:** Done. Created `./handoff.md`.

---
(Here I switched to Codex)

## Codex 

**User:** Read handoff.md. That document comes from Claude Code that tried to fix the cross context messaging issue, to no avail. Investigate and implement a real solution.

**Assistant:** Root cause: `tools.message.allowCrossContextSend` was missing from config schema so it was stripped; added schema support + UI hint + validation test.

**User:** go ahead and run tests

**Assistant:** `pnpm test --filter` failed (unsupported). Ran `pnpm test -- src/config/config.tools-message.test.ts`; suite finished with 1 unrelated failure in `session-updates.test.ts` (UTC timestamp mismatch). New test passed.

**User:** It's ok, do an atomic commit.

**Assistant:** Committed only the schema changes + test; reported commit and test status.


