### PR TITLE
CLI: fix duplicate UpdateStepResult import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Agents: scrub Anthropic refusal test token from prompts and add a live refusal regression probe.
-- CLI: fix duplicate UpdateStepResult import in update CLI wiring. (#1367, refs #1366) Thanks @24601.
 
 ## 2026.1.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Agents: scrub Anthropic refusal test token from prompts and add a live refusal regression probe.
+- CLI: fix duplicate UpdateStepResult import in update CLI wiring. (#1367, refs #1366) Thanks @24601.
 
 ## 2026.1.20
 

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -19,7 +19,6 @@ import {
   type UpdateStepInfo,
   type UpdateStepResult,
   type UpdateStepProgress,
-  type UpdateStepResult,
 } from "../infra/update-runner.js";
 import {
   detectGlobalInstallManagerByPresence,


### PR DESCRIPTION
## Summary
- remove the duplicate `UpdateStepResult` type import in `src/cli/update-cli.ts` to unblock `pnpm build`

## User-facing impact
- fixes TypeScript build failure in update CLI wiring

## Testing
- not run (not requested)

## Issue
- Closes #1366

## codex-assisted, yes, but I, the human/meat puppet, Basit, have reviewed and was in the loop and am filing this PR as a soft carbon based life form, no ai worth its salt would have such a huge markdown heading with terrible capitalization, riiiight? 
- AI-assisted: yes (Codex)
- Prompt/session logs: available on request
- I confirm I understand the change and why it fixes the duplicate identifier error
