### PR TITLE
ui(sessions): support editing session labels

### DIFF
--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -43,6 +43,7 @@ export async function patchSession(
   state: SessionsState,
   key: string,
   patch: {
+    label?: string | null;
     thinkingLevel?: string | null;
     verboseLevel?: string | null;
     reasoningLevel?: string | null;
@@ -50,6 +51,7 @@ export async function patchSession(
 ) {
   if (!state.client || !state.connected) return;
   const params: Record<string, unknown> = { key };
+  if ("label" in patch) params.label = patch.label;
   if ("thinkingLevel" in patch) params.thinkingLevel = patch.thinkingLevel;
   if ("verboseLevel" in patch) params.verboseLevel = patch.verboseLevel;
   if ("reasoningLevel" in patch) params.reasoningLevel = patch.reasoningLevel;

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -24,6 +24,7 @@ export type SessionsProps = {
   onPatch: (
     key: string,
     patch: {
+      label?: string | null;
       thinkingLevel?: string | null;
       verboseLevel?: string | null;
       reasoningLevel?: string | null;
@@ -195,7 +196,17 @@ function renderRow(
       <div class="mono">${canLink
         ? html`<a href=${chatUrl} class="session-link">${displayName}</a>`
         : displayName}</div>
-      <div>${row.label ?? ""}</div>
+      <div>
+        <input
+          .value=${row.label ?? ""}
+          ?disabled=${disabled}
+          placeholder="(optional)"
+          @change=${(e: Event) => {
+            const value = (e.target as HTMLInputElement).value.trim();
+            onPatch(row.key, { label: value || null });
+          }}
+        />
+      </div>
       <div>${row.kind}</div>
       <div>${updated}</div>
       <div>${formatSessionTokens(row)}</div>


### PR DESCRIPTION
## Summary
Allow editing the `label` for a session directly from the Sessions tab.

## Context (feature parity)
This PR exposes functionality that already exists in the gateway API (`sessions.patch` supports `label`), but is not currently exposed in any clients (e.g. the TUI and macOS app primarily patch thinking/verbose/model). 

It seems to have been added primarily for labelling subagents via the `sessions_spawn` and `sessions_send` calls.
Unsure if this is the direction you were going with session labels, no worries if not.

This UI addition is meant to improve usability now, and it should be straightforward to add the same capability to other clients later by passing `label` in their existing `sessions.patch` calls.

<img width="748" height="360" alt="Screenshot 2026-01-20 at 22 19 26" src="https://github.com/user-attachments/assets/62feebc6-f7bd-4038-9d0e-385a2f64ea73" />

## Problem
- Session keys are stable identifiers but not always human-friendly.
- While the gateway supports a `label` field for session entries, the Control UI does not expose a way to set/update it, making it harder to identify sessions and keep them organized.

## Changes
- Make the “Label” column editable in the Sessions table.
- Persist updates via `sessions.patch` using `{ key, label }`.
  - Empty input clears the label (sends `null`).

## Files
- `ui/src/ui/views/sessions.ts`
- `ui/src/ui/controllers/sessions.ts`

## Testing Notes
- Manually verified:
  - Changing the label and blurring the input updates the session label.
  - Clearing the input removes the label.
  - Refreshing Sessions shows the persisted label.

---

Implemented by Shellby (assistant) based on Bradley’s request; happy to iterate.