### PR TITLE
Fix(cli): Preserve delivery settings when updating message via cron edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.clawd.bot
 - Agents: avoid treating timeout errors with "aborted" messages as user aborts, so model fallback still runs.
 - Diagnostics: export OTLP logs, correct queue depth tracking, and document message-flow telemetry.
 - Diagnostics: emit message-flow diagnostics across channels via shared dispatch; gate heartbeat/webhook logging. (#1244) — thanks @oscargavin.
+- CLI: preserve cron delivery settings when editing message payloads. (#1322) — thanks @KrauseFx.
 - Model catalog: avoid caching import failures, log transient discovery errors, and keep partial results. (#1332) — thanks @dougvk.
 - Doctor: clarify plugin auto-enable hint text in the startup banner.
 - Gateway: clarify unauthorized handshake responses with token/password mismatch guidance.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -256,10 +256,9 @@ describe("cron cli", () => {
     registerCronCli(program);
 
     // Update message without delivery flags - should NOT include undefined delivery fields
-    await program.parseAsync(
-      ["cron", "edit", "job-1", "--message", "Updated message"],
-      { from: "user" },
-    );
+    await program.parseAsync(["cron", "edit", "job-1", "--message", "Updated message"], {
+      from: "user",
+    });
 
     const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
     const patch = updateCall?.[2] as {
@@ -276,7 +275,7 @@ describe("cron cli", () => {
 
     // Should include the new message
     expect(patch?.patch?.payload?.message).toBe("Updated message");
-    
+
     // Should NOT include delivery fields at all (to preserve existing values)
     expect(patch?.patch?.payload).not.toHaveProperty("deliver");
     expect(patch?.patch?.payload).not.toHaveProperty("channel");

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -326,4 +326,48 @@ describe("cron cli", () => {
     expect(patch?.patch?.payload?.channel).toBe("telegram");
     expect(patch?.patch?.payload?.to).toBe("19098680");
   });
+
+  it("includes best-effort delivery when provided with message", async () => {
+    callGatewayFromCli.mockClear();
+
+    const { registerCronCli } = await import("./cron-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerCronCli(program);
+
+    await program.parseAsync(
+      ["cron", "edit", "job-1", "--message", "Updated message", "--best-effort-deliver"],
+      { from: "user" },
+    );
+
+    const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
+    const patch = updateCall?.[2] as {
+      patch?: { payload?: { message?: string; bestEffortDeliver?: boolean } };
+    };
+
+    expect(patch?.patch?.payload?.message).toBe("Updated message");
+    expect(patch?.patch?.payload?.bestEffortDeliver).toBe(true);
+  });
+
+  it("includes no-best-effort delivery when provided with message", async () => {
+    callGatewayFromCli.mockClear();
+
+    const { registerCronCli } = await import("./cron-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerCronCli(program);
+
+    await program.parseAsync(
+      ["cron", "edit", "job-1", "--message", "Updated message", "--no-best-effort-deliver"],
+      { from: "user" },
+    );
+
+    const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
+    const patch = updateCall?.[2] as {
+      patch?: { payload?: { message?: string; bestEffortDeliver?: boolean } };
+    };
+
+    expect(patch?.patch?.payload?.message).toBe("Updated message");
+    expect(patch?.patch?.payload?.bestEffortDeliver).toBe(false);
+  });
 });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -10,6 +10,15 @@ import {
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
 
+const assignIf = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+  shouldAssign: boolean,
+) => {
+  if (shouldAssign) target[key] = value;
+};
+
 export function registerCronEditCommand(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -136,18 +145,19 @@ export function registerCronEditCommand(cron: Command) {
             };
           } else if (hasAgentTurnPatch) {
             const payload: Record<string, unknown> = { kind: "agentTurn" };
-            if (typeof opts.message === "string") payload.message = String(opts.message);
-            if (model) payload.model = model;
-            if (thinking) payload.thinking = thinking;
-            if (hasTimeoutSeconds) {
-              payload.timeoutSeconds = timeoutSeconds;
-            }
-            if (typeof opts.deliver === "boolean") payload.deliver = opts.deliver;
-            if (typeof opts.channel === "string") payload.channel = opts.channel;
-            if (typeof opts.to === "string") payload.to = opts.to;
-            if (typeof opts.bestEffortDeliver === "boolean") {
-              payload.bestEffortDeliver = opts.bestEffortDeliver;
-            }
+            assignIf(payload, "message", String(opts.message), typeof opts.message === "string");
+            assignIf(payload, "model", model, Boolean(model));
+            assignIf(payload, "thinking", thinking, Boolean(thinking));
+            assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
+            assignIf(payload, "deliver", opts.deliver, typeof opts.deliver === "boolean");
+            assignIf(payload, "channel", opts.channel, typeof opts.channel === "string");
+            assignIf(payload, "to", opts.to, typeof opts.to === "string");
+            assignIf(
+              payload,
+              "bestEffortDeliver",
+              opts.bestEffortDeliver,
+              typeof opts.bestEffortDeliver === "boolean",
+            );
             patch.payload = payload;
           }
 


### PR DESCRIPTION
### Problem

When using clawdbot cron edit --message to update a cron job's message, it wipes out existing delivery settings even when delivery flags aren't specified.

Example that breaks:

```sh
# Job initially has: deliver=true, channel="telegram", to="19098680"
clawdbot cron edit job-123 --message "New prompt text"
# After: deliver=undefined, channel=undefined, to=undefined (delivery disabled!)
```

### What happened:
The job stops sending notifications because the delivery configuration was silently removed.

### Root Cause

The CLI was building the payload patch like this:

```js
patch.payload = {
  kind: "agentTurn",
  message: "New prompt",
  deliver: undefined,      // ❌ Included even when not specified
  channel: undefined,      // ❌ Wipes out existing value
  to: undefined,           // ❌ Wipes out existing value
  bestEffortDeliver: undefined
};
```

When the gateway applied this patch, it treated undefined values as explicit removals, wiping out the stored delivery config.

### Why it matters

This is a destructive data loss bug that:

• Silently breaks notification delivery without warning
• Requires users to re-specify delivery flags every time they update the message
• Makes cron edit dangerous for production jobs
• Violated the principle of least surprise (updating one field shouldn't delete others)
Real-world impact: When I updated 6 cron jobs to use markdown prompt files, it accidentally disabled Telegram delivery for 3 of them.

### Solution

• Conditionally build the payload object
• Only include delivery fields when explicitly provided via flags
• Preserve existing delivery settings when not specified
• Added test coverage for both preservation and explicit override scenarios
After this fix:

```sh
# Preserves delivery settings
clawdbot cron edit job-123 --message "New prompt"
# ✅ Message updated, delivery config preserved
```

```sh
# Can still override delivery explicitly
clawdbot cron edit job-123 --message "New prompt" --deliver --channel telegram
# ✅ Both message and delivery updated
```

### Testing

Added 2 new test cases:

1. Verify delivery fields NOT included when updating only message
2. Verify delivery fields ARE included when explicitly provided with message
All tests passing (8/8).

### Implementation Notes
Written by Claude Code, didn't execute it, but only tested it through the unit tests