### PR TITLE
fix: include skills in minimal prompt mode for subagents

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -18,7 +18,7 @@ function buildSkillsSection(params: {
   readToolName: string;
 }) {
   const trimmed = params.skillsPrompt?.trim();
-  if (!trimmed || params.isMinimal) return [];
+  if (!trimmed) return [];
   return [
     "## Skills (mandatory)",
     "Before replying: scan <available_skills> <description> entries.",


### PR DESCRIPTION
Fixes #1312

## Problem
Subagents weren't receiving `available_skills` from the system prompt. The `buildSkillsSection` function was returning an empty array when `isMinimal` was true, which is always the case for subagents (they receive `promptMode: "minimal"`).

## Solution
Remove the `params.isMinimal` check from `buildSkillsSection`. Skills are capabilities, not behavioral guidance, and should be available to subagents.

## Changes
- `src/agents/system-prompt.ts`: Remove `|| params.isMinimal` from the early return in `buildSkillsSection`