### PR TITLE
feat(tui): add fuzzy search to session and agent pickers

### DIFF
--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -7,11 +7,7 @@ import {
 import { normalizeAgentId } from "../routing/session-key.js";
 import { helpText, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
-import {
-  createSearchableSelectList,
-  createSelectList,
-  createSettingsList,
-} from "./components/selectors.js";
+import { createSearchableSelectList, createSettingsList } from "./components/selectors.js";
 import type { GatewayChatClient } from "./gateway-chat.js";
 import { formatStatusSummary } from "./tui-status-summary.js";
 import type {
@@ -117,7 +113,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       label: agent.name ? `${agent.id} (${agent.name})` : agent.id,
       description: agent.id === state.agentDefaultId ? "default" : "",
     }));
-    const selector = createSelectList(items, 9);
+    const selector = createSearchableSelectList(items, 9);
     selector.onSelect = (item) => {
       void (async () => {
         closeOverlay();
@@ -147,7 +143,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           : formatSessionKey(session.key),
         description: session.updatedAt ? new Date(session.updatedAt).toLocaleString() : "",
       }));
-      const selector = createSelectList(items, 9);
+      const selector = createSearchableSelectList(items, 9);
       selector.onSelect = (item) => {
         void (async () => {
           closeOverlay();


### PR DESCRIPTION
## Summary

Extends the fuzzy search from the model picker to the session and agent pickers.

## Changes

- Use `SearchableSelectList` for `/sessions` picker
- Use `SearchableSelectList` for `/agents` picker
- Remove unused `createSelectList` import

## Behavior

Now when you open `/sessions` or `/agents`, you can type to filter:

- **Session picker**: Search by session key, display name, or timestamp
- **Agent picker**: Search by agent ID or name

Uses the same smart filtering as the model picker:
1. Exact substring matches (earliest position wins)
2. Word-boundary prefix matches  
3. Description matches
4. Fuzzy fallback

## Testing

- Reuses existing `SearchableSelectList` component (11 tests)
- Build passes
- Lint passes

---

🤖 AI-assisted (Claude)