### PR TITLE
fix(linux): add user bin directories to systemd service PATH for skill installation

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -5,45 +5,7 @@ import {
   buildNodeServiceEnvironment,
   buildServiceEnvironment,
   getMinimalServicePathParts,
-  resolveLinuxUserBinDirs,
 } from "./service-env.js";
-
-describe("resolveLinuxUserBinDirs", () => {
-  it("returns correct paths when HOME is provided", () => {
-    const dirs = resolveLinuxUserBinDirs("/home/testuser");
-
-    expect(dirs).toEqual([
-      "/home/testuser/.local/bin",
-      "/home/testuser/.npm-global/bin",
-      "/home/testuser/bin",
-      "/home/testuser/.nvm/current/bin",
-      "/home/testuser/.fnm/current/bin",
-      "/home/testuser/.volta/bin",
-      "/home/testuser/.asdf/shims",
-      "/home/testuser/.local/share/pnpm",
-      "/home/testuser/.bun/bin",
-    ]);
-  });
-
-  it("returns empty array when HOME is undefined", () => {
-    const dirs = resolveLinuxUserBinDirs(undefined);
-    expect(dirs).toEqual([]);
-  });
-
-  it("returns empty array when HOME is empty string", () => {
-    const dirs = resolveLinuxUserBinDirs("");
-    expect(dirs).toEqual([]);
-  });
-
-  it("handles root home directory correctly", () => {
-    const dirs = resolveLinuxUserBinDirs("/root");
-
-    expect(dirs).toContain("/root/.local/bin");
-    expect(dirs).toContain("/root/.npm-global/bin");
-    expect(dirs).toContain("/root/.nvm/current/bin");
-    expect(dirs.length).toBe(9);
-  });
-});
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
   it("includes user bin directories when HOME is set on Linux", () => {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -4,7 +4,135 @@ import {
   buildMinimalServicePath,
   buildNodeServiceEnvironment,
   buildServiceEnvironment,
+  getMinimalServicePathParts,
+  resolveLinuxUserBinDirs,
 } from "./service-env.js";
+
+describe("resolveLinuxUserBinDirs", () => {
+  it("returns correct paths when HOME is provided", () => {
+    const dirs = resolveLinuxUserBinDirs("/home/testuser");
+
+    expect(dirs).toEqual([
+      "/home/testuser/.local/bin",
+      "/home/testuser/.npm-global/bin",
+      "/home/testuser/bin",
+      "/home/testuser/.nvm/current/bin",
+      "/home/testuser/.fnm/current/bin",
+      "/home/testuser/.volta/bin",
+      "/home/testuser/.asdf/shims",
+      "/home/testuser/.local/share/pnpm",
+      "/home/testuser/.bun/bin",
+    ]);
+  });
+
+  it("returns empty array when HOME is undefined", () => {
+    const dirs = resolveLinuxUserBinDirs(undefined);
+    expect(dirs).toEqual([]);
+  });
+
+  it("returns empty array when HOME is empty string", () => {
+    const dirs = resolveLinuxUserBinDirs("");
+    expect(dirs).toEqual([]);
+  });
+
+  it("handles root home directory correctly", () => {
+    const dirs = resolveLinuxUserBinDirs("/root");
+
+    expect(dirs).toContain("/root/.local/bin");
+    expect(dirs).toContain("/root/.npm-global/bin");
+    expect(dirs).toContain("/root/.nvm/current/bin");
+    expect(dirs.length).toBe(9);
+  });
+});
+
+describe("getMinimalServicePathParts - Linux user directories", () => {
+  it("includes user bin directories when HOME is set on Linux", () => {
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+    });
+
+    // Should include all common user bin directories
+    expect(result).toContain("/home/testuser/.local/bin");
+    expect(result).toContain("/home/testuser/.npm-global/bin");
+    expect(result).toContain("/home/testuser/bin");
+    expect(result).toContain("/home/testuser/.nvm/current/bin");
+    expect(result).toContain("/home/testuser/.fnm/current/bin");
+    expect(result).toContain("/home/testuser/.volta/bin");
+    expect(result).toContain("/home/testuser/.asdf/shims");
+    expect(result).toContain("/home/testuser/.local/share/pnpm");
+    expect(result).toContain("/home/testuser/.bun/bin");
+  });
+
+  it("excludes user bin directories when HOME is undefined on Linux", () => {
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: undefined,
+    });
+
+    // Should only include system directories
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin"]);
+
+    // Should not include any user-specific paths
+    expect(result.some((p) => p.includes(".local"))).toBe(false);
+    expect(result.some((p) => p.includes(".npm-global"))).toBe(false);
+    expect(result.some((p) => p.includes(".nvm"))).toBe(false);
+  });
+
+  it("places user directories before system directories on Linux", () => {
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+    });
+
+    const userDirIndex = result.indexOf("/home/testuser/.local/bin");
+    const systemDirIndex = result.indexOf("/usr/bin");
+
+    expect(userDirIndex).toBeGreaterThan(-1);
+    expect(systemDirIndex).toBeGreaterThan(-1);
+    expect(userDirIndex).toBeLessThan(systemDirIndex);
+  });
+
+  it("places extraDirs before user directories on Linux", () => {
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+      extraDirs: ["/custom/bin"],
+    });
+
+    const extraDirIndex = result.indexOf("/custom/bin");
+    const userDirIndex = result.indexOf("/home/testuser/.local/bin");
+
+    expect(extraDirIndex).toBeGreaterThan(-1);
+    expect(userDirIndex).toBeGreaterThan(-1);
+    expect(extraDirIndex).toBeLessThan(userDirIndex);
+  });
+
+  it("does not include Linux user directories on macOS", () => {
+    const result = getMinimalServicePathParts({
+      platform: "darwin",
+      home: "/Users/testuser",
+    });
+
+    // Should not include Linux-specific user dirs even with HOME set
+    expect(result.some((p) => p.includes(".npm-global"))).toBe(false);
+    expect(result.some((p) => p.includes(".nvm"))).toBe(false);
+
+    // Should only include macOS system directories
+    expect(result).toContain("/opt/homebrew/bin");
+    expect(result).toContain("/usr/local/bin");
+  });
+
+  it("does not include Linux user directories on Windows", () => {
+    const result = getMinimalServicePathParts({
+      platform: "win32",
+      home: "C:\\Users\\testuser",
+    });
+
+    // Windows returns empty array (uses existing PATH)
+    expect(result).toEqual([]);
+  });
+});
 
 describe("buildMinimalServicePath", () => {
   it("includes Homebrew + system dirs on macOS", () => {
@@ -24,6 +152,51 @@ describe("buildMinimalServicePath", () => {
       platform: "win32",
     });
     expect(result).toBe("C:\\\\Windows\\\\System32");
+  });
+
+  it("includes Linux user directories when HOME is set in env", () => {
+    const result = buildMinimalServicePath({
+      platform: "linux",
+      env: { HOME: "/home/alice" },
+    });
+    const parts = result.split(path.delimiter);
+
+    // Verify user directories are included
+    expect(parts).toContain("/home/alice/.local/bin");
+    expect(parts).toContain("/home/alice/.npm-global/bin");
+    expect(parts).toContain("/home/alice/.nvm/current/bin");
+
+    // Verify system directories are also included
+    expect(parts).toContain("/usr/local/bin");
+    expect(parts).toContain("/usr/bin");
+    expect(parts).toContain("/bin");
+  });
+
+  it("excludes Linux user directories when HOME is not in env", () => {
+    const result = buildMinimalServicePath({
+      platform: "linux",
+      env: {},
+    });
+    const parts = result.split(path.delimiter);
+
+    // Should only have system directories
+    expect(parts).toEqual(["/usr/local/bin", "/usr/bin", "/bin"]);
+
+    // No user-specific paths
+    expect(parts.some((p) => p.includes("home"))).toBe(false);
+  });
+
+  it("ensures user directories come before system directories on Linux", () => {
+    const result = buildMinimalServicePath({
+      platform: "linux",
+      env: { HOME: "/home/bob" },
+    });
+    const parts = result.split(path.delimiter);
+
+    const firstUserDirIdx = parts.indexOf("/home/bob/.local/bin");
+    const firstSystemDirIdx = parts.indexOf("/usr/local/bin");
+
+    expect(firstUserDirIdx).toBeLessThan(firstSystemDirIdx);
   });
 
   it("includes extra directories when provided", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -17,6 +17,7 @@ import {
 export type MinimalServicePathOptions = {
   platform?: NodeJS.Platform;
   extraDirs?: string[];
+  home?: string;
 };
 
 type BuildServicePathOptions = MinimalServicePathOptions & {
@@ -33,6 +34,31 @@ function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
   return [];
 }
 
+/**
+ * Resolve common user bin directories for Linux.
+ * These are paths where npm global installs and node version managers typically place binaries.
+ */
+function resolveLinuxUserBinDirs(home: string | undefined): string[] {
+  if (!home) return [];
+
+  const dirs: string[] = [];
+
+  // Common user bin directories
+  dirs.push(`${home}/.local/bin`); // XDG standard, pip, etc.
+  dirs.push(`${home}/.npm-global/bin`); // npm custom prefix (recommended for non-root)
+  dirs.push(`${home}/bin`); // User's personal bin
+
+  // Node version managers
+  dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink
+  dirs.push(`${home}/.fnm/current/bin`); // fnm
+  dirs.push(`${home}/.volta/bin`); // Volta
+  dirs.push(`${home}/.asdf/shims`); // asdf
+  dirs.push(`${home}/.local/share/pnpm`); // pnpm global bin
+  dirs.push(`${home}/.bun/bin`); // Bun
+
+  return dirs;
+}
+
 export function getMinimalServicePathParts(options: MinimalServicePathOptions = {}): string[] {
   const platform = options.platform ?? process.platform;
   if (platform === "win32") return [];
@@ -41,12 +67,17 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   const extraDirs = options.extraDirs ?? [];
   const systemDirs = resolveSystemPathDirs(platform);
 
+  // Add Linux user bin directories (npm global, nvm, fnm, volta, etc.)
+  const linuxUserDirs = platform === "linux" ? resolveLinuxUserBinDirs(options.home) : [];
+
   const add = (dir: string) => {
     if (!dir) return;
     if (!parts.includes(dir)) parts.push(dir);
   };
 
   for (const dir of extraDirs) add(dir);
+  // User dirs first so user-installed binaries take precedence
+  for (const dir of linuxUserDirs) add(dir);
   for (const dir of systemDirs) add(dir);
 
   return parts;
@@ -59,7 +90,10 @@ export function buildMinimalServicePath(options: BuildServicePathOptions = {}): 
     return env.PATH ?? "";
   }
 
-  return getMinimalServicePathParts(options).join(path.delimiter);
+  return getMinimalServicePathParts({
+    ...options,
+    home: options.home ?? env.HOME,
+  }).join(path.delimiter);
 }
 
 export function buildServiceEnvironment(params: {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -38,7 +38,7 @@ function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
  * Resolve common user bin directories for Linux.
  * These are paths where npm global installs and node version managers typically place binaries.
  */
-function resolveLinuxUserBinDirs(home: string | undefined): string[] {
+export function resolveLinuxUserBinDirs(home: string | undefined): string[] {
   if (!home) return [];
 
   const dirs: string[] = [];


### PR DESCRIPTION
## Summary

Fixes #1503

**Problem:** Skill installation is broken on Linux when using systemd service. Binaries installed via npm global with custom prefix or through node version managers (nvm, fnm, volta, asdf) are not found because the systemd service PATH only includes system directories.

### Before (broken)
```
PATH=/usr/local/bin:/usr/bin:/bin
```
Skills that require binaries from `~/.local/bin`, `~/.npm-global/bin`, or version managers fail with "command not found".

### After (fixed)
```
PATH=/home/user/.local/bin:/home/user/.npm-global/bin:/home/user/bin:/home/user/.nvm/current/bin:/home/user/.fnm/current/bin:/home/user/.volta/bin:/home/user/.asdf/shims:/home/user/.local/share/pnpm:/home/user/.bun/bin:/usr/local/bin:/usr/bin:/bin
```

## Changes

Adds `resolveLinuxUserBinDirs()` function that includes common Linux user bin directories:

| Directory | Purpose |
|-----------|---------|
| `~/.local/bin` | XDG standard, pip, pipx installs |
| `~/.npm-global/bin` | npm custom prefix ([recommended approach](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)) |
| `~/bin` | User's personal bin directory |
| `~/.nvm/current/bin` | nvm (Node Version Manager) |
| `~/.fnm/current/bin` | fnm (Fast Node Manager) |
| `~/.volta/bin` | Volta |
| `~/.asdf/shims` | asdf version manager |
| `~/.local/share/pnpm` | pnpm global bin |
| `~/.bun/bin` | Bun runtime |

**Key behaviors:**
- User directories are added **before** system directories so user-installed binaries take precedence
- Only applied on Linux (macOS uses launchd with different PATH handling)
- Falls back to system-only PATH when `HOME` is not set

## Testing

- [x] Existing unit tests pass (7/7)
- [x] Added 9 new tests (7 → 16 total) covering:
  - Linux PATH includes user dirs when HOME is set
  - Linux PATH excludes user dirs when HOME is undefined  
  - Path ordering (extraDirs > user dirs > system dirs)
  - Platform-specific behavior (Linux vs macOS vs Windows)
  - Integration with `buildMinimalServicePath()`
- [x] Verified issue reproduction and fix on Ubuntu 24.04

## AI Disclosure

🤖 AI-assisted (Claude Opus 4.5 via Clawdbot)
📝 Testing: Comprehensive (16 unit tests covering all branches)
✅ I understand what this code does
