### PR TITLE
Fix formatting of 'Agent failed before reply' error messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -510,7 +510,7 @@ export async function runAgentTurnWithFallback(params: {
             ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
             : isRoleOrderingError
               ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-              : `⚠️ Agent failed before reply: ${message}. Check gateway logs for details.`,
+              : `⚠️ Agent failed before reply: ${message}\nCheck gateway logs for details.`,
         },
       };
     }


### PR DESCRIPTION
This change improves the formatting of error messages when an agent fails before replying. Previously, a trailing period in the error message would result in double periods:

>⚠️ Agent failed before reply: Sandbox image not found: clawdbot-sandbox:latest. Build or pull it first.. Check gateway logs for details.

The new format places the instruction on a new line and removes the redundant period:

>⚠️ Agent failed before reply: Sandbox image not found: clawdbot-sandbox:latest. Build or pull it first.
Check gateway logs for details.

(Code written by Google Jules)