### PR TITLE
fix(exec): pass undefined instead of null for optional approval params

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -896,8 +896,8 @@ export function createExecTool(
                   security: hostSecurity,
                   ask: hostAsk,
                   agentId: defaults?.agentId,
-                  resolvedPath: null,
-                  sessionKey: defaults?.sessionKey ?? null,
+                  resolvedPath: undefined,
+                  sessionKey: defaults?.sessionKey,
                   timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
                 },
               )) as { decision?: string } | null;
@@ -1060,7 +1060,7 @@ export function createExecTool(
           const approvalSlug = createApprovalSlug(approvalId);
           const expiresAtMs = Date.now() + DEFAULT_APPROVAL_TIMEOUT_MS;
           const contextKey = `exec:${approvalId}`;
-          const resolvedPath = analysis.segments[0]?.resolution?.resolvedPath ?? null;
+          const resolvedPath = analysis.segments[0]?.resolution?.resolvedPath;
           const noticeSeconds = Math.max(1, Math.round(approvalRunningNoticeMs / 1000));
           const commandText = params.command;
           const effectiveTimeout =
@@ -1082,7 +1082,7 @@ export function createExecTool(
                   ask: hostAsk,
                   agentId: defaults?.agentId,
                   resolvedPath,
-                  sessionKey: defaults?.sessionKey ?? null,
+                  sessionKey: defaults?.sessionKey,
                   timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
                 },
               )) as { decision?: string } | null;

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -267,8 +267,8 @@ export function registerNodesInvokeCommands(nodes: Command) {
               security: hostSecurity,
               ask: hostAsk,
               agentId,
-              resolvedPath: null,
-              sessionKey: null,
+              resolvedPath: undefined,
+              sessionKey: undefined,
               timeoutMs: 120_000,
             })) as { decision?: string } | null;
             const decision =


### PR DESCRIPTION
## Summary
- Fix Discord exec failing with "invalid exec.approval.request params: at /resolvedPath: must be string"
- TypeBox `Type.Optional(Type.String())` accepts `string | undefined` but NOT `null`
- Callers were passing `null` explicitly, causing AJV validation to reject the request
- Web UI worked because it skipped the approval request path (`requiresAsk = false`)

## Changes
- `src/agents/bash-tools.exec.ts`: Change `resolvedPath: null` → `undefined`, remove `?? null` fallbacks
- `src/cli/nodes-cli/register.invoke.ts`: Change `resolvedPath: null` → `undefined`, `sessionKey: null` → `undefined`
- `src/gateway/server-methods/exec-approval.test.ts`: Add regression tests documenting valid/invalid param values

## Test plan
- [x] `pnpm test src/gateway/server-methods/exec-approval.test.ts` passes (5 tests)
- [ ] Manual test: trigger exec from Discord session (e.g., `pwd`, `echo hi`)

🤖 Generated with [Claude Code](https://claude.ai/code)