### PR TITLE
ui(chat): fix double-scroll in web UI

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -6,6 +6,8 @@
   --shell-focus-duration: 220ms;
   --shell-focus-ease: cubic-bezier(0.2, 0.85, 0.25, 1);
   min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   display: grid;
   grid-template-columns: var(--shell-nav-width) minmax(0, 1fr);
   grid-template-rows: var(--shell-topbar-height) 1fr;
@@ -307,6 +309,11 @@
   min-height: 0;
   overflow-y: auto; /* Enable vertical scrolling for pages with long content */
   overflow-x: hidden;
+}
+
+/* Chat handles its own scrolling (chat-thread); avoid double scrollbars. */
+.content--chat {
+  overflow: hidden;
 }
 
 .shell--chat .content {


### PR DESCRIPTION
## Summary
Fix double-scrolling in the Control UI Chat tab when the nav sidebar is taller than the viewport.

## Steps to reproduce
1. Open the Control UI and go to **Chat**.
2. Expand the sidebar sections and/or make the window shorter (or otherwise ensure the left nav sidebar is longer than the viewport).
3. Scroll with mouse wheel/trackpad.
4. Notice the page can scroll independently from the chat thread (double-scroll).

## Expected behavior
Only the chat thread should scroll (and the nav sidebar should scroll independently), without the page/content area becoming a separate scroll container.

## Actual behavior
Both the page/content area and the chat thread can scroll independently, making scrolling feel inconsistent.

## Fix
Constrain the app shell to the viewport so the outer layout can’t scroll, and let the chat rely on the existing `.chat-thread` scroll container.

## Changes
- `ui/src/styles/layout.css`
  - Set `.shell` to `height: 100vh` and `overflow: hidden`

## Testing notes
- Manually verified the Chat tab no longer exhibits double-scroll when the nav sidebar exceeds viewport height.

## AI-assisted
This PR was AI-assisted (Shellby). Tested manually.