### PR TITLE
fix(session-memory): suppress user-visible confirmation message

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -160,11 +160,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
     await fs.writeFile(memoryFilePath, entry, "utf-8");
     console.log("[session-memory] Memory file written successfully");
 
-    // Send confirmation message to user with filename
+    // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
     const relPath = memoryFilePath.replace(os.homedir(), "~");
-    const confirmMsg = `💾 Session context saved to memory before reset.\n📄 ${relPath}`;
-    event.messages.push(confirmMsg);
-    console.log("[session-memory] Confirmation message queued:", confirmMsg);
+    console.log(`[session-memory] Session context saved to ${relPath}`);
   } catch (err) {
     console.error(
       "[session-memory] Failed to save session memory:",


### PR DESCRIPTION
## Problem

When users run `/new` or `/reset`, they see internal housekeeping messages that leak implementation details:

```
💾 Session context saved to memory before reset.
📄 ~/clawd/memory/2026-01-22-version-check.md
```

This is confusing for users and exposes internal behavior that should be silent.

## Solution

Remove the user-visible confirmation message while keeping the console.log for debugging. The session-memory hook continues to save context silently — users just don't see the confirmation anymore.

## Changes

- Remove `event.messages.push(confirmMsg)` that sent the user-visible message
- Keep console logging for debugging purposes
- Update comment to clarify the intent