### PR TITLE
feat(models): Add AWS Bedrock Converse Stream API support

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -39,7 +39,7 @@ export function resolveModel(
   if (!model) {
     const providers = cfg?.models?.providers ?? {};
     const inlineModels =
-      providers[provider]?.models ??
+      providers[provider]?.models?.map((entry) => ({ ...entry, provider })) ??
       Object.values(providers)
         .flatMap((entry) => entry?.models ?? [])
         .map((entry) => ({ ...entry, provider }));

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -3,7 +3,8 @@ export type ModelApi =
   | "openai-responses"
   | "anthropic-messages"
   | "google-generative-ai"
-  | "github-copilot";
+  | "github-copilot"
+  | "bedrock-converse-stream";
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -8,6 +8,7 @@ export const ModelApiSchema = z.union([
   z.literal("anthropic-messages"),
   z.literal("google-generative-ai"),
   z.literal("github-copilot"),
+  z.literal("bedrock-converse-stream"),
 ]);
 
 export const ModelCompatSchema = z


### PR DESCRIPTION
## Summary

Exposes the existing `bedrock-converse-stream` adapter as a valid API type for custom provider configurations, enabling native AWS Bedrock model support.

## Changes

### 1. Schema Updates
- Added `bedrock-converse-stream` to the `ModelApi` type union
- Added corresponding Zod schema literal for config validation

### 2. Model Resolution Fix  
- Fixed inline model resolution to properly attach provider context
- Without this, custom provider models fail to resolve because the provider name is lost during flatMap

## Usage

Users can now configure Bedrock models in `clawdbot.json`:

```json
{
  "models": {
    "providers": {
      "amazon-bedrock": {
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "api": "bedrock-converse-stream",
        "models": [
          {
            "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
            "name": "Claude Opus 4.5 (Bedrock)",
            "reasoning": true,
            "input": ["text", "image"],
            "contextWindow": 200000,
            "maxTokens": 8192
          }
        ]
      }
    }
  }
}
```

Authentication uses standard AWS credentials from `~/.aws/credentials` or environment variables.

## Testing

Verified working with Claude Opus 4.5 on Bedrock in production.