### PR TITLE
fix: allow token auth to bypass device identity requirement

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -254,7 +254,9 @@ export function attachGatewayWsMessageHandler(params: {
 
         const device = connectParams.device;
         let devicePublicKey: string | null = null;
-        if (!device) {
+        // Allow token-authenticated connections (e.g., control-ui) to skip device identity
+        const hasTokenAuth = !!connectParams.auth?.token;
+        if (!device && !hasTokenAuth) {
           setHandshakeState("failed");
           setCloseCause("device-required", {
             client: connectParams.client.id,
@@ -427,7 +429,7 @@ export function attachGatewayWsMessageHandler(params: {
         });
         let authOk = authResult.ok;
         let authMethod = authResult.method ?? "none";
-        if (!authOk && connectParams.auth?.token) {
+        if (!authOk && connectParams.auth?.token && device) {
           const tokenCheck = await verifyDeviceToken({
             deviceId: device.id,
             token: connectParams.auth.token,


### PR DESCRIPTION
## Summary
- The device identity check was rejecting connections before token authentication could be attempted
- This broke the control-ui (web UI) which uses token-based authentication via URL parameter (`?token=...`)

## Changes
- Skip device identity requirement when a token is provided in `connectParams.auth`
- Guard device token verification to only run when device is present

## Testing
- Control-ui can now connect using token auth without device identity
- Device-based auth still works as before

Fixes control-ui showing "device identity required" error when connecting with a valid token.

🤖 Generated with [Claude Code](https://claude.ai/code)