### PR TITLE
Fix sessions_spawn model override

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -136,7 +136,8 @@ export function createSessionsSpawnTool(opts?: {
       const resolvedModel =
         normalizeModelSelection(modelOverride) ??
         normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
-        normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
+        normalizeModelSelection(cfg.agents?.defaults?.subagents?.model) ??
+        normalizeModelSelection(targetAgentConfig?.model);
       if (resolvedModel) {
         try {
           await callGateway({


### PR DESCRIPTION
This fixes model overrides for sessions_spawn subagents so the requested model actually applies. It also adds a regression test to prevent future drift.\n\nChanges:\n- If a subagent config doesn\u2019t specify a model, fall back to the target agent\u2019s model.\n- Add a test covering sessions_spawn model overrides.\n\nTesting:\n- pnpm test src/agents/clawdbot-tools.subagents.sessions-spawn-applies-model-child-session.test.ts