### PR TITLE
Agents: remove redundant bash tool alias

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -253,11 +253,6 @@ export function createClawdbotCodingTools(options?: {
         }
       : undefined,
   });
-  const bashTool = {
-    ...(execTool as unknown as AnyAgentTool),
-    name: "bash",
-    label: "bash",
-  } satisfies AnyAgentTool;
   const processTool = createProcessTool({
     cleanupMs: cleanupMsOverride ?? execConfig.cleanupMs,
     scopeKey,
@@ -278,7 +273,6 @@ export function createClawdbotCodingTools(options?: {
       : []),
     ...(applyPatchTool ? [applyPatchTool as unknown as AnyAgentTool] : []),
     execTool as unknown as AnyAgentTool,
-    bashTool,
     processTool as unknown as AnyAgentTool,
     // Channel docking: include channel-defined agent tools (login, etc.).
     ...listChannelAgentTools({ cfg: options?.config }),

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -30,12 +30,6 @@
       "title": "Exec",
       "detailKeys": ["command"]
     },
-    "bash": {
-      "emoji": "🛠️",
-      "title": "Exec",
-      "label": "exec",
-      "detailKeys": ["command"]
-    },
     "process": {
       "emoji": "🧰",
       "title": "Process",

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -6,8 +6,8 @@ describe("tool-policy", () => {
     const expanded = expandToolGroups(["group:runtime", "BASH", "apply-patch", "group:fs"]);
     const set = new Set(expanded);
     expect(set.has("exec")).toBe(true);
-    expect(set.has("bash")).toBe(true);
     expect(set.has("process")).toBe(true);
+    expect(set.has("bash")).toBe(false);
     expect(set.has("apply_patch")).toBe(true);
     expect(set.has("read")).toBe(true);
     expect(set.has("write")).toBe(true);

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -17,7 +17,7 @@ export const TOOL_GROUPS: Record<string, string[]> = {
   // Basic workspace/file tools
   "group:fs": ["read", "write", "edit", "apply_patch"],
   // Host/runtime execution tools
-  "group:runtime": ["exec", "bash", "process"],
+  "group:runtime": ["exec", "process"],
   // Session management tools
   "group:sessions": [
     "sessions_list",


### PR DESCRIPTION
Agents: remove redundant bash tool alias

## Why
- In this session, the `bash` tool definition was showing up in the request to the provider even though it is just an alias of `exec`, which is redundant and confusing.
- Removing the alias from tool registration avoids advertising a duplicate tool and saves tokens on every request.
- Example of what was being sent to the provider (duplicate `exec`/`bash` definitions):

```json
{
  "name": "exec",
  "description": "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
  "input_schema": {
    "type": "object",
    "properties": {
      "command": { "description": "Shell command to execute", "type": "string" },
      "workdir": { "description": "Working directory (defaults to cwd)", "type": "string" },
      "env": { "type": "object" },
      "yieldMs": { "description": "Milliseconds to wait before backgrounding (default 10000)", "type": "number" },
      "background": { "description": "Run in background immediately", "type": "boolean" },
      "timeout": { "description": "Timeout in seconds (optional, kills process on expiry)", "type": "number" },
      "pty": { "description": "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)", "type": "boolean" },
      "elevated": { "description": "Run on the host with elevated permissions (if allowed)", "type": "boolean" },
      "host": { "description": "Exec host (sandbox|gateway|node).", "type": "string" },
      "security": { "description": "Exec security mode (deny|allowlist|full).", "type": "string" },
      "ask": { "description": "Exec ask mode (off|on-miss|always).", "type": "string" },
      "node": { "description": "Node id/name for host=node.", "type": "string" }
    },
    "required": ["command"]
  }
},
{
  "name": "bash",
  "description": "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
  "input_schema": {
    "type": "object",
    "properties": {
      "command": { "description": "Shell command to execute", "type": "string" },
      "workdir": { "description": "Working directory (defaults to cwd)", "type": "string" },
      "env": { "type": "object" },
      "yieldMs": { "description": "Milliseconds to wait before backgrounding (default 10000)", "type": "number" },
      "background": { "description": "Run in background immediately", "type": "boolean" },
      "timeout": { "description": "Timeout in seconds (optional, kills process on expiry)", "type": "number" },
      "pty": { "description": "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)", "type": "boolean" },
      "elevated": { "description": "Run on the host with elevated permissions (if allowed)", "type": "boolean" },
      "host": { "description": "Exec host (sandbox|gateway|node).", "type": "string" },
      "security": { "description": "Exec security mode (deny|allowlist|full).", "type": "string" },
      "ask": { "description": "Exec ask mode (off|on-miss|always).", "type": "string" },
      "node": { "description": "Node id/name for host=node.", "type": "string" }
    },
    "required": ["command"]
  }
}
```

## What
- Stop registering the `bash` alias tool in the tool list.
- Remove the `bash` entry from tool display metadata.
- Trim `bash` from the runtime tool group and adjust the test expectation.

## Notes
- The `bash -> exec` alias normalization remains so existing configs using `bash` continue to work.

## Testing
- Not run (tool alias removal only).
