### PR TITLE
docs(models): clarify model key format and /model command usage (related to #1019)

### DIFF
--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -88,9 +88,19 @@ export { DEFAULT_MODEL, DEFAULT_PROVIDER };
 /**
  * Model key format: "provider/model"
  *
- * The model key is displayed in `/model status` and used to reference models.
- * When using `/model <key>`, use the exact format shown (e.g., "openrouter/moonshotai/kimi-k2").
+ * The model key is displayed in `/model status` and is the internal identifier.
+ *
+ * When using `/model <key>` to switch models:
+ * - For Anthropic: use the model ID directly (e.g., `/model claude-opus-4-5`)
+ * - For OpenAI: use the model ID directly (e.g., `/model gpt-4.1`)
+ * - For OpenRouter: use the model ID without provider prefix (e.g., `/model moonshotai/kimi-k2`)
+ *
+ * Note: The status display shows "provider/model" for clarity, but when switching,
+ * omit the provider prefix for most providers. The parsing logic uses the first "/" to
+ * separate provider from model ID.
  *
  * For providers with hierarchical model IDs (e.g., OpenRouter), the model ID may include
- * sub-providers (e.g., "moonshotai/kimi-k2"), resulting in a key like "openrouter/moonshotai/kimi-k2".
+ * sub-providers (e.g., "moonshotai/kimi-k2"), resulting in a display key like "openrouter/moonshotai/kimi-k2".
+ *
+ * Related: See issue #1019 for OpenRouter model usage clarification.
  */


### PR DESCRIPTION
## Summary

Improved documentation to clarify how model keys work and the correct usage of the `/model` command.

## Changes

- Explained that `/model status` shows internal "provider/model" format for identification
- Added specific examples for different providers:
  - Anthropic: `/model claude-opus-4-5`
  - OpenAI: `/model gpt-4.1`
  - OpenRouter: `/model moonshotai/kimi-k2` (without provider prefix)
- Clarified that when switching models, the provider prefix should be omitted for most providers
- Noted that parsing uses the first "/" to separate provider from model ID
- Added reference to issue #1019

## Related

Relates to #1019 - OpenRouter models display/UX issue

---

This is a documentation-only change that helps users understand the difference between what's displayed in `/model status` and what to use with the `/model` command.