### PR TITLE
fix: update token count display after compaction

### DIFF
--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -59,6 +59,7 @@ export type EmbeddedPiCompactResult = {
     summary: string;
     firstKeptEntryId: string;
     tokensBefore: number;
+    tokensAfter?: number;
     details?: unknown;
   };
 };

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -104,7 +104,8 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   }
   // Use the post-compaction token count for context summary if available
   const tokensAfterCompaction = result.result?.tokensAfter;
-  const totalTokens = tokensAfterCompaction ??
+  const totalTokens =
+    tokensAfterCompaction ??
     params.sessionEntry.totalTokens ??
     (params.sessionEntry.inputTokens ?? 0) + (params.sessionEntry.outputTokens ?? 0);
   const contextSummary = formatContextUsageShort(

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -83,18 +83,13 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
   });
 
-  const totalTokens =
-    params.sessionEntry.totalTokens ??
-    (params.sessionEntry.inputTokens ?? 0) + (params.sessionEntry.outputTokens ?? 0);
-  const contextSummary = formatContextUsageShort(
-    totalTokens > 0 ? totalTokens : null,
-    params.contextTokens ?? params.sessionEntry.contextTokens ?? null,
-  );
   const compactLabel = result.ok
     ? result.compacted
-      ? result.result?.tokensBefore
-        ? `Compacted (${formatTokenCount(result.result.tokensBefore)} before)`
-        : "Compacted"
+      ? result.result?.tokensBefore != null && result.result?.tokensAfter != null
+        ? `Compacted (${formatTokenCount(result.result.tokensBefore)} → ${formatTokenCount(result.result.tokensAfter)})`
+        : result.result?.tokensBefore
+          ? `Compacted (${formatTokenCount(result.result.tokensBefore)} before)`
+          : "Compacted"
       : "Compaction skipped"
     : "Compaction failed";
   if (result.ok && result.compacted) {
@@ -103,8 +98,19 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       sessionStore: params.sessionStore,
       sessionKey: params.sessionKey,
       storePath: params.storePath,
+      // Update token counts after compaction
+      tokensAfter: result.result?.tokensAfter,
     });
   }
+  // Use the post-compaction token count for context summary if available
+  const tokensAfterCompaction = result.result?.tokensAfter;
+  const totalTokens = tokensAfterCompaction ??
+    params.sessionEntry.totalTokens ??
+    (params.sessionEntry.inputTokens ?? 0) + (params.sessionEntry.outputTokens ?? 0);
+  const contextSummary = formatContextUsageShort(
+    totalTokens > 0 ? totalTokens : null,
+    params.contextTokens ?? params.sessionEntry.contextTokens ?? null,
+  );
   const reason = result.reason?.trim();
   const line = reason
     ? `${compactLabel}: ${reason} • ${contextSummary}`

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -240,7 +240,14 @@ export async function incrementCompactionCount(params: {
   /** Token count after compaction - if provided, updates session token counts */
   tokensAfter?: number;
 }): Promise<number | undefined> {
-  const { sessionEntry, sessionStore, sessionKey, storePath, now = Date.now(), tokensAfter } = params;
+  const {
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    storePath,
+    now = Date.now(),
+    tokensAfter,
+  } = params;
   if (!sessionStore || !sessionKey) return undefined;
   const entry = sessionStore[sessionKey] ?? sessionEntry;
   if (!entry) return undefined;


### PR DESCRIPTION
Fixes #1299

## Problem

After running `/compact`, the `/status` command shows stale token counts until the next API call. Users see the pre-compaction token count (e.g., 85k) even though compaction reduced it significantly (e.g., to 35k).

## Solution

1. **Calculate `tokensAfter`** — After compaction completes, estimate the new token count by summing `estimateTokens()` for all remaining messages
2. **Update session entry** — Store the new token count in the session's cached `totalTokens`
3. **Display both values** — Show "Compacted (85k → 35k)" format instead of just "85k before"

## Changes

- `src/agents/pi-embedded-runner/compact.ts` — Calculate `tokensAfter` after compaction
- `src/agents/pi-embedded-runner/types.ts` — Add `tokensAfter` to result type
- `src/auto-reply/reply/commands-compact.ts` — Display new format, pass `tokensAfter` to session update
- `src/auto-reply/reply/session-updates.ts` — Update session's `totalTokens` after compaction

## Safety

- Try-catch around token estimation
- Sanity check: if `tokensAfter > tokensBefore`, discard estimate
- `tokensAfter` is optional, falls back gracefully to old behavior

## Upstream Note (pi-coding-agent)

This PR does **not** add `tokensAfter` to the session log `.jsonl` entry — that would require changes to pi-coding-agent's `SessionManager.appendCompaction()`. A separate issue should be opened in the pi-coding-agent repo to track this enhancement.

---

🤖 *This PR was developed with AI assistance (Claude/Clawdbot). The code was reviewed, tested with isolated unit tests, and verified to compile correctly.*