### PR TITLE
Voice-call: fix tailscale tunnel, Twilio signatures, and callbacks

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -389,12 +389,12 @@ export class TwilioProvider implements VoiceCallProvider {
 
     // Build request params - always use URL-based TwiML.
     // Twilio silently ignores `StatusCallback` when using the inline `Twiml` parameter.
-    const params: Record<string, string> = {
+    const params: Record<string, string | string[]> = {
       To: input.to,
       From: input.from,
       Url: url.toString(), // TwiML serving endpoint
       StatusCallback: statusUrl.toString(), // Separate status callback endpoint
-      StatusCallbackEvent: "initiated ringing answered completed",
+      StatusCallbackEvent: ["initiated", "ringing", "answered", "completed"],
       Timeout: "30",
     };
 

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -64,6 +64,8 @@ export class TwilioProvider implements VoiceCallProvider {
 
   /** Storage for TwiML content (for notify mode with URL-based TwiML) */
   private readonly twimlStorage = new Map<string, string>();
+  /** Track notify-mode calls to avoid streaming on follow-up callbacks */
+  private readonly notifyCalls = new Set<string>();
 
   /**
    * Delete stored TwiML for a given `callId`.
@@ -73,6 +75,7 @@ export class TwilioProvider implements VoiceCallProvider {
    */
   private deleteStoredTwiml(callId: string): void {
     this.twimlStorage.delete(callId);
+    this.notifyCalls.delete(callId);
   }
 
   /**
@@ -137,7 +140,7 @@ export class TwilioProvider implements VoiceCallProvider {
    */
   private async apiRequest<T = unknown>(
     endpoint: string,
-    params: Record<string, string>,
+    params: Record<string, string | string[]>,
     options?: { allowNotFound?: boolean },
   ): Promise<T> {
     return await twilioApiRequest<T>({
@@ -286,6 +289,9 @@ export class TwilioProvider implements VoiceCallProvider {
     if (!ctx) return TwilioProvider.EMPTY_TWIML;
 
     const params = new URLSearchParams(ctx.rawBody);
+    const type =
+      typeof ctx.query?.type === "string" ? ctx.query.type.trim() : undefined;
+    const isStatusCallback = type === "status";
     const callStatus = params.get("CallStatus");
     const direction = params.get("Direction");
     const callIdFromQuery =
@@ -297,13 +303,21 @@ export class TwilioProvider implements VoiceCallProvider {
 
     // Handle initial TwiML request (when Twilio first initiates the call)
     // Check if we have stored TwiML for this call (notify mode)
-    if (callIdFromQuery) {
+    if (callIdFromQuery && !isStatusCallback) {
       const storedTwiml = this.twimlStorage.get(callIdFromQuery);
       if (storedTwiml) {
         // Clean up after serving (one-time use)
         this.deleteStoredTwiml(callIdFromQuery);
         return storedTwiml;
       }
+      if (this.notifyCalls.has(callIdFromQuery)) {
+        return TwilioProvider.EMPTY_TWIML;
+      }
+    }
+
+    // Status callbacks should not receive TwiML.
+    if (isStatusCallback) {
+      return TwilioProvider.EMPTY_TWIML;
     }
 
     // Handle subsequent webhook requests (status callbacks, etc.)
@@ -385,6 +399,7 @@ export class TwilioProvider implements VoiceCallProvider {
     // We now serve it from the webhook endpoint instead of sending inline
     if (input.inlineTwiml) {
       this.twimlStorage.set(input.callId, input.inlineTwiml);
+      this.notifyCalls.add(input.callId);
     }
 
     // Build request params - always use URL-based TwiML.

--- a/extensions/voice-call/src/providers/twilio/api.ts
+++ b/extensions/voice-call/src/providers/twilio/api.ts
@@ -3,16 +3,33 @@ export async function twilioApiRequest<T = unknown>(params: {
   accountSid: string;
   authToken: string;
   endpoint: string;
-  body: Record<string, string>;
+  body: URLSearchParams | Record<string, string | string[]>;
   allowNotFound?: boolean;
 }): Promise<T> {
+  const bodyParams =
+    params.body instanceof URLSearchParams
+      ? params.body
+      : Object.entries(params.body).reduce<URLSearchParams>(
+          (acc, [key, value]) => {
+            if (Array.isArray(value)) {
+              for (const entry of value) {
+                acc.append(key, entry);
+              }
+            } else if (typeof value === "string") {
+              acc.append(key, value);
+            }
+            return acc;
+          },
+          new URLSearchParams(),
+        );
+
   const response = await fetch(`${params.baseUrl}${params.endpoint}`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${Buffer.from(`${params.accountSid}:${params.authToken}`).toString("base64")}`,
       "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: new URLSearchParams(params.body),
+    body: bodyParams,
   });
 
   if (!response.ok) {
@@ -26,4 +43,3 @@ export async function twilioApiRequest<T = unknown>(params: {
   const text = await response.text();
   return text ? (JSON.parse(text) as T) : (undefined as T);
 }
-

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -25,7 +25,7 @@ export function validateTwilioSignature(
 
   // Sort params alphabetically and append key+value
   const sortedParams = Array.from(params.entries()).sort((a, b) =>
-    a[0].localeCompare(b[0]),
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
   );
 
   for (const [key, value] of sortedParams) {


### PR DESCRIPTION
## Summary
- include webhook path in Tailscale serve/funnel targets so voice-call routes land on the correct handler
- fix Twilio signature validation by sorting params with ASCII ordering
- send StatusCallbackEvent as multiple values so Twilio delivers completion callbacks
- avoid streaming TwiML on notify-mode follow-up callbacks

## Testing
- notify mode + conversation mode with Tailscale Funnel
- notify mode + conversation mode with ngrok

## Note
- Tailscale Serve/Funnel does not auto-expose the media stream endpoint. If streaming is enabled, expose `/voice/stream` separately, for example:
  - `tailscale serve --bg --yes --set-path /voice/stream http://127.0.0.1:3334/voice/stream`
  - `tailscale funnel --bg --yes --set-path /voice/stream http://127.0.0.1:3334/voice/stream`
