### PR TITLE
fix(mac): avoid allowlist removal crash

### DIFF
--- a/apps/macos/Sources/Clawdbot/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/Clawdbot/SystemRunSettingsView.swift
@@ -123,12 +123,12 @@ struct SystemRunSettingsView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     VStack(alignment: .leading, spacing: 8) {
-                        ForEach(Array(self.model.entries.enumerated()), id: \.offset) { index, _ in
+                        ForEach(self.model.entries, id: \.id) { entry in
                             ExecAllowlistRow(
                                 entry: Binding(
-                                    get: { self.model.entries[index] },
-                                    set: { self.model.updateEntry($0, at: index) }),
-                                onRemove: { self.model.removeEntry(at: index) })
+                                    get: { self.model.entry(for: entry.id) ?? entry },
+                                    set: { self.model.updateEntry($0, id: entry.id) }),
+                                onRemove: { self.model.removeEntry(id: entry.id) })
                         }
                     }
                 }
@@ -373,18 +373,22 @@ final class ExecApprovalsSettingsModel {
         ExecApprovalsStore.updateAllowlist(agentId: self.selectedAgentId, allowlist: self.entries)
     }
 
-    func updateEntry(_ entry: ExecAllowlistEntry, at index: Int) {
+    func updateEntry(_ entry: ExecAllowlistEntry, id: UUID) {
         guard !self.isDefaultsScope else { return }
-        guard self.entries.indices.contains(index) else { return }
+        guard let index = self.entries.firstIndex(where: { $0.id == id }) else { return }
         self.entries[index] = entry
         ExecApprovalsStore.updateAllowlist(agentId: self.selectedAgentId, allowlist: self.entries)
     }
 
-    func removeEntry(at index: Int) {
+    func removeEntry(id: UUID) {
         guard !self.isDefaultsScope else { return }
-        guard self.entries.indices.contains(index) else { return }
+        guard let index = self.entries.firstIndex(where: { $0.id == id }) else { return }
         self.entries.remove(at: index)
         ExecApprovalsStore.updateAllowlist(agentId: self.selectedAgentId, allowlist: self.entries)
+    }
+
+    func entry(for id: UUID) -> ExecAllowlistEntry? {
+        self.entries.first(where: { $0.id == id })
     }
 
     func refreshSkillBins(force: Bool = false) async {


### PR DESCRIPTION
## Summary
Fix a crash when removing exec allowlist entries in the mac app by using stable entry IDs for list bindings.

## Bug
Removing a row could crash because SwiftUI re-evaluated stale index bindings after deletion.
Stack trace excerpt:
```
_assertionFailure
Array._checkSubscript
SystemRunSettingsView.allowlistView (SystemRunSettingsView.swift:129)
```

## Fix
- add stable UUID ids to ExecAllowlistEntry (backwards-compatible decoding)
- bind allowlist rows by id rather than array index

## Testing
- swift test --filter ExecAllowlistTests
- manual: removed and added items from allow list (reported)
