### PR TITLE
Make tool calls use human language by default.

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -358,6 +358,7 @@ export function buildAgentSystemPrompt(params: {
     "Default: do not narrate routine, low-risk tool calls (just call the tool).",
     "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
+    "Use plain human language for narration unless in a technical context.",
     "",
     "## Clawdbot CLI Quick Reference",
     "Clawdbot is controlled via subcommands. Do not invent commands.",


### PR DESCRIPTION
I noticed tool calls became more explicit in the latest version (with gpt-5.2). I really don't care, I just want the bot to talk to me like a human. This is an attempt to get it to speak more human.
