### PR TITLE
feat(nostr): add Nostr channel extension with messaging and profile management

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -40,7 +40,14 @@ import { renderOverview } from "./views/overview";
 import { renderSessions } from "./views/sessions";
 import { renderSkills } from "./views/skills";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers";
-import { loadChannels } from "./controllers/channels";
+import {
+  loadChannels,
+  startNostrProfileEdit,
+  cancelNostrProfileEdit,
+  updateNostrProfileField,
+  saveNostrProfile,
+  importNostrProfile,
+} from "./controllers/channels";
 import { loadPresence } from "./controllers/presence";
 import { deleteSession, loadSessions, patchSession } from "./controllers/sessions";
 import {
@@ -221,6 +228,18 @@ export function renderApp(state: AppViewState) {
               onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
               onConfigSave: () => state.handleChannelConfigSave(),
               onConfigReload: () => state.handleChannelConfigReload(),
+              // Nostr profile editing
+              nostrProfileEditing: state.nostrProfileEditing,
+              nostrProfileForm: state.nostrProfileForm,
+              nostrProfileSaving: state.nostrProfileSaving,
+              nostrProfileImporting: state.nostrProfileImporting,
+              nostrProfileError: state.nostrProfileError,
+              nostrProfileSuccess: state.nostrProfileSuccess,
+              onNostrEditProfile: () => startNostrProfileEdit(state),
+              onNostrCancelEdit: () => cancelNostrProfileEdit(state),
+              onNostrProfileFieldChange: (field, value) => updateNostrProfileField(state, field, value),
+              onNostrSaveProfile: () => saveNostrProfile(state),
+              onNostrImportProfile: () => importNostrProfile(state),
             })
           : nothing}
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -12,6 +12,7 @@ import type {
   HealthSnapshot,
   LogEntry,
   LogLevel,
+  NostrProfile,
   PresenceEntry,
   SessionsListResult,
   SkillStatusReport,
@@ -78,6 +79,13 @@ export type AppViewState = {
   whatsappLoginConnected: boolean | null;
   whatsappBusy: boolean;
   configFormDirty: boolean;
+  // Nostr profile editing
+  nostrProfileEditing: boolean;
+  nostrProfileForm: NostrProfile | null;
+  nostrProfileSaving: boolean;
+  nostrProfileImporting: boolean;
+  nostrProfileError: string | null;
+  nostrProfileSuccess: string | null;
   presenceLoading: boolean;
   presenceEntries: PresenceEntry[];
   presenceError: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -15,6 +15,7 @@ import type {
   HealthSnapshot,
   LogEntry,
   LogLevel,
+  NostrProfile,
   PresenceEntry,
   ChannelsStatusSnapshot,
   SessionsListResult,
@@ -142,6 +143,14 @@ export class ClawdbotApp extends LitElement {
   @state() whatsappLoginQrDataUrl: string | null = null;
   @state() whatsappLoginConnected: boolean | null = null;
   @state() whatsappBusy = false;
+
+  // Nostr profile editing
+  @state() nostrProfileEditing = false;
+  @state() nostrProfileForm: NostrProfile | null = null;
+  @state() nostrProfileSaving = false;
+  @state() nostrProfileImporting = false;
+  @state() nostrProfileError: string | null = null;
+  @state() nostrProfileSuccess: string | null = null;
 
   @state() presenceLoading = false;
   @state() presenceEntries: PresenceEntry[] = [];

--- a/ui/src/ui/controllers/channels.ts
+++ b/ui/src/ui/controllers/channels.ts
@@ -1,7 +1,14 @@
-import type { ChannelsStatusSnapshot } from "../types";
+import type { ChannelsStatusSnapshot, NostrProfile } from "../types";
 import type { ChannelsState } from "./channels.types";
 
 export type { ChannelsState };
+
+// Helper to get the gateway base URL from the WebSocket URL
+function getHttpBaseUrl(client: { url?: string } | null): string {
+  if (!client?.url) return "";
+  // Convert ws://host:port to http://host:port
+  return client.url.replace(/^ws(s)?:\/\//, "http$1://").replace(/\/$/, "");
+}
 
 export async function loadChannels(state: ChannelsState, probe: boolean) {
   if (!state.client || !state.connected) return;
@@ -72,5 +79,145 @@ export async function logoutWhatsApp(state: ChannelsState) {
     state.whatsappLoginMessage = String(err);
   } finally {
     state.whatsappBusy = false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Nostr Profile Management
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Start editing Nostr profile - loads current profile into form
+ */
+export function startNostrProfileEdit(state: ChannelsState) {
+  // Get current profile from snapshot
+  const nostrStatus = state.channelsSnapshot?.channels?.nostr as { profile?: NostrProfile } | undefined;
+  const currentProfile = nostrStatus?.profile ?? {};
+  
+  state.nostrProfileEditing = true;
+  state.nostrProfileForm = { ...currentProfile };
+  state.nostrProfileError = null;
+  state.nostrProfileSuccess = null;
+}
+
+/**
+ * Cancel profile editing
+ */
+export function cancelNostrProfileEdit(state: ChannelsState) {
+  state.nostrProfileEditing = false;
+  state.nostrProfileForm = null;
+  state.nostrProfileError = null;
+  state.nostrProfileSuccess = null;
+}
+
+/**
+ * Update a field in the profile form
+ */
+export function updateNostrProfileField(state: ChannelsState, field: keyof NostrProfile, value: string) {
+  if (!state.nostrProfileForm) return;
+  state.nostrProfileForm = {
+    ...state.nostrProfileForm,
+    [field]: value || undefined, // Convert empty string to undefined
+  };
+}
+
+/**
+ * Save and publish the Nostr profile via HTTP API
+ */
+export async function saveNostrProfile(
+  state: ChannelsState,
+  accountId: string = "default",
+): Promise<boolean> {
+  if (!state.client || !state.nostrProfileForm) return false;
+  if (state.nostrProfileSaving) return false;
+
+  state.nostrProfileSaving = true;
+  state.nostrProfileError = null;
+  state.nostrProfileSuccess = null;
+
+  try {
+    const baseUrl = getHttpBaseUrl(state.client as { url?: string });
+    const url = `${baseUrl}/api/channels/nostr/${accountId}/profile`;
+    
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(state.nostrProfileForm),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok) {
+      state.nostrProfileError = result.error ?? `HTTP ${response.status}`;
+      return false;
+    }
+
+    // Success - update state
+    state.nostrProfileSuccess = result.published
+      ? `Profile published to ${result.relayResults?.filter((r: { ok: boolean }) => r.ok).length ?? 0} relay(s)`
+      : "Profile saved locally";
+    
+    // Close form after short delay to show success message
+    setTimeout(() => {
+      state.nostrProfileEditing = false;
+      state.nostrProfileForm = null;
+    }, 1500);
+
+    // Refresh channels to get updated profile
+    await loadChannels(state, false);
+    return true;
+  } catch (err) {
+    state.nostrProfileError = err instanceof Error ? err.message : String(err);
+    return false;
+  } finally {
+    state.nostrProfileSaving = false;
+  }
+}
+
+/**
+ * Import profile from Nostr relays
+ */
+export async function importNostrProfile(
+  state: ChannelsState,
+  accountId: string = "default",
+): Promise<boolean> {
+  if (!state.client) return false;
+  if (state.nostrProfileImporting) return false;
+
+  state.nostrProfileImporting = true;
+  state.nostrProfileError = null;
+  state.nostrProfileSuccess = null;
+
+  try {
+    const baseUrl = getHttpBaseUrl(state.client as { url?: string });
+    const url = `${baseUrl}/api/channels/nostr/${accountId}/profile/import`;
+    
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok) {
+      state.nostrProfileError = result.error ?? `HTTP ${response.status}`;
+      return false;
+    }
+
+    if (!result.found) {
+      state.nostrProfileError = "No profile found on relays";
+      return false;
+    }
+
+    // Update form with imported profile
+    state.nostrProfileForm = result.profile;
+    state.nostrProfileSuccess = `Imported profile from ${result.relaysQueried} relay(s)`;
+    return true;
+  } catch (err) {
+    state.nostrProfileError = err instanceof Error ? err.message : String(err);
+    return false;
+  } finally {
+    state.nostrProfileImporting = false;
   }
 }

--- a/ui/src/ui/controllers/channels.types.ts
+++ b/ui/src/ui/controllers/channels.types.ts
@@ -1,5 +1,5 @@
 import type { GatewayBrowserClient } from "../gateway";
-import type { ChannelsStatusSnapshot } from "../types";
+import type { ChannelsStatusSnapshot, NostrProfile } from "../types";
 
 export type ChannelsState = {
   client: GatewayBrowserClient | null;
@@ -12,4 +12,11 @@ export type ChannelsState = {
   whatsappLoginQrDataUrl: string | null;
   whatsappLoginConnected: boolean | null;
   whatsappBusy: boolean;
+  // Nostr profile editing
+  nostrProfileEditing: boolean;
+  nostrProfileForm: NostrProfile | null;
+  nostrProfileSaving: boolean;
+  nostrProfileImporting: boolean;
+  nostrProfileError: string | null;
+  nostrProfileSuccess: string | null;
 };

--- a/ui/src/ui/views/channels.types.ts
+++ b/ui/src/ui/views/channels.types.ts
@@ -4,6 +4,8 @@ import type {
   ConfigUiHints,
   DiscordStatus,
   IMessageStatus,
+  NostrStatus,
+  NostrProfile,
   SignalStatus,
   SlackStatus,
   TelegramStatus,
@@ -35,6 +37,18 @@ export type ChannelsProps = {
   onConfigPatch: (path: Array<string | number>, value: unknown) => void;
   onConfigSave: () => void;
   onConfigReload: () => void;
+  // Nostr profile editing
+  nostrProfileEditing?: boolean;
+  nostrProfileForm?: NostrProfile | null;
+  nostrProfileSaving?: boolean;
+  nostrProfileImporting?: boolean;
+  nostrProfileError?: string | null;
+  nostrProfileSuccess?: string | null;
+  onNostrEditProfile?: () => void;
+  onNostrCancelEdit?: () => void;
+  onNostrProfileFieldChange?: (field: keyof NostrProfile, value: string) => void;
+  onNostrSaveProfile?: () => void;
+  onNostrImportProfile?: () => void;
 };
 
 export type ChannelsChannelData = {
@@ -44,5 +58,6 @@ export type ChannelsChannelData = {
   slack?: SlackStatus | null;
   signal?: SignalStatus | null;
   imessage?: IMessageStatus | null;
+  nostr?: NostrStatus | null;
   channelAccounts?: Record<string, ChannelAccountSnapshot[]> | null;
 };


### PR DESCRIPTION
## Summary

Complete Nostr channel extension for clawdbot - enables sending/receiving messages via Nostr protocol with profile management.

## Features

### Messaging Infrastructure
- **NostrBus** - Core message bus for Nostr protocol communication
- **Channel** - Full channel implementation for send/receive
- **SeenTracker** - Message deduplication with LRU cache
- **StateStore** - Persistent state management for relay connections

### Profile Management
- `PUT /api/channels/nostr/:accountId/profile` - update profile
- `GET /api/channels/nostr/:accountId/profile` - get current profile  
- `POST /api/channels/nostr/:accountId/profile/import` - import from relays
- UI form for editing name, about, picture, banner, website

### Security
- SSRF validation blocks private IPs (127.x, 10.x, 172.16-31.x, IPv4-mapped IPv6)
- Rate limiting (5 req/min per account)
- Mutex to prevent concurrent publish race conditions
- Profile import with signature verification
- Requires https:// for all image/website URLs

### Observability
- Metrics collection for relay connections, message counts, latency
- Integration with existing telemetry infrastructure

## Files Added
- `extensions/nostr/` - Complete Nostr extension (27 files, ~5500 lines)
- `ui/src/ui/views/channels.nostr.ts` - Nostr card UI
- `ui/src/ui/views/channels.nostr-profile-form.ts` - Profile edit form
- `docs/channels/nostr.md` - Documentation

## Tests
275 passing tests including:
- Unit tests for all components
- Fuzz tests for profile parsing and bus reliability
- Integration tests for relay communication

## Code Review
Reviewed by Claude Opus 4.5 - fixed race condition in mutex and SSRF bypass vulnerabilities.