### PR TITLE
CLI: fix Windows gateway startup

### DIFF
--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -115,7 +115,11 @@ if (!shouldBuild()) {
   runNode();
 } else {
   logRunner("Building TypeScript (dist is stale).");
-  const build = spawn("pnpm", ["exec", compiler, ...projectArgs], {
+  const pnpmArgs = ["exec", compiler, ...projectArgs];
+  const buildCmd = process.platform === "win32" ? "cmd.exe" : "pnpm";
+  const buildArgs =
+    process.platform === "win32" ? ["/d", "/s", "/c", "pnpm", ...pnpmArgs] : pnpmArgs;
+  const build = spawn(buildCmd, buildArgs, {
     cwd,
     env,
     stdio: "inherit",

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -94,9 +94,13 @@ export function buildParseArgv(params: {
       : baseArgv[0]?.endsWith("clawdbot")
         ? baseArgv.slice(1)
         : baseArgv;
-  const executable = normalizedArgv[0]?.split(/[/\\]/).pop() ?? "";
+  const executable = (normalizedArgv[0]?.split(/[/\\]/).pop() ?? "").toLowerCase();
   const looksLikeNode =
-    normalizedArgv.length >= 2 && (executable === "node" || executable === "bun");
+    normalizedArgv.length >= 2 &&
+    (executable === "node" ||
+      executable === "node.exe" ||
+      executable === "bun" ||
+      executable === "bun.exe");
   if (looksLikeNode) return normalizedArgv;
   return ["node", programName || "clawdbot", ...normalizedArgv];
 }


### PR DESCRIPTION
## Summary
- Fix lazy subcommand argv reconstruction on Windows when the executable is `node.exe`/`bun.exe`.
- Run the TypeScript build via `cmd.exe /c` on Windows so pnpm exec works from Node.

## Testing
- `pnpm clawdbot gateway --port 18789 --verbose --allow-unconfigured` (Windows 11, no WSL)
