### PR TITLE
Fix #1056: prevent macOS FD exhaustion by ignoring node_modules in skills watcher

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+const watchMock = vi.fn(() => ({
+  on: vi.fn(),
+  close: vi.fn(async () => undefined),
+}));
+
+vi.mock("chokidar", () => {
+  return {
+    default: { watch: watchMock },
+  };
+});
+
+describe("ensureSkillsWatcher", () => {
+  it("ignores node_modules and dist by default", async () => {
+    const mod = await import("./refresh.js");
+    mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
+
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    const opts = watchMock.mock.calls[0]?.[1] as { ignored?: unknown };
+
+    expect(Array.isArray(opts.ignored)).toBe(true);
+    const ignored = opts.ignored as RegExp[];
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/node_modules/pkg/index.js"))).toBe(
+      true,
+    );
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/dist/index.js"))).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
+  });
+});

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -125,6 +125,13 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Cla
       stabilityThreshold: debounceMs,
       pollInterval: 100,
     },
+    // Avoid FD exhaustion on macOS when a workspace contains huge trees.
+    // This watcher only needs to react to skill changes.
+    ignored: [
+      /(^|[\\/])\../, // dotfiles (includes .git)
+      /(^|[\\/])node_modules([\\/]|$)/,
+      /(^|[\\/])dist([\\/]|$)/,
+    ],
   });
 
   const state: SkillsWatchState = { watcher, pathsKey, debounceMs };


### PR DESCRIPTION
Fixes #1056.

Problem
- On macOS, `chokidar` can hold huge numbers of file descriptors when asked to watch deep dependency trees (notably `node_modules`).
- Clawdbot starts a skills watcher per workspace; if the workspace contains large trees under the watched paths, FD exhaustion can cause `child_process.spawn` to fail with `spawn EBADF`, breaking tool execution.

Fix
- The skills watcher only needs to react to skill changes, so add default `ignored` patterns to skip dotfiles (incl. `.git`), `node_modules`, and `dist`.

Tests
- Add `src/agents/skills/refresh.test.ts` asserting the watcher is configured with the ignore patterns.