### PR TITLE
fix(media): fallback to JPEG when PNG alpha too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Docs: https://docs.clawd.bot
 
+## 2026.1.23
+
+### Fixes
+- Media: preserve PNG alpha when possible; fall back to JPEG when still over size cap. (#1491) Thanks @robbyczgw-cla.
+
 ## 2026.1.22
 
 ### Changes


### PR DESCRIPTION
## Summary
- fall back to JPEG when transparent PNGs still exceed size cap
- add coverage for PNG alpha preservation + fallback behavior
- bump changelog to 2026.1.23 with thanks

## Testing
- pnpm lint
- pnpm build
- pnpm test (flake: src/auto-reply/reply.block-streaming.test.ts)
- pnpm exec vitest run src/auto-reply/reply.block-streaming.test.ts
