### PR TITLE
docs: add WSL2 SSH setup, TTS server docs, and XTTS client scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@
 - When working on a GitHub Issue or PR, print the full URL at the end of the task.
 - When answering questions, respond with high-confidence answers only: verify in code; do not guess.
 - Never update the Carbon dependency.
+- When SSH/LAN commands fail due to sandbox limits, offer to request elevated permissions for SSH commands.
 - Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
 - Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
 - CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Upgrading? [Updating guide](https://docs.clawd.bot/install/updating) (and run `c
 Switch channels (git + npm): `clawdbot update --channel stable|beta|dev`.
 Details: [Development channels](https://docs.clawd.bot/install/development-channels).
 
+## WSL2 remote nodes (quick notes)
+
+- WSL IPs change after restarts; keep your Windows portproxy pointing at the current WSL IP.
+- SSH from another machine goes to the Windows host IP and forwards to WSL (for example, `-p 2222`).
+- Remote nodes must point at a reachable Gateway URL (not loopback).
+- `clawdbot status --all` is the fastest way to confirm Gateway reachability.
+
+See [Windows (WSL2)](https://docs.clawd.bot/platforms/windows) for the full checklist.
+
 ## From source (development)
 
 Prefer `pnpm` for builds from source. Bun is optional for running TypeScript directly.

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -286,6 +286,11 @@ WhatsApp can automatically send emoji reactions to incoming messages immediately
     - CLI: `clawdbot message send --media <mp4> --gif-playback`
     - Gateway: `send` params include `gifPlayback: true`
 
+## Voice notes
+- WhatsApp voice notes are OGG/Opus. Convert WAV/MP3 before sending.
+- To force a voice bubble (instead of a file), include `[[audio_as_voice]]` and
+  send media with an OGG/Opus file (for example, `voice.ogg`).
+
 ## Media limits + optimization
 - Default outbound cap: 5 MB (per media item).
 - Override: `agents.defaults.mediaMaxMb`.

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -49,6 +49,135 @@ Repair/migrate:
 clawdbot doctor
 ```
 
+## SSH into WSL from another machine
+
+When you connect to WSL over the LAN (for example, from a Mac), you usually
+connect to the Windows host IP and forward a port to the WSL sshd. The WSL
+IP changes after restarts, so the Windows portproxy needs to be refreshed.
+
+### 1) Enable SSH in WSL
+
+Inside WSL:
+
+```bash
+sudo apt update
+sudo apt install -y openssh-server
+sudo service ssh start
+```
+
+### 2) Add a portproxy on Windows
+
+Open PowerShell **as Administrator**:
+
+```powershell
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=2222 `
+  connectaddress=<current-wsl-ip> connectport=22
+```
+
+Allow inbound TCP 2222 through Windows Firewall:
+
+```powershell
+New-NetFirewallRule -DisplayName "WSL SSH 2222" -Direction Inbound `
+  -Protocol TCP -LocalPort 2222 -Action Allow
+```
+
+Then connect from another machine:
+
+```bash
+ssh user@gateway-host -p 2222
+```
+
+### 3) Refresh the portproxy after WSL restarts
+
+Because the WSL IP changes, refresh the portproxy whenever WSL restarts.
+This PowerShell script re-points the forwarding rule:
+
+```powershell
+param(
+  [string]$Distro = "Ubuntu-20.04",
+  [int]$ListenPort = 2222,
+  [int]$WslPort = 22
+)
+
+$ip = (wsl -d $Distro -- hostname -I).Trim().Split(" ")[0]
+if (-not $ip) { throw "WSL IP not found." }
+
+netsh interface portproxy delete v4tov4 listenport=$ListenPort listenaddress=0.0.0.0 | Out-Null
+netsh interface portproxy add v4tov4 listenport=$ListenPort listenaddress=0.0.0.0 `
+  connectport=$WslPort connectaddress=$ip | Out-Null
+
+Write-Host "Portproxy $ListenPort -> $ip:$WslPort"
+```
+
+You can save this as `update-wsl-portproxy.ps1` and run it from an elevated
+PowerShell whenever WSL restarts. If you want this to be automatic, register a
+Scheduled Task to run at login.
+
+If you use the Clawdbot repo, `scripts/wsl-portproxy.ps1` refreshes both SSH
+(`2222->22`) and XTTS (`5002->5002`) mappings.
+
+### Expose local services (example: TTS)
+
+If you run a local service inside WSL (for example, a TTS server on port 5002),
+add a matching portproxy and firewall rule so the gateway host can reach it:
+
+```powershell
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=5002 `
+  connectaddress=<current-wsl-ip> connectport=5002
+
+New-NetFirewallRule -DisplayName "WSL TTS 5002" -Direction Inbound `
+  -Protocol TCP -LocalPort 5002 -Action Allow
+```
+
+### Run XTTS as a managed service (WSL)
+
+If you want the XTTS server to survive reboots and restarts, use a systemd user
+service inside WSL. This requires enabling systemd for the distro.
+
+Enable systemd:
+
+```bash
+sudo tee /etc/wsl.conf >/dev/null <<'EOF'
+[boot]
+systemd=true
+EOF
+```
+
+Then from PowerShell:
+
+```powershell
+wsl --shutdown
+```
+
+After reopening WSL, enable the service:
+
+```bash
+systemctl --user enable --now xtts.service
+systemctl --user status xtts.service
+```
+
+If you prefer tmux instead of systemd, launch the server in a detached session:
+
+```bash
+~/dev/xtts-tmux-start.sh
+```
+
+### Operational checklist (WSL node + remote gateway)
+
+- Ensure the Windows portproxy points at the current WSL IP.
+- Confirm `sshd` is running inside WSL and the firewall allows the listen port.
+- Verify the Gateway URL in the Clawdbot config points at a reachable gateway host.
+- Run `clawdbot status --all` and confirm the Gateway line is reachable.
+
+### Troubleshooting
+
+- `ssh` hangs: check the portproxy target and the WSL IP are in sync.
+- `Permission denied`: confirm your public key is in `~/.ssh/authorized_keys`.
+- `Connection refused`: check `sshd` is running inside WSL.
+
+See [Gateway troubleshooting](/gateway/troubleshooting) and [Doctor](/cli/doctor)
+for deeper checks.
+
 ## Step-by-step WSL2 install
 
 ### 1) Install WSL2 + Ubuntu

--- a/scripts/wsl-portproxy.ps1
+++ b/scripts/wsl-portproxy.ps1
@@ -1,0 +1,21 @@
+param(
+  [string]$Distro = "Ubuntu-20.04",
+  [string[]]$Ports = @("2222:22", "5002:5002"),
+  [string]$ListenAddress = "0.0.0.0"
+)
+
+$ip = (wsl -d $Distro -- hostname -I).Trim().Split(" ")[0]
+if (-not $ip) { throw "WSL IP not found." }
+
+foreach ($mapping in $Ports) {
+  $parts = $mapping.Split(":")
+  if ($parts.Length -ne 2) { throw "Invalid port mapping: $mapping (use listen:connect)" }
+  $listenPort = [int]$parts[0]
+  $connectPort = [int]$parts[1]
+
+  netsh interface portproxy delete v4tov4 listenport=$listenPort listenaddress=$ListenAddress | Out-Null
+  netsh interface portproxy add v4tov4 listenport=$listenPort listenaddress=$ListenAddress `
+    connectport=$connectPort connectaddress=$ip | Out-Null
+
+  Write-Host "Portproxy $ListenAddress:$listenPort -> $ip:$connectPort"
+}

--- a/scripts/xtts-client.sh
+++ b/scripts/xtts-client.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${TTS_HOST:-127.0.0.1}"
+PORT="${TTS_PORT:-5002}"
+SPEAKER="${TTS_SPEAKER:-Claribel Dervla}"
+LANG="${TTS_LANG:-en}"
+OUT="${TTS_OUT:-./tts.wav}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: TTS_HOST=<host> TTS_PORT=<port> $0 \"text to speak\""
+  exit 1
+fi
+
+TEXT="$*"
+
+curl -sS -X POST "http://${HOST}:${PORT}/api/tts" \
+  --data-urlencode "text=${TEXT}" \
+  --data-urlencode "speaker_id=${SPEAKER}" \
+  --data-urlencode "language_id=${LANG}" \
+  -o "${OUT}"
+
+echo "wrote ${OUT}"

--- a/scripts/xtts-voice.sh
+++ b/scripts/xtts-voice.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${TTS_HOST:-127.0.0.1}"
+PORT="${TTS_PORT:-5002}"
+SPEAKER="${TTS_SPEAKER:-Claribel Dervla}"
+LANG="${TTS_LANG:-en}"
+WAV_OUT="${TTS_WAV_OUT:-./tts.wav}"
+OGG_OUT="${TTS_OGG_OUT:-./tts.ogg}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: TTS_HOST=<host> TTS_PORT=<port> $0 \"text to speak\""
+  exit 1
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ffmpeg is required (brew install ffmpeg)."
+  exit 1
+fi
+
+TEXT="$*"
+
+curl -sS -X POST "http://${HOST}:${PORT}/api/tts" \
+  --data-urlencode "text=${TEXT}" \
+  --data-urlencode "speaker_id=${SPEAKER}" \
+  --data-urlencode "language_id=${LANG}" \
+  -o "${WAV_OUT}"
+
+ffmpeg -y -hide_banner -loglevel error \
+  -i "${WAV_OUT}" \
+  -c:a libopus -b:a 64k -vbr on -compression_level 10 -application voip \
+  "${OGG_OUT}"
+
+echo "wrote ${OGG_OUT}"


### PR DESCRIPTION
## Summary

- **docs/platforms/windows.md**: Comprehensive WSL2 SSH setup guide, Windows portproxy configuration, TTS server exposure, XTTS systemd service setup, operational checklist, and troubleshooting tips
- **docs/channels/whatsapp.md**: Voice notes format documentation (OGG/Opus requirement)
- **README.md**: Quick reference for WSL2 remote nodes
- **AGENTS.md**: SSH sandbox permissions note for agent workflows
- **scripts/xtts-client.sh**: Generic XTTS API client (env-configurable)
- **scripts/xtts-voice.sh**: XTTS client with OGG/Opus conversion for WhatsApp voice notes
- **scripts/wsl-portproxy.ps1**: Windows portproxy refresh helper for WSL IP changes

## Test plan

- [x] Shell scripts validated with `bash -n`
- [x] Scripts are executable (chmod +x)
- [x] Documentation links use correct Mintlify format (root-relative, no .md)
- [x] No changes to TypeScript source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)