### PR TITLE
Gateway: restart heartbeat on agents.list reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Docs: https://docs.clawd.bot
 - Android: remove legacy bridge transport code now that nodes use the gateway protocol.
 - Android: send structured payloads in node events/invokes and include user-agent metadata in gateway connects.
 
+### Fixes
+- Gateway: restart heartbeat runner on agents.list hot reloads so per-agent heartbeat changes apply without a full restart. (#1221)
+
 ## 2026.1.19-2
 
 ### Changes

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -85,6 +85,12 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.reloadHooks).toBe(true);
   });
 
+  it("restarts heartbeat when agents list changes", () => {
+    const plan = buildGatewayReloadPlan(["agents.list"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+  });
+
   it("restarts providers when provider config prefixes change", () => {
     const changedPaths = ["web.enabled", "channels.telegram.botToken"];
     const plan = buildGatewayReloadPlan(changedPaths);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -53,6 +53,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
+  {
+    prefix: "agents.list",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   {


### PR DESCRIPTION
## Summary
- Restart the heartbeat runner when `agents.list` changes are hot‑reloaded.
- Add coverage to ensure the reload plan flags `agents.list` as a heartbeat restart trigger.
- Document the fix in the changelog.

## Context / Problem
In multi‑agent setups, per‑agent heartbeat overrides live under `agents.list[].heartbeat`. Hot reload currently restarts heartbeat when `agents.defaults.heartbeat` changes, but **ignores `agents.list.*`** because the reload rules mark the `agents` tree as `kind: "none"`. As a result, config reloads that change per‑agent heartbeats do **not** restart the runner, leaving old timers running until a full gateway restart. This makes per‑agent heartbeat edits appear to “stick” in config while not taking effect at runtime.

## Why this approach
The gateway already treats heartbeat changes as hot‑reloadable (it restarts the heartbeat runner for `agents.defaults.heartbeat`). Extending this to `agents.list` keeps the behavior consistent and fixes the mismatch between config state and runtime state. The change is intentionally narrow: it only adds a single reload rule and a focused test to avoid changing broader reload semantics for other agent settings.

## Implementation details
- Add a reload rule for the `agents.list` prefix with `restart-heartbeat` action.
- Add a test that asserts `buildGatewayReloadPlan(["agents.list"])` sets `restartHeartbeat = true`.
- Changelog entry under 2026.1.19-3.

## Testing
- `pnpm test src/gateway/config-reload.test.ts`

## Notes
The rapid heartbeats reported in #1221 can also be triggered by `requestHeartbeatNow(...)` wake sources (cron/hooks/exec events). That behavior is separate from this fix and is unchanged here. This PR targets the missing hot‑reload restart for `agents.list`.

Closes #1221
