### PR TITLE
Plugins: auto-select exclusive slots

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -12,6 +12,7 @@ import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { createPluginRuntime } from "./runtime/index.js";
 import { setActivePluginRegistry } from "./runtime.js";
+import { defaultSlotIdForKey } from "./slots.js";
 import type {
   ClawdbotPluginConfigSchema,
   ClawdbotPluginDefinition,
@@ -92,7 +93,7 @@ const normalizePluginsConfig = (config?: ClawdbotConfig["plugins"]): NormalizedP
     deny: normalizeList(config?.deny),
     loadPaths: normalizeList(config?.load?.paths),
     slots: {
-      memory: memorySlot ?? "memory-core",
+      memory: memorySlot ?? defaultSlotIdForKey("memory"),
     },
     entries: normalizePluginEntries(config?.entries),
   };

--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { applyExclusiveSlotSelection } from "./slots.js";
+
+describe("applyExclusiveSlotSelection", () => {
+  it("selects the slot and disables other entries for the same kind", () => {
+    const config: ClawdbotConfig = {
+      plugins: {
+        slots: { memory: "memory-core" },
+        entries: {
+          "memory-core": { enabled: true },
+          memory: { enabled: true },
+        },
+      },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory",
+      selectedKind: "memory",
+      registry: {
+        plugins: [
+          { id: "memory-core", kind: "memory" },
+          { id: "memory", kind: "memory" },
+        ],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.slots?.memory).toBe("memory");
+    expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(false);
+    expect(result.warnings).toContain(
+      'Exclusive slot "memory" switched from "memory-core" to "memory".',
+    );
+    expect(result.warnings).toContain(
+      'Disabled other "memory" slot plugins: memory-core.',
+    );
+  });
+
+  it("does nothing when the slot already matches", () => {
+    const config: ClawdbotConfig = {
+      plugins: {
+        slots: { memory: "memory" },
+        entries: {
+          memory: { enabled: true },
+        },
+      },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory",
+      selectedKind: "memory",
+      registry: { plugins: [{ id: "memory", kind: "memory" }] },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.config).toBe(config);
+  });
+
+  it("warns when the slot falls back to a default", () => {
+    const config: ClawdbotConfig = {
+      plugins: {
+        entries: {
+          memory: { enabled: true },
+        },
+      },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory",
+      selectedKind: "memory",
+      registry: { plugins: [{ id: "memory", kind: "memory" }] },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.warnings).toContain(
+      'Exclusive slot "memory" switched from "memory-core" to "memory".',
+    );
+  });
+
+  it("skips changes when no exclusive slot applies", () => {
+    const config: ClawdbotConfig = {};
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "custom",
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.config).toBe(config);
+  });
+});

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -1,0 +1,102 @@
+import type { ClawdbotConfig } from "../config/config.js";
+import type { PluginSlotsConfig } from "../config/types.plugins.js";
+import type { PluginKind } from "./types.js";
+
+export type PluginSlotKey = keyof PluginSlotsConfig;
+
+type SlotPluginRecord = {
+  id: string;
+  kind?: PluginKind;
+};
+
+const SLOT_BY_KIND: Record<PluginKind, PluginSlotKey> = {
+  memory: "memory",
+};
+
+const DEFAULT_SLOT_BY_KEY: Record<PluginSlotKey, string> = {
+  memory: "memory-core",
+};
+
+export function slotKeyForPluginKind(kind?: PluginKind): PluginSlotKey | null {
+  if (!kind) return null;
+  return SLOT_BY_KIND[kind] ?? null;
+}
+
+export function defaultSlotIdForKey(slotKey: PluginSlotKey): string {
+  return DEFAULT_SLOT_BY_KEY[slotKey];
+}
+
+export type SlotSelectionResult = {
+  config: ClawdbotConfig;
+  warnings: string[];
+  changed: boolean;
+};
+
+export function applyExclusiveSlotSelection(params: {
+  config: ClawdbotConfig;
+  selectedId: string;
+  selectedKind?: PluginKind;
+  registry?: { plugins: SlotPluginRecord[] };
+}): SlotSelectionResult {
+  const slotKey = slotKeyForPluginKind(params.selectedKind);
+  if (!slotKey) {
+    return { config: params.config, warnings: [], changed: false };
+  }
+
+  const warnings: string[] = [];
+  const pluginsConfig = params.config.plugins ?? {};
+  const prevSlot = pluginsConfig.slots?.[slotKey];
+  const slots = {
+    ...(pluginsConfig.slots ?? {}),
+    [slotKey]: params.selectedId,
+  };
+
+  const inferredPrevSlot = prevSlot ?? defaultSlotIdForKey(slotKey);
+  if (inferredPrevSlot && inferredPrevSlot !== params.selectedId) {
+    warnings.push(
+      `Exclusive slot "${slotKey}" switched from "${inferredPrevSlot}" to "${params.selectedId}".`,
+    );
+  }
+
+  const entries = { ...(pluginsConfig.entries ?? {}) };
+  const disabledIds: string[] = [];
+  if (params.registry) {
+    for (const plugin of params.registry.plugins) {
+      if (plugin.id === params.selectedId) continue;
+      if (plugin.kind !== params.selectedKind) continue;
+      const entry = entries[plugin.id];
+      if (!entry || entry.enabled !== false) {
+        entries[plugin.id] = {
+          ...(entry ?? {}),
+          enabled: false,
+        };
+        disabledIds.push(plugin.id);
+      }
+    }
+  }
+
+  if (disabledIds.length > 0) {
+    warnings.push(
+      `Disabled other "${slotKey}" slot plugins: ${disabledIds.sort().join(", ")}.`,
+    );
+  }
+
+  const changed = prevSlot !== params.selectedId || disabledIds.length > 0;
+
+  if (!changed) {
+    return { config: params.config, warnings: [], changed: false };
+  }
+
+  return {
+    config: {
+      ...params.config,
+      plugins: {
+        ...pluginsConfig,
+        slots,
+        entries,
+      },
+    },
+    warnings,
+    changed: true,
+  };
+}


