### PR TITLE
feat: add Fly.io deployment support

### DIFF
--- a/docs/platforms/fly.md
+++ b/docs/platforms/fly.md
@@ -1,0 +1,74 @@
+---
+title: Fly.io
+description: Deploy Clawdbot on Fly.io
+---
+
+# Fly.io Deployment
+
+Deploy Clawdbot on [Fly.io](https://fly.io) with persistent storage and automatic HTTPS.
+
+## Prerequisites
+
+- [flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/) installed
+- Fly.io account
+
+## Quick Start
+
+```bash
+# Clone and enter the repo
+git clone https://github.com/clawdbot/clawdbot.git
+cd clawdbot
+
+# Create the app (first time only)
+fly apps create clawdbot
+
+# Create persistent volume for data
+fly volumes create clawdbot_data --size 1 --region lhr
+
+# Set your secrets
+fly secrets set ANTHROPIC_API_KEY=your-key-here
+# Add other provider keys as needed
+
+# Deploy
+fly deploy
+```
+
+## Configuration
+
+The included `fly.toml` configures:
+
+- **Region**: `lhr` (London) - change to your preferred [region](https://fly.io/docs/reference/regions/)
+- **VM**: `shared-cpu-1x` with 512MB RAM (sufficient for most use cases)
+- **Storage**: Persistent volume mounted at `/data`
+- **Auto-scaling**: Disabled to maintain persistent connections
+
+## Secrets
+
+Set your API keys as secrets (never commit these):
+
+```bash
+fly secrets set ANTHROPIC_API_KEY=sk-...
+fly secrets set OPENAI_API_KEY=sk-...
+fly secrets set GOOGLE_API_KEY=...
+```
+
+## Accessing the Gateway
+
+After deployment:
+
+```bash
+# Open the web UI
+fly open
+
+# Check logs
+fly logs
+
+# SSH into the machine
+fly ssh console
+```
+
+## Notes
+
+- Fly.io uses **x86** architecture (not ARM)
+- The Dockerfile is compatible with both architectures
+- For WhatsApp/Telegram, you'll need to run onboarding via `fly ssh console`

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+# Clawdbot Fly.io deployment configuration
+# See https://fly.io/docs/reference/configuration/
+
+app = "clawdbot"
+primary_region = "lhr"  # London
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  # Fly uses x86, but keep this for consistency
+  CLAWDBOT_PREFER_PNPM = "1"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = false  # Keep running for persistent connections
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[mounts]
+  source = "clawdbot_data"
+  destination = "/data"


### PR DESCRIPTION
Adds Fly.io deployment configuration and documentation.

## Changes
- `fly.toml` - Fly.io app configuration (London region, persistent volume, production settings)
- `docs/platforms/fly.md` - Deployment guide with quick start and secrets setup

## Usage
```bash
fly apps create clawdbot
fly volumes create clawdbot_data --size 1 --region lhr
fly secrets set ANTHROPIC_API_KEY=...
fly deploy
```

---
*🦞 Flawd is ready to fly!*