### PR TITLE
gateway: add /tools/invoke HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Docs: https://docs.clawd.bot
 ## 2026.1.23 (Unreleased)
 
 ### Changes
+- Gateway: add /tools/invoke HTTP endpoint for direct tool calls and document it. (#1575) Thanks @vignesh07.
 - Agents: keep system prompt time zone-only and move current time to `session_status` for better cache hits.
 - Agents: remove redundant bash tool alias from tool registration/display. (#1571) Thanks @Takhoffman.
 - Browser: add node-host proxy auto-routing for remote gateways (configurable per gateway/node).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -916,6 +916,7 @@
           "gateway/configuration-examples",
           "gateway/authentication",
           "gateway/openai-http-api",
+          "gateway/tools-invoke-http-api",
           "gateway/cli-backends",
           "gateway/local-models",
           "gateway/background-process",

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -30,6 +30,7 @@ pnpm gateway:watch
 - The same port also serves HTTP (control UI, hooks, A2UI). Single-port multiplex.
   - OpenAI Chat Completions (HTTP): [`/v1/chat/completions`](/gateway/openai-http-api).
   - OpenResponses (HTTP): [`/v1/responses`](/gateway/openresponses-http-api).
+  - Tools Invoke (HTTP): [`/tools/invoke`](/gateway/tools-invoke-http-api).
 - Starts a Canvas file server by default on `canvasHost.port` (default `18793`), serving `http://<gateway-host>:18793/__clawdbot__/canvas/` from `~/clawd/canvas`. Disable with `canvasHost.enabled=false` or `CLAWDBOT_SKIP_CANVAS_HOST=1`.
 - Logs to stdout; use launchd/systemd to keep it alive and rotate logs.
 - Pass `--verbose` to mirror debug logging (handshakes, req/res, events) from the log file into stdio when troubleshooting.

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -1,0 +1,79 @@
+---
+summary: "Invoke a single tool directly via the Gateway HTTP endpoint"
+read_when:
+  - Calling tools without running a full agent turn
+  - Building automations that need tool policy enforcement
+---
+# Tools Invoke (HTTP)
+
+Clawdbot’s Gateway exposes a simple HTTP endpoint for invoking a single tool directly. It is always enabled, but gated by Gateway auth and tool policy.
+
+- `POST /tools/invoke`
+- Same port as the Gateway (WS + HTTP multiplex): `http://<gateway-host>:<port>/tools/invoke`
+
+Default max payload size is 2 MB.
+
+## Authentication
+
+Uses the Gateway auth configuration. Send a bearer token:
+
+- `Authorization: Bearer <token>`
+
+Notes:
+- When `gateway.auth.mode="token"`, use `gateway.auth.token` (or `CLAWDBOT_GATEWAY_TOKEN`).
+- When `gateway.auth.mode="password"`, use `gateway.auth.password` (or `CLAWDBOT_GATEWAY_PASSWORD`).
+
+## Request body
+
+```json
+{
+  "tool": "sessions_list",
+  "action": "json",
+  "args": {},
+  "sessionKey": "main",
+  "dryRun": false
+}
+```
+
+Fields:
+- `tool` (string, required): tool name to invoke.
+- `action` (string, optional): mapped into args if the tool schema supports `action` and the args payload omitted it.
+- `args` (object, optional): tool-specific arguments.
+- `sessionKey` (string, optional): target session key. If omitted or `"main"`, the Gateway uses the configured main session key (honors `session.mainKey` and default agent, or `global` in global scope).
+- `dryRun` (boolean, optional): reserved for future use; currently ignored.
+
+## Policy + routing behavior
+
+Tool availability is filtered through the same policy chain used by Gateway agents:
+- `tools.profile` / `tools.byProvider.profile`
+- `tools.allow` / `tools.byProvider.allow`
+- `agents.<id>.tools.allow` / `agents.<id>.tools.byProvider.allow`
+- group policies (if the session key maps to a group or channel)
+- subagent policy (when invoking with a subagent session key)
+
+If a tool is not allowed by policy, the endpoint returns **404**.
+
+To help group policies resolve context, you can optionally set:
+- `x-clawdbot-message-channel: <channel>` (example: `slack`, `telegram`)
+- `x-clawdbot-account-id: <accountId>` (when multiple accounts exist)
+
+## Responses
+
+- `200` → `{ ok: true, result }`
+- `400` → `{ ok: false, error: { type, message } }` (invalid request or tool error)
+- `401` → unauthorized
+- `404` → tool not available (not found or not allowlisted)
+- `405` → method not allowed
+
+## Example
+
+```bash
+curl -sS http://127.0.0.1:18789/tools/invoke \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tool": "sessions_list",
+    "action": "json",
+    "args": {}
+  }'
+```

--- a/extensions/lobster/README.md
+++ b/extensions/lobster/README.md
@@ -30,6 +30,48 @@ Enable it in an agent allowlist:
 }
 ```
 
+## Using `clawd.invoke` (Lobster → Clawdbot tools)
+
+Some Lobster pipelines may include a `clawd.invoke` step to call back into Clawdbot tools/plugins (for example: `gog` for Google Workspace, `gh` for GitHub, `message.send`, etc.).
+
+For this to work, the Clawdbot Gateway must expose the tool bridge endpoint and the target tool must be allowed by policy:
+
+- Clawdbot provides an HTTP endpoint: `POST /tools/invoke`.
+- The request is gated by **gateway auth** (e.g. `Authorization: Bearer …` when token auth is enabled).
+- The invoked tool is gated by **tool policy** (global + per-agent + provider + group policy). If the tool is not allowed, Clawdbot returns `404 Tool not available`.
+
+### Allowlisting recommended
+
+To avoid letting workflows call arbitrary tools, set a tight allowlist on the agent that will be used by `clawd.invoke`.
+
+Example (allow only a small set of tools):
+
+```jsonc
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "tools": {
+          "allow": [
+            "lobster",
+            "web_fetch",
+            "web_search",
+            "gog",
+            "gh"
+          ],
+          "deny": ["gateway"]
+        }
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- If `tools.allow` is omitted or empty, it behaves like "allow everything (except denied)". For a real allowlist, set a **non-empty** `allow`.
+- Tool names depend on which plugins you have installed/enabled.
+
 ## Security
 
 - Runs the `lobster` executable as a local subprocess.

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -29,6 +29,7 @@ import {
 import { applyHookMappings } from "./hooks-mapping.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
+import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -229,6 +230,7 @@ export function createGatewayHttpServer(opts: {
       if (await handleHooksRequest(req, res)) return;
       if (await handleSlackHttpRequest(req, res)) return;
       if (handlePluginRequest && (await handlePluginRequest(req, res))) return;
+      if (await handleToolsInvokeHttpRequest(req, res, { auth: resolvedAuth })) return;
       if (openResponsesEnabled) {
         if (
           await handleOpenResponsesHttpRequest(req, res, {

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { installGatewayTestHooks, getFreePort } from "./test-helpers.server.js";
+import { startGatewayServer } from "./server.js";
+import { testState } from "./test-helpers.mocks.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("POST /tools/invoke", () => {
+  it("invokes a tool and returns {ok:true,result}", async () => {
+    testState.gatewayAuth = { mode: "none" } as any;
+
+    // Allow the sessions_list tool for main agent.
+    testState.agentsConfig = {
+      list: [
+        {
+          id: "main",
+          tools: {
+            allow: ["sessions_list"],
+          },
+        },
+      ],
+    } as any;
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+    });
+
+    const res = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tool: "sessions_list", action: "json", args: {}, sessionKey: "main" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body).toHaveProperty("result");
+
+    await server.close();
+  });
+
+  it("rejects unauthorized when auth mode is token and header is missing", async () => {
+    testState.gatewayAuth = { mode: "token", token: "t" } as any;
+    testState.agentsConfig = {
+      list: [
+        {
+          id: "main",
+          tools: {
+            allow: ["sessions_list"],
+          },
+        },
+      ],
+    } as any;
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, { bind: "loopback" });
+
+    const res = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tool: "sessions_list", action: "json", args: {}, sessionKey: "main" }),
+    });
+
+    expect(res.status).toBe(401);
+
+    await server.close();
+  });
+
+  it("returns 404 when tool is not allowlisted", async () => {
+    testState.gatewayAuth = { mode: "none" } as any;
+    testState.agentsConfig = {
+      list: [
+        {
+          id: "main",
+          tools: {
+            deny: ["sessions_list"],
+          },
+        },
+      ],
+    } as any;
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, { bind: "loopback" });
+
+    const res = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tool: "sessions_list", action: "json", args: {}, sessionKey: "main" }),
+    });
+
+    expect(res.status).toBe(404);
+
+    await server.close();
+  });
+});

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -1,0 +1,163 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { loadConfig } from "../config/config.js";
+import { resolveAgentIdFromSessionKey } from "../agents/agent-scope.js";
+import { createClawdbotTools } from "../agents/clawdbot-tools.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  isToolAllowedByPolicies,
+} from "../agents/pi-tools.policy.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+
+import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import { getBearerToken, getHeader } from "./http-utils.js";
+import {
+  readJsonBodyOrError,
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+  sendUnauthorized,
+} from "./http-common.js";
+
+const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
+
+type ToolsInvokeBody = {
+  tool?: unknown;
+  action?: unknown;
+  args?: unknown;
+  sessionKey?: unknown;
+  dryRun?: unknown;
+};
+
+function resolveSessionKeyFromBody(body: ToolsInvokeBody): string | undefined {
+  if (typeof body.sessionKey === "string" && body.sessionKey.trim()) return body.sessionKey.trim();
+  return undefined;
+}
+
+function mergeActionIntoArgsIfSupported(params: {
+  toolSchema: unknown;
+  action: string | undefined;
+  args: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { toolSchema, action, args } = params;
+  if (!action) return args;
+  if (args.action !== undefined) return args;
+  // TypeBox schemas are plain objects; many tools define an `action` property.
+  const schemaObj = toolSchema as { properties?: Record<string, unknown> } | null;
+  const hasAction = Boolean(
+    schemaObj &&
+    typeof schemaObj === "object" &&
+    schemaObj.properties &&
+    "action" in schemaObj.properties,
+  );
+  if (!hasAction) return args;
+  return { ...args, action };
+}
+
+export async function handleToolsInvokeHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: { auth: ResolvedGatewayAuth; maxBodyBytes?: number },
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  if (url.pathname !== "/tools/invoke") return false;
+
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return true;
+  }
+
+  const token = getBearerToken(req);
+  const authResult = await authorizeGatewayConnect({
+    auth: opts.auth,
+    connectAuth: token ? { token } : null,
+    req,
+  });
+  if (!authResult.ok) {
+    sendUnauthorized(res);
+    return true;
+  }
+
+  const bodyUnknown = await readJsonBodyOrError(req, res, opts.maxBodyBytes ?? DEFAULT_BODY_BYTES);
+  if (bodyUnknown === undefined) return true;
+  const body = (bodyUnknown ?? {}) as ToolsInvokeBody;
+
+  const toolName = typeof body.tool === "string" ? body.tool.trim() : "";
+  if (!toolName) {
+    sendInvalidRequest(res, "tools.invoke requires body.tool");
+    return true;
+  }
+
+  const action = typeof body.action === "string" ? body.action.trim() : undefined;
+
+  const argsRaw = body.args;
+  const args = (
+    argsRaw && typeof argsRaw === "object" && !Array.isArray(argsRaw)
+      ? (argsRaw as Record<string, unknown>)
+      : {}
+  ) as Record<string, unknown>;
+
+  const sessionKey = resolveSessionKeyFromBody(body) ?? "main";
+  const cfg = loadConfig();
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+
+  // Resolve message channel/account hints (optional headers) for policy inheritance.
+  const messageChannel = normalizeMessageChannel(
+    getHeader(req, "x-clawdbot-message-channel") ?? "",
+  );
+  const accountId = getHeader(req, "x-clawdbot-account-id")?.trim() || undefined;
+
+  // Build tool list (core + plugin tools).
+  const allTools = createClawdbotTools({
+    agentSessionKey: sessionKey,
+    agentChannel: messageChannel ?? undefined,
+    agentAccountId: accountId,
+    config: cfg,
+  });
+
+  const policy = resolveEffectiveToolPolicy({ config: cfg, sessionKey });
+  const groupPolicy = resolveGroupToolPolicy({
+    config: cfg,
+    sessionKey,
+    messageProvider: messageChannel ?? undefined,
+    accountId: accountId ?? null,
+  });
+
+  const allowed = (name: string) =>
+    isToolAllowedByPolicies(name, [
+      policy.globalPolicy,
+      policy.agentPolicy,
+      policy.globalProviderPolicy,
+      policy.agentProviderPolicy,
+      groupPolicy,
+    ]);
+
+  const tools = (allTools as any[]).filter((t) => allowed(t.name));
+
+  const tool = tools.find((t) => t.name === toolName);
+  if (!tool) {
+    sendJson(res, 404, {
+      ok: false,
+      error: { type: "not_found", message: `Tool not available: ${toolName}` },
+    });
+    return true;
+  }
+
+  try {
+    const toolArgs = mergeActionIntoArgsIfSupported({
+      toolSchema: (tool as any).parameters,
+      action,
+      args,
+    });
+    const result = await (tool as any).execute?.(`http-${Date.now()}`, toolArgs);
+    sendJson(res, 200, { ok: true, result });
+  } catch (err) {
+    sendJson(res, 400, {
+      ok: false,
+      error: { type: "tool_error", message: err instanceof Error ? err.message : String(err) },
+    });
+  }
+
+  return true;
+}


