### PR TITLE
fix: propagate delivery target (to) for subagent topic routing

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -27,6 +27,8 @@ export function createClawdbotTools(options?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
+  /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
+  agentTo?: string;
   agentDir?: string;
   sandboxRoot?: string;
   workspaceDir?: string;
@@ -108,6 +110,7 @@ export function createClawdbotTools(options?: {
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
       agentAccountId: options?.agentAccountId,
+      agentTo: options?.agentTo,
       sandboxed: options?.sandboxed,
     }),
     createSessionStatusTool({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -202,6 +202,7 @@ export async function runEmbeddedPiAgent(
             messageChannel: params.messageChannel,
             messageProvider: params.messageProvider,
             agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
             currentChannelId: params.currentChannelId,
             currentThreadTs: params.currentThreadTs,
             replyToMode: params.replyToMode,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -145,6 +145,7 @@ export async function runEmbeddedAttempt(
       sandbox,
       messageProvider: params.messageChannel ?? params.messageProvider,
       agentAccountId: params.agentAccountId,
+      messageTo: params.messageTo,
       sessionKey: params.sessionKey ?? params.sessionId,
       agentDir,
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -12,6 +12,8 @@ export type RunEmbeddedPiAgentParams = {
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
+  /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
+  messageTo?: string;
   /** Current channel ID for auto-threading (Slack). */
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading (Slack). */

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -19,6 +19,8 @@ export type EmbeddedRunAttemptParams = {
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
+  /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
+  messageTo?: string;
   currentChannelId?: string;
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all";

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -102,6 +102,8 @@ export function createClawdbotCodingTools(options?: {
   exec?: ExecToolDefaults & ProcessToolDefaults;
   messageProvider?: string;
   agentAccountId?: string;
+  /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
+  messageTo?: string;
   sandbox?: SandboxContext | null;
   sessionKey?: string;
   agentDir?: string;
@@ -265,6 +267,7 @@ export function createClawdbotCodingTools(options?: {
       agentSessionKey: options?.sessionKey,
       agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
       agentAccountId: options?.agentAccountId,
+      agentTo: options?.messageTo,
       agentDir: options?.agentDir,
       sandboxRoot,
       workspaceDir: options?.workspaceDir,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -61,6 +61,7 @@ export function createSessionsSpawnTool(opts?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
+  agentTo?: string;
   sandboxed?: boolean;
 }): AnyAgentTool {
   return {
@@ -83,6 +84,7 @@ export function createSessionsSpawnTool(opts?: {
       const requesterOrigin = normalizeDeliveryContext({
         channel: opts?.agentChannel,
         accountId: opts?.agentAccountId,
+        to: opts?.agentTo,
       });
       const runTimeoutSeconds = (() => {
         const explicit =

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -209,6 +209,7 @@ export async function runAgentTurnWithFallback(params: {
             sessionKey: params.sessionKey,
             messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
             agentAccountId: params.sessionCtx.AccountId,
+            messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,
             // Provider threading context for tool auto-injection
             ...buildThreadingToolContext({
               sessionCtx: params.sessionCtx,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -106,6 +106,7 @@ export async function runMemoryFlushIfNeeded(params: {
           sessionKey: params.sessionKey,
           messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
           agentAccountId: params.sessionCtx.AccountId,
+          messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,
           // Provider threading context for tool auto-injection
           ...buildThreadingToolContext({
             sessionCtx: params.sessionCtx,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -146,6 +146,7 @@ export function createFollowupRunner(params: {
               sessionKey: queued.run.sessionKey,
               messageProvider: queued.run.messageProvider,
               agentAccountId: queued.run.agentAccountId,
+              messageTo: queued.originatingTo,
               sessionFile: queued.run.sessionFile,
               workspaceDir: queued.run.workspaceDir,
               config: queued.run.config,


### PR DESCRIPTION
## Problem

When a subagent is spawned from a Telegram forum topic, the announce result was being sent to #general instead of the original topic.

## Root Cause

The `to` field (containing the full target path like `telegram:group:-123:topic:456`) was not being propagated through the tool chain. The `DeliveryContext` has a `to` field, but it was never populated when creating the `requesterOrigin` in `sessions-spawn-tool.ts`.

## Solution

Propagate the `to` field through the entire chain:

1. **sessions-spawn-tool.ts**: Added `agentTo` param, pass to `normalizeDeliveryContext`
2. **clawdbot-tools.ts**: Added `agentTo` param, forward to spawn tool
3. **pi-tools.ts**: Added `messageTo` param, forward to clawdbot-tools
4. **pi-embedded-runner/run/types.ts**: Added `messageTo` to `EmbeddedRunAttemptParams`
5. **pi-embedded-runner/run/params.ts**: Added `messageTo` to `RunEmbeddedPiAgentParams`
6. **pi-embedded-runner/run.ts**: Pass `messageTo` to attempt
7. **pi-embedded-runner/run/attempt.ts**: Pass `messageTo` to `createClawdbotCodingTools`
8. **agent-runner-execution.ts**: Pass `OriginatingTo` from `sessionCtx`
9. **agent-runner-memory.ts**: Pass `OriginatingTo` from `sessionCtx`
10. **followup-runner.ts**: Pass `originatingTo` from queued run

## Testing

- Existing tests pass
- Manual testing: spawn a subagent from a Telegram forum topic → result should now appear in the same topic