### PR TITLE
fix(fallback): Classify AbortError as timeout for model fallback

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -26,6 +26,8 @@ type FallbackAttempt = {
 
 function isAbortError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
+  // Do not treat FailoverErrors as aborts - they should always trigger fallback
+  if (isFailoverError(err)) return false;
   const name = "name" in err ? String(err.name) : "";
   if (name === "AbortError") return true;
   const message =


### PR DESCRIPTION
## Summary
Add `AbortError` to timeout classification so request cancellations trigger fallback.

## Problem
`AbortError` (from timeout signals) wasn't classified as timeout → no fallback.

## Solution
Check for `AbortError` name in `isTimeoutAssistantError()`.

## Test plan
- [ ] Trigger request timeout
- [ ] Verify classified as timeout
- [ ] Verify fallback attempted