### PR TITLE
fix(msteams): remove remaining /.default postfix

### DIFF
--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -65,7 +65,7 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   try {
     const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
     const tokenProvider = new sdk.MsalTokenProvider(authConfig);
-    await tokenProvider.getAccessToken("https://api.botframework.com/.default");
+    await tokenProvider.getAccessToken("https://api.botframework.com");
     let graph:
       | {
           ok: boolean;


### PR DESCRIPTION
This is a continuation of #1507 where I missed a spot (sorry)

This fixes fix doesnt actually influence if msteams works or not (which is why i missed it), instead its the msteams probe which otherwise incorrectly assumes teams is not working when you doctor etc