### PR TITLE
Fix #1004: handle embeddings 429 without crashing + codex OAuth fallback

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -8,7 +8,7 @@ import { resolveAgentConfig } from "./agent-scope.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;
-  provider: "openai" | "local";
+  provider: "openai" | "openai-codex" | "local";
   remote?: {
     baseUrl?: string;
     apiKey?: string;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -345,7 +345,7 @@ const FIELD_HELP: Record<string, string> = {
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
   "agents.defaults.memorySearch":
     "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
-  "agents.defaults.memorySearch.provider": 'Embedding provider ("openai" or "local").',
+  "agents.defaults.memorySearch.provider": 'Embedding provider ("openai", "openai-codex", or "local").',
   "agents.defaults.memorySearch.remote.baseUrl":
     "Custom OpenAI-compatible base URL (e.g. for Gemini/OpenRouter proxies).",
   "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -121,7 +121,7 @@ export type MemorySearchConfig = {
   /** Enable vector memory search (default: true). */
   enabled?: boolean;
   /** Embedding provider mode. */
-  provider?: "openai" | "local";
+  provider?: "openai" | "openai-codex" | "local";
   remote?: {
     baseUrl?: string;
     apiKey?: string;

--- a/src/memory/manager.sync-errors-do-not-crash.test.ts
+++ b/src/memory/manager.sync-errors-do-not-crash.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
+
+vi.mock("chokidar", () => ({
+  default: {
+    watch: vi.fn(() => ({
+      on: vi.fn(),
+      close: vi.fn(async () => undefined),
+    })),
+  },
+}));
+
+vi.mock("./embeddings.js", () => {
+  return {
+    createEmbeddingProvider: async () => ({
+      requestedProvider: "openai",
+      provider: {
+        id: "mock",
+        model: "mock-embed",
+        embedQuery: async () => [0, 0, 0],
+        embedBatch: async () => {
+          throw new Error("openai embeddings failed: 429 insufficient_quota");
+        },
+      },
+    }),
+  };
+});
+
+describe("memory manager sync failures", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-mem-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"));
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Hello");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("does not raise unhandledRejection when watch-triggered sync fails", async () => {
+    const unhandled: unknown[] = [];
+    const handler = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", handler);
+
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath },
+            sync: { watch: true, watchDebounceMs: 1, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    expect(result.manager).not.toBeNull();
+    if (!result.manager) throw new Error("manager missing");
+    manager = result.manager;
+
+    // Call the internal scheduler directly; it uses fire-and-forget sync.
+    (manager as unknown as { scheduleWatchSync: () => void }).scheduleWatchSync();
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    process.off("unhandledRejection", handler);
+    expect(unhandled).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #1004.

Problem
- MemorySearch indexing can run in watch/interval mode via fire-and-forget `sync()` calls. When remote embeddings fail (e.g. OpenAI 429 insufficient_quota), the rejected promise can become an unhandled rejection and the gateway exits.
- Embeddings auth was hardcoded to provider `openai`, so working `openai-codex:*` OAuth profiles (used for chat) were never attempted as a fallback when `OPENAI_API_KEY` is out of quota.

Fix
- Catch and log failures from watch/interval-triggered sync so the gateway stays up even when embeddings fail.
- Allow `agents.defaults.memorySearch.provider = "openai-codex"`.
- When the provider is `openai` and the embeddings endpoint returns 429 insufficient_quota, retry once using `openai-codex` credentials (if available).

Tests
- Add regression test that 429 insufficient_quota triggers a retry with `openai-codex`.
- Add regression test ensuring watch-triggered sync failures do not raise `unhandledRejection`.