### PR TITLE
fix: handle PID recycling in container gateway lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.clawd.bot
 - TTS: move Telegram TTS into core with auto-replies, commands, and gateway methods. (#1559) Thanks @Glucksberg.
 
 ### Fixes
+- Gateway: compare Linux process start time to avoid PID recycling lock loops; keep locks unless stale. (#1572) Thanks @steipete.
 - Skills: gate bird Homebrew install to macOS. (#1569) Thanks @bradleypriest.
 - Agents: ignore IDENTITY.md template placeholders when parsing identity to avoid placeholder replies. (#1556)
 - Docker: update gateway command in docker-compose and Hetzner guide. (#1514)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1045,6 +1045,7 @@
           "platforms/android",
           "platforms/windows",
           "platforms/linux",
+          "platforms/fly",
           "platforms/hetzner",
           "platforms/exe-dev"
         ]

--- a/docs/platforms/fly.md
+++ b/docs/platforms/fly.md
@@ -5,75 +5,49 @@ description: Deploy Clawdbot on Fly.io
 
 # Fly.io Deployment
 
-Deploy Clawdbot on [Fly.io](https://fly.io) with persistent storage and automatic HTTPS.
+**Goal:** Clawdbot Gateway running on a [Fly.io](https://fly.io) machine with persistent storage, automatic HTTPS, and Discord/channel access.
 
-## Prerequisites
+## What you need
 
 - [flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/) installed
-- Fly.io account
+- Fly.io account (free tier works)
+- Model auth: Anthropic API key (or other provider keys)
+- Channel credentials: Discord bot token, Telegram token, etc.
 
-## Quick Start
+## Beginner quick path
+
+1. Clone repo → customize `fly.toml`
+2. Create app + volume → set secrets
+3. Deploy with `fly deploy`
+4. SSH in to create config or use Control UI
+
+## 1) Create the Fly app
 
 ```bash
-# Clone and enter the repo
+# Clone the repo
 git clone https://github.com/clawdbot/clawdbot.git
 cd clawdbot
 
-# Create the app (first time only)
-fly apps create clawdbot
+# Create a new Fly app (pick your own name)
+fly apps create my-clawdbot
 
-# Create persistent volume for data
+# Create a persistent volume (1GB is usually enough)
 fly volumes create clawdbot_data --size 1 --region lhr
-
-# Set your secrets
-fly secrets set ANTHROPIC_API_KEY=your-key-here
-# Add other provider keys as needed
-
-# Deploy
-fly deploy
 ```
 
-## Configuration
+**Tip:** Choose a region close to you. Common options: `lhr` (London), `iad` (Virginia), `sjc` (San Jose).
 
-The included `fly.toml` is a starting template. Key settings to customize:
+## 2) Configure fly.toml
 
-### VM Size
-
-The default `shared-cpu-1x` with 512MB may be too small for production. Recommended:
+Edit `fly.toml` to match your app name and requirements:
 
 ```toml
-[[vm]]
-  size = "shared-cpu-2x"
-  memory = "2048mb"
-```
+app = "my-clawdbot"  # Your app name
+primary_region = "lhr"
 
-### Bind Address
+[build]
+  dockerfile = "Dockerfile"
 
-**Important**: The gateway must bind to `0.0.0.0` for Fly's proxy to reach it:
-
-```toml
-[processes]
-  app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
-```
-
-When using `--bind lan`, you must also set a gateway token for security:
-
-```bash
-fly secrets set CLAWDBOT_GATEWAY_TOKEN=$(openssl rand -hex 32)
-```
-
-### State Directory
-
-Store persistent data on the volume:
-
-```toml
-[env]
-  CLAWDBOT_STATE_DIR = "/data"
-```
-
-### Full Example
-
-```toml
 [env]
   NODE_ENV = "production"
   CLAWDBOT_PREFER_PNPM = "1"
@@ -83,33 +57,142 @@ Store persistent data on the volume:
 [processes]
   app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
 
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
 [[vm]]
   size = "shared-cpu-2x"
   memory = "2048mb"
+
+[mounts]
+  source = "clawdbot_data"
+  destination = "/data"
 ```
 
-## Secrets
+**Key settings:**
 
-Set your API keys as secrets (never commit these):
+| Setting | Why |
+|---------|-----|
+| `--bind lan` | Binds to `0.0.0.0` so Fly's proxy can reach the gateway |
+| `--allow-unconfigured` | Starts without a config file (you'll create one after) |
+| `memory = "2048mb"` | 512MB is too small; 2GB recommended |
+| `CLAWDBOT_STATE_DIR = "/data"` | Persists state on the volume |
+
+## 3) Set secrets
 
 ```bash
-fly secrets set ANTHROPIC_API_KEY=sk-...
+# Required: Gateway token (for non-loopback binding)
+fly secrets set CLAWDBOT_GATEWAY_TOKEN=$(openssl rand -hex 32)
+
+# Model provider API keys
+fly secrets set ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional: Other providers
 fly secrets set OPENAI_API_KEY=sk-...
 fly secrets set GOOGLE_API_KEY=...
+
+# Channel tokens
+fly secrets set DISCORD_BOT_TOKEN=MTQ...
 ```
 
-## Accessing the Gateway
+**Notes:**
+- Non-loopback binds (`--bind lan`) require `CLAWDBOT_GATEWAY_TOKEN` for security.
+- Treat these tokens like passwords.
 
-After deployment:
+## 4) Deploy
 
 ```bash
-# Open the web UI
-fly open
+fly deploy
+```
 
-# Check logs
+First deploy builds the Docker image (~2-3 minutes). Subsequent deploys are faster.
+
+After deployment, verify:
+```bash
+fly status
 fly logs
+```
 
-# SSH into the machine
+You should see:
+```
+[gateway] listening on ws://0.0.0.0:3000 (PID xxx)
+[discord] logged in to discord as xxx
+```
+
+## 5) Create config file
+
+SSH into the machine to create a proper config:
+
+```bash
+fly ssh console
+```
+
+Create the config directory and file:
+```bash
+mkdir -p /data/.clawdbot
+cat > /data/.clawdbot/clawdbot.json << 'EOF'
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "anthropic/claude-opus-4-5"
+      },
+      "models": {
+        "anthropic/claude-opus-4-5": {},
+        "anthropic/claude-sonnet-4-5": {}
+      },
+      "maxConcurrent": 4
+    },
+    "list": [
+      {
+        "id": "main",
+        "default": true
+      }
+    ]
+  },
+  "channels": {
+    "discord": {
+      "enabled": true
+    }
+  }
+}
+EOF
+```
+
+Restart to apply:
+```bash
+exit
+fly machine restart <machine-id>
+```
+
+## 6) Access the Gateway
+
+### Control UI
+
+Open in browser:
+```bash
+fly open
+```
+
+Or visit `https://my-clawdbot.fly.dev/`
+
+Paste your gateway token (the one from `CLAWDBOT_GATEWAY_TOKEN`) to authenticate.
+
+### Logs
+
+```bash
+fly logs              # Live logs
+fly logs --no-tail    # Recent logs
+```
+
+### SSH Console
+
+```bash
 fly ssh console
 ```
 
@@ -117,12 +200,15 @@ fly ssh console
 
 ### "App is not listening on expected address"
 
-If you see this warning, the gateway is binding to `127.0.0.1` instead of `0.0.0.0`. Add `--bind lan` to your process command (see Configuration above).
+The gateway is binding to `127.0.0.1` instead of `0.0.0.0`.
+
+**Fix:** Add `--bind lan` to your process command in `fly.toml`.
 
 ### OOM / Memory Issues
 
-If the container gets killed or restarts frequently, increase memory:
+Container keeps restarting or getting killed.
 
+**Fix:** Increase memory in `fly.toml`:
 ```toml
 [[vm]]
   memory = "2048mb"
@@ -130,18 +216,52 @@ If the container gets killed or restarts frequently, increase memory:
 
 ### Gateway Lock Issues
 
-If the gateway refuses to start with "already running" errors after a container restart, this is a stale PID lock. The lock file persists on the volume but the process doesn't survive restarts.
+Gateway refuses to start with "already running" errors.
 
-**Fix**: Delete the lock file via SSH:
+This happens when the container restarts but the PID lock file persists on the volume.
+
+**Fix:** Delete the lock file:
 ```bash
 fly ssh console
 rm /data/.clawdbot/run/gateway.*.lock
+exit
+fly machine restart <machine-id>
 ```
 
-Then restart the machine.
+### Config Not Being Read
+
+If using `--allow-unconfigured`, the gateway creates a minimal config. Your custom config at `/data/.clawdbot/clawdbot.json` should be read on restart.
+
+Verify the config exists:
+```bash
+fly ssh console --command "cat /data/.clawdbot/clawdbot.json"
+```
+
+## Updates
+
+```bash
+# Pull latest changes
+git pull
+
+# Redeploy
+fly deploy
+
+# Check health
+fly status
+fly logs
+```
 
 ## Notes
 
-- Fly.io uses **x86** architecture (not ARM)
+- Fly.io uses **x86 architecture** (not ARM)
 - The Dockerfile is compatible with both architectures
-- For WhatsApp/Telegram, you'll need to run onboarding via `fly ssh console`
+- For WhatsApp/Telegram onboarding, use `fly ssh console`
+- Persistent data lives on the volume at `/data`
+
+## Cost
+
+With the recommended config (`shared-cpu-2x`, 2GB RAM):
+- ~$10-15/month depending on usage
+- Free tier includes some allowance
+
+See [Fly.io pricing](https://fly.io/docs/about/pricing/) for details.

--- a/docs/platforms/fly.md
+++ b/docs/platforms/fly.md
@@ -1,0 +1,74 @@
+---
+title: Fly.io
+description: Deploy Clawdbot on Fly.io
+---
+
+# Fly.io Deployment
+
+Deploy Clawdbot on [Fly.io](https://fly.io) with persistent storage and automatic HTTPS.
+
+## Prerequisites
+
+- [flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/) installed
+- Fly.io account
+
+## Quick Start
+
+```bash
+# Clone and enter the repo
+git clone https://github.com/clawdbot/clawdbot.git
+cd clawdbot
+
+# Create the app (first time only)
+fly apps create clawdbot
+
+# Create persistent volume for data
+fly volumes create clawdbot_data --size 1 --region lhr
+
+# Set your secrets
+fly secrets set ANTHROPIC_API_KEY=your-key-here
+# Add other provider keys as needed
+
+# Deploy
+fly deploy
+```
+
+## Configuration
+
+The included `fly.toml` configures:
+
+- **Region**: `lhr` (London) - change to your preferred [region](https://fly.io/docs/reference/regions/)
+- **VM**: `shared-cpu-1x` with 512MB RAM (sufficient for most use cases)
+- **Storage**: Persistent volume mounted at `/data`
+- **Auto-scaling**: Disabled to maintain persistent connections
+
+## Secrets
+
+Set your API keys as secrets (never commit these):
+
+```bash
+fly secrets set ANTHROPIC_API_KEY=sk-...
+fly secrets set OPENAI_API_KEY=sk-...
+fly secrets set GOOGLE_API_KEY=...
+```
+
+## Accessing the Gateway
+
+After deployment:
+
+```bash
+# Open the web UI
+fly open
+
+# Check logs
+fly logs
+
+# SSH into the machine
+fly ssh console
+```
+
+## Notes
+
+- Fly.io uses **x86** architecture (not ARM)
+- The Dockerfile is compatible with both architectures
+- For WhatsApp/Telegram, you'll need to run onboarding via `fly ssh console`

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -23,6 +23,7 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 
 ## VPS & hosting
 
+- Fly.io: [Fly.io](/platforms/fly)
 - Hetzner (Docker): [Hetzner](/platforms/hetzner)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/platforms/exe-dev)
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+# Clawdbot Fly.io deployment configuration
+# See https://fly.io/docs/reference/configuration/
+
+app = "clawdbot"
+primary_region = "lhr"  # London
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  # Fly uses x86, but keep this for consistency
+  CLAWDBOT_PREFER_PNPM = "1"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = false  # Keep running for persistent connections
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[mounts]
+  source = "clawdbot_data"
+  destination = "/data"

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -1,10 +1,13 @@
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 
 async function makeEnv() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-gateway-lock-"));
@@ -20,6 +23,41 @@ async function makeEnv() {
       await fs.rm(dir, { recursive: true, force: true });
     },
   };
+}
+
+function resolveLockPath(env: NodeJS.ProcessEnv) {
+  const stateDir = resolveStateDir(env);
+  const configPath = resolveConfigPath(env, stateDir);
+  const hash = createHash("sha1").update(configPath).digest("hex").slice(0, 8);
+  return { lockPath: path.join(stateDir, `gateway.${hash}.lock`), configPath };
+}
+
+function makeProcStat(pid: number, startTime: number) {
+  const fields = [
+    "R",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    String(startTime),
+    "1",
+    "1",
+  ];
+  return `${pid} (node) ${fields.join(" ")}`;
 }
 
 describe("gateway lock", () => {
@@ -50,6 +88,100 @@ describe("gateway lock", () => {
       pollIntervalMs: 20,
     });
     await lock2?.release();
+    await cleanup();
+  });
+
+  it("treats recycled linux pid as stale when start time mismatches", async () => {
+    const { env, cleanup } = await makeEnv();
+    const { lockPath, configPath } = resolveLockPath(env);
+    const payload = {
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+      configPath,
+      startTime: 111,
+    };
+    await fs.writeFile(lockPath, JSON.stringify(payload), "utf8");
+
+    const readFileSync = fsSync.readFileSync;
+    const statValue = makeProcStat(process.pid, 222);
+    const spy = vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
+      if (filePath === `/proc/${process.pid}/stat`) {
+        return statValue;
+      }
+      return readFileSync(filePath as never, encoding as never) as never;
+    });
+
+    const lock = await acquireGatewayLock({
+      env,
+      allowInTests: true,
+      timeoutMs: 200,
+      pollIntervalMs: 20,
+      platform: "linux",
+    });
+    expect(lock).not.toBeNull();
+
+    await lock?.release();
+    spy.mockRestore();
+    await cleanup();
+  });
+
+  it("keeps lock on linux when proc access fails unless stale", async () => {
+    const { env, cleanup } = await makeEnv();
+    const { lockPath, configPath } = resolveLockPath(env);
+    const payload = {
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+      configPath,
+      startTime: 111,
+    };
+    await fs.writeFile(lockPath, JSON.stringify(payload), "utf8");
+
+    const readFileSync = fsSync.readFileSync;
+    const spy = vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
+      if (filePath === `/proc/${process.pid}/stat`) {
+        throw new Error("EACCES");
+      }
+      return readFileSync(filePath as never, encoding as never) as never;
+    });
+
+    await expect(
+      acquireGatewayLock({
+        env,
+        allowInTests: true,
+        timeoutMs: 120,
+        pollIntervalMs: 20,
+        staleMs: 10_000,
+        platform: "linux",
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
+
+    spy.mockRestore();
+
+    const stalePayload = {
+      ...payload,
+      createdAt: new Date(0).toISOString(),
+    };
+    await fs.writeFile(lockPath, JSON.stringify(stalePayload), "utf8");
+
+    const staleSpy = vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
+      if (filePath === `/proc/${process.pid}/stat`) {
+        throw new Error("EACCES");
+      }
+      return readFileSync(filePath as never, encoding as never) as never;
+    });
+
+    const lock = await acquireGatewayLock({
+      env,
+      allowInTests: true,
+      timeoutMs: 200,
+      pollIntervalMs: 20,
+      staleMs: 1,
+      platform: "linux",
+    });
+    expect(lock).not.toBeNull();
+
+    await lock?.release();
+    staleSpy.mockRestore();
     await cleanup();
   });
 });


### PR DESCRIPTION
## Problem

In containers (Docker, Fly.io, etc.), PIDs are recycled quickly after restarts. When a container restarts, a different process might get the same PID as the previous gateway, causing the lock check to incorrectly think the old gateway is still running.

This causes a boot-loop where the gateway refuses to start because it sees a 'stale' lock that actually belongs to a different process with the same PID.

## Solution

Add `isGatewayProcess()` which verifies on Linux that the PID actually belongs to a clawdbot gateway by checking `/proc/PID/cmdline`. If the cmdline doesn't contain 'clawdbot' or 'gateway', we assume the lock is stale and remove it.

On non-Linux platforms (macOS, Windows), we fall back to the existing behavior since PID recycling is less of an issue outside containers.

## Testing

- Tested by deploying to Fly.io where the boot-loop was occurring
- On macOS, behavior is unchanged (falls back to existing PID check)

---
*🦞 Fix discovered while deploying Flawd to Fly.io*