### PR TITLE
Discord: inherit thread allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Memory: split overly long lines to keep embeddings under token limits.
+- Discord: inherit parent channel allowlists for thread slash commands. (#1122)
 
 ## 2026.1.17-1
 

--- a/src/channels/channel-config.test.ts
+++ b/src/channels/channel-config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChannelKeyCandidates, resolveChannelEntryMatch } from "./channel-config.js";
+
+describe("buildChannelKeyCandidates", () => {
+  it("dedupes and trims keys", () => {
+    expect(buildChannelKeyCandidates(" a ", "a", "", "b", "b")).toEqual(["a", "b"]);
+  });
+});
+
+describe("resolveChannelEntryMatch", () => {
+  it("returns matched entry and wildcard metadata", () => {
+    const entries = { a: { allow: true }, "*": { allow: false } };
+    const match = resolveChannelEntryMatch({
+      entries,
+      keys: ["missing", "a"],
+      wildcardKey: "*",
+    });
+    expect(match.entry).toBe(entries.a);
+    expect(match.key).toBe("a");
+    expect(match.wildcardEntry).toBe(entries["*"]);
+    expect(match.wildcardKey).toBe("*");
+  });
+});

--- a/src/channels/channel-config.ts
+++ b/src/channels/channel-config.ts
@@ -1,0 +1,41 @@
+export type ChannelEntryMatch<T> = {
+  entry?: T;
+  key?: string;
+  wildcardEntry?: T;
+  wildcardKey?: string;
+};
+
+export function buildChannelKeyCandidates(
+  ...keys: Array<string | undefined | null>
+): string[] {
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const key of keys) {
+    if (typeof key !== "string") continue;
+    const trimmed = key.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    candidates.push(trimmed);
+  }
+  return candidates;
+}
+
+export function resolveChannelEntryMatch<T>(params: {
+  entries?: Record<string, T>;
+  keys: string[];
+  wildcardKey?: string;
+}): ChannelEntryMatch<T> {
+  const entries = params.entries ?? {};
+  const match: ChannelEntryMatch<T> = {};
+  for (const key of params.keys) {
+    if (!Object.prototype.hasOwnProperty.call(entries, key)) continue;
+    match.entry = entries[key];
+    match.key = key;
+    break;
+  }
+  if (params.wildcardKey && Object.prototype.hasOwnProperty.call(entries, params.wildcardKey)) {
+    match.wildcardEntry = entries[params.wildcardKey];
+    match.wildcardKey = params.wildcardKey;
+  }
+  return match;
+}

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeDiscordSlug,
   registerDiscordListener,
   resolveDiscordChannelConfig,
+  resolveDiscordChannelConfigWithFallback,
   resolveDiscordGuildEntry,
   resolveDiscordReplyTarget,
   resolveDiscordShouldRequireMention,
@@ -159,6 +160,46 @@ describe("discord guild/channel resolution", () => {
       channelSlug: "random",
     });
     expect(channel?.allowed).toBe(false);
