### PR TITLE
feat(queue): add per-channel debounce overrides

### DIFF
--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -13,6 +13,8 @@ export type QueueConfig = {
   mode?: QueueMode;
   byChannel?: QueueModeByProvider;
   debounceMs?: number;
+  /** Per-channel debounce overrides (ms). */
+  debounceMsByChannel?: InboundDebounceByProvider;
   cap?: number;
   drop?: QueueDropPolicy;
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -206,6 +206,7 @@ export const QueueSchema = z
     mode: QueueModeSchema.optional(),
     byChannel: QueueModeBySurfaceSchema,
     debounceMs: z.number().int().nonnegative().optional(),
+    debounceMsByChannel: DebounceMsBySurfaceSchema,
     cap: z.number().int().positive().optional(),
     drop: QueueDropSchema.optional(),
   })


### PR DESCRIPTION
## Summary

- Adds `debounceMsByChannel` config option to set different debounce values per channel
- Telegram can have faster response times (e.g., 100ms) while Discord batches longer (e.g., 90s)
- Follows existing pattern of `byChannel` for queue mode

## Configuration

```json
{
  "messages": {
    "queue": {
      "debounceMs": 1000,
      "debounceMsByChannel": {
        "telegram": 100,
        "discord": 90000,
        "whatsapp": 500,
        "signal": 200,
        "matrix": 300,
        "slack": 1000
      }
    }
  }
}
```

### Supported Channels

| Channel | Key | Typical Use Case |
|---------|-----|------------------|
| Telegram | `telegram` | Fast responses for real-time chat |
| Discord | `discord` | Longer batching for busy servers |
| WhatsApp | `whatsapp` | Balanced for mobile messaging |
| Signal | `signal` | Quick replies for secure chats |
| Matrix | `matrix` | Moderate batching for federated rooms |
| Slack | `slack` | Standard workspace messaging |

Channel keys match the provider name in lowercase. If a channel is not specified in `debounceMsByChannel`, it falls back to the global `debounceMs` value (default: 1000ms).