### PR DESCRIPTION
## What
Adds a new HTTP endpoint `POST /tools/invoke` that can execute a Clawdbot agent tool (core or plugin) on behalf of a caller. This unblocks Lobster’s `clawd.invoke` bridge (tool/action/args) without needing to go through the OpenAI-compatible chat endpoints.

Request body:

```json
{
  "tool": "sessions_list",
  "action": "json",
  "args": {
    "limit": 10
  },
  "sessionKey": "main"
}
```

Response:

```json
{
  "ok": true,
  "result": { "...": "tool result" }
}
```

## Policy & security
- Uses existing gateway auth (`Authorization: Bearer …`) via `authorizeGatewayConnect`.
- Enforces tool allow/deny policies derived from config + per-agent policies and group policy inheritance (when caller supplies channel/account headers).
- Only merges the top-level `action` into tool args when the tool’s schema actually declares an `action` property (avoids breaking tools like `llm-task` that don’t use actions).

## Threat model
- **Risk:** Adds a direct tool execution surface; if exposed without auth, could allow arbitrary tool invocation (including filesystem or messaging).
- **Mitigations:** Endpoint is gated by the same gateway auth mechanism as other HTTP surfaces. Tool execution is restricted by tool policy (global + agent + provider + group).
- **Residual risk:** Operators who set `gateway.auth.mode=none` and bind publicly could still be vulnerable (same as other HTTP endpoints); recommend loopback bind or token auth.

## Tests
- `src/gateway/tools-invoke-http.test.ts` covers success path, auth rejection, and policy-based tool unavailability.
