### PR TITLE
fix(sessions): preserve 0600 permissions on sessions.json writes

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -135,8 +135,10 @@ async function saveSessionStoreUnlocked(
 
   const tmp = `${storePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
   try {
-    await fs.promises.writeFile(tmp, json, "utf-8");
+    await fs.promises.writeFile(tmp, json, { mode: 0o600, encoding: "utf-8" });
     await fs.promises.rename(tmp, storePath);
+    // Ensure permissions are set even if rename loses them
+    await fs.promises.chmod(storePath, 0o600);
   } catch (err) {
     const code =
       err && typeof err === "object" && "code" in err
@@ -148,7 +150,8 @@ async function saveSessionStoreUnlocked(
       // Best-effort: try a direct write (recreating the parent dir), otherwise ignore.
       try {
         await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
-        await fs.promises.writeFile(storePath, json, "utf-8");
+        await fs.promises.writeFile(storePath, json, { mode: 0o600, encoding: "utf-8" });
+        await fs.promises.chmod(storePath, 0o600);
       } catch (err2) {
         const code2 =
           err2 && typeof err2 === "object" && "code" in err2


### PR DESCRIPTION
## Summary

Fixes #1020

`sessions.json` permissions revert to 644 after normal writes, so `clawdbot security audit` keeps warning that the store is readable by others even after fixing to 600.

## Root Cause

`saveSessionStoreUnlocked` writes a temp file and `rename()`s it into place, but never restores permissions. The temp file is created with default permissions (umask 022), so the final file ends up 644.

## Fix

After write/rename, the fix now calls `fs.chmod(storePath, 0o600)` to ensure permissions persist at 0600.

## Testing

- Reproduced: chmod 600 sessions.json, send message (triggers write), file becomes 644
- After fix: chmod 600 sessions.json, send message, file stays at 600
- Security audit no longer shows false positive warnings

## Files Changed

- `src/config/sessions/store.ts`: Added `fs.chmod(storePath, 0o600)` after write/rename

## Checklist

- [x] Code follows project style guidelines
- [x] Tested locally with my Clawdbot instance
- [x] Keeps PR focused (single fix)

🤖 **AI-assisted PR**
- Developed with assistance from Claude (Anthropic AI)
- Testing: Light testing (manual verification)
- I understand what the code does: this fix ensures secure file permissions persist