### PR TITLE
fix: prevent context-window-too-small error from being misclassified

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -421,7 +421,8 @@ export async function runAgentTurnWithFallback(params: {
       const message = err instanceof Error ? err.message : String(err);
       const isContextOverflow =
         isContextOverflowError(message) ||
-        /context.*overflow|too large|context window/i.test(message);
+        (/context.*overflow|too large|context window/i.test(message) &&
+          !/too small|minimum is/i.test(message));
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);


### PR DESCRIPTION
Fixes misleading error message when model context window is below minimum.

**Problem:** The regex `/context window/i` matches "Model context window too small" and rewrites it to generic "Context overflow" message, hiding the real issue.

**Fix:** Add exclusion for "too small|minimum is" patterns.

Tested locally.