### PR TITLE
fix(browser): register refs from AI snapshot for act commands

### DIFF
--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -9,6 +9,8 @@ import {
   DEFAULT_AI_SNAPSHOT_EFFICIENT_MAX_CHARS,
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
 } from "../constants.js";
+import { buildRoleSnapshotFromAiSnapshot } from "../pw-role-snapshot.js";
+import { rememberRoleRefsForTarget } from "../pw-session.js";
 import {
   DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
@@ -213,6 +215,20 @@ export function registerBrowserAgentSnapshotRoutes(app: express.Express, ctx: Br
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
                 ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),
+              })
+              .then((result) => {
+                // Extract and register refs from AI snapshot so act commands can resolve them.
+                // snapshotAiViaPlaywright returns raw text without ref registration.
+                const parsed = buildRoleSnapshotFromAiSnapshot(result.snapshot);
+                if (Object.keys(parsed.refs).length > 0) {
+                  rememberRoleRefsForTarget({
+                    cdpUrl: profileCtx.profile.cdpUrl,
+                    targetId: tab.targetId,
+                    refs: parsed.refs,
+                    mode: "aria",
+                  });
+                }
+                return { ...result, refs: parsed.refs };
               })
               .catch(async (err) => {
                 // Public-API fallback when Playwright's private _snapshotForAI is missing.


### PR DESCRIPTION
## Summary

When using the default AI snapshot format (without explicit options like `interactive`, `compact`, or `labels`), refs were not being registered because `snapshotAiViaPlaywright` returns raw text without ref registration.

This caused **'Unknown ref' errors** when subsequently using `act` commands with refs like `e12` that appeared in the snapshot text.

## The Fix

After `snapshotAiViaPlaywright` succeeds, extract refs using `buildRoleSnapshotFromAiSnapshot` and register them via `rememberRoleRefsForTarget` so `act` commands can resolve them.

## Changes

- Added imports for `buildRoleSnapshotFromAiSnapshot` and `rememberRoleRefsForTarget`
- Added a `.then()` handler after `snapshotAiViaPlaywright` to parse and register refs
- Returns the extracted refs in the response for consistency

## Testing

- All existing snapshot tests pass (`npm test -- snapshot`)
- Build passes (`npm run build`)

Fixes #1268