### PR TITLE
tui: support local shell commands via ! prefix

### DIFF
--- a/Swabble/Package.resolved
+++ b/Swabble/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c0677e232394b5f6b0191b6dbb5bae553d55264f65ae725cd03a8ffdfda9cdd3",
+  "originHash" : "10946d10a137b295c88bae6eb5b1d11f637a00bde46464b19cbf059f77d05e6f",
   "pins" : [
     {
       "identity" : "commander",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "9e349575c8e3c6745e81fe19e5bb5efa01b078ce",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "elevenlabskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/ElevenLabsKit",
+      "state" : {
+        "revision" : "7e3c948d8340abe3977014f3de020edf221e9269",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -26,6 +44,24 @@
       "state" : {
         "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
         "version" : "0.99.0"
+      }
+    },
+    {
+      "identity" : "swiftui-math",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swiftui-math",
+      "state" : {
+        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "textual",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/textual",
+      "state" : {
+        "revision" : "a03c1e103d88de4ea0dd8320ea1611ec0d4b29b3",
+        "version" : "0.2.0"
       }
     }
   ],

--- a/src/tui/tui-input-history.test.ts
+++ b/src/tui/tui-input-history.test.ts
@@ -13,6 +13,7 @@ describe("createEditorSubmitHandler", () => {
       editor,
       handleCommand: vi.fn(),
       sendMessage: vi.fn(),
+      handleBangLine: vi.fn(),
     });
 
     handler("hello world");
@@ -21,7 +22,7 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.addToHistory).toHaveBeenCalledWith("hello world");
   });
 
-  it("trims input before adding to history", () => {
+  it("does not trim input before adding to history", () => {
     const editor = {
       setText: vi.fn(),
       addToHistory: vi.fn(),
@@ -31,14 +32,15 @@ describe("createEditorSubmitHandler", () => {
       editor,
       handleCommand: vi.fn(),
       sendMessage: vi.fn(),
+      handleBangLine: vi.fn(),
     });
 
     handler("   hi   ");
 
-    expect(editor.addToHistory).toHaveBeenCalledWith("hi");
+    expect(editor.addToHistory).toHaveBeenCalledWith("   hi   ");
   });
 
-  it("does not add empty submissions to history", () => {
+  it("does not add empty-string submissions to history", () => {
     const editor = {
       setText: vi.fn(),
       addToHistory: vi.fn(),
@@ -48,9 +50,10 @@ describe("createEditorSubmitHandler", () => {
       editor,
       handleCommand: vi.fn(),
       sendMessage: vi.fn(),
+      handleBangLine: vi.fn(),
     });
 
-    handler("   ");
+    handler("");
 
     expect(editor.addToHistory).not.toHaveBeenCalled();
   });
@@ -67,6 +70,7 @@ describe("createEditorSubmitHandler", () => {
       editor,
       handleCommand,
       sendMessage,
+      handleBangLine: vi.fn(),
     });
 
     handler("/models");
@@ -88,6 +92,7 @@ describe("createEditorSubmitHandler", () => {
       editor,
       handleCommand,
       sendMessage,
+      handleBangLine: vi.fn(),
     });
 
     handler("hello");
@@ -95,5 +100,43 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.addToHistory).toHaveBeenCalledWith("hello");
     expect(sendMessage).toHaveBeenCalledWith("hello");
     expect(handleCommand).not.toHaveBeenCalled();
+  });
+
+  it("routes bang-prefixed lines to handleBangLine", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleBangLine = vi.fn();
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage: vi.fn(),
+      handleBangLine,
+    });
+
+    handler("!ls");
+
+    expect(handleBangLine).toHaveBeenCalledWith("!ls");
+  });
+
+  it("treats a lone ! as a normal message", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const sendMessage = vi.fn();
+
+    const handler = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage,
+      handleBangLine: vi.fn(),
+    });
+
+    handler("!");
+
+    expect(sendMessage).toHaveBeenCalledWith("!");
   });
 });

--- a/src/tui/tui-input-history.test.ts
+++ b/src/tui/tui-input-history.test.ts
@@ -22,7 +22,7 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.addToHistory).toHaveBeenCalledWith("hello world");
   });
 
