### PR TITLE
fix(sessions): reset token counts to 0 on /new (#1523)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -251,6 +251,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         lastChannel: entry?.lastChannel,
         lastTo: entry?.lastTo,
         skillsSnapshot: entry?.skillsSnapshot,
+        // Reset token counts to 0 on session reset (#1523)
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
       };
       store[primaryKey] = nextEntry;
       return nextEntry;

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -408,6 +408,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "new":
       case "reset":
         try {
+          // Clear token counts immediately to avoid stale display (#1523)
+          state.sessionInfo.inputTokens = null;
+          state.sessionInfo.outputTokens = null;
+          state.sessionInfo.totalTokens = null;
+          tui.requestRender();
+
           await client.resetSession(state.currentSessionKey);
           chatLog.addSystem(`session ${state.currentSessionKey} reset`);
           await loadHistory();


### PR DESCRIPTION
## Summary

Fixes TUI showing stale token counts (e.g., 92k) after `/new` session reset, when the actual count should be near 0.

## Problem

After `/new` reset:
| Point | TUI tokens | session_status |
|-------|------------|----------------|
| Immediately after /new | 92k ❌ | 21k |
| After 1-2 exchanges | 21k → 16k | 17k |
| After convergence | 17k | 17k ✅ |

The 92k appears consistently after reset **regardless of previous session size**.

## Root Cause

1. **`sessions.reset`** creates a new entry but **omits** `inputTokens`/`outputTokens`/`totalTokens` instead of explicitly setting them to 0
2. **TUI** doesn't clear its local `sessionInfo` immediately — shows cached values until `refreshSessionInfo()` completes

## Changes

### 1. Backend (`src/gateway/server-methods/sessions.ts`)
```typescript
const nextEntry: SessionEntry = {
  // ... existing fields ...
  // Reset token counts to 0 on session reset (#1523)
  inputTokens: 0,
  outputTokens: 0,
  totalTokens: 0,
};
```

### 2. TUI (`src/tui/tui-command-handlers.ts`)
```typescript
case "new":
case "reset":
  try {
    // Clear token counts immediately to avoid stale display (#1523)
    state.sessionInfo.inputTokens = null;
    state.sessionInfo.outputTokens = null;
    state.sessionInfo.totalTokens = null;
    tui.requestRender();

    await client.resetSession(state.currentSessionKey);
    // ...
```

## Testing

- ✅ `npm run lint` — 0 warnings, 0 errors
- ✅ `tsc --noEmit` — passes

## Related

- May also help #1516 (session token tracking shows 0) — similar root cause

---

## 🤖 AI-Assisted
- **Tool:** Claude (Opus 4.5) via Clawdbot
- **Testing:** Lightly tested (lint + tsc pass, no runtime test)
- **Understanding:** Yes — `sessions.reset` was creating new entries without token fields, causing fallback to stale cached values; TUI held onto old `sessionInfo` until async refresh completed

Fixes #1523