+  });
+
+  it("inherits parent config for thread channels", () => {
+    const guildInfo: DiscordGuildEntryResolved = {
+      channels: {
+        general: { allow: true },
+        random: { allow: false },
+      },
+    };
+    const thread = resolveDiscordChannelConfigWithFallback({
+      guildInfo,
+      channelId: "thread-123",
+      channelName: "topic",
+      channelSlug: "topic",
+      parentId: "999",
+      parentName: "random",
+      parentSlug: "random",
+      scope: "thread",
+    });
+    expect(thread?.allowed).toBe(false);
+  });
+
+  it("does not match thread name/slug when resolving allowlists", () => {
+    const guildInfo: DiscordGuildEntryResolved = {
+      channels: {
+        general: { allow: true },
+        random: { allow: false },
+      },
+    };
+    const thread = resolveDiscordChannelConfigWithFallback({
+      guildInfo,
+      channelId: "thread-999",
+      channelName: "general",
+      channelSlug: "general",
+      parentId: "999",
+      parentName: "random",
+      parentSlug: "random",
+      scope: "thread",
+    });
+    expect(thread?.allowed).toBe(false);
   });
 });
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -9,6 +9,7 @@ export {
   normalizeDiscordAllowList,
   normalizeDiscordSlug,
   resolveDiscordChannelConfig,
+  resolveDiscordChannelConfigWithFallback,
   resolveDiscordCommandAuthorized,
   resolveDiscordGuildEntry,
   resolveDiscordShouldRequireMention,

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -1,4 +1,5 @@
 import {
+  ChannelType,
   type Client,
   MessageCreateListener,
   MessageReactionAddListener,
@@ -12,11 +13,12 @@ import { createSubsystemLogger } from "../../logging.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
   normalizeDiscordSlug,
-  resolveDiscordChannelConfig,
+  resolveDiscordChannelConfigWithFallback,
   resolveDiscordGuildEntry,
   shouldEmitDiscordReactionNotification,
 } from "./allow-list.js";
 import { formatDiscordReactionEmoji, formatDiscordUserTag } from "./format.js";
+import { resolveDiscordChannelInfo } from "./message-utils.js";
 
 type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
 type RuntimeEnv = import("../../runtime.js").RuntimeEnv;
@@ -189,11 +191,34 @@ async function handleDiscordReactionEvent(params: {
     if (!channel) return;
     const channelName = "name" in channel ? (channel.name ?? undefined) : undefined;
     const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
-    const channelConfig = resolveDiscordChannelConfig({
+    const channelType = "type" in channel ? channel.type : undefined;
+    const isThreadChannel =
+      channelType === ChannelType.PublicThread ||
+      channelType === ChannelType.PrivateThread ||
+      channelType === ChannelType.AnnouncementThread;
+    let parentId = "parentId" in channel ? (channel.parentId ?? undefined) : undefined;
+    let parentName: string | undefined;
+    let parentSlug = "";
+    if (isThreadChannel) {
+      if (!parentId) {
+        const channelInfo = await resolveDiscordChannelInfo(client, data.channel_id);
+        parentId = channelInfo?.parentId;
+      }
+      if (parentId) {
+        const parentInfo = await resolveDiscordChannelInfo(client, parentId);
+        parentName = parentInfo?.name;
+        parentSlug = parentName ? normalizeDiscordSlug(parentName) : "";
+      }
+    }
+    const channelConfig = resolveDiscordChannelConfigWithFallback({
       guildInfo,
       channelId: data.channel_id,
       channelName,
       channelSlug,
+      parentId,
+      parentName,
+      parentSlug,
+      scope: isThreadChannel ? "thread" : "channel",
     });
     if (channelConfig?.allowed === false) return;
 

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -249,6 +249,7 @@ export async function preflightDiscordMessage(
         parentId: threadParentId ?? undefined,
         parentName: threadParentName ?? undefined,
         parentSlug: threadParentSlug,
+        scope: threadChannel ? "thread" : "channel",
       })
     : null;
   if (isGuildMessage && channelConfig?.enabled === false) {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -22,7 +22,7 @@ import {
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordAllowList,
   normalizeDiscordSlug,
-  resolveDiscordChannelConfig,
+  resolveDiscordChannelConfigWithFallback,
   resolveDiscordGuildEntry,
   resolveDiscordShouldRequireMention,
   resolveDiscordUserAllowed,
@@ -236,13 +236,19 @@ export async function preflightDiscordMessage(
     guildInfo?.slug ||
     (params.data.guild?.name ? normalizeDiscordSlug(params.data.guild.name) : "");
 
+  const threadChannelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+  const threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+
   const baseSessionKey = route.sessionKey;
   const channelConfig = isGuildMessage
-    ? resolveDiscordChannelConfig({
+    ? resolveDiscordChannelConfigWithFallback({
         guildInfo,
-        channelId: threadParentId ?? message.channelId,
-        channelName: configChannelName,
-        channelSlug: configChannelSlug,
+        channelId: message.channelId,
+        channelName,
+        channelSlug: threadChannelSlug,
+        parentId: threadParentId ?? undefined,
+        parentName: threadParentName ?? undefined,
+        parentSlug: threadParentSlug,
       })
     : null;
   if (isGuildMessage && channelConfig?.enabled === false) {

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -553,6 +553,7 @@ async function dispatchDiscordCommandInteraction(params: {
         parentId: threadParentId,
         parentName: threadParentName,
         parentSlug: threadParentSlug,
+        scope: isThreadChannel ? "thread" : "channel",
       })
     : null;
   if (channelConfig?.enabled === false) {


### PR DESCRIPTION
## Summary
- Inherit parent channel allowlist/config for Discord thread slash commands while honoring explicit thread overrides.
- Align message preflight and native command gating with the same fallback.
- Note: Slack threads reuse the parent channel ID and Telegram topics already inherit group config allowlists, so no changes needed.

## Testing
- Not run (not requested).

Fixes #1122.