### PR TITLE
Config: accept Perplexity for web_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.clawd.bot
 - Android: remove legacy bridge transport code now that nodes use the gateway protocol.
 - Android: send structured payloads in node events/invokes and include user-agent metadata in gateway connects.
 
+### Fixes
+- Gateway: restart heartbeat runner on agents.list hot reloads so per-agent heartbeat changes apply without a full restart. (#1221)
+- Config: allow Perplexity as a web_search provider in config validation. (#1230)
+
 ## 2026.1.19-2
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Docs: https://docs.clawd.bot
 - Android: send structured payloads in node events/invokes and include user-agent metadata in gateway connects.
 
 ### Fixes
-- Gateway: restart heartbeat runner on agents.list hot reloads so per-agent heartbeat changes apply without a full restart. (#1221)
 - Config: allow Perplexity as a web_search provider in config validation. (#1230)
 
 ## 2026.1.19-2

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfigObject } from "./config.js";
+
+describe("web search provider config", () => {
+  it("accepts perplexity provider and config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "perplexity",
+            perplexity: {
+              apiKey: "test-key",
+              baseUrl: "https://api.perplexity.ai",
+              model: "perplexity/sonar-pro",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -338,12 +338,18 @@ const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires Brave API key).",
-  "tools.web.search.provider": 'Search provider (only "brave" supported today).',
+  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
+  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
+  "tools.web.search.perplexity.apiKey":
+    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
+  "tools.web.search.perplexity.baseUrl":
+    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
+  "tools.web.search.perplexity.model":
+    'Perplexity model override (default: "perplexity/sonar-pro").',
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -124,11 +124,19 @@ export const ToolPolicySchema = z
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave")]).optional(),
+    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
+    perplexity: z
+      .object({
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- Fixes config validation to accept `tools.web.search.provider: "perplexity"` and the `tools.web.search.perplexity` block.
- Updates config schema hints to reflect Perplexity support.
- Adds a validation test for the Perplexity provider.

## Issue
Fixes #1230.

## Approach
- Align Zod schema (`ToolsWebSearchSchema`) with the already‑implemented runtime and documented config shape.
- Add UI hints for Perplexity config fields so config schema output is accurate.
- Add a focused validation test to prevent regressions.

## Decisions
- Keep `tools.web.search.apiKey` Brave‑only; Perplexity uses `tools.web.search.perplexity.apiKey` (or `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`).
- No runtime logic changes; only validation + schema hints + test.

## Testing
- `pnpm test -- src/config/config.web-search-provider.test.ts` (timed out after ~5 min; during run saw unrelated failures in `extensions/memory-lancedb/index.test.ts` and `src/agents/bash-tools.process.send-keys.test.ts`).
