### PR TITLE
fix(logging): use local time for rolling log filename [AI-assisted]

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -197,8 +197,15 @@ export function registerLogTransport(transport: LogTransport): () => void {
   };
 }
 
+function formatLocalDate(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 function defaultRollingPathForToday(): string {
-  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const today = formatLocalDate(new Date()); // YYYY-MM-DD in local time
   return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }
 


### PR DESCRIPTION
## Summary

Fixes the timezone mismatch where the Dashboard Logs page couldn't find log files because UTC time was used for the filename instead of local server time.

## 🤖 AI-Assisted PR

- **Tool**: Claude (via Clawdbot)
- **Testing**: ✅ Linted, code review verified
- **Linting**: `npx oxlint src/logging/logger.ts` → 0 errors
- **I understand what the code does**: Yes - changes `toISOString().slice(0,10)` (UTC) to local date formatting

## Problem

```typescript
// Before: UTC time
const today = new Date().toISOString().slice(0, 10);
// At 16:01 PST (Jan 20) = 00:01 UTC (Jan 21)
// Returns: "2026-01-21" but user expects "2026-01-20"
```

## Solution

```typescript
// After: Local server time
function formatLocalDate(date: Date): string {
  const yyyy = date.getFullYear();
  const mm = String(date.getMonth() + 1).padStart(2, "0");
  const dd = String(date.getDate()).padStart(2, "0");
  return `${yyyy}-${mm}-${dd}`;
}
```

## Changes

- `src/logging/logger.ts`: Added `formatLocalDate()` helper, updated `defaultRollingPathForToday()`

Fixes #1343