### PR TITLE
fix(discord): strip channel: prefix from channelId in message actions

### DIFF
--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -21,8 +21,11 @@ export async function handleDiscordMessageAction(
 ): Promise<AgentToolResult<unknown>> {
   const { action, params, cfg } = ctx;
 
-  const resolveChannelId = () =>
-    readStringParam(params, "channelId") ?? readStringParam(params, "to", { required: true });
+  const resolveChannelId = () => {
+    const raw = readStringParam(params, "channelId") ?? readStringParam(params, "to", { required: true });
+    // Strip "channel:" prefix if present (target resolver adds it for Discord numeric IDs)
+    return raw.startsWith("channel:") ? raw.slice(8) : raw;
+  };
 
   if (action === "send") {
     const to = readStringParam(params, "to", { required: true });


### PR DESCRIPTION
## Summary
The target resolver (`normalizeDiscordMessagingTarget`) adds a 'channel:' prefix to pure numeric Discord channel IDs. This prefix was being passed directly to Discord API calls for react and other non-send actions, causing the API to fail with an empty error message.

## Root Cause
`normalizeDiscordMessagingTarget('1461828827968962713')` returns `'channel:1461828827968962713'`, which then fails when passed to Discord's reaction endpoint expecting a raw numeric ID.

## Why send worked but react didn't
- `send` action uses `parseRecipient()` which strips the 'channel:' prefix
- `react` and other actions passed the raw value directly to the API

## Fix
Modified `resolveChannelId()` in `handle-action.ts` to strip the 'channel:' prefix before passing to Discord API calls.

## Testing
- [x] Verified fix locally - message tool `action=react` now returns `{ ok: true, added: '🧮' }`
- [x] Previously returned `{ status: 'error', error: 'Error' }`
- [x] Direct function call `reactMessageDiscord()` worked before and after (confirms root cause was in routing layer)
- [x] Linter passed: `Found 0 warnings and 0 errors`

## AI Disclosure
- [x] This PR was developed with AI assistance (Claude/Thufir Hawat + Codex for investigation)
- [x] Fully tested locally before submission
- [x] I understand what the code does

### Investigation Summary
1. Identified that direct `reactMessageDiscord()` calls worked but message tool routing failed
2. Used Codex (gpt-5.2-codex) to trace the parameter flow through the codebase
3. Found that `normalizeDiscordMessagingTarget` adds 'channel:' prefix to numeric IDs
4. Discovered `send` action uses `parseRecipient()` which handles the prefix, but `react` does not
5. Applied fix to strip prefix in `resolveChannelId()` function
6. Tested fix on live Clawdbot instance - confirmed working