### PR TITLE
feat: add plugin command API for LLM-free auto-reply commands

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -526,8 +526,8 @@ Command options:
 
 - `name`: Command name (without the leading `/`)
 - `description`: Help text shown in command lists
-- `acceptsArgs`: Whether the command accepts arguments (default: false)
-- `requireAuth`: Whether to require authorized sender (default: false)
+- `acceptsArgs`: Whether the command accepts arguments (default: false). If false and arguments are provided, the command won't match and the message falls through to other handlers
+- `requireAuth`: Whether to require authorized sender (default: true)
 - `handler`: Function that returns `{ text: string }` (can be async)
 
 Example with authorization and arguments:
@@ -550,6 +550,9 @@ Notes:
 - Plugin commands are processed **before** built-in commands and the AI agent
 - Commands are registered globally and work across all channels
 - Command names are case-insensitive (`/MyStatus` matches `/mystatus`)
+- Command names must start with a letter and contain only letters, numbers, hyphens, and underscores
+- Reserved command names (like `help`, `status`, `reset`, etc.) cannot be overridden by plugins
+- Duplicate command registration across plugins will fail with a diagnostic error
 
 ### Register background services
 

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -24,6 +24,7 @@ import {
   handleStopCommand,
   handleUsageCommand,
 } from "./commands-session.js";
