### PR TITLE
fix(doctor): check CLAWDBOT_GATEWAY_TOKEN env var for token auth

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -112,8 +112,10 @@ export async function doctorCommand(
   }
   if (resolveMode(cfg) === "local") {
     const authMode = cfg.gateway?.auth?.mode;
-    const token =
+    const configToken =
       typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway?.auth?.token.trim() : "";
+    const envToken = process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ?? "";
+    const token = configToken || envToken;
     const needsToken = authMode !== "password" && (authMode !== "token" || !token);
     if (needsToken) {
       note(


### PR DESCRIPTION
## Problem

`clawdbot doctor` shows a false positive warning about missing gateway token when the token is set via `CLAWDBOT_GATEWAY_TOKEN` environment variable instead of in the config file.

```
◇  Gateway auth ──────────────────────────────────────────────────╮
│                                                                 │
│  Gateway auth is off or missing a token. Token auth is now the  │
│  recommended default (including loopback).                      │
│                                                                 │
├─────────────────────────────────────────────────────────────────╯
```

This is a common setup when you want to keep secrets out of version-controlled config files.

## Solution

Check both `gateway.auth.token` config and `CLAWDBOT_GATEWAY_TOKEN` env var, matching the runtime behavior in `src/gateway/auth.ts`.

## Testing

Verified that doctor no longer shows the warning when `CLAWDBOT_GATEWAY_TOKEN` is set in the environment.