### PR TITLE
docs: remove misplaced Google Docs Editor from showcase

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -327,14 +327,8 @@ Full setup walkthrough (28m) by VelvetShark.
 
 <Card title="OpenRouter Transcription" icon="microphone" href="https://clawdhub.com/obviyus/openrouter-transcribe">
   **@obviyus** • `transcription` `multilingual` `skill`
-  
-  Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on ClawdHub.
-</Card>
 
-<Card title="Google Docs Editor" icon="file-word">
-  **Community** • `docs` `editing` `skill`
-  
-  Rich-text Google Docs editing skill. Built rapidly with Claude Code.
+  Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on ClawdHub.
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
## Why

1. **Wrong section**: It was placed in the "Voice & Phone" section, but it's a document editing skill
2. **No valid link**: The card had no `href` attribute (just `#` placeholder)
3. **Not a Clawdbot project**: The only Google Docs skill found online is a Claude Code skill (https://github.com/robtaylor/google-docs-skill), not a Clawdbot community project