### PR TITLE
Discord: fallback /skill when command limit exceeded

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -37,6 +37,15 @@ describe("resolveSkillCommandInvocation", () => {
     });
     expect(invocation).toBeNull();
   });
+
+  it("supports /skill with name argument", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/skill demo-skill do the thing",
+      skillCommands: [{ name: "demo_skill", skillName: "demo-skill", description: "Demo" }],
+    });
+    expect(invocation?.command.name).toBe("demo_skill");
+    expect(invocation?.args).toBe("do the thing");
+  });
 });
 
 describe("listSkillCommandsForAgents", () => {

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -55,6 +55,28 @@ export function listSkillCommandsForAgents(params: {
   return entries;
 }
 
+function normalizeSkillCommandLookup(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s_]+/g, "-");
+}
+
+function findSkillCommand(
+  skillCommands: SkillCommandSpec[],
+  rawName: string,
+): SkillCommandSpec | undefined {
+  const trimmed = rawName.trim();
+  if (!trimmed) return undefined;
+  const lowered = trimmed.toLowerCase();
+  const normalized = normalizeSkillCommandLookup(trimmed);
+  return skillCommands.find((entry) => {
+    if (entry.name.toLowerCase() === lowered) return true;
+    if (entry.skillName.toLowerCase() === lowered) return true;
+    return (
+      normalizeSkillCommandLookup(entry.name) === normalized ||
+      normalizeSkillCommandLookup(entry.skillName) === normalized
+    );
+  });
+}
+
 export function resolveSkillCommandInvocation(params: {
   commandBodyNormalized: string;
   skillCommands: SkillCommandSpec[];
@@ -65,6 +87,16 @@ export function resolveSkillCommandInvocation(params: {
   if (!match) return null;
   const commandName = match[1]?.trim().toLowerCase();
   if (!commandName) return null;
+  if (commandName === "skill") {
+    const remainder = match[2]?.trim();
+    if (!remainder) return null;
+    const skillMatch = remainder.match(/^([^\s]+)(?:\s+([\s\S]+))?$/);
+    if (!skillMatch) return null;
+    const skillCommand = findSkillCommand(params.skillCommands, skillMatch[1] ?? "");
+    if (!skillCommand) return null;
+    const args = skillMatch[2]?.trim();
+    return { command: skillCommand, args: args || undefined };
+  }
   const command = params.skillCommands.find((entry) => entry.name.toLowerCase() === commandName);
   if (!command) return null;
   const args = match[2]?.trim();


### PR DESCRIPTION
## Summary
- guard against Discord's 100-command cap by falling back to a generic `/skill` command when native skill commands would exceed the limit
- keep text-based skill invocation working via `/skill <name> [input]`

## Testing
- not run (not requested)

## Notes
- this is Discord-specific; other platforms do not appear to enforce the same hard limit

Fixes #1273
