### PR TITLE
fix(slack): support threadId in message read action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.clawd.bot
 - Agents/TUI: honor user-pinned auth profiles during cooldown and preserve search picker ranking. (#1432) Thanks @tobiasbischoff.
 - Mattermost (plugin): enforce pairing/allowlist gating, keep @username targets, and clarify plugin-only docs. (#1428) Thanks @damoahdominic.
 - Docs: fix gog auth services example to include docs scope. (#1454) Thanks @zerone0x.
+- Slack: read thread replies for message reads when threadId is provided (replies-only). (#1450) Thanks @rodrigouroz.
 - macOS: prefer linked channels in gateway summary to avoid false “not linked” status.
 - Providers: improve GitHub Copilot integration (enterprise support, base URL, and auth flow alignment).
 

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -357,6 +357,20 @@ describe("handleSlackAction", () => {
     expect(payload.messages[0].timestampUtc).toBe(new Date(expectedMs).toISOString());
   });
 
+  it("passes threadId through to readSlackMessages", async () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as ClawdbotConfig;
+    readSlackMessages.mockClear();
+    readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
+
+    await handleSlackAction(
+      { action: "readMessages", channelId: "C1", threadId: "12345.6789" },
+      cfg,
+    );
+
+    const [, opts] = readSlackMessages.mock.calls[0] ?? [];
+    expect(opts?.threadId).toBe("12345.6789");
+  });
+
   it("adds normalized timestamps to pin payloads", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as ClawdbotConfig;
     listSlackPins.mockResolvedValueOnce([

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -214,11 +214,13 @@ export async function handleSlackAction(
           typeof limitRaw === "number" && Number.isFinite(limitRaw) ? limitRaw : undefined;
         const before = readStringParam(params, "before");
         const after = readStringParam(params, "after");
+        const threadId = readStringParam(params, "threadId");
         const result = await readSlackMessages(channelId, {
           ...readOpts,
           limit,
           before: before ?? undefined,
           after: after ?? undefined,
+          threadId: threadId ?? undefined,
         });
         const messages = result.messages.map((message) =>
           withNormalizedTimestamp(

--- a/src/channels/plugins/slack.actions.test.ts
+++ b/src/channels/plugins/slack.actions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ClawdbotConfig } from "../../config/config.js";
+import { createSlackActions } from "./slack.actions.js";
+
+const handleSlackAction = vi.fn(async () => ({ details: { ok: true } }));
+
+vi.mock("../../agents/tools/slack-actions.js", () => ({
+  handleSlackAction: (...args: unknown[]) => handleSlackAction(...args),
+}));
+
+describe("slack actions adapter", () => {
+  it("forwards threadId for read", async () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as ClawdbotConfig;
+    const actions = createSlackActions("slack");
+
+    await actions.handleAction?.({
+      channel: "slack",
+      action: "read",
+      cfg,
+      params: {
+        channelId: "C1",
+        threadId: "171234.567",
+      },
+    });
+
+    const [params] = handleSlackAction.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      action: "readMessages",
+      channelId: "C1",
+      threadId: "171234.567",
+    });
+  });
+});

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -133,6 +133,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,

--- a/src/slack/actions.read.test.ts
+++ b/src/slack/actions.read.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WebClient } from "@slack/web-api";
+
+import { readSlackMessages } from "./actions.js";
+
+function createClient() {
+  return {
+    conversations: {
+      replies: vi.fn(async () => ({ messages: [], has_more: false })),
+      history: vi.fn(async () => ({ messages: [], has_more: false })),
+    },
+  } as unknown as WebClient & {
+    conversations: {
+      replies: ReturnType<typeof vi.fn>;
+      history: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+describe("readSlackMessages", () => {
+  it("uses conversations.replies and drops the parent message", async () => {
+    const client = createClient();
+    client.conversations.replies.mockResolvedValueOnce({
+      messages: [{ ts: "171234.567" }, { ts: "171234.890" }, { ts: "171235.000" }],
+      has_more: true,
+    });
+
+    const result = await readSlackMessages("C1", {
+      client,
+      threadId: "171234.567",
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.replies).toHaveBeenCalledWith({
+      channel: "C1",
+      ts: "171234.567",
+      limit: undefined,
+      latest: undefined,
+      oldest: undefined,
+    });
+    expect(client.conversations.history).not.toHaveBeenCalled();
+    expect(result.messages.map((message) => message.ts)).toEqual(["171234.890", "171235.000"]);
+  });
+
+  it("uses conversations.history when threadId is missing", async () => {
+    const client = createClient();
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [{ ts: "1" }],
+      has_more: false,
+    });
+
+    const result = await readSlackMessages("C1", {
+      client,
+      limit: 20,
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.history).toHaveBeenCalledWith({
+      channel: "C1",
+      limit: 20,
+      latest: undefined,
+      oldest: undefined,
+    });
+    expect(client.conversations.replies).not.toHaveBeenCalled();
+    expect(result.messages.map((message) => message.ts)).toEqual(["1"]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the `message read` action to support reading Slack thread replies.

## Changes
1. **`src/slack/actions.ts`**: Added `threadId` parameter to `readSlackMessages()` - when provided, uses `conversations.replies` instead of `conversations.history`
2. **`src/agents/tools/slack-actions.ts`**: Pass `threadId` from params through to `readSlackMessages()`

## threadId Flow
```
message tool schema (threadId param)
  → handleSlackAction (reads threadId)
    → readSlackMessages (uses conversations.replies when threadId present)
```

Closes #1449