### PR TITLE
Fix deps for matrix npm install

### DIFF
--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -25,9 +25,12 @@
   },
   "dependencies": {
     "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
-    "clawdbot": "workspace:*",
     "markdown-it": "14.1.0",
     "matrix-bot-sdk": "0.8.0",
-    "music-metadata": "^11.10.6"
+    "music-metadata": "^11.10.6",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "clawdbot": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

  - add zod to Matrix runtime dependencies (it’s imported in src/config-
    schema.ts)
  - move clawdbot to devDependencies for Matrix to avoid workspace:*
    breaking npm installs

  ## Why

  - npm installs run npm install --omit=dev inside the plugin directory;
    runtime imports must be in dependencies
  - workspace:* is a workspace-only spec and fails under npm when
    installing from the registry

## Testing

clawdbot wouldn't install the matrix plugin, I switched to `~/.clawdbot/extensions/matrix` and then ran:

```bash
npm install --omit=dev
clawdbot plugins enable matrix
```

