### PR TITLE
fix: recognize OAuth refresh errors as auth failures for model fallback

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -328,6 +328,8 @@ const ERROR_PATTERNS = {
     "incorrect api key",
     "invalid token",
     "authentication",
+    "re-authenticate",
+    "oauth token refresh failed",
     "unauthorized",
     "forbidden",
     "access denied",


### PR DESCRIPTION
## Summary
- Add `"re-authenticate"` and `"oauth token refresh failed"` to the auth error patterns
- This allows Anthropic OAuth token refresh failures to be recognized as auth errors, triggering model fallback instead of failing immediately
- Without this change, intermittent Claude OAuth failures cause the bot to just post repeated errors (example below).

## Example Anthropic OAuth Failure
> OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.

🤖 Assisted by Codex.
