### PR TITLE
fix(matrix): broken import and enhance direct room resolve logic

### DIFF
--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -53,7 +53,7 @@ export async function resolveMatrixAuth(params?: {
     saveMatrixCredentials,
     credentialsMatchConfig,
     touchMatrixCredentials,
-  } = await import("./credentials.js");
+  } = await import("../credentials.js");
 
   const cached = loadMatrixCredentials(env);
   const cachedCredentials =


### PR DESCRIPTION
1. Correct the import path for credentials (should've been in #1320 already but got lost somewhere)

2. Improve error handling and fallback logic in the `resolveDirectRoomId` function to ensure more robust operation when fetching direct room IDs. Right now, heartbeats etc don't reach the user if no "m.direct" flag is used by clients