### PR TITLE
feat(webchat): add configurable Enter-to-Submit behavior

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -44,6 +44,8 @@ export function renderChatControls(state: AppViewState) {
   // Refresh icon
   const refreshIcon = html`<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path><path d="M21 3v5h-5"></path></svg>`;
   const focusIcon = html`<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h3"></path><path d="M20 7V4h-3"></path><path d="M4 17v3h3"></path><path d="M20 17v3h-3"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
+  // Keyboard icon for submit mode toggle
+  const keyboardIcon = html`<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="M6 8h.001"></path><path d="M10 8h.001"></path><path d="M14 8h.001"></path><path d="M18 8h.001"></path><path d="M6 12h.001"></path><path d="M18 12h.001"></path><path d="M10 12h4"></path><path d="M6 16h12"></path></svg>`;
   return html`
     <div class="chat-controls">
       <label class="field chat-controls__session">
@@ -110,6 +112,18 @@ export function renderChatControls(state: AppViewState) {
         title="${state.settings.useNewChatLayout ? "Switch to list view" : "Switch to grouped view"}"
       >
         ${state.settings.useNewChatLayout ? groupIcon : listIcon}
+      </button>
+      <button
+        class="btn btn--sm btn--icon ${!state.settings.enterToSubmit ? "active" : ""}"
+        @click=${() =>
+          state.applySettings({
+            ...state.settings,
+            enterToSubmit: !state.settings.enterToSubmit,
+          })}
+        aria-pressed=${!state.settings.enterToSubmit}
+        title="${state.settings.enterToSubmit ? "Enter to send (click to switch to ⌘↩)" : "⌘↩ to send (click to switch to ↩)"}"
+      >
+        ${keyboardIcon}
       </button>
     </div>
   `;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -400,6 +400,7 @@ export function renderApp(state: AppViewState) {
                 state.toggleToolOutput(id, expanded),
               focusMode: state.settings.chatFocusMode,
               useNewChatLayout: state.settings.useNewChatLayout,
+              enterToSubmit: state.settings.enterToSubmit,
               onRefresh: () => {
                 state.resetToolStream();
                 return loadChatHistory(state);

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -13,6 +13,7 @@ export type UiSettings = {
   useNewChatLayout: boolean; // Slack-style grouped messages layout
   navCollapsed: boolean; // Collapsible sidebar state
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
+  enterToSubmit: boolean; // true: Enter submits, false: Cmd/Ctrl+Enter submits
 };
 
 export function loadSettings(): UiSettings {
@@ -32,6 +33,7 @@ export function loadSettings(): UiSettings {
     useNewChatLayout: true, // Enabled by default
     navCollapsed: false,
     navGroupsCollapsed: {},
+    enterToSubmit: true, // Enter to send, Shift+Enter for line breaks
   };
 
   try {
@@ -84,6 +86,10 @@ export function loadSettings(): UiSettings {
         parsed.navGroupsCollapsed !== null
           ? parsed.navGroupsCollapsed
           : defaults.navGroupsCollapsed,
+      enterToSubmit:
+        typeof parsed.enterToSubmit === "boolean"
+          ? parsed.enterToSubmit
+          : defaults.enterToSubmit,
     };
   } catch {
     return defaults;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -47,6 +47,8 @@ export type ChatProps = {
   sidebarContent?: string | null;
   sidebarError?: string | null;
   splitRatio?: number;
+  // Submit behavior: true = Enter sends, false = Cmd/Ctrl+Enter sends
+  enterToSubmit?: boolean;
   // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
@@ -71,8 +73,11 @@ export function renderChat(props: ChatProps) {
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = reasoningLevel !== "off";
 
+  const enterToSubmit = props.enterToSubmit ?? true;
   const composePlaceholder = props.connected
-    ? "Message (↩ to send, Shift+↩ for line breaks)"
+    ? enterToSubmit
+      ? "Message (↩ to send, Shift+↩ for line breaks)"
+      : "Message (⌘↩ to send, ↩ for line breaks)"
     : "Connect to the gateway to start chatting…";
 
   const splitRatio = props.splitRatio ?? 0.6;
@@ -212,7 +217,11 @@ export function renderChat(props: ChatProps) {
             @keydown=${(e: KeyboardEvent) => {
               if (e.key !== "Enter") return;
               if (e.isComposing || e.keyCode === 229) return;
-              if (e.shiftKey) return; // Allow Shift+Enter for line breaks
+              if (enterToSubmit) {
+                if (e.shiftKey) return; // Shift+Enter for line breaks
+              } else {
+                if (!e.metaKey && !e.ctrlKey) return; // Only Cmd/Ctrl+Enter submits
+              }
               if (!props.connected) return;
               e.preventDefault();
               if (canCompose) props.onSend();


### PR DESCRIPTION
## Summary
Add a configurable option for submit behavior in the webchat interface.

## Changes
- Added `enterToSubmit` setting to UiSettings (persisted in localStorage)
- Added keyboard toggle button in chat controls toolbar
- Default behavior: Enter sends, Shift+Enter for line breaks
- Alternative: Cmd/Ctrl+Enter sends, Enter for line breaks
- Dynamic placeholder text updates based on current mode

## Implementation
- **storage.ts**: Added `enterToSubmit` boolean with migration for existing settings
- **chat.ts**: Updated keydown handler to respect the setting
- **app-render.helpers.ts**: Added toggle button with keyboard icon
- **app-render.ts**: Passed setting to chat component

Fixes #411