### PR TITLE
fix(exec): derive agentId from sessionKey for allowlist lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.clawd.bot
 - Doctor: warn when gateway.mode is unset with configure/config guidance.
 - macOS: include Textual syntax highlighting resources in packaged app to prevent chat crashes. (#1362)
 - Cron: cap reminder context history to 10 messages and honor `contextMessages`. (#1103) Thanks @mkbehr.
+- Exec approvals: treat main as the default agent + migrate legacy default allowlists. (#1417) Thanks @czekaj.
 - UI: refresh debug panel on route-driven tab changes. (#1373) Thanks @yazinsai.
 
 ## 2026.1.21

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeSafeBins,
   resolveCommandResolution,
   resolveExecApprovals,
+  resolveExecApprovalsFromFile,
   type ExecAllowlistEntry,
 } from "./exec-approvals.js";
 
@@ -225,5 +226,37 @@ describe("exec approvals wildcard agent", () => {
     } finally {
       homedirSpy.mockRestore();
     }
+  });
+});
+
+describe("exec approvals default agent migration", () => {
+  it("migrates legacy default agent entries to main", () => {
+    const file = {
+      version: 1,
+      agents: {
+        default: { allowlist: [{ pattern: "/bin/legacy" }] },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file });
+    expect(resolved.allowlist.map((entry) => entry.pattern)).toEqual(["/bin/legacy"]);
+    expect(resolved.file.agents?.default).toBeUndefined();
+    expect(resolved.file.agents?.main?.allowlist?.[0]?.pattern).toBe("/bin/legacy");
+  });
+
+  it("prefers main agent settings when both main and default exist", () => {
+    const file = {
+      version: 1,
+      agents: {
+        main: { ask: "always", allowlist: [{ pattern: "/bin/main" }] },
+        default: { ask: "off", allowlist: [{ pattern: "/bin/legacy" }] },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file });
+    expect(resolved.agent.ask).toBe("always");
+    expect(resolved.allowlist.map((entry) => entry.pattern)).toEqual([
+      "/bin/main",
+      "/bin/legacy",
+    ]);
+    expect(resolved.file.agents?.default).toBeUndefined();
   });
 });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -91,7 +91,10 @@ function normalizeAllowlistPattern(value: string | undefined): string | null {
   return trimmed ? trimmed.toLowerCase() : null;
 }
 