### PR DESCRIPTION
## Problem
- Plugins in exclusive slots (like memory) can show as enabled in config while a different plugin owns the slot.
- This makes it look like a plugin is on when it is actually disabled by the slot selector, and there was no warning or automatic slot update.

## Fix
- Introduce slot utilities in `src/plugins/slots.ts`:
  - Map plugin `kind` -> slot key (extensible for future exclusive slots).
  - Centralize per-slot defaults (keeps loader defaults in sync).
  - `applyExclusiveSlotSelection` sets the slot to the selected plugin and disables other plugins of the same kind in `plugins.entries`, returning warnings.
- Use the shared default slot mapping in `src/plugins/loader.ts`.
- Update `src/cli/plugins-cli.ts` so `plugins enable` and plugin installs/links apply slot selection automatically and surface warnings.

## Behavior Changes
- Enabling/installing a memory plugin now:
  - Sets `plugins.slots.memory` to that plugin.
  - Disables other memory plugins in `plugins.entries` to avoid the “enabled but inactive” state.
  - Emits warnings when the slot changes or other plugins are auto-disabled.

## Testing
- `pnpm build`
- Manual: switched between `memory` and `memory-core` and it works as expected.

## LLM Review Prompt
Please review the changes for correctness and regressions. Focus on:
- Whether exclusive slot selection is applied consistently and safely.
- Default slot mapping consistency between loader and CLI.
- Config mutation correctness in `applyExclusiveSlotSelection` and CLI calls.
- Warning messaging clarity and potential edge cases (unknown plugin ids, missing registry entries).
Files: `src/plugins/slots.ts`, `src/cli/plugins-cli.ts`, `src/plugins/loader.ts`, `src/plugins/slots.test.ts`.
