### PR TITLE
feat(discord): add wildcard channel config support

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -281,6 +281,36 @@ describe("discord guild/channel resolution", () => {
     });
     expect(thread?.allowed).toBe(false);
   });
+
+  it("applies wildcard channel config when no specific match", () => {
+    const guildInfo: DiscordGuildEntryResolved = {
+      channels: {
+        general: { allow: true, requireMention: false },
+        "*": { allow: true, autoThread: true, requireMention: true },
+      },
+    };
+    // Specific channel should NOT use wildcard
+    const general = resolveDiscordChannelConfig({
+      guildInfo,
+      channelId: "123",
+      channelName: "general",
+      channelSlug: "general",
+    });
+    expect(general?.allowed).toBe(true);
+    expect(general?.requireMention).toBe(false);
+    expect(general?.autoThread).toBeUndefined();
+
+    // Unknown channel should use wildcard
+    const random = resolveDiscordChannelConfig({
+      guildInfo,
+      channelId: "999",
+      channelName: "random",
+      channelSlug: "random",
+    });
+    expect(random?.allowed).toBe(true);
+    expect(random?.autoThread).toBe(true);
+    expect(random?.requireMention).toBe(true);
+  });
 });
 
 describe("discord mention gating", () => {

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -234,7 +234,14 @@ export function resolveDiscordChannelConfig(params: {
     name: channelName,
     slug: channelSlug,
   });
-  if (!match.entry || !match.matchKey) return { allowed: false };
+  if (!match.entry || !match.matchKey) {
+    // Wildcard fallback: apply to all channels if "*" is configured
+    const wildcard = channels["*"];
+    if (wildcard) {
+      return resolveDiscordChannelConfigEntry(wildcard, "*", "direct");
+    }
+    return { allowed: false };
+  }
   return resolveDiscordChannelConfigEntry(match.entry, match.matchKey, "direct");
 }
 
@@ -283,6 +290,11 @@ export function resolveDiscordChannelConfigWithFallback(params: {
       match.matchKey,
       match.matchSource === "parent" ? "parent" : "direct",
     );
+  }
+  // Wildcard fallback: apply to all channels if "*" is configured
+  const wildcard = channels["*"];
+  if (wildcard) {
+    return resolveDiscordChannelConfigEntry(wildcard, "*", "direct");
   }
   return { allowed: false };
 }


### PR DESCRIPTION
## Summary
Add support for `*` wildcard in Discord channel configuration, matching the existing guild-level wildcard behavior.

## Motivation
Currently, to apply settings like `autoThread` to all channels in a guild, you need to list each channel explicitly. This PR adds wildcard support so you can configure defaults for all channels:

```yaml
guilds:
  '*':
    channels:
      '*': { autoThread: true }
```

Specific channel configs still take precedence over the wildcard.

## Changes
- `src/discord/monitor/allow-list.ts`: Added wildcard fallback in `resolveDiscordChannelConfig`
- `src/discord/monitor.test.ts`: Added test for wildcard channel config

## Testing
- All existing tests pass
- New test added for wildcard channel behavior
- Verified build succeeds