### PR TITLE
Fix missing previousSessionEntry reference

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -29,6 +29,7 @@ export async function handleInlineActions(params: {
   cfg: ClawdbotConfig;
   agentId: string;
   sessionEntry?: SessionEntry;
+  previousSessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey: string;
   storePath?: string;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -173,6 +173,8 @@ export async function getReplyFromConfig(
   provider = resolvedProvider;
   model = resolvedModel;
 
+  const previousSessionEntry = sessionStore?.[sessionKey];
+
   const inlineActionResult = await handleInlineActions({
     ctx,
     sessionCtx,


### PR DESCRIPTION
Fixes a TypeScript compile error in get-reply by defining `previousSessionEntry` before inline actions and threading it through the inline action params type.\n\nChanges:\n- Define previousSessionEntry in get-reply.ts.\n- Add the optional param to the inline action signature.\n\nTesting:\n- Not run (type-only fix).