### PR TITLE
fix(ui): enable shell mode for spawn on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.clawd.bot
 - TUI: add syntax highlighting for code blocks. (#1200) — thanks @vignesh07.
 
 ### Fixes
+- UI: enable shell mode for sync Windows spawns to avoid `pnpm ui:build` EINVAL. (#1212) — thanks @longmaba.
 - Plugins: surface plugin load/register/config errors in gateway logs with plugin/source context.
 - Agents: propagate accountId into embedded runs so sub-agent announce routing honors the originating account. (#1058)
 - Compaction: include tool failure summaries in safeguard compaction to prevent retry loops. (#1084)

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -68,6 +68,7 @@ function runSync(cmd, args, envOverride) {
     cwd: uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,
+    shell: process.platform === "win32",
   });
   if (result.signal) process.exit(1);
   if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -55,6 +55,7 @@ function run(cmd, args) {
     cwd: uiDir,
     stdio: "inherit",
     env: process.env,
+    shell: process.platform === "win32",
   });
   child.on("exit", (code, signal) => {
     if (signal) process.exit(1);


### PR DESCRIPTION
Fixes \`EINVAL\` error when running \`pnpm ui:build\` on Windows.