### PR TITLE
fix: include HOME in LaunchAgent environment

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -48,6 +48,7 @@ describe("buildServiceEnvironment", () => {
       port: 18789,
       token: "secret",
     });
+    expect(env.HOME).toBe("/home/user");
     if (process.platform === "win32") {
       expect(env.PATH).toBe("");
     } else {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -75,6 +75,7 @@ export function buildServiceEnvironment(params: {
     (process.platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
   return {
+    HOME: env.HOME,
     PATH: buildMinimalServicePath({ env }),
     CLAWDBOT_PROFILE: profile,
     CLAWDBOT_STATE_DIR: env.CLAWDBOT_STATE_DIR,
@@ -94,6 +95,7 @@ export function buildNodeServiceEnvironment(params: {
 }): Record<string, string | undefined> {
   const { env } = params;
   return {
+    HOME: env.HOME,
     PATH: buildMinimalServicePath({ env }),
     CLAWDBOT_STATE_DIR: env.CLAWDBOT_STATE_DIR,
     CLAWDBOT_CONFIG_PATH: env.CLAWDBOT_CONFIG_PATH,


### PR DESCRIPTION
## Summary
- Adds HOME environment variable to LaunchAgent plist generation
- Fixes "Missing HOME" error when daemon runs with Node from version managers (NVM, fnm, etc.)
- Affects both gateway and node service environments

## Problem
LaunchAgents run in a minimal environment that doesn't include HOME by default. When using Node from NVM or other version managers, the daemon would fail with `Error: Missing HOME` because various Node operations depend on HOME being set.

## Solution
Added `HOME: env.HOME` to both `buildServiceEnvironment()` and `buildNodeServiceEnvironment()` in `src/daemon/service-env.ts`.

## Test plan
- [x] Ran `pnpm lint` - passes
- [x] Ran `pnpm build` - passes  
- [x] Ran `pnpm test src/daemon/service-env.test.ts` - passes
- [x] Verified `clawdbot daemon install --force` now includes HOME in plist
- [x] Verified daemon starts successfully with NVM-managed Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)