### PR TITLE
fix(ui): Make sidebar sticky while scrolling content

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -5,7 +5,7 @@
   --shell-topbar-height: 56px;
   --shell-focus-duration: 220ms;
   --shell-focus-ease: cubic-bezier(0.2, 0.85, 0.25, 1);
-  min-height: 100vh;
+  height: 100vh;
   display: grid;
   grid-template-columns: var(--shell-nav-width) minmax(0, 1fr);
   grid-template-rows: var(--shell-topbar-height) 1fr;
@@ -15,6 +15,13 @@
   gap: 0;
   animation: dashboard-enter 0.6s ease-out;
   transition: grid-template-columns var(--shell-focus-duration) var(--shell-focus-ease);
+  overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  .shell {
+    height: 100dvh;
+  }
 }
 
 .shell--chat {
@@ -148,6 +155,7 @@
   backdrop-filter: blur(18px);
   transition: width var(--shell-focus-duration) var(--shell-focus-ease),
     padding var(--shell-focus-duration) var(--shell-focus-ease);
+  min-height: 0; /* Allow grid item to shrink and enable scrolling */
 }
 
 .shell--chat-focus .nav {


### PR DESCRIPTION
## Summary
Fixed left navigation sidebar scrolling away when scrolling through long content pages (e.g., `/skills`).

## Changes
- Changed `.shell` from `min-height: 100vh` to `height: 100vh` with `overflow: hidden`
- Added `min-height: 0` to `.nav` for proper grid-based scrolling  
- Added `100dvh` support for mobile browsers

## Test plan
- [x] Navigate to `/skills` page
- [x] Scroll down through the skills list
- [x] Verify left sidebar stays fixed/visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)