### PR TITLE
fix(exec): only set security=full when elevated mode is full

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -791,7 +791,7 @@ export function createExecTool(
       const configuredSecurity = defaults?.security ?? (host === "sandbox" ? "deny" : "allowlist");
       const requestedSecurity = normalizeExecSecurity(params.security);
       let security = minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity);
-      if (elevatedRequested) {
+      if (elevatedRequested && elevatedMode === "full") {
         security = "full";
       }
       const configuredAsk = defaults?.ask ?? "on-miss";


### PR DESCRIPTION
## fix(exec): only set security=full when elevated mode is full

### Problem

When using `elevated ASK` mode, the exec approval flow was being bypassed entirely. Commands like `crontab` that weren't on the allowlist would run without requiring approval.

### Root Cause

In `bash-tools.exec.ts` line 794:
```typescript
if (elevatedRequested) {
  security = "full";
}
```

This set `security = "full"` for **all** elevated modes (ASK and FULL), not just FULL mode.

Since `requiresExecApproval()` only requires approval when `security === "allowlist"`:
```typescript
return (
  params.ask === "always" ||
  (params.ask === "on-miss" &&
    params.security === "allowlist" &&  // <-- "full" ≠ "allowlist"
    (!params.analysisOk || !params.allowlistSatisfied))
);
```

The approval check was always skipped in ASK mode because `security` was `"full"` instead of `"allowlist"`.

### Fix

Only set `security = "full"` when `elevatedMode === "full"`:
```typescript
if (elevatedRequested && elevatedMode === "full") {
  security = "full";
}
```

This allows ASK mode to properly enforce the approval flow for non-allowlisted commands.

### Testing

- Build passes (`npm run build`)
- Verified the logic flow through code review
