### PR TITLE
fix(security): add SSRF protection to web_fetch tool

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+// Import the internal functions we want to test
+// We'll test by trying to access the module and checking behavior
+
+describe("web-fetch SSRF protection", () => {
+  // Test the URL validation logic directly by importing the module
+  // and checking that blocked URLs throw errors
+
+  it("should block localhost URLs", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(tool.execute("test-call", { url: "http://localhost/test" })).rejects.toThrow(
+        /Blocked hostname/,
+      );
+    }
+  });
+
+  it("should block 127.0.0.1 URLs", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(tool.execute("test-call", { url: "http://127.0.0.1/test" })).rejects.toThrow(
+        /private|internal|Blocked/i,
+      );
+    }
+  });
+
+  it("should block metadata service IP (169.254.169.254)", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(
+        tool.execute("test-call", {
+          url: "http://169.254.169.254/latest/meta-data/",
+        }),
+      ).rejects.toThrow(/private|internal|Blocked/i);
+    }
+  });
+
+  it("should block .internal hostnames", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(
+        tool.execute("test-call", { url: "http://something.internal/test" }),
+      ).rejects.toThrow(/Blocked hostname/);
+    }
+  });
+
+  it("should block metadata.google.internal", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(
+        tool.execute("test-call", {
+          url: "http://metadata.google.internal/computeMetadata/v1/",
+        }),
+      ).rejects.toThrow(/Blocked hostname/);
+    }
+  });
+
+  it("should block private IP ranges (10.x.x.x)", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(tool.execute("test-call", { url: "http://10.0.0.1/admin" })).rejects.toThrow(
+        /private|internal|Blocked/i,
+      );
+    }
+  });
+
+  it("should block private IP ranges (192.168.x.x)", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(tool.execute("test-call", { url: "http://192.168.1.1/admin" })).rejects.toThrow(
+        /private|internal|Blocked/i,
+      );
+    }
+  });
+
+  it("should block private IP ranges (172.16-31.x.x)", async () => {
+    const { createWebFetchTool } = await import("./web-fetch.js");
+    const tool = createWebFetchTool();
+    expect(tool).not.toBeNull();
+
+    if (tool) {
+      await expect(tool.execute("test-call", { url: "http://172.16.0.1/admin" })).rejects.toThrow(
+        /private|internal|Blocked/i,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds SSRF (Server-Side Request Forgery) protection to the `web_fetch` tool
- Blocks requests to private IP ranges, localhost, cloud metadata endpoints
- Aligns with existing protections already present in `src/media/input-files.ts`

## Problem

The `web_fetch` tool validates URL protocol (http/https) but doesn't check if the resolved hostname points to internal/private networks. This creates an SSRF vulnerability where:

1. A malicious website can redirect to internal resources (`http://192.168.1.1/admin`)
2. Cloud metadata services can be accessed (`http://169.254.169.254/latest/meta-data/`)
3. Local services can be probed (`http://localhost:8080/`)

This is especially dangerous when running on cloud VMs where the metadata service exposes IAM credentials.

## Solution

Port the SSRF protections from `input-files.ts` to `web-fetch.ts`:

- DNS resolution check before fetching
- Block private IPv4 ranges: `127.x`, `10.x`, `192.168.x`, `172.16-31.x`, `169.254.x`
- Block private IPv6: `::1`, `fe80:`, `fec0:`, `fc`, `fd`
- Block hostnames: `localhost`, `*.localhost`, `*.local`, `*.internal`, `metadata.google.internal`

## Test plan

- [x] Added 8 new test cases in `web-fetch.ssrf.test.ts`
- [x] All existing tests pass (219 tests in media + agents/tools)
- [x] Typecheck passes
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.ai/code)