### PR TITLE
daemon: prefer symlinked paths over realpath for stable service configs

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -45,6 +45,26 @@ describe("resolveGatewayProgramArguments", () => {
     ]);
   });
 
+  it("prefers symlinked path over realpath for stable service config", async () => {
+    // Simulates pnpm global install where node_modules/clawdbot is a symlink
+    // to .pnpm/clawdbot@X.Y.Z/node_modules/clawdbot
+    const symlinkPath = path.resolve(
+      "/Users/test/Library/pnpm/global/5/node_modules/clawdbot/dist/entry.js",
+    );
+    const realpathResolved = path.resolve(
+      "/Users/test/Library/pnpm/global/5/node_modules/.pnpm/clawdbot@2026.1.21-2/node_modules/clawdbot/dist/entry.js",
+    );
+    process.argv = ["node", symlinkPath];
+    fsMocks.realpath.mockResolvedValue(realpathResolved);
+    fsMocks.access.mockResolvedValue(undefined); // Both paths exist
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    // Should use the symlinked path, not the realpath-resolved versioned path
+    expect(result.programArguments[1]).toBe(symlinkPath);
+    expect(result.programArguments[1]).not.toContain("@2026.1.21-2");
+  });
+
   it("falls back to node_modules package dist when .bin path is not resolved", async () => {
     const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/clawdbot");
     const indexPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/clawdbot/dist/index.js");

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -27,6 +27,20 @@ async function resolveCliEntrypointPathForService(): Promise<string> {
   const looksLikeDist = /[/\\]dist[/\\].+\.(cjs|js|mjs)$/.test(resolvedPath);
   if (looksLikeDist) {
     await fs.access(resolvedPath);
+    // Prefer the original (possibly symlinked) path over the resolved realpath.
+    // This keeps LaunchAgent/systemd paths stable across package version updates,
+    // since symlinks like node_modules/clawdbot -> .pnpm/clawdbot@X.Y.Z/...
+    // are automatically updated by pnpm, while the resolved path contains
+    // version-specific directories that break after updates.
+    const normalizedLooksLikeDist = /[/\\]dist[/\\].+\.(cjs|js|mjs)$/.test(normalized);
+    if (normalizedLooksLikeDist && normalized !== resolvedPath) {
+      try {
+        await fs.access(normalized);
+        return normalized;
+      } catch {
+        // Fall through to return resolvedPath
+      }
+    }
     return resolvedPath;
   }
 


### PR DESCRIPTION
## Summary
- Fix LaunchAgent/systemd service breaking after pnpm package updates
- Prefer the original symlinked path (e.g. `node_modules/clawdbot/dist/entry.js`) over the realpath-resolved versioned path (e.g. `.pnpm/clawdbot@X.Y.Z/.../dist/entry.js`)

## Problem
When installing the LaunchAgent/systemd service, the CLI was using `fs.realpath()` to resolve the `entry.js` path. This converted stable symlinked paths into version-specific paths.

After a pnpm update:
1. pnpm updates the symlink to point to the new version
2. pnpm removes the old version's files
3. The LaunchAgent plist still points to the old version's path → **service fails to start**

## Solution
Now we check if the original (non-realpath-resolved) path is valid and prefer it when:
- It looks like a dist path (`/dist/*.js`)
- It exists and is accessible

This keeps service configs stable because pnpm automatically updates the symlink during package updates.

## Test plan
- [x] Added unit test for new behavior
- [x] All existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)