### PR TITLE
exec: prefer bash when fish is default shell

### DIFF
--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import path from "node:path";
 
 export function getShellConfig(): { shell: string; args: string[] } {
   if (process.platform === "win32") {
@@ -13,7 +14,13 @@ export function getShellConfig(): { shell: string; args: string[] } {
     };
   }
 
-  const shell = process.env.SHELL?.trim() || "sh";
+  const envShell = process.env.SHELL?.trim();
+  const shellName = envShell ? path.basename(envShell) : "";
+  // Fish rejects common bashisms used by tools, so prefer bash when detected.
+  if (shellName === "fish") {
+    return { shell: "/bin/bash", args: ["-c"] };
+  }
+  const shell = envShell || "sh";
   return { shell, args: ["-c"] };
 }
 


### PR DESCRIPTION
## Summary
- Prefer `/bin/bash` when the default shell is fish to avoid incompatibilities with bash-style tool commands.
- Keep existing behavior for other shells; Windows remains on PowerShell.

## Repro
```
[tools] bash failed: funcsave: wrote /Users/alexanderadamov/.config/fish/functions/rj.fish
fish: Unsupported use of '='. In fish, please use 'set PROMPT $(cat <<'EOF'
...snip...
EOF
)'.
```

## Testing
- pnpm lint

## AI-assisted
- Yes (Codex). I reviewed the change and understand it.