### PR TITLE
feat: native image injection for vision-capable models

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -41,12 +41,15 @@ export function createClawdbotTools(options?: {
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** If true, the model has native vision capability */
+  modelHasVision?: boolean;
 }): AnyAgentTool[] {
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
         config: options?.config,
         agentDir: options.agentDir,
         sandboxRoot: options?.sandboxRoot,
+        modelHasVision: options?.modelHasVision,
       })
     : null;
   const memorySearchTool = createMemorySearchTool({

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+
+import { detectImageReferences, modelSupportsImages } from "./images.js";
+
+describe("detectImageReferences", () => {
+  it("detects absolute file paths with common extensions", () => {
+    const prompt = "Check this image /path/to/screenshot.png and tell me what you see";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toEqual({
+      raw: "/path/to/screenshot.png",
+      type: "path",
+      resolved: "/path/to/screenshot.png",
+    });
+  });
+
+  it("detects relative paths starting with ./", () => {
+    const prompt = "Look at ./images/photo.jpg";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("./images/photo.jpg");
+    expect(refs[0]?.type).toBe("path");
+  });
+
+  it("detects relative paths starting with ../", () => {
+    const prompt = "The file is at ../screenshots/test.jpeg";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("../screenshots/test.jpeg");
+    expect(refs[0]?.type).toBe("path");
+  });
+
+  it("detects home directory paths starting with ~/", () => {
+    const prompt = "My photo is at ~/Pictures/vacation.png";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("~/Pictures/vacation.png");
+    expect(refs[0]?.type).toBe("path");
+    // Resolved path should expand ~
+    expect(refs[0]?.resolved).not.toContain("~");
+  });
+
+  it("detects HTTP URLs with image extensions", () => {
+    const prompt = "Check this URL: https://mysite.com/images/logo.png";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toEqual({
+      raw: "https://mysite.com/images/logo.png",
+      type: "url",
+      resolved: "https://mysite.com/images/logo.png",
+    });
+  });
+
+  it("detects HTTPS URLs with query parameters", () => {
+    const prompt = "Image from https://cdn.mysite.com/img.jpg?size=large&v=2";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.type).toBe("url");
+    expect(refs[0]?.raw).toContain("https://cdn.mysite.com/img.jpg");
+  });
+
+  it("detects multiple image references in a prompt", () => {
+    const prompt = `
+      Compare these two images:
+      1. /home/user/photo1.png
+      2. https://mysite.com/photo2.jpg
+    `;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(2);
+    expect(refs.some((r) => r.type === "path")).toBe(true);
+    expect(refs.some((r) => r.type === "url")).toBe(true);
+  });
+
+  it("handles various image extensions", () => {
+    const extensions = ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic"];
+    for (const ext of extensions) {
+      const prompt = `Image: /test/image.${ext}`;
+      const refs = detectImageReferences(prompt);
+      expect(refs.length).toBeGreaterThanOrEqual(1);
+      expect(refs[0]?.raw).toContain(`.${ext}`);
+    }
+  });
+
+  it("deduplicates repeated image references", () => {
+    const prompt = "Look at /path/image.png and also /path/image.png again";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+  });
+
+  it("returns empty array when no images found", () => {
+    const prompt = "Just some text without any image references";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(0);
+  });
+
+  it("ignores non-image file extensions", () => {
+    const prompt = "Check /path/to/document.pdf and /code/file.ts";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(0);
+  });
+
+  it("handles paths inside quotes (without spaces)", () => {
+    const prompt = 'The file is at "/path/to/image.png"';
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("/path/to/image.png");
+  });
+
+  it("handles paths in parentheses", () => {
+    const prompt = "See the image (./screenshot.png) for details";
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("./screenshot.png");
+  });
+
+  it("detects [Image: source: ...] format from messaging systems", () => {
+    const prompt = `What does this image show?
+[Image: source: /Users/tyleryust/Library/Messages/Attachments/IMG_0043.jpeg]`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("/Users/tyleryust/Library/Messages/Attachments/IMG_0043.jpeg");
+    expect(refs[0]?.type).toBe("path");
+  });
+
+  it("handles complex message attachment paths", () => {
+    const prompt = `[Image: source: /Users/tyleryust/Library/Messages/Attachments/23/03/AA4726EA-DB27-4269-BA56-1436936CC134/5E3E286A-F585-4E5E-9043-5BC2AFAFD81BIMG_0043.jpeg]`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.resolved).toContain("IMG_0043.jpeg");
+  });
+
+  it("detects multiple images in [media attached: ...] format", () => {
+    // Multi-file format uses separate brackets on separate lines
+    const prompt = `[media attached: 2 files]
+[media attached 1/2: /Users/tyleryust/.clawdbot/media/IMG_6430.jpeg (image/jpeg)]
+[media attached 2/2: /Users/tyleryust/.clawdbot/media/IMG_6431.jpeg (image/jpeg)]
+what about these images?`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(2);
+    expect(refs[0]?.resolved).toContain("IMG_6430.jpeg");
+    expect(refs[1]?.resolved).toContain("IMG_6431.jpeg");
+  });
+
+  it("does not double-count path and url in same bracket", () => {
+    // Single file with URL (| separates path from url, not multiple files)
+    const prompt = `[media attached: /cache/IMG_6430.jpeg (image/jpeg) | /cache/IMG_6430.jpeg]`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.resolved).toContain("IMG_6430.jpeg");
+  });
+
+  it("skips example.com URLs as they are documentation examples", () => {
+    const prompt = `To send an image: MEDIA:https://example.com/image.jpg
+Here is my actual image: /path/to/real.png`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.raw).toBe("/path/to/real.png");
+  });
+
+  it("handles single file format with URL (no index)", () => {
+    const prompt = `[media attached: /cache/photo.jpeg (image/jpeg) | https://example.com/url]
+what is this?`;
+    const refs = detectImageReferences(prompt);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.resolved).toContain("photo.jpeg");
+  });
+
+  it("handles paths with spaces in filename", () => {
+    // URL after | is https, not a local path, so only the local path should be detected
+    const prompt = `[media attached: /Users/test/.clawdbot/media/ChatGPT Image Apr 21, 2025.png (image/png) | https://example.com/same.png]
+what is this?`;
+    const refs = detectImageReferences(prompt);
+
+    // Only 1 ref - the local path (example.com URLs are skipped)
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.resolved).toContain("ChatGPT Image Apr 21, 2025.png");
+  });
+});
+
+describe("modelSupportsImages", () => {
+  it("returns true when model input includes image", () => {
+    const model = { input: ["text", "image"] };
+    expect(modelSupportsImages(model)).toBe(true);
+  });
+
+  it("returns false when model input does not include image", () => {
+    const model = { input: ["text"] };
+    expect(modelSupportsImages(model)).toBe(false);
+  });
+
+  it("returns false when model input is undefined", () => {
+    const model = {};
+    expect(modelSupportsImages(model)).toBe(false);
+  });
+
+  it("returns false when model input is empty", () => {
+    const model = { input: [] };
+    expect(modelSupportsImages(model)).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,0 +1,379 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { ImageContent } from "@mariozechner/pi-ai";
+
+import { assertSandboxPath } from "../../sandbox-paths.js";
+import { extractTextFromMessage } from "../../../tui/tui-formatters.js";
+import { loadWebMedia } from "../../../web/media.js";
+import { resolveUserPath } from "../../../utils.js";
+import { log } from "../logger.js";
+
+/**
+ * Common image file extensions for detection.
+ */
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".tiff",
+  ".tif",
+  ".heic",
+  ".heif",
+]);
+
+/**
+ * Result of detecting an image reference in text.
+ */
+export interface DetectedImageRef {
+  /** The raw matched string from the prompt */
+  raw: string;
+  /** The type of reference (path or url) */
+  type: "path" | "url";
+  /** The resolved/normalized path or URL */
+  resolved: string;
+  /** Index of the message this ref was found in (for history images) */
+  messageIndex?: number;
+}
+
+/**
+ * Checks if a file extension indicates an image file.
+ */
+function isImageExtension(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Detects image references in a user prompt.
+ *
+ * Patterns detected:
+ * - Absolute paths: /path/to/image.png
+ * - Relative paths: ./image.png, ../images/photo.jpg
+ * - Home paths: ~/Pictures/screenshot.png
+ * - HTTP(S) URLs: https://example.com/image.png
+ * - Message attachments: [Image: source: /path/to/image.jpg]
+ *
+ * @param prompt The user prompt text to scan
+ * @returns Array of detected image references
+ */
+export function detectImageReferences(prompt: string): DetectedImageRef[] {
+  const refs: DetectedImageRef[] = [];
+  const seen = new Set<string>();
+
+  // Helper to add a path ref
+  const addPathRef = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed || seen.has(trimmed.toLowerCase())) return;
+    if (!isImageExtension(trimmed)) return;
+    seen.add(trimmed.toLowerCase());
+    const resolved = trimmed.startsWith("~") ? resolveUserPath(trimmed) : trimmed;
+    refs.push({ raw: trimmed, type: "path", resolved });
+  };
+
+  // Pattern for [media attached: path (type) | url] or [media attached N/M: path (type) | url] format
+  // Each bracket = ONE file. The | separates path from URL, not multiple files.
+  // Multi-file format uses separate brackets on separate lines.
+  const mediaAttachedPattern = /\[media attached(?:\s+\d+\/\d+)?:\s*([^\]]+)\]/gi;
+  let match: RegExpExecArray | null;
+  while ((match = mediaAttachedPattern.exec(prompt)) !== null) {
+    const content = match[1];
+
+    // Skip "[media attached: N files]" header lines
+    if (/^\d+\s+files?$/i.test(content.trim())) {
+      continue;
+    }
+
+    // Extract path before the (mime/type) or | delimiter
+    // Format is: path (type) | url  OR  just: path (type)
+    // Path may contain spaces (e.g., "ChatGPT Image Apr 21.png")
+    // Use non-greedy .+? to stop at first image extension
+    const pathMatch = content.match(
+      /^\s*(.+?\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif))\s*(?:\(|$|\|)/i,
+    );
+    if (pathMatch?.[1]) {
+      addPathRef(pathMatch[1].trim());
+    }
+  }
+
+  // Pattern for [Image: source: /path/...] format from messaging systems
+  const messageImagePattern = /\[Image:\s*source:\s*([^\]]+\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif))\]/gi;
+  while ((match = messageImagePattern.exec(prompt)) !== null) {
+    const raw = match[1]?.trim();
+    if (raw) addPathRef(raw);
+  }
+
+  // Pattern for HTTP(S) URLs ending in image extensions
+  // Skip example.com URLs as they're often just documentation examples
+  const urlPattern =
+    /https?:\/\/[^\s<>"'`\]]+\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif)(?:\?[^\s<>"'`\]]*)?/gi;
+  while ((match = urlPattern.exec(prompt)) !== null) {
+    const raw = match[0];
+    // Skip example.com URLs - they're documentation, not real images
+    if (raw.includes("example.com")) continue;
+    if (seen.has(raw.toLowerCase())) continue;
+    seen.add(raw.toLowerCase());
+    refs.push({ raw, type: "url", resolved: raw });
+  }
+
+  // Pattern for file paths (absolute, relative, or home)
+  // Matches:
+  // - /absolute/path/to/file.ext (including paths with special chars like Messages/Attachments)
+  // - ./relative/path.ext
+  // - ../parent/path.ext
+  // - ~/home/path.ext
+  const pathPattern = /(?:^|\s|["'`(])((\.\.?\/|[~/])[^\s"'`()[\]]*\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif))/gi;
+  while ((match = pathPattern.exec(prompt)) !== null) {
+    const raw = match[1] || match[0];
+    addPathRef(raw);
+  }
+
+  return refs;
+}
+
+/**
+ * Loads an image from a file path or URL and returns it as ImageContent.
+ *
+ * @param ref The detected image reference
+ * @param workspaceDir The current workspace directory for resolving relative paths
+ * @param options Optional settings for sandbox and size limits
+ * @returns The loaded image content, or null if loading failed
+ */
+export async function loadImageFromRef(
+  ref: DetectedImageRef,
+  workspaceDir: string,
+  options?: {
+    maxBytes?: number;
+    /** If set, enforce that file paths are within this sandbox root */
+    sandboxRoot?: string;
+  },
+): Promise<ImageContent | null> {
+  try {
+    let targetPath = ref.resolved;
+
+    // When sandbox is enabled, block remote URL loading to maintain network boundary
+    if (ref.type === "url" && options?.sandboxRoot) {
+      log.debug(`Native image: rejecting remote URL in sandboxed session: ${ref.resolved}`);
+      return null;
+    }
+
+    // For file paths, resolve relative to the appropriate root:
+    // - When sandbox is enabled, resolve relative to sandboxRoot for security
+    // - Otherwise, resolve relative to workspaceDir
+    if (ref.type === "path" && !path.isAbsolute(targetPath)) {
+      const resolveRoot = options?.sandboxRoot ?? workspaceDir;
+      targetPath = path.resolve(resolveRoot, targetPath);
+    }
+
+    // Enforce sandbox restrictions if sandboxRoot is set
+    if (ref.type === "path" && options?.sandboxRoot) {
+      try {
+        const validated = await assertSandboxPath({
+          filePath: targetPath,
+          cwd: options.sandboxRoot,
+          root: options.sandboxRoot,
+        });
+        targetPath = validated.resolved;
+      } catch (err) {
+        // Log the actual error for debugging (sandbox violation or other path error)
+        log.debug(`Native image: sandbox validation failed for ${ref.resolved}: ${err instanceof Error ? err.message : String(err)}`);
+        return null;
+      }
+    }
+
+    // Check file exists for local paths
+    if (ref.type === "path") {
+      try {
+        await fs.stat(targetPath);
+      } catch {
+        log.debug(`Native image: file not found: ${targetPath}`);
+        return null;
+      }
+    }
+
+    // loadWebMedia handles both file paths and HTTP(S) URLs
+    const media = await loadWebMedia(targetPath, options?.maxBytes);
+
+    if (media.kind !== "image") {
+      log.debug(`Native image: not an image file: ${targetPath} (got ${media.kind})`);
+      return null;
+    }
+
+    // EXIF orientation is already normalized by loadWebMedia -> resizeToJpeg
+    const mimeType = media.contentType ?? "image/png";
+    const data = media.buffer.toString("base64");
+
+    return { type: "image", data, mimeType };
+  } catch (err) {
+    // Log the actual error for debugging (size limits, network failures, etc.)
+    log.debug(`Native image: failed to load ${ref.resolved}: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Checks if a model supports image input based on its input capabilities.
+ *
+ * @param model The model object with input capability array
+ * @returns True if the model supports image input
+ */
+export function modelSupportsImages(model: { input?: string[] }): boolean {
+  return model.input?.includes("image") ?? false;
+}
+
+/**
+ * Extracts image references from conversation history messages.
+ * Scans user messages for image paths/URLs that can be loaded.
+ * Each ref includes the messageIndex so images can be injected at their original location.
+ *
+ * Note: Global deduplication is intentional - if the same image appears in multiple
+ * messages, we only inject it at the FIRST occurrence. This is sufficient because:
+ * 1. The model sees all message content including the image
+ * 2. Later references to "the image" or "that picture" will work since it's in context
+ * 3. Injecting duplicates would waste tokens and potentially hit size limits
+ */
+function detectImagesFromHistory(messages: unknown[]): DetectedImageRef[] {
+  const allRefs: DetectedImageRef[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    const message = msg as { role?: string };
+    // Only scan user messages for image references
+    if (message.role !== "user") continue;
+
+    const text = extractTextFromMessage(msg);
+    if (!text) continue;
+
+    const refs = detectImageReferences(text);
+    for (const ref of refs) {
+      const key = ref.resolved.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      allRefs.push({ ...ref, messageIndex: i });
+    }
+  }
+
+  return allRefs;
+}
+
+/**
+ * Detects and loads images referenced in a prompt for models with vision capability.
+ *
+ * This function scans the prompt for image references (file paths and URLs),
+ * loads them, and returns them as ImageContent array ready to be passed to
+ * the model's prompt method.
+ *
+ * Also scans conversation history for images from previous turns and returns
+ * them mapped by message index so they can be injected at their original location.
+ *
+ * @param params Configuration for image detection and loading
+ * @returns Object with loaded images for current prompt and history images by message index
+ */
+export async function detectAndLoadPromptImages(params: {
+  prompt: string;
+  workspaceDir: string;
+  model: { input?: string[] };
+  existingImages?: ImageContent[];
+  historyMessages?: unknown[];
+  maxBytes?: number;
+  /** If set, enforce that file paths are within this sandbox root */
+  sandboxRoot?: string;
+}): Promise<{
+  /** Images for the current prompt (existingImages + detected in current prompt) */
+  images: ImageContent[];
+  /** Images from history messages, keyed by message index */
+  historyImagesByIndex: Map<number, ImageContent[]>;
+  detectedRefs: DetectedImageRef[];
+  loadedCount: number;
+  skippedCount: number;
+}> {
+  // If model doesn't support images, return empty results
+  if (!modelSupportsImages(params.model)) {
+    return {
+      images: params.existingImages ?? [],
+      historyImagesByIndex: new Map(),
+      detectedRefs: [],
+      loadedCount: 0,
+      skippedCount: 0,
+    };
+  }
+
+  // Detect images from current prompt
+  const promptRefs = detectImageReferences(params.prompt);
+
+  // Detect images from conversation history (with message indices)
+  const historyRefs = params.historyMessages
+    ? detectImagesFromHistory(params.historyMessages)
+    : [];
+
+  // Deduplicate: if an image is in the current prompt, don't also load it from history.
+  // Current prompt images are passed via the `images` parameter to prompt(), while history
+  // images are injected into their original message positions. We don't want the same
+  // image loaded and sent twice (wasting tokens and potentially causing confusion).
+  const seenPaths = new Set(promptRefs.map((r) => r.resolved.toLowerCase()));
+  const uniqueHistoryRefs = historyRefs.filter(
+    (r) => !seenPaths.has(r.resolved.toLowerCase()),
+  );
+
+  const allRefs = [...promptRefs, ...uniqueHistoryRefs];
+
+  if (allRefs.length === 0) {
+    return {
+      images: params.existingImages ?? [],
+      historyImagesByIndex: new Map(),
+      detectedRefs: [],
+      loadedCount: 0,
+      skippedCount: 0,
+    };
+  }
+
+  log.debug(
+    `Native image: detected ${allRefs.length} image refs (${promptRefs.length} in prompt, ${uniqueHistoryRefs.length} in history)`,
+  );
+
+  // Load images for current prompt
+  const promptImages: ImageContent[] = [...(params.existingImages ?? [])];
+  // Load images for history, grouped by message index
+  const historyImagesByIndex = new Map<number, ImageContent[]>();
+
+  let loadedCount = 0;
+  let skippedCount = 0;
+
+  for (const ref of allRefs) {
+    const image = await loadImageFromRef(ref, params.workspaceDir, {
+      maxBytes: params.maxBytes,
+      sandboxRoot: params.sandboxRoot,
+    });
+    if (image) {
+      if (ref.messageIndex !== undefined) {
+        // History image - add to the appropriate message index
+        const existing = historyImagesByIndex.get(ref.messageIndex);
+        if (existing) {
+          existing.push(image);
+        } else {
+          historyImagesByIndex.set(ref.messageIndex, [image]);
+        }
+      } else {
+        // Current prompt image
+        promptImages.push(image);
+      }
+      loadedCount++;
+      log.debug(`Native image: loaded ${ref.type} ${ref.resolved}`);
+    } else {
+      skippedCount++;
+    }
+  }
+
+  return {
+    images: promptImages,
+    historyImagesByIndex,
+    detectedRefs: allRefs,
+    loadedCount,
+    skippedCount,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -128,8 +128,12 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     if (seen.has(raw.toLowerCase())) continue;
     seen.add(raw.toLowerCase());
     // Use fileURLToPath for proper handling (e.g., file://localhost/path)
-    const resolved = fileURLToPath(raw);
-    refs.push({ raw, type: "path", resolved });
+    try {
+      const resolved = fileURLToPath(raw);
+      refs.push({ raw, type: "path", resolved });
+    } catch {
+      // Skip malformed file:// URLs
+    }
   }
 
   // Pattern for file paths (absolute, relative, or home)

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -163,6 +163,8 @@ export async function loadImageFromRef(
     // For file paths, resolve relative to the appropriate root:
     // - When sandbox is enabled, resolve relative to sandboxRoot for security
     // - Otherwise, resolve relative to workspaceDir
+    // Note: ref.resolved may already be absolute (e.g., after ~ expansion in detectImageReferences),
+    // in which case we skip relative resolution.
     if (ref.type === "path" && !path.isAbsolute(targetPath)) {
       const resolveRoot = options?.sandboxRoot ?? workspaceDir;
       targetPath = path.resolve(resolveRoot, targetPath);

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -106,6 +106,8 @@ export function createClawdbotCodingTools(options?: {
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** If true, the model has native vision capability */
+  modelHasVision?: boolean;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -238,6 +240,7 @@ export function createClawdbotCodingTools(options?: {
       currentThreadTs: options?.currentThreadTs,
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
+      modelHasVision: options?.modelHasVision,
     }),
   ];
   const toolsFiltered = profilePolicy ? filterToolsByPolicy(tools, profilePolicy) : tools;

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -302,9 +302,16 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
     const messageText = (message.text ?? "").trim();
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
-    const firstAttachment = attachments?.find((entry) => entry?.original_path && !entry?.missing);
+    // Filter to valid attachments with paths
+    const validAttachments = attachments.filter(
+      (entry) => entry?.original_path && !entry?.missing,
+    );
+    const firstAttachment = validAttachments[0];
     const mediaPath = firstAttachment?.original_path ?? undefined;
     const mediaType = firstAttachment?.mime_type ?? undefined;
+    // Build arrays for all attachments (for multi-image support)
+    const mediaPaths = validAttachments.map((a) => a.original_path).filter(Boolean) as string[];
+    const mediaTypes = validAttachments.map((a) => a.mime_type ?? undefined);
     const kind = mediaKindFromMime(mediaType ?? undefined);
     const placeholder = kind ? `<media:${kind}>` : attachments?.length ? "<media:attachment>" : "";
     const bodyText = messageText || placeholder;
@@ -440,6 +447,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       MediaPath: mediaPath,
       MediaType: mediaType,
       MediaUrl: mediaPath,
+      MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+      MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+      MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
       MediaRemoteHost: remoteHost,
       WasMentioned: effectiveWasMentioned,
       CommandAuthorized: commandAuthorized,

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { type MediaKind, maxBytesForKind, mediaKindFromMime } from "../media/constants.js";
@@ -24,8 +25,9 @@ async function loadWebMediaInternal(
   options: WebMediaOptions = {},
 ): Promise<WebMediaResult> {
   const { maxBytes, optimizeImages = true } = options;
+  // Use fileURLToPath for proper handling of file:// URLs (handles file://localhost/path, etc.)
   if (mediaUrl.startsWith("file://")) {
-    mediaUrl = mediaUrl.replace("file://", "");
+    mediaUrl = fileURLToPath(mediaUrl);
   }
 
   const optimizeAndClampImage = async (buffer: Buffer, cap: number) => {
@@ -57,7 +59,7 @@ async function loadWebMediaInternal(
     kind: MediaKind;
     fileName?: string;
   }): Promise<WebMediaResult> => {
-    const cap = Math.min(maxBytes ?? maxBytesForKind(params.kind), maxBytesForKind(params.kind));
+    const cap = maxBytes !== undefined ? Math.min(maxBytes, maxBytesForKind(params.kind)) : maxBytesForKind(params.kind);
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -27,7 +27,11 @@ async function loadWebMediaInternal(
   const { maxBytes, optimizeImages = true } = options;
   // Use fileURLToPath for proper handling of file:// URLs (handles file://localhost/path, etc.)
   if (mediaUrl.startsWith("file://")) {
-    mediaUrl = fileURLToPath(mediaUrl);
+    try {
+      mediaUrl = fileURLToPath(mediaUrl);
+    } catch {
+      throw new Error(`Invalid file:// URL: ${mediaUrl}`);
+    }
   }
 
   const optimizeAndClampImage = async (buffer: Buffer, cap: number) => {

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -161,23 +161,27 @@ export async function optimizeImageToJpeg(
 
   for (const side of sides) {
     for (const quality of qualities) {
-      const out = await resizeToJpeg({
-        buffer,
-        maxSide: side,
-        quality,
-        withoutEnlargement: true,
-      });
-      const size = out.length;
-      if (!smallest || size < smallest.size) {
-        smallest = { buffer: out, size, resizeSide: side, quality };
-      }
-      if (size <= maxBytes) {
-        return {
-          buffer: out,
-          optimizedSize: size,
-          resizeSide: side,
+      try {
+        const out = await resizeToJpeg({
+          buffer,
+          maxSide: side,
           quality,
-        };
+          withoutEnlargement: true,
+        });
+        const size = out.length;
+        if (!smallest || size < smallest.size) {
+          smallest = { buffer: out, size, resizeSide: side, quality };
+        }
+        if (size <= maxBytes) {
+          return {
+            buffer: out,
+            optimizedSize: size,
+            resizeSide: side,
+            quality,
+          };
+        }
+      } catch {
+        // Continue trying other size/quality combinations
       }
     }
   }


### PR DESCRIPTION
## Summary

When a model supports native image input, this PR auto-detects image references in prompts and injects them directly into the model context. This eliminates the need for explicit "image" tool calls and enables follow-up questions about earlier images.

**Key changes:**
- Auto-detect image paths/URLs in user prompts
- Inject history images at their original message positions (not all lumped on current prompt)
- Fix EXIF orientation - rotate images before resizing
- Sandbox security hardening

## Why this approach?

Previous commit `b6ea5895b` hid the image tool when the primary model supported vision. That didn't solve the actual problem: if a user says "analyze ~/screenshot.png", the model couldn't see it because the path was just text.

Now: image paths in prompts are auto-detected, loaded, and injected natively.

## Core changes

### 1. Image detection & loading (`images.ts`)
- **Path patterns detected:**
  - Absolute: `/path/to/image.png`
  - Relative: `./image.png`, `../image.png`
  - Home: `~/Pictures/photo.jpg`
  - URLs: `https://example.com/image.png`, `file:///path/to/image.png`
  - Attachments: `[media attached: /path (type)]`

- **History scanning:** Scans conversation history for images, tracks message index so images inject at their original position

### 2. EXIF orientation fix (`image-ops.ts`)
- Added `readJpegExifOrientation()` - parses EXIF orientation from JPEG buffer
- Added `sipsApplyOrientation()` - rotates using sips based on orientation value
- Modified `resizeToJpeg()` to rotate BEFORE resizing (critical fix - rotation must happen first or EXIF gets stripped)

### 3. Sandbox security
- **Path validation:** Uses `assertSandboxPath` when sandbox is enabled
- **URL blocking:** Remote URLs rejected in sandboxed sessions
- **Relative path resolution:** Resolves relative to `sandboxRoot` (not `workspaceDir`) when sandbox enabled

### 4. History injection (`attempt.ts`)
- Injects images into their original message positions in `activeSession.messages`
- Converts string content to array format if needed
- Deduplicates to prevent same image appearing multiple times
- Bounds check on message indices

## Code review fixes

- Fixed redundant `Math.min` logic in `media.ts` cap calculation
- Use `fileURLToPath()` for proper `file://` URL handling (handles `file://localhost/path`)
- Added try/catch around `fileURLToPath()` calls to handle malformed URLs gracefully
- Fixed default MIME fallback from `image/png` to `image/jpeg` (optimization outputs JPEG)
- Added try/catch in `optimizeImageToJpeg` loop so one resize failure doesn't abort all attempts
- Fixed path regex to only use capture group, avoiding delimiter prefix in extracted paths

## Test plan

- [x] Build passes
- [x] 38 tests pass (24 images + 14 image-tool)
- [x] Manual: send rotated iPhone photo, verify orientation correct
- [x] Manual: send image in turn 1, ask follow-up in turn 3
- [ ] Manual: verify sandbox blocks paths outside workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)