### PR TITLE
Remove extra 'logging' page in the docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -894,7 +894,6 @@
           "gateway/heartbeat",
           "gateway/doctor",
           "gateway/logging",
-          "logging",
           "gateway/security",
           "gateway/sandbox-vs-tool-policy-vs-elevated",
           "gateway/sandboxing",


### PR DESCRIPTION
Removed 'logging' page from the list of gateway pages; duplicate of `gateway/logging`.

(wasn't sure if this is worth a PR; it would've gotten fixed eventually but it's been duped for some time)