### PR TITLE
feat: persist WhatsApp group names to sessions.json

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -341,8 +341,9 @@ export async function updateLastRoute(params: {
   to?: string;
   accountId?: string;
   deliveryContext?: DeliveryContext;
+  groupName?: string;
 }) {
-  const { storePath, sessionKey, channel, to, accountId } = params;
+  const { storePath, sessionKey, channel, to, accountId, groupName } = params;
   return await withSessionStoreLock(storePath, async () => {
     const store = loadSessionStore(storePath);
     const existing = store[sessionKey];
@@ -368,6 +369,7 @@ export async function updateLastRoute(params: {
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
+      ...(groupName ? { subject: groupName } : {}),
     });
     store[sessionKey] = next;
     await saveSessionStoreUnlocked(storePath, store);

--- a/src/web/auto-reply/monitor/last-route.ts
+++ b/src/web/auto-reply/monitor/last-route.ts
@@ -20,6 +20,7 @@ export function updateLastRouteInBackground(params: {
   channel: "whatsapp";
   to: string;
   accountId?: string;
+  groupName?: string;
   warn: (obj: unknown, msg: string) => void;
 }) {
   const storePath = resolveStorePath(params.cfg.session?.store, {
@@ -33,6 +34,7 @@ export function updateLastRouteInBackground(params: {
       to: params.to,
       accountId: params.accountId,
     },
+    groupName: params.groupName,
   }).catch((err) => {
     params.warn(
       {

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -102,6 +102,7 @@ export function createWebOnMessageHandler(params: {
         channel: "whatsapp",
         to: conversationId,
         accountId: route.accountId,
+        groupName: msg.groupSubject,
         warn: params.replyLogger.warn.bind(params.replyLogger),
       });
 


### PR DESCRIPTION
## Summary
- Persist WhatsApp group names to the session store
- Pass `msg.groupSubject` through `updateLastRouteInBackground` to `updateLastRoute`
- Stores the group name in the session's `subject` field

This enables Observatory and other tools to display human-readable group names instead of just group IDs.

## Changes
- `src/config/sessions/store.ts` - Add `groupName` param to `updateLastRoute`, persist as `subject`
- `src/web/auto-reply/monitor/last-route.ts` - Add `groupName` param to pass through
- `src/web/auto-reply/monitor/on-message.ts` - Pass `msg.groupSubject` when processing group messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)