### PR TITLE
ui(chat): fix markdown ordered list numbering

### DIFF
--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -5,7 +5,6 @@ import { truncateText } from "./format";
 marked.setOptions({
   gfm: true,
   breaks: true,
-  headerIds: false,
   mangle: false,
 });
 
@@ -37,7 +36,7 @@ const allowedTags = [
   "ul",
 ];
 
-const allowedAttrs = ["class", "href", "rel", "target", "title"];
+const allowedAttrs = ["class", "href", "rel", "target", "title", "start"];
 
 let hooksInstalled = false;
 const MARKDOWN_CHAR_LIMIT = 140_000;


### PR DESCRIPTION
## Summary
Fix Control UI markdown rendering so ordered lists preserve their numbering by allowing the `start` attribute through sanitization. 

Also remove a deprecated Marked option (`headerIds`) that no longer exists in Marked v17 types.

## Problem
- Ordered lists with explicit numbering (e.g. continuing a sequence) can render incorrectly after sanitization.
- This shows up as “list numbering resets / looks wrong” in the web UI even when the markdown source is correct.

<img width="438" height="365" alt="Screenshot 2026-01-21 at 12 10 57" src="https://github.com/user-attachments/assets/cbbb7207-04ec-4494-a54f-d0747dab9e98" />


## Changes
- Allow the `start` attribute on `<ol>` through DOMPurify sanitization so ordered lists preserve their intended numbering.
- Remove the deprecated Marked option `headerIds` (not present in Marked v17 types).

## Files
- `ui/src/ui/markdown.ts`

## Testing Notes
- Manually verified:
  - Markdown ordered lists with explicit numbering render with correct numbering (no unexpected resets).
  - No obvious regressions in general markdown rendering after allowing `start` on `<ol>`.

Example text
```md
 If you want to specifically test <ol start="5"> behavior, paste something like:

 5. starts at five
 6. then six
 7. then seven
```
Before:

<img width="701" height="153" alt="Screenshot 2026-01-21 at 12 08 11" src="https://github.com/user-attachments/assets/01616ae2-7cc1-4813-8590-8d292e966e72" />


After: 
<img width="655" height="171" alt="Screenshot 2026-01-21 at 12 09 02" src="https://github.com/user-attachments/assets/a7523036-24ed-4140-9b0d-3f921f2ccd0e" />


## Security Notes

Yes - blanket-whitelisting `start` is generally safe in this context.

 - `start` on `<ol>` is a numeric attribute that only affects list numbering (presentation). It
 doesn’t trigger script execution, network access, navigation, or CSS injection by itself.
 - Even if someone sets something weird like `start="-999999"` or `start="999999999"`, the worst case
 is **ugly/odd numbering** or minor layout quirks—not XSS.

 Two small caveats (not security-critical):
 - If you want to be stricter, you could allow `start` only on `<ol>` (DOMPurify supports `ADD_ATTR`
 plus hooks to conditionally remove attrs based on tag).
 - You might also clamp/validate to a reasonable integer range to avoid extreme rendering edge
 cases, but that’s more “polish” than security.

 Given we already allow `href`, `class`, `title`, etc., adding `start` is a low-risk, appropriate fix for
 preserving ordered list semantics.

However, if needed, strict sanitisation can be achieved like this:

```ts
DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
  if (node.nodeName === "OL" && data.attrName === "start") {
    const s = String(data.attrValue).trim();
    if (!/^\d+$/.test(s)) {
      data.keepAttr = false;
      return;
    }
    const n = Math.min(Math.max(Number(s), 1), 1_000_000);
    data.attrValue = String(n);
  }
});

// when calling sanitize:
DOMPurify.sanitize(html, {
  ADD_ATTR: ["start"],
});
```
---

Implemented by Shellby (assistant) based on Bradley’s report; happy to iterate.