### PR TITLE
fix(agent): Enable model fallback for prompt-phase quota/rate limit errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -318,6 +318,19 @@ export async function runEmbeddedPiAgent(
               thinkLevel = fallbackThinking;
               continue;
             }
+            // FIX: Throw FailoverError for prompt errors when fallbacks configured
+            // This enables model fallback for quota/rate limit errors during prompt submission
+            const promptFallbackConfigured =
+              (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+            if (promptFallbackConfigured && isFailoverErrorMessage(errorText)) {
+              throw new FailoverError(errorText, {
+                reason: promptFailoverReason ?? "unknown",
+                provider,
+                model: modelId,
+                profileId: lastProfileId,
+                status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+              });
+            }
             throw promptError;
           }
 


### PR DESCRIPTION
## Summary
When a prompt submission fails with quota or rate limit errors, throw `FailoverError` instead of `promptError`, enabling model fallback.

## Problem
Rate limit errors during **prompt phase** bypass fallback. Only response-phase errors trigger it.

## Solution
Check if fallbacks configured + error is failover-eligible → wrap in `FailoverError`.

## Test plan
- [x] Configure primary model with fallbacks
- [x] Rate-limit primary model
- [x] Verify fallback on prompt errors