### PR TITLE
fix(status): show 2 usage windows in /status command

### DIFF
--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -14,7 +14,6 @@ import type { ClawdbotConfig } from "../../config/config.js";
 import type { SessionEntry, SessionScope } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import {
-  formatUsageSummaryLine,
   formatUsageWindowSummary,
   loadProviderUsageSummary,
   resolveUsageProviderId,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -15,6 +15,7 @@ import type { SessionEntry, SessionScope } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import {
   formatUsageSummaryLine,
+  formatUsageWindowSummary,
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../../infra/provider-usage.js";
@@ -148,11 +149,12 @@ export async function buildStatusReply(params: {
         providers: [currentUsageProvider],
         agentDir: statusAgentDir,
       });
-      const summaryLine = formatUsageSummaryLine(usageSummary, {
+      const summaryLine = formatUsageWindowSummary(usageSummary.providers[0], {
         now: Date.now(),
-        maxProviders: 1,
+        maxWindows: 2,
+        includeResets: true,
       });
-      if (summaryLine) usageLine = summaryLine;
+      if (summaryLine) usageLine = `📊 Usage: ${summaryLine}`;
     } catch {
       usageLine = null;
     }


### PR DESCRIPTION
- Changed from formatUsageSummaryLine to formatUsageWindowSummary
- Shows both short-term and long-term usage windows (e.g., 5h + Weekly)
- Added includeResets to show time until reset
- Fixes Z.AI showing MCP usage instead of tokens (where MCP usage % was higher)


Before:
<img width="494" height="289" alt="image" src="https://github.com/user-attachments/assets/919882aa-727f-47be-8cf0-8d15bd69331c" />

After:
<img width="517" height="174" alt="image" src="https://github.com/user-attachments/assets/1b45888c-1d64-4a31-bb36-650565f72d08" />

AI assisted PR. 
Lightly tested: Checked usage of GPT and GLM. 
I understand what the code does! 
