### PR TITLE
fix(auth): deduplicate Codex OAuth profile on gateway startup

### DIFF
--- a/src/agents/auth-profiles.external-cli-credential-sync.skips-codex-sync-when-credentials-exist-in-another-profile.test.ts
+++ b/src/agents/auth-profiles.external-cli-credential-sync.skips-codex-sync-when-credentials-exist-in-another-profile.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { CODEX_CLI_PROFILE_ID, ensureAuthProfileStore } from "./auth-profiles.js";
+
+describe("external CLI credential sync", () => {
+  it("skips codex-cli sync when credentials already exist in another openai-codex profile", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawdbot-codex-dedup-skip-"));
+    try {
+      await withTempHome(
+        async (tempHome) => {
+          // Set up Codex CLI credentials with shared tokens
+          const codexDir = path.join(tempHome, ".codex");
+          fs.mkdirSync(codexDir, { recursive: true });
+          const codexAuthPath = path.join(codexDir, "auth.json");
+          fs.writeFileSync(
+            codexAuthPath,
+            JSON.stringify({
+              tokens: {
+                access_token: "shared-access-token",
+                refresh_token: "shared-refresh-token",
+              },
+            }),
+          );
+          fs.utimesSync(codexAuthPath, new Date(), new Date());
+
+          // Set up auth-profiles.json with an existing profile using the SAME tokens
+          const authPath = path.join(agentDir, "auth-profiles.json");
+          fs.writeFileSync(
+            authPath,
+            JSON.stringify({
+              version: 1,
+              profiles: {
+                "openai-codex:my-custom-profile": {
+                  type: "oauth",
+                  provider: "openai-codex",
+                  access: "shared-access-token",
+                  refresh: "shared-refresh-token",
+                  expires: Date.now() + 3600000, // 1 hour from now
+                },
+              },
+            }),
+          );
+
+          // Call ensureAuthProfileStore - should NOT create codex-cli profile
+          const store = ensureAuthProfileStore(agentDir);
+
+          // codex-cli profile should NOT exist because tokens match existing profile
+          expect(store.profiles[CODEX_CLI_PROFILE_ID]).toBeUndefined();
+          // The custom profile should still be there
+          expect(store.profiles["openai-codex:my-custom-profile"]).toBeDefined();
+        },
+        { prefix: "clawdbot-home-" },
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates codex-cli profile when credentials differ from existing openai-codex profiles", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawdbot-codex-dedup-create-"));
+    try {
+      await withTempHome(
+        async (tempHome) => {
+          // Set up Codex CLI credentials with unique tokens
+          const codexDir = path.join(tempHome, ".codex");
+          fs.mkdirSync(codexDir, { recursive: true });
+          const codexAuthPath = path.join(codexDir, "auth.json");
+          fs.writeFileSync(
+            codexAuthPath,
+            JSON.stringify({
+              tokens: {
+                access_token: "unique-access-token",
+                refresh_token: "unique-refresh-token",
+              },
+            }),
+          );
+          fs.utimesSync(codexAuthPath, new Date(), new Date());
+
+          // Set up auth-profiles.json with an existing profile using DIFFERENT tokens
+          const authPath = path.join(agentDir, "auth-profiles.json");
+          fs.writeFileSync(
+            authPath,
+            JSON.stringify({
+              version: 1,
+              profiles: {
+                "openai-codex:my-custom-profile": {
+                  type: "oauth",
+                  provider: "openai-codex",
+                  access: "different-access-token",
+                  refresh: "different-refresh-token",
+                  expires: Date.now() + 3600000, // 1 hour from now
+                },
+              },
+            }),
+          );
+
+          // Call ensureAuthProfileStore - SHOULD create codex-cli profile
+          const store = ensureAuthProfileStore(agentDir);
+
+          // codex-cli profile SHOULD exist because tokens are different
+          expect(store.profiles[CODEX_CLI_PROFILE_ID]).toBeDefined();
+          expect((store.profiles[CODEX_CLI_PROFILE_ID] as { access: string }).access).toBe(
+            "unique-access-token",
+          );
+          // The custom profile should still be there
+          expect(store.profiles["openai-codex:my-custom-profile"]).toBeDefined();
+        },
+        { prefix: "clawdbot-home-" },
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -3,8 +3,13 @@ import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import lockfile from "proper-lockfile";
 import { resolveOAuthPath } from "../../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
-import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
-import { syncExternalCliCredentials } from "./external-cli-sync.js";
+import {
+  AUTH_STORE_LOCK_OPTIONS,
+  AUTH_STORE_VERSION,
+  CODEX_CLI_PROFILE_ID,
+  log,
+} from "./constants.js";
+import { findDuplicateCodexProfile, syncExternalCliCredentials } from "./external-cli-sync.js";
 import { ensureAuthStoreFile, resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
 import type { AuthProfileCredential, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
@@ -330,7 +335,26 @@ export function ensureAuthProfileStore(
   }
 
   const mainStore = loadAuthProfileStoreForAgent(undefined, options);
-  return mergeAuthProfileStores(mainStore, store);
+  const merged = mergeAuthProfileStores(mainStore, store);
+
+  // Post-merge deduplication: The main store sync might have created codex-cli
+  // without knowing about agent store profiles. Check if codex-cli duplicates
+  // another openai-codex profile and remove it if so.
+  const codexProfile = merged.profiles[CODEX_CLI_PROFILE_ID];
+  if (codexProfile?.type === "oauth") {
+    const duplicateId = findDuplicateCodexProfile(merged, codexProfile);
+    if (duplicateId) {
+      delete merged.profiles[CODEX_CLI_PROFILE_ID];
+      log.info(
+        "removed codex-cli profile after merge: credentials already exist in another profile",
+        {
+          existingProfileId: duplicateId,
+        },
+      );
+    }
+  }
+
+  return merged;
 }
 
 export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string): void {


### PR DESCRIPTION
## Summary
Prevents duplicate `openai-codex:codex-cli` profile creation when the same OAuth credentials already exist in another `openai-codex:*` profile.

## Changes
- Added `findDuplicateCodexProfile(store, creds)` function in `external-cli-sync.ts` that checks if access+refresh tokens already exist in any `openai-codex:*` profile (excluding `codex-cli` itself)
- During CLI credential sync, skip creating `codex-cli` if duplicate credentials found
- Added post-merge deduplication in `ensureAuthProfileStore` to handle the case where the main store creates `codex-cli` before knowing about agent store profiles
- Added comprehensive test coverage for both scenarios (duplicate found → skip, different tokens → create)

## Test Plan
- `pnpm test -- --run 'skips-codex-sync'` passes
- All 11 existing external CLI sync tests still pass

Fixes #1258