### PR TITLE
feat(workspace): add START_HERE.md and MEMORY.md to bootstrap files

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -8,7 +8,9 @@ import {
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
   DEFAULT_SOUL_FILENAME,
+  DEFAULT_START_HERE_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
@@ -106,6 +108,18 @@ describe("filterBootstrapFilesForSession", () => {
       content: "bootstrap",
       missing: false,
     },
+    {
+      name: DEFAULT_START_HERE_FILENAME,
+      path: "/tmp/START_HERE.md",
+      content: "start here",
+      missing: false,
+    },
+    {
+      name: DEFAULT_MEMORY_FILENAME,
+      path: "/tmp/MEMORY.md",
+      content: "memory",
+      missing: false,
+    },
   ];
 
   it("keeps full bootstrap set for non-subagent sessions", () => {
@@ -118,6 +132,7 @@ describe("filterBootstrapFilesForSession", () => {
     expect(result.map((file) => file.name)).toEqual([
       DEFAULT_AGENTS_FILENAME,
       DEFAULT_TOOLS_FILENAME,
+      DEFAULT_START_HERE_FILENAME,
     ]);
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -26,6 +26,8 @@ export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
 export const DEFAULT_USER_FILENAME = "USER.md";
 export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
+export const DEFAULT_START_HERE_FILENAME = "START_HERE.md";
+export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 
 const DEFAULT_AGENTS_TEMPLATE = `# AGENTS.md - Clawdbot Workspace
 
@@ -192,7 +194,9 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_IDENTITY_FILENAME
   | typeof DEFAULT_USER_FILENAME
   | typeof DEFAULT_HEARTBEAT_FILENAME
-  | typeof DEFAULT_BOOTSTRAP_FILENAME;
+  | typeof DEFAULT_BOOTSTRAP_FILENAME
+  | typeof DEFAULT_START_HERE_FILENAME
+  | typeof DEFAULT_MEMORY_FILENAME;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -326,6 +330,14 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       name: DEFAULT_BOOTSTRAP_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
     },
+    {
+      name: DEFAULT_START_HERE_FILENAME,
+      filePath: path.join(resolvedDir, DEFAULT_START_HERE_FILENAME),
+    },
+    {
+      name: DEFAULT_MEMORY_FILENAME,
+      filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
+    },
   ];
 
   const result: WorkspaceBootstrapFile[] = [];
@@ -345,7 +357,11 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_START_HERE_FILENAME,
+]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],


### PR DESCRIPTION
## Summary

- Add `START_HERE.md` and `MEMORY.md` to the list of workspace bootstrap files that are loaded into agent context
- `START_HERE.md` is also added to the subagent allowlist so subagents can use routing information

## Motivation

Users who set up their workspace for Claude Code (using `CLAUDE.md`) or have custom entrypoints like `START_HERE.md` currently don't get this context loaded when using clawdbot with other models like Gemini. This creates an inconsistent experience where the agent "doesn't know where files are" because it never sees the routing table.

These two files are commonly used:
- **START_HERE.md**: Routing table / entrypoint that tells the agent which skill or doc to read for a given topic
- **MEMORY.md**: Durable decisions, history, and TODOs that persist across sessions

## Changes

1. Added `DEFAULT_START_HERE_FILENAME` and `DEFAULT_MEMORY_FILENAME` constants
2. Added both to `WorkspaceBootstrapFileName` type union
3. Added entries in `loadWorkspaceBootstrapFiles()` to load these files if present
4. Added `START_HERE.md` to `SUBAGENT_BOOTSTRAP_ALLOWLIST` so subagents can see routing info
5. Updated tests to cover the new files

## Test plan

- [x] Updated `workspace.test.ts` with new bootstrap files
- [ ] CI should validate types and run tests

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)