### PR TITLE
fix(ui): parse gatewayUrl from URL params

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -62,6 +62,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
   const tokenRaw = params.get("token");
   const passwordRaw = params.get("password");
   const sessionRaw = params.get("session");
+  const gatewayUrlRaw = params.get("gatewayUrl");
   let shouldCleanUrl = false;
 
   if (tokenRaw != null) {
@@ -92,6 +93,15 @@ export function applySettingsFromUrl(host: SettingsHost) {
         lastActiveSessionKey: session,
       });
     }
+  }
+
+  if (gatewayUrlRaw != null) {
+    const gatewayUrl = gatewayUrlRaw.trim();
+    if (gatewayUrl && gatewayUrl !== host.settings.gatewayUrl) {
+      applySettings(host, { ...host.settings, gatewayUrl });
+    }
+    params.delete("gatewayUrl");
+    shouldCleanUrl = true;
   }
 
   if (!shouldCleanUrl) return;


### PR DESCRIPTION
## Summary
- Adds support for `gatewayUrl` URL parameter in WebChat control-ui
- Allows connecting to remote gateways (e.g., VPS) instead of defaulting to localhost
- The URL is cleaned from the browser address bar after being applied (security)

## Usage
```
http://localhost:5173/?gatewayUrl=ws://<vps-ip>:18789&token=<token>
```

## Test plan
- [ ] Clear localStorage in browser
- [ ] Access WebChat with `?gatewayUrl=ws://<vps-ip>:18789&token=<token>`
- [ ] Verify connection to remote gateway succeeds
- [ ] Verify `gatewayUrl` is removed from URL after load
- [ ] Verify `gatewayUrl` is persisted in localStorage settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)