### PR TITLE
Matrix: fix redundant allowFrom assignment in monitorMatrixProvider

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -201,7 +201,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const dmEnabled = dmConfig?.enabled ?? true;
   const dmPolicyRaw = dmConfig?.policy ?? "pairing";
   const dmPolicy = allowlistOnly && dmPolicyRaw !== "disabled" ? "allowlist" : dmPolicyRaw;
-  const allowFrom = dmConfig?.allowFrom ?? [];
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "matrix");
   const mediaMaxMb = opts.mediaMaxMb ?? cfg.channels?.matrix?.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;


### PR DESCRIPTION
Remove unnecessary assignment of allowFrom in the monitorMatrixProvider function to streamline the code.

It solves:

```
error gateway/channels/matrix {"subsystem":"gateway/channels/matrix"} [default] channel exited: ParseError: Identifier 'allowFrom' has already been declared. 
```

Still working on getting matrix working in the released artifacts. Tbh I don't know why some agent breaks this every time in your releases. 

Everything works locally, I switch back to main after PR is merged and it's broken again.

So today one more try 🤗 Crossing my fingers and just wanted to provide this experience quickly.