### PR TITLE
test: cover doctor launchctl env overrides

### DIFF
--- a/apps/macos/Sources/Clawdbot/ConnectionModeResolver.swift
+++ b/apps/macos/Sources/Clawdbot/ConnectionModeResolver.swift
@@ -47,4 +47,3 @@ enum ConnectionModeResolver {
         return EffectiveConnectionMode(mode: seen ? .local : .unconfigured, source: .onboarding)
     }
 }
-

--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,0 +1,61 @@
+import type { ClawdbotConfig } from "../config/config.js";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { noteMacLaunchctlGatewayEnvOverrides } from "./doctor-platform-notes.js";
+
+describe("noteMacLaunchctlGatewayEnvOverrides", () => {
+  it("prints clear unsetenv instructions for token override", async () => {
+    const noteFn = vi.fn();
+    const getenv = vi.fn(async (name: string) =>
+      name === "CLAWDBOT_GATEWAY_TOKEN" ? "launchctl-token" : undefined,
+    );
+    const cfg = {
+      gateway: {
+        auth: {
+          token: "config-token",
+        },
+      },
+    } as ClawdbotConfig;
+
+    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    expect(getenv).toHaveBeenCalledTimes(2);
+
+    const [message, title] = noteFn.mock.calls[0] ?? [];
+    expect(title).toBe("Gateway (macOS)");
+    expect(message).toContain("launchctl environment overrides detected");
+    expect(message).toContain("CLAWDBOT_GATEWAY_TOKEN");
+    expect(message).toContain("launchctl unsetenv CLAWDBOT_GATEWAY_TOKEN");
+    expect(message).not.toContain("CLAWDBOT_GATEWAY_PASSWORD");
+  });
+
+  it("does nothing when config has no gateway credentials", async () => {
+    const noteFn = vi.fn();
+    const getenv = vi.fn(async () => "launchctl-token");
+    const cfg = {} as ClawdbotConfig;
+
+    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
+
+    expect(getenv).not.toHaveBeenCalled();
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on non-darwin platforms", async () => {
+    const noteFn = vi.fn();
+    const getenv = vi.fn(async () => "launchctl-token");
+    const cfg = {
+      gateway: {
+        auth: {
+          token: "config-token",
+        },
+      },
+    } as ClawdbotConfig;
+
+    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "linux", getenv, noteFn });
+
+    expect(getenv).not.toHaveBeenCalled();
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a cross-platform unit test for the macOS `launchctl getenv` override warning path in `clawdbot doctor` by dependency-injecting `platform/getenv/note`.

Local:
- pnpm format:fix
- pnpm test src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
- pnpm lint
- pnpm build