### PR TITLE
fix: refine Bedrock discovery defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.clawd.bot
 ### Changes
 - CLI: restart the gateway by default after `clawdbot update`; add `--no-restart` to skip it.
 - CLI: add live auth probes to `clawdbot models status` for per-profile verification.
+- Agents: add Bedrock auto-discovery defaults + config overrides. (#1543) Thanks @fal3.
 - Docs: add cron vs heartbeat decision guide (with Lobster workflow notes). (#1533) Thanks @JustYannicc.
 - Markdown: add per-channel table conversion (bullets for Signal/WhatsApp, code blocks elsewhere). (#1495) Thanks @odysseus0.
 - Tlon: add Urbit channel plugin (DMs, group mentions, thread replies). (#1544) Thanks @wca4a.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.clawd.bot
 ### Changes
 - CLI: restart the gateway by default after `clawdbot update`; add `--no-restart` to skip it.
 - CLI: add live auth probes to `clawdbot models status` for per-profile verification.
-- Agents: add Bedrock auto-discovery defaults + config overrides. (#1543) Thanks @fal3.
+- Agents: add Bedrock auto-discovery defaults + config overrides. (#1553) Thanks @fal3.
 - Docs: add cron vs heartbeat decision guide (with Lobster workflow notes). (#1533) Thanks @JustYannicc.
 - Markdown: add per-channel table conversion (bullets for Signal/WhatsApp, code blocks elsewhere). (#1495) Thanks @odysseus0.
 - Tlon: add Urbit channel plugin (DMs, group mentions, thread replies). (#1544) Thanks @wca4a.

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -32,7 +32,9 @@ Config options live under `models.bedrockDiscovery`:
       enabled: true,
       region: "us-east-1",
       providerFilter: ["anthropic", "amazon"],
-      refreshInterval: 3600
+      refreshInterval: 3600,
+      defaultContextWindow: 32000,
+      defaultMaxTokens: 4096
     }
   }
 }
@@ -43,6 +45,8 @@ Notes:
 - `region` defaults to `AWS_REGION` or `AWS_DEFAULT_REGION`, then `us-east-1`.
 - `providerFilter` matches Bedrock provider names (for example `anthropic`).
 - `refreshInterval` is seconds; set to `0` to disable caching.
+- `defaultContextWindow` (default: `32000`) and `defaultMaxTokens` (default: `4096`)
+  are used for discovered models (override if you know your model limits).
 
 ## Setup (manual)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,9 +311,6 @@ importers:
       '@matrix-org/matrix-sdk-crypto-nodejs':
         specifier: ^0.4.0
         version: 0.4.0
-      clawdbot:
-        specifier: workspace:*
-        version: link:../..
       markdown-it:
         specifier: 14.1.0
         version: 14.1.0
@@ -323,6 +320,13 @@ importers:
       music-metadata:
         specifier: ^11.10.6
         version: 11.10.6
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
+    devDependencies:
+      clawdbot:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/mattermost: {}
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -75,12 +75,12 @@ function resolveEnvSourceLabel(params: {
   return `${prefix}${params.label}`;
 }
 
-export function resolveAwsSdkEnvVarName(): string | undefined {
-  if (process.env[AWS_BEARER_ENV]?.trim()) return AWS_BEARER_ENV;
-  if (process.env[AWS_ACCESS_KEY_ENV]?.trim() && process.env[AWS_SECRET_KEY_ENV]?.trim()) {
+export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (env[AWS_BEARER_ENV]?.trim()) return AWS_BEARER_ENV;
+  if (env[AWS_ACCESS_KEY_ENV]?.trim() && env[AWS_SECRET_KEY_ENV]?.trim()) {
     return AWS_ACCESS_KEY_ENV;
   }
-  if (process.env[AWS_PROFILE_ENV]?.trim()) return AWS_PROFILE_ENV;
+  if (env[AWS_PROFILE_ENV]?.trim()) return AWS_PROFILE_ENV;
   return undefined;
 }
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -385,7 +385,7 @@ export async function resolveImplicitBedrockProvider(params: {
   const env = params.env ?? process.env;
   const discoveryConfig = params.config?.models?.bedrockDiscovery;
   const enabled = discoveryConfig?.enabled;
-  const hasAwsCreds = resolveAwsSdkEnvVarName() !== undefined;
+  const hasAwsCreds = resolveAwsSdkEnvVarName(env) !== undefined;
   if (enabled === false) return null;
   if (enabled !== true && !hasAwsCreds) return null;
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -48,6 +48,8 @@ export type BedrockDiscoveryConfig = {
   region?: string;
   providerFilter?: string[];
   refreshInterval?: number;
+  defaultContextWindow?: number;
+  defaultMaxTokens?: number;
 };
 
 export type ModelsConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -65,6 +65,8 @@ export const BedrockDiscoverySchema = z
     region: z.string().optional(),
     providerFilter: z.array(z.string()).optional(),
     refreshInterval: z.number().int().nonnegative().optional(),
+    defaultContextWindow: z.number().int().positive().optional(),
+    defaultMaxTokens: z.number().int().positive().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- Tune Bedrock discovery defaults and allow config overrides
- Add cache + default override tests for Bedrock discovery
- Honor injected env when checking AWS creds for implicit Bedrock provider

## Testing
- pnpm lint && pnpm build && pnpm test
