### PR TITLE
Fix logging recursion error if config has errors

### DIFF
--- a/src/logging/console-settings.test.ts
+++ b/src/logging/console-settings.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./config.js", () => ({
+  readLoggingConfig: () => undefined,
+}));
+
+vi.mock("./logger.js", () => ({
+  getLogger: () => ({
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+  }),
+}));
+
+let loadConfigCalls = 0;
+vi.mock("node:module", async () => {
+  const actual = await vi.importActual<typeof import("node:module")>("node:module");
+  return {
+    ...actual,
+    createRequire: (url: string | URL) => {
+      const realRequire = actual.createRequire(url);
+      return (specifier: string) => {
+        if (specifier.endsWith("config.js")) {
+          return {
+            loadConfig: () => {
+              loadConfigCalls += 1;
+              if (loadConfigCalls > 5) {
+                return {};
+              }
+              console.error("config load failed");
+              return {};
+            },
+          };
+        }
+        return realRequire(specifier);
+      };
+    },
+  };
+});
+let originalIsTty: boolean | undefined;
+
+beforeEach(() => {
+  loadConfigCalls = 0;
+  vi.resetModules();
+  originalIsTty = process.stdout.isTTY;
+  Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(process.stdout, "isTTY", { value: originalIsTty, configurable: true });
+  vi.restoreAllMocks();
+});
+
+async function loadLogging() {
+  const logging = await import("../logging.js");
+  const state = await import("./state.js");
+  state.loggingState.cachedConsoleSettings = null;
+  return { logging, state };
+}
+
+describe("getConsoleSettings", () => {
+  it("does not recurse when loadConfig logs during resolution", async () => {
+    const { logging } = await loadLogging();
+    logging.setConsoleTimestampPrefix(true);
+    logging.enableConsoleCapture();
+    const { getConsoleSettings } = logging;
+    getConsoleSettings();
+    expect(loadConfigCalls).toBe(1);
+  });
+
+  it("skips config fallback during re-entrant resolution", async () => {
+    const { logging, state } = await loadLogging();
+    state.loggingState.resolvingConsoleSettings = true;
+    logging.setConsoleTimestampPrefix(true);
+    logging.enableConsoleCapture();
+    logging.getConsoleSettings();
+    expect(loadConfigCalls).toBe(0);
+    state.loggingState.resolvingConsoleSettings = false;
+  });
+});

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -35,13 +35,20 @@ function resolveConsoleSettings(): ConsoleSettings {
   let cfg: ClawdbotConfig["logging"] | undefined =
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   if (!cfg) {
-    try {
-      const loaded = requireConfig("../config/config.js") as {
-        loadConfig?: () => ClawdbotConfig;
-      };
-      cfg = loaded.loadConfig?.().logging;
-    } catch {
+    if (loggingState.resolvingConsoleSettings) {
       cfg = undefined;
+    } else {
+      loggingState.resolvingConsoleSettings = true;
+      try {
+        const loaded = requireConfig("../config/config.js") as {
+          loadConfig?: () => ClawdbotConfig;
+        };
+        cfg = loaded.loadConfig?.().logging;
+      } catch {
+        cfg = undefined;
+      } finally {
+        loggingState.resolvingConsoleSettings = false;
+      }
     }
   }
   const level = normalizeConsoleLevel(cfg?.consoleLevel);

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -7,6 +7,7 @@ export const loggingState = {
   forceConsoleToStderr: false,
   consoleTimestampPrefix: false,
   consoleSubsystemFilter: null as string[] | null,
+  resolvingConsoleSettings: false,
   rawConsole: null as {
     log: typeof console.log;
     info: typeof console.info;


### PR DESCRIPTION
**Problem**
When the config loader (loadConfig) emits warnings or errors, it logs via console.warn/error. Console logging is patched to go through getConsoleSettings() so the log output respects the configured console level/style. If readLoggingConfig() cannot read the raw logging block, resolveConsoleSettings() falls back to calling loadConfig() to fetch logging.* from the full config. That creates a re‑entrant call chain:

  loadConfig → console.warn/error → getConsoleSettings → resolveConsoleSettings → loadConfig → …

Under repeated config warnings (e.g., duplicate plugin IDs), this recursion repeats until Node throws RangeError: Maximum call stack size exceeded, and the config read fails.

**Solution**
Add a re‑entrancy guard around the loadConfig() fallback inside resolveConsoleSettings():

  - A new loggingState.resolvingConsoleSettings flag is set while console settings are being resolved.
  - If logging resolution is already in progress, we skip the fallback to loadConfig() and use defaults instead.
  - In the non‑reentrant case, behavior is unchanged: we still try to read from loadConfig() when the raw logging block can’t be read.

This preserves the original intent (honor config‑based logging when possible) while preventing recursion.

**Changes**

  - src/logging/state.ts: add resolvingConsoleSettings flag.
  - src/logging/console.ts: wrap the loadConfig() fallback with the re‑entrancy guard.
  - src/logging/console-settings.test.ts: new test that asserts defaults are used in the re‑entrant path.

**Impact**

  - Prevents loadConfig() → console → loadConfig() recursion and stack overflows.
  - Keeps existing behavior for normal startup (still reads logging from config when it’s safe).
  - No changes to config parsing or plugin validation.

**Testing**

  - Added console-settings.test.ts for the guarded path.
