### PR TITLE
CLI FIX: include --profile in doctor command suggestions

### DIFF
--- a/src/agents/auth-profiles/doctor.ts
+++ b/src/agents/auth-profiles/doctor.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../../cli/profile.js";
 import type { ClawdbotConfig } from "../../config/config.js";
 import { normalizeProviderId } from "../model-selection.js";
 import { listProfilesForProvider } from "./profiles.js";
@@ -37,6 +38,6 @@ export function formatAuthDoctorHint(params: {
     }`,
     `- auth store oauth profiles: ${storeOauthProfiles || "(none)"}`,
     `- suggested profile: ${suggested}`,
-    'Fix: run "clawdbot doctor --yes"',
+    `Fix: run "${formatCliCommand("clawdbot doctor --yes")}"`,
   ].join("\n");
 }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -5,6 +5,7 @@ import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
+import { formatCliCommand } from "./profile.js";
 import { theme } from "../terminal/theme.js";
 
 type PathSegment = string;
@@ -171,7 +172,7 @@ async function loadValidConfig() {
   for (const issue of snapshot.issues) {
     defaultRuntime.error(`- ${issue.path || "<root>"}: ${issue.message}`);
   }
-  defaultRuntime.error("Run `clawdbot doctor` to repair, then retry.");
+  defaultRuntime.error(`Run \`${formatCliCommand("clawdbot doctor")}\` to repair, then retry.`);
   defaultRuntime.exit(1);
   return snapshot;
 }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -13,6 +13,7 @@ import { isWSLEnv } from "../../infra/wsl.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { defaultRuntime } from "../../runtime.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
