### PR TITLE
feat: include recent delivery-channel history into heartbeat prompt

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1728,6 +1728,8 @@ Z.AI models are available as `zai/<model>` (e.g. `zai/glm-4.7`) and require
   `30m`. Set `0m` to disable.
 - `model`: optional override model for heartbeat runs (`provider/model`).
 - `includeReasoning`: when `true`, heartbeats will also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`). Default: `false`.
+- `includeDeliveryChannelHistory`: when `true`, prepend recent delivery-channel message history when the heartbeat session differs from the delivery session. Default: `false`.
+- `deliveryChannelHistoryLimit`: number of recent delivery-channel messages to prepend (default: 10).
 - `target`: optional delivery channel (`last`, `whatsapp`, `telegram`, `discord`, `slack`, `signal`, `imessage`, `none`). Default: `last`.
 - `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp, chat id for Telegram).
 - `prompt`: optional override for the heartbeat body (default: `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`). Overrides are sent verbatim; include a `Read HEARTBEAT.md` line if you still want the file read.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -25,6 +25,8 @@ Example config:
         every: "30m",
         target: "last",
         // includeReasoning: true, // optional: send separate `Reasoning:` message too
+        // includeDeliveryChannelHistory: false, // optional: disable delivery-channel history
+        // deliveryChannelHistoryLimit: 6, // optional: override history size
       }
     }
   }
@@ -123,6 +125,8 @@ Example: two agents, only the second agent runs heartbeats.
 - `every`: heartbeat interval (duration string; default unit = minutes).
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
+- `includeDeliveryChannelHistory`: when enabled, prepend recent delivery-channel message history if the heartbeat session differs from the delivery session (default: false).
+- `deliveryChannelHistoryLimit`: number of recent delivery-channel messages to prepend (default: 10; only used when `includeDeliveryChannelHistory` is true).
 - `target`:
   - `last` (default): deliver to the last used external channel.
   - explicit channel: `whatsapp` / `telegram` / `discord` / `slack` / `signal` / `imessage`.
@@ -140,6 +144,15 @@ Example: two agents, only the second agent runs heartbeats.
   outbound message is sent.
 - Heartbeat-only replies do **not** keep the session alive; the last `updatedAt`
   is restored so idle expiry behaves normally.
+
+### Delivery session context
+
+Heartbeats always run in the agent's main session, but they can deliver to a different
+channel (the delivery session) when `target` points somewhere else (e.g. a Discord channel).
+If you want heartbeat replies to be aware of the recent conversation in that delivery channel,
+enable `includeDeliveryChannelHistory` and optionally tune `deliveryChannelHistoryLimit`.
+When enabled, the delivery-channel history is prepended to the heartbeat prompt and stored
+in the main session transcript.
 
 ## HEARTBEAT.md (optional)
 

--- a/src/channels/plugins/discord.ts
+++ b/src/channels/plugins/discord.ts
@@ -15,7 +15,11 @@ import {
   sendPollDiscord,
 } from "../../discord/send.js";
 import { shouldLogVerbose } from "../../globals.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildSessionKeyFromContext,
+  normalizeAccountId,
+} from "../../routing/session-key.js";
 import { getChatChannelMeta } from "../registry.js";
 import { DiscordConfigSchema } from "../../config/zod-schema.providers-core.js";
 import { discordMessageActions } from "./actions/discord.js";
