### PR TITLE
fix(bird skill): gate brew install to macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.clawd.bot
 - Channels: allow per-group tool allow/deny policies across built-in + plugin channels. (#1546) Thanks @adam91holt.
 
 ### Fixes
+- Skills: gate bird Homebrew install to macOS. (#1569) Thanks @bradleypriest.
 - Agents: ignore IDENTITY.md template placeholders when parsing identity to avoid placeholder replies. (#1556)
 - Docker: update gateway command in docker-compose and Hetzner guide. (#1514)
 - Sessions: reject array-backed session stores to prevent silent wipes. (#1469)

--- a/skills/bird/SKILL.md
+++ b/skills/bird/SKILL.md
@@ -2,7 +2,7 @@
 name: bird
 description: X/Twitter CLI for reading, searching, posting, and engagement via cookies.
 homepage: https://bird.fast
-metadata: {"clawdbot":{"emoji":"🐦","requires":{"bins":["bird"]},"install":[{"id":"brew","kind":"brew","formula":"steipete/tap/bird","bins":["bird"],"label":"Install bird (brew)"},{"id":"npm","kind":"node","package":"@steipete/bird","bins":["bird"],"label":"Install bird (npm)"}]}}
+metadata: {"clawdbot":{"emoji":"🐦","requires":{"bins":["bird"]},"install":[{"id":"brew","kind":"brew","formula":"steipete/tap/bird","bins":["bird"],"label":"Install bird (brew)","os":["darwin"]},{"id":"npm","kind":"node","package":"@steipete/bird","bins":["bird"],"label":"Install bird (npm)"}]}}
 ---
 
 # bird 🐦


### PR DESCRIPTION

## Summary

Fix the bundled **bird** skill install UX on Linux: Homebrew currently installs a macOS-only `bird` binary, so the Web Chat Skills UI offers a broken flow on Linux.

This change gates the **brew** installer to **macOS only**, and leaves the **npm** installer available cross-platform.

## Problem

- The `bird` AgentSkill metadata currently offers `brew install steipete/tap/bird`.
- On Linux, that formula points at a **macOS universal tarball**, which yields a non-runnable binary (and can appear as “Permission denied” / wrong executable format).
- Users on Linux are guided into the wrong installer path via the Skills UI.

## Changes

- Update `skills/bird/SKILL.md` metadata:
  - `brew` install spec now includes `os: ["darwin"]`
  - `npm` install spec remains available on all platforms (no `os` filter)

This uses the documented `install[].os` filter support (`docs.clawd.bot/tools/skills#format-agentskills-+-pi-compatible`).

## Testing Notes

- Local sanity check:
  - `clawdbot skills info bird` shows the skill as available/ready when `bird` is installed.
- Expected behavior:
  - On Linux, the Skills UI should no longer suggest the brew install option for bird.
  - On macOS, brew remains available.

## AI-assisted

🤖 AI-assisted (Shellby / Clawdbot). Small metadata-only change; no behavior changes outside installer option filtering.
