### PR TITLE
fix: thread accountId through subagent announce delivery chain

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -107,6 +107,7 @@ export function createClawdbotTools(options?: {
     createSessionsSpawnTool({
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
+      agentAccountId: options?.agentAccountId,
       sandboxed: options?.sandboxed,
     }),
     createSessionStatusTool({

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -187,6 +187,7 @@ export async function runSubagentAnnounceFlow(params: {
   childRunId: string;
   requesterSessionKey: string;
   requesterChannel?: string;
+  requesterAccountId?: string;
   requesterDisplayKey: string;
   task: string;
   timeoutMs: number;
@@ -285,6 +286,8 @@ export async function runSubagentAnnounceFlow(params: {
         sessionKey: params.requesterSessionKey,
         message: triggerMessage,
         deliver: true,
+        channel: params.requesterChannel,
+        accountId: params.requesterAccountId,
         idempotencyKey: crypto.randomUUID(),
       },
       timeoutMs: 60_000,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -13,6 +13,7 @@ export type SubagentRunRecord = {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterChannel?: string;
+  requesterAccountId?: string;
   requesterDisplayKey: string;
   task: string;
   cleanup: "delete" | "keep";
@@ -59,6 +60,7 @@ function resumeSubagentRun(runId: string) {
       childRunId: entry.runId,
       requesterSessionKey: entry.requesterSessionKey,
       requesterChannel: entry.requesterChannel,
+      requesterAccountId: entry.requesterAccountId,
       requesterDisplayKey: entry.requesterDisplayKey,
       task: entry.task,
       timeoutMs: 30_000,
@@ -199,6 +201,7 @@ function ensureListener() {
       childRunId: entry.runId,
       requesterSessionKey: entry.requesterSessionKey,
       requesterChannel: entry.requesterChannel,
+      requesterAccountId: entry.requesterAccountId,
       requesterDisplayKey: entry.requesterDisplayKey,
       task: entry.task,
       timeoutMs: 30_000,
@@ -248,6 +251,7 @@ export function registerSubagentRun(params: {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterChannel?: string;
+  requesterAccountId?: string;
   requesterDisplayKey: string;
   task: string;
   cleanup: "delete" | "keep";
@@ -264,6 +268,7 @@ export function registerSubagentRun(params: {
     childSessionKey: params.childSessionKey,
     requesterSessionKey: params.requesterSessionKey,
     requesterChannel: params.requesterChannel,
+    requesterAccountId: params.requesterAccountId,
     requesterDisplayKey: params.requesterDisplayKey,
     task: params.task,
     cleanup: params.cleanup,
@@ -318,6 +323,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       childRunId: entry.runId,
       requesterSessionKey: entry.requesterSessionKey,
       requesterChannel: entry.requesterChannel,
+      requesterAccountId: entry.requesterAccountId,
       requesterDisplayKey: entry.requesterDisplayKey,
       task: entry.task,
       timeoutMs: 30_000,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -48,6 +48,7 @@ function normalizeModelSelection(value: unknown): string | undefined {
 export function createSessionsSpawnTool(opts?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
+  agentAccountId?: string;
   sandboxed?: boolean;
 }): AnyAgentTool {
   return {
@@ -206,6 +207,7 @@ export function createSessionsSpawnTool(opts?: {
         childSessionKey,
         requesterSessionKey: requesterInternalKey,
         requesterChannel: opts?.agentChannel,
+        requesterAccountId: opts?.agentAccountId,
         requesterDisplayKey,
         task,
         cleanup,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -23,6 +23,8 @@ export type AgentCommandOpts = {
   /** Message channel context (webchat|voicewake|whatsapp|...). */
   messageChannel?: string;
   channel?: string; // delivery channel (whatsapp|telegram|...)
+  /** Account ID for multi-account channel routing (e.g., WhatsApp account). */
+  accountId?: string;
   deliveryTargetMode?: ChannelOutboundTargetMode;
   bestEffortDeliver?: boolean;
   abortSignal?: AbortSignal;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -50,6 +50,7 @@ export const AgentParamsSchema = Type.Object(
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     channel: Type.Optional(Type.String()),
+    accountId: Type.Optional(Type.String()),
     timeout: Type.Optional(Type.Integer({ minimum: 0 })),
     lane: Type.Optional(Type.String()),
     extraSystemPrompt: Type.Optional(Type.String()),


### PR DESCRIPTION
Fixes #1058

## Summary

When a subagent completes, the announce flow now properly routes delivery through the correct channel account (e.g., WhatsApp account `kev` instead of falling back to `default`).

## Problem

The announce delivery was failing with:
```
Delivery failed (whatsapp to +64273991111): Error: No active WhatsApp Web listener (account: default)
```

`accountId` was not being threaded through the subagent spawn → announce → delivery chain.

## Solution

Thread `accountId` through the entire lifecycle:

1. **`sessions-spawn-tool.ts`**: Accept `agentAccountId`, pass to `registerSubagentRun()`
2. **`subagent-registry.ts`**: Store `requesterAccountId` in run record, pass to announce flow
3. **`subagent-announce.ts`**: Pass `channel` + `accountId` to gateway agent call
4. **`gateway/agent.ts`**: Accept `accountId` param, resolve with session fallback
5. **`delivery.ts`**: Use `opts.accountId` with session-based fallback
6. **`agent schema`**: Add `accountId` to `AgentParamsSchema`

## Testing

Tested manually on WhatsApp:
- Before: Subagent announce delivery fails with "account: default" error
- After: Delivery succeeds via correct account (`kev`)