### PR TITLE
Fix TS compile errors blocking macOS packaging (package-mac-app.sh)

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -89,7 +89,7 @@ function resolveActiveHoursTimezone(cfg: ClawdbotConfig, raw?: string): string {
   }
 }
 
-function parseActiveHoursTime(raw?: string, opts: { allow24: boolean }): number | null {
+function parseActiveHoursTime(raw: string | undefined, opts: { allow24: boolean }): number | null {
   if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) return null;
   const [hourStr, minuteStr] = raw.split(":");
   const hour = Number(hourStr);

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -589,7 +589,7 @@ async function handleInvoke(
     ? analyzeShellCommand({ command: rawCommand, cwd: params.cwd ?? undefined, env })
     : analyzeArgvCommand({ argv, cwd: params.cwd ?? undefined, env });
   const cfg = loadConfig();
-  const agentExec = resolveAgentConfig(cfg, agentId)?.tools?.exec;
+  const agentExec = agentId ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
   const safeBins = resolveSafeBins(agentExec?.safeBins ?? cfg.tools?.exec?.safeBins);
   const allowlistMatches: ExecAllowlistEntry[] = [];
   const bins = autoAllowSkills ? await skillBins.current() : new Set<string>();


### PR DESCRIPTION
### Summary
While running `scripts/package-mac-app.sh` (per apps/macos README), `pnpm exec tsc` fails with two TypeScript errors. This prevents building/packaging the macOS app from source.

This PR fixes both issues with minimal, safe changes:
1) Fixes an invalid function signature in `heartbeat-runner.ts` (required param after optional).
2) Guards an optional `agentId` before passing it into `resolveAgentConfig(...)` in `node-host/runner.ts`.

### Repro
From repo root:
```
pnpm install
pnpm exec tsc
# or
scripts/package-mac-app.sh
```

Observed errors:
- `src/infra/heartbeat-runner.ts:92: TS1016 A required parameter cannot follow an optional parameter.`
- `src/node-host/runner.ts:592: TS2345 Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`

### Changes
- `src/infra/heartbeat-runner.ts`
  - `parseActiveHoursTime(raw?: string, opts: ...)` → `parseActiveHoursTime(raw: string | undefined, opts: ...)`
  - No behavioral change; still returns `null` when `raw` is missing/invalid.
- `src/node-host/runner.ts`
  - Guard `agentId` before calling `resolveAgentConfig(cfg, agentId)`
  - When `agentId` is absent, `agentExec` is `undefined` (matches intended behavior and avoids passing `undefined` into a `string` parameter).

### Why this matters
These errors break `pnpm exec tsc`, blocking `scripts/package-mac-app.sh` and making it harder to build/test the macOS app from source.

### Testing
- `pnpm exec tsc` (should pass)
- `scripts/package-mac-app.sh` (should proceed past the TS compile step)