### PR TITLE
Discord: improve onboarding text for Message Content Intent [AI Assisted]

### DIFF
--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -47,7 +47,7 @@ async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
       "1) Discord Developer Portal → Applications → New Application",
       "2) Bot → Add Bot → Reset Token → copy token",
       "3) OAuth2 → URL Generator → scope 'bot' → invite to your server",
-      "Tip: enable Message Content Intent if you need message text.",
+      "Tip: enable Message Content Intent if you need message text. (Bot → Privileged Gateway Intents → Message Content Intent)",
       `Docs: ${formatDocsLink("/discord", "discord")}`,
     ].join("\n"),
     "Discord bot token",


### PR DESCRIPTION
Improve Discord setup onboarding text to explicitly show where to enable Message Content Intent.

Changes:
- Updated tip in `src/channels/plugins/onboarding/discord.ts` to include navigation path: `(Bot → Privileged Gateway Intents → Message Content Intent)`.

Testing:
- Lightly tested (linted and verified text format).

[AI Assisted]
This PR was prepared with the assistance of an AI agent.