### PR TITLE
fix: use explicit union type for optional param in parseActiveHoursTime

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -89,7 +89,7 @@ function resolveActiveHoursTimezone(cfg: ClawdbotConfig, raw?: string): string {
   }
 }
 
-function parseActiveHoursTime(raw?: string, opts: { allow24: boolean }): number | null {
+function parseActiveHoursTime(raw: string | undefined, opts: { allow24: boolean }): number | null {
   if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) return null;
   const [hourStr, minuteStr] = raw.split(":");
   const hour = Number(hourStr);


### PR DESCRIPTION
## Summary

- Fixes TS1016 build error in `src/infra/heartbeat-runner.ts` where a required parameter followed an optional one
- Changed `raw?: string` to `raw: string | undefined` to preserve semantics while keeping `opts` required

## Root Cause

The function signature on line 92 had:
```typescript
function parseActiveHoursTime(raw?: string, opts: { allow24: boolean }): number | null {
```

TypeScript doesn't allow required parameters after optional ones (TS1016).

## Test plan

- [x] `pnpm build` passes
- [x] No changes needed to call sites (both calls already pass both arguments)

Fixes #1403

🤖 Generated with [Claude Code](https://claude.ai/code)