-  it("does not trim input before adding to history", () => {
+  it("trims input before adding to history", () => {
     const editor = {
       setText: vi.fn(),
       addToHistory: vi.fn(),
@@ -37,7 +37,7 @@ describe("createEditorSubmitHandler", () => {
 
     handler("   hi   ");
 
-    expect(editor.addToHistory).toHaveBeenCalledWith("   hi   ");
+    expect(editor.addToHistory).toHaveBeenCalledWith("hi");
   });
 
   it("does not add empty-string submissions to history", () => {

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -50,7 +50,7 @@ describe("createEditorSubmitHandler", () => {
     expect(sendMessage).toHaveBeenCalledWith("!");
   });
 
-  it("does not trim input", () => {
+  it("trims normal messages before sending and adding to history", () => {
     const editor = {
       setText: vi.fn(),
       addToHistory: vi.fn(),
@@ -68,7 +68,7 @@ describe("createEditorSubmitHandler", () => {
 
     onSubmit("  hello  ");
 
-    expect(sendMessage).toHaveBeenCalledWith("  hello  ");
-    expect(editor.addToHistory).toHaveBeenCalledWith("  hello  ");
+    expect(sendMessage).toHaveBeenCalledWith("hello");
+    expect(editor.addToHistory).toHaveBeenCalledWith("hello");
   });
 });

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEditorSubmitHandler } from "./tui.js";
+
+describe("createEditorSubmitHandler", () => {
+  it("routes lines starting with ! to handleBangLine", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleCommand = vi.fn();
+    const sendMessage = vi.fn();
+    const handleBangLine = vi.fn();
+
+    const onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand,
+      sendMessage,
+      handleBangLine,
+    });
+
+    onSubmit("!ls");
+
+    expect(handleBangLine).toHaveBeenCalledTimes(1);
+    expect(handleBangLine).toHaveBeenCalledWith("!ls");
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(handleCommand).not.toHaveBeenCalled();
+  });
+
+  it("treats a lone ! as a normal message", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleCommand = vi.fn();
+    const sendMessage = vi.fn();
+    const handleBangLine = vi.fn();
+
+    const onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand,
+      sendMessage,
+      handleBangLine,
+    });
+
+    onSubmit("!");
+
+    expect(handleBangLine).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("!");
+  });
+
+  it("does not trim input", () => {
+    const editor = {
+      setText: vi.fn(),
+      addToHistory: vi.fn(),
+    };
+    const handleCommand = vi.fn();
+    const sendMessage = vi.fn();
+    const handleBangLine = vi.fn();
+
+    const onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand,
+      sendMessage,
+      handleBangLine,
+    });
+
+    onSubmit("  hello  ");
+
+    expect(sendMessage).toHaveBeenCalledWith("  hello  ");
+    expect(editor.addToHistory).toHaveBeenCalledWith("  hello  ");
+  });
+});

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -525,6 +525,9 @@ export async function runTui(opts: TuiOptions) {
 
     return await new Promise<boolean>((resolve) => {
       chatLog.addSystem("Allow local shell commands for this session?");
+      chatLog.addSystem(
+        "This runs commands on YOUR machine (not the gateway) and may delete files or reveal secrets.",
+      );
       chatLog.addSystem("Select Yes/No (arrows + Enter), Esc to cancel.");
       const selector = createSearchableSelectList(
         [

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -6,6 +6,7 @@ import {
   Text,
   TUI,
 } from "@mariozechner/pi-tui";
+import { spawn } from "node:child_process";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -21,6 +22,7 @@ import { GatewayChatClient } from "./gateway-chat.js";
 import { editorTheme, theme } from "./theme/theme.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
+import { createSearchableSelectList } from "./components/selectors.js";
 import { formatTokens } from "./tui-formatters.js";
 import { buildWaitingStatusMessage, defaultWaitingPhrases } from "./tui-waiting.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
@@ -43,19 +45,30 @@ export function createEditorSubmitHandler(params: {
   };
   handleCommand: (value: string) => Promise<void> | void;
   sendMessage: (value: string) => Promise<void> | void;
+  handleBangLine: (value: string) => Promise<void> | void;
 }) {
   return (text: string) => {
-    const value = text.trim();
+    // NOTE: We intentionally do not trim here.
+    // The caller decides how to interpret whitespace.
+    const value = text;
     params.editor.setText("");
     if (!value) return;
 
     // Enable built-in editor prompt history navigation (up/down).
     params.editor.addToHistory(value);
 
+    // Bash mode: only if the very first character is '!' and it's not just '!'.
+    // Per requirement: a lone '!' should be treated as a normal message.
+    if (value.startsWith("!") && value !== "!") {
+      void params.handleBangLine(value);
+      return;
+    }
+
     if (value.startsWith("/")) {
       void params.handleCommand(value);
       return;
     }
+
     void params.sendMessage(value);
   };
 }
@@ -77,6 +90,12 @@ export async function runTui(opts: TuiOptions) {
   let isConnected = false;
   let toolsExpanded = false;
   let showThinking = false;
+
+  // Local "bash mode" (lines starting with '!') state.
+  // Permission is asked once per TUI session.
+  let localExecAsked = false;
+  let localExecAllowed = false;
+
   const deliverDefault = opts.deliver ?? false;
   const autoMessage = opts.message?.trim();
   let autoMessageSent = false;
@@ -496,11 +515,105 @@ export async function runTui(opts: TuiOptions) {
       formatSessionKey,
     });
 
+  const ensureLocalExecAllowed = async (): Promise<boolean> => {
+    if (localExecAllowed) return true;
+    if (localExecAsked) return false;
+    localExecAsked = true;
+
+    return await new Promise<boolean>((resolve) => {
+      chatLog.addSystem("Allow local shell commands for this session?");
+      chatLog.addSystem("Select Yes/No (arrows + Enter), Esc to cancel.");
+      const selector = createSearchableSelectList(
+        [
+          { value: "no", label: "No" },
+          { value: "yes", label: "Yes" },
+        ],
+        2,
+      );
+      selector.onSelect = (item) => {
+        closeOverlay();
+        if (item.value === "yes") {
+          localExecAllowed = true;
+          chatLog.addSystem("local shell: enabled for this session");
+          resolve(true);
+        } else {
+          chatLog.addSystem("local shell: not enabled");
+          resolve(false);
+        }
+        tui.requestRender();
+      };
+      selector.onCancel = () => {
+        closeOverlay();
+        chatLog.addSystem("local shell: cancelled");
+        tui.requestRender();
+        resolve(false);
+      };
+      openOverlay(selector);
+      tui.requestRender();
+    });
+  };
+
+  const runLocalShellLine = async (line: string) => {
+    // line starts with '!'
+    const cmd = line.slice(1);
+    // NOTE: A lone '!' is handled by the submit handler as a normal message.
+    // Keep this guard anyway in case this is called directly.
+    if (cmd === "") return;
+
+    const allowed = await ensureLocalExecAllowed();
+    if (!allowed) return;
+
+    chatLog.addSystem(`[local] $ ${cmd}`);
+    tui.requestRender();
+
+    await new Promise<void>((resolve) => {
+      const child = spawn(cmd, {
+        shell: true,
+        cwd: process.cwd(),
+        env: process.env,
+      });
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (buf) => {
+        stdout += buf.toString("utf8");
+      });
+      child.stderr.on("data", (buf) => {
+        stderr += buf.toString("utf8");
+      });
+
+      child.on("close", (code, signal) => {
+        const maxChars = 40_000;
+        const combined = (stdout + (stderr ? (stdout ? "\n" : "") + stderr : ""))
+          .slice(0, maxChars)
+          .trimEnd();
+
+        if (combined) {
+          for (const line of combined.split("\n")) {
+            chatLog.addSystem(`[local] ${line}`);
+          }
+        }
+        chatLog.addSystem(
+          `[local] exit ${code ?? "?"}${signal ? ` (signal ${String(signal)})` : ""}`,
+        );
+        tui.requestRender();
+        resolve();
+      });
+
+      child.on("error", (err) => {
+        chatLog.addSystem(`[local] error: ${String(err)}`);
+        tui.requestRender();
+        resolve();
+      });
+    });
+  };
+
   updateAutocompleteProvider();
   editor.onSubmit = createEditorSubmitHandler({
     editor,
     handleCommand,
     sendMessage,
+    handleBangLine: runLocalShellLine,
   });
 
   editor.onEscape = () => {


### PR DESCRIPTION
## Summary

Adds a TUI-only escape hatch: input lines whose first character is `!` are executed locally (in the same working directory as the TUI process) instead of being sent to the gateway chat.

- Prompts once per TUI session to allow local shell execution.
- Captures stdout/stderr and prints results back into the chat log with a `[local]` prefix.
- A lone `!` is treated as a normal message (not a command).

## Behavior (important)

This is intentionally **simple**: each `!` command is executed in a **fresh child shell**.

- **Working directory:** commands run with `cwd = process.cwd()` (the directory where the TUI was started).
- **No persistent shell state:** commands like `cd ...`, `export FOO=...`, shell functions/aliases, etc. do **not** persist to subsequent `!` commands.
- **Non-interactive:** this uses a non-PTY spawn and captures output. Full-screen / interactive programs (e.g. `vim`, `less`, `ssh` prompts, `fzf`) may not behave as expected.
- **Bang detection:** only when the **very first character** is `!` (no whitespace handling). If the first character is not `!`, the line is treated as a normal message.

## Testing

- `pnpm lint`
- `pnpm test src/tui/tui-input-history.test.ts src/tui/tui.submit-handler.test.ts`

## AI-assisted

This PR was AI-assisted. I reviewed the changes and ran the tests above.
