### PR TITLE
docs(gog): fix invalid service name in auth example

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -11,7 +11,7 @@ Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
 Setup (once)
 - `gog auth credentials /path/to/client_secret.json`
-- `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,sheets,docs`
+- `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,tasks,people,sheets`
 - `gog auth list`
 
 Common commands


### PR DESCRIPTION
## Summary
Fixes #1433

The gog skill documentation listed an invalid `docs` service in the auth setup example. This caused the command to fail:

```
gog auth add you@gmail.com --services gmail,calendar,drive,contacts,sheets,docs
# Error: unknown service "docs" (expected gmail|calendar|drive|contacts|tasks|people|sheets)
```

## Changes
- Replace `docs` with `tasks,people` in the services list example
- Note: `gog docs` subcommands (export/cat) work via Drive auth, not a separate "docs" service

---
🤖 Generated with [Claude Code](https://claude.ai/code)