### PR TITLE
Add Anthropic OAuth provider configuration example

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2449,6 +2449,61 @@ Notes:
 - Available model: `MiniMax-M2.1` (default).
 - Update pricing in `models.json` if you need exact cost tracking.
 
+### Anthropic (OAuth)
+
+Use Anthropic directly via OAuth (no API key required):
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "anthropic/claude-sonnet-4-20250514" },
+      models: {
+        "anthropic/claude-sonnet-4-20250514": { alias: "Sonnet 4" },
+        "anthropic/claude-opus-4-5": { alias: "Opus 4.5" }
+      }
+    }
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      anthropic: {
+        // No apiKey required - uses OAuth for authentication
+        // Auth handled automatically by Clawdbot gateway
+        baseUrl: "https://api.anthropic.com/v1",
+        api: "anthropic-messages",
+        models: [
+          {
+            id: "claude-sonnet-4-20250514",
+            name: "Sonnet 4",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 3, output: 15 },
+            contextWindow: 200000,
+            maxTokens: 8192
+          },
+          {
+            id: "claude-opus-4-5",
+            name: "Opus 4.5",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 15, output: 75 },
+            contextWindow: 200000,
+            maxTokens: 8192
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Notes:
+- OAuth authentication is automatic - no API key needed
+- Requires gateway configured with Anthropic OAuth credentials
+- Available models: Sonnet 4, Opus 4.5 (add more as needed)
+- Update pricing in `models.json` if you need exact cost tracking.
+
 ### Cerebras (GLM 4.6 / 4.7)
 
 Use Cerebras via their OpenAI-compatible endpoint:


### PR DESCRIPTION
Prevents 'Model not allowed' errors by documenting provider definition for Anthropic OAuth authentication.

## Summary
This PR adds documentation for configuring Anthropic via OAuth authentication, which eliminates the need for API keys and prevents the common 'Model not allowed' error.

## Changes
- Added new section `### Anthropic (OAuth)` in `docs/gateway/configuration.md`
- Includes complete JSON configuration example with Sonnet 4 and Opus 4.5 models
- Documents OAuth authentication requirements and available models

## Motivation
Users configuring Anthropic OAuth were encountering 'Model not allowed' errors because the provider definition was missing from their configuration. This documentation clarifies the required setup.

## Testing
- Documentation builds successfully with existing configuration
- Example is valid JSON5 format matching existing provider examples

See: https://github.com/clawdbot/clawdbot/issues/XXXX