### PR TITLE
fix(telegram): answer callback queries immediately to prevent retries

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -179,6 +179,8 @@ export const registerTelegramHandlers = ({
     const callback = ctx.callbackQuery;
     if (!callback) return;
     if (shouldSkipUpdate(ctx)) return;
+    // Answer immediately to prevent Telegram from retrying while we process
+    await bot.api.answerCallbackQuery(callback.id).catch(() => {});
     try {
       const data = (callback.data ?? "").trim();
       const callbackMessage = callback.message;
@@ -323,8 +325,6 @@ export const registerTelegramHandlers = ({
       });
     } catch (err) {
       runtime.error?.(danger(`callback handler failed: ${String(err)}`));
-    } finally {
-      await bot.api.answerCallbackQuery(callback.id).catch(() => {});
     }
   });
 


### PR DESCRIPTION
## Problem

Telegram retries callback queries if they aren't acknowledged quickly. When using inline buttons, this causes duplicate callbacks to be processed if the agent takes more than a few seconds to respond.

## Root Cause

Previously, `answerCallbackQuery` was called in a `finally` block AFTER `processMessage()` completed. Since agent processing can take several seconds (especially with reasoning models), Telegram would retry the callback, leading to duplicate message handling.

## Solution

Move `answerCallbackQuery` to immediately after basic validation, BEFORE any processing begins:

```diff
     if (shouldSkipUpdate(ctx)) return;
+    // Answer immediately to prevent Telegram from retrying while we process
+    await bot.api.answerCallbackQuery(callback.id).catch(() => {});
     try {
```

This tells Telegram "got it" right away, preventing retries while the agent thinks.

## Testing

- Manually tested with rapid button taps
- Existing deduplication tests should still pass (they test by update_id, which is unaffected)