+import { formatCliCommand } from "../profile.js";
 import { formatRuntimeStatus, renderRuntimeHints, safeDaemonEnv } from "./shared.js";
 import {
   type DaemonStatus,
@@ -70,7 +71,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       defaultRuntime.error(`${warnText("Service config issue:")} ${issue.message}${detail}`);
     }
     defaultRuntime.error(
-      warnText('Recommendation: run "clawdbot doctor" (or "clawdbot doctor --repair").'),
+      warnText(`Recommendation: run "${formatCliCommand("clawdbot doctor")}" (or "${formatCliCommand("clawdbot doctor --repair")}").`),
     );
   }
 

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -71,7 +71,9 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       defaultRuntime.error(`${warnText("Service config issue:")} ${issue.message}${detail}`);
     }
     defaultRuntime.error(
-      warnText(`Recommendation: run "${formatCliCommand("clawdbot doctor")}" (or "${formatCliCommand("clawdbot doctor --repair")}").`),
+      warnText(
+        `Recommendation: run "${formatCliCommand("clawdbot doctor")}" (or "${formatCliCommand("clawdbot doctor --repair")}").`,
+      ),
     );
   }
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -6,6 +6,7 @@ import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
+import { formatCliCommand } from "./profile.js";
 
 type LogsTailPayload = {
   file?: string;
@@ -117,7 +118,7 @@ function emitGatewayError(
 ) {
   const details = buildGatewayConnectionDetails({ url: opts.url });
   const message = "Gateway not reachable. Is it running and accessible?";
-  const hint = "Hint: run `clawdbot doctor`.";
+  const hint = `Hint: run \`${formatCliCommand("clawdbot doctor")}\`.`;
   const errorText = err instanceof Error ? err.message : String(err);
 
   if (mode === "json") {

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
+import { applyCliProfileEnv, formatCliCommand, parseCliProfileArgs } from "./profile.js";
 
 describe("parseCliProfileArgs", () => {
   it("leaves gateway --dev for subcommands", () => {
@@ -74,5 +74,41 @@ describe("applyCliProfileEnv", () => {
     expect(env.CLAWDBOT_STATE_DIR).toBe("/custom");
     expect(env.CLAWDBOT_GATEWAY_PORT).toBe("19099");
     expect(env.CLAWDBOT_CONFIG_PATH).toBe(path.join("/custom", "clawdbot.json"));
+  });
+});
+
+describe("formatCliCommand", () => {
+  it("returns command unchanged when no profile is set", () => {
+    expect(formatCliCommand("clawdbot doctor --fix", {})).toBe("clawdbot doctor --fix");
+  });
+
+  it("returns command unchanged when profile is default", () => {
+    expect(formatCliCommand("clawdbot doctor --fix", { CLAWDBOT_PROFILE: "default" })).toBe(
+      "clawdbot doctor --fix",
+    );
+  });
+
+  it("returns command unchanged when profile is Default (case-insensitive)", () => {
+    expect(formatCliCommand("clawdbot doctor --fix", { CLAWDBOT_PROFILE: "Default" })).toBe(
+      "clawdbot doctor --fix",
+    );
+  });
+
+  it("inserts --profile flag when profile is set", () => {
+    expect(formatCliCommand("clawdbot doctor --fix", { CLAWDBOT_PROFILE: "work" })).toBe(
+      "clawdbot --profile work doctor --fix",
+    );
+  });
+
+  it("trims whitespace from profile", () => {
+    expect(formatCliCommand("clawdbot doctor --fix", { CLAWDBOT_PROFILE: "  jbclawd  " })).toBe(
+      "clawdbot --profile jbclawd doctor --fix",
+    );
+  });
+
+  it("handles command with no args after clawdbot", () => {
+    expect(formatCliCommand("clawdbot", { CLAWDBOT_PROFILE: "test" })).toBe(
+      "clawdbot --profile test",
+    );
   });
 });

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -113,3 +113,17 @@ export function applyCliProfileEnv(params: {
     env.CLAWDBOT_GATEWAY_PORT = "19001";
   }
 }
+
+/**
+ * Formats a CLI command with the current profile flag if set.
+ * E.g., "clawdbot doctor --fix" becomes "clawdbot --profile foo doctor --fix"
+ */
+export function formatCliCommand(
+  command: string,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): string {
+  const profile = env.CLAWDBOT_PROFILE?.trim();
+  if (!profile || profile.toLowerCase() === "default") return command;
+  // Insert --profile after "clawdbot"
+  return command.replace(/^clawdbot\b/, `clawdbot --profile ${profile}`);
+}

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -2,6 +2,7 @@ import { readConfigFileSnapshot } from "../../config/config.js";
 import { loadAndMaybeMigrateDoctorConfig } from "../../commands/doctor-config-flow.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadClawdbotPlugins } from "../../plugins/loader.js";
+import { formatCliCommand } from "../profile.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status", "service"]);
@@ -60,7 +61,7 @@ export async function ensureConfigReady(params: {
   if (pluginIssues.length > 0) {
     params.runtime.error(`Plugin config errors:\n${pluginIssues.join("\n")}`);
   }
-  params.runtime.error("Run `clawdbot doctor --fix` to repair, then retry.");
+  params.runtime.error(`Run \`${formatCliCommand("clawdbot doctor --fix")}\` to repair, then retry.`);
   if (!allowInvalid) {
     params.runtime.exit(1);
   }

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -61,7 +61,9 @@ export async function ensureConfigReady(params: {
   if (pluginIssues.length > 0) {
     params.runtime.error(`Plugin config errors:\n${pluginIssues.join("\n")}`);
   }
-  params.runtime.error(`Run \`${formatCliCommand("clawdbot doctor --fix")}\` to repair, then retry.`);
+  params.runtime.error(
+    `Run \`${formatCliCommand("clawdbot doctor --fix")}\` to repair, then retry.`,
+  );
   if (!allowInvalid) {
     params.runtime.exit(1);
   }

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -15,6 +15,7 @@ import {
 } from "../infra/update-runner.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
+import { formatCliCommand } from "./profile.js";
 import { stylePromptMessage } from "../terminal/prompt-style.js";
 import { theme } from "../terminal/theme.js";
 
@@ -373,7 +374,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     if (result.reason === "not-git-install") {
       defaultRuntime.log(
         theme.warn(
-          "Skipped: this Clawdbot install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run `clawdbot doctor` and `clawdbot daemon restart`.",
+          `Skipped: this Clawdbot install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${formatCliCommand("clawdbot doctor")}\` and \`${formatCliCommand("clawdbot daemon restart")}\`.`,
         ),
       );
       defaultRuntime.log(
@@ -410,7 +411,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       if (!opts.json) {
         defaultRuntime.log(theme.warn(`Daemon restart failed: ${String(err)}`));
         defaultRuntime.log(
-          theme.muted("You may need to restart the daemon manually: clawdbot daemon restart"),
+          theme.muted(`You may need to restart the daemon manually: ${formatCliCommand("clawdbot daemon restart")}`),
         );
       }
     }
@@ -419,12 +420,12 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     if (result.mode === "npm" || result.mode === "pnpm") {
       defaultRuntime.log(
         theme.muted(
-          "Tip: Run `clawdbot doctor`, then `clawdbot daemon restart` to apply updates to a running gateway.",
+          `Tip: Run \`${formatCliCommand("clawdbot doctor")}\`, then \`${formatCliCommand("clawdbot daemon restart")}\` to apply updates to a running gateway.`,
         ),
       );
     } else {
       defaultRuntime.log(
-        theme.muted("Tip: Run `clawdbot daemon restart` to apply updates to a running gateway."),
+        theme.muted(`Tip: Run \`${formatCliCommand("clawdbot daemon restart")}\` to apply updates to a running gateway.`),
       );
     }
   }

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -411,7 +411,9 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       if (!opts.json) {
         defaultRuntime.log(theme.warn(`Daemon restart failed: ${String(err)}`));
         defaultRuntime.log(
-          theme.muted(`You may need to restart the daemon manually: ${formatCliCommand("clawdbot daemon restart")}`),
+          theme.muted(
+            `You may need to restart the daemon manually: ${formatCliCommand("clawdbot daemon restart")}`,
+          ),
         );
       }
     }
@@ -425,7 +427,9 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       );
     } else {
       defaultRuntime.log(
-        theme.muted(`Tip: Run \`${formatCliCommand("clawdbot daemon restart")}\` to apply updates to a running gateway.`),
+        theme.muted(
+          `Tip: Run \`${formatCliCommand("clawdbot daemon restart")}\` to apply updates to a running gateway.`,
+        ),
       );
     }
   }

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../cli/profile.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import {
   CONFIG_PATH_CLAWDBOT,
@@ -198,7 +199,7 @@ export async function runConfigureWizard(
         );
       }
       if (!snapshot.valid) {
-        outro("Config invalid. Run `clawdbot doctor` to repair it, then re-run configure.");
+        outro(`Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run configure.`);
         runtime.exit(1);
         return;
       }

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -199,7 +199,9 @@ export async function runConfigureWizard(
         );
       }
       if (!snapshot.valid) {
-        outro(`Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run configure.`);
+        outro(
+          `Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run configure.`,
+        );
         runtime.exit(1);
         return;
       }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -5,6 +5,7 @@ import {
   readConfigFileSnapshot,
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { formatCliCommand } from "../cli/profile.js";
 import { note } from "../terminal/note.js";
 import { normalizeLegacyConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
@@ -65,7 +66,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       if (changes.length > 0) note(changes.join("\n"), "Doctor changes");
       if (migrated) cfg = migrated;
     } else {
-      note('Run "clawdbot doctor --fix" to apply legacy migrations.', "Doctor");
+      note(`Run "${formatCliCommand("clawdbot doctor --fix")}" to apply legacy migrations.`, "Doctor");
     }
   }
 
@@ -75,7 +76,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     if (shouldRepair) {
       cfg = normalized.config;
     } else {
-      note('Run "clawdbot doctor --fix" to apply these changes.', "Doctor");
+      note(`Run "${formatCliCommand("clawdbot doctor --fix")}" to apply these changes.`, "Doctor");
     }
   }
 
@@ -85,7 +86,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     if (shouldRepair) {
       cfg = autoEnable.config;
     } else {
-      note('Run "clawdbot doctor --fix" to apply these changes.', "Doctor");
+      note(`Run "${formatCliCommand("clawdbot doctor --fix")}" to apply these changes.`, "Doctor");
     }
   }
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -66,7 +66,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       if (changes.length > 0) note(changes.join("\n"), "Doctor changes");
       if (migrated) cfg = migrated;
     } else {
-      note(`Run "${formatCliCommand("clawdbot doctor --fix")}" to apply legacy migrations.`, "Doctor");
+      note(
+        `Run "${formatCliCommand("clawdbot doctor --fix")}" to apply legacy migrations.`,
+        "Doctor",
+      );
     }
   }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import {
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
+import { formatCliCommand } from "../cli/profile.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import { CONFIG_PATH_CLAWDBOT, writeConfigFile } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
@@ -252,7 +253,7 @@ export async function doctorCommand(
     await writeConfigFile(cfg);
     runtime.log(`Updated ${CONFIG_PATH_CLAWDBOT}`);
   } else {
-    runtime.log('Run "clawdbot doctor --fix" to apply changes.');
+    runtime.log(`Run "${formatCliCommand("clawdbot doctor --fix")}" to apply changes.`);
   }
 
   if (options.workspaceSuggestions !== false) {

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../cli/profile.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -12,7 +13,7 @@ export async function runNonInteractiveOnboarding(
 ) {
   const snapshot = await readConfigFileSnapshot();
   if (snapshot.exists && !snapshot.valid) {
-    runtime.error("Config invalid. Run `clawdbot doctor` to repair it, then re-run onboarding.");
+    runtime.error(`Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run onboarding.`);
     runtime.exit(1);
     return;
   }

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -13,7 +13,9 @@ export async function runNonInteractiveOnboarding(
 ) {
   const snapshot = await readConfigFileSnapshot();
   if (snapshot.exists && !snapshot.valid) {
-    runtime.error(`Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run onboarding.`);
+    runtime.error(
+      `Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run onboarding.`,
+    );
     runtime.exit(1);
     return;
   }

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -1,5 +1,6 @@
 import { installSkill } from "../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
+import { formatCliCommand } from "../cli/profile.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -152,7 +153,7 @@ export async function setupSkills(
         spin.stop(`Install failed: ${name}${code}${detail ? ` — ${detail}` : ""}`);
         if (result.stderr) runtime.log(result.stderr.trim());
         else if (result.stdout) runtime.log(result.stdout.trim());
-        runtime.log("Tip: run `clawdbot doctor` to review skills + requirements.");
+        runtime.log(`Tip: run \`${formatCliCommand("clawdbot doctor")}\` to review skills + requirements.`);
         runtime.log("Docs: https://docs.clawd.bot/skills");
       }
     }

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -153,7 +153,9 @@ export async function setupSkills(
         spin.stop(`Install failed: ${name}${code}${detail ? ` — ${detail}` : ""}`);
         if (result.stderr) runtime.log(result.stderr.trim());
         else if (result.stdout) runtime.log(result.stdout.trim());
-        runtime.log(`Tip: run \`${formatCliCommand("clawdbot doctor")}\` to review skills + requirements.`);
+        runtime.log(
+          `Tip: run \`${formatCliCommand("clawdbot doctor")}\` to review skills + requirements.`,
+        );
         runtime.log("Docs: https://docs.clawd.bot/skills");
       }
     }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -4,6 +4,7 @@ import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { createDefaultDeps } from "../cli/deps.js";
+import { formatCliCommand } from "../cli/profile.js";
 import {
   CONFIG_PATH_CLAWDBOT,
   isNixMode,
@@ -150,7 +151,7 @@ export async function startGatewayServer(
     const { config: migrated, changes } = migrateLegacyConfig(configSnapshot.parsed);
     if (!migrated) {
       throw new Error(
-        'Legacy config entries detected but auto-migration failed. Run "clawdbot doctor" to migrate.',
+        `Legacy config entries detected but auto-migration failed. Run "${formatCliCommand("clawdbot doctor")}" to migrate.`,
       );
     }
     await writeConfigFile(migrated);
@@ -172,7 +173,7 @@ export async function startGatewayServer(
             .join("\n")
         : "Unknown validation issue.";
     throw new Error(
-      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "clawdbot doctor" to repair, then retry.`,
+      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("clawdbot doctor")}" to repair, then retry.`,
     );
   }
 

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -26,6 +26,7 @@ import type {
   OnboardOptions,
   ResetScope,
 } from "../commands/onboard-types.js";
+import { formatCliCommand } from "../cli/profile.js";
 import type { ClawdbotConfig } from "../config/config.js";
 import {
   CONFIG_PATH_CLAWDBOT,
@@ -97,7 +98,7 @@ export async function runOnboardingWizard(
 
     if (!snapshot.valid) {
       await prompter.outro(
-        "Config invalid. Run `clawdbot doctor` to repair it, then re-run onboarding.",
+        `Config invalid. Run \`${formatCliCommand("clawdbot doctor")}\` to repair it, then re-run onboarding.`,
       );
       runtime.exit(1);
       return;


### PR DESCRIPTION
## Summary

- Fixes the `doctor --fix` hint to include the active `--profile` flag when set
- Adds `formatCliCommand()` helper in `src/cli/profile.ts` that inserts `--profile <name>` after "clawdbot" when `CLAWDBOT_PROFILE` is set
- Updates all 5 locations mentioned in the issue plus 10 additional files with similar hardcoded command suggestions

## Before

```bash
clawdbot --profile jbphoenix doctor
# Output: Run "clawdbot doctor --fix" to apply changes.
```

## After

```bash
clawdbot --profile jbphoenix doctor
# Output: Run "clawdbot --profile jbphoenix doctor --fix" to apply changes.
```

Fixes #1249