### PR TITLE
chore: update readme, added a note for shallow git sub module cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ git submodule update --init --recursive
 ./scripts/restart-mac.sh
 ```
 
+> **Note**: If a shallow submodule copy is preferred, use:
+> ```bash
+> git submodule update --init --recursive --progress --verbose --depth 1 --jobs 8
+> ```
+
 ### macOS (Clawdbot.app) (optional)
 
 - Menu bar control for the Gateway and health.
@@ -454,7 +459,7 @@ Use these when you’re past the onboarding flow and want the deeper reference.
 
 ## Clawd
 
-Clawdbot was built for **Clawd**, a space lobster AI assistant. 🦞  
+Clawdbot was built for **Clawd**, a space lobster AI assistant. 🦞
 by Peter Steinberger and the community.
 
 - [clawd.me](https://clawd.me)
@@ -463,7 +468,7 @@ by Peter Steinberger and the community.
 
 ## Community
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.  
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.
 AI/vibe-coded PRs welcome! 🤖
 
 Special thanks to @andrewting19 for the Anthropic OAuth tool-name fix.

--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -22,6 +22,11 @@ Clawdbot depends on several submodules (like `Peekaboo`). You must initialize th
 git submodule update --init --recursive
 ```
 
+> **Note**: If a shallow submodule copy is preferred, use:
+> ```bash
+> git submodule update --init --recursive --progress --verbose --depth 1 --jobs 8
+> ```
+
 ## 2. Install Dependencies
 
 Install the project-wide dependencies:
@@ -38,7 +43,7 @@ To build the macOS app and package it into `dist/Clawdbot.app`, run:
 ./scripts/package-mac-app.sh
 ```
 
-If you don't have an Apple Developer ID certificate, the script will automatically use **ad-hoc signing** (`-`). 
+If you don't have an Apple Developer ID certificate, the script will automatically use **ad-hoc signing** (`-`).
 
 > **Note**: Ad-hoc signed apps may trigger security prompts. If the app crashes immediately with "Abort trap 6", see the [Troubleshooting](#troubleshooting) section.
 


### PR DESCRIPTION
Suggest adding this note to make it easier to clone the sub modules when devs are not interested in cloning the history of sub modules.