### PR TITLE
fix(typing): signal instant typing at actual run start

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -113,6 +113,8 @@ export async function runReplyAgent(params: {
     isHeartbeat,
   });
 
+  // Signal typing immediately for instant mode
+  await typingSignals.signalRunStart();
   const shouldEmitToolResult = createShouldEmitToolResult({
     sessionKey,
     storePath,


### PR DESCRIPTION
Previously, signalRunStart() was only called after the model returned payloads (inside signalTypingIfNeeded), so typingMode=instant never actually showed typing immediately.

This PR calls signalRunStart() right after the typing signaler is created, before any model calls, ensuring typing indicators appear immediately when messages are received.

**Testing:**
- Verified typing indicator now shows immediately on message receipt
- No regressions in typing behavior