### PR TITLE
fix(ios): prevent Talk mode crash on simulator

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -132,6 +132,12 @@ final class TalkModeManager: NSObject {
     }
 
     private func startRecognition() throws {
+        #if targetEnvironment(simulator)
+            throw NSError(domain: "TalkMode", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Talk mode is not supported on the iOS simulator",
+            ])
+        #endif
+
         self.stopRecognition()
         self.speechRecognizer = SFSpeechRecognizer()
         guard let recognizer = self.speechRecognizer else {
@@ -146,6 +152,11 @@ final class TalkModeManager: NSObject {
 
         let input = self.audioEngine.inputNode
         let format = input.outputFormat(forBus: 0)
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            throw NSError(domain: "TalkMode", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid audio input format",
+            ])
+        }
         input.removeTap(onBus: 0)
         let tapBlock = Self.makeAudioTapAppendCallback(request: request)
         input.installTap(onBus: 0, bufferSize: 2048, format: format, block: tapBlock)


### PR DESCRIPTION
## Summary

Prevents the iOS app from crashing when Talk mode is started on the iOS Simulator.

## Context

On simulator, attempting to start speech recognition/audio capture can crash with an AVFAudio assertion (invalid sample rate / channel count). This makes nodes testing and general iOS dev workflows painful.

## Changes

- In `TalkModeManager.startRecognition()`, early-return with a user-visible error on `targetEnvironment(simulator)`.
- Add a small runtime validation for audio input format (`sampleRate > 0`, `channelCount > 0`) before installing the audio tap.

## Testing

- Ran the iOS app on simulator and tapped Talk; app no longer crashes and instead surfaces the error.

---

🤖 AI-assisted
