### PR TITLE
CLI: fix Windows node argv stripping

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -82,13 +83,16 @@ function stripWindowsNodeExec(argv: string[]): string[] {
   const execBase = path.basename(execPath).toLowerCase();
   const isExecPath = (value: string | undefined): boolean => {
     if (!value) return false;
-    const lower = normalizeCandidate(value).toLowerCase();
+    const normalized = normalizeCandidate(value);
+    if (!normalized) return false;
+    const lower = normalized.toLowerCase();
     return (
       lower === execPathLower ||
       path.basename(lower) === execBase ||
       lower.endsWith("\\node.exe") ||
       lower.endsWith("/node.exe") ||
-      lower.includes("node.exe")
+      lower.includes("node.exe") ||
+      (path.basename(lower) === "node.exe" && fs.existsSync(normalized))
     );
   };
   const filtered = argv.filter((arg, index) => index === 0 || !isExecPath(arg));


### PR DESCRIPTION
## Summary
- treat real node.exe paths as strip-eligible in Windows argv normalization
- avoids mis-parsing node.exe as a CLI command after respawn

## Why
On Windows, the CLI respawn path can leave a literal C:\Program Files\nodejs\node.exe in argv. Commander then treats it as a subcommand, causing rror: unknown command 'C:\Program Files\nodejs\node.exe' and preventing clawdbot gateway run from starting. This patch expands the Windows argv stripping to treat any real node.exe path as executable and remove it.

## Testing
- not run (Windows runtime path fix)