### PR TITLE
feat(agents): add usageFormat config for response footer

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -73,12 +73,27 @@ export const formatResponseUsageLine = (params: {
     cacheRead: number;
     cacheWrite: number;
   };
+  /** Usage format: "inout" (default) or "context". */
+  format?: "inout" | "context";
+  /** Context window size (for "context" format). */
+  contextTokens?: number;
 }): string | null => {
   const usage = params.usage;
   if (!usage) return null;
   const input = usage.input;
   const output = usage.output;
   if (typeof input !== "number" && typeof output !== "number") return null;
+
+  // Context format: "Usage: 16k/200k (8%)"
+  if (params.format === "context" && params.contextTokens && typeof input === "number") {
+    const totalUsed = input + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+    const usedLabel = formatTokenCount(totalUsed);
+    const maxLabel = formatTokenCount(params.contextTokens);
+    const pct = Math.round((totalUsed / params.contextTokens) * 100);
+    return `Usage: ${usedLabel}/${maxLabel} (${pct}%)`;
+  }
+
+  // Default "inout" format: "Usage: 10 in / 93 out · est $0.01"
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";
   const outputLabel = typeof output === "number" ? formatTokenCount(output) : "?";
   const cost =

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -470,10 +470,13 @@ export async function runReplyAgent(params: {
             config: cfg,
           })
         : undefined;
+      const usageFormat = cfg?.agents?.defaults?.usageFormat ?? "inout";
       const formatted = formatResponseUsageLine({
         usage,
         showCost,
         costConfig,
+        format: usageFormat,
+        contextTokens: contextTokensUsed,
       });
       if (formatted) responseUsageLine = formatted;
     }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -107,6 +107,8 @@ export type AgentDefaultsConfig = {
   timeFormat?: "auto" | "12" | "24";
   /** Optional display-only context window override (used for % in status UIs). */
   contextTokens?: number;
+  /** Usage footer format: "inout" (10 in / 93 out) or "context" (16k/200k 8%). */
+  usageFormat?: "inout" | "context";
   /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -43,6 +43,7 @@ export const AgentDefaultsSchema = z
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     contextTokens: z.number().int().positive().optional(),
+    usageFormat: z.union([z.literal("inout"), z.literal("context")]).optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,
     contextPruning: z


### PR DESCRIPTION
## Summary
- Adds a new `usageFormat` option in `agents.defaults` to switch response usage footer format
- Supports `"inout"` (default): `Usage: 10 in / 93 out · est $0.01`
- Supports `"context"`: `Usage: 16k/200k (8%)` showing context window usage percentage

## Config Example
```json
{
  "agents": {
    "defaults": {
      "usageFormat": "context"
    }
  }
}
```

## Usage
1. Add `usageFormat: "context"` to your config (as shown above)
2. Enable the usage footer in your session with `/cost on`
3. Responses will now show `Usage: 16k/200k (8%)` instead of `Usage: 10 in / 93 out`

Note: `/usage` is an alias for `/status`. Use `/cost on` to enable the per-response usage footer.

## Test Plan
- [x] Build passes
- [x] Tested with `usageFormat: "context"` - footer shows `Usage: Xk/200k (Y%)`
- [x] Tested with `usageFormat: "inout"` (default) - confirms original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)