### PR TITLE
fix(msteams): remove .default suffix from graph scopes

### DIFF
--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -68,10 +68,10 @@ function scopeCandidatesForUrl(url: string): string[] {
       host.endsWith("1drv.ms") ||
       host.includes("sharepoint");
     return looksLikeGraph
-      ? ["https://graph.microsoft.com/.default", "https://api.botframework.com/.default"]
-      : ["https://api.botframework.com/.default", "https://graph.microsoft.com/.default"];
+      ? ["https://graph.microsoft.com", "https://api.botframework.com"]
+      : ["https://api.botframework.com", "https://graph.microsoft.com"];
   } catch {
-    return ["https://api.botframework.com/.default", "https://graph.microsoft.com/.default"];
+    return ["https://api.botframework.com", "https://graph.microsoft.com"];
   }
 }
 

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -198,7 +198,7 @@ export async function downloadMSTeamsGraphMedia(params: {
   const messageUrl = params.messageUrl;
   let accessToken: string;
   try {
-    accessToken = await params.tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+    accessToken = await params.tokenProvider.getAccessToken("https://graph.microsoft.com");
   } catch {
     return { media: [], messageUrl, tokenError: true };
   }

--- a/extensions/msteams/src/directory-live.ts
+++ b/extensions/msteams/src/directory-live.ts
@@ -64,7 +64,7 @@ async function resolveGraphToken(cfg: unknown): Promise<string> {
   if (!creds) throw new Error("MS Teams credentials missing");
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
   const tokenProvider = new sdk.MsalTokenProvider(authConfig);
-  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
   const accessToken = readAccessToken(token);
   if (!accessToken) throw new Error("MS Teams graph token unavailable");
   return accessToken;

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -13,7 +13,7 @@ import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 
 const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
 const GRAPH_BETA = "https://graph.microsoft.com/beta";
-const GRAPH_SCOPE = "https://graph.microsoft.com/.default";
+const GRAPH_SCOPE = "https://graph.microsoft.com";
 
 export interface OneDriveUploadResult {
   id: string;

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -143,7 +143,7 @@ async function resolveGraphToken(cfg: unknown): Promise<string> {
   if (!creds) throw new Error("MS Teams credentials missing");
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
   const tokenProvider = new sdk.MsalTokenProvider(authConfig);
-  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com/.default");
+  const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
   const accessToken = readAccessToken(token);
   if (!accessToken) throw new Error("MS Teams graph token unavailable");
   return accessToken;


### PR DESCRIPTION
The @microsoft/agents-hosting SDK's MsalTokenProvider automatically appends `/.default` to all scope strings in its token acquisition methods (acquireAccessTokenViaSecret, acquireAccessTokenViaFIC, acquireAccessTokenViaWID, acquireTokenWithCertificate in msalTokenProvider.ts). This is consistent SDK behavior, not a recent change.

The current code is including `.default` in scope URLs, resulting in invalid double suffixes like `https://graph.microsoft.com/.default/.default`.  I am not sure how the .default postfixed worked in the past for you if I am honest.

This was confirmed to cause Graph API authentication errors. Removing the `.default` suffix from our scope strings allows the SDK to append it correctly, resolving the issue. I confirmed it manually on my teams setup

Before: we pass `.default` -> SDK appends -> double `.default` (broken)
After:  we pass base URL  -> SDK appends -> single `.default` (works)