### PR TITLE
Telegram: threaded conversation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.clawd.bot
 - Messaging: keep newline chunking safe for fenced markdown blocks across channels.
 - Tests: cap Vitest workers on CI macOS to reduce timeouts.
 - Tests: avoid fake-timer dependency in embedded runner stream mock to reduce CI flakes.
+- Tests: increase embedded runner ordering test timeout to reduce CI flakes.
 
 ## 2026.1.23-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Docs: https://docs.clawd.bot
 - Docs: add Bedrock EC2 instance role setup + IAM steps. (#1625) Thanks @sergical. https://docs.clawd.bot/bedrock
 - Exec approvals: forward approval prompts to chat with `/approve` for all channels (including plugins). (#1621) Thanks @czekaj. https://docs.clawd.bot/tools/exec-approvals https://docs.clawd.bot/tools/slash-commands
 - Gateway: expose config.patch in the gateway tool with safe partial updates + restart sentinel. (#1653) Thanks @Glucksberg.
+- Telegram: treat DM topics as separate sessions and keep DM history limits stable with thread suffixes.
+- Telegram: add verbose raw-update logging for inbound Telegram updates.
 
 ### Fixes
 - BlueBubbles: keep part-index GUIDs in reply tags when short IDs are missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Docs: https://docs.clawd.bot
 - Docs: add Bedrock EC2 instance role setup + IAM steps. (#1625) Thanks @sergical. https://docs.clawd.bot/bedrock
 - Exec approvals: forward approval prompts to chat with `/approve` for all channels (including plugins). (#1621) Thanks @czekaj. https://docs.clawd.bot/tools/exec-approvals https://docs.clawd.bot/tools/slash-commands
 - Gateway: expose config.patch in the gateway tool with safe partial updates + restart sentinel. (#1653) Thanks @Glucksberg.
-- Telegram: treat DM topics as separate sessions and keep DM history limits stable with thread suffixes.
-- Telegram: add verbose raw-update logging for inbound Telegram updates.
+- Telegram: treat DM topics as separate sessions and keep DM history limits stable with thread suffixes. (#1597) Thanks @rohannagpal.
+- Telegram: add verbose raw-update logging for inbound Telegram updates. (#1597) Thanks @rohannagpal.
 
 ### Fixes
 - BlueBubbles: keep part-index GUIDs in reply tags when short IDs are missing.
@@ -41,9 +41,9 @@ Docs: https://docs.clawd.bot
 - Google Chat: tighten email allowlist matching, typing cleanup, media caps, and onboarding/docs/tests. (#1635) Thanks @iHildy.
 - Google Chat: normalize space targets without double `spaces/` prefix.
 - Messaging: keep newline chunking safe for fenced markdown blocks across channels.
-- Tests: cap Vitest workers on CI macOS to reduce timeouts.
-- Tests: avoid fake-timer dependency in embedded runner stream mock to reduce CI flakes.
-- Tests: increase embedded runner ordering test timeout to reduce CI flakes.
+- Tests: cap Vitest workers on CI macOS to reduce timeouts. (#1597) Thanks @rohannagpal.
+- Tests: avoid fake-timer dependency in embedded runner stream mock to reduce CI flakes. (#1597) Thanks @rohannagpal.
+- Tests: increase embedded runner ordering test timeout to reduce CI flakes. (#1597) Thanks @rohannagpal.
 
 ## 2026.1.23-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.clawd.bot
 - Google Chat: normalize space targets without double `spaces/` prefix.
 - Messaging: keep newline chunking safe for fenced markdown blocks across channels.
 - Tests: cap Vitest workers on CI macOS to reduce timeouts.
+- Tests: avoid fake-timer dependency in embedded runner stream mock to reduce CI flakes.
 
 ## 2026.1.23-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.clawd.bot
 - Google Chat: tighten email allowlist matching, typing cleanup, media caps, and onboarding/docs/tests. (#1635) Thanks @iHildy.
 - Google Chat: normalize space targets without double `spaces/` prefix.
 - Messaging: keep newline chunking safe for fenced markdown blocks across channels.
+- Tests: cap Vitest workers to reduce CI timeouts, especially on macOS.
 
 ## 2026.1.23-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Docs: https://docs.clawd.bot
 - Google Chat: tighten email allowlist matching, typing cleanup, media caps, and onboarding/docs/tests. (#1635) Thanks @iHildy.
 - Google Chat: normalize space targets without double `spaces/` prefix.
 - Messaging: keep newline chunking safe for fenced markdown blocks across channels.
-- Tests: cap Vitest workers to reduce CI timeouts, especially on macOS.
+- Tests: cap Vitest workers on CI macOS to reduce timeouts.
 
 ## 2026.1.23-1
 

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -22,13 +22,15 @@ const parallelRuns = runs.filter((entry) => entry.name !== "gateway");
 const serialRuns = runs.filter((entry) => entry.name === "gateway");
 
 const children = new Set();
+const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+const isMacOS = process.platform === "darwin" || process.env.RUNNER_OS === "macOS";
 const overrideWorkers = Number.parseInt(process.env.CLAWDBOT_TEST_WORKERS ?? "", 10);
 const resolvedOverride = Number.isFinite(overrideWorkers) && overrideWorkers > 0 ? overrideWorkers : null;
 const localWorkers = Math.max(4, Math.min(16, os.cpus().length));
 const perRunWorkers = Math.max(1, Math.floor(localWorkers / parallelRuns.length));
-// Keep worker counts predictable across local runs and CI (avoid oversubscribing runners).
-// Total workers ~= localWorkers since we run unit/extensions in parallel.
-const maxWorkers = resolvedOverride ?? perRunWorkers;
+// Keep worker counts predictable for local runs and for CI on macOS.
+// In CI on linux/windows, prefer Vitest defaults to avoid cross-test interference from lower worker counts.
+const maxWorkers = resolvedOverride ?? (isCI && !isMacOS ? null : perRunWorkers);
 
 const WARNING_SUPPRESSION_FLAGS = [
   "--disable-warning=ExperimentalWarning",

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -22,12 +22,13 @@ const parallelRuns = runs.filter((entry) => entry.name !== "gateway");
 const serialRuns = runs.filter((entry) => entry.name === "gateway");
 
 const children = new Set();
-const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const overrideWorkers = Number.parseInt(process.env.CLAWDBOT_TEST_WORKERS ?? "", 10);
 const resolvedOverride = Number.isFinite(overrideWorkers) && overrideWorkers > 0 ? overrideWorkers : null;
 const localWorkers = Math.max(4, Math.min(16, os.cpus().length));
 const perRunWorkers = Math.max(1, Math.floor(localWorkers / parallelRuns.length));
-const maxWorkers = isCI ? null : resolvedOverride ?? perRunWorkers;
+// Keep worker counts predictable across local runs and CI (avoid oversubscribing runners).
+// Total workers ~= localWorkers since we run unit/extensions in parallel.
+const maxWorkers = resolvedOverride ?? perRunWorkers;
 
 const WARNING_SUPPRESSION_FLAGS = [
   "--disable-warning=ExperimentalWarning",

--- a/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
+++ b/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
@@ -121,6 +121,16 @@ describe("getDmHistoryLimitFromSessionKey", () => {
     } as ClawdbotConfig;
     expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123", config)).toBe(10);
   });
+  it("strips thread suffix from dm session keys", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 10, dms: { "123": { historyLimit: 7 } } } },
+    } as ClawdbotConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123:thread:999", config)).toBe(
+      7,
+    );
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123:topic:555", config)).toBe(7);
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123:thread:999", config)).toBe(7);
+  });
   it("returns undefined for non-dm session kinds", () => {
     const config = {
       channels: {

--- a/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
+++ b/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
@@ -131,6 +131,16 @@ describe("getDmHistoryLimitFromSessionKey", () => {
     expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123:topic:555", config)).toBe(7);
     expect(getDmHistoryLimitFromSessionKey("telegram:dm:123:thread:999", config)).toBe(7);
   });
+  it("keeps non-numeric thread markers in dm ids", () => {
+    const config = {
+      channels: {
+        telegram: { dms: { "user:thread:abc": { historyLimit: 9 } } },
+      },
+    } as ClawdbotConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:user:thread:abc", config)).toBe(
+      9,
+    );
+  });
   it("returns undefined for non-dm session kinds", () => {
     const config = {
       channels: {

--- a/src/agents/pi-embedded-runner.test.ts
+++ b/src/agents/pi-embedded-runner.test.ts
@@ -213,7 +213,7 @@ describe("runEmbeddedPiAgent", () => {
 
   itIfNotWin32(
     "persists the first user message before assistant output",
-    { timeout: 60_000 },
+    { timeout: 120_000 },
     async () => {
       const sessionFile = nextSessionFile();
       const cfg = makeOpenAiConfig(["mock-1"]);

--- a/src/agents/pi-embedded-runner.test.ts
+++ b/src/agents/pi-embedded-runner.test.ts
@@ -70,7 +70,7 @@ vi.mock("@mariozechner/pi-ai", async () => {
     },
     streamSimple: (model: { api: string; provider: string; id: string }) => {
       const stream = new actual.AssistantMessageEventStream();
-      setTimeout(() => {
+      queueMicrotask(() => {
         stream.push({
           type: "done",
           reason: "stop",
@@ -80,7 +80,7 @@ vi.mock("@mariozechner/pi-ai", async () => {
               : buildAssistantMessage(model),
         });
         stream.end();
-      }, 0);
+      });
       return stream;
     },
   };

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -2,6 +2,19 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 import type { ClawdbotConfig } from "../../config/config.js";
 
+const THREAD_SUFFIX_MARKERS = [":thread:", ":topic:"];
+
+function stripThreadSuffix(value: string): string {
+  const lower = value.toLowerCase();
+  let idx = -1;
+  for (const marker of THREAD_SUFFIX_MARKERS) {
+    const pos = lower.lastIndexOf(marker);
+    if (pos > idx) idx = pos;
+  }
+  if (idx <= 0) return value;
+  return value.slice(0, idx);
+}
+
 /**
  * Limits conversation history to the last N user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
@@ -44,7 +57,8 @@ export function getDmHistoryLimitFromSessionKey(
   if (!provider) return undefined;
 
   const kind = providerParts[1]?.toLowerCase();
-  const userId = providerParts.slice(2).join(":");
+  const userIdRaw = providerParts.slice(2).join(":");
+  const userId = stripThreadSuffix(userIdRaw);
   if (kind !== "dm") return undefined;
 
   const getLimit = (

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -2,17 +2,11 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 import type { ClawdbotConfig } from "../../config/config.js";
 
-const THREAD_SUFFIX_MARKERS = [":thread:", ":topic:"];
+const THREAD_SUFFIX_REGEX = /^(.*)(?::(?:thread|topic):\d+)$/i;
 
 function stripThreadSuffix(value: string): string {
-  const lower = value.toLowerCase();
-  let idx = -1;
-  for (const marker of THREAD_SUFFIX_MARKERS) {
-    const pos = lower.lastIndexOf(marker);
-    if (pos > idx) idx = pos;
-  }
-  if (idx <= 0) return value;
-  return value.slice(0, idx);
+  const match = value.match(THREAD_SUFFIX_REGEX);
+  return match?.[1] ?? value;
 }
 
 /**

--- a/src/telegram/bot-message-context.dm-threads.test.ts
+++ b/src/telegram/bot-message-context.dm-threads.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+
+describe("buildTelegramMessageContext dm thread sessions", () => {
+  const baseConfig = {
+    agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/clawd" } },
+    channels: { telegram: {} },
+    messages: { groupChat: { mentionPatterns: [] } },
+  } as never;
+
+  const buildContext = async (message: Record<string, unknown>) =>
+    await buildTelegramMessageContext({
+      primaryCtx: {
+        message,
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+  it("uses thread session key for dm topics", async () => {
+    const ctx = await buildContext({
+      message_id: 1,
+      chat: { id: 1234, type: "private" },
+      date: 1700000000,
+      text: "hello",
+      message_thread_id: 42,
+      from: { id: 42, first_name: "Alice" },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.MessageThreadId).toBe(42);
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main:thread:42");
+  });
+
+  it("keeps legacy dm session key when no thread id", async () => {
+    const ctx = await buildContext({
+      message_id: 2,
+      chat: { id: 1234, type: "private" },
+      date: 1700000001,
+      text: "hello",
+      from: { id: 42, first_name: "Alice" },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.MessageThreadId).toBeUndefined();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+});

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -2163,6 +2163,46 @@ describe("createTelegramBot", () => {
       expect.objectContaining({ message_thread_id: 99 }),
     );
   });
+  it("sets command target session key for dm topic commands", async () => {
+    onSpy.mockReset();
+    sendMessageSpy.mockReset();
+    commandSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
+    replySpy.mockReset();
+    replySpy.mockResolvedValue({ text: "response" });
+
+    loadConfig.mockReturnValue({
+      commands: { native: true },
+      channels: {
+        telegram: {
+          dmPolicy: "pairing",
+        },
+      },
+    });
+    readTelegramAllowFromStore.mockResolvedValueOnce(["12345"]);
+
+    createTelegramBot({ token: "tok" });
+    const handler = commandSpy.mock.calls.find((call) => call[0] === "status")?.[1] as
+      | ((ctx: Record<string, unknown>) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("status command handler missing");
+
+    await handler({
+      message: {
+        chat: { id: 12345, type: "private" },
+        from: { id: 12345, username: "testuser" },
+        text: "/status",
+        date: 1736380800,
+        message_id: 42,
+        message_thread_id: 99,
+      },
+      match: "",
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    expect(payload.CommandTargetSessionKey).toBe("agent:main:main:thread:99");
+  });
 
   it("allows native DM commands for paired users", async () => {
     onSpy.mockReset();
@@ -2788,5 +2828,42 @@ describe("createTelegramBot", () => {
     // Verify session key does NOT contain :topic:
     const sessionKey = enqueueSystemEvent.mock.calls[0][1].sessionKey;
     expect(sessionKey).not.toContain(":topic:");
+  });
+  it("uses thread session key for dm reactions with topic id", async () => {
+    onSpy.mockReset();
+    enqueueSystemEvent.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 508 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 300,
+        message_thread_id: 42,
+        user: { id: 12, first_name: "Dana" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "🔥" }],
+      },
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "Telegram reaction added: 🔥 by Dana on msg 300",
+      expect.objectContaining({
+        sessionKey: expect.stringContaining(":thread:42"),
+        contextKey: expect.stringContaining("telegram:reaction:add:1234:300:12"),
+      }),
+    );
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -20,9 +20,11 @@ import {
 } from "../config/group-policy.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
+import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import {
@@ -161,7 +163,18 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     return skipped;
   };
 
+  const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
+
   bot.use(async (ctx, next) => {
+    if (shouldLogVerbose()) {
+      try {
+        const raw = JSON.stringify(ctx.update ?? null);
+        const preview = raw.length > 8000 ? raw.slice(0, 8000) + "…" : raw;
+        rawUpdateLogger.debug(`telegram update: ${preview}`);
+      } catch (err) {
+        rawUpdateLogger.debug(`telegram update log failed: ${String(err)}`);
+      }
+    }
     await next();
     recordUpdateId(ctx);
   });
@@ -372,13 +385,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         accountId: account.accountId,
         peer: { kind: isGroup ? "group" : "dm", id: peerId },
       });
+      const baseSessionKey = route.sessionKey;
+      const dmThreadId = !isGroup ? resolvedThreadId : undefined;
+      const threadKeys =
+        dmThreadId != null
+          ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(dmThreadId) })
+          : null;
+      const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
 
       // Enqueue system event for each added reaction
       for (const r of addedReactions) {
         const emoji = r.emoji;
         const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
         enqueueSystemEvent(text, {
-          sessionKey: route.sessionKey,
+          sessionKey: sessionKey,
           contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);


### PR DESCRIPTION
## Summary

  Adds DM thread awareness to Telegram sessions and improves inbound logging to
  make DM threads observable and testable.

## Why

  Adds support for threaded conversations in Telegram.

## How

- Derives a thread-aware session key for DM topics so each thread becomes its
  own session context.
- Keeps DM history limits stable by stripping thread suffixes when parsing
  session keys.
- Adds verbose raw-update logging so inbound DM thread ids are visible during
  debugging.
- Adjusts DM command targeting to respect thread-aware session keys.
- Adds coverage for DM thread keying, DM command targeting, and DM history-
  limit parsing.

## Tests

- `pnpm test` (Full suite, vm)
- `pnpm test src/telegram/bot-message-context.DM-threads.test.ts`
- `pnpm test src/telegram/bot.test.ts`
- `pnpm test src/agents/pi-embedded-runner.get-DM-history-limit-from-session-
  key.returns-undefined-sessionkey-is-undefined.test.ts`

## Manual testing

- With DM threads enabled, I sent two DM messages in different threads and
  confirmed distinct sessions in `/status` and different `message_thread_id`
  values in logs.
- With DM threads disabled, I sent DM messages and confirmed
  `message_thread_id` was absent in logs and sessions behaved as a single
  thread.

## Breaking changes

  None.

## Changelog

  Added entries under `2026.1.23 (Unreleased)`.

## AI assistance

- AI-assisted: Yes
- Testing: Fully tested (Unit + integration + manual DM checks)
- Prompts/logs: Available in session history and vm logs if needed
- Understanding: I tested it thoroughly, used `/review` in codex, and skimmed
  through the code.
