### PR TITLE
fix: handle object-format capabilities in normalizeCapabilities

### DIFF
--- a/src/config/channel-capabilities.test.ts
+++ b/src/config/channel-capabilities.test.ts
@@ -105,6 +105,26 @@ describe("resolveChannelCapabilities", () => {
       }),
     ).toEqual(["polls"]);
   });
+
+  it("handles object-format capabilities gracefully (e.g., { inlineButtons: 'dm' })", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          // Object format - used for granular control like inlineButtons scope.
+          // Channel-specific handlers (resolveTelegramInlineButtonsScope) process these.
+          capabilities: { inlineButtons: "dm" },
+        },
+      },
+    };
+
+    // Should return undefined (not crash), allowing channel-specific handlers to process it.
+    expect(
+      resolveChannelCapabilities({
+        cfg: cfg as ClawdbotConfig,
+        channel: "telegram",
+      }),
+    ).toBeUndefined();
+  });
 });
 
 const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry => ({

--- a/src/config/channel-capabilities.ts
+++ b/src/config/channel-capabilities.ts
@@ -4,6 +4,9 @@ import type { ClawdbotConfig } from "./config.js";
 
 function normalizeCapabilities(capabilities: string[] | undefined): string[] | undefined {
   if (!capabilities) return undefined;
+  // Handle object-format capabilities (e.g., { inlineButtons: "dm" }) gracefully.
+  // Channel-specific handlers (like resolveTelegramInlineButtonsScope) process these separately.
+  if (!Array.isArray(capabilities)) return undefined;
   const normalized = capabilities.map((entry) => entry.trim()).filter(Boolean);
   return normalized.length > 0 ? normalized : undefined;
 }


### PR DESCRIPTION
When using the new Telegram inline buttons scoping feature (`channels.telegram.capabilities.inlineButtons = "dm"`), the agent crashes with:

```
Agent failed before reply: capabilities.map is not a function
```

**Root cause:** `normalizeCapabilities()` expects `string[]` but `TelegramCapabilitiesConfig` can be an object `{ inlineButtons: "dm" }`.

**Fix:** Add `Array.isArray()` guard. Returns `undefined` for non-array, letting `resolveTelegramInlineButtonsScope()` handle object format.

Tested locally with `capabilities: { inlineButtons: "dm" }` config.