### PR TITLE
fix: correct identity config path in BOOTSTRAP.md template

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -135,7 +135,7 @@ After the user chooses, update:
 - Notes
 
 3) ~/.clawdbot/clawdbot.json
-Set identity.name, identity.theme, identity.emoji to match IDENTITY.md.
+Under agents.list[0].identity, set name, theme, and emoji to match IDENTITY.md.
 
 ## Cleanup
 Delete BOOTSTRAP.md once this is complete.


### PR DESCRIPTION
## Summary
- Fix BOOTSTRAP.md template to use correct config path for agent identity

## Problem
The BOOTSTRAP.md template instructed agents to set `identity.*` at the config root level, but the schema was updated to `agents.list[].identity` for multi-agent support.

This caused onboarding to produce invalid configs with "Unrecognized key: identity" validation errors, making the gateway crash on startup (crash-restart loop causing 100% CPU).

## Test plan
- [x] Fresh install with `--install-method git`
- [x] Reproduced bug: onboarding set identity at root level → validation errors
- [x] Verified fix uses correct path `agents.list[0].identity`