### PR TITLE
feat(telegram): convert markdown tables to bullet points

### DIFF
--- a/src/markdown/ir.table-bullets.test.ts
+++ b/src/markdown/ir.table-bullets.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { markdownToIR } from "./ir.js";
+
+describe("markdownToIR tableMode bullets", () => {
+  it("converts simple table to bullets", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| A    | 1     |
+| B    | 2     |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "bullets" });
+    
+    // Should contain bullet points with header:value format
+    expect(ir.text).toContain("• Value: 1");
+    expect(ir.text).toContain("• Value: 2");
+    // Should use first column as labels
+    expect(ir.text).toContain("A");
+    expect(ir.text).toContain("B");
+  });
+
+  it("handles table with multiple columns", () => {
+    const md = `
+| Feature | SQLite | Postgres |
+|---------|--------|----------|
+| Speed   | Fast   | Medium   |
+| Scale   | Small  | Large    |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "bullets" });
+    
+    // First column becomes row label
+    expect(ir.text).toContain("Speed");
+    expect(ir.text).toContain("Scale");
+    // Other columns become bullet points
+    expect(ir.text).toContain("• SQLite: Fast");
+    expect(ir.text).toContain("• Postgres: Medium");
+    expect(ir.text).toContain("• SQLite: Small");
+    expect(ir.text).toContain("• Postgres: Large");
+  });
+
+  it("preserves flat mode as default", () => {
+    const md = `
+| A | B |
+|---|---|
+| 1 | 2 |
+`.trim();
+
+    const ir = markdownToIR(md); // default is flat
+    
+    // Flat mode uses tabs
+    expect(ir.text).toContain("A");
+    expect(ir.text).toContain("B");
+    expect(ir.text).toContain("1");
+    expect(ir.text).toContain("2");
+    // Should not have bullet formatting
+    expect(ir.text).not.toContain("•");
+  });
+
+  it("handles empty cells gracefully", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| A    |       |
+| B    | 2     |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "bullets" });
+    
+    // Should handle empty cell without crashing
+    expect(ir.text).toContain("B");
+    expect(ir.text).toContain("• Value: 2");
+  });
+
+  it("bolds row labels in bullets mode", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| Row1 | Data1 |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "bullets" });
+    
+    // Should have bold style for row label
+    const hasRowLabelBold = ir.styles.some(
+      (s) => s.style === "bold" && ir.text.slice(s.start, s.end) === "Row1"
+    );
+    expect(hasRowLabelBold).toBe(true);
+  });
+});

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -51,6 +51,7 @@ export function markdownToTelegramHtml(markdown: string): string {
     linkify: true,
     headingStyle: "none",
     blockquotePrefix: "",
+    tableMode: "bullets",
   });
   return renderTelegramHtml(ir);
 }
@@ -63,6 +64,7 @@ export function markdownToTelegramChunks(
     linkify: true,
     headingStyle: "none",
     blockquotePrefix: "",
+    tableMode: "bullets",
   });
   const chunks = chunkMarkdownIR(ir, limit);
   return chunks.map((chunk) => ({


### PR DESCRIPTION
## Problem

Markdown tables render poorly in Telegram:
- Pipes get stripped by Clawdbot's markdown-to-HTML conversion
- Whitespace collapses in HTML rendering
- Result: unreadable jumbled text like `SQLite Postgres Single writer Many writers`

## Solution

Add a `tableMode` option to `markdownToIR()` that converts tables to nested bullet points:

**Before (flat mode):**
```
| Feature | SQLite | Postgres |
|---------|--------|----------|
| Speed   | Fast   | Medium   |
```
→ `Feature SQLite Postgres Speed Fast Medium` (garbled)

**After (bullets mode):**
```
Speed
• SQLite: Fast
• Postgres: Medium
```
→ Clean, readable on mobile

## Changes

- `src/markdown/ir.ts`: Add `tableMode: 'flat' | 'bullets'` option with table state tracking
- `src/telegram/format.ts`: Enable `tableMode: 'bullets'` for Telegram
- `src/markdown/ir.table-bullets.test.ts`: Test coverage for table-to-bullets conversion

## Design decisions

- First column becomes **bolded row label** (common pattern: feature/category names)
- Other columns become bullet points with header as key
- Gracefully handles empty cells
- Default remains `flat` for backward compatibility
- Only Telegram uses `bullets` mode (could extend to Signal/SMS later)

## Testing

```bash
pnpm test src/markdown/ir.table-bullets.test.ts
# ✓ converts simple table to bullets
# ✓ handles table with multiple columns  
# ✓ preserves flat mode as default
# ✓ handles empty cells gracefully
# ✓ bolds row labels in bullets mode
```