### PR TITLE
Tailscale: attempt non-interactive sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.clawd.bot
 
 ### Fixes
 - Voice wake: auto-save wake words on blur/submit across iOS/Android and align limits with macOS.
+- Tailscale: retry serve/funnel with sudo only for permission errors and keep original failure details. (#1551) Thanks @sweepies.
 - Discord: limit autoThread mention bypass to bot-owned threads; keep ack reactions mention-gated. (#1511) Thanks @pvoo.
 - Gateway: accept null optional fields in exec approval requests. (#1511) Thanks @pvoo.
 - TUI: forward unknown slash commands (for example, `/context`) to the Gateway.

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { ensureGoInstalled, ensureTailscaledInstalled, getTailnetHostname } from "./tailscale.js";
+import {
+  ensureGoInstalled,
+  ensureTailscaledInstalled,
+  getTailnetHostname,
+  enableTailscaleServe,
+  disableTailscaleServe,
+  enableTailscaleFunnel,
+  disableTailscaleFunnel,
+  ensureFunnel
+} from "./tailscale.js";
 
 describe("tailscale helpers", () => {
   it("parses DNS name from tailscale status", async () => {
@@ -47,5 +56,76 @@ describe("tailscale helpers", () => {
     };
     await ensureTailscaledInstalled(exec as never, prompt, runtime);
     expect(exec).toHaveBeenCalledWith("brew", ["install", "tailscale"]);
+  });
+
+  it("enableTailscaleServe uses sudo", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "" });
+    await enableTailscaleServe(3000, exec as never);
+    expect(exec).toHaveBeenCalledWith(
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "serve", "--bg", "--yes", "3000"]),
+      expect.any(Object)
+    );
+  });
+
+  it("disableTailscaleServe uses sudo", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "" });
+    await disableTailscaleServe(exec as never);
+    expect(exec).toHaveBeenCalledWith(
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "serve", "reset"]),
+      expect.any(Object)
+    );
+  });
+
+  it("enableTailscaleFunnel uses sudo", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "" });
+    await enableTailscaleFunnel(4000, exec as never);
+    expect(exec).toHaveBeenCalledWith(
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "funnel", "--bg", "--yes", "4000"]),
+      expect.any(Object)
+    );
+  });
+
+  it("disableTailscaleFunnel uses sudo", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "" });
+    await disableTailscaleFunnel(exec as never);
+    expect(exec).toHaveBeenCalledWith(
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "funnel", "reset"]),
+      expect.any(Object)
+    );
+  });
+
+  it("ensureFunnel uses sudo for enabling", async () => {
+    // Mock exec: first call is status (not sudo), second call is enable (sudo)
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ BackendState: "Running" }) }) // status
+      .mockResolvedValueOnce({ stdout: "" }); // enable
+
+    const runtime = {
+      error: vi.fn(),
+      log: vi.fn(),
+      exit: vi.fn() as unknown as (code: number) => never,
+    };
+    const prompt = vi.fn();
+
+    await ensureFunnel(8080, exec as never, runtime, prompt);
+
+    // First call: check status (no sudo)
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      "tailscale",
+      expect.arrayContaining(["funnel", "status", "--json"])
+    );
+
+    // Second call: enable (sudo)
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "funnel", "--yes", "--bg", "8080"]),
+      expect.any(Object)
+    );
   });
 });

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { ensureGoInstalled, ensureTailscaledInstalled, getTailnetHostname } from "./tailscale.js";
+import {
+  ensureGoInstalled,
+  ensureTailscaledInstalled,
+  getTailnetHostname,
+  enableTailscaleServe,
+  disableTailscaleServe,
+  enableTailscaleFunnel,
+  disableTailscaleFunnel,
+  ensureFunnel
+} from "./tailscale.js";
 
 describe("tailscale helpers", () => {
   it("parses DNS name from tailscale status", async () => {
@@ -47,5 +56,101 @@ describe("tailscale helpers", () => {
     };
     await ensureTailscaledInstalled(exec as never, prompt, runtime);
     expect(exec).toHaveBeenCalledWith("brew", ["install", "tailscale"]);
+  });
+
+  it("enableTailscaleServe attempts normal first, then sudo", async () => {
+    // 1. First attempt fails
+    // 2. Second attempt (sudo) succeeds
+    const exec = vi.fn()
+      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockResolvedValueOnce({ stdout: "" });
+
+    await enableTailscaleServe(3000, exec as never);
+
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      "tailscale",
+      expect.arrayContaining(["serve", "--bg", "--yes", "3000"]),
+      expect.any(Object)
+    );
+
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "serve", "--bg", "--yes", "3000"]),
+      expect.any(Object)
+    );
+  });
+
+  it("enableTailscaleServe does NOT use sudo if first attempt succeeds", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "" });
+
+    await enableTailscaleServe(3000, exec as never);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith(
+      "tailscale",
+      expect.arrayContaining(["serve", "--bg", "--yes", "3000"]),
+      expect.any(Object)
+    );
+  });
+
+  it("disableTailscaleServe uses fallback", async () => {
+    const exec = vi.fn()
+      .mockRejectedValueOnce(new Error("failed"))
+      .mockResolvedValueOnce({ stdout: "" });
+
+    await disableTailscaleServe(exec as never);
+
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "serve", "reset"]),
+      expect.any(Object)
+    );
+  });
+
+  it("ensureFunnel uses fallback for enabling", async () => {
+    // Mock exec:
+    // 1. status (success)
+    // 2. enable (fails)
+    // 3. enable sudo (success)
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ BackendState: "Running" }) }) // status
+      .mockRejectedValueOnce(new Error("failed")) // enable normal
+      .mockResolvedValueOnce({ stdout: "" }); // enable sudo
+
+    const runtime = {
+      error: vi.fn(),
+      log: vi.fn(),
+      exit: vi.fn() as unknown as (code: number) => never,
+    };
+    const prompt = vi.fn();
+
+    await ensureFunnel(8080, exec as never, runtime, prompt);
+
+    // 1. status
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      "tailscale",
+      expect.arrayContaining(["funnel", "status", "--json"])
+    );
+
+    // 2. enable normal
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      "tailscale",
+      expect.arrayContaining(["funnel", "--yes", "--bg", "8080"]),
+      expect.any(Object)
+    );
+
+    // 3. enable sudo
+    expect(exec).toHaveBeenNthCalledWith(
+      3,
+      "sudo",
+      expect.arrayContaining(["-n", "tailscale", "funnel", "--yes", "--bg", "8080"]),
+      expect.any(Object)
+    );
   });
 });

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,15 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  ensureGoInstalled,
-  ensureTailscaledInstalled,
-  getTailnetHostname,
-  enableTailscaleServe,
-  disableTailscaleServe,
-  enableTailscaleFunnel,
-  disableTailscaleFunnel,
-  ensureFunnel
-} from "./tailscale.js";
+import { ensureGoInstalled, ensureTailscaledInstalled, getTailnetHostname } from "./tailscale.js";
 
 describe("tailscale helpers", () => {
   it("parses DNS name from tailscale status", async () => {
@@ -56,76 +47,5 @@ describe("tailscale helpers", () => {
     };
     await ensureTailscaledInstalled(exec as never, prompt, runtime);
     expect(exec).toHaveBeenCalledWith("brew", ["install", "tailscale"]);
-  });
-
-  it("enableTailscaleServe uses sudo", async () => {
-    const exec = vi.fn().mockResolvedValue({ stdout: "" });
-    await enableTailscaleServe(3000, exec as never);
-    expect(exec).toHaveBeenCalledWith(
-      "sudo",
-      expect.arrayContaining(["-n", "tailscale", "serve", "--bg", "--yes", "3000"]),
-      expect.any(Object)
-    );
-  });
-
-  it("disableTailscaleServe uses sudo", async () => {
-    const exec = vi.fn().mockResolvedValue({ stdout: "" });
-    await disableTailscaleServe(exec as never);
-    expect(exec).toHaveBeenCalledWith(
-      "sudo",
-      expect.arrayContaining(["-n", "tailscale", "serve", "reset"]),
-      expect.any(Object)
-    );
-  });
-
-  it("enableTailscaleFunnel uses sudo", async () => {
-    const exec = vi.fn().mockResolvedValue({ stdout: "" });
-    await enableTailscaleFunnel(4000, exec as never);
-    expect(exec).toHaveBeenCalledWith(
-      "sudo",
-      expect.arrayContaining(["-n", "tailscale", "funnel", "--bg", "--yes", "4000"]),
-      expect.any(Object)
-    );
-  });
-
-  it("disableTailscaleFunnel uses sudo", async () => {
-    const exec = vi.fn().mockResolvedValue({ stdout: "" });
-    await disableTailscaleFunnel(exec as never);
-    expect(exec).toHaveBeenCalledWith(
-      "sudo",
-      expect.arrayContaining(["-n", "tailscale", "funnel", "reset"]),
-      expect.any(Object)
-    );
-  });
-
-  it("ensureFunnel uses sudo for enabling", async () => {
-    // Mock exec: first call is status (not sudo), second call is enable (sudo)
-    const exec = vi.fn()
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ BackendState: "Running" }) }) // status
-      .mockResolvedValueOnce({ stdout: "" }); // enable
-
-    const runtime = {
-      error: vi.fn(),
-      log: vi.fn(),
-      exit: vi.fn() as unknown as (code: number) => never,
-    };
-    const prompt = vi.fn();
-
-    await ensureFunnel(8080, exec as never, runtime, prompt);
-
-    // First call: check status (no sudo)
-    expect(exec).toHaveBeenNthCalledWith(
-      1,
-      "tailscale",
-      expect.arrayContaining(["funnel", "status", "--json"])
-    );
-
-    // Second call: enable (sudo)
-    expect(exec).toHaveBeenNthCalledWith(
-      2,
-      "sudo",
-      expect.arrayContaining(["-n", "tailscale", "funnel", "--yes", "--bg", "8080"]),
-      expect.any(Object)
-    );
   });
 });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -237,7 +237,7 @@ export async function ensureFunnel(
     }
 
     logVerbose(`Enabling funnel on port ${port}…`);
