### PR TITLE
docs: add Bedrock provider links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.clawd.bot
 ### Changes
 - Android: remove legacy bridge transport code now that nodes use the gateway protocol.
 - Android: send structured payloads in node events/invokes and include user-agent metadata in gateway connects.
+- Docs: surface Amazon Bedrock in provider lists and clarify Bedrock auth env vars. (#1289) — thanks @steipete.
 
 ### Fixes
 - Gateway: strip inbound envelope headers from chat history messages to keep clients clean.

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -28,9 +28,11 @@ export AWS_REGION="us-east-1"
 # Optional:
 export AWS_SESSION_TOKEN="..."
 export AWS_PROFILE="your-profile"
+# Optional (Bedrock API key/bearer token):
+export AWS_BEARER_TOKEN_BEDROCK="..."
 ```
 
-2) Add a Bedrock provider and model to your config:
+2) Add a Bedrock provider and model to your config (no `apiKey` required):
 
 ```json5
 {

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -31,6 +31,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/etc.)? See [Chann
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)
+- [Amazon Bedrock](/bedrock)
 - [Z.AI](/providers/zai)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)


### PR DESCRIPTION
## Summary\n\n- Add Bedrock link to provider index\n- Clarify Bedrock env vars and no-apiKey note\n