### PR TITLE
fix(slack): use named imports from @slack/bolt for Bun compatibility

### DIFF
--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-import SlackBolt from "@slack/bolt";
+import { App, HTTPReceiver } from "@slack/bolt";
 
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
@@ -26,7 +26,6 @@ import { normalizeAllowList } from "./allow-list.js";
 
 import type { MonitorSlackOpts } from "./types.js";
 
-const { App, HTTPReceiver } = SlackBolt as typeof import("@slack/bolt");
 function parseApiAppIdFromAppToken(raw?: string) {
   const token = raw?.trim();
   if (!token) return undefined;


### PR DESCRIPTION
## Summary
- Fixed Slack channel failing to start under Bun with "undefined is not a constructor" error
- Changed from default import + destructure pattern to direct named imports

## Problem
The default import pattern doesn't work in Bun due to how Bun handles CommonJS module interop:
```typescript
// Before (broken in Bun)
import SlackBolt from "@slack/bolt";
const { App, HTTPReceiver } = SlackBolt as typeof import("@slack/bolt");
```

## Solution
```typescript
// After (works in both Bun and Node)
import { App, HTTPReceiver } from "@slack/bolt";
```

## Test plan
- [x] Verified Slack channel starts successfully under Bun
- [x] Verified "socket mode connected" appears in logs
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)