+import { handlePluginCommand } from "./commands-plugin.js";
 import type {
   CommandHandler,
   CommandHandlerResult,
@@ -31,6 +32,8 @@ import type {
 } from "./commands-types.js";
 
 const HANDLERS: CommandHandler[] = [
+  // Plugin commands are processed first, before built-in commands
+  handlePluginCommand,
   handleBashCommand,
   handleActivationCommand,
   handleSendPolicyCommand,

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -1,0 +1,46 @@
+/**
+ * Plugin Command Handler
+ *
+ * Handles commands registered by plugins, bypassing the LLM agent.
+ * This handler is called before built-in command handlers.
+ */
+
+import { matchPluginCommand, executePluginCommand } from "../../plugins/commands.js";
+import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
+
+/**
+ * Handle plugin-registered commands.
+ * Returns a result if a plugin command was matched and executed,
+ * or null to continue to the next handler.
+ */
+export const handlePluginCommand: CommandHandler = async (
+  params,
+  _allowTextCommands,
+): Promise<CommandHandlerResult | null> => {
+  const { command, cfg } = params;
+
+  // Try to match a plugin command
+  const match = matchPluginCommand(command.commandBodyNormalized);
+  if (!match) return null;
+
+  // Execute the plugin command
+  const result = await executePluginCommand({
+    command: match.command,
+    args: match.args,
+    senderId: command.senderId,
+    channel: command.channel,
+    isAuthorizedSender: command.isAuthorizedSender,
+    commandBody: command.commandBodyNormalized,
+    config: cfg,
+  });
+
+  if (result) {
+    return {
+      shouldContinue: false,
+      reply: { text: result.text },
+    };
+  }
+
+  // Command was blocked (e.g., unauthorized) - don't continue to agent
+  return { shouldContinue: false };
+};

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -23,7 +23,7 @@ export const handlePluginCommand: CommandHandler = async (
   const match = matchPluginCommand(command.commandBodyNormalized);
   if (!match) return null;
 
-  // Execute the plugin command
+  // Execute the plugin command (always returns a result)
   const result = await executePluginCommand({
     command: match.command,
     args: match.args,
@@ -34,13 +34,8 @@ export const handlePluginCommand: CommandHandler = async (
     config: cfg,
   });
 
-  if (result) {
-    return {
-      shouldContinue: false,
-      reply: { text: result.text },
-    };
-  }
-
-  // Command was blocked (e.g., unauthorized) - don't continue to agent
-  return { shouldContinue: false };
+  return {
+    shouldContinue: false,
+    reply: { text: result.text },
+  };
 };

--- a/src/gateway/server/__tests__/test-utils.ts
+++ b/src/gateway/server/__tests__/test-utils.ts
@@ -12,6 +12,7 @@ export const createTestRegistry = (overrides: Partial<PluginRegistry> = {}): Plu
     httpHandlers: [],
     cliRegistrars: [],
     services: [],
+    commands: [],
     diagnostics: [],
   };
   const merged = { ...base, ...overrides };

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -140,6 +140,7 @@ const createStubPluginRegistry = (): PluginRegistry => ({
   httpHandlers: [],
   cliRegistrars: [],
   services: [],
+  commands: [],
   diagnostics: [],
 });
 

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -1,0 +1,151 @@
+/**
+ * Plugin Command Registry
+ *
+ * Manages commands registered by plugins that bypass the LLM agent.
+ * These commands are processed before built-in commands and before agent invocation.
+ */
+
+import type { ClawdbotConfig } from "../config/config.js";
+import type { ClawdbotPluginCommandDefinition, PluginCommandContext } from "./types.js";
+import { logVerbose } from "../globals.js";
+
+type RegisteredPluginCommand = ClawdbotPluginCommandDefinition & {
+  pluginId: string;
+};
+
+// Registry of plugin commands
+const pluginCommands: Map<string, RegisteredPluginCommand> = new Map();
+
+/**
+ * Register a plugin command.
+ */
+export function registerPluginCommand(
+  pluginId: string,
+  command: ClawdbotPluginCommandDefinition,
+): void {
+  const key = `/${command.name.toLowerCase()}`;
+  if (pluginCommands.has(key)) {
+    logVerbose(
+      `Plugin command ${key} already registered, overwriting with plugin ${pluginId}`,
+    );
+  }
+  pluginCommands.set(key, { ...command, pluginId });
+  logVerbose(`Registered plugin command: ${key} (plugin: ${pluginId})`);
+}
+
+/**
+ * Clear all registered plugin commands.
+ * Called during plugin reload.
+ */
+export function clearPluginCommands(): void {
+  pluginCommands.clear();
+}
+
+/**
+ * Clear plugin commands for a specific plugin.
+ */
+export function clearPluginCommandsForPlugin(pluginId: string): void {
+  for (const [key, cmd] of pluginCommands.entries()) {
+    if (cmd.pluginId === pluginId) {
+      pluginCommands.delete(key);
+    }
+  }
+}
+
+/**
+ * Check if a command body matches a registered plugin command.
+ * Returns the command definition and parsed args if matched.
+ */
+export function matchPluginCommand(
+  commandBody: string,
+): { command: RegisteredPluginCommand; args?: string } | null {
+  const trimmed = commandBody.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  // Extract command name and args
+  const spaceIndex = trimmed.indexOf(" ");
+  const commandName = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
+  const args = spaceIndex === -1 ? undefined : trimmed.slice(spaceIndex + 1).trim();
+
+  const key = commandName.toLowerCase();
+  const command = pluginCommands.get(key);
+
+  if (!command) return null;
+
+  // If command doesn't accept args but args were provided, don't match
+  if (args && !command.acceptsArgs) return null;
+
+  return { command, args: args || undefined };
+}
+
+/**
+ * Execute a plugin command handler.
+ */
+export async function executePluginCommand(params: {
+  command: RegisteredPluginCommand;
+  args?: string;
+  senderId?: string;
+  channel: string;
+  isAuthorizedSender: boolean;
+  commandBody: string;
+  config: ClawdbotConfig;
+}): Promise<{ text: string } | null> {
+  const { command, args, senderId, channel, isAuthorizedSender, commandBody, config } =
+    params;
+
+  // Check authorization
+  const requireAuth = command.requireAuth !== false; // Default to true
+  if (requireAuth && !isAuthorizedSender) {
+    logVerbose(
+      `Plugin command /${command.name} blocked: unauthorized sender ${senderId || "<unknown>"}`,
+    );
+    return null; // Silently ignore unauthorized commands
+  }
+
+  const ctx: PluginCommandContext = {
+    senderId,
+    channel,
+    isAuthorizedSender,
+    args,
+    commandBody,
+    config,
+  };
+
+  try {
+    const result = await command.handler(ctx);
+    return { text: result.text };
+  } catch (err) {
+    const error = err as Error;
+    logVerbose(`Plugin command /${command.name} error: ${error.message}`);
+    return { text: `⚠️ Command failed: ${error.message}` };
+  }
+}
+
+/**
+ * List all registered plugin commands.
+ * Used for /help and /commands output.
+ */
+export function listPluginCommands(): Array<{
+  name: string;
+  description: string;
+  pluginId: string;
+}> {
+  return Array.from(pluginCommands.values()).map((cmd) => ({
+    name: cmd.name,
+    description: cmd.description,
+    pluginId: cmd.pluginId,
+  }));
+}
+
+/**
+ * Get plugin command specs for native command registration (e.g., Telegram).
+ */
+export function getPluginCommandSpecs(): Array<{
+  name: string;
+  description: string;
+}> {
+  return Array.from(pluginCommands.values()).map((cmd) => ({
+    name: cmd.name,
+    description: cmd.description,
+  }));
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -147,6 +147,7 @@ function createPluginRecord(params: {
     gatewayMethods: [],
     cliCommands: [],
     services: [],
+    commands: [],
     httpHandlers: 0,
     hookCount: 0,
     configSchema: params.configSchema,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -16,6 +16,7 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
+import { clearPluginCommands } from "./commands.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { createPluginRuntime } from "./runtime/index.js";
 import { setActivePluginRegistry } from "./runtime.js";
@@ -177,6 +178,9 @@ export function loadClawdbotPlugins(options: PluginLoadOptions = {}): PluginRegi
       return cached;
     }
   }
+
+  // Clear previously registered plugin commands before reloading
+  clearPluginCommands();
 
   const runtime = createPluginRuntime();
   const { registry, createApi } = createPluginRegistry({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -374,14 +374,25 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
+
+    // Register with the plugin command system (validates name and checks for duplicates)
+    const result = registerPluginCommand(record.id, command);
+    if (!result.ok) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `command registration failed: ${result.error}`,
+      });
+      return;
+    }
+
     record.commands.push(name);
     registry.commands.push({
       pluginId: record.id,
       command,
       source: record.source,
     });
-    // Register with the plugin command system
-    registerPluginCommand(record.id, command);
   };
 
   const registerTypedHook = <K extends PluginHookName>(

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -11,6 +11,7 @@ const createEmptyRegistry = (): PluginRegistry => ({
   httpHandlers: [],
   cliRegistrars: [],
   services: [],
+  commands: [],
   diagnostics: [],
 });
 

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -19,6 +19,7 @@ export const createTestRegistry = (channels: PluginRegistry["channels"] = []): P
   httpHandlers: [],
   cliRegistrars: [],
   services: [],
+  commands: [],
   diagnostics: [],
 });
 


### PR DESCRIPTION
## Summary

- Adds a new API for plugins to register slash commands that execute immediately without invoking the LLM agent
- Useful for state toggles, status checks, and quick actions
- Commands are processed before built-in handlers
- Supports authorization, argument parsing, and validation

### Key features:
- `registerCommand()` API for plugins to register commands
- Command validation (reserved names, invalid characters)
- Authorization enforcement via existing allowlist
- Input sanitization and error handling
- Registry locking during execution to prevent modifications

### Files changed:
- `src/plugins/commands.ts` - Core command registration and execution
- `src/plugins/types.ts` - TypeScript types for command definitions
- `src/plugins/registry.ts` - Integration with plugin registry
- `src/plugins/runtime.ts` - Runtime API exposure
- `src/plugins/loader.ts` - Command cleanup on plugin reload
- `src/auto-reply/reply/commands-plugin.ts` - Command handler in auto-reply chain
- `src/auto-reply/reply/commands-core.ts` - Integration with core command handler
- `docs/plugin.md` - Documentation for the new API

## Test plan

- [ ] Run `pnpm test` to verify all tests pass
- [ ] Manually test command registration from a plugin
- [ ] Verify reserved commands cannot be overridden
- [ ] Test authorization enforcement for restricted commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)