### PR TITLE
fix: preserve channel routing across gateway restart

### DIFF
--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -32,6 +32,12 @@ export type RestartSentinelPayload = {
   status: "ok" | "error" | "skipped";
   ts: number;
   sessionKey?: string;
+  /** Delivery context captured at restart time to ensure channel routing survives restart */
+  deliveryContext?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+  };
   message?: string | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;


### PR DESCRIPTION
## Problem
When restarting via `gateway restart`, the wake-up message would route to terminal instead of the originating channel (e.g., Slack).

## Root Cause
The session store uses a 45-second cache and may not be flushed to disk when SIGUSR1 fires. The restart sentinel handler tries to load deliveryContext from the session store after restart, but the data isn't guaranteed to be on disk.

## Solution
Capture `deliveryContext` (channel/to/accountId) from the session store at the time of the restart request and include it directly in the restart sentinel payload. The sentinel handler now prefers this captured context over the session store lookup.

## Changes
- `src/agents/tools/gateway-tool.ts`: Extract and include deliveryContext in sentinel payload
- `src/infra/restart-sentinel.ts`: Add deliveryContext to RestartSentinelPayload type  
- `src/gateway/server-restart-sentinel.ts`: Prefer sentinel deliveryContext over session lookup

## Testing
Verified locally - restart now routes wake message back to originating Slack thread with deliveryContext in payload:
```json
{
  "sessionKey": "agent:main:main:thread:...",
  "deliveryContext": {
    "channel": "slack",
    "to": "user:U09TG1A7S2D",
    "accountId": "default"
  }
}
```