### PR TITLE
ui(chat): add copy-as-markdown button

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -91,6 +91,7 @@
 
 /* Minimal Bubble Design - dynamic width based on content */
 .chat-bubble {
+  position: relative;
   display: inline-block;
   border: 1px solid var(--border);
   background: rgba(0, 0, 0, 0.12);
@@ -100,6 +101,42 @@
   transition: background 150ms ease-out, border-color 150ms ease-out;
   max-width: 100%;
   word-wrap: break-word;
+}
+
+.chat-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--muted);
+  border-radius: 8px;
+  padding: 4px 6px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease-out, background 120ms ease-out;
+}
+
+.chat-bubble:hover .chat-copy-btn {
+  opacity: 1;
+}
+
+.chat-copy-btn:hover {
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.chat-copy-btn[data-copied="1"] {
+  opacity: 1;
+  border-color: rgba(52, 199, 183, 0.8);
+  background: rgba(52, 199, 183, 0.18);
+  color: rgba(52, 199, 183, 1);
+}
+
+.chat-copy-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .chat-bubble:hover {

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -1,0 +1,44 @@
+import { html, type TemplateResult } from "lit";
+
+const COPIED_FOR_MS = 1500;
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (!text) return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function renderCopyAsMarkdownButton(markdown: string): TemplateResult {
+  return html`
+    <button
+      class="chat-copy-btn"
+      type="button"
+      title="Copy as markdown"
+      aria-label="Copy as markdown"
+      @click=${async (e: Event) => {
+        const btn = e.currentTarget as HTMLButtonElement | null;
+        const icon = btn?.querySelector(
+          ".chat-copy-btn__icon",
+        ) as HTMLElement | null;
+
+        if (btn) btn.dataset.copied = "1";
+        if (icon) icon.textContent = "Copied";
+
+        window.setTimeout(() => {
+          if (!btn?.isConnected) return;
+          delete btn.dataset.copied;
+          if (icon) icon.textContent = "📋";
+        }, COPIED_FOR_MS);
+
+        await copyTextToClipboard(markdown);
+      }}
+    >
+      <span class="chat-copy-btn__icon" aria-hidden="true">📋</span>
+    </button>
+  `;
+}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -3,6 +3,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { toSanitizedMarkdownHtml } from "../markdown";
 import type { MessageGroup } from "../types/chat-types";
+import { renderCopyAsMarkdownButton } from "./copy-as-markdown";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer";
 import {
   extractText,
@@ -167,8 +168,12 @@ function renderGroupedMessage(
 
   if (!markdown && !hasToolCards) return nothing;
 
+  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+
   return html`
     <div class="${bubbleClasses}">
+      ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
+
       ${reasoningMarkdown
         ? html`<div class="chat-thinking">${unsafeHTML(
             toSanitizedMarkdownHtml(reasoningMarkdown),

--- a/ui/src/ui/chat/legacy-render.ts
+++ b/ui/src/ui/chat/legacy-render.ts
@@ -6,6 +6,7 @@ import {
   isToolResultMessage,
   normalizeRoleForGrouping,
 } from "./message-normalizer";
+import { renderCopyAsMarkdownButton } from "./copy-as-markdown";
 import {
   extractText,
   extractThinking,
@@ -72,6 +73,8 @@ export function renderMessage(
   const timestamp =
     typeof m.timestamp === "number" ? new Date(m.timestamp).toLocaleTimeString() : "";
 
+  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+
   const normalizedRole = normalizeRoleForGrouping(role);
   const klass =
     normalizedRole === "assistant"
@@ -101,6 +104,8 @@ export function renderMessage(
     <div class="chat-line ${klass}">
       <div class="chat-msg">
         <div class="chat-bubble ${opts?.streaming ? "streaming" : ""}">
+          ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
+
           ${reasoningMarkdown
             ? html`<div class="chat-thinking">${unsafeHTML(
                 toSanitizedMarkdownHtml(reasoningMarkdown),


### PR DESCRIPTION
### Summary
Adds a small developer-focused affordance to the web Control UI chat: assistant messages now have an icon-only “copy as markdown” button (shown on hover) that copies the underlying markdown to the clipboard, with brief visual “Copied” feedback.

### What changed
- Added a hover-only copy button for assistant chat bubbles in **both** renderers:
  - grouped chat renderer
  - legacy chat renderer
- Copy feedback is handled via a temporary icon swap (“📋” → “Copied” for ~1.5s) and existing `data-copied` styling.
- Uses the modern Clipboard API (`navigator.clipboard.writeText`) (The Control UI already requires a secure context as of https://github.com/clawdbot/clawdbot/commit/dfbf6ac263d8f6d8076f6809f73cacbb47f476a0#diff-00a9ed8142568d7f03c71379792dadd38b539aad56e38c0770eb38d58388bb56, so API should be available).


### Why
Developers often want to quickly copy the assistant response as markdown for reuse in docs/issues/notes without losing formatting.

### Notes / Testing
- Manual: verified button appears on hover for assistant messages, copies markdown content, and shows brief “Copied” feedback.
- Works in both grouped and legacy chat views.

### Screenshots
<img width="914" height="119" alt="Screenshot 2026-01-21 at 13 15 03" src="https://github.com/user-attachments/assets/fd9f7237-12d9-43f0-a120-e6a374472da8" />

