### PR TITLE
fix: sanitize tool call text in sessions-helpers extractAssistantText

### DIFF
--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -9,7 +9,7 @@ import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
  * - <invoke name="...">...</invoke> blocks
  * - </minimax:tool_call> closing tags
  */
-function stripMinimaxToolCallXml(text: string): string {
+export function stripMinimaxToolCallXml(text: string): string {
   if (!text) return text;
   if (!/minimax:tool_call/i.test(text)) return text;
 
@@ -28,7 +28,7 @@ function stripMinimaxToolCallXml(text: string): string {
  * downgraded to text blocks like `[Tool Call: name (ID: ...)]`. These should
  * not be shown to users.
  */
-function stripDowngradedToolCallText(text: string): string {
+export function stripDowngradedToolCallText(text: string): string {
   if (!text) return text;
   if (!/\[Tool (?:Call|Result)/i.test(text)) return text;
 
@@ -165,7 +165,7 @@ function stripDowngradedToolCallText(text: string): string {
  * This is a safety net for cases where the model outputs <think> tags
  * that slip through other filtering mechanisms.
  */
-function stripThinkingTagsFromText(text: string): string {
+export function stripThinkingTagsFromText(text: string): string {
   if (!text) return text;
   // Quick check to avoid regex overhead when no tags present.
   if (!/(?:think(?:ing)?|thought|antthinking)/i.test(text)) return text;


### PR DESCRIPTION
## Summary
Fixes #1269

Adds sanitization to `extractAssistantText` in `sessions-helpers.ts` to prevent tool call text from leaking to users. Previously, messages retrieved from chat history via `sessions-helpers.ts` could expose:

- Minimax XML tool calls (`<invoke>...</invoke>`)
- Downgraded tool call markers (`[Tool Call: name (ID: ...)]`)
- Thinking tags (`<think>...</think>`)

## Changes
- Export the stripping functions (`stripMinimaxToolCallXml`, `stripDowngradedToolCallText`, `stripThinkingTagsFromText`) from `pi-embedded-utils.ts`
- Add a new `sanitizeTextContent` helper in `sessions-helpers.ts` that chains the sanitization functions
- Update `extractAssistantText` in `sessions-helpers.ts` to sanitize text content before returning
- Update `extractMessageText` in `commands-subagents.ts` to use the same sanitization

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test src/agents/pi-embedded-utils.test.ts` passes (existing tests for the stripping functions)
- [ ] Manual testing: verify tool call markers no longer appear in `/subagents log` output

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)