-function mergeLegacyAgent(current: ExecApprovalsAgent, legacy: ExecApprovalsAgent): ExecApprovalsAgent {
+function mergeLegacyAgent(
+  current: ExecApprovalsAgent,
+  legacy: ExecApprovalsAgent,
+): ExecApprovalsAgent {
   const allowlist: ExecAllowlistEntry[] = [];
   const seen = new Set<string>();
   const pushEntry = (entry: ExecAllowlistEntry) => {
@@ -120,13 +123,11 @@ function ensureDir(filePath: string) {
 export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
   const socketPath = file.socket?.path?.trim();
   const token = file.socket?.token?.trim();
-  const agents = { ...(file.agents ?? {}) };
+  const agents = { ...file.agents };
   const legacyDefault = agents.default;
   if (legacyDefault) {
     const main = agents[DEFAULT_AGENT_ID];
-    agents[DEFAULT_AGENT_ID] = main
-      ? mergeLegacyAgent(main, legacyDefault)
-      : legacyDefault;
+    agents[DEFAULT_AGENT_ID] = main ? mergeLegacyAgent(main, legacyDefault) : legacyDefault;
     delete agents.default;
   }
   const normalized: ExecApprovalsFile = {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -4,6 +4,8 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+
 export type ExecHost = "sandbox" | "gateway" | "node";
 export type ExecSecurity = "deny" | "allowlist" | "full";
 export type ExecAsk = "off" | "on-miss" | "always";
@@ -84,6 +86,32 @@ export function resolveExecApprovalsSocketPath(): string {
   return expandHome(DEFAULT_SOCKET);
 }
 
+function normalizeAllowlistPattern(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function mergeLegacyAgent(current: ExecApprovalsAgent, legacy: ExecApprovalsAgent): ExecApprovalsAgent {
+  const allowlist: ExecAllowlistEntry[] = [];
+  const seen = new Set<string>();
+  const pushEntry = (entry: ExecAllowlistEntry) => {
+    const key = normalizeAllowlistPattern(entry.pattern);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    allowlist.push(entry);
+  };
+  for (const entry of current.allowlist ?? []) pushEntry(entry);
+  for (const entry of legacy.allowlist ?? []) pushEntry(entry);
+
+  return {
+    security: current.security ?? legacy.security,
+    ask: current.ask ?? legacy.ask,
+    askFallback: current.askFallback ?? legacy.askFallback,
+    autoAllowSkills: current.autoAllowSkills ?? legacy.autoAllowSkills,
+    allowlist: allowlist.length > 0 ? allowlist : undefined,
+  };
+}
+
 function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
@@ -92,6 +120,15 @@ function ensureDir(filePath: string) {
 export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
   const socketPath = file.socket?.path?.trim();
   const token = file.socket?.token?.trim();
+  const agents = { ...(file.agents ?? {}) };
+  const legacyDefault = agents.default;
+  if (legacyDefault) {
+    const main = agents[DEFAULT_AGENT_ID];
+    agents[DEFAULT_AGENT_ID] = main
+      ? mergeLegacyAgent(main, legacyDefault)
+      : legacyDefault;
+    delete agents.default;
+  }
   const normalized: ExecApprovalsFile = {
     version: 1,
     socket: {
@@ -104,7 +141,7 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
       askFallback: file.defaults?.askFallback,
       autoAllowSkills: file.defaults?.autoAllowSkills,
     },
-    agents: file.agents ?? {},
+    agents,
   };
   return normalized;
 }
@@ -231,7 +268,7 @@ export function resolveExecApprovalsFromFile(params: {
 }): ExecApprovalsResolved {
   const file = normalizeExecApprovals(params.file);
   const defaults = file.defaults ?? {};
-  const agentKey = params.agentId ?? "default";
+  const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
   const agent = file.agents?.[agentKey] ?? {};
   const wildcard = file.agents?.["*"] ?? {};
   const fallbackSecurity = params.overrides?.security ?? DEFAULT_SECURITY;


### PR DESCRIPTION
## Summary
- Fix exec allowlist not matching entries in `agents.main` when triggered via chat/Discord
- When `createExecTool` was called without explicit `agentId` (e.g., from `bash-command.ts`), the allowlist lookup used `"default"` instead of deriving the agent from `sessionKey`
- User's allowlist entries in `agents.main` were never matched, causing repeated approval prompts

## Root Cause
In `bash-command.ts:333`, `createExecTool` was called with `sessionKey` but NOT `agentId`:
```typescript
const execTool = createExecTool({
  scopeKey: CHAT_BASH_SCOPE_KEY,
  sessionKey: params.sessionKey,  // ← sessionKey passed
  // agentId NOT passed!
});
```

In `bash-tools.exec.ts`, the allowlist lookup used `defaults?.agentId`:
```typescript
const approvals = resolveExecApprovals(defaults?.agentId, ...);
```

With `agentId` undefined, `resolveExecApprovalsFromFile` fell back to:
```typescript
const agentKey = params.agentId ?? "default";
```

This looked up `agents.default` instead of `agents.main`, missing all user allowlist entries.

## Fix
Derive `agentId` from `sessionKey` if not explicitly provided:
```typescript
const agentId = defaults?.agentId ?? resolveAgentIdFromSessionKey(defaults?.sessionKey);
```

Then use the derived `agentId` in all allowlist operations.

## Test plan
- [x] `pnpm test src/agents/bash-tools.test.ts` passes (16 tests)
- [x] `pnpm test src/infra/exec-approvals.test.ts` passes (15 tests)
- [ ] Manual test: trigger exec from Discord with allowlist entries in `agents.main`

🤖 Generated with [Claude Code](https://claude.ai/code)