### PR TITLE
Remove dynamic time section from system prompt and add current time to Cron so it knows the time in cron

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -132,9 +132,9 @@ describe("buildAgentSystemPrompt", () => {
       userTimeFormat: "12",
     });
 
-    expect(prompt).toContain("## Current Date & Time");
-    expect(prompt).toContain("Monday, January 5th, 2026 — 3:26 PM (America/Chicago)");
-    expect(prompt).toContain("Time format: 12-hour");
+    expect(prompt).not.toContain("## Current Date & Time");
+    expect(prompt).not.toContain("Monday, January 5th, 2026 — 3:26 PM (America/Chicago)");
+    expect(prompt).not.toContain("Time format: 12-hour");
   });
 
   it("includes user time when provided (24-hour)", () => {
@@ -145,9 +145,9 @@ describe("buildAgentSystemPrompt", () => {
       userTimeFormat: "24",
     });
 
-    expect(prompt).toContain("## Current Date & Time");
-    expect(prompt).toContain("Monday, January 5th, 2026 — 15:26 (America/Chicago)");
-    expect(prompt).toContain("Time format: 24-hour");
+    expect(prompt).not.toContain("## Current Date & Time");
+    expect(prompt).not.toContain("Monday, January 5th, 2026 — 15:26 (America/Chicago)");
+    expect(prompt).not.toContain("Time format: 24-hour");
   });
 
   it("shows UTC fallback when only timezone is provided", () => {
@@ -157,10 +157,8 @@ describe("buildAgentSystemPrompt", () => {
       userTimeFormat: "24",
     });
 
-    expect(prompt).toContain("## Current Date & Time");
-    expect(prompt).toContain(
-      "Time zone: America/Chicago. Current time unknown; assume UTC for date/time references.",
-    );
+    expect(prompt).not.toContain("## Current Date & Time");
+    expect(prompt).not.toContain("Time zone: America/Chicago.");
   });
 
   it("includes model alias guidance when aliases are provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -49,24 +49,6 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: {
-  userTimezone?: string;
-  userTime?: string;
-  userTimeFormat?: ResolvedTimeFormat;
-}) {
-  if (!params.userTimezone && !params.userTime) return [];
-  return [
-    "## Current Date & Time",
-    params.userTime
-      ? `${params.userTime} (${params.userTimezone ?? "unknown"})`
-      : `Time zone: ${params.userTimezone}. Current time unknown; assume UTC for date/time references.`,
-    params.userTimeFormat
-      ? `Time format: ${params.userTimeFormat === "24" ? "24-hour" : "12-hour"}`
-      : "",
-    "",
-  ];
-}
-
 function buildReplyTagsSection(isMinimal: boolean) {
   if (isMinimal) return [];
   return [
@@ -301,8 +283,6 @@ export function buildAgentSystemPrompt(params: {
       ].join(" ")
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
-  const userTimezone = params.userTimezone?.trim();
-  const userTime = params.userTime?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const heartbeatPromptLine = heartbeatPrompt
@@ -368,6 +348,7 @@ export function buildAgentSystemPrompt(params: {
     "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
+    `When you need the current date/time, use ${execToolName} to query the system clock (e.g., "date" or "Get-Date") rather than guessing.`,
     "",
     "## Clawdbot CLI Quick Reference",
     "Clawdbot is controlled via subcommands. Do not invent commands.",
@@ -463,11 +444,6 @@ export function buildAgentSystemPrompt(params: {
       : "",
     params.sandboxInfo?.enabled ? "" : "",
     ...buildUserIdentitySection(ownerLine, isMinimal),
-    ...buildTimeSection({
-      userTimezone,
-      userTime,
-      userTimeFormat: params.userTimeFormat,
-    }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Clawdbot and included below in Project Context.",
     "",

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -82,13 +83,16 @@ function stripWindowsNodeExec(argv: string[]): string[] {
   const execBase = path.basename(execPath).toLowerCase();
   const isExecPath = (value: string | undefined): boolean => {
     if (!value) return false;
-    const lower = normalizeCandidate(value).toLowerCase();
+    const normalized = normalizeCandidate(value);
+    if (!normalized) return false;
+    const lower = normalized.toLowerCase();
     return (
       lower === execPathLower ||
       path.basename(lower) === execBase ||
       lower.endsWith("\\node.exe") ||
       lower.endsWith("/node.exe") ||
-      lower.includes("node.exe")
+      lower.includes("node.exe") ||
+      (path.basename(lower) === "node.exe" && fs.existsSync(normalized))
     );
   };
   const filtered = argv.filter((arg, index) => index === 0 || !isExecPath(arg));

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -83,16 +82,13 @@ function stripWindowsNodeExec(argv: string[]): string[] {
   const execBase = path.basename(execPath).toLowerCase();
   const isExecPath = (value: string | undefined): boolean => {
     if (!value) return false;
-    const normalized = normalizeCandidate(value);
-    if (!normalized) return false;
-    const lower = normalized.toLowerCase();
+    const lower = normalizeCandidate(value).toLowerCase();
     return (
       lower === execPathLower ||
       path.basename(lower) === execBase ||
       lower.endsWith("\\node.exe") ||
       lower.endsWith("/node.exe") ||
-      lower.includes("node.exe") ||
-      (path.basename(lower) === "node.exe" && fs.existsSync(normalized))
+      lower.includes("node.exe")
     );
   };
   const filtered = argv.filter((arg, index) => index === 0 || !isExecPath(arg));

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -25,6 +25,7 @@ import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
+import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../../agents/date-time.js";
 import {
   formatXHighModelHint,
   normalizeThinkLevel,
@@ -225,8 +226,14 @@ export async function runCronIsolatedAgentTurn(params: {
     to: agentPayload?.to,
   });
 
+  const userTimezone = resolveUserTimezone(params.cfg.agents?.defaults?.userTimezone);
+  const userTimeFormat = resolveUserTimeFormat(params.cfg.agents?.defaults?.timeFormat);
+  const formattedTime =
+    formatUserTime(new Date(now), userTimezone, userTimeFormat) ??
+    new Date(now).toISOString();
+  const timeLine = `Current time: ${formattedTime} (${userTimezone})`;
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
-  const commandBody = base;
+  const commandBody = `${timeLine}\n${base}`.trim();
 
   const existingSnapshot = cronSession.sessionEntry.skillsSnapshot;
   const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);


### PR DESCRIPTION
## Summary
- remove dynamic time section from system prompt to preserve cache stability
- add cron prompt prefix with current time + timezone
- instruct agents to use exec to query current time when needed

## Why
In this session we saw that embedding a timestamp in the system prompt busts caching, but cron prompts still need a reliable current time. This moves the dynamic time into cron-only prompts (where it actually matters) and replaces the system prompt time block with guidance to fetch time via shell when needed, keeping the system prompt stable for caching.

## Testing
- not run (prompt-only changes)