### PR TITLE
fix(slack): support threadId in readSlackMessages

### DIFF
--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -186,9 +186,26 @@ export async function readSlackMessages(
     limit?: number;
     before?: string;
     after?: string;
+    threadId?: string;
   } = {},
 ): Promise<{ messages: SlackMessageSummary[]; hasMore: boolean }> {
   const client = await getClient(opts);
+
+  // Use conversations.replies for thread messages, conversations.history for channel messages
+  if (opts.threadId) {
+    const result = await client.conversations.replies({
+      channel: channelId,
+      ts: opts.threadId,
+      limit: opts.limit,
+      latest: opts.before,
+      oldest: opts.after,
+    });
+    return {
+      messages: (result.messages ?? []) as SlackMessageSummary[],
+      hasMore: Boolean(result.has_more),
+    };
+  }
+
   const result = await client.conversations.history({
     channel: channelId,
     limit: opts.limit,


### PR DESCRIPTION
## Summary

When `threadId` is passed to the `message read` action (via `readSlackMessages`), the function now uses `conversations.replies` API instead of `conversations.history` to properly fetch thread messages.

## Problem

Previously, `readSlackMessages` ignored the `threadId` parameter and always used `conversations.history`, which returns channel-level messages rather than thread replies. This made it impossible to read messages within a specific thread.

## Solution

Added conditional logic to check for `opts.threadId`:
- If `threadId` is provided: use `client.conversations.replies` with the thread timestamp
- Otherwise: use existing `client.conversations.history` logic

## Changes

- Added `threadId?: string` to the opts type
- Added branch to call `conversations.replies` when `threadId` is present

## Testing

The fix follows the same pattern as the existing code and uses the same response structure.