### PR TITLE
feat(bluebubbles): add asVoice support for voice memos

### DIFF
--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -356,6 +356,7 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
       const caption = readStringParam(params, "caption");
       const contentType =
         readStringParam(params, "contentType") ?? readStringParam(params, "mimeType");
+      const asVoice = readBooleanParam(params, "asVoice");
 
       // Buffer can come from params.buffer (base64) or params.path (file path)
       const base64Buffer = readStringParam(params, "buffer");
@@ -380,6 +381,7 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
         filename,
         contentType: contentType ?? undefined,
         caption: caption ?? undefined,
+        asVoice: asVoice ?? undefined,
         opts,
       });
 

--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -59,6 +59,7 @@ export async function sendBlueBubblesMedia(params: {
   caption?: string;
   replyToId?: string | null;
   accountId?: string;
+  asVoice?: boolean;
 }) {
   const {
     cfg,
@@ -71,6 +72,7 @@ export async function sendBlueBubblesMedia(params: {
     caption,
     replyToId,
     accountId,
+    asVoice,
   } = params;
   const core = getBlueBubblesRuntime();
   const maxBytes = resolveChannelMediaMaxBytes({
@@ -146,6 +148,7 @@ export async function sendBlueBubblesMedia(params: {
     filename: resolvedFilename ?? "attachment",
     contentType: resolvedContentType ?? undefined,
     replyToMessageGuid,
+    asVoice,
     opts: {
       cfg,
       accountId,


### PR DESCRIPTION
## Summary

Add `asVoice` parameter to BlueBubbles attachment sending that converts audio to iMessage voice memo format and sends as a proper voice message.

## Changes

- Add `asVoice?: boolean` parameter to `sendBlueBubblesAttachment()`
- When `asVoice=true`:
  - Convert audio to Opus CAF format (48kHz) using ffmpeg - this matches iMessage's native voice memo format
  - Set `isAudioMessage=true` in the BlueBubbles API request
- Pass `asVoice` through the action handler and `sendBlueBubblesMedia()`

## Why

The message tool already has a standardized `asVoice` parameter that Telegram supports. This brings BlueBubbles to parity.

Voice memos sent this way appear as native iMessage audio messages with the waveform UI and inline playback, rather than as file attachments.

## Testing

- Tested locally with Kokoro TTS audio converted and sent as voice memo
- Verified the message appears correctly in iMessage with proper duration and playback

## Requirements

- Requires `ffmpeg` with `libopus` support on the host system