### PR TITLE
fix: guard setCliSessionId calls with providerUsed check [BUILD BLOCKER]

### DIFF
--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -42,7 +42,7 @@ export async function persistSessionUsageUpdate(params: {
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };
-          if (params.cliSessionId) {
+          if (params.cliSessionId && params.providerUsed) {
             const nextEntry = { ...entry, ...patch };
             setCliSessionId(nextEntry, params.providerUsed, params.cliSessionId);
             return {
@@ -73,7 +73,7 @@ export async function persistSessionUsageUpdate(params: {
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };
-          if (params.cliSessionId) {
+          if (params.cliSessionId && params.providerUsed) {
             const nextEntry = { ...entry, ...patch };
             setCliSessionId(nextEntry, params.providerUsed, params.cliSessionId);
             return {


### PR DESCRIPTION
## 🚨 Build Blocker

This PR fixes a TypeScript error that **breaks the build** on `main`.

## Problem

Commit `1bbbb10ab` introduced `session-usage.ts` with calls to `setCliSessionId(entry, params.providerUsed, ...)`, but:

- `setCliSessionId` requires `provider: string`
- `params.providerUsed` is `string | undefined`

This causes:
```
src/auto-reply/reply/session-usage.ts(47,40): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
src/auto-reply/reply/session-usage.ts(78,40): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

## Solution

Add `&& params.providerUsed` to the existing `if (params.cliSessionId)` guards (lines 45 and 76).

This is semantically correct: we can't set a CLI session ID without knowing the provider.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)