### PR TITLE
Add Kimi Code provider onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 
 ### Changes
 - macOS: strip prerelease/build suffixes when parsing gateway semver patches. (#1110) — thanks @zerone0x.
+- Models: add Kimi Code provider onboarding and docs. (#1085) — thanks @dan-dr.
 
 ## 2026.1.16-2
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -292,7 +292,7 @@ Options:
 - `--non-interactive`
 - `--mode <local|remote>`
 - `--flow <quickstart|advanced>`
-- `--auth-choice <setup-token|claude-cli|token|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|opencode-zen|skip>`
+- `--auth-choice <setup-token|claude-cli|token|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|opencode-zen|skip>`
 - `--token-provider <id>` (non-interactive; used with `--auth-choice token`)
 - `--token <token>` (non-interactive; used with `--auth-choice token`)
 - `--token-profile-id <id>` (non-interactive; default: `<provider>:manual`)
@@ -302,6 +302,7 @@ Options:
 - `--openrouter-api-key <key>`
 - `--ai-gateway-api-key <key>`
 - `--moonshot-api-key <key>`
+- `--kimi-code-api-key <key>`
 - `--gemini-api-key <key>`
 - `--zai-api-key <key>`
 - `--minimax-api-key <key>`

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -155,6 +155,34 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 }
 ```
 
+### Kimi Code
+
+Kimi Code uses a dedicated endpoint and key (separate from Moonshot):
+
+- Provider: `kimi-code`
+- Auth: `KIMICODE_API_KEY`
+- Example model: `kimi-code/kimi-for-coding`
+
+```json5
+{
+  env: { KIMICODE_API_KEY: "sk-..." },
+  agents: {
+    defaults: { model: { primary: "kimi-code/kimi-for-coding" } }
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      "kimi-code": {
+        baseUrl: "https://api.kimi.com/coding/v1",
+        apiKey: "${KIMICODE_API_KEY}",
+        api: "openai-completions",
+        models: [{ id: "kimi-for-coding", name: "Kimi For Coding" }]
+      }
+    }
+  }
+}
+```
+
 ### Synthetic
 
 Synthetic provides Anthropic-compatible models behind the `synthetic` provider:

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2234,6 +2234,49 @@ Notes:
 - Model ref: `moonshot/kimi-k2-0905-preview`.
 - Use `https://api.moonshot.cn/v1` if you need the China endpoint.
 
+### Kimi Code
+
+Use Kimi Code's dedicated OpenAI-compatible endpoint (separate from Moonshot):
+
+```json5
+{
+  env: { KIMICODE_API_KEY: "sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "kimi-code/kimi-for-coding" },
+      models: { "kimi-code/kimi-for-coding": { alias: "Kimi Code" } }
+    }
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      "kimi-code": {
+        baseUrl: "https://api.kimi.com/coding/v1",
+        apiKey: "${KIMICODE_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "kimi-for-coding",
+            name: "Kimi For Coding",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 262144,
+            maxTokens: 32768,
+            headers: { "User-Agent": "KimiCLI/0.77" },
+            compat: { supportsDeveloperRole: false }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Notes:
+- Set `KIMICODE_API_KEY` in the environment or use `clawdbot onboard --auth-choice kimi-code-api-key`.
+- Model ref: `kimi-code/kimi-for-coding`.
+
 ### Synthetic (Anthropic-compatible)
 
 Use Synthetic's Anthropic-compatible endpoint:

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,7 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/etc.)? See [Chann
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [OpenRouter](/providers/openrouter)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
-- [Moonshot AI (Kimi)](/providers/moonshot)
+- [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)
 - [Z.AI](/providers/zai)
 - [GLM models](/providers/glm)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -26,7 +26,7 @@ model as `provider/model`.
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [OpenRouter](/providers/openrouter)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
-- [Moonshot AI (Kimi)](/providers/moonshot)
+- [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
 - [Synthetic](/providers/synthetic)
 - [OpenCode Zen](/providers/opencode)
 - [Z.AI](/providers/zai)

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -1,13 +1,16 @@
 ---
-summary: "Use Moonshot AI (Kimi K2) with Clawdbot"
+summary: "Configure Moonshot K2 vs Kimi Code (separate providers + keys)"
 read_when:
-  - You want to use Moonshot/Kimi models in Clawdbot
-  - You need the Moonshot auth + config example
+  - You want Moonshot K2 (Moonshot Open Platform) vs Kimi Code setup
+  - You need to understand separate endpoints, keys, and model refs
+  - You want copy/paste config for either provider
 ---
+
 # Moonshot AI (Kimi)
 
 Moonshot provides the Kimi API with OpenAI-compatible endpoints. Configure the
-provider and set the default model to `moonshot/kimi-k2-0905-preview`.
+provider and set the default model to `moonshot/kimi-k2-0905-preview`, or use
+Kimi Code with `kimi-code/kimi-for-coding`.
 
 Current Kimi K2 model IDs:
 {/* moonshot-kimi-k2-ids:start */}
@@ -21,7 +24,15 @@ Current Kimi K2 model IDs:
 clawdbot onboard --auth-choice moonshot-api-key
 ```
 
