### PR TITLE
CLI: warn on bleeding-edge updates

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -11,6 +11,9 @@ Safely update a **source checkout** (git install) of Clawdbot.
 
 If you installed via **npm/pnpm** (global install, no git metadata), use the package manager flow in [Updating](/install/updating).
 
+> [!NOTE]
+> Two-clone workflow: keep a stable clone on tagged releases (`git checkout --tag latest`), and a separate clone for bleeding-edge hacking (`git pull`).
+
 ## Usage
 
 ```bash

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -9,6 +9,9 @@ read_when:
 
 Clawdbot is moving fast (pre “1.0”). Treat updates like shipping infra: update → run checks → restart → verify.
 
+> [!NOTE]
+> Two-clone workflow: keep a stable clone on tagged releases (`git checkout --tag latest`), and a separate clone for bleeding-edge hacking (`git pull`).
+
 ## Recommended: re-run the website installer (upgrade in place)
 
 The **preferred** update path is to re-run the installer from the website. It

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -14,6 +14,9 @@ Last updated: 2026-01-01
 - **Stable workflow:** install the macOS app; let it run the bundled Gateway.
 - **Bleeding edge workflow:** run the Gateway yourself via `pnpm gateway:watch`, then let the macOS app attach in Local mode.
 
+> [!NOTE]
+> Two-clone workflow: keep a stable clone on tagged releases (`git checkout --tag latest`), and a separate clone for bleeding-edge hacking (`git pull`).
+
 ## Prereqs (from source)
 - Node `>=22`
 - `pnpm`

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -351,6 +351,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     argv1: process.argv[1],
     timeoutMs,
     progress,
+    interactive: !opts.json,
     tag,
   });
 

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -49,6 +49,7 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     const result = await runGatewayUpdate({
       cwd: params.root,
       argv1: process.argv[1],
+      interactive: params.options.nonInteractive !== true,
     });
     note(
       [

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -58,6 +58,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         timeoutMs,
         cwd: root,
         argv1: process.argv[1],
+        interactive: false,
       });
     } catch (err) {
       result = {


### PR DESCRIPTION
## Summary
- Add a main-branch warning + confirm prompt in `clawdbot update` when ahead of the latest tag.
- Skip the prompt for non-interactive update paths (RPC, doctor --non-interactive, JSON).
- Add a short note about the stable-vs-bleeding-edge two-clone workflow in the update docs.

## Impact
Improves DX by avoiding frustrations about accidentally running too-advanced versions; example: https://x.com/richardpoelderl/status/2013284020809773506?s=20

This PR essentially adds Peter’s callout into the update flow whenever you risk hitting it:
> If you live on the bleeding edge, there will be bugs! If you want to just have sth that works, use the tagged releases.

Source: https://x.com/steipete/status/2013536906617749558?s=20

## Docs
callout added to:
- `docs/cli/update.md`
- `docs/install/updating.md`
- `docs/start/setup.md`

## Testing
- `pnpm test -- src/cli/update-cli.test.ts src/infra/update-runner.test.ts` (suite ran locally; 1 failure)

## Test Failure
```
FAIL  src/memory/manager.atomic-reindex.test.ts > memory manager atomic reindex > keeps the prior index when a full reindex fails
AssertionError: expected 0 to be greater than 0
 ❯ src/memory/manager.atomic-reindex.test.ts:84:27
     82|     await manager.sync({ force: true });
     83|     const before = await manager.search("Hello");
     84|     expect(before.length).toBeGreaterThan(0);
       |                           ^
     85|
     86|     shouldFail = true;

Test Files  1 failed | 792 passed | 1 skipped (794)
Tests  1 failed | 4200 passed | 7 skipped (4208)
```
