### PR TITLE
fix(bluebubbles): call stop typing on idle and NO_REPLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Docs: https://docs.clawd.bot
 
+## 2026.1.22
+
+### Fixes
+- BlueBubbles: stop typing indicator on idle/no-reply. (#1439) Thanks @Nicell.
+
 ## 2026.1.21-2
 
 ### Fixes

--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/bluebubbles",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot BlueBubbles channel plugin",
   "clawdbot": {

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/copilot-proxy",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Copilot Proxy provider plugin",
   "clawdbot": {

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/diagnostics-otel",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot diagnostics OpenTelemetry exporter",
   "clawdbot": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/discord",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Discord channel plugin",
   "clawdbot": {

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/google-antigravity-auth",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Google Antigravity OAuth provider plugin",
   "clawdbot": {

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/google-gemini-cli-auth",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Gemini CLI OAuth provider plugin",
   "clawdbot": {

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/imessage",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot iMessage channel plugin",
   "clawdbot": {

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/lobster",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "clawdbot": {

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/matrix",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Matrix channel plugin",
   "clawdbot": {

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/memory-core",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot core memory search plugin",
   "clawdbot": {

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/memory-lancedb",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot LanceDB-backed long-term memory plugin with auto-recall/capture",
   "dependencies": {

--- a/extensions/msteams/CHANGELOG.md
+++ b/extensions/msteams/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/msteams",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Microsoft Teams channel plugin",
   "clawdbot": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/nextcloud-talk",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Nextcloud Talk channel plugin",
   "clawdbot": {

--- a/extensions/nostr/CHANGELOG.md
+++ b/extensions/nostr/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/nostr",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Nostr channel plugin for NIP-04 encrypted DMs",
   "clawdbot": {

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/signal",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Signal channel plugin",
   "clawdbot": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/slack",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Slack channel plugin",
   "clawdbot": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/telegram",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Telegram channel plugin",
   "clawdbot": {

--- a/extensions/voice-call/CHANGELOG.md
+++ b/extensions/voice-call/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/voice-call",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot voice-call plugin",
   "dependencies": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/whatsapp",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot WhatsApp channel plugin",
   "clawdbot": {

--- a/extensions/zalo/CHANGELOG.md
+++ b/extensions/zalo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/zalo",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Zalo channel plugin",
   "clawdbot": {

--- a/extensions/zalouser/CHANGELOG.md
+++ b/extensions/zalouser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.1.22
+
+### Changes
+- Version alignment with core Clawdbot release numbers.
+
 ## 2026.1.21
 
 ### Changes

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdbot/zalouser",
-  "version": "2026.1.21",
+  "version": "2026.1.22",
   "type": "module",
   "description": "Clawdbot Zalo Personal Account plugin via zca-cli",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdbot",
-  "version": "2026.1.21-2",
+  "version": "2026.1.22",
   "description": "WhatsApp gateway CLI (Baileys web) with Pi RPC agent",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Fixes typing indicators not being stopped when:
- Agent goes idle after processing
- Agent replies with NO_REPLY

## Background

The typing stop was previously disabled because BlueBubbles Server had a bug where the DELETE `/typing` endpoint called `startTyping()` instead of `stopTyping()`. That bug has been fixed (PR pending in BlueBubbles Server), so we can now properly stop typing indicators.

## Changes

- `onIdle`: now calls `sendBlueBubblesTyping(false)` to stop typing
- `finally` block: stops typing when no message was sent (NO_REPLY case)

## Related

- BlueBubbles Server fix: [pending PR](https://github.com/BlueBubblesApp/bluebubbles-server/pull/768)