### PR TITLE
fix(macos): clear stale gateway/node-service errors on recovery

### DIFF
--- a/apps/macos/Sources/Clawdbot/ConnectionModeCoordinator.swift
+++ b/apps/macos/Sources/Clawdbot/ConnectionModeCoordinator.swift
@@ -12,9 +12,8 @@ final class ConnectionModeCoordinator {
     func apply(mode: AppState.ConnectionMode, paused: Bool) async {
         switch mode {
         case .unconfigured:
-            if let error = await NodeServiceManager.stop() {
-                NodesStore.shared.lastError = "Node service stop failed: \(error)"
-            }
+            // Best-effort stop; don't surface errors for a service that may not be running.
+            _ = await NodeServiceManager.stop()
             await RemoteTunnelManager.shared.stopAll()
             WebChatManager.shared.resetTunnels()
             GatewayProcessManager.shared.stop()
@@ -23,9 +22,8 @@ final class ConnectionModeCoordinator {
             Task.detached { await PortGuardian.shared.sweep(mode: .unconfigured) }
 
         case .local:
-            if let error = await NodeServiceManager.stop() {
-                NodesStore.shared.lastError = "Node service stop failed: \(error)"
-            }
+            // Best-effort stop; don't surface errors for a service that may not be running.
+            _ = await NodeServiceManager.stop()
             await RemoteTunnelManager.shared.stopAll()
             WebChatManager.shared.resetTunnels()
             let shouldStart = GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: paused)

--- a/apps/macos/Sources/Clawdbot/ControlChannel.swift
+++ b/apps/macos/Sources/Clawdbot/ControlChannel.swift
@@ -60,6 +60,7 @@ final class ControlChannel {
             switch self.state {
             case .connected:
                 self.logger.info("control channel state -> connected")
+                GatewayProcessManager.shared.clearLastFailure()
             case .connecting:
                 self.logger.info("control channel state -> connecting")
             case .disconnected:

--- a/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
@@ -363,6 +363,10 @@ final class GatewayProcessManager {
         return false
     }
 
+    func clearLastFailure() {
+        self.lastFailureReason = nil
+    }
+
     func clearLog() {
         self.log = ""
         try? FileManager().removeItem(atPath: GatewayLaunchAgentManager.launchdGatewayLogPath())


### PR DESCRIPTION
## Summary

Fixes a bug where the **chat panel shows an infinite loading spinner** even though the connection status shows "Connected". Also fixes related stale error messages in the menu bar and Settings.

## The Problem

During app startup, if the gateway is restarting (common after a build/update), a race condition causes error states to be set but never cleared when recovery succeeds:

1. **Chat never loads** — The spinner runs forever because `chatHistory()` requests are blocked by the degraded connection state. The WebSocket event stream connects (showing "Connected" in the status bar) but the HTTP-style history request fails.

2. **"Node service stop failed" error in menu** — This error persists even after gateway connects. The node service isn't running in local mode, so stop() failures are expected and shouldn't be surfaced.

3. **Stale gateway failure in Settings** — A failure message like "Gateway listener found on port 18791 but health check failed" persists in Settings even after recovery.

**Root cause:** Error states are set on failure but never cleared when recovery succeeds.

## The Fix

**3 files, +9/-6 lines:**

1. **ConnectionModeCoordinator.swift**: Treat `NodeServiceManager.stop()` as best-effort in local/unconfigured modes

2. **GatewayProcessManager.swift**: Add `clearLastFailure()` method

3. **ControlChannel.swift**: Call `clearLastFailure()` when transitioning to `.connected` state

## Test plan

- [ ] Open chat panel during gateway restart → spinner stops and messages load once connected
- [ ] Start app in local mode with no node service installed → no error in menu
- [ ] Force gateway restart during app startup → Settings error clears once connection recovers