### PR TITLE
feat(tui): add input history (↑/↓) for submitted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.clawd.bot
 - Skills: add download installs with OS-filtered install options; add local sherpa-onnx-tts skill.
 - Docs: clarify WhatsApp voice notes and Windows WSL portproxy LAN access notes.
 - UI: add copy-as-markdown with error feedback and drop legacy list view. (#1345) — thanks @bradleypriest.
+- TUI: add input history (up/down) for submitted messages. (#1348) — thanks @vignesh07.
 ### Fixes
 - Discovery: shorten Bonjour DNS-SD service type to `_clawdbot-gw._tcp` and update discovery clients/docs.
 - Agents: preserve subagent announce thread/topic routing + queued replies across channels. (#1241) — thanks @gnarco.

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -70,7 +70,6 @@ const routeSessions: RouteSpec = {
   match: (path) => path[0] === "sessions",
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
-    const verbose = getVerboseFlag(argv);
     const store = getFlagValue(argv, "--store");
     if (store === null) return false;
     const active = getFlagValue(argv, "--active");

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -18,7 +18,7 @@ const shouldRegisterPrimaryOnly = (argv: string[]) => {
   return true;
 };
 
-const shouldEagerRegisterSubcommands = (argv: string[]) => {
+const shouldEagerRegisterSubcommands = (_argv: string[]) => {
   return isTruthyEnvValue(process.env.CLAWDBOT_DISABLE_LAZY_SUBCOMMANDS);
 };
 

--- a/src/tui/tui-input-history.test.ts
+++ b/src/tui/tui-input-history.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEditorSubmitHandler } from "./tui.js";
+
+describe("createEditorSubmitHandler", () => {
+  it("adds submitted messages to editor history", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage: vi.fn(),
+    });
+
+    handler("hello world");
+
+    expect(editor.setText).toHaveBeenCalledWith("");
+    expect(editor.addToHistory).toHaveBeenCalledWith("hello world");
+  });
+
+  it("trims input before adding to history", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage: vi.fn(),
+    });
+
+    handler("   hi   ");
+
+    expect(editor.addToHistory).toHaveBeenCalledWith("hi");
+  });
+
+  it("does not add empty submissions to history", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage: vi.fn(),
+    });
+
+    handler("   ");
+
+    expect(editor.addToHistory).not.toHaveBeenCalled();
+  });
+
+  it("routes slash commands to handleCommand", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleCommand = vi.fn();
+    const sendMessage = vi.fn();
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand,
+      sendMessage,
+    });
+
+    handler("/models");
+
+    expect(editor.addToHistory).toHaveBeenCalledWith("/models");
+    expect(handleCommand).toHaveBeenCalledWith("/models");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("routes normal messages to sendMessage", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleCommand = vi.fn();
+    const sendMessage = vi.fn();
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand,
+      sendMessage,
+    });
+
+    handler("hello");
+
+    expect(editor.addToHistory).toHaveBeenCalledWith("hello");
+    expect(sendMessage).toHaveBeenCalledWith("hello");
+    expect(handleCommand).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds shell-style input history to the TUI editor: submitted prompts are recorded so you can use ↑ / ↓ to recall previous messages. Provides parity with existing CLI AI tools.

## Details

- Records every non-empty submission (messages and slash commands)
- Uses the existing `@mariozechner/pi-tui` Editor history navigation
- Keeps behavior minimal and in-memory (no persistence)

## Testing

- `pnpm test src/tui/tui-input-history.test.ts`
- `pnpm lint`
- `pnpm build`

---

🤖 AI-assisted

## Codex Review

<details>
<summary> Codex did not find any issues; expand for code review details </summary>
```
>> Code review started: current changes <<

• Ran git diff

• Ran git log -1

• Ran git show HEAD

• Explored
  └ Search addToHistory in tui
    Search class .*Editor in tui
    Read custom-editor.ts
    Search class Editor in *editor*
    Search addToHistory in node_modules
    Search history in pi-tui
    List pi-tui
    Search history in pi-tui
    Read editor.js
    Search \.\/tui\.js in src
    Search addToHistory in pi-tui
    List components
    Read editor.d.ts, tui.test.ts, tui.ts
    Search function handleCommand in tui
    Search createCommandHandlers in *.ts
    Read tui-command-handlers.ts
    Search handleCommand in tui-command-handlers.ts
    Read tui-command-handlers.ts
    Search addToHistory

The helper that records editor submissions mirrors the previous onSubmit logic while adding prompt history support, and the accompanying tests assert the expected routing behavior. No regressions or obvious issues are introduced by the refactor.

<< Code review finished >>
```
<details>
