### PR TITLE
fix(slack): remove deprecated filetype field from files.uploadV2 [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Control UI: ignore bootstrap identity placeholder text for avatar values and fall back to the default avatar. https://docs.clawd.bot/cli/agents https://docs.clawd.bot/web/control-ui
+- Slack: remove deprecated `filetype` field from `files.uploadV2` to eliminate API warnings. (#1447)
 
 ## 2026.1.21
 

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -94,7 +94,7 @@ async function uploadSlackFile(params: {
     file: buffer,
     filename: fileName,
     ...(params.caption ? { initial_comment: params.caption } : {}),
-    ...(contentType ? { filetype: contentType } : {}),
+    // Note: filetype is deprecated in files.uploadV2, Slack auto-detects from file content
   };
   const payload: FilesUploadV2Arguments = params.threadTs
     ? { ...basePayload, thread_ts: params.threadTs }


### PR DESCRIPTION
## Summary

Removes the deprecated `filetype` field from Slack's `files.uploadV2` API calls.

## Problem

Slack's `files.uploadV2` API no longer supports the `filetype` field and logs deprecation warnings when it's included:

```
[WARN] web-api:WebClient filetype is no longer a supported field in files.uploadV2.
```

These warnings appear repeatedly in logs during file uploads.

## Solution

Remove the `filetype` field from the upload payload. Slack auto-detects the file type from the file content, so this field is unnecessary.

## Testing

- [x] Lint passes (`pnpm lint`)
- [x] Build passes (`pnpm build`)
- [x] File uploads continue to work (tested locally - Slack auto-detects content type)
- [x] Warning messages no longer appear in logs

**Testing level:** Lightly tested (manual verification of file uploads working)

## Related

This was discovered while debugging file upload issues - the main fix for `path`/`filePath` parameters was already addressed in commit `0f7f7bb95f`.

---

## 🤖 AI-Assisted PR

- [x] This PR was AI-assisted (Nuri/Claude)
- [x] **Testing level:** Lightly tested - lint, build, manual file upload verification
- [x] **I understand the code:** Yes - the change removes a single deprecated API field (`filetype`) from the Slack `files.uploadV2` payload. Slack's API auto-detects file types from content, making this field unnecessary and its inclusion causes deprecation warnings.

**Context:** Discovered while debugging Slack file upload issues reported by user. Analyzed logs showing repeated `[WARN] web-api:WebClient filetype is no longer a supported field` warnings, traced to `src/slack/send.ts:uploadSlackFile()`, and removed the deprecated field.