### PR TITLE
feat(agents): add lobster tool to run Lobster pipelines

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -9,6 +9,7 @@ import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
+import { createLobsterTool } from "./tools/lobster-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
@@ -80,6 +81,7 @@ export function createClawdbotTools(options?: {
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
     }),
+    createLobsterTool(),
     createMessageTool({
       agentAccountId: options?.agentAccountId,
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/tools/lobster-tool.ts
+++ b/src/agents/tools/lobster-tool.ts
@@ -1,0 +1,117 @@
+import { spawn } from "node:child_process";
+
+import { Type } from "@sinclair/typebox";
+
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_CHARS = 50_000;
+
+const LobsterToolSchema = Type.Object({
+  pipeline: Type.String({ description: "Lobster pipeline string to run." }),
+  timeoutMs: Type.Optional(
+    Type.Number({
+      description: "Timeout in milliseconds (kills the lobster process on expiry).",
+      minimum: 1_000,
+    }),
+  ),
+  maxChars: Type.Optional(
+    Type.Number({
+      description: "Maximum characters to return from lobster stdout/stderr.",
+      minimum: 1_000,
+    }),
+  ),
+});
+
+type LobsterEnvelope = {
+  protocolVersion?: number;
+  ok: boolean;
+  status?: string;
+  output?: unknown;
+  error?: { type?: string; message?: string };
+  requiresApproval?: unknown;
+};
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars) + `\n…(truncated ${text.length - maxChars} chars)`;
+}
+
+async function runLobsterToolMode(params: {
+  pipeline: string;
+  timeoutMs: number;
+  maxChars: number;
+}): Promise<LobsterEnvelope> {
+  const lobsterBin = (process.env.LOBSTER_BIN ?? "lobster").trim() || "lobster";
+  const argv = ["run", "--mode", "tool", params.pipeline];
+
+  return await new Promise<LobsterEnvelope>((resolve, reject) => {
+    const child = spawn(lobsterBin, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`lobster timeout after ${params.timeoutMs}ms`));
+    }, params.timeoutMs);
+
+    child.stdout?.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr?.on("data", (d) => {
+      stderr += d.toString();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        const msg = truncate(
+          (stderr || stdout).trim() || `lobster exited ${code}`,
+          params.maxChars,
+        );
+        reject(new Error(msg));
+        return;
+      }
+
+      const trimmed = stdout.trim();
+      try {
+        resolve(JSON.parse(trimmed) as LobsterEnvelope);
+      } catch (err) {
+        const msg = truncate(
+          `lobster returned invalid JSON: ${String(err)}\n${truncate(stdout, params.maxChars)}`,
+          params.maxChars,
+        );
+        reject(new Error(msg));
+      }
+    });
+  });
+}
+
+export function createLobsterTool(): AnyAgentTool {
+  return {
+    label: "Lobster",
+    name: "lobster",
+    description:
+      "Run Lobster pipelines (tool-mode JSON) to build deterministic workflows and recipes.",
+    parameters: LobsterToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const pipeline = readStringParam(params, "pipeline", { required: true, trim: false });
+      const timeoutMs = readNumberParam(params, "timeoutMs") ?? DEFAULT_TIMEOUT_MS;
+      const maxChars = readNumberParam(params, "maxChars") ?? DEFAULT_MAX_CHARS;
+
+      const envelope = await runLobsterToolMode({ pipeline, timeoutMs, maxChars });
+      return jsonResult(envelope);
+    },
+  };
+}


### PR DESCRIPTION
Adds a new agent tool `lobster` that runs Lobster pipelines in tool-mode and returns the parsed JSON envelope.

Why:
- Enables Clawdbot (and cron-driven agent turns) to invoke deterministic Lobster pipelines/recipes without hand-rolling `exec` calls.
- Pairs with Lobster's `commands.list`/`workflows.list` so the agent can discover available stages and build pipelines.

Behavior:
- Executes `lobster run --mode tool <pipeline>` via a local subprocess.
- Lobster executable is resolved via `LOBSTER_BIN` env var (default `lobster`).
- Supports `timeoutMs` and `maxChars`.

Testing:
- `pnpm lint`
- `pnpm test src/agents/pi-tools.create-clawdbot-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts`

Notes:
- This is a thin runner; policy/approvals can be layered later similarly to other exec-like tools.