-## Config snippet
+Kimi Code:
+
+```bash
+clawdbot onboard --auth-choice kimi-code-api-key
+```
+
+Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeable, endpoints differ, and model refs differ (Moonshot uses `moonshot/...`, Kimi Code uses `kimi-code/...`).
+
+## Config snippet (Moonshot API)
 
 ```json5
 {
@@ -92,9 +103,48 @@ clawdbot onboard --auth-choice moonshot-api-key
 }
 ```
 
+## Kimi Code
+
+```json5
+{
+  env: { KIMICODE_API_KEY: "sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "kimi-code/kimi-for-coding" },
+      models: {
+        "kimi-code/kimi-for-coding": { alias: "Kimi Code" }
+      }
+    }
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      "kimi-code": {
+        baseUrl: "https://api.kimi.com/coding/v1",
+        apiKey: "${KIMICODE_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "kimi-for-coding",
+            name: "Kimi For Coding",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 262144,
+            maxTokens: 32768,
+            headers: { "User-Agent": "KimiCLI/0.77" },
+            compat: { supportsDeveloperRole: false }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ## Notes
 
-- Model refs use `moonshot/<modelId>`.
+- Moonshot model refs use `moonshot/<modelId>`. Kimi Code model refs use `kimi-code/<modelId>`.
 - Override pricing and context metadata in `models.providers` if needed.
 - If Moonshot publishes different context limits for a model, adjust
   `contextWindow` accordingly.

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -95,7 +95,8 @@ Tip: `--json` does **not** imply non-interactive mode. Use `--non-interactive` (
    - **Synthetic (Anthropic-compatible)**: prompts for `SYNTHETIC_API_KEY`.
    - More detail: [Synthetic](/providers/synthetic)
    - **Moonshot (Kimi K2)**: config is auto-written.
-   - More detail: [Moonshot AI](/providers/moonshot)
+   - **Kimi Code**: config is auto-written.
+   - More detail: [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
    - **Skip**: no auth configured yet.
    - Pick a default model from detected options (or enter provider/model manually).
    - Wizard runs a model check and warns if the configured model is unknown or missing auth.

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -157,6 +157,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     openrouter: "OPENROUTER_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
+    "kimi-code": "KIMICODE_API_KEY",
     minimax: "MINIMAX_API_KEY",
     synthetic: "SYNTHETIC_API_KEY",
     mistral: "MISTRAL_API_KEY",

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -43,6 +43,12 @@ const KIMI_CODE_CONTEXT_WINDOW = 262144;
 const KIMI_CODE_MAX_TOKENS = 32768;
 const KIMI_CODE_HEADERS = { "User-Agent": "KimiCLI/0.77" } as const;
 const KIMI_CODE_COMPAT = { supportsDeveloperRole: false } as const;
+const KIMI_CODE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
 
 function normalizeApiKeyConfig(value: string): string {
   const trimmed = value.trim();
@@ -200,7 +206,7 @@ function buildKimiCodeProvider(): ProviderConfig {
         name: "Kimi For Coding",
         reasoning: true,
         input: ["text"],
-        cost: MOONSHOT_DEFAULT_COST,
+        cost: KIMI_CODE_DEFAULT_COST,
         contextWindow: KIMI_CODE_CONTEXT_WINDOW,
         maxTokens: KIMI_CODE_MAX_TOKENS,
         headers: KIMI_CODE_HEADERS,

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -180,6 +180,29 @@ describe("cli program (smoke)", () => {
     );
   });
 
+  it("passes kimi code api key to onboard", async () => {
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        "onboard",
+        "--non-interactive",
+        "--auth-choice",
+        "kimi-code-api-key",
+        "--kimi-code-api-key",
+        "sk-kimi-code-test"
+      ],
+      { from: "user" },
+    );
+    expect(onboardCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonInteractive: true,
+        authChoice: "kimi-code-api-key",
+        kimiCodeApiKey: "sk-kimi-code-test"
+      }),
+      runtime,
+    );
+  });
+
   it("passes synthetic api key to onboard", async () => {
     const program = buildProgram();
     await program.parseAsync(

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -51,7 +51,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|claude-cli|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|synthetic-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|claude-cli|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
     )
     .option(
       "--token-provider <id>",
@@ -68,6 +68,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--openrouter-api-key <key>", "OpenRouter API key")
     .option("--ai-gateway-api-key <key>", "Vercel AI Gateway API key")
     .option("--moonshot-api-key <key>", "Moonshot API key")
+    .option("--kimi-code-api-key <key>", "Kimi Code API key")
     .option("--gemini-api-key <key>", "Gemini API key")
     .option("--zai-api-key <key>", "Z.AI API key")
     .option("--minimax-api-key <key>", "MiniMax API key")
@@ -116,6 +117,7 @@ export function registerOnboardCommand(program: Command) {
             openrouterApiKey: opts.openrouterApiKey as string | undefined,
             aiGatewayApiKey: opts.aiGatewayApiKey as string | undefined,
             moonshotApiKey: opts.moonshotApiKey as string | undefined,
+            kimiCodeApiKey: opts.kimiCodeApiKey as string | undefined,
             geminiApiKey: opts.geminiApiKey as string | undefined,
             zaiApiKey: opts.zaiApiKey as string | undefined,
             minimaxApiKey: opts.minimaxApiKey as string | undefined,

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -100,6 +100,7 @@ describe("buildAuthChoiceOptions", () => {
     });
 
     expect(options.some((opt) => opt.value === "moonshot-api-key")).toBe(true);
+    expect(options.some((opt) => opt.value === "kimi-code-api-key")).toBe(true);
   });
 
   it("includes Vercel AI Gateway auth choice", () => {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -79,8 +79,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "moonshot",
     label: "Moonshot AI",
-    hint: "Kimi K2 preview",
-    choices: ["moonshot-api-key"],
+    hint: "Kimi K2 + Kimi Code",
+    choices: ["moonshot-api-key", "kimi-code-api-key"],
   },
   {
     value: "zai",
@@ -180,6 +180,7 @@ export function buildAuthChoiceOptions(params: {
     label: "Vercel AI Gateway API key",
   });
   options.push({ value: "moonshot-api-key", label: "Moonshot AI API key" });
+  options.push({ value: "kimi-code-api-key", label: "Kimi Code API key" });
   options.push({ value: "synthetic-api-key", label: "Synthetic API key" });
   options.push({
     value: "github-copilot",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -13,6 +13,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "openrouter-api-key": "openrouter",
   "ai-gateway-api-key": "vercel-ai-gateway",
   "moonshot-api-key": "moonshot",
+  "kimi-code-api-key": "kimi-code",
   "gemini-api-key": "google",
   "zai-api-key": "zai",
   "synthetic-api-key": "synthetic",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -11,7 +11,11 @@ import {
   ZAI_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";
 import {
+  buildKimiCodeModelDefinition,
   buildMoonshotModelDefinition,
+  KIMI_CODE_BASE_URL,
+  KIMI_CODE_MODEL_ID,
+  KIMI_CODE_MODEL_REF,
   MOONSHOT_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
@@ -186,6 +190,71 @@ export function applyMoonshotConfig(cfg: ClawdbotConfig): ClawdbotConfig {
               }
             : undefined),
           primary: MOONSHOT_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+}
+
+export function applyKimiCodeProviderConfig(cfg: ClawdbotConfig): ClawdbotConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[KIMI_CODE_MODEL_REF] = {
+    ...models[KIMI_CODE_MODEL_REF],
+    alias: models[KIMI_CODE_MODEL_REF]?.alias ?? "Kimi Code"
+  };
+
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers["kimi-code"];
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const defaultModel = buildKimiCodeModelDefinition();
+  const hasDefaultModel = existingModels.some((model) => model.id === KIMI_CODE_MODEL_ID);
+  const mergedModels = hasDefaultModel ? existingModels : [...existingModels, defaultModel];
+  const { apiKey: existingApiKey, ...existingProviderRest } = (existingProvider ?? {}) as Record<
+    string,
+    unknown
+  > as { apiKey?: string };
+  const resolvedApiKey = typeof existingApiKey === "string" ? existingApiKey : undefined;
+  const normalizedApiKey = resolvedApiKey?.trim();
+  providers["kimi-code"] = {
+    ...existingProviderRest,
+    baseUrl: KIMI_CODE_BASE_URL,
+    api: "openai-completions",
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: mergedModels.length > 0 ? mergedModels : [defaultModel]
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export function applyKimiCodeConfig(cfg: ClawdbotConfig): ClawdbotConfig {
+  const next = applyKimiCodeProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: KIMI_CODE_MODEL_REF
         },
       },
     },

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -73,6 +73,19 @@ export async function setMoonshotApiKey(key: string, agentDir?: string) {
   });
 }
 
+export async function setKimiCodeApiKey(key: string, agentDir?: string) {
+  // Write to resolved agent dir so gateway finds credentials on startup.
+  upsertAuthProfile({
+    profileId: "kimi-code:default",
+    credential: {
+      type: "api_key",
+      provider: "kimi-code",
+      key
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export async function setSyntheticApiKey(key: string, agentDir?: string) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -12,6 +12,13 @@ export const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2-0905-preview";
 export const MOONSHOT_DEFAULT_MODEL_REF = `moonshot/${MOONSHOT_DEFAULT_MODEL_ID}`;
 export const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
 export const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
+export const KIMI_CODE_BASE_URL = "https://api.kimi.com/coding/v1";
+export const KIMI_CODE_MODEL_ID = "kimi-for-coding";
+export const KIMI_CODE_MODEL_REF = `kimi-code/${KIMI_CODE_MODEL_ID}`;
+export const KIMI_CODE_CONTEXT_WINDOW = 262144;
+export const KIMI_CODE_MAX_TOKENS = 32768;
+export const KIMI_CODE_HEADERS = { "User-Agent": "KimiCLI/0.77" } as const;
+export const KIMI_CODE_COMPAT = { supportsDeveloperRole: false } as const;
 
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 export const MINIMAX_API_COST = {
@@ -37,6 +44,12 @@ export const MOONSHOT_DEFAULT_COST = {
   output: 0,
   cacheRead: 0,
   cacheWrite: 0,
+};
+export const KIMI_CODE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0
 };
 
 const MINIMAX_MODEL_CATALOG = {
@@ -87,5 +100,19 @@ export function buildMoonshotModelDefinition(): ModelDefinitionConfig {
     cost: MOONSHOT_DEFAULT_COST,
     contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function buildKimiCodeModelDefinition(): ModelDefinitionConfig {
+  return {
+    id: KIMI_CODE_MODEL_ID,
+    name: "Kimi For Coding",
+    reasoning: true,
+    input: ["text"],
+    cost: KIMI_CODE_DEFAULT_COST,
+    contextWindow: KIMI_CODE_CONTEXT_WINDOW,
+    maxTokens: KIMI_CODE_MAX_TOKENS,
+    headers: KIMI_CODE_HEADERS,
+    compat: KIMI_CODE_COMPAT
   };
 }

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -4,6 +4,8 @@ export {
 } from "../agents/synthetic-models.js";
 export {
   applyAuthProfileConfig,
+  applyKimiCodeConfig,
+  applyKimiCodeProviderConfig,
   applyMoonshotConfig,
   applyMoonshotProviderConfig,
   applyOpenrouterConfig,
@@ -31,6 +33,7 @@ export {
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setGeminiApiKey,
+  setKimiCodeApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
   setOpencodeZenApiKey,
@@ -43,10 +46,14 @@ export {
   ZAI_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";
 export {
+  buildKimiCodeModelDefinition,
   buildMinimaxApiModelDefinition,
   buildMinimaxModelDefinition,
   buildMoonshotModelDefinition,
   DEFAULT_MINIMAX_BASE_URL,
+  KIMI_CODE_BASE_URL,
+  KIMI_CODE_MODEL_ID,
+  KIMI_CODE_MODEL_REF,
   MINIMAX_API_BASE_URL,
   MINIMAX_HOSTED_MODEL_ID,
   MINIMAX_HOSTED_MODEL_REF,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -13,6 +13,7 @@ import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-tok
 import { applyGoogleGeminiModelDefault } from "../../google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyKimiCodeConfig,
   applyMinimaxApiConfig,
   applyMinimaxConfig,
   applyMoonshotConfig,
@@ -23,6 +24,7 @@ import {
   applyZaiConfig,
   setAnthropicApiKey,
   setGeminiApiKey,
+  setKimiCodeApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
   setOpencodeZenApiKey,
@@ -229,6 +231,25 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyMoonshotConfig(nextConfig);
+  }
+
+  if (authChoice === "kimi-code-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "kimi-code",
+      cfg: baseConfig,
+      flagValue: opts.kimiCodeApiKey,
+      flagName: "--kimi-code-api-key",
+      envVar: "KIMICODE_API_KEY",
+      runtime
+    });
+    if (!resolved) return null;
+    if (resolved.source !== "profile") await setKimiCodeApiKey(resolved.key);
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "kimi-code:default",
+      provider: "kimi-code",
+      mode: "api_key"
+    });
+    return applyKimiCodeConfig(nextConfig);
   }
 
   if (authChoice === "synthetic-api-key") {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -14,6 +14,7 @@ export type AuthChoice =
   | "openrouter-api-key"
   | "ai-gateway-api-key"
   | "moonshot-api-key"
+  | "kimi-code-api-key"
   | "synthetic-api-key"
   | "codex-cli"
   | "apiKey"
@@ -57,6 +58,7 @@ export type OnboardOptions = {
   openrouterApiKey?: string;
   aiGatewayApiKey?: string;
   moonshotApiKey?: string;
+  kimiCodeApiKey?: string;
   geminiApiKey?: string;
   zaiApiKey?: string;
   minimaxApiKey?: string;


### PR DESCRIPTION
## Summary
- add Kimi Code provider + auth choice alongside Moonshot
- wire CLI flags and non-interactive onboarding paths
- document Moonshot vs Kimi Code setup and model refs

## Testing
- pnpm lint (fails: src/media-understanding/runner.ts no-unused-vars mergeProviderQuery; unicorn no-useless-fallback-in-spread)