### PR TITLE
fix: remove duplicate UpdateStepResult import

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -19,7 +19,6 @@ import {
   type UpdateStepInfo,
   type UpdateStepResult,
   type UpdateStepProgress,
-  type UpdateStepResult,
 } from "../infra/update-runner.js";
 import {
   detectGlobalInstallManagerByPresence,


### PR DESCRIPTION
## Summary
- Fixes TypeScript compilation error caused by duplicate import of `UpdateStepResult` type in `src/cli/update-cli.ts`

## Changes
- Removed duplicate `UpdateStepResult` import on line 22

## Context
The build was failing with:
```
src/cli/update-cli.ts:20:8 - error TS2300: Duplicate identifier 'UpdateStepResult'.
src/cli/update-cli.ts:22:8 - error TS2300: Duplicate identifier 'UpdateStepResult'.
```

## Test plan
- [x] `pnpm build` completes successfully
- [x] TypeScript compilation passes