### PR TITLE
ui(chat): separate tool/thinking output and add toggle

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -84,6 +84,11 @@
   color: rgba(150, 150, 150, 1);
 }
 
+.chat-avatar.tool {
+  background: rgba(134, 142, 150, 0.2);
+  color: rgba(134, 142, 150, 1);
+}
+
 /* Minimal Bubble Design - dynamic width based on content */
 .chat-bubble {
   display: inline-block;

--- a/ui/src/styles/chat/legacy.css
+++ b/ui/src/styles/chat/legacy.css
@@ -12,8 +12,14 @@
 }
 
 .chat-line.assistant,
-.chat-line.other {
+.chat-line.other,
+.chat-line.tool {
   justify-content: flex-start;
+}
+
+.chat-line.tool .chat-bubble {
+  border-style: dashed;
+  opacity: 0.95;
 }
 
 .chat-msg {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -2,6 +2,22 @@
    CHAT TEXT STYLING
    ============================================= */
 
+.chat-thinking {
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+:root[data-theme="light"] .chat-thinking {
+  border-color: rgba(16, 24, 40, 0.18);
+  background: rgba(16, 24, 40, 0.03);
+}
+
 .chat-text {
   font-size: 14px;
   line-height: 1.5;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -93,6 +93,18 @@ export function renderChatControls(state: AppViewState) {
       </button>
       <span class="chat-controls__separator">|</span>
       <button
+        class="btn btn--sm btn--icon ${state.settings.chatShowThinking ? "active" : ""}"
+        @click=${() =>
+          state.applySettings({
+            ...state.settings,
+            chatShowThinking: !state.settings.chatShowThinking,
+          })}
+        aria-pressed=${state.settings.chatShowThinking}
+        title="Toggle assistant thinking/working output"
+      >
+        🧠
+      </button>
+      <button
         class="btn btn--sm btn--icon ${state.settings.chatFocusMode ? "active" : ""}"
         @click=${() =>
           state.applySettings({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -382,6 +382,7 @@ export function renderApp(state: AppViewState) {
                 void loadChatHistory(state);
               },
               thinkingLevel: state.chatThinkingLevel,
+              showThinking: state.settings.chatShowThinking,
               loading: state.chatLoading,
               sending: state.chatSending,
               messages: state.chatMessages,

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -106,8 +106,22 @@ export function renderMessageGroup(
 
 function renderAvatar(role: string) {
   const normalized = normalizeRoleForGrouping(role);
-  const initial = normalized === "user" ? "U" : normalized === "assistant" ? "A" : "?";
-  const className = normalized === "user" ? "user" : normalized === "assistant" ? "assistant" : "other";
+  const initial =
+    normalized === "user"
+      ? "U"
+      : normalized === "assistant"
+        ? "A"
+        : normalized === "tool"
+          ? "⚙"
+          : "?";
+  const className =
+    normalized === "user"
+      ? "user"
+      : normalized === "assistant"
+        ? "assistant"
+        : normalized === "tool"
+          ? "tool"
+          : "other";
   return html`<div class="chat-avatar ${className}">${initial}</div>`;
 }
 
@@ -132,11 +146,10 @@ function renderGroupedMessage(
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinking(message) : null;
   const markdownBase = extractedText?.trim() ? extractedText : null;
-  const markdown = extractedThinking
-    ? [formatReasoningMarkdown(extractedThinking), markdownBase]
-        .filter(Boolean)
-        .join("\n\n")
-    : markdownBase;
+  const reasoningMarkdown = extractedThinking
+    ? formatReasoningMarkdown(extractedThinking)
+    : null;
+  const markdown = markdownBase;
 
   const bubbleClasses = [
     "chat-bubble",
@@ -156,6 +169,11 @@ function renderGroupedMessage(
 
   return html`
     <div class="${bubbleClasses}">
+      ${reasoningMarkdown
+        ? html`<div class="chat-thinking">${unsafeHTML(
+            toSanitizedMarkdownHtml(reasoningMarkdown),
+          )}</div>`
+        : nothing}
       ${markdown
         ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
         : nothing}

--- a/ui/src/ui/chat/legacy-render.ts
+++ b/ui/src/ui/chat/legacy-render.ts
@@ -64,11 +64,10 @@ export function renderMessage(
     display?.kind === "json"
       ? ["```json", display.value, "```"].join("\n")
       : (display?.value ?? null);
-  const markdown = extractedThinking
-    ? [formatReasoningMarkdown(extractedThinking), markdownBase]
-        .filter(Boolean)
-        .join("\n\n")
-    : markdownBase;
+  const reasoningMarkdown = extractedThinking
+    ? formatReasoningMarkdown(extractedThinking)
+    : null;
+  const markdown = markdownBase;
 
   const timestamp =
     typeof m.timestamp === "number" ? new Date(m.timestamp).toLocaleTimeString() : "";
@@ -79,13 +78,17 @@ export function renderMessage(
       ? "assistant"
       : normalizedRole === "user"
         ? "user"
-        : "other";
+        : normalizedRole === "tool"
+          ? "tool"
+          : "other";
   const who =
     normalizedRole === "assistant"
       ? "Assistant"
       : normalizedRole === "user"
         ? "You"
-        : normalizedRole;
+        : normalizedRole === "tool"
+          ? "Working"
+          : normalizedRole;
 
   const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
   const toolCardBase =
@@ -98,6 +101,11 @@ export function renderMessage(
     <div class="chat-line ${klass}">
       <div class="chat-msg">
         <div class="chat-bubble ${opts?.streaming ? "streaming" : ""}">
+          ${reasoningMarkdown
+            ? html`<div class="chat-thinking">${unsafeHTML(
+                toSanitizedMarkdownHtml(reasoningMarkdown),
+              )}</div>`
+            : nothing}
           ${markdown
             ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
             : nothing}

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -103,25 +103,25 @@ describe("message-normalizer", () => {
   });
 
   describe("normalizeRoleForGrouping", () => {
-    it("returns assistant for toolresult", () => {
-      expect(normalizeRoleForGrouping("toolresult")).toBe("assistant");
-      expect(normalizeRoleForGrouping("toolResult")).toBe("assistant");
-      expect(normalizeRoleForGrouping("TOOLRESULT")).toBe("assistant");
+    it("returns tool for toolresult", () => {
+      expect(normalizeRoleForGrouping("toolresult")).toBe("tool");
+      expect(normalizeRoleForGrouping("toolResult")).toBe("tool");
+      expect(normalizeRoleForGrouping("TOOLRESULT")).toBe("tool");
     });
 
-    it("returns assistant for tool_result", () => {
-      expect(normalizeRoleForGrouping("tool_result")).toBe("assistant");
-      expect(normalizeRoleForGrouping("TOOL_RESULT")).toBe("assistant");
+    it("returns tool for tool_result", () => {
+      expect(normalizeRoleForGrouping("tool_result")).toBe("tool");
+      expect(normalizeRoleForGrouping("TOOL_RESULT")).toBe("tool");
     });
 
-    it("returns assistant for tool", () => {
-      expect(normalizeRoleForGrouping("tool")).toBe("assistant");
-      expect(normalizeRoleForGrouping("Tool")).toBe("assistant");
+    it("returns tool for tool", () => {
+      expect(normalizeRoleForGrouping("tool")).toBe("tool");
+      expect(normalizeRoleForGrouping("Tool")).toBe("tool");
     });
 
-    it("returns assistant for function", () => {
-      expect(normalizeRoleForGrouping("function")).toBe("assistant");
-      expect(normalizeRoleForGrouping("Function")).toBe("assistant");
+    it("returns tool for function", () => {
+      expect(normalizeRoleForGrouping("function")).toBe("tool");
+      expect(normalizeRoleForGrouping("Function")).toBe("tool");
     });
 
     it("preserves user role", () => {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -9,6 +9,7 @@ export type UiSettings = {
   lastActiveSessionKey: string;
   theme: ThemeMode;
   chatFocusMode: boolean;
+  chatShowThinking: boolean;
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
   useNewChatLayout: boolean; // Slack-style grouped messages layout
   navCollapsed: boolean; // Collapsible sidebar state
@@ -28,6 +29,7 @@ export function loadSettings(): UiSettings {
     lastActiveSessionKey: "main",
     theme: "system",
     chatFocusMode: false,
+    chatShowThinking: true,
     splitRatio: 0.6,
     useNewChatLayout: true, // Enabled by default
     navCollapsed: false,
@@ -65,6 +67,10 @@ export function loadSettings(): UiSettings {
         typeof parsed.chatFocusMode === "boolean"
           ? parsed.chatFocusMode
           : defaults.chatFocusMode,
+      chatShowThinking:
+        typeof parsed.chatShowThinking === "boolean"
+          ? parsed.chatShowThinking
+          : defaults.chatShowThinking,
       splitRatio:
         typeof parsed.splitRatio === "number" &&
         parsed.splitRatio >= 0.4 &&


### PR DESCRIPTION
## Summary
Improve the Control UI chat message rendering by separating tool/thinking output from normal assistant messages, and adding a UI toggle to show/hide that output.

Note: I just went for a show/hide toggle for now, maybe collapsing by default or something similar is a better solution.
I haven't used any of the GUI apps, so unsure of their behaviors here.

## Problem
- Assistant “thinking/working” output (reasoning + tool stream) is hard to distinguish from normal assistant messages.
- Users may want to hide tool/thinking output to focus on the conversation.
- Some tool-like events arrive in shapes that previously rendered as normal assistant messages.

## Changes
- Render assistant reasoning as a distinct block (`.chat-thinking`) instead of prepending it into the main `.chat-text`.
- Improve tool detection/normalization so tool-like messages can be styled separately.
- Add a “🧠” toggle in Chat controls to show/hide thinking + tool output.
  - Persists via UI settings (`chatShowThinking`).
  - When off, tool stream output is hidden and tool-like history entries are filtered from the chat view.

## Files
- Chat rendering + normalization:
  - `ui/src/ui/chat/legacy-render.ts`
  - `ui/src/ui/chat/grouped-render.ts`
  - `ui/src/ui/chat/message-normalizer.ts`
  - `ui/src/ui/chat/message-normalizer.test.ts`
  - `ui/src/ui/views/chat.ts`
- UI plumbing:
  - `ui/src/ui/app-render.ts`
  - `ui/src/ui/app-render.helpers.ts`
  - `ui/src/ui/storage.ts`
- Styling:
  - `ui/src/styles/chat/text.css`
  - `ui/src/styles/chat/legacy.css`
  - `ui/src/styles/chat/grouped.css`

## Testing Notes
- Manually verified:
  - Tool/thinking output is visually distinct from normal assistant messages.
  - 🧠 toggle hides/shows tool + thinking output as expected.
  - Toggle state persists across reloads.

---

Implemented by Shellby (assistant) based on Bradley’s report; happy to iterate.