### PR TITLE
Plugin API: tool-dispatched skill commands + tool_result_persist hook

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -73,6 +73,7 @@ These run inside the agent loop or gateway pipeline:
 - **`agent_end`**: inspect the final message list and run metadata after completion.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
+- **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -82,6 +82,12 @@ Notes:
   - `homepage` — URL surfaced as “Website” in the macOS Skills UI (also supported via `metadata.clawdbot.homepage`).
   - `user-invocable` — `true|false` (default: `true`). When `true`, the skill is exposed as a user slash command.
   - `disable-model-invocation` — `true|false` (default: `false`). When `true`, the skill is excluded from the model prompt (still available via user invocation).
+  - `command-dispatch` — `tool` (optional). When set to `tool`, the slash command bypasses the model and dispatches directly to a tool.
+  - `command-tool` — tool name to invoke when `command-dispatch: tool` is set.
+  - `command-arg-mode` — `raw` (default). For tool dispatch, forwards the raw args string to the tool (no core parsing).
+
+    The tool is invoked with params:
+    `{ command: "<raw args>", commandName: "<slash command>", skillName: "<skill name>" }`.
 
 ## Gating (load-time filters)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -102,6 +102,8 @@ Notes:
 - Currently: `/help`, `/commands`, `/status`, `/whoami` (`/id`).
 - Unauthorized command-only messages are silently ignored, and inline `/...` tokens are treated as plain text.
 - **Skill commands:** `user-invocable` skills are exposed as slash commands. Names are sanitized to `a-z0-9_` (max 32 chars); collisions get numeric suffixes (e.g. `_2`).
+  - By default, skill commands are forwarded to the model as a normal request.
+  - Skills may optionally declare `command-dispatch: tool` to route the command directly to a tool (deterministic, no model).
 - **Native command arguments:** Discord uses autocomplete for dynamic options (and button menus when you omit required args). Telegram and Slack show a button menu when a command supports choices and you omit the arg.
 
 ## Usage surfaces (what shows where)

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -286,7 +286,10 @@ export async function compactEmbeddedPiSession(params: {
         });
         try {
           await prewarmSessionFile(params.sessionFile);
-          const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile));
+          const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
+            agentId: sessionAgentId,
+            sessionKey: params.sessionKey,
+          });
           trackSessionManagerAccess(params.sessionFile);
           const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
           ensurePiCompactionReserveTokens({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -284,7 +284,10 @@ export async function runEmbeddedAttempt(
         .catch(() => false);
 
       await prewarmSessionFile(params.sessionFile);
-      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile));
+      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
+      });
       trackSessionManagerAccess(params.sessionFile);
 
       await prepareSessionManagerForRun({

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,5 +1,6 @@
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 
 export type GuardedSessionManager = SessionManager & {
@@ -11,12 +12,38 @@ export type GuardedSessionManager = SessionManager & {
  * Apply the tool-result guard to a SessionManager exactly once and expose
  * a flush method on the instance for easy teardown handling.
  */
-export function guardSessionManager(sessionManager: SessionManager): GuardedSessionManager {
+export function guardSessionManager(
+  sessionManager: SessionManager,
+  opts?: { agentId?: string; sessionKey?: string },
+): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
     return sessionManager as GuardedSessionManager;
   }
 
-  const guard = installSessionToolResultGuard(sessionManager);
+  const hookRunner = getGlobalHookRunner();
+  const transform = hookRunner?.hasHooks("tool_result_persist")
+    ? (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
+        const out = hookRunner.runToolResultPersist(
+          {
+            toolName: meta.toolName,
+            toolCallId: meta.toolCallId,
+            message,
+            isSynthetic: meta.isSynthetic,
+          },
+          {
+            agentId: opts?.agentId,
+            sessionKey: opts?.sessionKey,
+            toolName: meta.toolName,
+            toolCallId: meta.toolCallId,
+          },
+        );
+        return out?.message ?? message;
+      }
+    : undefined;
+
+  const guard = installSessionToolResultGuard(sessionManager, {
+    transformToolResultForPersistence: transform,
+  });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   return sessionManager as GuardedSessionManager;
 }

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, afterEach } from "vitest";
+
+import { loadClawdbotPlugins } from "../plugins/loader.js";
+import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
+
+const EMPTY_CONFIG_SCHEMA = `configSchema: {
+  validate: () => ({ ok: true }),
+  jsonSchema: { type: "object", additionalProperties: true },
+  uiHints: {}
+}`;
+
+function writeTempPlugin(params: { dir: string; id: string; body: string }): string {
+  const file = path.join(params.dir, `${params.id}.mjs`);
+  fs.writeFileSync(file, params.body, "utf-8");
+  return file;
+}
+
+afterEach(() => {
+  resetGlobalHookRunner();
+});
+
+describe("tool_result_persist hook", () => {
+  it("does not modify persisted toolResult messages when no hook is registered", () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    } as AgentMessage);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      details: { big: "x".repeat(10_000) },
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+    expect(toolResult.details).toBeTruthy();
+  });
+
+  it("composes transforms in priority order and allows stripping toolResult.details", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawdbot-toolpersist-"));
+    process.env.CLAWDBOT_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const pluginA = writeTempPlugin({
+      dir: tmp,
+      id: "persist-a",
+      body: `export default { id: "persist-a", ${EMPTY_CONFIG_SCHEMA}, register(api) {
+  api.on("tool_result_persist", (event, ctx) => {
+    const msg = event.message;
+    // Example: remove large diagnostic payloads before persistence.
+    const { details: _details, ...rest } = msg;
+    return { message: { ...rest, persistOrder: ["a"], agentSeen: ctx.agentId ?? null } };
+  }, { priority: 10 });
+} };`,
+    });
+
+    const pluginB = writeTempPlugin({
+      dir: tmp,
+      id: "persist-b",
+      body: `export default { id: "persist-b", ${EMPTY_CONFIG_SCHEMA}, register(api) {
+  api.on("tool_result_persist", (event) => {
+    const prior = (event.message && event.message.persistOrder) ? event.message.persistOrder : [];
+    return { message: { ...event.message, persistOrder: [...prior, "b"] } };
+  }, { priority: 5 });
+} };`,
+    });
+
+    loadClawdbotPlugins({
+      cache: false,
+      workspaceDir: tmp,
+      config: {
+        plugins: {
+          load: { paths: [pluginA, pluginB] },
+          allow: ["persist-a", "persist-b"],
+        },
+      },
+    });
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    // Tool call (so the guard can infer tool name -> id mapping).
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    } as AgentMessage);
+
+    // Tool result containing a large-ish details payload.
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      details: { big: "x".repeat(10_000) },
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+
+    // Default behavior: strip details.
+    expect(toolResult.details).toBeUndefined();
+
+    // Hook composition: priority 10 runs before priority 5.
+    expect(toolResult.persistOrder).toEqual(["a", "b"]);
+    expect(toolResult.agentSeen).toBe("main");
+  });
+});

