### PR TITLE
fix: use session label as fallback in session switcher

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -806,11 +806,11 @@ export class MemoryIndexManager {
           label: undefined,
           report: (update) => {
             if (!params.progress) return;
-            if (update.label) progress.label = update.label;
+            if (update.label) progress!.label = update.label;
             const label =
-              update.total > 0 && progress.label
-                ? `${progress.label} ${update.completed}/${update.total}`
-                : progress.label;
+              update.total > 0 && progress!.label
+                ? `${progress!.label} ${update.completed}/${update.total}`
+                : progress!.label;
             params.progress({
               completed: update.completed,
               total: update.total,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -134,8 +134,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       });
       const items = result.sessions.map((session) => ({
         value: session.key,
-        label: session.displayName
-          ? `${session.displayName} (${formatSessionKey(session.key)})`
+        label: (session.displayName || session.label)
+          ? `${session.displayName || session.label} (${formatSessionKey(session.key)})`
           : formatSessionKey(session.key),
         description: session.updatedAt ? new Date(session.updatedAt).toLocaleString() : "",
       }));


### PR DESCRIPTION
When `displayName` is not set, fall back to `session.label` for better visibility in the session switcher UI.

This makes spawned sub-agent sessions (which use `label`) display their descriptive names in the session list instead of just the session key.