### PR TITLE
fix(ui): allow relative URLs in avatar validation

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -407,7 +407,18 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     const cfg = loadConfig();
     const identity = resolveAssistantIdentity({ cfg, agentId });
-    respond(true, identity, undefined);
+    // Resolve local file avatars to /avatar/{agentId} URL
+    let avatarValue = identity.avatar;
+    if (
+      avatarValue &&
+      !/^https?:\/\//i.test(avatarValue) &&
+      !/^data:image\//i.test(avatarValue) &&
+      /\.(png|jpe?g|gif|webp|svg|ico)$/i.test(avatarValue) &&
+      identity.agentId
+    ) {
+      avatarValue = `/avatar/${identity.agentId}`;
+    }
+    respond(true, { ...identity, avatar: avatarValue }, undefined);
   },
   "agent.wait": async ({ params, respond }) => {
     if (!validateAgentWaitParams(params)) {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -158,7 +158,8 @@ function renderAvatar(
 function isAvatarUrl(value: string): boolean {
   return (
     /^https?:\/\//i.test(value) ||
-    /^data:image\//i.test(value)
+    /^data:image\//i.test(value) ||
+    /^\//.test(value) // Relative paths from avatar endpoint
   );
 }
 


### PR DESCRIPTION
## Problem
Local file avatars configured in `identity.avatar` display as text instead of images in the webchat UI.

## Root Cause (3-layer bug)

### 1. Frontend - URL validation too strict
`isAvatarUrl()` only accepted `http://`, `https://`, or `data:` URLs:
```typescript
// Before: didn't accept relative paths
/^https?:\/\//i.test(value) || /^data:image\//i.test(value)
```

### 2. Backend HTML injection
`serveIndexHtml()` injected the raw avatar filename into HTML instead of the resolved URL.

### 3. Backend RPC
`agent.identity.get` returned the raw filename, which overwrote the HTML-injected value when the frontend fetched identity.

## Fix

1. **Frontend**: Accept relative paths starting with `/`
2. **Backend (control-ui.ts)**: Resolve local file avatars to `/avatar/{agentId}` URL before injection
3. **Backend (agent.ts)**: Resolve local file avatars in RPC response

## Testing
- Configure `identity.avatar: "myavatar.png"` in agent config
- Place image in workspace
- Avatar now displays correctly in webchat

Regression from #1329 refactor in 8544df36b.