### PR TITLE
feat: add avatar support for agent identity

### DIFF
--- a/apps/macos/Sources/Clawdbot/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/Clawdbot/ExecApprovalsSocket.swift
@@ -319,7 +319,7 @@ private enum ExecHostExecutor {
             security: context.security,
             allowlistMatch: context.allowlistMatch,
             skillAllow: context.skillAllow),
-           approvalDecision == nil
+            approvalDecision == nil
         {
             let decision = ExecApprovalsPromptPresenter.prompt(
                 ExecApprovalPromptRequest(

--- a/apps/macos/Sources/ClawdbotMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/ClawdbotMacCLI/ConnectCommand.swift
@@ -7,7 +7,7 @@ struct ConnectOptions {
     var token: String?
     var password: String?
     var mode: String?
-    var timeoutMs: Int = 15_000
+    var timeoutMs: Int = 15000
     var json: Bool = false
     var probe: Bool = false
     var clientId: String = "clawdbot-macos"
@@ -254,8 +254,12 @@ private func resolveGatewayEndpoint(opts: ConnectOptions, config: GatewayConfig)
 
     if resolvedMode == "remote" {
         guard let raw = config.remoteUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !raw.isEmpty else {
-            throw NSError(domain: "Gateway", code: 1, userInfo: [NSLocalizedDescriptionKey: "gateway.remote.url is missing"])
+              !raw.isEmpty
+        else {
+            throw NSError(
+                domain: "Gateway",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "gateway.remote.url is missing"])
         }
         guard let url = URL(string: raw) else {
             throw NSError(domain: "Gateway", code: 1, userInfo: [NSLocalizedDescriptionKey: "invalid url: \(raw)"])
@@ -270,7 +274,10 @@ private func resolveGatewayEndpoint(opts: ConnectOptions, config: GatewayConfig)
     let port = config.port ?? 18789
     let host = "127.0.0.1"
     guard let url = URL(string: "ws://\(host):\(port)") else {
-        throw NSError(domain: "Gateway", code: 1, userInfo: [NSLocalizedDescriptionKey: "invalid url: ws://\(host):\(port)"])
+        throw NSError(
+            domain: "Gateway",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "invalid url: ws://\(host):\(port)"])
     }
     return GatewayEndpoint(
         url: url,
@@ -280,7 +287,7 @@ private func resolveGatewayEndpoint(opts: ConnectOptions, config: GatewayConfig)
 }
 
 private func bestEffortEndpoint(opts: ConnectOptions, config: GatewayConfig) -> GatewayEndpoint? {
-    return try? resolveGatewayEndpoint(opts: opts, config: config)
+    try? resolveGatewayEndpoint(opts: opts, config: config)
 }
 
 private func resolvedToken(opts: ConnectOptions, mode: String, config: GatewayConfig) -> String? {

--- a/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/ClawdbotProtocol/GatewayModels.swift
@@ -473,6 +473,7 @@ public struct AgentParams: Codable, Sendable {
     public let replychannel: String?
     public let accountid: String?
     public let replyaccountid: String?
+    public let threadid: String?
     public let timeout: Int?
     public let lane: String?
     public let extrasystemprompt: String?
@@ -494,6 +495,7 @@ public struct AgentParams: Codable, Sendable {
         replychannel: String?,
         accountid: String?,
         replyaccountid: String?,
+        threadid: String?,
         timeout: Int?,
         lane: String?,
         extrasystemprompt: String?,
@@ -514,6 +516,7 @@ public struct AgentParams: Codable, Sendable {
         self.replychannel = replychannel
         self.accountid = accountid
         self.replyaccountid = replyaccountid
+        self.threadid = threadid
         self.timeout = timeout
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
@@ -535,6 +538,7 @@ public struct AgentParams: Codable, Sendable {
         case replychannel = "replyChannel"
         case accountid = "accountId"
         case replyaccountid = "replyAccountId"
+        case threadid = "threadId"
         case timeout
         case lane
         case extrasystemprompt = "extraSystemPrompt"
@@ -835,35 +839,47 @@ public struct SessionsListParams: Codable, Sendable {
     public let activeminutes: Int?
     public let includeglobal: Bool?
     public let includeunknown: Bool?
+    public let includederivedtitles: Bool?
+    public let includelastmessage: Bool?
     public let label: String?
     public let spawnedby: String?
     public let agentid: String?
+    public let search: String?
 
     public init(
         limit: Int?,
         activeminutes: Int?,
         includeglobal: Bool?,
         includeunknown: Bool?,
+        includederivedtitles: Bool?,
+        includelastmessage: Bool?,
         label: String?,
         spawnedby: String?,
-        agentid: String?
+        agentid: String?,
+        search: String?
     ) {
         self.limit = limit
         self.activeminutes = activeminutes
         self.includeglobal = includeglobal
         self.includeunknown = includeunknown
+        self.includederivedtitles = includederivedtitles
+        self.includelastmessage = includelastmessage
         self.label = label
         self.spawnedby = spawnedby
         self.agentid = agentid
+        self.search = search
     }
     private enum CodingKeys: String, CodingKey {
         case limit
         case activeminutes = "activeMinutes"
         case includeglobal = "includeGlobal"
         case includeunknown = "includeUnknown"
+        case includederivedtitles = "includeDerivedTitles"
+        case includelastmessage = "includeLastMessage"
         case label
         case spawnedby = "spawnedBy"
         case agentid = "agentId"
+        case search
     }
 }
 

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotProtocol/GatewayModels.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotProtocol/GatewayModels.swift
@@ -473,6 +473,7 @@ public struct AgentParams: Codable, Sendable {
     public let replychannel: String?
     public let accountid: String?
     public let replyaccountid: String?
+    public let threadid: String?
     public let timeout: Int?
     public let lane: String?
     public let extrasystemprompt: String?
@@ -494,6 +495,7 @@ public struct AgentParams: Codable, Sendable {
         replychannel: String?,
         accountid: String?,
         replyaccountid: String?,
+        threadid: String?,
         timeout: Int?,
         lane: String?,
         extrasystemprompt: String?,
@@ -514,6 +516,7 @@ public struct AgentParams: Codable, Sendable {
         self.replychannel = replychannel
         self.accountid = accountid
         self.replyaccountid = replyaccountid
+        self.threadid = threadid
         self.timeout = timeout
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
@@ -535,6 +538,7 @@ public struct AgentParams: Codable, Sendable {
         case replychannel = "replyChannel"
         case accountid = "accountId"
         case replyaccountid = "replyAccountId"
+        case threadid = "threadId"
         case timeout
         case lane
         case extrasystemprompt = "extraSystemPrompt"
@@ -835,35 +839,47 @@ public struct SessionsListParams: Codable, Sendable {
     public let activeminutes: Int?
     public let includeglobal: Bool?
     public let includeunknown: Bool?
+    public let includederivedtitles: Bool?
+    public let includelastmessage: Bool?
     public let label: String?
     public let spawnedby: String?
     public let agentid: String?
+    public let search: String?
 
     public init(
         limit: Int?,
         activeminutes: Int?,
         includeglobal: Bool?,
         includeunknown: Bool?,
+        includederivedtitles: Bool?,
+        includelastmessage: Bool?,
         label: String?,
         spawnedby: String?,
-        agentid: String?
+        agentid: String?,
+        search: String?
     ) {
         self.limit = limit
         self.activeminutes = activeminutes
         self.includeglobal = includeglobal
         self.includeunknown = includeunknown
+        self.includederivedtitles = includederivedtitles
+        self.includelastmessage = includelastmessage
         self.label = label
         self.spawnedby = spawnedby
         self.agentid = agentid
+        self.search = search
     }
     private enum CodingKeys: String, CodingKey {
         case limit
         case activeminutes = "activeMinutes"
         case includeglobal = "includeGlobal"
         case includeunknown = "includeUnknown"
+        case includederivedtitles = "includeDerivedTitles"
+        case includelastmessage = "includeLastMessage"
         case label
         case spawnedby = "spawnedBy"
         case agentid = "agentId"
+        case search
     }
 }
 
@@ -1324,6 +1340,9 @@ public struct ChannelsStatusResult: Codable, Sendable {
     public let ts: Int
     public let channelorder: [String]
     public let channellabels: [String: AnyCodable]
+    public let channeldetaillabels: [String: AnyCodable]?
+    public let channelsystemimages: [String: AnyCodable]?
+    public let channelmeta: [[String: AnyCodable]]?
     public let channels: [String: AnyCodable]
     public let channelaccounts: [String: AnyCodable]
     public let channeldefaultaccountid: [String: AnyCodable]
@@ -1332,6 +1351,9 @@ public struct ChannelsStatusResult: Codable, Sendable {
         ts: Int,
         channelorder: [String],
         channellabels: [String: AnyCodable],
+        channeldetaillabels: [String: AnyCodable]?,
+        channelsystemimages: [String: AnyCodable]?,
+        channelmeta: [[String: AnyCodable]]?,
         channels: [String: AnyCodable],
         channelaccounts: [String: AnyCodable],
         channeldefaultaccountid: [String: AnyCodable]
@@ -1339,6 +1361,9 @@ public struct ChannelsStatusResult: Codable, Sendable {
         self.ts = ts
         self.channelorder = channelorder
         self.channellabels = channellabels
+        self.channeldetaillabels = channeldetaillabels
+        self.channelsystemimages = channelsystemimages
+        self.channelmeta = channelmeta
         self.channels = channels
         self.channelaccounts = channelaccounts
         self.channeldefaultaccountid = channeldefaultaccountid
@@ -1347,6 +1372,9 @@ public struct ChannelsStatusResult: Codable, Sendable {
         case ts
         case channelorder = "channelOrder"
         case channellabels = "channelLabels"
+        case channeldetaillabels = "channelDetailLabels"
+        case channelsystemimages = "channelSystemImages"
+        case channelmeta = "channelMeta"
         case channels
         case channelaccounts = "channelAccounts"
         case channeldefaultaccountid = "channelDefaultAccountId"

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -34,6 +34,7 @@ export type AgentIdentity = {
   creature?: string;
   vibe?: string;
   theme?: string;
+  avatar?: string;
 };
 
 export function listAgentEntries(cfg: ClawdbotConfig): AgentEntry[] {
@@ -90,6 +91,7 @@ export function parseIdentityMarkdown(content: string): AgentIdentity {
     if (label === "creature") identity.creature = value;
     if (label === "vibe") identity.vibe = value;
     if (label === "theme") identity.theme = value;
+    if (label === "avatar") identity.avatar = value;
   }
   return identity;
 }
@@ -99,7 +101,7 @@ export function loadAgentIdentity(workspace: string): AgentIdentity | null {
   try {
     const content = fs.readFileSync(identityPath, "utf-8");
     const parsed = parseIdentityMarkdown(content);
-    if (!parsed.name && !parsed.emoji && !parsed.theme && !parsed.creature && !parsed.vibe) {
+    if (!parsed.name && !parsed.emoji && !parsed.theme && !parsed.creature && !parsed.vibe && !parsed.avatar) {
       return null;
     }
     return parsed;

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -101,7 +101,14 @@ export function loadAgentIdentity(workspace: string): AgentIdentity | null {
   try {
     const content = fs.readFileSync(identityPath, "utf-8");
     const parsed = parseIdentityMarkdown(content);
-    if (!parsed.name && !parsed.emoji && !parsed.theme && !parsed.creature && !parsed.vibe && !parsed.avatar) {
+    if (
+      !parsed.name &&
+      !parsed.emoji &&
+      !parsed.theme &&
+      !parsed.creature &&
+      !parsed.vibe &&
+      !parsed.avatar
+    ) {
       return null;
     }
     return parsed;

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -144,4 +144,6 @@ export type IdentityConfig = {
   name?: string;
   theme?: string;
   emoji?: string;
+  /** Path to a custom avatar image (relative to workspace or absolute). */
+  avatar?: string;
 };

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -3,92 +3,92 @@ import { Type } from "@sinclair/typebox";
 import { NonEmptyString, SessionLabelString } from "./primitives.js";
 
 export const SessionsListParamsSchema = Type.Object(
-	{
-		limit: Type.Optional(Type.Integer({ minimum: 1 })),
-		activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
-		includeGlobal: Type.Optional(Type.Boolean()),
-		includeUnknown: Type.Optional(Type.Boolean()),
-		/**
-		 * Read first 8KB of each session transcript to derive title from first user message.
-		 * Performs a file read per session - use `limit` to bound result set on large stores.
-		 */
-		includeDerivedTitles: Type.Optional(Type.Boolean()),
-		/**
-		 * Read last 16KB of each session transcript to extract most recent message preview.
-		 * Performs a file read per session - use `limit` to bound result set on large stores.
-		 */
-		includeLastMessage: Type.Optional(Type.Boolean()),
-		label: Type.Optional(SessionLabelString),
-		spawnedBy: Type.Optional(NonEmptyString),
-		agentId: Type.Optional(NonEmptyString),
-		search: Type.Optional(Type.String()),
-	},
-	{ additionalProperties: false },
+  {
+    limit: Type.Optional(Type.Integer({ minimum: 1 })),
+    activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
+    includeGlobal: Type.Optional(Type.Boolean()),
+    includeUnknown: Type.Optional(Type.Boolean()),
+    /**
+     * Read first 8KB of each session transcript to derive title from first user message.
+     * Performs a file read per session - use `limit` to bound result set on large stores.
+     */
+    includeDerivedTitles: Type.Optional(Type.Boolean()),
+    /**
+     * Read last 16KB of each session transcript to extract most recent message preview.
+     * Performs a file read per session - use `limit` to bound result set on large stores.
+     */
+    includeLastMessage: Type.Optional(Type.Boolean()),
+    label: Type.Optional(SessionLabelString),
+    spawnedBy: Type.Optional(NonEmptyString),
+    agentId: Type.Optional(NonEmptyString),
+    search: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
 );
 
 export const SessionsResolveParamsSchema = Type.Object(
-	{
-		key: Type.Optional(NonEmptyString),
-		label: Type.Optional(SessionLabelString),
-		agentId: Type.Optional(NonEmptyString),
-		spawnedBy: Type.Optional(NonEmptyString),
-		includeGlobal: Type.Optional(Type.Boolean()),
-		includeUnknown: Type.Optional(Type.Boolean()),
-	},
-	{ additionalProperties: false },
+  {
+    key: Type.Optional(NonEmptyString),
+    label: Type.Optional(SessionLabelString),
+    agentId: Type.Optional(NonEmptyString),
+    spawnedBy: Type.Optional(NonEmptyString),
+    includeGlobal: Type.Optional(Type.Boolean()),
+    includeUnknown: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
 );
 
 export const SessionsPatchParamsSchema = Type.Object(
-	{
-		key: NonEmptyString,
-		label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
-		thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		responseUsage: Type.Optional(
-			Type.Union([
-				Type.Literal("off"),
-				Type.Literal("tokens"),
-				Type.Literal("full"),
-				// Backward compat with older clients/stores.
-				Type.Literal("on"),
-				Type.Null(),
-			]),
-		),
-		elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-		sendPolicy: Type.Optional(
-			Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()]),
-		),
-		groupActivation: Type.Optional(
-			Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
-		),
-	},
-	{ additionalProperties: false },
+  {
+    key: NonEmptyString,
+    label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
+    thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    responseUsage: Type.Optional(
+      Type.Union([
+        Type.Literal("off"),
+        Type.Literal("tokens"),
+        Type.Literal("full"),
+        // Backward compat with older clients/stores.
+        Type.Literal("on"),
+        Type.Null(),
+      ]),
+    ),
+    elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    sendPolicy: Type.Optional(
+      Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()]),
+    ),
+    groupActivation: Type.Optional(
+      Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
+    ),
+  },
+  { additionalProperties: false },
 );
 
 export const SessionsResetParamsSchema = Type.Object(
-	{ key: NonEmptyString },
-	{ additionalProperties: false },
+  { key: NonEmptyString },
+  { additionalProperties: false },
 );
 
 export const SessionsDeleteParamsSchema = Type.Object(
-	{
-		key: NonEmptyString,
-		deleteTranscript: Type.Optional(Type.Boolean()),
-	},
-	{ additionalProperties: false },
+  {
+    key: NonEmptyString,
+    deleteTranscript: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
 );
 
 export const SessionsCompactParamsSchema = Type.Object(
-	{
-		key: NonEmptyString,
-		maxLines: Type.Optional(Type.Integer({ minimum: 1 })),
-	},
-	{ additionalProperties: false },
+  {
+    key: NonEmptyString,
+    maxLines: Type.Optional(Type.Integer({ minimum: 1 })),
+  },
+  { additionalProperties: false },
 );

--- a/src/tui/components/fuzzy-filter.ts
+++ b/src/tui/components/fuzzy-filter.ts
@@ -11,7 +11,7 @@ const WORD_BOUNDARY_CHARS = /[\s\-_./:#@]/;
  * Check if position is at a word boundary.
  */
 export function isWordBoundary(text: string, index: number): boolean {
-	return index === 0 || WORD_BOUNDARY_CHARS.test(text[index - 1] ?? "");
+  return index === 0 || WORD_BOUNDARY_CHARS.test(text[index - 1] ?? "");
 }
 
 /**
@@ -19,17 +19,17 @@ export function isWordBoundary(text: string, index: number): boolean {
  * Returns null if no match.
  */
 export function findWordBoundaryIndex(text: string, query: string): number | null {
-	if (!query) return null;
-	const textLower = text.toLowerCase();
-	const queryLower = query.toLowerCase();
-	const maxIndex = textLower.length - queryLower.length;
-	if (maxIndex < 0) return null;
-	for (let i = 0; i <= maxIndex; i++) {
-		if (textLower.startsWith(queryLower, i) && isWordBoundary(textLower, i)) {
-			return i;
-		}
-	}
-	return null;
+  if (!query) return null;
+  const textLower = text.toLowerCase();
+  const queryLower = query.toLowerCase();
+  const maxIndex = textLower.length - queryLower.length;
+  if (maxIndex < 0) return null;
+  for (let i = 0; i <= maxIndex; i++) {
+    if (textLower.startsWith(queryLower, i) && isWordBoundary(textLower, i)) {
+      return i;
+    }
+  }
+  return null;
 }
 
 /**
@@ -37,31 +37,31 @@ export function findWordBoundaryIndex(text: string, query: string): number | nul
  * Returns score (lower = better) or null if no match.
  */
 export function fuzzyMatchLower(queryLower: string, textLower: string): number | null {
-	if (queryLower.length === 0) return 0;
-	if (queryLower.length > textLower.length) return null;
+  if (queryLower.length === 0) return 0;
+  if (queryLower.length > textLower.length) return null;
 
-	let queryIndex = 0;
-	let score = 0;
-	let lastMatchIndex = -1;
-	let consecutiveMatches = 0;
+  let queryIndex = 0;
+  let score = 0;
+  let lastMatchIndex = -1;
+  let consecutiveMatches = 0;
 
-	for (let i = 0; i < textLower.length && queryIndex < queryLower.length; i++) {
-		if (textLower[i] === queryLower[queryIndex]) {
-			const isAtWordBoundary = isWordBoundary(textLower, i);
-			if (lastMatchIndex === i - 1) {
-				consecutiveMatches++;
-				score -= consecutiveMatches * 5; // Reward consecutive matches
-			} else {
-				consecutiveMatches = 0;
-				if (lastMatchIndex >= 0) score += (i - lastMatchIndex - 1) * 2; // Penalize gaps
-			}
-			if (isAtWordBoundary) score -= 10; // Reward word boundary matches
-			score += i * 0.1; // Slight penalty for later matches
-			lastMatchIndex = i;
-			queryIndex++;
-		}
-	}
-	return queryIndex < queryLower.length ? null : score;
+  for (let i = 0; i < textLower.length && queryIndex < queryLower.length; i++) {
+    if (textLower[i] === queryLower[queryIndex]) {
+      const isAtWordBoundary = isWordBoundary(textLower, i);
+      if (lastMatchIndex === i - 1) {
+        consecutiveMatches++;
+        score -= consecutiveMatches * 5; // Reward consecutive matches
+      } else {
+        consecutiveMatches = 0;
+        if (lastMatchIndex >= 0) score += (i - lastMatchIndex - 1) * 2; // Penalize gaps
+      }
+      if (isAtWordBoundary) score -= 10; // Reward word boundary matches
+      score += i * 0.1; // Slight penalty for later matches
+      lastMatchIndex = i;
+      queryIndex++;
+    }
+  }
+  return queryIndex < queryLower.length ? null : score;
 }
 
 /**
@@ -69,46 +69,46 @@ export function fuzzyMatchLower(queryLower: string, textLower: string): number |
  * Supports space-separated tokens (all must match).
  */
 export function fuzzyFilterLower<T extends { searchTextLower?: string }>(
-	items: T[],
-	queryLower: string,
+  items: T[],
+  queryLower: string,
 ): T[] {
-	const trimmed = queryLower.trim();
-	if (!trimmed) return items;
+  const trimmed = queryLower.trim();
+  if (!trimmed) return items;
 
-	const tokens = trimmed.split(/\s+/).filter((t) => t.length > 0);
-	if (tokens.length === 0) return items;
+  const tokens = trimmed.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) return items;
 
-	const results: { item: T; score: number }[] = [];
-	for (const item of items) {
-		const text = item.searchTextLower ?? "";
-		let totalScore = 0;
-		let allMatch = true;
-		for (const token of tokens) {
-			const score = fuzzyMatchLower(token, text);
-			if (score !== null) {
-				totalScore += score;
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-		if (allMatch) results.push({ item, score: totalScore });
-	}
-	results.sort((a, b) => a.score - b.score);
-	return results.map((r) => r.item);
+  const results: { item: T; score: number }[] = [];
+  for (const item of items) {
+    const text = item.searchTextLower ?? "";
+    let totalScore = 0;
+    let allMatch = true;
+    for (const token of tokens) {
+      const score = fuzzyMatchLower(token, text);
+      if (score !== null) {
+        totalScore += score;
+      } else {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) results.push({ item, score: totalScore });
+  }
+  results.sort((a, b) => a.score - b.score);
+  return results.map((r) => r.item);
 }
 
 /**
  * Prepare items for fuzzy filtering by pre-computing lowercase search text.
  */
-export function prepareSearchItems<T extends { label?: string; description?: string; searchText?: string }>(
-	items: T[],
-): (T & { searchTextLower: string })[] {
-	return items.map((item) => {
-		const parts: string[] = [];
-		if (item.label) parts.push(item.label);
-		if (item.description) parts.push(item.description);
-		if (item.searchText) parts.push(item.searchText);
-		return { ...item, searchTextLower: parts.join(" ").toLowerCase() };
-	});
+export function prepareSearchItems<
+  T extends { label?: string; description?: string; searchText?: string },
+>(items: T[]): (T & { searchTextLower: string })[] {
+  return items.map((item) => {
+    const parts: string[] = [];
+    if (item.label) parts.push(item.label);
+    if (item.description) parts.push(item.description);
+    if (item.searchText) parts.push(item.searchText);
+    return { ...item, searchTextLower: parts.join(" ").toLowerCase() };
+  });
 }

--- a/src/tui/components/selectors.ts
+++ b/src/tui/components/selectors.ts
@@ -5,10 +5,7 @@ import {
   selectListTheme,
   settingsListTheme,
 } from "../theme/theme.js";
-import {
-  FilterableSelectList,
-  type FilterableSelectItem,
-} from "./filterable-select-list.js";
+import { FilterableSelectList, type FilterableSelectItem } from "./filterable-select-list.js";
 import { SearchableSelectList } from "./searchable-select-list.js";
 
 export function createSelectList(items: SelectItem[], maxVisible = 7) {

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -1,15 +1,15 @@
 export function formatRelativeTime(timestamp: number): string {
-	const now = Date.now();
-	const diff = now - timestamp;
-	const seconds = Math.floor(diff / 1000);
-	const minutes = Math.floor(seconds / 60);
-	const hours = Math.floor(minutes / 60);
-	const days = Math.floor(hours / 24);
+  const now = Date.now();
+  const diff = now - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
 
-	if (seconds < 60) return "just now";
-	if (minutes < 60) return `${minutes}m ago`;
-	if (hours < 24) return `${hours}h ago`;
-	if (days === 1) return "Yesterday";
-	if (days < 7) return `${days}d ago`;
-	return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (seconds < 60) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -89,6 +89,12 @@
   color: rgba(134, 142, 150, 1);
 }
 
+/* Image avatar support */
+img.chat-avatar {
+  object-fit: cover;
+  object-position: center;
+}
+
 /* Minimal Bubble Design - dynamic width based on content */
 .chat-bubble {
   display: inline-block;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -104,7 +104,7 @@ export function renderMessageGroup(
   `;
 }
 
-function renderAvatar(role: string) {
+function renderAvatar(role: string, avatarUrl?: string) {
   const normalized = normalizeRoleForGrouping(role);
   const initial =
     normalized === "user"
@@ -122,6 +122,12 @@ function renderAvatar(role: string) {
         : normalized === "tool"
           ? "tool"
           : "other";
+  
+  // If avatar URL is provided for assistant, show image
+  if (avatarUrl && normalized === "assistant") {
+    return html`<img class="chat-avatar ${className}" src="${avatarUrl}" alt="Assistant" />`;
+  }
+  
   return html`<div class="chat-avatar ${className}">${initial}</div>`;
 }
 


### PR DESCRIPTION
## Summary
Add support for custom avatars in the webchat for assistant messages.

## Changes
- Add `avatar` field to `IdentityConfig` type in `src/config/types.base.ts`
- Add avatar parsing from IDENTITY.md in `src/commands/agents.config.ts`
- Update `renderAvatar()` in webchat to support image avatars
- Add CSS styling for image avatars in `ui/src/styles/chat/grouped.css`

## Usage
Users can configure a custom avatar by:
1. Adding `Avatar: /path/to/avatar.png` to their workspace's `IDENTITY.md`
2. Or setting `identity.avatar` in the agent config in `clawdbot.json`

For now, the avatar image needs to be manually placed in the control-ui assets folder. Future improvements could include automatic copying or an API endpoint.

## Testing
- [x] Added avatar field to config types
- [x] Updated IDENTITY.md parsing
- [x] Modified webchat renderAvatar function
- [x] Added CSS for image avatars

---
*First open source contribution in many years!*