--- a/src/agents/skills.buildworkspaceskillcommands.test.ts
+++ b/src/agents/skills.buildworkspaceskillcommands.test.ts
@@ -89,4 +89,18 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     expect(longCmd?.description.endsWith("…")).toBe(true);
     expect(shortCmd?.description).toBe("Short description");
   });
+
+  it("includes tool-dispatch metadata from frontmatter", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "tool-dispatch"),
+      name: "tool-dispatch",
+      description: "Dispatch to a tool",
+      frontmatterExtra: "command-dispatch: tool\ncommand-tool: sessions_send",
+    });
+
+    const commands = buildWorkspaceSkillCommandSpecs(workspaceDir);
+    const cmd = commands.find((entry) => entry.skillName === "tool-dispatch");
+    expect(cmd?.dispatch).toEqual({ kind: "tool", toolName: "sessions_send", argMode: "raw" });
+  });
 });

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -31,10 +31,23 @@ export type SkillInvocationPolicy = {
   disableModelInvocation: boolean;
 };
 
+export type SkillCommandDispatchSpec = {
+  kind: "tool";
+  /** Name of the tool to invoke (AnyAgentTool.name). */
+  toolName: string;
+  /**
+   * How to forward user-provided args to the tool.
+   * - raw: forward the raw args string (no core parsing).
+   */
+  argMode?: "raw";
+};
+
 export type SkillCommandSpec = {
   name: string;
   skillName: string;
   description: string;
+  /** Optional deterministic dispatch behavior for this command. */
+  dispatch?: SkillCommandDispatchSpec;
 };
 
 export type SkillsInstallPreferences = {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -178,6 +178,7 @@ export async function getReplyFromConfig(
     sessionCtx,
     cfg,
     agentId,
+    agentDir,
     sessionEntry,
     previousSessionEntry,
     sessionStore,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Command } from "commander";
 
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
@@ -231,6 +233,7 @@ export type PluginHookName =
   | "message_sent"
   | "before_tool_call"
   | "after_tool_call"
+  | "tool_result_persist"
   | "session_start"
   | "session_end"
   | "gateway_start"
@@ -338,6 +341,30 @@ export type PluginHookAfterToolCallEvent = {
   durationMs?: number;
 };
 
+// tool_result_persist hook
+export type PluginHookToolResultPersistContext = {
+  agentId?: string;
+  sessionKey?: string;
+  toolName?: string;
+  toolCallId?: string;
+};
+
+export type PluginHookToolResultPersistEvent = {
+  toolName?: string;
+  toolCallId?: string;
+  /**
+   * The toolResult message about to be written to the session transcript.
+   * Handlers may return a modified message (e.g. drop non-essential fields).
+   */
+  message: AgentMessage;
+  /** True when the tool result was synthesized by a guard/repair step. */
+  isSynthetic?: boolean;
+};
+
+export type PluginHookToolResultPersistResult = {
+  message?: AgentMessage;
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -407,6 +434,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookAfterToolCallEvent,
     ctx: PluginHookToolContext,
   ) => Promise<void> | void;
+  tool_result_persist: (
+    event: PluginHookToolResultPersistEvent,
+    ctx: PluginHookToolResultPersistContext,
+  ) => PluginHookToolResultPersistResult | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,


### PR DESCRIPTION
## Summary

This PR adds two extension points aimed at making “command-like” workflows and transcript hygiene possible:

1) **Skill command tool dispatch (opt-in)**: workspace skills can declare that their user slash command should dispatch directly to a tool (deterministic, no model).
2) **`tool_result_persist` plugin hook (sync)**: plugins can synchronously transform toolResult messages right before they are written to the session transcript (composed by priority).

