### PR TITLE
ui(chat): persist session in URL and stabilize picker

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,8 +1,10 @@
 import { html } from "lit";
+import { repeat } from "lit/directives/repeat.js";
 
 import type { AppViewState } from "./app-view-state";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation";
 import { loadChatHistory } from "./controllers/chat";
+import { syncUrlWithSessionKey } from "./app-settings";
 import type { SessionsListResult } from "./types";
 import type { ThemeMode } from "./theme";
 import type { ThemeTransitionContext } from "./theme-transition";
@@ -64,10 +66,13 @@ export function renderChatControls(state: AppViewState) {
               sessionKey: next,
               lastActiveSessionKey: next,
             });
+            syncUrlWithSessionKey(state, next, true);
             void loadChatHistory(state);
           }}
         >
-          ${sessionOptions.map(
+          ${repeat(
+            sessionOptions,
+            (entry) => entry.key,
             (entry) =>
               html`<option value=${entry.key}>
                 ${entry.displayName ?? entry.key}
@@ -119,9 +124,11 @@ function resolveSessionOptions(sessionKey: string, sessions: SessionsListResult 
   const seen = new Set<string>();
   const options: Array<{ key: string; displayName?: string }> = [];
 
+  const resolvedCurrent = sessions?.sessions?.find((s) => s.key === sessionKey);
+
   // Add current session key first
   seen.add(sessionKey);
-  options.push({ key: sessionKey });
+  options.push({ key: sessionKey, displayName: resolvedCurrent?.displayName });
 
   // Add sessions from the result
   if (sessions?.sessions) {


### PR DESCRIPTION
## Summary
Persist the selected chat session in the URL and make the session picker render more reliably.

## Problem
- The selected session is not reflected in the URL, so deep-linking/reloading does not preserve which session you’re viewing.
- The session picker can occasionally display the wrong label for the active session (DOM reuse / unstable option rendering).

## Changes
- Persist the active session key in `?session=...` on the Chat tab.
  - Ensures reloads and copy/paste links keep the same session selected.
  - Avoids leaking `session` onto non-Chat routes.
- Stabilize the session picker option rendering.
  - Render options with stable keys (prevents intermittent label mixups).
  - Prefer resolved `displayName` for the current session option when available.

## Files
- `ui/src/ui/app-settings.ts`
- `ui/src/ui/app-render.helpers.ts`

## Testing Notes
- Manually verified:
  - Selecting a session updates the URL `?session=...` while on Chat.
  - Navigating away from Chat removes the `session` query param.
  - Refreshing Chat preserves the selected session.
  - Session picker label remains stable across session list refreshes.

---

Implemented by Shellby (assistant) based on Bradley’s report; happy to iterate.