### PR TITLE
TUI: refresh token counts after agent runs complete

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -8,10 +8,11 @@ type EventHandlerContext = {
   tui: TUI;
   state: TuiStateAccess;
   setActivityStatus: (text: string) => void;
+  refreshSessionInfo?: () => Promise<void>;
 };
 
 export function createEventHandlers(context: EventHandlerContext) {
-  const { chatLog, tui, state, setActivityStatus } = context;
+  const { chatLog, tui, state, setActivityStatus, refreshSessionInfo } = context;
   const finalizedRuns = new Map<string, number>();
 
   const noteFinalizedRun = (runId: string) => {
@@ -64,6 +65,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus(stopReason === "error" ? "error" : "idle");
+      // Refresh session info to update token counts in footer
+      void refreshSessionInfo?.();
     }
     if (evt.state === "aborted") {
       chatLog.addSystem("run aborted");

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -399,6 +399,7 @@ export async function runTui(opts: TuiOptions) {
     tui,
     state,
     setActivityStatus,
+    refreshSessionInfo,
   });
 
   const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =


### PR DESCRIPTION
## Summary

- Fixes the TUI footer showing `tokens 0/200k (0%)` even when sessions have significant token usage
- Adds `refreshSessionInfo()` call after agent runs complete to update the footer with accurate token counts

## Problem

The TUI never refreshed session info after agent runs, so token counts stayed at their initial values (often 0). This prevented users from seeing context buildup and getting warnings before hitting the 200K context limit.

## Changes

- `src/tui/tui-event-handlers.ts`: Added `refreshSessionInfo` to context and call it when `evt.state === "final"`
- `src/tui/tui.ts`: Pass `refreshSessionInfo` to `createEventHandlers()`

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All 3,204 tests pass (`pnpm test`)
- [ ] Manual: Start TUI, send messages, verify token counter updates in footer after each response

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)