### PR TITLE
fix(node): enforce timeout for node.invoke handlers

### DIFF
--- a/apps/shared/ClawdbotKit/Tests/ClawdbotKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/ClawdbotKit/Tests/ClawdbotKitTests/GatewayNodeSessionTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import ClawdbotKit
+import ClawdbotProtocol
+
+struct GatewayNodeSessionTests {
+    @Test
+    func invokeWithTimeoutReturnsUnderlyingResponseBeforeTimeout() async {
+        let request = BridgeInvokeRequest(id: "1", command: "x", paramsJSON: nil)
+        let response = await GatewayNodeSession.invokeWithTimeout(
+            request: request,
+            timeoutMs: 50,
+            onInvoke: { req in
+                #expect(req.id == "1")
+                return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: "{}", error: nil)
+            }
+        )
+
+        #expect(response.ok == true)
+        #expect(response.error == nil)
+        #expect(response.payloadJSON == "{}")
+    }
+
+    @Test
+    func invokeWithTimeoutReturnsTimeoutError() async {
+        let request = BridgeInvokeRequest(id: "abc", command: "x", paramsJSON: nil)
+        let response = await GatewayNodeSession.invokeWithTimeout(
+            request: request,
+            timeoutMs: 10,
+            onInvoke: { _ in
+                try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
+                return BridgeInvokeResponse(id: "abc", ok: true, payloadJSON: "{}", error: nil)
+            }
+        )
+
+        #expect(response.ok == false)
+        #expect(response.error?.code == .unavailable)
+        #expect(response.error?.message.contains("timed out") == true)
+    }
+
+    @Test
+    func invokeWithTimeoutZeroDisablesTimeout() async {
+        let request = BridgeInvokeRequest(id: "1", command: "x", paramsJSON: nil)
+        let response = await GatewayNodeSession.invokeWithTimeout(
+            request: request,
+            timeoutMs: 0,
+            onInvoke: { req in
+                try? await Task.sleep(nanoseconds: 5_000_000)
+                return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            }
+        )
+
+        #expect(response.ok == true)
+        #expect(response.error == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Ensures node clients always respond to `node.invoke` requests within the request's `timeoutMs`, returning a structured error instead of hanging until the gateway-side timeout.

## Context

During nodes testing (especially on iOS simulator), several allowed commands (e.g. `camera.*`, `screen.record`, `canvas.*`) could stall and never return a `node.invoke.result`, causing the gateway to time out after a long wait. The `timeoutMs` is already part of the invoke request payload, but the node-side implementation did not enforce it.

## Changes

- Add `GatewayNodeSession.invokeWithTimeout(...)` and use it when handling invoke requests.
- If the handler does not return before `timeoutMs`, respond with `ClawdbotNodeError(code: .unavailable, message: "node invoke timed out")`.

## Testing

- `swift test --filter GatewayNodeSessionTests` (new tests)
- `pnpm build`

---

🤖 AI-assisted
