### PR TITLE
Browser: suppress Chrome restore prompt

### DIFF
--- a/src/browser/chrome.profile-decoration.ts
+++ b/src/browser/chrome.profile-decoration.ts
@@ -180,3 +180,11 @@ export function decorateClawdProfile(
     // ignore
   }
 }
+
+export function ensureProfileCleanExit(userDataDir: string) {
+  const preferencesPath = path.join(userDataDir, "Default", "Preferences");
+  const prefs = safeReadJson(preferencesPath) ?? {};
+  setDeep(prefs, ["exit_type"], "Normal");
+  setDeep(prefs, ["exited_cleanly"], true);
+  safeWriteJson(preferencesPath, prefs);
+}

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   decorateClawdProfile,
+  ensureProfileCleanExit,
   findChromeExecutableMac,
   findChromeExecutableWindows,
   isChromeReachable,
@@ -98,6 +99,18 @@ describe("browser chrome profile decoration", () => {
 
       const prefs = await readJson(path.join(userDataDir, "Default", "Preferences"));
       expect(typeof prefs.profile).toBe("object");
+    } finally {
+      await fsp.rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes clean exit prefs to avoid restore prompts", async () => {
+    const userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "clawdbot-chrome-test-"));
+    try {
+      ensureProfileCleanExit(userDataDir);
+      const prefs = await readJson(path.join(userDataDir, "Default", "Preferences"));
+      expect(prefs.exit_type).toBe("Normal");
+      expect(prefs.exited_cleanly).toBe(true);
     } finally {
       await fsp.rm(userDataDir, { recursive: true, force: true });
     }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -13,7 +13,11 @@ import {
   type BrowserExecutable,
   resolveBrowserExecutableForPlatform,
 } from "./chrome.executables.js";
-import { decorateClawdProfile, isProfileDecorated } from "./chrome.profile-decoration.js";
+import {
+  decorateClawdProfile,
+  ensureProfileCleanExit,
+  isProfileDecorated,
+} from "./chrome.profile-decoration.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { DEFAULT_CLAWD_BROWSER_COLOR, DEFAULT_CLAWD_BROWSER_PROFILE_NAME } from "./constants.js";
 
@@ -26,7 +30,11 @@ export {
   findChromeExecutableWindows,
   resolveBrowserExecutableForPlatform,
 } from "./chrome.executables.js";
-export { decorateClawdProfile, isProfileDecorated } from "./chrome.profile-decoration.js";
+export {
+  decorateClawdProfile,
+  ensureProfileCleanExit,
+  isProfileDecorated,
+} from "./chrome.profile-decoration.js";
 
 function exists(filePath: string) {
   try {
@@ -178,6 +186,8 @@ export async function launchClawdChrome(
       "--disable-background-networking",
       "--disable-component-update",
       "--disable-features=Translate,MediaRouter",
+      "--disable-session-crashed-bubble",
+      "--hide-crash-restore-bubble",
       "--password-store=basic",
     ];
 
@@ -244,6 +254,12 @@ export async function launchClawdChrome(
     } catch (err) {
       log.warn(`clawd browser profile decoration failed: ${String(err)}`);
     }
+  }
+
+  try {
+    ensureProfileCleanExit(userDataDir);
+  } catch (err) {
+    log.warn(`clawd browser clean-exit prefs failed: ${String(err)}`);
   }
 
   const proc = spawnOnce();


### PR DESCRIPTION
This PR prevents popup of "Restore pages?" prompt when Clawdbot launches chrome browsers. The prompt wasn't blocking any functionality but was visually annoying.

I've tested this. 

## Codex prompt: 

Fix Chrome "Restore pages?" prompt for Clawdbot browser profiles.

Context:
- Clawdbot manages multiple Chrome profiles at ~/.clawdbot/browser/{profile}/user-data/
- Chrome shows "Restore pages?" dialog on startup after unclean shutdown
- This is annoying

Goals:
1. Prevent the restore prompt from appearing
2. Apply fix to all Clawdbot browser profiles

Approaches to consider:
- Set Chrome preferences in Default/Preferences JSON (exit_type, exited_cleanly)
- Add Chrome launch flags (--disable-session-crashed-bubble, --hide-crash-restore-bubble)
- Modify profile Preferences file on browser stop/start

Deliverable:
- Identify the best approach
- Implement it (either via launch flags in Clawdbot config or a script to patch Preferences files)
- Test that the prompt no longer appears