@@ -156,6 +160,23 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   },
   messaging: {
     normalizeTarget: normalizeDiscordMessagingTarget,
+    resolveTargetSessionKey: ({ cfg, mainSessionKey, to }) => {
+      if (!to) return null;
+      const normalized = normalizeDiscordMessagingTarget(to);
+      if (!normalized) return null;
+      const [prefix, ...rest] = normalized.split(":");
+      const peerId = rest.join(":").trim();
+      if (!peerId) return null;
+      const peerKind = prefix === "user" ? "dm" : "channel";
+      return buildSessionKeyFromContext({
+        mainSessionKey,
+        channel: "discord",
+        peerKind,
+        peerId,
+        dmScope: cfg.session?.dmScope,
+        identityLinks: cfg.session?.identityLinks,
+      });
+    },
     targetResolver: {
       looksLikeId: looksLikeDiscordTargetId,
       hint: "<channelId|user:ID|channel:ID>",

--- a/src/channels/plugins/heartbeat-session-key.test.ts
+++ b/src/channels/plugins/heartbeat-session-key.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { ClawdbotConfig } from "../../config/config.js";
+import { resolveAgentIdFromSessionKey, resolveMainSessionKey } from "../../config/sessions.js";
+import { buildAgentPeerSessionKey } from "../../routing/session-key.js";
+import { buildTelegramGroupPeerId } from "../../telegram/bot/helpers.js";
+import { getChannelPlugin } from "./index.js";
+
+describe("heartbeat session key resolution", () => {
+  it("resolves discord channel targets", () => {
+    const cfg: ClawdbotConfig = {};
+    const mainSessionKey = resolveMainSessionKey(cfg);
+    const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+    const expected = buildAgentPeerSessionKey({
+      agentId,
+      channel: "discord",
+      peerKind: "channel",
+      peerId: "123",
+    });
+
+    const plugin = getChannelPlugin("discord");
+    const actual = plugin?.messaging?.resolveTargetSessionKey({
+      cfg,
+      mainSessionKey,
+      to: "channel:123",
+    });
+
+    expect(actual).toBe(expected);
+  });
+
+  it("resolves telegram topic targets as group sessions", () => {
+    const cfg: ClawdbotConfig = {};
+    const mainSessionKey = resolveMainSessionKey(cfg);
+    const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+    const peerId = buildTelegramGroupPeerId("-1001234567890", 456);
+    const expected = buildAgentPeerSessionKey({
+      agentId,
+      channel: "telegram",
+      peerKind: "group",
+      peerId,
+    });
+
+    const plugin = getChannelPlugin("telegram");
+    const actual = plugin?.messaging?.resolveTargetSessionKey({
+      cfg,
+      mainSessionKey,
+      to: "-1001234567890:topic:456",
+    });
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/src/channels/plugins/signal.ts
+++ b/src/channels/plugins/signal.ts
@@ -1,5 +1,9 @@
 import { chunkText } from "../../auto-reply/chunk.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildSessionKeyFromContext,
+  normalizeAccountId,
+} from "../../routing/session-key.js";
 import {
   listSignalAccountIds,
   type ResolvedSignalAccount,
@@ -118,6 +122,23 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
   },
   messaging: {
     normalizeTarget: normalizeSignalMessagingTarget,
+    resolveTargetSessionKey: ({ cfg, mainSessionKey, to }) => {
+      if (!to) return null;
+      const normalized = normalizeSignalMessagingTarget(to);
+      if (!normalized) return null;
+      const lower = normalized.toLowerCase();
+      const isGroup = lower.startsWith("group:");
+      const peerId = isGroup ? normalized.slice("group:".length).trim() : normalized;
+      if (!peerId) return null;
+      return buildSessionKeyFromContext({
+        mainSessionKey,
+        channel: "signal",
+        peerKind: isGroup ? "group" : "dm",
+        peerId,
+        dmScope: cfg.session?.dmScope,
+        identityLinks: cfg.session?.identityLinks,
+      });
+    },
     targetResolver: {
       looksLikeId: looksLikeSignalTargetId,
       hint: "<E.164|group:ID|signal:group:ID|signal:+E.164>",

--- a/src/channels/plugins/telegram.ts
+++ b/src/channels/plugins/telegram.ts
@@ -2,7 +2,11 @@ import { chunkMarkdownText } from "../../auto-reply/chunk.js";
 import type { ClawdbotConfig } from "../../config/config.js";
 import { writeConfigFile } from "../../config/config.js";
 import { shouldLogVerbose } from "../../globals.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildSessionKeyFromContext,
+  normalizeAccountId,
+} from "../../routing/session-key.js";
 import {
   listTelegramAccountIds,
   type ResolvedTelegramAccount,
@@ -16,6 +20,8 @@ import {
 import { probeTelegram } from "../../telegram/probe.js";
 import { sendMessageTelegram } from "../../telegram/send.js";
 import { resolveTelegramToken } from "../../telegram/token.js";
+import { parseTelegramTarget } from "../../telegram/targets.js";
+import { buildTelegramGroupPeerId } from "../../telegram/bot/helpers.js";
 import { getChatChannelMeta } from "../registry.js";
 import { TelegramConfigSchema } from "../../config/zod-schema.providers-core.js";
 import { telegramMessageActions } from "./actions/telegram.js";
@@ -164,6 +170,29 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount> = {
   },
   messaging: {
     normalizeTarget: normalizeTelegramMessagingTarget,
+    resolveTargetSessionKey: ({ cfg, mainSessionKey, to }) => {
+      if (!to) return null;
+      const normalized = normalizeTelegramMessagingTarget(to);
+      if (!normalized) return null;
+      const parsed = parseTelegramTarget(normalized);
+      const chatId = parsed.chatId.trim();
+      if (!chatId) return null;
+      const hasGroupPrefix = /(^|\b)(telegram:)?group:/i.test(to);
+      const isGroup =
+        hasGroupPrefix ||
+        parsed.messageThreadId != null ||
+        chatId.startsWith("-") ||
+        chatId.startsWith("@");
+      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, parsed.messageThreadId) : chatId;
+      return buildSessionKeyFromContext({
+        mainSessionKey,
+        channel: "telegram",
+        peerKind: isGroup ? "group" : "dm",
+        peerId,
+        dmScope: cfg.session?.dmScope,
+        identityLinks: cfg.session?.identityLinks,
+      });
+    },
     targetResolver: {
       looksLikeId: looksLikeTelegramTargetId,
       hint: "<chatId>",

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -217,6 +217,11 @@ export type ChannelThreadingToolContext = {
 
 export type ChannelMessagingAdapter = {
   normalizeTarget?: (raw: string) => string | undefined;
+  resolveTargetSessionKey?: (params: {
+    cfg: ClawdbotConfig;
+    mainSessionKey: string;
+    to?: string | null;
+  }) => string | null;
   targetResolver?: {
     looksLikeId?: (raw: string, normalized?: string) => boolean;
     hint?: string;

--- a/src/channels/plugins/whatsapp.ts
+++ b/src/channels/plugins/whatsapp.ts
@@ -2,7 +2,11 @@ import { createActionGate, readStringParam } from "../../agents/tools/common.js"
 import { handleWhatsAppAction } from "../../agents/tools/whatsapp-actions.js";
 import { chunkText } from "../../auto-reply/chunk.js";
 import { shouldLogVerbose } from "../../globals.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildSessionKeyFromContext,
+  normalizeAccountId,
+} from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
 import {
   listWhatsAppAccountIds,
@@ -226,6 +230,20 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
   },
   messaging: {
     normalizeTarget: normalizeWhatsAppMessagingTarget,
+    resolveTargetSessionKey: ({ cfg, mainSessionKey, to }) => {
+      if (!to) return null;
+      const normalized = normalizeWhatsAppMessagingTarget(to);
+      if (!normalized) return null;
+      const isGroup = isWhatsAppGroupJid(normalized);
+      return buildSessionKeyFromContext({
+        mainSessionKey,
+        channel: "whatsapp",
+        peerKind: isGroup ? "group" : "dm",
+        peerId: normalized,
+        dmScope: cfg.session?.dmScope,
+        identityLinks: cfg.session?.identityLinks,
+      });
+    },
     targetResolver: {
       looksLikeId: looksLikeWhatsAppTargetId,
       hint: "<E.164|group JID>",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -167,6 +167,10 @@ export type AgentDefaultsConfig = {
     prompt?: string;
     /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
     ackMaxChars?: number;
+    /** Include recent delivery-channel message history when target differs from heartbeat session. */
+    includeDeliveryChannelHistory?: boolean;
+    /** Max number of delivery-channel messages to prepend (default: 10). */
+    deliveryChannelHistoryLimit?: number;
     /**
      * When enabled, deliver the model's reasoning payload for heartbeat runs (when available)
      * as a separate message prefixed with `Reasoning:` (same as `/reasoning on`).

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -13,6 +13,8 @@ export const HeartbeatSchema = z
     every: z.string().optional(),
     model: z.string().optional(),
     includeReasoning: z.boolean().optional(),
+    includeDeliveryChannelHistory: z.boolean().optional(),
+    deliveryChannelHistoryLimit: z.number().int().positive().optional(),
     target: z
       .union([
         z.literal("last"),

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -141,6 +141,36 @@ export function buildAgentPeerSessionKey(params: {
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
+function resolveMainKeyFromSessionKey(sessionKey: string | undefined | null): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) return DEFAULT_MAIN_KEY;
+  const rest = parsed.rest.trim();
+  if (!rest || rest.includes(":")) return DEFAULT_MAIN_KEY;
+  return normalizeMainKey(rest);
+}
+
+export function buildSessionKeyFromContext(params: {
+  mainSessionKey: string;
+  channel: string;
+  peerKind?: "dm" | "group" | "channel" | null;
+  peerId?: string | null;
+  /** DM session scope. */
+  dmScope?: "main" | "per-peer" | "per-channel-peer";
+  identityLinks?: Record<string, string[]>;
+}): string {
+  const agentId = resolveAgentIdFromSessionKey(params.mainSessionKey);
+  const mainKey = resolveMainKeyFromSessionKey(params.mainSessionKey);
+  return buildAgentPeerSessionKey({
+    agentId,
+    mainKey,
+    channel: params.channel,
+    peerKind: params.peerKind,
+    peerId: params.peerId,
+    dmScope: params.dmScope,
+    identityLinks: params.identityLinks,
+  });
+}
+
 function resolveLinkedPeerId(params: {
   identityLinks?: Record<string, string[]>;
   channel: string;


### PR DESCRIPTION
## Problem
When the `heartbeat.target` is configured to a non-main session channel (e.g. Discord #general), the heartbeat message feels disjointed from the conversation. Additionally, if the user replies to the heartbeat message, any subsequent heartbeats fail to contextualize with the user's reply which feels un-natural.

## Solution
This change optionally injects the delivery channel’s recent messages into the heartbeat prompt, so the reply fits the thread.

Example functionality (BEFORE FEAT):
> Bot (Heartbeat): Hey user! It's 10am! Hope you're off to work..
> User: Yup! Already here and drinking my coffee.
> Bot: Nice! Enjoy.
> <...>
> Bot (Heartbeat): User! It's 11am! Hope you're having a productive day at work.

Example functionality (AFTER FEAT):
> Bot (Heartbeat): Hey user! It's 10am! Hope you're off to work..
> User: Yup! Already here and drinking my coffee.
> Bot: Nice! Enjoy.
> <...>
> Bot (Heartbeat): User! It's 11am! Time for another coffee? <-- (CONTEXTUAL)

This extends beyond just the semantics of how natural the bot's reply feels (e.g. if the user were to say "stop chatting about my work day" in the example above, future heartbeats would stop talking about the work day, at least until some time has passed).

The bot only gets `heartbeat.deliveryChannelHistoryLimit` number of messages in its prompt, but in my testing this has a dramatic improvement on how life-like the bot feels, as well as the quality of its heartbeat reasoning.

## Configuration
New config is added to gate this feature. It is off by default, since the "default" clawdbot behavior likely has users chatting into the main session anyway.

`includeDeliveryChannelHistory`: when `true`, prepend recent delivery-channel message history when the heartbeat session differs from the delivery session. Default: `false`
`deliveryChannelHistoryLimit`: number of recent delivery-channel messages to prepend (default: 10).

## Alternative Solutions
There are several alternative solutions for this, including allowing the heartbeat configuration to work from a different session. This solution was chosen because it is the least invasive (e.g. changing the heartbeat to run outside of the main session would require also changing where system events are persisted). The user could also adjust the heartbeat prompt to read from session history, but since heartbeat's have native support for posting to alternative channels, I think it makes sense to also natively consider that channel's context before posting.

## AI
Assisted by Codex.
