### PR TITLE
Fix CI format/protocol/lint regressions

### DIFF
--- a/apps/macos/Sources/Clawdbot/ChannelsSettings+ChannelState.swift
+++ b/apps/macos/Sources/Clawdbot/ChannelsSettings+ChannelState.swift
@@ -434,25 +434,25 @@ extension ChannelsSettings {
 
     private func resolveChannelDetailTitle(_ id: String) -> String {
         switch id {
-        case "whatsapp": return "WhatsApp Web"
-        case "telegram": return "Telegram Bot"
-        case "discord": return "Discord Bot"
-        case "slack": return "Slack Bot"
-        case "signal": return "Signal REST"
-        case "imessage": return "iMessage"
-        default: return self.resolveChannelTitle(id)
+        case "whatsapp": "WhatsApp Web"
+        case "telegram": "Telegram Bot"
+        case "discord": "Discord Bot"
+        case "slack": "Slack Bot"
+        case "signal": "Signal REST"
+        case "imessage": "iMessage"
+        default: self.resolveChannelTitle(id)
         }
     }
 
     private func resolveChannelSystemImage(_ id: String) -> String {
         switch id {
-        case "whatsapp": return "message"
-        case "telegram": return "paperplane"
-        case "discord": return "bubble.left.and.bubble.right"
-        case "slack": return "number"
-        case "signal": return "antenna.radiowaves.left.and.right"
-        case "imessage": return "message.fill"
-        default: return "message"
+        case "whatsapp": "message"
+        case "telegram": "paperplane"
+        case "discord": "bubble.left.and.bubble.right"
+        case "slack": "number"
+        case "signal": "antenna.radiowaves.left.and.right"
+        case "imessage": "message.fill"
+        default: "message"
         }
     }
 

--- a/apps/macos/Sources/Clawdbot/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/Clawdbot/ChannelsStore+Config.swift
@@ -57,7 +57,7 @@ extension ChannelsStore {
             return value
         }
         guard path.count >= 2 else { return nil }
-        if case .key("channels") = path[0], case .key(_) = path[1] {
+        if case .key("channels") = path[0], case .key = path[1] {
             let fallbackPath = Array(path.dropFirst())
             return valueAtPath(self.configDraft, path: fallbackPath)
         }
@@ -93,10 +93,10 @@ private func valueAtPath(_ root: Any, path: ConfigPath) -> Any? {
     var current: Any? = root
     for segment in path {
         switch segment {
-        case .key(let key):
+        case let .key(key):
             guard let dict = current as? [String: Any] else { return nil }
             current = dict[key]
-        case .index(let index):
+        case let .index(index):
             guard let array = current as? [Any], array.indices.contains(index) else { return nil }
             current = array[index]
         }
@@ -107,7 +107,7 @@ private func valueAtPath(_ root: Any, path: ConfigPath) -> Any? {
 private func setValue(_ root: inout Any, path: ConfigPath, value: Any?) {
     guard let segment = path.first else { return }
     switch segment {
-    case .key(let key):
+    case let .key(key):
         var dict = root as? [String: Any] ?? [:]
         if path.count == 1 {
             if let value {
@@ -122,7 +122,7 @@ private func setValue(_ root: inout Any, path: ConfigPath, value: Any?) {
         setValue(&child, path: Array(path.dropFirst()), value: value)
         dict[key] = child
         root = dict
-    case .index(let index):
+    case let .index(index):
         var array = root as? [Any] ?? []
         if index >= array.count {
             array.append(contentsOf: repeatElement(NSNull() as Any, count: index - array.count + 1))

--- a/apps/macos/Sources/Clawdbot/ConfigSchemaSupport.swift
+++ b/apps/macos/Sources/Clawdbot/ConfigSchemaSupport.swift
@@ -133,7 +133,7 @@ struct ConfigSchemaNode {
         for segment in path {
             guard let node = current else { return nil }
             switch segment {
-            case .key(let key):
+            case let .key(key):
                 if node.schemaType == "object" {
                     if let next = node.properties[key] {
                         current = next
@@ -174,7 +174,7 @@ func hintForPath(_ path: ConfigPath, hints: [String: ConfigUiHint]) -> ConfigUiH
         var match = true
         for (index, seg) in segments.enumerated() {
             let hintSegment = hintSegments[index]
-            if hintSegment != "*" && hintSegment != seg {
+            if hintSegment != "*", hintSegment != seg {
                 match = false
                 break
             }
@@ -196,7 +196,7 @@ func isSensitivePath(_ path: ConfigPath) -> Bool {
 func pathKey(_ path: ConfigPath) -> String {
     path.compactMap { segment -> String? in
         switch segment {
-        case .key(let key): return key
+        case let .key(key): return key
         case .index: return nil
         }
     }

--- a/apps/macos/Sources/Clawdbot/ConfigSettings.swift
+++ b/apps/macos/Sources/Clawdbot/ConfigSettings.swift
@@ -47,7 +47,7 @@ extension ConfigSettings {
                         .foregroundStyle(.secondary)
                 }
             }
-            if self.store.configDirty && !self.isNixMode {
+            if self.store.configDirty, !self.isNixMode {
                 Text("Unsaved changes")
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
@@ -357,7 +357,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
-        sessionkey: String? = nil,
+        sessionkey: String?,
         idempotencykey: String
     ) {
         self.to = to
@@ -431,6 +431,7 @@ public struct AgentParams: Codable, Sendable {
     public let deliver: Bool?
     public let attachments: [AnyCodable]?
     public let channel: String?
+    public let accountid: String?
     public let timeout: Int?
     public let lane: String?
     public let extrasystemprompt: String?
@@ -447,6 +448,7 @@ public struct AgentParams: Codable, Sendable {
         deliver: Bool?,
         attachments: [AnyCodable]?,
         channel: String?,
+        accountid: String?,
         timeout: Int?,
         lane: String?,
         extrasystemprompt: String?,
@@ -462,6 +464,7 @@ public struct AgentParams: Codable, Sendable {
         self.deliver = deliver
         self.attachments = attachments
         self.channel = channel
+        self.accountid = accountid
         self.timeout = timeout
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
@@ -478,6 +481,7 @@ public struct AgentParams: Codable, Sendable {
         case deliver
         case attachments
         case channel
+        case accountid = "accountId"
         case timeout
         case lane
         case extrasystemprompt = "extraSystemPrompt"

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -16,10 +16,7 @@ import {
 } from "../auto-reply/reply/queue.js";
 import { callGateway } from "../gateway/call.js";
 import { defaultRuntime } from "../runtime.js";
-import {
-  type DeliveryContext,
-  normalizeDeliveryContext,
-} from "../utils/delivery-context.js";
+import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./pi-embedded.js";
 import { readLatestAssistantReply } from "./tools/agent-step.js";
 

--- a/src/channels/plugins/discord.ts
+++ b/src/channels/plugins/discord.ts
@@ -234,8 +234,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         }
       }
       const filtered = q ? rows.filter((row) => row.name?.toLowerCase().includes(q)) : rows;
-      const limited =
-        typeof limit === "number" && limit > 0 ? filtered.slice(0, limit) : filtered;
+      const limited = typeof limit === "number" && limit > 0 ? filtered.slice(0, limit) : filtered;
       return limited;
     },
   },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -275,8 +275,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text prefix for cross-context markers (supports "{channel}").',
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
-  "tools.message.broadcast.enabled":
-    "Enable broadcast action (default: true).",
+  "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires Brave API key).",
   "tools.web.search.provider": 'Search provider (only "brave" supported today).',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -202,8 +202,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     const lastChannel = sessionEntry?.lastChannel;
     const lastTo = typeof sessionEntry?.lastTo === "string" ? sessionEntry.lastTo.trim() : "";
     const resolvedAccountId =
-      normalizeAccountId(request.accountId) ??
-      normalizeAccountId(sessionEntry?.lastAccountId);
+      normalizeAccountId(request.accountId) ?? normalizeAccountId(sessionEntry?.lastAccountId);
 
     const wantsDelivery = request.deliver === true;
 

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -157,7 +157,10 @@ describe("runMessageAction context isolation", () => {
         to: "imessage:+15551230000",
         message: "hi",
       },
-      toolContext: { currentChannelId: "imessage:+15551234567", currentChannelProvider: "imessage" },
+      toolContext: {
+        currentChannelId: "imessage:+15551234567",
+        currentChannelProvider: "imessage",
+      },
       dryRun: true,
     });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,7 +14,10 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { ClawdbotConfig } from "../../config/config.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
-import { listConfiguredMessageChannels, resolveMessageChannelSelection } from "./channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "./channel-selection.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { sendMessage, sendPoll } from "./message.js";
@@ -174,7 +177,8 @@ function enforceContextIsolation(params: {
   if (params.cfg.tools?.message?.allowCrossContextSend) return;
 
   const currentProvider = params.toolContext?.currentChannelProvider;
-  const allowWithinProvider = params.cfg.tools?.message?.crossContext?.allowWithinProvider !== false;
+  const allowWithinProvider =
+    params.cfg.tools?.message?.crossContext?.allowWithinProvider !== false;
   const allowAcrossProviders =
     params.cfg.tools?.message?.crossContext?.allowAcrossProviders === true;
 
@@ -215,7 +219,9 @@ async function resolveChannel(cfg: ClawdbotConfig, params: Record<string, unknow
 }
 
 function shouldApplyCrossContextMarker(action: ChannelMessageActionName): boolean {
-  return action === "send" || action === "poll" || action === "thread-reply" || action === "sticker";
+  return (
+    action === "send" || action === "poll" || action === "thread-reply" || action === "sticker"
+  );
 }
 
 async function buildCrossContextMarker(params: {
@@ -445,7 +451,9 @@ export async function runMessageAction(
         : null;
     const useTextMarker = !(channel === "discord" && marker?.discordEmbeds?.length);
     if (useTextMarker && (marker?.prefix || marker?.suffix)) {
-      const merged = `${marker?.prefix ?? ""}${message}${marker?.suffix ?? ""}`;
+      const markerPrefix = typeof marker?.prefix === "string" ? marker.prefix : "";
+      const markerSuffix = typeof marker?.suffix === "string" ? marker.suffix : "";
+      const merged = `${markerPrefix}${message}${markerSuffix}`;
       params.message = merged;
       message = merged;
     }

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -51,7 +51,10 @@ function normalizeQuery(value: string): string {
 }
 
 function stripTargetPrefixes(value: string): string {
-  return value.replace(/^(channel|group|user):/i, "").replace(/^[@#]/, "").trim();
+  return value
+    .replace(/^(channel|group|user):/i, "")
+    .replace(/^[@#]/, "")
+    .trim();
 }
 
 function preserveTargetCase(channel: ChannelId, raw: string, normalized: string): string {
@@ -152,7 +155,7 @@ async function listDirectoryEntries(params: {
   const runtime = params.runtime ?? defaultRuntime;
   const useLive = params.source === "live";
   if (params.kind === "user") {
-    const fn = useLive ? directory.listPeersLive ?? directory.listPeers : directory.listPeers;
+    const fn = useLive ? (directory.listPeersLive ?? directory.listPeers) : directory.listPeers;
     if (!fn) return [];
     return await fn({
       cfg: params.cfg,
@@ -162,7 +165,7 @@ async function listDirectoryEntries(params: {
       runtime,
     });
   }
-  const fn = useLive ? directory.listGroupsLive ?? directory.listGroups : directory.listGroups;
+  const fn = useLive ? (directory.listGroupsLive ?? directory.listGroups) : directory.listGroups;
   if (!fn) return [];
   return await fn({
     cfg: params.cfg,
@@ -277,9 +280,7 @@ export async function resolveMessagingTarget(params: {
   if (match.kind === "ambiguous") {
     return {
       ok: false,
-      error: new Error(
-        `Ambiguous target "${raw}". Provide a unique name or an explicit id.`,
-      ),
+      error: new Error(`Ambiguous target "${raw}". Provide a unique name or an explicit id.`),
       candidates: match.entries,
     };
   }

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -8,8 +8,7 @@ export type DeliveryContext = {
 
 export function normalizeDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
   if (!context) return undefined;
-  const channel =
-    typeof context.channel === "string" ? context.channel.trim() : undefined;
+  const channel = typeof context.channel === "string" ? context.channel.trim() : undefined;
   const to = typeof context.to === "string" ? context.to.trim() : undefined;
   const accountId = normalizeAccountId(context.accountId);
   if (!channel && !to && !accountId) return undefined;


### PR DESCRIPTION
## Summary\n- Fix TS build errors in message-action runner/tool.\n- Apply oxfmt formatting to touched TS files.\n- Regenerate protocol Swift models (GatewayModels.swift).\n- Apply SwiftFormat fixes for macOS sources.\n\n## Details\n- Addresses CI failures in build/format/protocol/lint.\n\n## Testing\n- pnpm format\n- pnpm build\n- pnpm protocol:check\n- swiftformat --lint apps/macos/Sources --config .swiftformat