### PR TITLE
feat: add label support for command arg choices

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -282,7 +282,16 @@ function buildChatCommands(): ChatCommandDefinition[] {
           name: "action",
           description: "on | off | status | provider | limit | summary | audio | help",
           type: "string",
-          choices: ["on", "off", "status", "provider", "limit", "summary", "audio", "help"],
+          choices: [
+            { value: "on", label: "🔊 On" },
+            { value: "off", label: "🔇 Off" },
+            { value: "status", label: "📊 Status" },
+            { value: "provider", label: "🎙️ Provider" },
+            { value: "limit", label: "📏 Limit" },
+            { value: "summary", label: "📝 Summary" },
+            { value: "audio", label: "🔈 Audio" },
+            { value: "help", label: "❓ Help" },
+          ],
         },
         {
           name: "value",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -229,7 +229,12 @@ describe("commands registry args", () => {
 
     const menu = resolveCommandArgMenu({ command, args: undefined, cfg: {} as never });
     expect(menu?.arg.name).toBe("mode");
-    expect(menu?.choices).toEqual(["off", "tokens", "full", "cost"]);
+    expect(menu?.choices).toEqual([
+      { value: "off", label: "off" },
+      { value: "tokens", label: "tokens" },
+      { value: "full", label: "full" },
+      { value: "cost", label: "cost" },
+    ]);
   });
 
   it("does not show menus when arg already provided", () => {
@@ -284,7 +289,10 @@ describe("commands registry args", () => {
 
     const menu = resolveCommandArgMenu({ command, args: undefined, cfg: {} as never });
     expect(menu?.arg.name).toBe("level");
-    expect(menu?.choices).toEqual(["low", "high"]);
+    expect(menu?.choices).toEqual([
+      { value: "low", label: "low" },
+      { value: "high", label: "high" },
+    ]);
     expect(seen?.commandKey).toBe("think");
     expect(seen?.argName).toBe("level");
     expect(seen?.provider).toBeTruthy();

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -12,14 +12,20 @@ export type CommandArgChoiceContext = {
   arg: CommandArgDefinition;
 };
 
-export type CommandArgChoicesProvider = (context: CommandArgChoiceContext) => string[];
+/** A choice can be a plain string or an object with separate value and display label. */
+export type CommandArgChoice = string | { value: string; label: string };
+
+/** Normalized choice with both value and label always present. */
+export type ResolvedCommandArgChoice = { value: string; label: string };
+
+export type CommandArgChoicesProvider = (context: CommandArgChoiceContext) => CommandArgChoice[];
 
 export type CommandArgDefinition = {
   name: string;
   description: string;
   type: CommandArgType;
   required?: boolean;
-  choices?: string[] | CommandArgChoicesProvider;
+  choices?: CommandArgChoice[] | CommandArgChoicesProvider;
   captureRemaining?: boolean;
 };
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -93,16 +93,18 @@ function buildDiscordCommandOptions(params: {
             typeof focused?.value === "string" ? focused.value.trim().toLowerCase() : "";
           const choices = resolveCommandArgChoices({ command, arg, cfg });
           const filtered = focusValue
-            ? choices.filter((choice) => choice.toLowerCase().includes(focusValue))
+            ? choices.filter((choice) => choice.value.toLowerCase().includes(focusValue))
             : choices;
           await interaction.respond(
-            filtered.slice(0, 25).map((choice) => ({ name: choice, value: choice })),
+            filtered.slice(0, 25).map((choice) => ({ name: choice.label, value: choice.value })),
           );
         }
       : undefined;
     const choices =
       resolvedChoices.length > 0 && !autocomplete
-        ? resolvedChoices.slice(0, 25).map((choice) => ({ name: choice, value: choice }))
+        ? resolvedChoices
+            .slice(0, 25)
+            .map((choice) => ({ name: choice.label, value: choice.value }))
         : undefined;
     return {
       name: arg.name,
@@ -351,7 +353,11 @@ export function createDiscordCommandArgFallbackButton(params: DiscordCommandArgC
 
 function buildDiscordCommandArgMenu(params: {
   command: ChatCommandDefinition;
-  menu: { arg: CommandArgDefinition; choices: string[]; title?: string };
+  menu: {
+    arg: CommandArgDefinition;
+    choices: Array<{ value: string; label: string }>;
+    title?: string;
+  };
   interaction: CommandInteraction;
   cfg: ReturnType<typeof loadConfig>;
   discordConfig: DiscordConfig;
@@ -365,11 +371,11 @@ function buildDiscordCommandArgMenu(params: {
     const buttons = choices.map(
       (choice) =>
         new DiscordCommandArgButton({
-          label: choice,
+          label: choice.label,
           customId: buildDiscordCommandArgCustomId({
             command: commandLabel,
             arg: menu.arg.name,
-            value: choice,
+            value: choice.value,
             userId,
           }),
           cfg: params.cfg,

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -102,7 +102,7 @@ function buildSlackCommandArgMenuBlocks(params: {
   title: string;
   command: string;
   arg: string;
-  choices: string[];
+  choices: Array<{ value: string; label: string }>;
   userId: string;
 }) {
   const rows = chunkItems(params.choices, 5).map((choices) => ({
@@ -110,11 +110,11 @@ function buildSlackCommandArgMenuBlocks(params: {
     elements: choices.map((choice) => ({
       type: "button",
       action_id: SLACK_COMMAND_ARG_ACTION_ID,
-      text: { type: "plain_text", text: choice },
+      text: { type: "plain_text", text: choice.label },
       value: encodeSlackCommandArgValue({
         command: params.command,
         arg: params.arg,
-        value: choice,
+        value: choice.value,
         userId: params.userId,
       }),
     })),

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -245,10 +245,10 @@ export const registerTelegramNativeCommands = ({
               rows.push(
                 slice.map((choice) => {
                   const args: CommandArgs = {
-                    values: { [menu.arg.name]: choice },
+                    values: { [menu.arg.name]: choice.value },
                   };
                   return {
-                    text: choice,
+                    text: choice.label,
                     callback_data: buildCommandTextFromArgs(commandDefinition, args),
                   };
                 }),


### PR DESCRIPTION
## Summary

Allow command argument choices to have separate display labels and values. This enables emoji-prefixed labels in interactive menus while keeping the underlying command value clean.

### TTS command now shows:

| Button | Label |
|--------|-------|
| on | 🔊 On |
| off | 🔇 Off |
| status | 📊 Status |
| provider | 🎙️ Provider |
| limit | 📏 Limit |
| summary | 📝 Summary |
| audio | 🔈 Audio |
| help | ❓ Help |

### Changes

- Add `CommandArgChoice` type: `string | { value: string; label: string }`
- Add `ResolvedCommandArgChoice` type for normalized choices
- Update `resolveCommandArgChoices` to return normalized objects
- Update Telegram, Discord, and Slack renderers to use `choice.label` for display and `choice.value` for callback data
- Add emoji labels to TTS command

### Backward compatible

Plain string choices continue to work unchanged - they are normalized to `{ value: "x", label: "x" }` internally.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm test` passes (674 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)