### PR TITLE
fix(configure): filter openrouter/auto from model selection list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.clawd.bot
 - Dependencies: update core + plugin deps (grammy, vitest, openai, Microsoft agents hosting, etc.).
 
 ### Fixes
-- macOS: load menu session previews asynchronously so items populate while the menu is open.
+- Configure: hide OpenRouter auto routing model from the model picker. (#1182) — thanks @zerone0x.
 
 ## 2026.1.18-4
 

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+import { makePrompter } from "./onboarding/__tests__/test-utils.js";
+import { promptDefaultModel } from "./model-picker.js";
+
+const loadModelCatalog = vi.hoisted(() => vi.fn());
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog,
+}));
+
+const ensureAuthProfileStore = vi.hoisted(() =>
+  vi.fn(() => ({
+    version: 1,
+    profiles: {},
+  })),
+);
+const listProfilesForProvider = vi.hoisted(() => vi.fn(() => []));
+vi.mock("../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+}));
+
+const resolveEnvApiKey = vi.hoisted(() => vi.fn(() => undefined));
+const getCustomProviderApiKey = vi.hoisted(() => vi.fn(() => undefined));
+vi.mock("../agents/model-auth.js", () => ({
+  resolveEnvApiKey,
+  getCustomProviderApiKey,
+}));
+
+describe("promptDefaultModel", () => {
+  it("filters internal router models from the selection list", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openrouter",
+        id: "auto",
+        name: "OpenRouter Auto",
+      },
+      {
+        provider: "openrouter",
+        id: "meta-llama/llama-3.3-70b:free",
+        name: "Llama 3.3 70B",
+      },
+    ]);
+
+    const select = vi.fn(async (params) => {
+      const first = params.options[0];
+      return first?.value ?? "";
+    });
+    const prompter = makePrompter({ select });
+    const config = { agents: { defaults: {} } } as ClawdbotConfig;
+
+    await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+    });
+
+    const options = select.mock.calls[0]?.[0]?.options ?? [];
+    expect(options.some((opt) => opt.value === "openrouter/auto")).toBe(false);
+    expect(
+      options.some((opt) => opt.value === "openrouter/meta-llama/llama-3.3-70b:free"),
+    ).toBe(true);
+  });
+});

--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -17,6 +17,11 @@ const KEEP_VALUE = "__keep__";
 const MANUAL_VALUE = "__manual__";
 const PROVIDER_FILTER_THRESHOLD = 30;
 
+// Models that are internal routing features and should not be shown in selection lists.
+// These may be valid as defaults (e.g., set automatically during auth flow) but are not
+// directly callable via API and would cause "Unknown model" errors if selected manually.
+const HIDDEN_ROUTER_MODELS = new Set(["openrouter/auto"]);
+
 type PromptDefaultModelParams = {
   config: ClawdbotConfig;
   prompter: WizardPrompter;
@@ -183,6 +188,8 @@ export async function promptDefaultModel(
   }) => {
     const key = modelKey(entry.provider, entry.id);
     if (seen.has(key)) return;
+    // Skip internal router models that can't be directly called via API.
+    if (HIDDEN_ROUTER_MODELS.has(key)) return;
     const hints: string[] = [];
     if (entry.name && entry.name !== entry.id) hints.push(entry.name);
     if (entry.contextWindow) hints.push(`ctx ${formatTokenK(entry.contextWindow)}`);


### PR DESCRIPTION
## Summary
Fixes #1115

The `openrouter/auto` model identifier appears in the configure wizard's model selection list, but it's not a valid callable model - it's OpenRouter's internal routing feature. When users select it manually, they get "Unknown model: openrouter/auto" errors at runtime.

This PR filters out `openrouter/auto` from the model picker selection list while preserving its use as an automatic default when authenticating with OpenRouter.

## Changes
- Add `HIDDEN_ROUTER_MODELS` set in `src/commands/model-picker.ts` for internal router models
- Filter out models in this set from the selection list in `addModelOption()`

## Test plan
- [ ] Run `clawdbot configure` and select OpenRouter as provider
- [ ] Verify `openrouter/auto` does not appear in the model selection dropdown
- [ ] Verify other OpenRouter models still appear correctly
- [ ] Verify existing OpenRouter auth flow still sets `openrouter/auto` as default

---
🤖 Generated with Claude Code