### PR TITLE
fix: respect "none" value for plugins.slots.memory

### DIFF
--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePluginsConfig } from "./config-state.js";
+
+describe("normalizePluginsConfig", () => {
+  it("uses default memory slot when not specified", () => {
+    const result = normalizePluginsConfig({});
+    expect(result.slots.memory).toBe("memory-core");
+  });
+
+  it("respects explicit memory slot value", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "custom-memory" },
+    });
+    expect(result.slots.memory).toBe("custom-memory");
+  });
+
+  it("disables memory slot when set to 'none'", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "none" },
+    });
+    expect(result.slots.memory).toBeNull();
+  });
+
+  it("disables memory slot when set to 'None' (case insensitive)", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "None" },
+    });
+    expect(result.slots.memory).toBeNull();
+  });
+
+  it("trims whitespace from memory slot value", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "  custom-memory  " },
+    });
+    expect(result.slots.memory).toBe("custom-memory");
+  });
+
+  it("uses default when memory slot is empty string", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "" },
+    });
+    expect(result.slots.memory).toBe("memory-core");
+  });
+
+  it("uses default when memory slot is whitespace only", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "   " },
+    });
+    expect(result.slots.memory).toBe("memory-core");
+  });
+});

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -58,7 +58,7 @@ export const normalizePluginsConfig = (
     deny: normalizeList(config?.deny),
     loadPaths: normalizeList(config?.load?.paths),
     slots: {
-      memory: memorySlot ?? defaultSlotIdForKey("memory"),
+      memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
     },
     entries: normalizePluginEntries(config?.entries),
   };


### PR DESCRIPTION
### Problem

Setting `plugins.slots.memory = "none"` to disable memory plugins doesn't work. The config validation fails with:

plugin not found: memory-core

This breaks headless Linux deployments where `memory-core` isn't available, making it impossible to run the gateway on Linux servers.

### Root Cause

In `src/plugins/config-state.ts`, `normalizeSlotValue("none")` correctly returns `null` to indicate "disabled". However, line 61 uses nullish coalescing:

```javascript
memory: memorySlot ?? defaultSlotIdForKey("memory"),
```

Since null ?? value returns value (null is nullish), the explicit "none" setting gets replaced with the default "memory-core", which then fails validation when the plugin isn't installed.
