### PR TITLE
chore(auth): Improve Anthropic token option hints in onboarding wizard

### DIFF
--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -26,7 +26,7 @@ describe("buildAuthChoiceOptions", () => {
 
     const claudeCli = options.find((opt) => opt.value === "claude-cli");
     expect(claudeCli).toBeDefined();
-    expect(claudeCli?.hint).toBe("requires Keychain access");
+    expect(claudeCli?.hint).toBe("reuses existing Claude Code auth · requires Keychain access");
   });
 
   it("skips missing Claude Code CLI option off macOS", () => {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -160,26 +160,26 @@ export function buildAuthChoiceOptions(params: {
     options.push({
       value: "claude-cli",
       label: "Anthropic token (Claude Code CLI)",
-      hint: formatOAuthHint(claudeCli.expires),
+      hint: `reuses existing Claude Code auth · ${formatOAuthHint(claudeCli.expires)}`,
     });
   } else if (params.includeClaudeCliIfMissing && platform === "darwin") {
     options.push({
       value: "claude-cli",
       label: "Anthropic token (Claude Code CLI)",
-      hint: "requires Keychain access",
+      hint: "reuses existing Claude Code auth · requires Keychain access",
     });
   }
 
   options.push({
     value: "setup-token",
     label: "Anthropic token (run setup-token)",
-    hint: "Runs `claude setup-token`",
+    hint: "runs `claude setup-token` · opens browser for fresh OAuth login",
   });
 
   options.push({
     value: "token",
     label: "Anthropic token (paste setup-token)",
-    hint: "Run `claude setup-token`, then paste the token",
+    hint: "run `claude setup-token` elsewhere, then paste the token here",
   });
 
   options.push({


### PR DESCRIPTION
  ## Summary
  - Adds clearer hints to Anthropic authentication options during onboarding
  - Helps users understand the difference between the three token options at a glance

  ## Changes

Even though I was in the loop on how claude code works together with clawd bot, I was still unsure on which option to choose. Here's a screenshot of the *before*

<img width="932" height="134" alt="CleanShot 2026-01-18 at 18 42 14" src="https://github.com/user-attachments/assets/0e2e2ef5-7f64-4894-9dfa-51417adf1366" />

This PR aims to keep all existing text and hints, but adds only a few additional words that can help make the distinction

  ## Test plan
  - [x] `pnpm vitest run src/commands/auth-choice-options.test.ts` passes (11/11)
  - [x] `pnpm lint` passes
  - [x] `pnpm build` passes

  🤖 Generated with [Claude Code Opus 4.5](https://claude.ai/code)