### PR TITLE
[Feature]: Add file upload support and adaptive cards for DMs and group messages

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -319,7 +319,7 @@ Notes:
 Send messages and channel actions across Discord/Slack/Telegram/WhatsApp/Signal/iMessage/MS Teams.
 
 Core actions:
-- `send` (text + optional media)
+- `send` (text + optional media; MS Teams also supports `card` for Adaptive Cards)
 - `poll` (WhatsApp/Discord/MS Teams polls)
 - `react` / `reactions` / `read` / `edit` / `delete`
 - `pin` / `unpin` / `list-pins`

--- a/extensions/msteams/src/attachments.ts
+++ b/extensions/msteams/src/attachments.ts
@@ -1,4 +1,8 @@
-export { downloadMSTeamsImageAttachments } from "./attachments/download.js";
+export {
+  downloadMSTeamsAttachments,
+  /** @deprecated Use `downloadMSTeamsAttachments` instead. */
+  downloadMSTeamsImageAttachments,
+} from "./attachments/download.js";
 export { buildMSTeamsGraphMessageUrls, downloadMSTeamsGraphMedia } from "./attachments/graph.js";
 export {
   buildMSTeamsAttachmentPlaceholder,

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -2,7 +2,7 @@ import { getMSTeamsRuntime } from "../runtime.js";
 import {
   extractInlineImageCandidates,
   inferPlaceholder,
-  isLikelyImageAttachment,
+  isDownloadableAttachment,
   isRecord,
   isUrlAllowed,
   normalizeContentType,
@@ -68,10 +68,10 @@ function scopeCandidatesForUrl(url: string): string[] {
       host.endsWith("1drv.ms") ||
       host.includes("sharepoint");
     return looksLikeGraph
-      ? ["https://graph.microsoft.com/.default", "https://api.botframework.com/.default"]
-      : ["https://api.botframework.com/.default", "https://graph.microsoft.com/.default"];
+      ? ["https://graph.microsoft.com", "https://api.botframework.com"]
+      : ["https://api.botframework.com", "https://graph.microsoft.com"];
   } catch {
-    return ["https://api.botframework.com/.default", "https://graph.microsoft.com/.default"];
+    return ["https://api.botframework.com", "https://graph.microsoft.com"];
   }
 }
 
@@ -102,23 +102,31 @@ async function fetchWithAuthFallback(params: {
   return firstAttempt;
 }
 
-export async function downloadMSTeamsImageAttachments(params: {
+/**
+ * Download all file attachments from a Teams message (images, documents, etc.).
+ * Renamed from downloadMSTeamsImageAttachments to support all file types.
+ */
+export async function downloadMSTeamsAttachments(params: {
   attachments: MSTeamsAttachmentLike[] | undefined;
   maxBytes: number;
   tokenProvider?: MSTeamsAccessTokenProvider;
   allowHosts?: string[];
   fetchFn?: typeof fetch;
+  /** When true, embeds original filename in stored path for later extraction. */
+  preserveFilenames?: boolean;
 }): Promise<MSTeamsInboundMedia[]> {
   const list = Array.isArray(params.attachments) ? params.attachments : [];
   if (list.length === 0) return [];
   const allowHosts = resolveAllowedHosts(params.allowHosts);
 
-  const candidates: DownloadCandidate[] = list
-    .filter(isLikelyImageAttachment)
+  // Download ANY downloadable attachment (not just images)
+  const downloadable = list.filter(isDownloadableAttachment);
+  const candidates: DownloadCandidate[] = downloadable
     .map(resolveDownloadCandidate)
     .filter(Boolean) as DownloadCandidate[];
 
   const inlineCandidates = extractInlineImageCandidates(list);
+
   const seenUrls = new Set<string>();
   for (const inline of inlineCandidates) {
     if (inline.kind === "url") {
@@ -133,7 +141,6 @@ export async function downloadMSTeamsImageAttachments(params: {
       });
     }
   }
-
   if (candidates.length === 0 && inlineCandidates.length === 0) return [];
 
   const out: MSTeamsInboundMedia[] = [];
@@ -141,6 +148,7 @@ export async function downloadMSTeamsImageAttachments(params: {
     if (inline.kind !== "data") continue;
     if (inline.data.byteLength > params.maxBytes) continue;
     try {
+      // Data inline candidates (base64 data URLs) don't have original filenames
       const saved = await getMSTeamsRuntime().channel.media.saveMediaBuffer(
         inline.data,
         inline.contentType,
@@ -172,11 +180,13 @@ export async function downloadMSTeamsImageAttachments(params: {
         headerMime: res.headers.get("content-type"),
         filePath: candidate.fileHint ?? candidate.url,
       });
+      const originalFilename = params.preserveFilenames ? candidate.fileHint : undefined;
       const saved = await getMSTeamsRuntime().channel.media.saveMediaBuffer(
         buffer,
         mime ?? candidate.contentTypeHint,
         "inbound",
         params.maxBytes,
+        originalFilename,
       );
       out.push({
         path: saved.path,
@@ -184,8 +194,13 @@ export async function downloadMSTeamsImageAttachments(params: {
         placeholder: candidate.placeholder,
       });
     } catch {
-      // Ignore download failures and continue.
+      // Ignore download failures and continue with next candidate.
     }
   }
   return out;
 }
+
+/**
+ * @deprecated Use `downloadMSTeamsAttachments` instead (supports all file types).
+ */
+export const downloadMSTeamsImageAttachments = downloadMSTeamsAttachments;

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -1,6 +1,6 @@
 import { getMSTeamsRuntime } from "../runtime.js";
-import { downloadMSTeamsImageAttachments } from "./download.js";
-import { GRAPH_ROOT, isRecord, normalizeContentType, resolveAllowedHosts } from "./shared.js";
+import { downloadMSTeamsAttachments } from "./download.js";
+import { GRAPH_ROOT, inferPlaceholder, isRecord, normalizeContentType, resolveAllowedHosts } from "./shared.js";
 import type {
   MSTeamsAccessTokenProvider,
   MSTeamsAttachmentLike,
@@ -128,11 +128,16 @@ function normalizeGraphAttachment(att: GraphAttachment): MSTeamsAttachmentLike {
   };
 }
 
-async function downloadGraphHostedImages(params: {
+/**
+ * Download all hosted content from a Teams message (images, documents, etc.).
+ * Renamed from downloadGraphHostedImages to support all file types.
+ */
+async function downloadGraphHostedContent(params: {
   accessToken: string;
   messageUrl: string;
   maxBytes: number;
   fetchFn?: typeof fetch;
+  preserveFilenames?: boolean;
 }): Promise<{ media: MSTeamsInboundMedia[]; status: number; count: number }> {
   const hosted = await fetchGraphCollection<GraphHostedContent>({
     url: `${params.messageUrl}/hostedContents`,
@@ -158,7 +163,7 @@ async function downloadGraphHostedImages(params: {
       buffer,
       headerMime: item.contentType ?? undefined,
     });
-    if (mime && !mime.startsWith("image/")) continue;
+    // Download any file type, not just images
     try {
       const saved = await getMSTeamsRuntime().channel.media.saveMediaBuffer(
         buffer,
@@ -169,7 +174,7 @@ async function downloadGraphHostedImages(params: {
       out.push({
         path: saved.path,
         contentType: saved.contentType,
-        placeholder: "<media:image>",
+        placeholder: inferPlaceholder({ contentType: saved.contentType }),
       });
     } catch {
       // Ignore save failures.
@@ -185,22 +190,106 @@ export async function downloadMSTeamsGraphMedia(params: {
   maxBytes: number;
   allowHosts?: string[];
   fetchFn?: typeof fetch;
+  /** When true, embeds original filename in stored path for later extraction. */
+  preserveFilenames?: boolean;
 }): Promise<MSTeamsGraphMediaResult> {
   if (!params.messageUrl || !params.tokenProvider) return { media: [] };
   const allowHosts = resolveAllowedHosts(params.allowHosts);
   const messageUrl = params.messageUrl;
   let accessToken: string;
   try {
-    accessToken = await params.tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+    accessToken = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
   } catch {
     return { media: [], messageUrl, tokenError: true };
   }
 
-  const hosted = await downloadGraphHostedImages({
+  // Fetch the full message to get SharePoint file attachments (for group chats)
+  const fetchFn = params.fetchFn ?? fetch;
+  const sharePointMedia: MSTeamsInboundMedia[] = [];
+  try {
+    const msgRes = await fetchFn(messageUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (msgRes.ok) {
+      const msgData = (await msgRes.json()) as {
+        body?: { content?: string; contentType?: string };
+        attachments?: Array<{
+          id?: string;
+          contentUrl?: string;
+          contentType?: string;
+          name?: string;
+        }>;
+      };
+
+      // Extract SharePoint file attachments (contentType: "reference")
+      // Download any file type, not just images
+      const spAttachments = (msgData.attachments ?? []).filter(
+        (a) => a.contentType === "reference" && a.contentUrl && a.name,
+      );
+      for (const att of spAttachments) {
+        const name = att.name ?? "file";
+
+        try {
+          // SharePoint URLs need to be accessed via Graph shares API
+          const shareUrl = att.contentUrl!;
+          const encodedUrl = Buffer.from(shareUrl).toString("base64url");
+          const sharesUrl = `${GRAPH_ROOT}/shares/u!${encodedUrl}/driveItem/content`;
+
+          const spRes = await fetchFn(sharesUrl, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            redirect: "follow",
+          });
+
+          if (spRes.ok) {
+            const buffer = Buffer.from(await spRes.arrayBuffer());
+            if (buffer.byteLength <= params.maxBytes) {
+              const mime = await getMSTeamsRuntime().media.detectMime({
+                buffer,
+                headerMime: spRes.headers.get("content-type") ?? undefined,
+                filePath: name,
+              });
+              const originalFilename = params.preserveFilenames ? name : undefined;
+              const saved = await getMSTeamsRuntime().channel.media.saveMediaBuffer(
+                buffer,
+                mime ?? "application/octet-stream",
+                "inbound",
+                params.maxBytes,
+                originalFilename,
+              );
+              sharePointMedia.push({
+                path: saved.path,
+                contentType: saved.contentType,
+                placeholder: inferPlaceholder({ contentType: saved.contentType, fileName: name }),
+              });
+            }
+          }
+        } catch {
+          // Ignore SharePoint download failures.
+        }
+      }
+    }
+  } catch {
+    // Ignore message fetch failures.
+  }
+
+  // If we got SharePoint media, return it directly
+  if (sharePointMedia.length > 0) {
+    return {
+      media: sharePointMedia,
+      hostedCount: 0,
+      attachmentCount: sharePointMedia.length,
+      hostedStatus: 0,
+      attachmentStatus: 200,
+      messageUrl,
+    };
+  }
+
+  const hosted = await downloadGraphHostedContent({
     accessToken,
     messageUrl,
     maxBytes: params.maxBytes,
     fetchFn: params.fetchFn,
+    preserveFilenames: params.preserveFilenames,
   });
 
   const attachments = await fetchGraphCollection<GraphAttachment>({
@@ -210,12 +299,13 @@ export async function downloadMSTeamsGraphMedia(params: {
   });
 
   const normalizedAttachments = attachments.items.map(normalizeGraphAttachment);
-  const attachmentMedia = await downloadMSTeamsImageAttachments({
+  const attachmentMedia = await downloadMSTeamsAttachments({
     attachments: normalizedAttachments,
     maxBytes: params.maxBytes,
     tokenProvider: params.tokenProvider,
     allowHosts,
     fetchFn: params.fetchFn,
+    preserveFilenames: params.preserveFilenames,
   });
 
   return {

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -37,6 +37,15 @@ export const DEFAULT_MEDIA_HOST_ALLOWLIST = [
   "statics.teams.cdn.office.net",
   "office.com",
   "office.net",
+  // Azure Media Services / Skype CDN for clipboard-pasted images
+  "asm.skype.com",
+  "ams.skype.com",
+  "media.ams.skype.com",
+  // Bot Framework attachment URLs
+  "trafficmanager.net",
+  "blob.core.windows.net",
+  "azureedge.net",
+  "microsoft.com",
 ] as const;
 
 export const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
@@ -80,6 +89,30 @@ export function isLikelyImageAttachment(att: MSTeamsAttachmentLike): boolean {
     if (fileType && IMAGE_EXT_RE.test(`x.${fileType}`)) return true;
     const fileName = typeof att.content.fileName === "string" ? att.content.fileName : "";
     if (fileName && IMAGE_EXT_RE.test(fileName)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the attachment can be downloaded (any file type).
+ * Used when downloading all files, not just images.
+ */
+export function isDownloadableAttachment(att: MSTeamsAttachmentLike): boolean {
+  const contentType = normalizeContentType(att.contentType) ?? "";
+
+  // Teams file download info always has a downloadUrl
+  if (
+    contentType === "application/vnd.microsoft.teams.file.download.info" &&
+    isRecord(att.content) &&
+    typeof att.content.downloadUrl === "string"
+  ) {
+    return true;
+  }
+
+  // Any attachment with a contentUrl can be downloaded
+  if (typeof att.contentUrl === "string" && att.contentUrl.trim()) {
+    return true;
   }
 
   return false;

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -17,7 +17,7 @@ import {
   resolveMSTeamsChannelAllowlist,
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
-import { sendMessageMSTeams } from "./send.js";
+import { sendAdaptiveCardMSTeams, sendMessageMSTeams } from "./send.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 import {
   listMSTeamsDirectoryGroupsLive,
@@ -63,6 +63,13 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
     polls: true,
     threads: true,
     media: true,
+  },
+  threading: {
+    buildToolContext: ({ context, hasRepliedRef }) => ({
+      currentChannelId: context.To?.trim() || undefined,
+      currentThreadTs: context.ReplyToId,
+      hasRepliedRef,
+    }),
   },
   reload: { configPrefixes: ["channels.msteams"] },
   configSchema: buildChannelConfigSchema(MSTeamsConfigSchema),
@@ -137,7 +144,12 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
       looksLikeId: (raw) => {
         const trimmed = raw.trim();
         if (!trimmed) return false;
-        if (/^(conversation:|user:)/i.test(trimmed)) return true;
+        if (/^conversation:/i.test(trimmed)) return true;
+        if (/^user:/i.test(trimmed)) {
+          // Only treat as ID if the value after user: looks like a UUID
+          const id = trimmed.slice("user:".length).trim();
+          return /^[0-9a-fA-F-]{16,}$/.test(id);
+        }
         return trimmed.includes("@thread");
       },
       hint: "<conversationId|user:ID|conversation:ID>",
@@ -319,6 +331,50 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
         Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams));
       if (!enabled) return [];
       return ["poll"] satisfies ChannelMessageActionName[];
+    },
+    supportsCards: ({ cfg }) => {
+      return (
+        cfg.channels?.msteams?.enabled !== false &&
+        Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams))
+      );
+    },
+    handleAction: async (ctx) => {
+      // Handle send action with card parameter
+      if (ctx.action === "send" && ctx.params.card) {
+        const card = ctx.params.card as Record<string, unknown>;
+        const to =
+          typeof ctx.params.to === "string"
+            ? ctx.params.to.trim()
+            : typeof ctx.params.target === "string"
+              ? ctx.params.target.trim()
+              : "";
+        if (!to) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "Card send requires a target (to)." }],
+          };
+        }
+        const result = await sendAdaptiveCardMSTeams({
+          cfg: ctx.cfg,
+          to,
+          card,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                ok: true,
+                channel: "msteams",
+                messageId: result.messageId,
+                conversationId: result.conversationId,
+              }),
+            },
+          ],
+        };
+      }
+      // Return null to fall through to default handler
+      return null as never;
     },
   },
   outbound: msteamsOutbound,

--- a/extensions/msteams/src/directory-live.ts
+++ b/extensions/msteams/src/directory-live.ts
@@ -64,7 +64,7 @@ async function resolveGraphToken(cfg: unknown): Promise<string> {
   if (!creds) throw new Error("MS Teams credentials missing");
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
   const tokenProvider = new sdk.MsalTokenProvider(authConfig);
-  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
   const accessToken = readAccessToken(token);
   if (!accessToken) throw new Error("MS Teams graph token unavailable");
   return accessToken;

--- a/extensions/msteams/src/file-consent-helpers.test.ts
+++ b/extensions/msteams/src/file-consent-helpers.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
+import * as pendingUploads from "./pending-uploads.js";
+
+describe("requiresFileConsent", () => {
+  const thresholdBytes = 4 * 1024 * 1024; // 4MB
+
+  it("returns true for personal chat with non-image", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: "application/pdf",
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for personal chat with large image", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: "image/png",
+        bufferSize: 5 * 1024 * 1024, // 5MB
+        thresholdBytes,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for personal chat with small image", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: "image/png",
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for group chat with large non-image", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "groupChat",
+        contentType: "application/pdf",
+        bufferSize: 5 * 1024 * 1024,
+        thresholdBytes,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for channel with large non-image", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "channel",
+        contentType: "application/pdf",
+        bufferSize: 5 * 1024 * 1024,
+        thresholdBytes,
+      }),
+    ).toBe(false);
+  });
+
+  it("handles case-insensitive conversation type", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "Personal",
+        contentType: "application/pdf",
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(true);
+
+    expect(
+      requiresFileConsent({
+        conversationType: "PERSONAL",
+        contentType: "application/pdf",
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when conversationType is undefined", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: undefined,
+        contentType: "application/pdf",
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for personal chat when contentType is undefined (non-image)", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: undefined,
+        bufferSize: 1000,
+        thresholdBytes,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for personal chat with file exactly at threshold", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: "image/jpeg",
+        bufferSize: thresholdBytes, // exactly 4MB
+        thresholdBytes,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for personal chat with file just below threshold", () => {
+    expect(
+      requiresFileConsent({
+        conversationType: "personal",
+        contentType: "image/jpeg",
+        bufferSize: thresholdBytes - 1, // 4MB - 1 byte
+        thresholdBytes,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("prepareFileConsentActivity", () => {
+  const mockUploadId = "test-upload-id-123";
+
+  beforeEach(() => {
+    vi.spyOn(pendingUploads, "storePendingUpload").mockReturnValue(mockUploadId);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates activity with consent card attachment", () => {
+    const result = prepareFileConsentActivity({
+      media: {
+        buffer: Buffer.from("test content"),
+        filename: "test.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "conv123",
+      description: "My file",
+    });
+
+    expect(result.uploadId).toBe(mockUploadId);
+    expect(result.activity.type).toBe("message");
+    expect(result.activity.attachments).toHaveLength(1);
+
+    const attachment = (result.activity.attachments as unknown[])[0] as Record<string, unknown>;
+    expect(attachment.contentType).toBe("application/vnd.microsoft.teams.card.file.consent");
+    expect(attachment.name).toBe("test.pdf");
+  });
+
+  it("stores pending upload with correct data", () => {
+    const buffer = Buffer.from("test content");
+    prepareFileConsentActivity({
+      media: {
+        buffer,
+        filename: "test.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "conv123",
+      description: "My file",
+    });
+
+    expect(pendingUploads.storePendingUpload).toHaveBeenCalledWith({
+      buffer,
+      filename: "test.pdf",
+      contentType: "application/pdf",
+      conversationId: "conv123",
+    });
+  });
+
+  it("uses default description when not provided", () => {
+    const result = prepareFileConsentActivity({
+      media: {
+        buffer: Buffer.from("test"),
+        filename: "document.docx",
+        contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+      conversationId: "conv456",
+    });
+
+    const attachment = (result.activity.attachments as unknown[])[0] as Record<string, { description: string }>;
+    expect(attachment.content.description).toBe("File: document.docx");
+  });
+
+  it("uses provided description", () => {
+    const result = prepareFileConsentActivity({
+      media: {
+        buffer: Buffer.from("test"),
+        filename: "report.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "conv789",
+      description: "Q4 Financial Report",
+    });
+
+    const attachment = (result.activity.attachments as unknown[])[0] as Record<string, { description: string }>;
+    expect(attachment.content.description).toBe("Q4 Financial Report");
+  });
+
+  it("includes uploadId in consent card context", () => {
+    const result = prepareFileConsentActivity({
+      media: {
+        buffer: Buffer.from("test"),
+        filename: "file.txt",
+        contentType: "text/plain",
+      },
+      conversationId: "conv000",
+    });
+
+    const attachment = (result.activity.attachments as unknown[])[0] as Record<string, { acceptContext: { uploadId: string } }>;
+    expect(attachment.content.acceptContext.uploadId).toBe(mockUploadId);
+  });
+
+  it("handles media without contentType", () => {
+    const result = prepareFileConsentActivity({
+      media: {
+        buffer: Buffer.from("binary data"),
+        filename: "unknown.bin",
+      },
+      conversationId: "conv111",
+    });
+
+    expect(result.uploadId).toBe(mockUploadId);
+    expect(result.activity.type).toBe("message");
+  });
+});

--- a/extensions/msteams/src/file-consent-helpers.ts
+++ b/extensions/msteams/src/file-consent-helpers.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared helpers for FileConsentCard flow in MSTeams.
+ *
+ * FileConsentCard is required for:
+ * - Personal (1:1) chats with large files (>=4MB)
+ * - Personal chats with non-image files (PDFs, documents, etc.)
+ *
+ * This module consolidates the logic used by both send.ts (proactive sends)
+ * and messenger.ts (reply path) to avoid duplication.
+ */
+
+import { buildFileConsentCard } from "./file-consent.js";
+import { storePendingUpload } from "./pending-uploads.js";
+
+export type FileConsentMedia = {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+};
+
+export type FileConsentActivityResult = {
+  activity: Record<string, unknown>;
+  uploadId: string;
+};
+
+/**
+ * Prepare a FileConsentCard activity for large files or non-images in personal chats.
+ * Returns the activity object and uploadId - caller is responsible for sending.
+ */
+export function prepareFileConsentActivity(params: {
+  media: FileConsentMedia;
+  conversationId: string;
+  description?: string;
+}): FileConsentActivityResult {
+  const { media, conversationId, description } = params;
+
+  const uploadId = storePendingUpload({
+    buffer: media.buffer,
+    filename: media.filename,
+    contentType: media.contentType,
+    conversationId,
+  });
+
+  const consentCard = buildFileConsentCard({
+    filename: media.filename,
+    description: description || `File: ${media.filename}`,
+    sizeInBytes: media.buffer.length,
+    context: { uploadId },
+  });
+
+  const activity: Record<string, unknown> = {
+    type: "message",
+    attachments: [consentCard],
+  };
+
+  return { activity, uploadId };
+}
+
+/**
+ * Check if a file requires FileConsentCard flow.
+ * True for: personal chat AND (large file OR non-image)
+ */
+export function requiresFileConsent(params: {
+  conversationType: string | undefined;
+  contentType: string | undefined;
+  bufferSize: number;
+  thresholdBytes: number;
+}): boolean {
+  const isPersonal = params.conversationType?.toLowerCase() === "personal";
+  const isImage = params.contentType?.startsWith("image/") ?? false;
+  const isLargeFile = params.bufferSize >= params.thresholdBytes;
+  return isPersonal && (isLargeFile || !isImage);
+}

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -1,0 +1,122 @@
+/**
+ * FileConsentCard utilities for MS Teams large file uploads (>4MB) in personal chats.
+ *
+ * Teams requires user consent before the bot can upload large files. This module provides
+ * utilities for:
+ * - Building FileConsentCard attachments (to request upload permission)
+ * - Building FileInfoCard attachments (to confirm upload completion)
+ * - Parsing fileConsent/invoke activities
+ */
+
+export interface FileConsentCardParams {
+  filename: string;
+  description?: string;
+  sizeInBytes: number;
+  /** Custom context data to include in the card (passed back in the invoke) */
+  context?: Record<string, unknown>;
+}
+
+export interface FileInfoCardParams {
+  filename: string;
+  contentUrl: string;
+  uniqueId: string;
+  fileType: string;
+}
+
+/**
+ * Build a FileConsentCard attachment for requesting upload permission.
+ * Use this for files >= 4MB in personal (1:1) chats.
+ */
+export function buildFileConsentCard(params: FileConsentCardParams) {
+  return {
+    contentType: "application/vnd.microsoft.teams.card.file.consent",
+    name: params.filename,
+    content: {
+      description: params.description ?? `File: ${params.filename}`,
+      sizeInBytes: params.sizeInBytes,
+      acceptContext: { filename: params.filename, ...params.context },
+      declineContext: { filename: params.filename, ...params.context },
+    },
+  };
+}
+
+/**
+ * Build a FileInfoCard attachment for confirming upload completion.
+ * Send this after successfully uploading the file to the consent URL.
+ */
+export function buildFileInfoCard(params: FileInfoCardParams) {
+  return {
+    contentType: "application/vnd.microsoft.teams.card.file.info",
+    contentUrl: params.contentUrl,
+    name: params.filename,
+    content: {
+      uniqueId: params.uniqueId,
+      fileType: params.fileType,
+    },
+  };
+}
+
+export interface FileConsentUploadInfo {
+  name: string;
+  uploadUrl: string;
+  contentUrl: string;
+  uniqueId: string;
+  fileType: string;
+}
+
+export interface FileConsentResponse {
+  action: "accept" | "decline";
+  uploadInfo?: FileConsentUploadInfo;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Parse a fileConsent/invoke activity.
+ * Returns null if the activity is not a file consent invoke.
+ */
+export function parseFileConsentInvoke(activity: {
+  name?: string;
+  value?: unknown;
+}): FileConsentResponse | null {
+  if (activity.name !== "fileConsent/invoke") return null;
+
+  const value = activity.value as {
+    type?: string;
+    action?: string;
+    uploadInfo?: FileConsentUploadInfo;
+    context?: Record<string, unknown>;
+  };
+
+  if (value?.type !== "fileUpload") return null;
+
+  return {
+    action: value.action === "accept" ? "accept" : "decline",
+    uploadInfo: value.uploadInfo,
+    context: value.context,
+  };
+}
+
+/**
+ * Upload a file to the consent URL provided by Teams.
+ * The URL is provided in the fileConsent/invoke response after user accepts.
+ */
+export async function uploadToConsentUrl(params: {
+  url: string;
+  buffer: Buffer;
+  contentType?: string;
+  fetchFn?: typeof fetch;
+}): Promise<void> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const res = await fetchFn(params.url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": params.contentType ?? "application/octet-stream",
+      "Content-Range": `bytes 0-${params.buffer.length - 1}/${params.buffer.length}`,
+    },
+    body: new Uint8Array(params.buffer),
+  });
+
+  if (!res.ok) {
+    throw new Error(`File upload to consent URL failed: ${res.status} ${res.statusText}`);
+  }
+}

--- a/extensions/msteams/src/graph-chat.ts
+++ b/extensions/msteams/src/graph-chat.ts
@@ -1,0 +1,52 @@
+/**
+ * Native Teams file card attachments for Bot Framework.
+ *
+ * The Bot Framework SDK supports `application/vnd.microsoft.teams.card.file.info`
+ * content type which produces native Teams file cards.
+ *
+ * @see https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4
+ */
+
+import type { DriveItemProperties } from "./graph-upload.js";
+
+/**
+ * Build a native Teams file card attachment for Bot Framework.
+ *
+ * This uses the `application/vnd.microsoft.teams.card.file.info` content type
+ * which is supported by Bot Framework and produces native Teams file cards
+ * (the same display as when a user manually shares a file).
+ *
+ * @param file - DriveItem properties from getDriveItemProperties()
+ * @returns Attachment object for Bot Framework sendActivity()
+ */
+export function buildTeamsFileInfoCard(file: DriveItemProperties): {
+  contentType: string;
+  contentUrl: string;
+  name: string;
+  content: {
+    uniqueId: string;
+    fileType: string;
+  };
+} {
+  // Extract unique ID from eTag (remove quotes, braces, and version suffix)
+  // Example eTag formats: "{GUID},version" or "\"{GUID},version\""
+  const rawETag = file.eTag;
+  const uniqueId = rawETag
+    .replace(/^["']|["']$/g, "") // Remove outer quotes
+    .replace(/[{}]/g, "") // Remove curly braces
+    .split(",")[0] ?? rawETag; // Take the GUID part before comma
+
+  // Extract file extension from filename
+  const lastDot = file.name.lastIndexOf(".");
+  const fileType = lastDot >= 0 ? file.name.slice(lastDot + 1).toLowerCase() : "";
+
+  return {
+    contentType: "application/vnd.microsoft.teams.card.file.info",
+    contentUrl: file.webDavUrl,
+    name: file.name,
+    content: {
+      uniqueId,
+      fileType,
+    },
+  };
+}

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -1,0 +1,444 @@
+/**
+ * OneDrive/SharePoint upload utilities for MS Teams file sending.
+ *
+ * For group chats and channels, files are uploaded to SharePoint and shared via a link.
+ * This module provides utilities for:
+ * - Uploading files to OneDrive (personal scope - now deprecated for bot use)
+ * - Uploading files to SharePoint (group/channel scope)
+ * - Creating sharing links (organization-wide or per-user)
+ * - Getting chat members for per-user sharing
+ */
+
+import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+
+const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
+const GRAPH_BETA = "https://graph.microsoft.com/beta";
+
+export interface OneDriveUploadResult {
+  id: string;
+  webUrl: string;
+  name: string;
+}
+
+/**
+ * Upload a file to the user's OneDrive root folder.
+ * For larger files, this uses the simple upload endpoint (up to 4MB).
+ * TODO: For files >4MB, implement resumable upload session.
+ */
+export async function uploadToOneDrive(params: {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  fetchFn?: typeof fetch;
+}): Promise<OneDriveUploadResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+
+  // Use "ClawdbotShared" folder to organize bot-uploaded files
+  const uploadPath = `/ClawdbotShared/${encodeURIComponent(params.filename)}`;
+
+  const res = await fetchFn(`${GRAPH_ROOT}/me/drive/root:${uploadPath}:/content`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": params.contentType ?? "application/octet-stream",
+    },
+    body: new Uint8Array(params.buffer),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`OneDrive upload failed: ${res.status} ${res.statusText} - ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    id?: string;
+    webUrl?: string;
+    name?: string;
+  };
+
+  if (!data.id || !data.webUrl || !data.name) {
+    throw new Error("OneDrive upload response missing required fields");
+  }
+
+  return {
+    id: data.id,
+    webUrl: data.webUrl,
+    name: data.name,
+  };
+}
+
+export interface OneDriveSharingLink {
+  webUrl: string;
+}
+
+/**
+ * Create a sharing link for a OneDrive file.
+ * The link allows organization members to view the file.
+ */
+export async function createSharingLink(params: {
+  itemId: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  /** Sharing scope: "organization" (default) or "anonymous" */
+  scope?: "organization" | "anonymous";
+  fetchFn?: typeof fetch;
+}): Promise<OneDriveSharingLink> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+
+  const res = await fetchFn(`${GRAPH_ROOT}/me/drive/items/${params.itemId}/createLink`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      type: "view",
+      scope: params.scope ?? "organization",
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Create sharing link failed: ${res.status} ${res.statusText} - ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    link?: { webUrl?: string };
+  };
+
+  if (!data.link?.webUrl) {
+    throw new Error("Create sharing link response missing webUrl");
+  }
+
+  return {
+    webUrl: data.link.webUrl,
+  };
+}
+
+/**
+ * Upload a file to OneDrive and create a sharing link.
+ * Convenience function for the common case.
+ */
+export async function uploadAndShareOneDrive(params: {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  scope?: "organization" | "anonymous";
+  fetchFn?: typeof fetch;
+}): Promise<{
+  itemId: string;
+  webUrl: string;
+  shareUrl: string;
+  name: string;
+}> {
+  const uploaded = await uploadToOneDrive({
+    buffer: params.buffer,
+    filename: params.filename,
+    contentType: params.contentType,
+    tokenProvider: params.tokenProvider,
+    fetchFn: params.fetchFn,
+  });
+
+  const shareLink = await createSharingLink({
+    itemId: uploaded.id,
+    tokenProvider: params.tokenProvider,
+    scope: params.scope,
+    fetchFn: params.fetchFn,
+  });
+
+  return {
+    itemId: uploaded.id,
+    webUrl: uploaded.webUrl,
+    shareUrl: shareLink.webUrl,
+    name: uploaded.name,
+  };
+}
+
+// ============================================================================
+// SharePoint upload functions for group chats and channels
+// ============================================================================
+
+/**
+ * Upload a file to a SharePoint site.
+ * This is used for group chats and channels where /me/drive doesn't work for bots.
+ *
+ * @param params.siteId - SharePoint site ID (e.g., "contoso.sharepoint.com,guid1,guid2")
+ */
+export async function uploadToSharePoint(params: {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  siteId: string;
+  fetchFn?: typeof fetch;
+}): Promise<OneDriveUploadResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+
+  // Use "ClawdbotShared" folder to organize bot-uploaded files
+  const uploadPath = `/ClawdbotShared/${encodeURIComponent(params.filename)}`;
+
+  const res = await fetchFn(`${GRAPH_ROOT}/sites/${params.siteId}/drive/root:${uploadPath}:/content`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": params.contentType ?? "application/octet-stream",
+    },
+    body: new Uint8Array(params.buffer),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`SharePoint upload failed: ${res.status} ${res.statusText} - ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    id?: string;
+    webUrl?: string;
+    name?: string;
+  };
+
+  if (!data.id || !data.webUrl || !data.name) {
+    throw new Error("SharePoint upload response missing required fields");
+  }
+
+  return {
+    id: data.id,
+    webUrl: data.webUrl,
+    name: data.name,
+  };
+}
+
+export interface ChatMember {
+  aadObjectId: string;
+  displayName?: string;
+}
+
+/**
+ * Properties needed for native Teams file card attachments.
+ * The eTag is used as the attachment ID and webDavUrl as the contentUrl.
+ */
+export interface DriveItemProperties {
+  /** The eTag of the driveItem (used as attachment ID) */
+  eTag: string;
+  /** The WebDAV URL of the driveItem (used as contentUrl for reference attachment) */
+  webDavUrl: string;
+  /** The filename */
+  name: string;
+}
+
+/**
+ * Get driveItem properties needed for native Teams file card attachments.
+ * This fetches the eTag and webDavUrl which are required for "reference" type attachments.
+ *
+ * @param params.siteId - SharePoint site ID
+ * @param params.itemId - The driveItem ID (returned from upload)
+ */
+export async function getDriveItemProperties(params: {
+  siteId: string;
+  itemId: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  fetchFn?: typeof fetch;
+}): Promise<DriveItemProperties> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+
+  const res = await fetchFn(
+    `${GRAPH_ROOT}/sites/${params.siteId}/drive/items/${params.itemId}?$select=eTag,webDavUrl,name`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Get driveItem properties failed: ${res.status} ${res.statusText} - ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    eTag?: string;
+    webDavUrl?: string;
+    name?: string;
+  };
+
+  if (!data.eTag || !data.webDavUrl || !data.name) {
+    throw new Error("DriveItem response missing required properties (eTag, webDavUrl, or name)");
+  }
+
+  return {
+    eTag: data.eTag,
+    webDavUrl: data.webDavUrl,
+    name: data.name,
+  };
+}
+
+/**
+ * Get members of a Teams chat for per-user sharing.
+ * Used to create sharing links scoped to only the chat participants.
+ */
+export async function getChatMembers(params: {
+  chatId: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  fetchFn?: typeof fetch;
+}): Promise<ChatMember[]> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+
+  const res = await fetchFn(`${GRAPH_ROOT}/chats/${params.chatId}/members`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Get chat members failed: ${res.status} ${res.statusText} - ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    value?: Array<{
+      userId?: string;
+      displayName?: string;
+    }>;
+  };
+
+  return (data.value ?? [])
+    .map((m) => ({
+      aadObjectId: m.userId ?? "",
+      displayName: m.displayName,
+    }))
+    .filter((m) => m.aadObjectId);
+}
+
+/**
+ * Create a sharing link for a SharePoint drive item.
+ * For organization scope (default), uses v1.0 API.
+ * For per-user scope, uses beta API with recipients.
+ */
+export async function createSharePointSharingLink(params: {
+  siteId: string;
+  itemId: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  /** Sharing scope: "organization" (default) or "users" (per-user with recipients) */
+  scope?: "organization" | "users";
+  /** Required when scope is "users": AAD object IDs of recipients */
+  recipientObjectIds?: string[];
+  fetchFn?: typeof fetch;
+}): Promise<OneDriveSharingLink> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const token = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
+  const scope = params.scope ?? "organization";
+
+  // Per-user sharing requires beta API
+  const apiRoot = scope === "users" ? GRAPH_BETA : GRAPH_ROOT;
+
+  const body: Record<string, unknown> = {
+    type: "view",
+    scope: scope === "users" ? "users" : "organization",
+  };
+
+  // Add recipients for per-user sharing
+  if (scope === "users" && params.recipientObjectIds?.length) {
+    body.recipients = params.recipientObjectIds.map((id) => ({ objectId: id }));
+  }
+
+  const res = await fetchFn(`${apiRoot}/sites/${params.siteId}/drive/items/${params.itemId}/createLink`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const respBody = await res.text().catch(() => "");
+    throw new Error(`Create SharePoint sharing link failed: ${res.status} ${res.statusText} - ${respBody}`);
+  }
+
+  const data = (await res.json()) as {
+    link?: { webUrl?: string };
+  };
+
+  if (!data.link?.webUrl) {
+    throw new Error("Create SharePoint sharing link response missing webUrl");
+  }
+
+  return {
+    webUrl: data.link.webUrl,
+  };
+}
+
+/**
+ * Upload a file to SharePoint and create a sharing link.
+ *
+ * For group chats, this creates a per-user sharing link scoped to chat members.
+ * For channels, this creates an organization-wide sharing link.
+ *
+ * @param params.siteId - SharePoint site ID
+ * @param params.chatId - Optional chat ID for per-user sharing (group chats)
+ * @param params.usePerUserSharing - Whether to use per-user sharing (requires beta API + Chat.Read.All)
+ */
+export async function uploadAndShareSharePoint(params: {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  siteId: string;
+  chatId?: string;
+  usePerUserSharing?: boolean;
+  fetchFn?: typeof fetch;
+}): Promise<{
+  itemId: string;
+  webUrl: string;
+  shareUrl: string;
+  name: string;
+}> {
+  // 1. Upload file to SharePoint
+  const uploaded = await uploadToSharePoint({
+    buffer: params.buffer,
+    filename: params.filename,
+    contentType: params.contentType,
+    tokenProvider: params.tokenProvider,
+    siteId: params.siteId,
+    fetchFn: params.fetchFn,
+  });
+
+  // 2. Determine sharing scope
+  let scope: "organization" | "users" = "organization";
+  let recipientObjectIds: string[] | undefined;
+
+  if (params.usePerUserSharing && params.chatId) {
+    try {
+      const members = await getChatMembers({
+        chatId: params.chatId,
+        tokenProvider: params.tokenProvider,
+        fetchFn: params.fetchFn,
+      });
+
+      if (members.length > 0) {
+        scope = "users";
+        recipientObjectIds = members.map((m) => m.aadObjectId);
+      }
+    } catch {
+      // Fall back to organization scope if we can't get chat members
+      // (e.g., missing Chat.Read.All permission)
+    }
+  }
+
+  // 3. Create sharing link
+  const shareLink = await createSharePointSharingLink({
+    siteId: params.siteId,
+    itemId: uploaded.id,
+    tokenProvider: params.tokenProvider,
+    scope,
+    recipientObjectIds,
+    fetchFn: params.fetchFn,
+  });
+
+  return {
+    itemId: uploaded.id,
+    webUrl: uploaded.webUrl,
+    shareUrl: shareLink.webUrl,
+    name: uploaded.name,
+  };
+}

--- a/extensions/msteams/src/media-helpers.test.ts
+++ b/extensions/msteams/src/media-helpers.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
+
+describe("msteams media-helpers", () => {
+  describe("getMimeType", () => {
+    it("detects png from URL", async () => {
+      expect(await getMimeType("https://example.com/image.png")).toBe("image/png");
+    });
+
+    it("detects jpeg from URL (both extensions)", async () => {
+      expect(await getMimeType("https://example.com/photo.jpg")).toBe("image/jpeg");
+      expect(await getMimeType("https://example.com/photo.jpeg")).toBe("image/jpeg");
+    });
+
+    it("detects gif from URL", async () => {
+      expect(await getMimeType("https://example.com/anim.gif")).toBe("image/gif");
+    });
+
+    it("detects webp from URL", async () => {
+      expect(await getMimeType("https://example.com/modern.webp")).toBe("image/webp");
+    });
+
+    it("handles URLs with query strings", async () => {
+      expect(await getMimeType("https://example.com/image.png?v=123")).toBe("image/png");
+    });
+
+    it("handles data URLs", async () => {
+      expect(await getMimeType("data:image/png;base64,iVBORw0KGgo=")).toBe("image/png");
+      expect(await getMimeType("data:image/jpeg;base64,/9j/4AAQ")).toBe("image/jpeg");
+      expect(await getMimeType("data:image/gif;base64,R0lGOD")).toBe("image/gif");
+    });
+
+    it("handles data URLs without base64", async () => {
+      expect(await getMimeType("data:image/svg+xml,%3Csvg")).toBe("image/svg+xml");
+    });
+
+    it("handles local paths", async () => {
+      expect(await getMimeType("/tmp/image.png")).toBe("image/png");
+      expect(await getMimeType("/Users/test/photo.jpg")).toBe("image/jpeg");
+    });
+
+    it("handles tilde paths", async () => {
+      expect(await getMimeType("~/Downloads/image.gif")).toBe("image/gif");
+    });
+
+    it("defaults to application/octet-stream for unknown extensions", async () => {
+      expect(await getMimeType("https://example.com/image")).toBe("application/octet-stream");
+      expect(await getMimeType("https://example.com/image.unknown")).toBe("application/octet-stream");
+    });
+
+    it("is case-insensitive", async () => {
+      expect(await getMimeType("https://example.com/IMAGE.PNG")).toBe("image/png");
+      expect(await getMimeType("https://example.com/Photo.JPEG")).toBe("image/jpeg");
+    });
+
+    it("detects document types", async () => {
+      expect(await getMimeType("https://example.com/doc.pdf")).toBe("application/pdf");
+      expect(await getMimeType("https://example.com/doc.docx")).toBe(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      );
+      expect(await getMimeType("https://example.com/spreadsheet.xlsx")).toBe(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      );
+    });
+  });
+
+  describe("extractFilename", () => {
+    it("extracts filename from URL with extension", async () => {
+      expect(await extractFilename("https://example.com/photo.jpg")).toBe("photo.jpg");
+    });
+
+    it("extracts filename from URL with path", async () => {
+      expect(await extractFilename("https://example.com/images/2024/photo.png")).toBe("photo.png");
+    });
+
+    it("handles URLs without extension by deriving from MIME", async () => {
+      // Now defaults to application/octet-stream → .bin fallback
+      expect(await extractFilename("https://example.com/images/photo")).toBe("photo.bin");
+    });
+
+    it("handles data URLs", async () => {
+      expect(await extractFilename("data:image/png;base64,iVBORw0KGgo=")).toBe("image.png");
+      expect(await extractFilename("data:image/jpeg;base64,/9j/4AAQ")).toBe("image.jpg");
+    });
+
+    it("handles document data URLs", async () => {
+      expect(await extractFilename("data:application/pdf;base64,JVBERi0")).toBe("file.pdf");
+    });
+
+    it("handles local paths", async () => {
+      expect(await extractFilename("/tmp/screenshot.png")).toBe("screenshot.png");
+      expect(await extractFilename("/Users/test/photo.jpg")).toBe("photo.jpg");
+    });
+
+    it("handles tilde paths", async () => {
+      expect(await extractFilename("~/Downloads/image.gif")).toBe("image.gif");
+    });
+
+    it("returns fallback for empty URL", async () => {
+      expect(await extractFilename("")).toBe("file.bin");
+    });
+
+    it("extracts original filename from embedded pattern", async () => {
+      // Pattern: {original}---{uuid}.{ext}
+      expect(
+        await extractFilename("/media/inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf"),
+      ).toBe("report.pdf");
+    });
+
+    it("extracts original filename with uppercase UUID", async () => {
+      expect(
+        await extractFilename("/media/inbound/Document---A1B2C3D4-E5F6-7890-ABCD-EF1234567890.docx"),
+      ).toBe("Document.docx");
+    });
+
+    it("falls back to UUID filename for legacy paths", async () => {
+      // UUID-only filename (legacy format, no embedded name)
+      expect(
+        await extractFilename("/media/inbound/a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf"),
+      ).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf");
+    });
+
+    it("handles --- in filename without valid UUID pattern", async () => {
+      // foo---bar.txt (bar is not a valid UUID)
+      expect(await extractFilename("/media/inbound/foo---bar.txt")).toBe("foo---bar.txt");
+    });
+  });
+
+  describe("isLocalPath", () => {
+    it("returns true for file:// URLs", () => {
+      expect(isLocalPath("file:///tmp/image.png")).toBe(true);
+      expect(isLocalPath("file://localhost/tmp/image.png")).toBe(true);
+    });
+
+    it("returns true for absolute paths", () => {
+      expect(isLocalPath("/tmp/image.png")).toBe(true);
+      expect(isLocalPath("/Users/test/photo.jpg")).toBe(true);
+    });
+
+    it("returns true for tilde paths", () => {
+      expect(isLocalPath("~/Downloads/image.png")).toBe(true);
+    });
+
+    it("returns false for http URLs", () => {
+      expect(isLocalPath("http://example.com/image.png")).toBe(false);
+      expect(isLocalPath("https://example.com/image.png")).toBe(false);
+    });
+
+    it("returns false for data URLs", () => {
+      expect(isLocalPath("data:image/png;base64,iVBORw0KGgo=")).toBe(false);
+    });
+  });
+
+  describe("extractMessageId", () => {
+    it("extracts id from valid response", () => {
+      expect(extractMessageId({ id: "msg123" })).toBe("msg123");
+    });
+
+    it("returns null for missing id", () => {
+      expect(extractMessageId({ foo: "bar" })).toBeNull();
+    });
+
+    it("returns null for empty id", () => {
+      expect(extractMessageId({ id: "" })).toBeNull();
+    });
+
+    it("returns null for non-string id", () => {
+      expect(extractMessageId({ id: 123 })).toBeNull();
+      expect(extractMessageId({ id: null })).toBeNull();
+    });
+
+    it("returns null for null response", () => {
+      expect(extractMessageId(null)).toBeNull();
+    });
+
+    it("returns null for undefined response", () => {
+      expect(extractMessageId(undefined)).toBeNull();
+    });
+
+    it("returns null for non-object response", () => {
+      expect(extractMessageId("string")).toBeNull();
+      expect(extractMessageId(123)).toBeNull();
+    });
+  });
+});

--- a/extensions/msteams/src/media-helpers.ts
+++ b/extensions/msteams/src/media-helpers.ts
@@ -1,0 +1,77 @@
+/**
+ * MIME type detection and filename extraction for MSTeams media attachments.
+ */
+
+import path from "node:path";
+
+import {
+  detectMime,
+  extensionForMime,
+  extractOriginalFilename,
+  getFileExtension,
+} from "clawdbot/plugin-sdk";
+
+/**
+ * Detect MIME type from URL extension or data URL.
+ * Uses shared MIME detection for consistency with core handling.
+ */
+export async function getMimeType(url: string): Promise<string> {
+  // Handle data URLs: data:image/png;base64,...
+  if (url.startsWith("data:")) {
+    const match = url.match(/^data:([^;,]+)/);
+    if (match?.[1]) return match[1];
+  }
+
+  // Use shared MIME detection (extension-based for URLs)
+  const detected = await detectMime({ filePath: url });
+  return detected ?? "application/octet-stream";
+}
+
+/**
+ * Extract filename from URL or local path.
+ * For local paths, extracts original filename if stored with embedded name pattern.
+ * Falls back to deriving the extension from MIME type when no extension present.
+ */
+export async function extractFilename(url: string): Promise<string> {
+  // Handle data URLs: derive extension from MIME
+  if (url.startsWith("data:")) {
+    const mime = await getMimeType(url);
+    const ext = extensionForMime(mime) ?? ".bin";
+    const prefix = mime.startsWith("image/") ? "image" : "file";
+    return `${prefix}${ext}`;
+  }
+
+  // Try to extract from URL pathname
+  try {
+    const pathname = new URL(url).pathname;
+    const basename = path.basename(pathname);
+    const existingExt = getFileExtension(pathname);
+    if (basename && existingExt) return basename;
+    // No extension in URL, derive from MIME
+    const mime = await getMimeType(url);
+    const ext = extensionForMime(mime) ?? ".bin";
+    const prefix = mime.startsWith("image/") ? "image" : "file";
+    return basename ? `${basename}${ext}` : `${prefix}${ext}`;
+  } catch {
+    // Local paths - use extractOriginalFilename to extract embedded original name
+    return extractOriginalFilename(url);
+  }
+}
+
+/**
+ * Check if a URL refers to a local file path.
+ */
+export function isLocalPath(url: string): boolean {
+  return url.startsWith("file://") || url.startsWith("/") || url.startsWith("~");
+}
+
+/**
+ * Extract the message ID from a Bot Framework response.
+ */
+export function extractMessageId(response: unknown): string | null {
+  if (!response || typeof response !== "object") return null;
+  if (!("id" in response)) return null;
+  const { id } = response as { id?: unknown };
+  if (typeof id !== "string" || !id) return null;
+  return id;
+}

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -51,7 +51,7 @@ describe("msteams messenger", () => {
         [{ text: "hi", mediaUrl: "https://example.com/a.png" }],
         { textChunkLimit: 4000 },
       );
-      expect(messages).toEqual(["hi", "https://example.com/a.png"]);
+      expect(messages).toEqual([{ text: "hi" }, { mediaUrl: "https://example.com/a.png" }]);
     });
 
     it("supports inline media mode", () => {
@@ -59,7 +59,7 @@ describe("msteams messenger", () => {
         [{ text: "hi", mediaUrl: "https://example.com/a.png" }],
         { textChunkLimit: 4000, mediaMode: "inline" },
       );
-      expect(messages).toEqual(["hi\n\nhttps://example.com/a.png"]);
+      expect(messages).toEqual([{ text: "hi", mediaUrl: "https://example.com/a.png" }]);
     });
 
     it("chunks long text when enabled", () => {
@@ -101,7 +101,7 @@ describe("msteams messenger", () => {
         appId: "app123",
         conversationRef: baseRef,
         context: ctx,
-        messages: ["one", "two"],
+        messages: [{ text: "one" }, { text: "two" }],
       });
 
       expect(sent).toEqual(["one", "two"]);
@@ -129,7 +129,7 @@ describe("msteams messenger", () => {
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        messages: ["hello"],
+        messages: [{ text: "hello" }],
       });
 
       expect(seen.texts).toEqual(["hello"]);
@@ -168,7 +168,7 @@ describe("msteams messenger", () => {
         appId: "app123",
         conversationRef: baseRef,
         context: ctx,
-        messages: ["one"],
+        messages: [{ text: "one" }],
         retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
         onRetry: (e) => retryEvents.push({ nextAttempt: e.nextAttempt, delayMs: e.delayMs }),
       });
@@ -196,7 +196,7 @@ describe("msteams messenger", () => {
           appId: "app123",
           conversationRef: baseRef,
           context: ctx,
-          messages: ["one"],
+          messages: [{ text: "one" }],
           retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
         }),
       ).rejects.toMatchObject({ statusCode: 400 });
@@ -227,7 +227,7 @@ describe("msteams messenger", () => {
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        messages: ["hello"],
+        messages: [{ text: "hello" }],
         retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
       });
 

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,8 +1,14 @@
 import type { ClawdbotConfig, RuntimeEnv } from "clawdbot/plugin-sdk";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
+import {
+  buildFileInfoCard,
+  parseFileConsentInvoke,
+  uploadToConsentUrl,
+} from "./file-consent.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import type { MSTeamsPollStore } from "./polls.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
@@ -17,6 +23,7 @@ export type MSTeamsActivityHandler = {
   onMembersAdded: (
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
   ) => MSTeamsActivityHandler;
+  run?: (context: unknown) => Promise<void>;
 };
 
 export type MSTeamsMessageHandlerDeps = {
@@ -32,11 +39,109 @@ export type MSTeamsMessageHandlerDeps = {
   log: MSTeamsMonitorLogger;
 };
 
+/**
+ * Handle fileConsent/invoke activities for large file uploads.
+ */
+async function handleFileConsentInvoke(
+  context: MSTeamsTurnContext,
+  log: MSTeamsMonitorLogger,
+): Promise<boolean> {
+  const activity = context.activity;
+  if (activity.type !== "invoke" || activity.name !== "fileConsent/invoke") {
+    return false;
+  }
+
+  const consentResponse = parseFileConsentInvoke(activity);
+  if (!consentResponse) {
+    log.debug("invalid file consent invoke", { value: activity.value });
+    return false;
+  }
+
+  const uploadId =
+    typeof consentResponse.context?.uploadId === "string"
+      ? consentResponse.context.uploadId
+      : undefined;
+
+  if (consentResponse.action === "accept" && consentResponse.uploadInfo) {
+    const pendingFile = getPendingUpload(uploadId);
+    if (pendingFile) {
+      log.debug("user accepted file consent, uploading", {
+        uploadId,
+        filename: pendingFile.filename,
+        size: pendingFile.buffer.length,
+      });
+
+      try {
+        // Upload file to the provided URL
+        await uploadToConsentUrl({
+          url: consentResponse.uploadInfo.uploadUrl,
+          buffer: pendingFile.buffer,
+          contentType: pendingFile.contentType,
+        });
+
+        // Send confirmation card
+        const fileInfoCard = buildFileInfoCard({
+          filename: consentResponse.uploadInfo.name,
+          contentUrl: consentResponse.uploadInfo.contentUrl,
+          uniqueId: consentResponse.uploadInfo.uniqueId,
+          fileType: consentResponse.uploadInfo.fileType,
+        });
+
+        await context.sendActivity({
+          type: "message",
+          attachments: [fileInfoCard],
+        });
+
+        log.info("file upload complete", {
+          uploadId,
+          filename: consentResponse.uploadInfo.name,
+          uniqueId: consentResponse.uploadInfo.uniqueId,
+        });
+      } catch (err) {
+        log.debug("file upload failed", { uploadId, error: String(err) });
+        await context.sendActivity(`File upload failed: ${String(err)}`);
+      } finally {
+        removePendingUpload(uploadId);
+      }
+    } else {
+      log.debug("pending file not found for consent", { uploadId });
+      await context.sendActivity(
+        "The file upload request has expired. Please try sending the file again.",
+      );
+    }
+  } else {
+    // User declined
+    log.debug("user declined file consent", { uploadId });
+    removePendingUpload(uploadId);
+  }
+
+  return true;
+}
+
 export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   handler: T,
   deps: MSTeamsMessageHandlerDeps,
 ): T {
   const handleTeamsMessage = createMSTeamsMessageHandler(deps);
+
+  // Wrap the original run method to intercept invokes
+  const originalRun = handler.run;
+  if (originalRun) {
+    handler.run = async (context: unknown) => {
+      const ctx = context as MSTeamsTurnContext;
+      // Handle file consent invokes before passing to normal flow
+      if (ctx.activity?.type === "invoke" && ctx.activity?.name === "fileConsent/invoke") {
+        const handled = await handleFileConsentInvoke(ctx, deps.log);
+        if (handled) {
+          // Send invoke response for file consent
+          await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
+          return;
+        }
+      }
+      return originalRun.call(handler, context);
+    };
+  }
+
   handler.onMessage(async (context, next) => {
     try {
       await handleTeamsMessage(context as MSTeamsTurnContext);

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -1,7 +1,7 @@
 import {
   buildMSTeamsGraphMessageUrls,
+  downloadMSTeamsAttachments,
   downloadMSTeamsGraphMedia,
-  downloadMSTeamsImageAttachments,
   type MSTeamsAccessTokenProvider,
   type MSTeamsAttachmentLike,
   type MSTeamsHtmlAttachmentSummary,
@@ -24,6 +24,8 @@ export async function resolveMSTeamsInboundMedia(params: {
   conversationMessageId?: string;
   activity: Pick<MSTeamsTurnContext["activity"], "id" | "replyToId" | "channelData">;
   log: MSTeamsLogger;
+  /** When true, embeds original filename in stored path for later extraction. */
+  preserveFilenames?: boolean;
 }): Promise<MSTeamsInboundMedia[]> {
   const {
     attachments,
@@ -36,13 +38,15 @@ export async function resolveMSTeamsInboundMedia(params: {
     conversationMessageId,
     activity,
     log,
+    preserveFilenames,
   } = params;
 
-  let mediaList = await downloadMSTeamsImageAttachments({
+  let mediaList = await downloadMSTeamsAttachments({
     attachments,
     maxBytes,
     tokenProvider,
     allowHosts,
+    preserveFilenames,
   });
 
   if (mediaList.length === 0) {
@@ -81,6 +85,7 @@ export async function resolveMSTeamsInboundMedia(params: {
             tokenProvider,
             maxBytes,
             allowHosts,
+            preserveFilenames,
           });
           attempts.push({
             url: messageUrl,
@@ -104,7 +109,7 @@ export async function resolveMSTeamsInboundMedia(params: {
   }
 
   if (mediaList.length > 0) {
-    log.debug("downloaded image attachments", { count: mediaList.length });
+    log.debug("downloaded attachments", { count: mediaList.length });
   } else if (htmlSummary?.imgTags) {
     log.debug("inline images detected but none downloaded", {
       imgTags: htmlSummary.imgTags,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -402,7 +402,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         channelData: activity.channelData,
       },
       log,
-	    });
+      preserveFilenames: cfg.media?.preserveFilenames,
+    });
 
 	    const mediaPayload = buildMSTeamsMediaPayload(mediaList);
 	    const envelopeFrom = isDirectMessage ? senderName : conversationType;
@@ -476,6 +477,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     logVerboseMessage(`msteams inbound: from=${ctxPayload.From} preview="${preview}"`);
 
+    const sharePointSiteId = msteamsCfg?.sharePointSiteId;
     const { dispatcher, replyOptions, markDispatchIdle } = createMSTeamsReplyDispatcher({
       cfg,
       agentId: route.agentId,
@@ -492,6 +494,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           recordMSTeamsSentMessage(conversationId, id);
         }
       },
+      tokenProvider,
+      sharePointSiteId,
     });
 
     log.info("dispatching to agent", { sessionKey: route.sessionKey });

--- a/extensions/msteams/src/pending-uploads.ts
+++ b/extensions/msteams/src/pending-uploads.ts
@@ -1,0 +1,87 @@
+/**
+ * In-memory storage for files awaiting user consent in the FileConsentCard flow.
+ *
+ * When sending large files (>=4MB) in personal chats, Teams requires user consent
+ * before upload. This module stores the file data temporarily until the user
+ * accepts or declines, or until the TTL expires.
+ */
+
+import crypto from "node:crypto";
+
+export interface PendingUpload {
+  id: string;
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  conversationId: string;
+  createdAt: number;
+}
+
+const pendingUploads = new Map<string, PendingUpload>();
+
+/** TTL for pending uploads: 5 minutes */
+const PENDING_UPLOAD_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Store a file pending user consent.
+ * Returns the upload ID to include in the FileConsentCard context.
+ */
+export function storePendingUpload(
+  upload: Omit<PendingUpload, "id" | "createdAt">,
+): string {
+  const id = crypto.randomUUID();
+  const entry: PendingUpload = {
+    ...upload,
+    id,
+    createdAt: Date.now(),
+  };
+  pendingUploads.set(id, entry);
+
+  // Auto-cleanup after TTL
+  setTimeout(() => {
+    pendingUploads.delete(id);
+  }, PENDING_UPLOAD_TTL_MS);
+
+  return id;
+}
+
+/**
+ * Retrieve a pending upload by ID.
+ * Returns undefined if not found or expired.
+ */
+export function getPendingUpload(id?: string): PendingUpload | undefined {
+  if (!id) return undefined;
+  const entry = pendingUploads.get(id);
+  if (!entry) return undefined;
+
+  // Check if expired (in case timeout hasn't fired yet)
+  if (Date.now() - entry.createdAt > PENDING_UPLOAD_TTL_MS) {
+    pendingUploads.delete(id);
+    return undefined;
+  }
+
+  return entry;
+}
+
+/**
+ * Remove a pending upload (after successful upload or user decline).
+ */
+export function removePendingUpload(id?: string): void {
+  if (id) {
+    pendingUploads.delete(id);
+  }
+}
+
+/**
+ * Get the count of pending uploads (for monitoring/debugging).
+ */
+export function getPendingUploadCount(): number {
+  return pendingUploads.size;
+}
+
+/**
+ * Clear all pending uploads (for testing).
+ */
+export function clearPendingUploads(): void {
+  pendingUploads.clear();
+}

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -76,7 +76,7 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
       | undefined;
     try {
       const graphToken = await tokenProvider.getAccessToken(
-        "https://graph.microsoft.com/.default",
+        "https://graph.microsoft.com",
       );
       const accessToken = readAccessToken(graphToken);
       const payload = accessToken ? decodeJwtPayload(accessToken) : null;

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -143,7 +143,7 @@ async function resolveGraphToken(cfg: unknown): Promise<string> {
   if (!creds) throw new Error("MS Teams credentials missing");
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
   const tokenProvider = new sdk.MsalTokenProvider(authConfig);
-  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
   const accessToken = readAccessToken(token);
   if (!accessToken) throw new Error("MS Teams graph token unavailable");
   return accessToken;

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -1,18 +1,22 @@
+import { loadWebMedia, resolveChannelMediaMaxBytes } from "clawdbot/plugin-sdk";
 import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
-import type { StoredConversationReference } from "./conversation-store.js";
 import { createMSTeamsConversationStoreFs } from "./conversation-store-fs.js";
 import {
   classifyMSTeamsSendError,
   formatMSTeamsSendErrorHint,
   formatUnknownError,
 } from "./errors.js";
+import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
+import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
-  buildConversationReference,
-  type MSTeamsAdapter,
-  sendMSTeamsMessages,
-} from "./messenger.js";
+  getDriveItemProperties,
+  uploadAndShareOneDrive,
+  uploadAndShareSharePoint,
+} from "./graph-upload.js";
+import { extractFilename, extractMessageId } from "./media-helpers.js";
+import { buildConversationReference, sendMSTeamsMessages } from "./messenger.js";
 import { buildMSTeamsPollCard } from "./polls.js";
-import { resolveMSTeamsSendContext } from "./send-context.js";
+import { resolveMSTeamsSendContext, type MSTeamsProactiveContext } from "./send-context.js";
 
 export type SendMSTeamsMessageParams = {
   /** Full config (for credentials) */
@@ -28,7 +32,18 @@ export type SendMSTeamsMessageParams = {
 export type SendMSTeamsMessageResult = {
   messageId: string;
   conversationId: string;
+  /** If a FileConsentCard was sent instead of the file, this contains the upload ID */
+  pendingUploadId?: string;
 };
+
+/** Threshold for large files that require FileConsentCard flow in personal chats */
+const FILE_CONSENT_THRESHOLD_BYTES = 4 * 1024 * 1024; // 4MB
+
+/**
+ * MSTeams-specific media size limit (100MB).
+ * Higher than the default because OneDrive upload handles large files well.
+ */
+const MSTEAMS_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
 
 export type SendMSTeamsPollParams = {
   /** Full config (for credentials) */
@@ -49,32 +64,19 @@ export type SendMSTeamsPollResult = {
   conversationId: string;
 };
 
-function extractMessageId(response: unknown): string | null {
-  if (!response || typeof response !== "object") return null;
-  if (!("id" in response)) return null;
-  const { id } = response as { id?: unknown };
-  if (typeof id !== "string" || !id) return null;
-  return id;
-}
+export type SendMSTeamsCardParams = {
+  /** Full config (for credentials) */
+  cfg: ClawdbotConfig;
+  /** Conversation ID or user ID to send to */
+  to: string;
+  /** Adaptive Card JSON object */
+  card: Record<string, unknown>;
+};
 
-async function sendMSTeamsActivity(params: {
-  adapter: MSTeamsAdapter;
-  appId: string;
-  conversationRef: StoredConversationReference;
-  activity: Record<string, unknown>;
-}): Promise<string> {
-  const baseRef = buildConversationReference(params.conversationRef);
-  const proactiveRef = {
-    ...baseRef,
-    activityId: undefined,
-  };
-  let messageId = "unknown";
-  await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
-    const response = await ctx.sendActivity(params.activity);
-    messageId = extractMessageId(response) ?? "unknown";
-  });
-  return messageId;
-}
+export type SendMSTeamsCardResult = {
+  messageId: string;
+  conversationId: string;
+};
 
 /**
  * Send a message to a Teams conversation or user.
@@ -82,23 +84,219 @@ async function sendMSTeamsActivity(params: {
  * Uses the stored ConversationReference from previous interactions.
  * The bot must have received at least one message from the conversation
  * before proactive messaging works.
+ *
+ * File handling by conversation type:
+ * - Personal (1:1) chats: small images (<4MB) use base64, large files and non-images use FileConsentCard
+ * - Group chats / channels: files are uploaded to OneDrive and shared via link
  */
 export async function sendMessageMSTeams(
   params: SendMSTeamsMessageParams,
 ): Promise<SendMSTeamsMessageResult> {
   const { cfg, to, text, mediaUrl } = params;
-  const { adapter, appId, conversationId, ref, log } = await resolveMSTeamsSendContext({
-    cfg,
-    to,
-  });
+  const ctx = await resolveMSTeamsSendContext({ cfg, to });
+  const { adapter, appId, conversationId, ref, log, conversationType, tokenProvider, sharePointSiteId } = ctx;
 
   log.debug("sending proactive message", {
     conversationId,
+    conversationType,
     textLength: text.length,
     hasMedia: Boolean(mediaUrl),
   });
 
-  const message = mediaUrl ? (text ? `${text}\n\n${mediaUrl}` : mediaUrl) : text;
+  // Handle media if present
+  if (mediaUrl) {
+    const mediaMaxBytes = resolveChannelMediaMaxBytes({
+      cfg,
+      resolveChannelLimitMb: ({ cfg }) => cfg.channels?.msteams?.mediaMaxMb,
+    }) ?? MSTEAMS_MAX_MEDIA_BYTES;
+    const media = await loadWebMedia(mediaUrl, mediaMaxBytes);
+    const isLargeFile = media.buffer.length >= FILE_CONSENT_THRESHOLD_BYTES;
+    const isImage = media.contentType?.startsWith("image/") ?? false;
+    const fallbackFileName = await extractFilename(mediaUrl);
+    const fileName = media.fileName ?? fallbackFileName;
+
+    log.debug("processing media", {
+      fileName,
+      contentType: media.contentType,
+      size: media.buffer.length,
+      isLargeFile,
+      isImage,
+      conversationType,
+    });
+
+    // Personal chats: base64 only works for images; use FileConsentCard for large files or non-images
+    if (requiresFileConsent({
+      conversationType,
+      contentType: media.contentType,
+      bufferSize: media.buffer.length,
+      thresholdBytes: FILE_CONSENT_THRESHOLD_BYTES,
+    })) {
+      const { activity, uploadId } = prepareFileConsentActivity({
+        media: { buffer: media.buffer, filename: fileName, contentType: media.contentType },
+        conversationId,
+        description: text || undefined,
+      });
+
+      log.debug("sending file consent card", { uploadId, fileName, size: media.buffer.length });
+
+      const baseRef = buildConversationReference(ref);
+      const proactiveRef = { ...baseRef, activityId: undefined };
+
+      let messageId = "unknown";
+      try {
+        await adapter.continueConversation(appId, proactiveRef, async (turnCtx) => {
+          const response = await turnCtx.sendActivity(activity);
+          messageId = extractMessageId(response) ?? "unknown";
+        });
+      } catch (err) {
+        const classification = classifyMSTeamsSendError(err);
+        const hint = formatMSTeamsSendErrorHint(classification);
+        const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
+        throw new Error(
+          `msteams consent card send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
+        );
+      }
+
+      log.info("sent file consent card", { conversationId, messageId, uploadId });
+
+      return {
+        messageId,
+        conversationId,
+        pendingUploadId: uploadId,
+      };
+    }
+
+    // Personal chat with small image: use base64 (only works for images)
+    if (conversationType === "personal") {
+
+      // Small image in personal chat: use base64 (only works for images)
+      const base64 = media.buffer.toString("base64");
+      const finalMediaUrl = `data:${media.contentType};base64,${base64}`;
+
+      return sendTextWithMedia(ctx, text, finalMediaUrl);
+    }
+
+    // Group chat or channel: upload to SharePoint (if siteId configured) or OneDrive
+    try {
+      if (sharePointSiteId) {
+        // Use SharePoint upload + Graph API for native file card
+        log.debug("uploading to SharePoint for native file card", {
+          fileName,
+          conversationType,
+          siteId: sharePointSiteId,
+        });
+
+        const uploaded = await uploadAndShareSharePoint({
+          buffer: media.buffer,
+          filename: fileName,
+          contentType: media.contentType,
+          tokenProvider,
+          siteId: sharePointSiteId,
+          chatId: conversationId,
+          usePerUserSharing: conversationType === "groupChat",
+        });
+
+        log.debug("SharePoint upload complete", {
+          itemId: uploaded.itemId,
+          shareUrl: uploaded.shareUrl,
+        });
+
+        // Get driveItem properties needed for native file card
+        const driveItem = await getDriveItemProperties({
+          siteId: sharePointSiteId,
+          itemId: uploaded.itemId,
+          tokenProvider,
+        });
+
+        log.debug("driveItem properties retrieved", {
+          eTag: driveItem.eTag,
+          webDavUrl: driveItem.webDavUrl,
+        });
+
+        // Build native Teams file card attachment and send via Bot Framework
+        const fileCardAttachment = buildTeamsFileInfoCard(driveItem);
+        const activity = {
+          type: "message",
+          text: text || undefined,
+          attachments: [fileCardAttachment],
+        };
+
+        const baseRef = buildConversationReference(ref);
+        const proactiveRef = { ...baseRef, activityId: undefined };
+
+        let messageId = "unknown";
+        await adapter.continueConversation(appId, proactiveRef, async (turnCtx) => {
+          const response = await turnCtx.sendActivity(activity);
+          messageId = extractMessageId(response) ?? "unknown";
+        });
+
+        log.info("sent native file card", {
+          conversationId,
+          messageId,
+          fileName: driveItem.name,
+        });
+
+        return { messageId, conversationId };
+      }
+
+      // Fallback: no SharePoint site configured, use OneDrive with markdown link
+      log.debug("uploading to OneDrive (no SharePoint site configured)", { fileName, conversationType });
+
+      const uploaded = await uploadAndShareOneDrive({
+        buffer: media.buffer,
+        filename: fileName,
+        contentType: media.contentType,
+        tokenProvider,
+      });
+
+      log.debug("OneDrive upload complete", {
+        itemId: uploaded.itemId,
+        shareUrl: uploaded.shareUrl,
+      });
+
+      // Send message with file link (Bot Framework doesn't support "reference" attachment type for sending)
+      const fileLink = `📎 [${uploaded.name}](${uploaded.shareUrl})`;
+      const activity = {
+        type: "message",
+        text: text ? `${text}\n\n${fileLink}` : fileLink,
+      };
+
+      const baseRef = buildConversationReference(ref);
+      const proactiveRef = { ...baseRef, activityId: undefined };
+
+      let messageId = "unknown";
+      await adapter.continueConversation(appId, proactiveRef, async (turnCtx) => {
+        const response = await turnCtx.sendActivity(activity);
+        messageId = extractMessageId(response) ?? "unknown";
+      });
+
+      log.info("sent message with OneDrive file link", { conversationId, messageId, shareUrl: uploaded.shareUrl });
+
+      return { messageId, conversationId };
+    } catch (err) {
+      const classification = classifyMSTeamsSendError(err);
+      const hint = formatMSTeamsSendErrorHint(classification);
+      const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
+      throw new Error(
+        `msteams file send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
+      );
+    }
+  }
+
+  // No media: send text only
+  return sendTextWithMedia(ctx, text, undefined);
+}
+
+/**
+ * Send a text message with optional base64 media URL.
+ */
+async function sendTextWithMedia(
+  ctx: MSTeamsProactiveContext,
+  text: string,
+  mediaUrl: string | undefined,
+): Promise<SendMSTeamsMessageResult> {
+  const { adapter, appId, conversationId, ref, log, tokenProvider, sharePointSiteId, mediaMaxBytes } = ctx;
+
   let messageIds: string[];
   try {
     messageIds = await sendMSTeamsMessages({
@@ -106,12 +304,14 @@ export async function sendMessageMSTeams(
       adapter,
       appId,
       conversationRef: ref,
-      messages: [message],
-      // Enable default retry/backoff for throttling/transient failures.
+      messages: [{ text: text || undefined, mediaUrl }],
       retry: {},
       onRetry: (event) => {
         log.debug("retrying send", { conversationId, ...event });
       },
+      tokenProvider,
+      sharePointSiteId,
+      mediaMaxBytes,
     });
   } catch (err) {
     const classification = classifyMSTeamsSendError(err);
@@ -121,8 +321,8 @@ export async function sendMessageMSTeams(
       `msteams send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
     );
   }
-  const messageId = messageIds[0] ?? "unknown";
 
+  const messageId = messageIds[0] ?? "unknown";
   log.info("sent proactive message", { conversationId, messageId });
 
   return {
@@ -157,7 +357,6 @@ export async function sendPollMSTeams(
 
   const activity = {
     type: "message",
-    text: pollCard.fallbackText,
     attachments: [
       {
         contentType: "application/vnd.microsoft.card.adaptive",
@@ -166,13 +365,18 @@ export async function sendPollMSTeams(
     ],
   };
 
-  let messageId: string;
+  // Send poll via proactive conversation (Adaptive Cards require direct activity send)
+  const baseRef = buildConversationReference(ref);
+  const proactiveRef = {
+    ...baseRef,
+    activityId: undefined,
+  };
+
+  let messageId = "unknown";
   try {
-    messageId = await sendMSTeamsActivity({
-      adapter,
-      appId,
-      conversationRef: ref,
-      activity,
+    await adapter.continueConversation(appId, proactiveRef, async (ctx) => {
+      const response = await ctx.sendActivity(activity);
+      messageId = extractMessageId(response) ?? "unknown";
     });
   } catch (err) {
     const classification = classifyMSTeamsSendError(err);
@@ -187,6 +391,64 @@ export async function sendPollMSTeams(
 
   return {
     pollId: pollCard.pollId,
+    messageId,
+    conversationId,
+  };
+}
+
+/**
+ * Send an arbitrary Adaptive Card to a Teams conversation or user.
+ */
+export async function sendAdaptiveCardMSTeams(
+  params: SendMSTeamsCardParams,
+): Promise<SendMSTeamsCardResult> {
+  const { cfg, to, card } = params;
+  const { adapter, appId, conversationId, ref, log } = await resolveMSTeamsSendContext({
+    cfg,
+    to,
+  });
+
+  log.debug("sending adaptive card", {
+    conversationId,
+    cardType: card.type,
+    cardVersion: card.version,
+  });
+
+  const activity = {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: card,
+      },
+    ],
+  };
+
+  // Send card via proactive conversation
+  const baseRef = buildConversationReference(ref);
+  const proactiveRef = {
+    ...baseRef,
+    activityId: undefined,
+  };
+
+  let messageId = "unknown";
+  try {
+    await adapter.continueConversation(appId, proactiveRef, async (ctx) => {
+      const response = await ctx.sendActivity(activity);
+      messageId = extractMessageId(response) ?? "unknown";
+    });
+  } catch (err) {
+    const classification = classifyMSTeamsSendError(err);
+    const hint = formatMSTeamsSendErrorHint(classification);
+    const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
+    throw new Error(
+      `msteams card send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
+    );
+  }
+
+  log.info("sent adaptive card", { conversationId, messageId });
+
+  return {
     messageId,
     conversationId,
   };

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -84,6 +84,7 @@ function buildMessagingSection(params: {
   availableTools: Set<string>;
   messageChannelOptions: string;
   inlineButtonsEnabled: boolean;
+  adaptiveCardsEnabled: boolean;
   runtimeChannel?: string;
 }) {
   if (params.isMinimal) return [];
@@ -105,6 +106,12 @@ function buildMessagingSection(params: {
             : params.runtimeChannel
               ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",
+          params.adaptiveCardsEnabled
+            ? "- Adaptive Cards supported (MSTeams). Use `action=send` with `card={type,version,body}` to send rich cards."
+            : "",
+          params.runtimeChannel === "msteams"
+            ? "- MSTeams targeting: omit `target` to reply to the current conversation (auto-inferred). Explicit targets: `user:ID` or `user:Display Name` (requires Graph API) for DMs, `conversation:19:...@thread.tacv2` for groups/channels. Prefer IDs over display names for speed."
+            : "",
         ]
           .filter(Boolean)
           .join("\n")
@@ -309,6 +316,8 @@ export function buildAgentSystemPrompt(params: {
     .filter(Boolean);
   const runtimeCapabilitiesLower = new Set(runtimeCapabilities.map((cap) => cap.toLowerCase()));
   const inlineButtonsEnabled = runtimeCapabilitiesLower.has("inlinebuttons");
+  const adaptiveCardsEnabled =
+    runtimeChannel === "msteams" || runtimeCapabilitiesLower.has("adaptivecards");
   const messageChannelOptions = listDeliverableMessageChannels().join("|");
   const promptMode = params.promptMode ?? "full";
   const isMinimal = promptMode === "minimal" || promptMode === "none";
@@ -467,6 +476,7 @@ export function buildAgentSystemPrompt(params: {
       availableTools,
       messageChannelOptions,
       inlineButtonsEnabled,
+      adaptiveCardsEnabled,
       runtimeChannel,
     }),
   ];

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import {
   listChannelMessageActions,
   supportsChannelMessageButtons,
+  supportsChannelMessageCards,
 } from "../../channels/plugins/message-actions.js";
 import {
   CHANNEL_MESSAGE_ACTION_NAMES,
@@ -36,7 +37,7 @@ function buildRoutingSchema() {
   };
 }
 
-function buildSendSchema(options: { includeButtons: boolean }) {
+function buildSendSchema(options: { includeButtons: boolean; includeCards: boolean }) {
   const props: Record<string, unknown> = {
     message: Type.Optional(Type.String()),
     effectId: Type.Optional(
@@ -77,8 +78,18 @@ function buildSendSchema(options: { includeButtons: boolean }) {
         },
       ),
     ),
+    card: Type.Optional(
+      Type.Object(
+        {},
+        {
+          additionalProperties: true,
+          description: "Adaptive Card JSON object (MSTeams only)",
+        },
+      ),
+    ),
   };
   if (!options.includeButtons) delete props.buttons;
+  if (!options.includeCards) delete props.card;
   return props;
 }
 
@@ -192,7 +203,7 @@ function buildChannelManagementSchema() {
   };
 }
 
-function buildMessageToolSchemaProps(options: { includeButtons: boolean }) {
+function buildMessageToolSchemaProps(options: { includeButtons: boolean; includeCards: boolean }) {
   return {
     ...buildRoutingSchema(),
     ...buildSendSchema(options),
@@ -211,7 +222,7 @@ function buildMessageToolSchemaProps(options: { includeButtons: boolean }) {
 
 function buildMessageToolSchemaFromActions(
   actions: readonly string[],
-  options: { includeButtons: boolean },
+  options: { includeButtons: boolean; includeCards: boolean },
 ) {
   const props = buildMessageToolSchemaProps(options);
   return Type.Object({
@@ -222,6 +233,7 @@ function buildMessageToolSchemaFromActions(
 
 const MessageToolSchema = buildMessageToolSchemaFromActions(AllMessageActions, {
   includeButtons: true,
+  includeCards: true,
 });
 
 type MessageToolOptions = {
@@ -238,8 +250,10 @@ type MessageToolOptions = {
 function buildMessageToolSchema(cfg: ClawdbotConfig) {
   const actions = listChannelMessageActions(cfg);
   const includeButtons = supportsChannelMessageButtons(cfg);
+  const includeCards = supportsChannelMessageCards(cfg);
   return buildMessageToolSchemaFromActions(actions.length > 0 ? actions : ["send"], {
     includeButtons,
+    includeCards,
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,7 +1,7 @@
 import type { NormalizedUsage } from "../../agents/usage.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
-import { normalizeChannelId } from "../../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { ClawdbotConfig } from "../../config/config.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
@@ -23,7 +23,7 @@ export function buildThreadingToolContext(params: {
   if (!config) return {};
   const rawProvider = sessionCtx.Provider?.trim().toLowerCase();
   if (!rawProvider) return {};
-  const provider = normalizeChannelId(rawProvider);
+  const provider = normalizeChannelId(rawProvider) ?? normalizeAnyChannelId(rawProvider);
   // Fallback for unrecognized/plugin channels (e.g., BlueBubbles before plugin registry init)
   const dock = provider ? getChannelDock(provider) : undefined;
   if (!dock?.threading?.buildToolContext) {

--- a/src/channels/plugins/message-actions.ts
+++ b/src/channels/plugins/message-actions.ts
@@ -21,6 +21,13 @@ export function supportsChannelMessageButtons(cfg: ClawdbotConfig): boolean {
   return false;
 }
 
+export function supportsChannelMessageCards(cfg: ClawdbotConfig): boolean {
+  for (const plugin of listChannelPlugins()) {
+    if (plugin.actions?.supportsCards?.({ cfg })) return true;
+  }
+  return false;
+}
+
 export async function dispatchChannelMessageAction(
   ctx: ChannelMessageActionContext,
 ): Promise<AgentToolResult<unknown> | null> {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -281,6 +281,7 @@ export type ChannelMessageActionAdapter = {
   listActions?: (params: { cfg: ClawdbotConfig }) => ChannelMessageActionName[];
   supportsAction?: (params: { action: ChannelMessageActionName }) => boolean;
   supportsButtons?: (params: { cfg: ClawdbotConfig }) => boolean;
+  supportsCards?: (params: { cfg: ClawdbotConfig }) => boolean;
   extractToolSend?: (params: { args: Record<string, unknown> }) => ChannelToolSend | null;
   handleAction?: (ctx: ChannelMessageActionContext) => Promise<AgentToolResult<unknown>>;
 };

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -5,6 +5,7 @@ import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-targ
 import { defaultRuntime } from "../../../runtime.js";
 import { createDefaultDeps } from "../../deps.js";
 import { runCommandWithRuntime } from "../../cli-utils.js";
+import { ensurePluginRegistryLoaded } from "../../plugin-registry.js";
 
 export type MessageCliHelpers = {
   withMessageBase: (command: Command) => Command;
@@ -32,6 +33,7 @@ export function createMessageCliHelpers(
 
   const runMessageAction = async (action: string, opts: Record<string, unknown>) => {
     setVerbose(Boolean(opts.verbose));
+    ensurePluginRegistryLoaded();
     const deps = createDefaultDeps();
     await runCommandWithRuntime(
       defaultRuntime,

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -19,6 +19,7 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
           "--buttons <json>",
           "Telegram inline keyboard buttons as JSON (array of button rows)",
         )
+        .option("--card <json>", "Adaptive Card JSON object (MSTeams only)")
         .option("--reply-to <id>", "Reply-to message id")
         .option("--thread-id <id>", "Thread id (Telegram forum thread)")
         .option("--gif-playback", "Treat video media as GIF playback (WhatsApp only).", false),

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -78,4 +78,8 @@ export type MSTeamsConfig = {
   replyStyle?: MSTeamsReplyStyle;
   /** Per-team config. Key is team ID (from the /team/ URL path segment). */
   teams?: Record<string, MSTeamsTeamConfig>;
+  /** Max media size in MB (default: 100MB for OneDrive upload support). */
+  mediaMaxMb?: number;
+  /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2"). */
+  sharePointSiteId?: string;
 };

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -599,6 +599,10 @@ export const MSTeamsConfigSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     replyStyle: MSTeamsReplyStyleSchema.optional(),
     teams: z.record(z.string(), MSTeamsTeamSchema.optional()).optional(),
+    /** Max media size in MB (default: 100MB for OneDrive upload support). */
+    mediaMaxMb: z.number().positive().optional(),
+    /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2") */
+    sharePointSiteId: z.string().optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -191,6 +191,12 @@ export const ClawdbotSchema = z
     bindings: BindingsSchema,
     broadcast: BroadcastSchema,
     audio: AudioSchema,
+    media: z
+      .object({
+        preserveFilenames: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     messages: MessagesSchema,
     commands: CommandsSchema,
     session: SessionSchema,

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -32,9 +32,11 @@ const EXT_BY_MIME: Record<string, string> = {
   "text/markdown": ".md",
 };
 
-const MIME_BY_EXT: Record<string, string> = Object.fromEntries(
-  Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime]),
-);
+const MIME_BY_EXT: Record<string, string> = {
+  ...Object.fromEntries(Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime])),
+  // Additional extension aliases
+  ".jpeg": "image/jpeg",
+};
 
 const AUDIO_FILE_EXTENSIONS = new Set([
   ".aac",

--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -19,7 +19,6 @@ describe("plugin-sdk exports", () => {
       "writeConfigFile",
       "runCommandWithTimeout",
       "enqueueSystemEvent",
-      "detectMime",
       "fetchRemoteMedia",
       "saveMediaBuffer",
       "formatAgentEnvelope",

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -206,6 +206,8 @@ export type {
   DiagnosticWebhookProcessedEvent,
   DiagnosticWebhookReceivedEvent,
 } from "../infra/diagnostic-events.js";
+export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js";
+export { extractOriginalFilename } from "../media/store.js";
 
 // Channel: Discord
 export {
@@ -282,3 +284,6 @@ export { collectWhatsAppStatusIssues } from "../channels/plugins/status-issues/w
 
 // Channel: BlueBubbles
 export { collectBlueBubblesStatusIssues } from "../channels/plugins/status-issues/bluebubbles.js";
+
+// Media utilities
+export { loadWebMedia, type WebMediaResult } from "../web/media.js";

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -4,11 +4,12 @@ import { fileURLToPath } from "node:url";
 
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { type MediaKind, maxBytesForKind, mediaKindFromMime } from "../media/constants.js";
+import { resolveUserPath } from "../utils.js";
 import { fetchRemoteMedia } from "../media/fetch.js";
 import { convertHeicToJpeg, resizeToJpeg } from "../media/image-ops.js";
 import { detectMime, extensionForMime } from "../media/mime.js";
 
-type WebMediaResult = {
+export type WebMediaResult = {
   buffer: Buffer;
   contentType?: string;
   kind: MediaKind;
@@ -89,10 +90,9 @@ async function loadWebMediaInternal(
     kind: MediaKind;
     fileName?: string;
   }): Promise<WebMediaResult> => {
-    const cap =
-      maxBytes !== undefined
-        ? Math.min(maxBytes, maxBytesForKind(params.kind))
-        : maxBytesForKind(params.kind);
+    // If caller explicitly provides maxBytes, trust it (for channels like MSTeams that handle large files).
+    // Otherwise fall back to per-kind defaults.
+    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {
@@ -139,6 +139,11 @@ async function loadWebMediaInternal(
     const { buffer, contentType, fileName } = fetched;
     const kind = mediaKindFromMime(contentType);
     return await clampAndFinalize({ buffer, contentType, kind, fileName });
+  }
+
+  // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
+  if (mediaUrl.startsWith("~")) {
+    mediaUrl = resolveUserPath(mediaUrl);
   }
 
   // Local path


### PR DESCRIPTION
I admit this is quite a large amount of changes, but I tackled it step by step with a active Teams setup and verified it one final time that features work in production. I refactored it multiple times to clean up duplication etc. Some surface level duplication is left but the reply vs send benefits from some isolation i think.

I didnt get to try out teams channels yet.


| <img width="520" height="511" alt="grafik" src="https://github.com/user-attachments/assets/4a94cead-df96-453e-b5a0-bd2cc0f30ab7" /> |  <img width="592" height="620" alt="grafik" src="https://github.com/user-attachments/assets/6eaead8a-5691-43c7-9bf6-3ed81d72046d" /> |
|----|----|


## The Problem

Here some features that didnt work before that works now:

- Direct Messages:
  - Bot did not see uploaded files from a user
  - Bot did not see uploaded image from a user if that image came from clipboard
  - Bot could not reply or send an image to user
  - Bot could not reply or send a file to user
  - Bot could not send an arbitrary adaptive card to user
- Group Chats (requires completely different approach!)
  - Bot did not see uploaded files from a user
  - Bot did not see uploaded image from a user
  - Bot could not reply or send an image to user
  - Bot could not reply or send a file to user
  - Bot could not send an arbitrary adaptive card to user
- CLI
  - Was out of date and now also supports adaptive cards 

There were a number of bugs in multiple place i dont recall all details. but for example the graph URL was broken and the way the prompt was written caused the bot to use parameters incorrectly which then looked like permission errors and were difficult to diagnose

---

## The Solution

Three-path routing based on conversation context:

```
                         ┌─────────────────┐
                         │  File to Send   │
                         └────────┬────────┘
                                  │
                    ┌─────────────┼─────────────┐
                    ▼             ▼             ▼
              ┌──────────┐ ┌──────────┐ ┌──────────┐
              │ Personal │ │  Group   │ │ Channel  │
              │   Chat   │ │   Chat   │ │ (Future) │
              └────┬─────┘ └────┬─────┘ └──────────┘
                   │            │
         ┌─────────┴─────┐      │
         ▼               ▼      ▼
    ┌─────────┐    ┌──────────┐ ┌──────────┐
    │ Small   │    │  Large/  │ │SharePoint│
    │ Image   │    │ Non-Img  │ │  Upload  │
    │ (<4MB)  │    │  File    │ │          │
    └────┬────┘    └────┬─────┘ └────┬─────┘
         │              │            │
         ▼              ▼            ▼
    ┌─────────┐    ┌──────────┐ ┌──────────┐
    │ Base64  │    │  File    │ │  Native  │
    │ Inline  │    │ Consent  │ │  Teams   │
    │         │    │  Card    │ │File Card │
    └─────────┘    └──────────┘ └──────────┘
```

---

<details>
<summary><strong>📁 Path 1: FileConsentCard (Personal Chats)</strong></summary>

**When:** Personal chat + (file ≥4MB OR non-image file)

**Why:** Teams requires explicit user consent before bots can upload large files to personal OneDrive.

**Flow:**
1. Bot stores file in memory with 5-minute TTL
2. Sends FileConsentCard with Accept/Decline buttons
3. User clicks Accept → Teams provides temporary upload URL
4. Bot uploads file and sends confirmation FileInfoCard

**Key files:**
- `file-consent.ts` - Card builders and upload logic
- `file-consent-helpers.ts` - Decision logic (`requiresFileConsent()`)
- `pending-uploads.ts` - In-memory store with auto-cleanup

**Design decisions:**
- **In-memory store vs database:** Chose simplicity. Files are ephemeral (5min TTL), single-instance assumption is acceptable for v1.
- **5-minute TTL:** Balances user response time vs memory. Most users respond in <30 seconds.
- **UUID keys:** Unguessable, prevents manipulation of other users' uploads.

</details>

<details>
<summary><strong>☁️ Path 2: Graph API Upload (Group Chats)</strong></summary>

**When:** Group chat or channel

**Why:** Bots have no personal OneDrive in group contexts (`/me/drive` fails). SharePoint is the team's shared storage.

**Flow:**
1. Upload to SharePoint via Graph API
2. Create sharing link (per-user or org-wide)
3. Fetch DriveItem properties (eTag, webDavUrl)
4. Build native Teams file card

**Key files:**
- `graph-upload.ts` - OneDrive/SharePoint upload functions
- `graph-chat.ts` - Native Teams file card builder

**Design decisions:**
- **SharePoint primary, OneDrive fallback:** SharePoint enables native file cards. OneDrive fallback when `sharePointSiteId` not configured.
- **Per-user sharing:** Group chats use per-user sharing (requires `Chat.Read.All`). Gracefully falls back to org-wide if permission missing.
- **Simple upload (4MB limit):** Covers 99% of use cases. Resumable upload is TODO for future.

</details>

<details>
<summary><strong>🎴 Adaptive Cards CLI</strong></summary>

**New option:** `--card <json>`

```bash
clawdbot message send --to "user:abc123" --card '{"type":"AdaptiveCard",...}'
```

**Key points:**
- Message body is optional when card present (unlike Telegram buttons)
- Card parameter only appears in agent tool schema when MS Teams configured
- Minimal validation (JSON syntax only) - Teams service validates the schema

**Capability detection:**
```typescript
supportsCards: ({ cfg }) => {
  return cfg.channels?.msteams?.enabled !== false &&
         Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams));
}
```

</details>

<details>
<summary><strong>📥 All-File-Type Downloads</strong></summary>

**Before:** Only images downloaded; PDFs and documents silently ignored.

**After:** All file types downloaded with correct placeholders.

**Changes:**
- Renamed `downloadMSTeamsImageAttachments` → `downloadMSTeamsAttachments` (old name aliased)
- New `isDownloadableAttachment()` replaces `isLikelyImageAttachment()`
- SharePoint "reference" attachments handled via Graph shares API
- Expanded host allowlist: `asm.skype.com`, `blob.core.windows.net`, `azureedge.net`

</details>

<details>
<summary><strong>📛 Filename Preservation</strong></summary>

**Problem:** Downloaded files had opaque UUIDs (`a1b2c3d4-...pdf`).

**Solution:** Embed sanitized original name in storage path:
```
report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf
^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
original           UUID for uniqueness
```

**Why triple-hyphen?** Single/double hyphens appear in filenames and UUIDs. Triple is unambiguous.

**Sanitization:** Removes `<>:"/\|?*` and control chars for cross-platform safety (Windows, SharePoint, Unix).

**Config:** `media.preserveFilenames: true`

</details>

---

## New Configuration Options

```yaml
media:
  preserveFilenames: true  # Embed original filenames in stored paths

channels:
  msteams:
    mediaMaxMb: 100                                    # Per-channel size limit
    sharePointSiteId: "contoso.sharepoint.com,g1,g2"  # For group chat uploads
```

---

## Files Changed

| Category | Files | Purpose |
|----------|-------|---------|
| **New: FileConsent** | 4 files | Consent card flow for personal chats |
| **New: Graph Upload** | 2 files | OneDrive/SharePoint integration |
| **New: Media Helpers** | 2 files | MIME detection, filename utilities |
| **Modified: Send** | `send.ts`, `messenger.ts` | Upload orchestration |
| **Modified: Downloads** | `attachments/*.ts` | All-file-type support |
| **Modified: Config** | `zod-schema*.ts`, `types.*.ts` | New options |
| **Modified: CLI** | `register.send.ts` | `--card` option |

**Total:** 44 files, +2,615 / -175 lines

---

## Testing

- [x] Unit tests for FileConsentCard helpers (17 tests)
- [x] Unit tests for filename sanitization/extraction (15 tests)
- [x] Unit tests for media helpers (28 tests)
- [x] Unit tests for attachment downloads (12 tests)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Manual testing with real Teams bot (requires Azure setup)

---

## Breaking Changes

None I hope for other channels. I really tried to make all changes are backward compatible (aside from teams which was broken anyway):
- Old function names aliased (`downloadMSTeamsImageAttachments`)
- New config options are optional with sensible defaults
- Existing behavior unchanged when new features not configured