### PR TITLE
fix: add bluebubbles to heartbeat targets validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.clawd.bot
 - TTS: move Telegram TTS into core with auto-replies, commands, and gateway methods. (#1559) Thanks @Glucksberg.
 
 ### Fixes
+- Heartbeat: add `bluebubbles` to schema-allowed heartbeat targets.
 - Gateway: compare Linux process start time to avoid PID recycling lock loops; keep locks unless stale. (#1572) Thanks @steipete.
 - Skills: gate bird Homebrew install to macOS. (#1569) Thanks @bradleypriest.
 - Slack: honor open groupPolicy for unlisted channels in message + slash gating. (#1563) Thanks @itsjaydesu.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -177,7 +177,7 @@ export type AgentDefaultsConfig = {
     model?: string;
     /** Session key for heartbeat runs ("main" or explicit session key). */
     session?: string;
-    /** Delivery target (last|whatsapp|telegram|discord|slack|mattermost|msteams|signal|imessage|none). */
+    /** Delivery target (last|whatsapp|telegram|discord|slack|mattermost|msteams|signal|imessage|bluebubbles|none). */
     target?:
       | "last"
       | "whatsapp"
@@ -188,6 +188,7 @@ export type AgentDefaultsConfig = {
       | "msteams"
       | "signal"
       | "imessage"
+      | "bluebubbles"
       | "none";
     /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). */
     to?: string;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -32,6 +32,7 @@ export const HeartbeatSchema = z
         z.literal("msteams"),
         z.literal("signal"),
         z.literal("imessage"),
+        z.literal("bluebubbles"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -501,9 +501,7 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "alerts-disabled" };
   }
 
-  const heartbeatOkText = responsePrefix
-    ? `${responsePrefix} ${HEARTBEAT_TOKEN}`
-    : HEARTBEAT_TOKEN;
+  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
   const canAttemptHeartbeatOk = Boolean(
     visibility.showOk && delivery.channel !== "none" && delivery.to,
   );
@@ -559,11 +557,7 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
-    const normalized = normalizeHeartbeatReply(
-      replyPayload,
-      responsePrefix,
-      ackMaxChars,
-    );
+    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
     const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia;
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({


### PR DESCRIPTION
`bluebubbles` passes `normalizeChannelId()`, but it's considered invalid by the schema. would be helpful to have since we are deprecating `imsg`