-    const { stdout } = await exec(tailscaleBin, ["funnel", "--yes", "--bg", `${port}`], {
+    const { stdout } = await exec("sudo", ["-n", tailscaleBin, "funnel", "--yes", "--bg", `${port}`], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });
@@ -288,7 +288,7 @@ export async function ensureFunnel(
 
 export async function enableTailscaleServe(port: number, exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await exec(tailscaleBin, ["serve", "--bg", "--yes", `${port}`], {
+  await exec("sudo", ["-n", tailscaleBin, "serve", "--bg", "--yes", `${port}`], {
     maxBuffer: 200_000,
     timeoutMs: 15_000,
   });
@@ -296,7 +296,7 @@ export async function enableTailscaleServe(port: number, exec: typeof runExec = 
 
 export async function disableTailscaleServe(exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await exec(tailscaleBin, ["serve", "reset"], {
+  await exec("sudo", ["-n", tailscaleBin, "serve", "reset"], {
     maxBuffer: 200_000,
     timeoutMs: 15_000,
   });
@@ -304,7 +304,7 @@ export async function disableTailscaleServe(exec: typeof runExec = runExec) {
 
 export async function enableTailscaleFunnel(port: number, exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await exec(tailscaleBin, ["funnel", "--bg", "--yes", `${port}`], {
+  await exec("sudo", ["-n", tailscaleBin, "funnel", "--bg", "--yes", `${port}`], {
     maxBuffer: 200_000,
     timeoutMs: 15_000,
   });
@@ -312,7 +312,7 @@ export async function enableTailscaleFunnel(port: number, exec: typeof runExec =
 
 export async function disableTailscaleFunnel(exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await exec(tailscaleBin, ["funnel", "reset"], {
+  await exec("sudo", ["-n", tailscaleBin, "funnel", "reset"], {
     maxBuffer: 200_000,
     timeoutMs: 15_000,
   });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -206,6 +206,39 @@ export async function ensureTailscaledInstalled(
   await exec("brew", ["install", "tailscale"]);
 }
 
+type ExecErrorDetails = {
+  stdout?: unknown;
+  stderr?: unknown;
+  message?: unknown;
+  code?: unknown;
+};
+
+function extractExecErrorText(err: unknown) {
+  const errOutput = err as ExecErrorDetails;
+  const stdout = typeof errOutput.stdout === "string" ? errOutput.stdout : "";
+  const stderr = typeof errOutput.stderr === "string" ? errOutput.stderr : "";
+  const message = typeof errOutput.message === "string" ? errOutput.message : "";
+  const code = typeof errOutput.code === "string" ? errOutput.code : "";
+  return { stdout, stderr, message, code };
+}
+
+function isPermissionDeniedError(err: unknown): boolean {
+  const { stdout, stderr, message, code } = extractExecErrorText(err);
+  if (code.toUpperCase() === "EACCES") return true;
+  const combined = `${stdout}\n${stderr}\n${message}`.toLowerCase();
+  return (
+    combined.includes("permission denied") ||
+    combined.includes("access denied") ||
+    combined.includes("operation not permitted") ||
+    combined.includes("not permitted") ||
+    combined.includes("requires root") ||
+    combined.includes("must be run as root") ||
+    combined.includes("must be run with sudo") ||
+    combined.includes("requires sudo") ||
+    combined.includes("need sudo")
+  );
+}
+
 // Helper to attempt a command, and retry with sudo if it fails.
 async function execWithSudoFallback(
   exec: typeof runExec,
@@ -216,12 +249,18 @@ async function execWithSudoFallback(
   try {
     return await exec(bin, args, opts);
   } catch (err) {
-    // If the error suggests permission denied or access denied, try with sudo.
-    // Or honestly, for any error in these specific ops, trying sudo is a reasonable fallback
-    // given the context of what we're doing (system-level network config).
-    // We'll log a verbose message that we're falling back.
+    if (!isPermissionDeniedError(err)) {
+      throw err;
+    }
     logVerbose(`Command failed, retrying with sudo: ${bin} ${args.join(" ")}`);
-    return await exec("sudo", ["-n", bin, ...args], opts);
+    try {
+      return await exec("sudo", ["-n", bin, ...args], opts);
+    } catch (sudoErr) {
+      const { stderr, message } = extractExecErrorText(sudoErr);
+      const detail = (stderr || message).trim();
+      if (detail) logVerbose(`Sudo retry failed: ${detail}`);
+      throw err;
+    }
   }
 }
 
@@ -313,52 +352,32 @@ export async function ensureFunnel(
 
 export async function enableTailscaleServe(port: number, exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await execWithSudoFallback(
-    exec,
-    tailscaleBin,
-    ["serve", "--bg", "--yes", `${port}`],
-    {
-      maxBuffer: 200_000,
-      timeoutMs: 15_000,
-    },
-  );
+  await execWithSudoFallback(exec, tailscaleBin, ["serve", "--bg", "--yes", `${port}`], {
+    maxBuffer: 200_000,
+    timeoutMs: 15_000,
+  });
 }
 
 export async function disableTailscaleServe(exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await execWithSudoFallback(
-    exec,
-    tailscaleBin,
-    ["serve", "reset"],
-    {
-      maxBuffer: 200_000,
-      timeoutMs: 15_000,
-    },
-  );
+  await execWithSudoFallback(exec, tailscaleBin, ["serve", "reset"], {
+    maxBuffer: 200_000,
+    timeoutMs: 15_000,
+  });
 }
 
 export async function enableTailscaleFunnel(port: number, exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await execWithSudoFallback(
-    exec,
-    tailscaleBin,
-    ["funnel", "--bg", "--yes", `${port}`],
-    {
-      maxBuffer: 200_000,
-      timeoutMs: 15_000,
-    },
-  );
+  await execWithSudoFallback(exec, tailscaleBin, ["funnel", "--bg", "--yes", `${port}`], {
+    maxBuffer: 200_000,
+    timeoutMs: 15_000,
+  });
 }
 
 export async function disableTailscaleFunnel(exec: typeof runExec = runExec) {
   const tailscaleBin = await getTailscaleBinary();
-  await execWithSudoFallback(
-    exec,
-    tailscaleBin,
-    ["funnel", "reset"],
-    {
-      maxBuffer: 200_000,
-      timeoutMs: 15_000,
-    },
-  );
+  await execWithSudoFallback(exec, tailscaleBin, ["funnel", "reset"], {
+    maxBuffer: 200_000,
+    timeoutMs: 15_000,
+  });
 }


### PR DESCRIPTION
Modifying Tailscale configuration does not work without sudo by default. By attempting passwordless sudo (`sudo -n`) we can potentially streamline the setup for non-root installs. Currently Tailscale errors are guaranteed to happen unless Clawdbot is running as root or the user has manually enabled nonroot user Tailscale control already.

(Code written by Google Jules)