### PR TITLE
CLI: skip rebuild when dist is fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Tests: stabilize Windows gateway/CLI tests by skipping sidecars, normalizing argv, and extending timeouts.
+- CLI: skip runner rebuilds when dist is fresh. (#1231) — thanks @mukhtharcm, @thewilloftheshadow.
 
 ## 2026.1.19-1
 

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -1,27 +1,75 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import process from "node:process";
 
 const args = process.argv.slice(2);
 const env = { ...process.env };
 const cwd = process.cwd();
 
-const build = spawn("pnpm", ["exec", "tsc", "-p", "tsconfig.json"], {
-  cwd,
-  env,
-  stdio: "inherit",
-});
+const distEntry = path.join(cwd, "dist", "entry.js");
+const srcRoot = path.join(cwd, "src");
+const configFiles = [path.join(cwd, "tsconfig.json"), path.join(cwd, "package.json")];
 
-build.on("exit", (code, signal) => {
-  if (signal) {
-    process.exit(1);
-    return;
+const statMtime = (filePath) => {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
   }
-  if (code !== 0 && code !== null) {
-    process.exit(code);
-    return;
+};
+
+const findLatestMtime = (dirPath) => {
+  let latest = null;
+  const queue = [dirPath];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) continue;
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const mtime = statMtime(fullPath);
+      if (mtime == null) continue;
+      if (latest == null || mtime > latest) {
+        latest = mtime;
+      }
+    }
+  }
+  return latest;
+};
+
+const shouldBuild = () => {
+  if (env.CLAWDBOT_FORCE_BUILD === "1") return true;
+  const distMtime = statMtime(distEntry);
+  if (distMtime == null) return true;
+
+  for (const filePath of configFiles) {
+    const mtime = statMtime(filePath);
+    if (mtime != null && mtime > distMtime) return true;
   }
 
+  const srcMtime = findLatestMtime(srcRoot);
+  if (srcMtime != null && srcMtime > distMtime) return true;
+  return false;
+};
+
+const logRunner = (message) => {
+  if (env.CLAWDBOT_RUNNER_LOG === "0") return;
+  process.stderr.write(`[clawdbot] ${message}\n`);
+};
+
+const runNode = () => {
   const nodeProcess = spawn(process.execPath, ["dist/entry.js", ...args], {
     cwd,
     env,
@@ -35,4 +83,28 @@ build.on("exit", (code, signal) => {
     }
     process.exit(exitCode ?? 1);
   });
-});
+};
+
+if (!shouldBuild()) {
+  logRunner("Skipping build; dist is fresh.");
+  runNode();
+} else {
+  logRunner("Building TypeScript (dist is stale).");
+  const build = spawn("pnpm", ["exec", "tsc", "-p", "tsconfig.json"], {
+    cwd,
+    env,
+    stdio: "inherit",
+  });
+
+  build.on("exit", (code, signal) => {
+    if (signal) {
+      process.exit(1);
+      return;
+    }
+    if (code !== 0 && code !== null) {
+      process.exit(code);
+      return;
+    }
+    runNode();
+  });
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -102,8 +102,10 @@ const normalizePluginsConfig = (config?: ClawdbotConfig["plugins"]): NormalizedP
 
 const resolvePluginSdkAlias = (): string | null => {
   try {
-    const preferDist = process.env.VITEST || process.env.NODE_ENV === "test";
-    let cursor = path.dirname(fileURLToPath(import.meta.url));
+    const modulePath = fileURLToPath(import.meta.url);
+    const isDistRuntime = modulePath.split(path.sep).includes("dist");
+    const preferDist = process.env.VITEST || process.env.NODE_ENV === "test" || isDistRuntime;
+    let cursor = path.dirname(modulePath);
     for (let i = 0; i < 6; i += 1) {
       const srcCandidate = path.join(cursor, "src", "plugin-sdk", "index.ts");
       const distCandidate = path.join(cursor, "dist", "plugin-sdk", "index.js");


### PR DESCRIPTION
## Summary
- skip the dev runner TypeScript build when `dist/` is newer than `src/`, `tsconfig.json`, and `package.json`
- log whether the runner is building or skipping (set `CLAWDBOT_RUNNER_LOG=0` to silence)
- prefer the dist plugin SDK when running from `dist/` to avoid jiti compiling the TS graph

## Regression context
- The slowdown was introduced by commit `ee380e9ab` ("run cli scripts via node build runner") which runs `tsc` on every `pnpm clawdbot` invocation to avoid the tsx `__name` crash.
- This PR keeps the safer runner but avoids rebuilds when nothing changed.

## Testing
- `pnpm build`
