### PR TITLE
fix(node): handle invoke approvals and errors

### DIFF
--- a/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayChannel.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayChannel.swift
@@ -571,7 +571,14 @@ public actor GatewayChannelActor {
             id: id,
             method: method,
             params: paramsObject)
-        let data = try self.encoder.encode(frame)
+        let data: Data
+        do {
+            data = try self.encoder.encode(frame)
+        } catch {
+            self.logger.error(
+                "gateway request encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
         let response = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GatewayFrame, Error>) in
             self.pending[id] = cont
             Task { [weak self] in

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayNodeSession.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayNodeSession.swift
@@ -219,8 +219,8 @@ public actor GatewayNodeSession {
         }
         if let error = response.error {
             params["error"] = AnyCodable([
-                "code": AnyCodable(error.code.rawValue),
-                "message": AnyCodable(error.message),
+                "code": error.code.rawValue,
+                "message": error.message,
             ])
         }
         do {

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotKit/SystemCommands.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotKit/SystemCommands.swift
@@ -30,6 +30,7 @@ public struct ClawdbotSystemRunParams: Codable, Sendable, Equatable {
     public var agentId: String?
     public var sessionKey: String?
     public var approved: Bool?
+    public var approvalDecision: String?
 
     public init(
         command: [String],
@@ -40,7 +41,8 @@ public struct ClawdbotSystemRunParams: Codable, Sendable, Equatable {
         needsScreenRecording: Bool? = nil,
         agentId: String? = nil,
         sessionKey: String? = nil,
-        approved: Bool? = nil)
+        approved: Bool? = nil,
+        approvalDecision: String? = nil)
     {
         self.command = command
         self.rawCommand = rawCommand
@@ -51,6 +53,7 @@ public struct ClawdbotSystemRunParams: Codable, Sendable, Equatable {
         self.agentId = agentId
         self.sessionKey = sessionKey
         self.approved = approved
+        self.approvalDecision = approvalDecision
     }
 }
 


### PR DESCRIPTION
## Summary
- prompt on allowlist miss for mac node exec approvals and persist allowlist decisions
- flatten node invoke error payload to avoid JSON encode failures
- log gateway request encode failures for visibility

## Testing
- manual: ran exec commands; toggled exec approval between allowlist and always approve; toggled ask-on-allowlist-miss

## User-facing changes
- mac node now prompts on allowlist miss and honors allow/deny decisions
- node invoke result errors no longer fail to encode (reduces timeouts)
