### PR TITLE
tui: filter agent events by active chat run id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.clawd.bot
 - Exec approvals: persist allowlist entry ids to keep macOS allowlist rows stable. (#1521) Thanks @ngutman.
 - MS Teams (plugin): remove `.default` suffix from Graph scopes to avoid double-appending. (#1507) Thanks @Evizero.
 - Browser: keep extension relay tabs controllable when the extension reuses a session id after switching tabs. (#1160)
+- TUI: track active run ids from chat events so tool/lifecycle updates show for non-TUI runs. (#1567) Thanks @vignesh07.
 
 ## 2026.1.22
 

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEventHandlers } from "./tui-event-handlers.js";
+import type { AgentEvent, TuiStateAccess } from "./tui-types.js";
+
+type MockChatLog = {
+  startTool: ReturnType<typeof vi.fn>;
+  updateToolResult: ReturnType<typeof vi.fn>;
+  addSystem: ReturnType<typeof vi.fn>;
+  updateAssistant: ReturnType<typeof vi.fn>;
+  finalizeAssistant: ReturnType<typeof vi.fn>;
+};
+
+describe("tui-event-handlers: handleAgentEvent", () => {
+  const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
+    agentDefaultId: "main",
+    sessionMainKey: "agent:main:main",
+    sessionScope: "global",
+    agents: [],
+    currentAgentId: "main",
+    currentSessionKey: "agent:main:main",
+    currentSessionId: "session-1",
+    activeChatRunId: "run-1",
+    historyLoaded: true,
+    sessionInfo: {},
+    initialSessionApplied: true,
+    isConnected: true,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: "connected",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
+    ...overrides,
+  });
+
+  const makeContext = (state: TuiStateAccess) => {
+    const chatLog: MockChatLog = {
+      startTool: vi.fn(),
+      updateToolResult: vi.fn(),
+      addSystem: vi.fn(),
+      updateAssistant: vi.fn(),
+      finalizeAssistant: vi.fn(),
+    };
+    const tui = { requestRender: vi.fn() };
+    const setActivityStatus = vi.fn();
+
+    return { chatLog, tui, state, setActivityStatus };
+  };
+
+  it("processes tool events when runId matches activeChatRunId (even if sessionId differs)", () => {
+    const state = makeState({ currentSessionId: "session-xyz", activeChatRunId: "run-123" });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleAgentEvent } = createEventHandlers({
+      // Casts are fine here: TUI runtime shape is larger than we need in unit tests.
+      chatLog: chatLog as any,
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    const evt: AgentEvent = {
+      runId: "run-123",
+      stream: "tool",
+      data: {
+        phase: "start",
+        toolCallId: "tc1",
+        name: "exec",
+        args: { command: "echo hi" },
+      },
+    };
+
+    handleAgentEvent(evt);
+
+    expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "exec", { command: "echo hi" });
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores tool events when runId does not match activeChatRunId", () => {
+    const state = makeState({ activeChatRunId: "run-1" });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleAgentEvent } = createEventHandlers({
+      chatLog: chatLog as any,
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    const evt: AgentEvent = {
+      runId: "run-2",
+      stream: "tool",
+      data: { phase: "start", toolCallId: "tc1", name: "exec" },
+    };
+
+    handleAgentEvent(evt);
+
+    expect(chatLog.startTool).not.toHaveBeenCalled();
+    expect(chatLog.updateToolResult).not.toHaveBeenCalled();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
+  it("processes lifecycle events when runId matches activeChatRunId", () => {
+    const state = makeState({ activeChatRunId: "run-9" });
+    const { tui, setActivityStatus } = makeContext(state);
+    const { handleAgentEvent } = createEventHandlers({
+      chatLog: { startTool: vi.fn(), updateToolResult: vi.fn() } as any,
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    const evt: AgentEvent = {
+      runId: "run-9",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    };
+
+    handleAgentEvent(evt);
+
+    expect(setActivityStatus).toHaveBeenCalledWith("running");
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -15,32 +15,57 @@ type EventHandlerContext = {
 export function createEventHandlers(context: EventHandlerContext) {
   const { chatLog, tui, state, setActivityStatus, refreshSessionInfo } = context;
   const finalizedRuns = new Map<string, number>();
-  const streamAssembler = new TuiStreamAssembler();
+  const sessionRuns = new Map<string, number>();
+  let streamAssembler = new TuiStreamAssembler();
+  let lastSessionKey = state.currentSessionKey;
+
+  const pruneRunMap = (runs: Map<string, number>) => {
+    if (runs.size <= 200) return;
+    const keepUntil = Date.now() - 10 * 60 * 1000;
+    for (const [key, ts] of runs) {
+      if (runs.size <= 150) break;
+      if (ts < keepUntil) runs.delete(key);
+    }
+    if (runs.size > 200) {
+      for (const key of runs.keys()) {
+        runs.delete(key);
+        if (runs.size <= 150) break;
+      }
+    }
+  };
+
+  const syncSessionKey = () => {
+    if (state.currentSessionKey === lastSessionKey) return;
+    lastSessionKey = state.currentSessionKey;
+    finalizedRuns.clear();
+    sessionRuns.clear();
+    streamAssembler = new TuiStreamAssembler();
+  };
+
+  const noteSessionRun = (runId: string) => {
+    sessionRuns.set(runId, Date.now());
+    pruneRunMap(sessionRuns);
+  };
 
   const noteFinalizedRun = (runId: string) => {
     finalizedRuns.set(runId, Date.now());
+    sessionRuns.delete(runId);
     streamAssembler.drop(runId);
-    if (finalizedRuns.size <= 200) return;
-    const keepUntil = Date.now() - 10 * 60 * 1000;
-    for (const [key, ts] of finalizedRuns) {
-      if (finalizedRuns.size <= 150) break;
-      if (ts < keepUntil) finalizedRuns.delete(key);
-    }
-    if (finalizedRuns.size > 200) {
-      for (const key of finalizedRuns.keys()) {
-        finalizedRuns.delete(key);
-        if (finalizedRuns.size <= 150) break;
-      }
-    }
+    pruneRunMap(finalizedRuns);
   };
 
   const handleChatEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") return;
     const evt = payload as ChatEvent;
+    syncSessionKey();
     if (evt.sessionKey !== state.currentSessionKey) return;
     if (finalizedRuns.has(evt.runId)) {
       if (evt.state === "delta") return;
       if (evt.state === "final") return;
+    }
+    noteSessionRun(evt.runId);
+    if (!state.activeChatRunId) {
+      state.activeChatRunId = evt.runId;
     }
     if (evt.state === "delta") {
       const displayText = streamAssembler.ingestDelta(evt.runId, evt.message, state.showThinking);
@@ -78,6 +103,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "aborted") {
       chatLog.addSystem("run aborted");
       streamAssembler.drop(evt.runId);
+      sessionRuns.delete(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus("aborted");
       void refreshSessionInfo?.();
@@ -85,6 +111,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "error") {
       chatLog.addSystem(`run error: ${evt.errorMessage ?? "unknown"}`);
       streamAssembler.drop(evt.runId);
+      sessionRuns.delete(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus("error");
       void refreshSessionInfo?.();
@@ -95,9 +122,10 @@ export function createEventHandlers(context: EventHandlerContext) {
   const handleAgentEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") return;
     const evt = payload as AgentEvent;
+    syncSessionKey();
     // Agent events (tool streaming, lifecycle) are emitted per-run. Filter against the
     // active chat run id, not the session id.
-    if (!state.activeChatRunId || evt.runId !== state.activeChatRunId) return;
+    if (evt.runId !== state.activeChatRunId && !sessionRuns.has(evt.runId)) return;
     if (evt.stream === "tool") {
       const data = evt.data ?? {};
       const phase = asString(data.phase, "");

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -95,7 +95,9 @@ export function createEventHandlers(context: EventHandlerContext) {
   const handleAgentEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") return;
     const evt = payload as AgentEvent;
-    if (!state.currentSessionId || evt.runId !== state.currentSessionId) return;
+    // Agent events (tool streaming, lifecycle) are emitted per-run. Filter against the
+    // active chat run id, not the session id.
+    if (!state.activeChatRunId || evt.runId !== state.activeChatRunId) return;
     if (evt.stream === "tool") {
       const data = evt.data ?? {};
       const phase = asString(data.phase, "");


### PR DESCRIPTION
## What
Fix TUI agent-event routing: agent events (tool streaming + lifecycle) are emitted per **runId**, not per session id.

The TUI was filtering agent events against `state.currentSessionId`, which can differ from the run id and causes tool/lifecycle updates to be dropped for the active chat run.

This PR filters agent events against `state.activeChatRunId` instead.

## Why
Without this, tool streaming and lifecycle status can fail to show up in the TUI whenever `runId !== currentSessionId` (which is the normal case).

## Tests
- Added `src/tui/tui-event-handlers.test.ts` covering:
  - accepts tool events when `runId === activeChatRunId` (even if session id differs)
  - ignores tool events when runId doesn’t match
  - updates activity status on lifecycle events when runId matches

## AI assistance
AI-assisted. Tested locally (vitest).