Both changes are opt-in / additive and keep existing behavior by default.

---

## 1) Tool-dispatched skill commands

### Opt-in frontmatter
```yaml
command-dispatch: tool
command-tool: <toolName>
command-arg-mode: raw
```

When configured, `/my_command ...` bypasses prompt rewriting and calls the tool directly.

The tool is invoked with:
```ts
{ command: "<raw args>", commandName: "<slash command>", skillName: "<skill name>" }
```

Tools are resolved via the standard tool registry (including plugin-provided tools).

Backwards compatible: skills without `command-dispatch` retain existing behavior.

---

## 2) `tool_result_persist` hook (sync)

New plugin hook:
- name: `tool_result_persist`
- sync-only (runs in a synchronous transcript append path)
- sequential composition in priority order; handlers may return `{ message }` to replace the message for downstream handlers

This is intended for “persistence shaping” of tool results only (e.g. removing non-essential fields, trimming oversized data, etc.) without rewriting full chat history.

Backwards compatible: if no plugin registers `tool_result_persist`, tool results are persisted unchanged.

---

## Commits (separated by feature)

1) #1 Skill command tool dispatch:
- `9f280454b` feat: tool-dispatch skill commands

2) #2 Tool result persistence shaping hook:
- `c3a34408f` feat: add tool_result_persist hook

---

## Files changed (explicit)

### #1 Skill command tool dispatch
- `docs/tools/skills.md`
- `docs/tools/slash-commands.md`
- `src/agents/skills/types.ts`
- `src/agents/skills/workspace.ts`
- `src/agents/skills.buildworkspaceskillcommands.test.ts`
- `src/auto-reply/reply/get-reply-inline-actions.ts`
- `src/auto-reply/reply/get-reply.ts`

### #2 tool_result_persist hook
- `docs/concepts/agent-loop.md`
- `src/plugins/types.ts`
- `src/plugins/hooks.ts`
- `src/agents/session-tool-result-guard.ts`
- `src/agents/session-tool-result-guard-wrapper.ts`
- `src/agents/pi-embedded-runner/run/attempt.ts`
- `src/agents/pi-embedded-runner/compact.ts`
- `src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`

---

## PR stats
- Branch: `feat/tool-dispatch-skill-commands`
- Commits: 2 (`9f280454b`, `c3a34408f`)
- Files changed: 15
- Insertions: 447
- Deletions: 7
