### PR TITLE
Fix node daemon command

### DIFF
--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -237,7 +237,7 @@ export async function resolveNodeProgramArguments(params: {
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
-  const args = ["node", "start", "--host", params.host, "--port", String(params.port)];
+  const args = ["node", "run", "--host", params.host, "--port", String(params.port)];
   if (params.tls || params.tlsFingerprint) args.push("--tls");
   if (params.tlsFingerprint) args.push("--tls-fingerprint", params.tlsFingerprint);
   if (params.nodeId) args.push("--node-id", params.nodeId);


### PR DESCRIPTION
## Summary
- use `node run` when generating node daemon program arguments
- prevents LaunchAgent/systemd from calling unsupported `node start`

## Testing
- pnpm build
