### PR TITLE
fix(browser): remote profile tab ops follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Sessions: repair orphaned user turns before embedded prompts.
 - Channels: treat replies to the bot as implicit mentions across supported channels.
 - Browser: remote profile tab operations prefer persistent Playwright and avoid silent HTTP fallbacks. (#1057) — thanks @mukhtharcm.
+- Browser: remote profile tab ops follow-up: shared Playwright loader, Playwright-based focus, and more coverage (incl. opt-in live Browserless test). (follow-up to #1057) — thanks @mukhtharcm.
 - WhatsApp: scope self-chat response prefix; inject pending-only group history and clear after any processed message.
 - Agents: drop unsigned Gemini tool calls and avoid JSON Schema `format` keyword collisions.
 - Auth: inherit/merge sub-agent auth profiles from the main agent.

--- a/src/browser/pw-ai-module.ts
+++ b/src/browser/pw-ai-module.ts
@@ -1,0 +1,41 @@
+import { extractErrorCode, formatErrorMessage } from "../infra/errors.js";
+
+export type PwAiModule = typeof import("./pw-ai.js");
+
+type PwAiLoadMode = "soft" | "strict";
+
+let pwAiModuleSoft: Promise<PwAiModule | null> | null = null;
+let pwAiModuleStrict: Promise<PwAiModule | null> | null = null;
+
+function isModuleNotFoundError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (code === "ERR_MODULE_NOT_FOUND") return true;
+  const msg = formatErrorMessage(err);
+  return (
+    msg.includes("Cannot find module") ||
+    msg.includes("Cannot find package") ||
+    msg.includes("Failed to resolve import") ||
+    msg.includes("Failed to resolve entry for package") ||
+    msg.includes("Failed to load url")
+  );
+}
+
+async function loadPwAiModule(mode: PwAiLoadMode): Promise<PwAiModule | null> {
+  try {
+    return await import("./pw-ai.js");
+  } catch (err) {
+    if (mode === "soft") return null;
+    if (isModuleNotFoundError(err)) return null;
+    throw err;
+  }
+}
+
+export async function getPwAiModule(opts?: { mode?: PwAiLoadMode }): Promise<PwAiModule | null> {
+  const mode: PwAiLoadMode = opts?.mode ?? "soft";
+  if (mode === "soft") {
+    if (!pwAiModuleSoft) pwAiModuleSoft = loadPwAiModule("soft");
+    return await pwAiModuleSoft;
+  }
+  if (!pwAiModuleStrict) pwAiModuleStrict = loadPwAiModule("strict");
+  return await pwAiModuleStrict;
+}

--- a/src/browser/pw-ai.ts
+++ b/src/browser/pw-ai.ts
@@ -4,6 +4,7 @@ export {
   closePlaywrightBrowserConnection,
   createPageViaPlaywright,
   ensurePageState,
+  focusPageByTargetIdViaPlaywright,
   getPageForTargetId,
   listPagesViaPlaywright,
   refLocator,

--- a/src/browser/pw-session.browserless.live.test.ts
+++ b/src/browser/pw-session.browserless.live.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "vitest";
+
+const LIVE = process.env.LIVE === "1" || process.env.CLAWDBOT_LIVE_TEST === "1";
+const CDP_URL = process.env.CLAWDBOT_LIVE_BROWSER_CDP_URL?.trim() || "";
+const describeLive = LIVE && CDP_URL ? describe : describe.skip;
+
+async function waitFor(
+  fn: () => Promise<boolean>,
+  opts: { timeoutMs: number; intervalMs: number },
+): Promise<void> {
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return;
+    await new Promise((r) => setTimeout(r, opts.intervalMs));
+  }
+  throw new Error("timed out");
+}
+
+describeLive("browser (live): remote CDP tab persistence", () => {
+  it("creates, lists, focuses, and closes tabs via Playwright", { timeout: 60_000 }, async () => {
+    const pw = await import("./pw-ai.js");
+    await pw.closePlaywrightBrowserConnection().catch(() => {});
+
+    const created = await pw.createPageViaPlaywright({ cdpUrl: CDP_URL, url: "about:blank" });
+    try {
+      await waitFor(
+        async () => {
+          const pages = await pw.listPagesViaPlaywright({ cdpUrl: CDP_URL });
+          return pages.some((p) => p.targetId === created.targetId);
+        },
+        { timeoutMs: 10_000, intervalMs: 250 },
+      );
+
+      await pw.focusPageByTargetIdViaPlaywright({ cdpUrl: CDP_URL, targetId: created.targetId });
+
+      await pw.closePageByTargetIdViaPlaywright({ cdpUrl: CDP_URL, targetId: created.targetId });
+
+      await waitFor(
+        async () => {
+          const pages = await pw.listPagesViaPlaywright({ cdpUrl: CDP_URL });
+          return !pages.some((p) => p.targetId === created.targetId);
+        },
+        { timeoutMs: 10_000, intervalMs: 250 },
+      );
+    } finally {
+      await pw.closePlaywrightBrowserConnection().catch(() => {});
+    }
+  });
+});

--- a/src/browser/routes/agent.shared.ts
+++ b/src/browser/routes/agent.shared.ts
@@ -1,6 +1,8 @@
 import type express from "express";
 
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
+import type { PwAiModule } from "../pw-ai-module.js";
+import { getPwAiModule as getPwAiModuleBase } from "../pw-ai-module.js";
 import { getProfileContext, jsonError } from "./utils.js";
 
 export const SELECTOR_UNSUPPORTED_MESSAGE = [
@@ -38,20 +40,8 @@ export function resolveProfileContext(
   return profileCtx;
 }
 
-export type PwAiModule = typeof import("../pw-ai.js");
-
-let pwAiModule: Promise<PwAiModule | null> | null = null;
-
 export async function getPwAiModule(): Promise<PwAiModule | null> {
-  if (pwAiModule) return pwAiModule;
-  pwAiModule = (async () => {
-    try {
-      return await import("../pw-ai.js");
-    } catch {
-      return null;
-    }
-  })();
-  return pwAiModule;
+  return await getPwAiModuleBase({ mode: "soft" });
 }
 
 export async function requirePwAi(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -463,10 +463,7 @@ function isObjectSchema(schema: JsonSchemaObject): boolean {
 }
 
 function mergeObjectSchema(base: JsonSchemaObject, extension: JsonSchemaObject): JsonSchemaObject {
-  const mergedRequired = new Set<string>([
-    ...(base.required ?? []),
-    ...(extension.required ?? []),
-  ]);
+  const mergedRequired = new Set<string>([...(base.required ?? []), ...(extension.required ?? [])]);
   const merged: JsonSchemaObject = {
     ...base,
     ...extension,
@@ -598,12 +595,17 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
 
   for (const plugin of plugins) {
     if (!plugin.configSchema) continue;
-    const entrySchema = entryBase ? cloneSchema(entryBase) : ({ type: "object" } as JsonSchemaObject);
+    const entrySchema = entryBase
+      ? cloneSchema(entryBase)
+      : ({ type: "object" } as JsonSchemaObject);
     const entryObject = asSchemaObject(entrySchema) ?? ({ type: "object" } as JsonSchemaObject);
     const baseConfigSchema = asSchemaObject(entryObject.properties?.config);
     const pluginSchema = asSchemaObject(plugin.configSchema);
     const nextConfigSchema =
-      baseConfigSchema && pluginSchema && isObjectSchema(baseConfigSchema) && isObjectSchema(pluginSchema)
+      baseConfigSchema &&
+      pluginSchema &&
+      isObjectSchema(baseConfigSchema) &&
+      isObjectSchema(pluginSchema)
         ? mergeObjectSchema(baseConfigSchema, pluginSchema)
         : cloneSchema(plugin.configSchema);
 
@@ -683,10 +685,7 @@ export function buildConfigSchema(params?: {
   const mergedHints = applySensitiveHints(
     applyChannelHints(applyPluginHints(base.uiHints, plugins), channels),
   );
-  const mergedSchema = applyChannelSchemas(
-    applyPluginSchemas(base.schema, plugins),
-    channels,
-  );
+  const mergedSchema = applyChannelSchemas(applyPluginSchemas(base.schema, plugins), channels);
   return {
     ...base,
     schema: mergedSchema,


### PR DESCRIPTION
Follow-up to #1057.

- Factor Playwright AI module loading into a shared lazy-loader (soft/strict modes)
- Prefer Playwright-based focus (bringToFront / CDP Page.bringToFront fallback) for remote profiles
- Add more unit coverage for remote tab ops, plus an opt-in live Browserless CDP smoke test

Testing: pnpm lint && pnpm build && pnpm test

Thanks @mukhtharcm!