### PR TITLE
Fix: Slack Channel, hydrate files from thread root message on replies

### DIFF
--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -53,6 +53,7 @@ export type SlackThreadStarter = {
   text: string;
   userId?: string;
   ts?: string;
+  files?: SlackFile[];
 };
 
 const THREAD_STARTER_CACHE = new Map<string, SlackThreadStarter>();
@@ -71,7 +72,7 @@ export async function resolveSlackThreadStarter(params: {
       ts: params.threadTs,
       limit: 1,
       inclusive: true,
-    })) as { messages?: Array<{ text?: string; user?: string; ts?: string }> };
+    })) as { messages?: Array<{ text?: string; user?: string; ts?: string; files?: SlackFile[] }> };
     const message = response?.messages?.[0];
     const text = (message?.text ?? "").trim();
     if (!message || !text) return null;
@@ -79,6 +80,7 @@ export async function resolveSlackThreadStarter(params: {
       text,
       userId: message.user,
       ts: message.ts,
+      files: message.files,
     };
     THREAD_STARTER_CACHE.set(cacheKey, starter);
     return starter;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -434,6 +434,7 @@ export async function prepareSlackMessage(params: {
 
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
+  let threadStarterMedia: Awaited<ReturnType<typeof resolveSlackMedia>> = null;
   if (isThreadReply && threadTs) {
     const starter = await resolveSlackThreadStarter({
       channelId: message.channel,
@@ -453,10 +454,26 @@ export async function prepareSlackMessage(params: {
       });
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
       threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
+      // If current message has no files but thread starter does, fetch starter's files
+      if (!media && starter.files && starter.files.length > 0) {
+        threadStarterMedia = await resolveSlackMedia({
+          files: starter.files,
+          token: ctx.botToken,
+          maxBytes: ctx.mediaMaxBytes,
+        });
+        if (threadStarterMedia) {
+          logVerbose(
+            `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,
+          );
+        }
+      }
     } else {
       threadLabel = `Slack thread ${roomLabel}`;
     }
   }
+
+  // Use thread starter media if current message has none
+  const effectiveMedia = media ?? threadStarterMedia;
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -483,9 +500,9 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: media?.path,
-    MediaType: media?.contentType,
-    MediaUrl: media?.path,
+    MediaPath: effectiveMedia?.path,
+    MediaType: effectiveMedia?.contentType,
+    MediaUrl: effectiveMedia?.path,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,


### PR DESCRIPTION
 When replying to a Slack thread, files attached to the root message were
  not being fetched. The existing `resolveSlackThreadStarter()` fetched the
  root message text via `conversations.replies` but ignored the `files[]`
  array in the response.

  Changes:
  - Add `files` to `SlackThreadStarter` type and extract from API response
  - Download thread starter files when the reply message has no attachments
  - Add verbose log for thread starter file hydration

  Fixes issue where asking about a file in a thread reply would fail because
  the model never received the file content from the root message.

<img width="300" height="622" alt="Screenshot 2026-01-22 at 10 53 27 PM" src="https://github.com/user-attachments/assets/238287f5-1622-4369-bf2c-45a03e877f3e" />
<img width="300" height="622" alt="Screenshot 2026-01-22 at 10 47 55 PM" src="https://github.com/user-attachments/assets/db16a931-80ce-4a81-88d3-de65a5ff4354" />

