### PR TITLE
fix: handle multi-line metadata blocks in HOOK.md frontmatter

### DIFF
--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter, resolveClawdbotMetadata } from "./frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  it("parses single-line key-value pairs", () => {
+    const content = `---
+name: test-hook
+description: "A test hook"
+homepage: https://example.com
+---
+
+# Test Hook
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("test-hook");
+    expect(result.description).toBe("A test hook");
+    expect(result.homepage).toBe("https://example.com");
+  });
+
+  it("handles missing frontmatter", () => {
+    const content = "# Just a markdown file";
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  it("handles unclosed frontmatter", () => {
+    const content = `---
+name: broken
+`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  it("parses multi-line metadata block with indented JSON", () => {
+    const content = `---
+name: session-memory
+description: "Save session context"
+metadata:
+  {
+    "clawdbot": {
+      "emoji": "💾",
+      "events": ["command:new"]
+    }
+  }
+---
+
+# Session Memory Hook
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("session-memory");
+    expect(result.description).toBe("Save session context");
+    expect(result.metadata).toBeDefined();
+    expect(typeof result.metadata).toBe("string");
+
+    // Verify the metadata is valid JSON
+    const parsed = JSON.parse(result.metadata as string);
+    expect(parsed.clawdbot.emoji).toBe("💾");
+    expect(parsed.clawdbot.events).toEqual(["command:new"]);
+  });
+
+  it("parses multi-line metadata with complex nested structure", () => {
+    const content = `---
+name: command-logger
+description: "Log all command events"
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "📝",
+        "events": ["command"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled" }]
+      }
+  }
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("command-logger");
+    expect(result.metadata).toBeDefined();
+
+    const parsed = JSON.parse(result.metadata as string);
+    expect(parsed.clawdbot.emoji).toBe("📝");
+    expect(parsed.clawdbot.events).toEqual(["command"]);
+    expect(parsed.clawdbot.requires.config).toEqual(["workspace.dir"]);
+    expect(parsed.clawdbot.install[0].kind).toBe("bundled");
+  });
+
+  it("handles single-line metadata (inline JSON)", () => {
+    const content = `---
+name: simple-hook
+metadata: {"clawdbot": {"events": ["test"]}}
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("simple-hook");
+    expect(result.metadata).toBe('{"clawdbot": {"events": ["test"]}}');
+  });
+
+  it("handles mixed single-line and multi-line values", () => {
+    const content = `---
+name: mixed-hook
+description: "A hook with mixed values"
+homepage: https://example.com
+metadata:
+  {
+    "clawdbot": {
+      "events": ["command:new"]
+    }
+  }
+enabled: true
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("mixed-hook");
+    expect(result.description).toBe("A hook with mixed values");
+    expect(result.homepage).toBe("https://example.com");
+    expect(result.metadata).toBeDefined();
+    expect(result.enabled).toBe("true");
+  });
+
+  it("strips surrounding quotes from values", () => {
+    const content = `---
+name: "quoted-name"
+description: 'single-quoted'
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("quoted-name");
+    expect(result.description).toBe("single-quoted");
+  });
+
+  it("handles CRLF line endings", () => {
+    const content = "---\r\nname: test\r\ndescription: crlf\r\n---\r\n";
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("test");
+    expect(result.description).toBe("crlf");
+  });
+
+  it("handles CR line endings", () => {
+    const content = "---\rname: test\rdescription: cr\r---\r";
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe("test");
+    expect(result.description).toBe("cr");
+  });
+});
+
+describe("resolveClawdbotMetadata", () => {
+  it("extracts clawdbot metadata from parsed frontmatter", () => {
+    const frontmatter = {
+      name: "test-hook",
+      metadata: JSON.stringify({
+        clawdbot: {
+          emoji: "🔥",
+          events: ["command:new", "command:reset"],
+          requires: {
+            config: ["workspace.dir"],
+            bins: ["git"],
+          },
+        },
+      }),
+    };
+
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result).toBeDefined();
+    expect(result?.emoji).toBe("🔥");
+    expect(result?.events).toEqual(["command:new", "command:reset"]);
+    expect(result?.requires?.config).toEqual(["workspace.dir"]);
+    expect(result?.requires?.bins).toEqual(["git"]);
+  });
+
+  it("returns undefined when metadata is missing", () => {
+    const frontmatter = { name: "no-metadata" };
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when clawdbot key is missing", () => {
+    const frontmatter = {
+      metadata: JSON.stringify({ other: "data" }),
+    };
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    const frontmatter = {
+      metadata: "not valid json {",
+    };
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result).toBeUndefined();
+  });
+
+  it("handles install specs", () => {
+    const frontmatter = {
+      metadata: JSON.stringify({
+        clawdbot: {
+          events: ["command"],
+          install: [
+            { id: "bundled", kind: "bundled", label: "Bundled with Clawdbot" },
+            { id: "npm", kind: "npm", package: "@clawdbot/hook" },
+          ],
+        },
+      }),
+    };
+
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result?.install).toHaveLength(2);
+    expect(result?.install?.[0].kind).toBe("bundled");
+    expect(result?.install?.[1].kind).toBe("npm");
+    expect(result?.install?.[1].package).toBe("@clawdbot/hook");
+  });
+
+  it("handles os restrictions", () => {
+    const frontmatter = {
+      metadata: JSON.stringify({
+        clawdbot: {
+          events: ["command"],
+          os: ["darwin", "linux"],
+        },
+      }),
+    };
+
+    const result = resolveClawdbotMetadata(frontmatter);
+    expect(result?.os).toEqual(["darwin", "linux"]);
+  });
+
+  it("parses real session-memory HOOK.md format", () => {
+    // This is the actual format used in the bundled hooks
+    const content = `---
+name: session-memory
+description: "Save session context to memory when /new command is issued"
+homepage: https://docs.clawd.bot/hooks#session-memory
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "💾",
+        "events": ["command:new"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with Clawdbot" }],
+      },
+  }
+---
+
+# Session Memory Hook
+`;
+
+    const frontmatter = parseFrontmatter(content);
+    expect(frontmatter.name).toBe("session-memory");
+    expect(frontmatter.metadata).toBeDefined();
+
+    const clawdbot = resolveClawdbotMetadata(frontmatter);
+    expect(clawdbot).toBeDefined();
+    expect(clawdbot?.emoji).toBe("💾");
+    expect(clawdbot?.events).toEqual(["command:new"]);
+    expect(clawdbot?.requires?.config).toEqual(["workspace.dir"]);
+    expect(clawdbot?.install?.[0].kind).toBe("bundled");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1113

The frontmatter parser was using a simple line-by-line regex that only captured single-line key-value pairs. This meant multi-line metadata blocks (as used by bundled hooks like `session-memory` and `command-logger`) were not parsed correctly.

## The Problem

Bundled HOOK.md files use multi-line YAML metadata:

```yaml
metadata:
  {
    "clawdbot":
      {
        "events": ["command:new"],
        ...
      }
  }
```

The old parser only captured what was on the same line as the key, resulting in:
- `Hook warning: Hook 'session-memory' has no events defined in metadata`
- Hooks discovered but never registered
- `/new` command not triggering session-memory hook

## Changes

1. **Add `extractMultiLineValue()`** - Handles indented continuation lines for YAML-style multi-line values
2. **Use JSON5 instead of JSON.parse()** - Supports trailing commas used in the HOOK.md files
3. **Add comprehensive test coverage** - 17 new tests for frontmatter parsing including edge cases

## Testing

- All 58 tests in `src/hooks/` pass
- Verified against the actual bundled HOOK.md files
- Tested single-line, multi-line, mixed, and edge cases (CRLF, quotes, etc.)

## Verification

```js
const { parseFrontmatter, resolveClawdbotMetadata } = require('./dist/hooks/frontmatter.js');
const fs = require('fs');
const content = fs.readFileSync('./dist/hooks/bundled/session-memory/HOOK.md', 'utf-8');
const fm = parseFrontmatter(content);
const clawdbot = resolveClawdbotMetadata(fm);
console.log(clawdbot.events); // ['command:new'] ✓
```