### PR TITLE
fix(macos): parse semver patch correctly when version has prerelease suffix

### DIFF
--- a/apps/macos/Sources/Clawdbot/GatewayEnvironment.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayEnvironment.swift
@@ -25,8 +25,10 @@ struct Semver: Comparable, CustomStringConvertible, Sendable {
               let major = Int(parts[0]),
               let minor = Int(parts[1])
         else { return nil }
-        let patch = Int(parts[2]) ?? 0
-        return Semver(major: major, minor: minor, patch: patch)
+        // Strip prerelease suffix (e.g., "11-4" → "11", "5-beta.1" → "5")
+        let patchRaw = String(parts[2])
+        let patchNumeric = patchRaw.split { $0 == "-" || $0 == "+" }.first.flatMap { Int($0) } ?? 0
+        return Semver(major: major, minor: minor, patch: patchNumeric)
     }
 
     func compatible(with required: Semver) -> Bool {

--- a/apps/macos/Tests/ClawdbotIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/GatewayEnvironmentTests.swift
@@ -6,7 +6,8 @@ import Testing
     @Test func semverParsesCommonForms() {
         #expect(Semver.parse("1.2.3") == Semver(major: 1, minor: 2, patch: 3))
         #expect(Semver.parse("v2.0.0") == Semver(major: 2, minor: 0, patch: 0))
-        #expect(Semver.parse("3.4.5-beta.1") == Semver(major: 3, minor: 4, patch: 0)) // patch drops trailing text
+        #expect(Semver.parse("3.4.5-beta.1") == Semver(major: 3, minor: 4, patch: 5)) // prerelease suffix stripped
+        #expect(Semver.parse("2026.1.11-4") == Semver(major: 2026, minor: 1, patch: 11)) // build suffix stripped
         #expect(Semver.parse(nil) == nil)
         #expect(Semver.parse("invalid") == nil)
     }


### PR DESCRIPTION
## Summary
Fixes #1107

When the macOS app version has a prerelease/build suffix like `2026.1.11-4`, the `Semver.parse()` function was incorrectly parsing the patch number. `Int("11-4")` returns `nil`, causing the fallback to `0`, which resulted in the app trying to install `clawdbot@2026.1.0` (a nonexistent version) instead of `clawdbot@2026.1.11`.

## Changes
- Strip prerelease (`-beta.1`) and build (`-4`, `+build.123`) suffixes from the patch component before parsing as integer
- Update test expectations to reflect correct behavior
- Add test case for the exact issue scenario (`2026.1.11-4` → `patch: 11`)

## Test plan
- [x] Verified fix with standalone Swift test covering:
  - Regular versions (`1.2.3`)
  - v-prefix versions (`v2.0.0`)
  - Prerelease suffixes (`3.4.5-beta.1` → patch 5)
  - Build suffixes (`2026.1.11-4` → patch 11)
  - Build metadata with `+` (`1.0.5+build.123` → patch 5)
  - nil and invalid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)