### PR TITLE
fix: suppress spinner in logs --follow mode

### DIFF
--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -23,13 +23,14 @@ export async function callGatewayFromCli(
   method: string,
   opts: GatewayRpcOpts,
   params?: unknown,
-  extra?: { expectFinal?: boolean },
+  extra?: { expectFinal?: boolean; progress?: boolean },
 ) {
+  const showProgress = extra?.progress ?? opts.json !== true;
   return await withProgress(
     {
       label: `Gateway ${method}`,
       indeterminate: true,
-      enabled: opts.json !== true,
+      enabled: showProgress,
     },
     async () =>
       await callGateway({


### PR DESCRIPTION
## Summary
- Fix repeated spinner frames (◇ │) appearing every polling interval in `clawdbot logs --follow`
- Add `progress` option to `callGatewayFromCli` to allow callers to control spinner visibility
- Disable spinner during follow mode polling, only show on first fetch

## Problem
The progress spinner was being shown for each gateway RPC call during log tailing. In `--follow` mode, this caused spinner end-frames to appear every ~1 second, cluttering the output.

```
  00:35:56 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ channels.status 445ms conn=152b0b18…2a84 id=5e30076d…507c
  Log tail truncated (increase --max-bytes).
  │
  ◇
  │
  ◇
  │
  ◇
  │
  ◇
  │
  ◇
  │
  ◇
  ^C%
  ```

## Test plan
- [x] Run `clawdbot logs --follow` and verify no spinner frames appear during polling
- [x] Run `clawdbot logs` (without --follow) and verify spinner still appears on initial fetch
- [x] `pnpm lint && pnpm build` passes
- [x] `pnpm test logs` passes

🤖 Generated with [Claude Code](https://claude.ai/code)