### PR TITLE
fix: only show model switch success when persist succeeds (fixes #1435)

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.model-persist.test.ts
+++ b/src/auto-reply/reply/directive-handling.impl.model-persist.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { ClawdbotConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { parseInlineDirectives } from "./directive-handling.js";
+import { handleDirectiveOnly } from "./directive-handling.impl.js";
+
+// Mock dependencies
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: vi.fn(() => ({})),
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveSessionAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("../../agents/sandbox.js", () => ({
+  resolveSandboxRuntimeStatus: vi.fn(() => ({ sandboxed: false })),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: vi.fn(async () => {}),
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+function baseAliasIndex(): ModelAliasIndex {
+  return { byAlias: new Map(), byKey: new Map() };
+}
+
+function baseConfig(): ClawdbotConfig {
+  return {
+    commands: { text: true },
+    agents: { defaults: {} },
+  } as unknown as ClawdbotConfig;
+}
+
+describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
+  const allowedModelKeys = new Set(["anthropic/claude-opus-4-5", "openai/gpt-4o"]);
+  const allowedModelCatalog = [
+    { provider: "anthropic", id: "claude-opus-4-5" },
+    { provider: "openai", id: "gpt-4o" },
+  ];
+
+  it("shows success message when session state is available", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { "agent:main:dm:1": sessionEntry };
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:dm:1",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      allowedModelCatalog,
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    expect(result?.text).toContain("Model set to");
+    expect(result?.text).toContain("openai/gpt-4o");
+    expect(result?.text).not.toContain("failed");
+  });
+
+  it("shows error message when sessionEntry is missing", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionStore = {};
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry: undefined, // Missing!
+      sessionStore,
+      sessionKey: "agent:main:dm:1",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      allowedModelCatalog,
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    expect(result?.text).toContain("failed");
+    expect(result?.text).toContain("session state unavailable");
+  });
+
+  it("shows error message when sessionStore is missing", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+    };
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry,
+      sessionStore: undefined, // Missing!
+      sessionKey: "agent:main:dm:1",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      allowedModelCatalog,
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    expect(result?.text).toContain("failed");
+    expect(result?.text).toContain("session state unavailable");
+  });
+
+  it("shows no model message when no /model directive", async () => {
+    const directives = parseInlineDirectives("hello world");
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { "agent:main:dm:1": sessionEntry };
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:dm:1",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      allowedModelCatalog,
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    // No model directive = no model message
+    expect(result?.text ?? "").not.toContain("Model set to");
+    expect(result?.text ?? "").not.toContain("failed");
+  });
+});

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -461,7 +461,9 @@ export async function handleDirectiveOnly(params: {
       parts.push(`Auth profile set to ${profileOverride}.`);
     }
   } else if (modelSelection && !didPersistModel) {
-    parts.push(`Model switch to ${modelSelection.provider}/${modelSelection.model} failed (session state unavailable).`);
+    parts.push(
+      `Model switch to ${modelSelection.provider}/${modelSelection.model} failed (session state unavailable).`,
+    );
   }
   if (directives.hasQueueDirective && directives.queueMode) {
     parts.push(formatDirectiveAck(`Queue mode set to ${directives.queueMode}.`));

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -288,6 +288,7 @@ export async function handleDirectiveOnly(params: {
     nextThinkLevel === "xhigh" &&
     !supportsXHighThinking(resolvedProvider, resolvedModel);
 
+  let didPersistModel = false;
   if (sessionEntry && sessionStore && sessionKey) {
     const prevElevatedLevel =
       currentElevatedLevel ??
@@ -346,6 +347,7 @@ export async function handleDirectiveOnly(params: {
         selection: modelSelection,
         profileOverride,
       });
+      didPersistModel = true;
     }
     if (directives.hasQueueDirective && directives.queueReset) {
       delete sessionEntry.queueMode;
@@ -447,7 +449,7 @@ export async function handleDirectiveOnly(params: {
       `Thinking level set to high (xhigh not supported for ${resolvedProvider}/${resolvedModel}).`,
     );
   }
-  if (modelSelection) {
+  if (modelSelection && didPersistModel) {
     const label = `${modelSelection.provider}/${modelSelection.model}`;
     const labelWithAlias = modelSelection.alias ? `${modelSelection.alias} (${label})` : label;
     parts.push(
@@ -458,6 +460,8 @@ export async function handleDirectiveOnly(params: {
     if (profileOverride) {
       parts.push(`Auth profile set to ${profileOverride}.`);
     }
+  } else if (modelSelection && !didPersistModel) {
+    parts.push(`Model switch to ${modelSelection.provider}/${modelSelection.model} failed (session state unavailable).`);
   }
   if (directives.hasQueueDirective && directives.queueMode) {
     parts.push(formatDirectiveAck(`Queue mode set to ${directives.queueMode}.`));


### PR DESCRIPTION
## Summary

Fixes #1435 - Model switch via `/model` command reports success but doesn't actually switch.

## Root Cause Analysis

In `src/auto-reply/reply/directive-handling.impl.ts`, the `handleDirectiveOnly` function has two separate code blocks:

**Block 1 (lines 291-397):** Session state persistence
```typescript
if (sessionEntry && sessionStore && sessionKey) {
  // ... other directives ...
  if (modelSelection) {
    applyModelOverrideToSessionEntry({...});  // Actually saves the model
  }
  // ... persist to disk ...
}
```

**Block 2 (lines 450-463):** User feedback message generation
```typescript
if (modelSelection) {
  parts.push(`Model set to ${label}.`);  // Always shown if modelSelection exists!
}
```

**The bug:** Block 2 runs regardless of whether Block 1 executed. So when `sessionEntry`, `sessionStore`, or `sessionKey` is missing:
- ❌ Model override is NOT persisted
- ✅ "Model set to X" message IS shown
- → User sees success, but `/status` still shows old model

## The Fix

Track whether the persist actually happened:

```diff
+  let didPersistModel = false;
   if (sessionEntry && sessionStore && sessionKey) {
     ...
     if (modelSelection) {
       applyModelOverrideToSessionEntry({...});
+      didPersistModel = true;
     }
   }
   
   // User feedback - now conditional on actual persist
-  if (modelSelection) {
+  if (modelSelection && didPersistModel) {
     parts.push(`Model set to ${labelWithAlias}.`);
+  } else if (modelSelection && !didPersistModel) {
+    parts.push(`Model switch to ${provider}/${model} failed (session state unavailable).`);
   }
```

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Session state available | "Model set to X" ✅ | "Model set to X" ✅ |
| Session state missing | "Model set to X" ❌ | "Model switch failed..." ✅ |
| No /model directive | (nothing) | (nothing) |

## Testing

Added unit tests covering all edge cases in `directive-handling.impl.model-persist.test.ts`:

```
✓ shows success message when session state is available
✓ shows error message when sessionEntry is missing  
✓ shows error message when sessionStore is missing
✓ shows no model message when no /model directive

Test Files  1 passed (1)
Tests       4 passed (4)
```

## How to Verify

1. Apply this PR
2. Simulate missing session state (e.g., fresh session before store is initialized)
3. Run `/model <some-model>`
4. **Before fix:** "Model set to X" shown, but `/status` shows old model
5. **After fix:** "Model switch failed (session state unavailable)" shown

## Files Changed

- `src/auto-reply/reply/directive-handling.impl.ts` - 5 lines changed (the fix)
- `src/auto-reply/reply/directive-handling.impl.model-persist.test.ts` - new file (174 lines, unit tests)

## AI Disclosure

- 🤖 **AI-assisted:** Claude Opus 4.5 via Clawdbot
- 🧪 **Testing:** Fully tested - 4 unit tests added, all passing
- ✅ **Code understanding:** Yes, traced through the codebase to find root cause
- 📝 **Prompts/context:** Available on request

---

Minimal, surgical fix. No unrelated changes. Tests cover all edge cases.