### PR TITLE
fix(openai-http): preserve conversation context in messages array

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,8 @@ importers:
         specifier: 3.14.5
         version: 3.14.5(typescript@5.9.3)
 
+  extensions/bluebubbles: {}
+
   extensions/copilot-proxy: {}
 
   extensions/google-antigravity-auth: {}

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -108,13 +108,23 @@ export function handleMessageUpdate(
     })
     .trim();
   if (next && next !== ctx.state.lastStreamedAssistant) {
+    const previousText = ctx.state.lastStreamedAssistant ?? "";
     ctx.state.lastStreamedAssistant = next;
     const { text: cleanedText, mediaUrls } = parseReplyDirectives(next);
+
+    // Compute delta: the new content since last emission
+    // This is needed for OpenAI-compatible streaming which expects deltas, not full text
+    const { text: previousCleanedText } = parseReplyDirectives(previousText);
+    const deltaText = cleanedText.startsWith(previousCleanedText)
+      ? cleanedText.slice(previousCleanedText.length)
+      : cleanedText;
+
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "assistant",
       data: {
         text: cleanedText,
+        delta: deltaText,
         mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
       },
     });
@@ -122,6 +132,7 @@ export function handleMessageUpdate(
       stream: "assistant",
       data: {
         text: cleanedText,
+        delta: deltaText,
         mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
       },
     });


### PR DESCRIPTION
## Problem

The OpenAI-compatible `/v1/chat/completions` endpoint was only extracting the **last user message** from the `messages` array, ignoring all prior conversation turns. This meant follow-up questions had no context.

OpenAI's Chat Completions API is stateless by design — clients like Open WebUI send the full conversation history with each request. Clawdbot was discarding this history.

## Solution

Modified `buildAgentPrompt()` to format the full conversation into context:

- **Multi-turn conversations** are formatted as:
  ```
  [Conversation history]
  User: first question
  Assistant: first response
  
  [Current message]
  latest question
  ```

- **Single-message requests** remain unchanged (no headers added)
- **Added support for `developer` role** (OpenAI's newer system prompt role)

## Testing

- Added 3 e2e tests covering conversation history, single messages, and developer role
- Manually verified with Open WebUI — follow-up questions now have context

## Notes

This is the first of two fixes for the OpenAI-compatible API. A follow-up PR will address streaming delta handling (currently sends full text instead of incremental chunks).