### PR TITLE
fix: preserve Telegram topic in sub-agent announcements

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -311,6 +311,9 @@ export const registerTelegramNativeCommands = ({
             CommandTargetSessionKey: route.sessionKey,
             MessageThreadId: resolvedThreadId,
             IsForum: isForum,
+            // Originating context for sub-agent announce routing
+            OriginatingChannel: "telegram" as const,
+            OriginatingTo: `telegram:${chatId}`,
           });
 
           const disableBlockStreaming =


### PR DESCRIPTION
## Problem

When native slash commands are executed in Telegram topics/forums, sub-agent announcements were being delivered to the wrong topic (often archived or general channel).

## Root Cause

Native slash command context did not set `OriginatingChannel` and `OriginatingTo`, causing session delivery context to fallback to the user's personal ID instead of the group ID + topic.

## Solution

Added `OriginatingChannel` and `OriginatingTo` fields to native slash command context in `bot-native-commands.ts`.

## Changes

- Added 2 lines to preserve originating channel and target for sub-agent announcement routing
- Ensures `lastThreadId` and `lastTo` are correctly set with topic information

## Testing

Verified that:
- ✅ Sub-agent announcements now route to the correct Telegram topic
- ✅ Session `deliveryContext` includes `threadId`
- ✅ `lastTo` is set to group ID instead of user ID
- ✅ No regression in non-topic group behavior

## Related

Fixes sub-agent announcement routing in Telegram forum topics when triggered via native slash commands.