### PR TITLE
fix: ensure tool calls have arguments field for Cloud Code Assist

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.ensures-tool-call-arguments.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.ensures-tool-call-arguments.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeSessionMessagesImages } from "./pi-embedded-helpers/images.js";
+
+describe("sanitizeSessionMessagesImages ensures tool call arguments", () => {
+  it("adds arguments to toolCall blocks missing input/arguments field", async () => {
+    const input = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "toolCall", id: "call_1", name: "session_status" }, // missing arguments
+        ],
+      },
+    ];
+    const out = await sanitizeSessionMessagesImages(input, "test");
+    const assistant = out[0] as { content: Array<{ arguments?: unknown }> };
+    const toolCall = assistant.content[0];
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("adds arguments to toolUse blocks missing input/arguments field", async () => {
+    const input = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "toolUse", id: "call_2", name: "read" }, // missing input
+        ],
+      },
+    ];
+    const out = await sanitizeSessionMessagesImages(input, "test");
+    const assistant = out[0] as { content: Array<{ arguments?: unknown }> };
+    const toolCall = assistant.content[0];
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("preserves existing arguments on tool calls", async () => {
+    const input = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "toolCall", id: "call_3", name: "read", arguments: { path: "file.txt" } },
+        ],
+      },
+    ];
+    const out = await sanitizeSessionMessagesImages(input, "test");
+    const assistant = out[0] as { content: Array<{ arguments?: unknown }> };
+    const toolCall = assistant.content[0];
+    expect(toolCall.arguments).toEqual({ path: "file.txt" });
+  });
+
+  it("preserves existing input on tool calls", async () => {
+    const input = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "toolUse", id: "call_4", name: "exec", input: { command: "ls" } },
+        ],
+      },
+    ];
+    const out = await sanitizeSessionMessagesImages(input, "test");
+    const assistant = out[0] as { content: Array<{ input?: unknown; arguments?: unknown }> };
+    const toolCall = assistant.content[0];
+    expect(toolCall.input).toEqual({ command: "ls" });
+    expect(toolCall.arguments).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.ensures-tool-call-arguments.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.ensures-tool-call-arguments.test.ts
@@ -51,9 +51,7 @@ describe("sanitizeSessionMessagesImages ensures tool call arguments", () => {
     const input = [
       {
         role: "assistant" as const,
-        content: [
-          { type: "toolUse", id: "call_4", name: "exec", input: { command: "ls" } },
-        ],
+        content: [{ type: "toolUse", id: "call_4", name: "exec", input: { command: "ls" } }],
       },
     ];
     const out = await sanitizeSessionMessagesImages(input, "test");

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
@@ -86,7 +86,7 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(toolResult.role).toBe("toolResult");
     expect(toolResult.toolCallId).toBe("call123fc456");
   });
-  it("does not synthesize tool call input when missing", async () => {
+  it("synthesizes empty arguments for tool calls missing input/arguments (Cloud Code Assist requirement)", async () => {
     const input = [
       {
         role: "assistant",
@@ -98,7 +98,8 @@ describe("sanitizeSessionMessagesImages", () => {
     const assistant = out[0] as { content?: Array<Record<string, unknown>> };
     const toolCall = assistant.content?.find((b) => b.type === "toolCall");
     expect(toolCall).toBeTruthy();
-    expect("input" in (toolCall ?? {})).toBe(false);
-    expect("arguments" in (toolCall ?? {})).toBe(false);
+    // Cloud Code Assist requires tool_use.input to be present
+    expect("arguments" in (toolCall ?? {})).toBe(true);
+    expect(toolCall?.arguments).toEqual({});
   });
 });

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -21,6 +21,19 @@ export function isEmptyAssistantMessageContent(
   });
 }
 
+/**
+ * Sanitizes session messages before sending to LLM APIs.
+ *
+ * NOTE: Despite the name, this function handles more than just images.
+ * It performs general session message sanitization including:
+ * - Image resizing/format normalization
+ * - Tool call ID sanitization for strict providers
+ * - Empty text block filtering
+ * - Thinking signature handling
+ * - Tool call arguments normalization (ensuring input/arguments field exists)
+ *
+ * The name is historical - consider renaming to sanitizeSessionMessages.
+ */
 export async function sanitizeSessionMessagesImages(
   messages: AgentMessage[],
   label: string,


### PR DESCRIPTION
## Summary

When Google Antigravity (Cloud Code Assist) returns tool calls with no arguments, the response sometimes lacks the `input`/`arguments` field entirely. This corrupts the session history because subsequent API calls require `tool_use.input` to be present.

## Problem

1. User calls a tool like `session_status` that takes no arguments
2. Antigravity returns: `{"type":"toolCall","id":"toolu_xxx","name":"session_status"}` (no `arguments` field)
3. This gets saved to session history
4. All subsequent API calls fail with: `messages.N.content.X.tool_use.input: Field required`
5. Session is permanently broken until `/reset`

## Fix

Adds a normalization step to `sanitizeSessionMessagesImages()` that ensures all `toolCall`/`toolUse`/`functionCall` blocks have an `arguments` field, defaulting to `{}` if missing.

## Changes

- `src/agents/pi-embedded-helpers/images.ts`: Add normalization for tool call arguments
- Added test file for the new behavior

Fixes #1508