### PR TITLE
fix(sessions): resolve sessionId to sessionKey in sessions_history

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -115,6 +115,14 @@ export function sanitizeTextContent(text: string): string {
   return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
 }
 
+/**
+ * Check if a string looks like a UUID (sessionId format).
+ * Pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ */
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
 export function extractAssistantText(message: unknown): string | undefined {
   if (!message || typeof message !== "object") return undefined;
   if ((message as { role?: unknown }).role !== "assistant") return undefined;


### PR DESCRIPTION
## Summary

Fixes #1518 - `sessions_history` now accepts sessionId (UUID) in addition to sessionKey.

## Problem

When calling `sessions_history` with a sessionId (UUID) instead of the full sessionKey, the tool silently returns empty results `{ messages: [] }` - which is indistinguishable from an actually empty session.

```typescript
// Previously returned empty (confusing!)
sessions_history({ sessionKey: "e5face22-019e-4968-b505-1083c6129d22" })
// Result: { sessionKey: "...", messages: [] }
```

This is confusing because:
- `sessions_list` shows both `sessionId` and `key` fields
- Natural assumption is that either identifier should work
- No indication that the lookup failed vs the session being empty

## Solution

1. **Added `isUuidLike()` helper** in `sessions-helpers.ts` to detect UUID format
2. **Added `lookupSessionKeyById()` function** that queries `sessions.list` to find the matching sessionKey
3. **Modified `sessions_history` execute logic** to:
   - Check if input looks like a UUID
   - If yes, look up the actual sessionKey
   - If found → use it and proceed normally
   - If not found → return helpful error with hint

## After this fix

```typescript
// Now works! Looks up the sessionKey automatically
sessions_history({ sessionKey: "e5face22-019e-4968-b505-1083c6129d22" })
// Result: { sessionKey: "agent:main:discord:channel:123", messages: [...] }

// If sessionId not found, returns helpful error
sessions_history({ sessionKey: "nonexistent-uuid-here" })
// Result: { 
//   status: "error", 
//   error: "Session not found for sessionId: nonexistent-uuid-here",
//   hint: "Use the full sessionKey (e.g., 'agent:main:telegram:dm:123') or verify the sessionId exists via sessions_list."
// }
```

## Testing

- ✅ Lint passes (`npm run lint`)
- ✅ Build passes (`npm run build`)
- ⚠️ **Lightly tested** - verified UUID detection logic, but full integration test pending

## 🤖 AI-Assisted

- **Tool:** Claude Opus 4.5 via Clawdbot
- **Testing:** Lightly tested (lint + build pass)
- **Understanding:** Yes - the fix adds a sessionId lookup layer before the existing sessionKey resolution logic. When a UUID is detected, it queries `sessions.list` to find the matching session entry and extracts its key.

## Checklist

- [x] Tested locally (lint + build)
- [x] Follows existing code patterns (uses same `callGateway` pattern as `isSpawnedSessionAllowed`)
- [x] Focused PR (one thing only)
- [x] Described what & why