### PR TITLE
feat(browser): use persistent Playwright connections for remote profile tab operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Sessions: reset `compactionCount` on `/new` and `/reset`, and preserve `sessions.json` file mode (0600).
 - Sessions: repair orphaned user turns before embedded prompts.
 - Channels: treat replies to the bot as implicit mentions across supported channels.
+- Browser: remote profile tab operations prefer persistent Playwright and avoid silent HTTP fallbacks. (#1057) — thanks @mukhtharcm.
 - WhatsApp: scope self-chat response prefix; inject pending-only group history and clear after any processed message.
 - Agents: drop unsigned Gemini tool calls and avoid JSON Schema `format` keyword collisions.
 - Auth: inherit/merge sub-agent auth profiles from the main agent.

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -33,7 +33,9 @@ export async function stageSandboxMedia(params: {
   });
 
   // For remote attachments without sandbox, use ~/.clawdbot/media (not agent workspace for privacy)
-  const remoteMediaCacheDir = ctx.MediaRemoteHost ? path.join(CONFIG_DIR, "media", "remote-cache", sessionKey) : null;
+  const remoteMediaCacheDir = ctx.MediaRemoteHost
+    ? path.join(CONFIG_DIR, "media", "remote-cache", sessionKey)
+    : null;
   const effectiveWorkspaceDir = sandbox?.workspaceDir ?? remoteMediaCacheDir;
   if (!effectiveWorkspaceDir) return;
 
@@ -53,7 +55,9 @@ export async function stageSandboxMedia(params: {
 
   try {
     // For sandbox: <workspace>/media/inbound, for remote cache: use dir directly
-    const destDir = sandbox ? path.join(effectiveWorkspaceDir, "media", "inbound") : effectiveWorkspaceDir;
+    const destDir = sandbox
+      ? path.join(effectiveWorkspaceDir, "media", "inbound")
+      : effectiveWorkspaceDir;
     await fs.mkdir(destDir, { recursive: true });
 
     const usedNames = new Set<string>();

--- a/src/browser/pw-ai.ts
+++ b/src/browser/pw-ai.ts
@@ -1,8 +1,11 @@
 export {
   type BrowserConsoleMessage,
+  closePageByTargetIdViaPlaywright,
   closePlaywrightBrowserConnection,
+  createPageViaPlaywright,
   ensurePageState,
   getPageForTargetId,
+  listPagesViaPlaywright,
   refLocator,
   type WithSnapshotForAI,
 } from "./pw-session.js";

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -394,9 +394,7 @@ export async function closePlaywrightBrowserConnection(): Promise<void> {
  * List all pages/tabs from the persistent Playwright connection.
  * Used for remote profiles where HTTP-based /json/list is ephemeral.
  */
-export async function listPagesViaPlaywright(opts: {
-  cdpUrl: string;
-}): Promise<
+export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
   Array<{
     targetId: string;
     title: string;
@@ -432,25 +430,15 @@ export async function listPagesViaPlaywright(opts: {
  * Used for remote profiles where HTTP-based /json/new is ephemeral.
  * Returns the new page's targetId and metadata.
  */
-export async function createPageViaPlaywright(opts: {
-  cdpUrl: string;
-  url: string;
-}): Promise<{
+export async function createPageViaPlaywright(opts: { cdpUrl: string; url: string }): Promise<{
   targetId: string;
   title: string;
   url: string;
   type: string;
 }> {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const contexts = browser.contexts();
-  // Use the first context if available, otherwise this is a fresh connection
-  // and we need to use the default context that Browserless provides
-  let context = contexts[0];
-  if (!context) {
-    // For Browserless over CDP, there should be at least one context
-    // If not, we can try accessing pages directly from contexts
-    throw new Error("No browser context available for creating a new page");
-  }
+  const context = browser.contexts()[0] ?? (await browser.newContext());
+  ensureContextState(context);
 
   const page = await context.newPage();
   ensurePageState(page);


### PR DESCRIPTION
## Summary

This PR completes the persistent connection support for remote CDP profiles (e.g., Browserless) that was originally intended in #895. While #895 successfully added authentication support (Basic Auth + query tokens), the tab operations continued using stateless HTTP requests, causing tabs to be terminated after each request on remote browser services.

## Problem

With remote Browserless-style services, the existing HTTP-based tab operations:
- `listTabs()` → `GET /json/list`
- `openTab()` → `PUT /json/new`
- `closeTab()` → `PUT /json/close/{id}`

...create ephemeral sessions. Browserless terminates the browser session when the HTTP request completes, so tabs don't persist between operations.

## Solution

For remote profiles (`!profile.cdpIsLoopback`), this PR switches tab operations to use Playwright's persistent connection (via the existing `connectBrowser()` caching mechanism in `pw-session.ts`):

### New functions in `pw-session.ts`:
- `listPagesViaPlaywright()` - Lists tabs via the cached Playwright connection
- `createPageViaPlaywright()` - Creates tabs via `context.newPage()`
- `closePageByTargetIdViaPlaywright()` - Closes tabs via the persistent connection

### Modified `server-context.ts`:
- `listTabs()` - Uses Playwright for remote profiles, HTTP for local
- `openTab()` - Uses Playwright for remote profiles, HTTP for local
- `closeTab()` - Uses Playwright for remote profiles, HTTP for local
- `ensureTabAvailable()` - Fixed to not require `wsUrl` for remote profiles (Playwright accesses pages directly)

## Why a Separate PR?

The original #895 PR description stated:
> **server-context.ts**: Updated to switch between "Local" (CDP) and "Remote" (Playwright) logic for listing, opening, and closing tabs. Remote profiles now use persistent Playwright connections instead of stateless HTTP requests.

However, only the authentication changes were merged. This PR implements the persistence logic that was described but not included in the final merge.

## What's NOT Affected

| Component | Impact |
|-----------|--------|
| Local profiles (loopback) | No change — still uses HTTP endpoints |
| Chrome extension relay | No change — uses its own driver |
| Snapshots/actions | Already used Playwright's persistent connection |

## Testing

- Existing unit tests pass (no regressions)
- Manually tested with a remote Browserless instance:
  - `open` → `tabs` → `snapshot` → `screenshot` all work on persistent tabs
  - Tabs survive across multiple operations

**Note:** No new unit tests added for the new functions. The existing tests use mocks and don't cover remote profile behavior.