### PR TITLE
fix: handle telegram: prefix in resolveTelegramTargetChatType

### DIFF
--- a/src/telegram/inline-buttons.test.ts
+++ b/src/telegram/inline-buttons.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTelegramTargetChatType } from "./inline-buttons.js";
+
+describe("resolveTelegramTargetChatType", () => {
+  it("returns 'direct' for positive numeric IDs", () => {
+    expect(resolveTelegramTargetChatType("5232990709")).toBe("direct");
+    expect(resolveTelegramTargetChatType("123456789")).toBe("direct");
+  });
+
+  it("returns 'group' for negative numeric IDs", () => {
+    expect(resolveTelegramTargetChatType("-123456789")).toBe("group");
+    expect(resolveTelegramTargetChatType("-1001234567890")).toBe("group");
+  });
+
+  it("handles telegram: prefix from normalizeTelegramMessagingTarget", () => {
+    expect(resolveTelegramTargetChatType("telegram:5232990709")).toBe("direct");
+    expect(resolveTelegramTargetChatType("telegram:-123456789")).toBe("group");
+    expect(resolveTelegramTargetChatType("TELEGRAM:5232990709")).toBe("direct");
+  });
+
+  it("returns 'unknown' for usernames", () => {
+    expect(resolveTelegramTargetChatType("@username")).toBe("unknown");
+    expect(resolveTelegramTargetChatType("telegram:@username")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for empty strings", () => {
+    expect(resolveTelegramTargetChatType("")).toBe("unknown");
+    expect(resolveTelegramTargetChatType("   ")).toBe("unknown");
+  });
+});

--- a/src/telegram/inline-buttons.ts
+++ b/src/telegram/inline-buttons.ts
@@ -61,8 +61,12 @@ export function isTelegramInlineButtonsEnabled(params: {
 }
 
 export function resolveTelegramTargetChatType(target: string): "direct" | "group" | "unknown" {
-  const trimmed = target.trim();
+  let trimmed = target.trim();
   if (!trimmed) return "unknown";
+  // Strip telegram: prefix added by normalizeTelegramMessagingTarget
+  if (trimmed.toLowerCase().startsWith("telegram:")) {
+    trimmed = trimmed.slice("telegram:".length).trim();
+  }
   if (/^-?\d+$/.test(trimmed)) {
     return trimmed.startsWith("-") ? "group" : "direct";
   }


### PR DESCRIPTION
When using `inlineButtons="dm"` or `"group"` scope, the validation in `resolveTelegramTargetChatType()` fails for numeric chat IDs.

**Root cause:** `normalizeTelegramMessagingTarget()` adds a `telegram:` prefix during target resolution:
- Input: `"5232990709"`
- After normalization: `"telegram:5232990709"`

But `resolveTelegramTargetChatType()` expects a pure numeric string and its regex `/^-?\d+$/` fails on the prefixed value.

**Error seen:**
```
Telegram inline buttons require a numeric chat id when inlineButtons="dm".
```

**Fix:** Strip the `telegram:` prefix before checking the numeric pattern.

**Tests:** Added test file for `resolveTelegramTargetChatType` covering:
- Positive numeric IDs (DMs)
- Negative numeric IDs (groups)
- Prefixed targets (`telegram:xxx`)
- Usernames
- Empty strings