### PR TITLE
feat(gateway-tool): add config.patch action for safe partial config updates

### DIFF
--- a/src/agents/clawdbot-gateway-tool.test.ts
+++ b/src/agents/clawdbot-gateway-tool.test.ts
@@ -89,6 +89,32 @@ describe("gateway tool", () => {
     );
   });
 
+  it("passes config.patch through gateway call", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const tool = createClawdbotTools({
+      agentSessionKey: "agent:main:whatsapp:dm:+15555550123",
+    }).find((candidate) => candidate.name === "gateway");
+    expect(tool).toBeDefined();
+    if (!tool) throw new Error("missing gateway tool");
+
+    const raw = '{\n  channels: { telegram: { groups: { "*": { requireMention: false } } } }\n}\n';
+    await tool.execute("call4", {
+      action: "config.patch",
+      raw,
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith("config.get", expect.any(Object), {});
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "config.patch",
+      expect.any(Object),
+      expect.objectContaining({
+        raw: raw.trim(),
+        baseHash: "hash-1",
+        sessionKey: "agent:main:whatsapp:dm:+15555550123",
+      }),
+    );
+  });
+
   it("passes update.run through gateway call", async () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const tool = createClawdbotTools({

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -20,6 +20,7 @@ const GATEWAY_ACTIONS = [
   "config.get",
   "config.schema",
   "config.apply",
+  "config.patch",
   "update.run",
 ] as const;
 
@@ -35,10 +36,10 @@ const GatewayToolSchema = Type.Object({
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
   timeoutMs: Type.Optional(Type.Number()),
-  // config.apply
+  // config.apply, config.patch
   raw: Type.Optional(Type.String()),
   baseHash: Type.Optional(Type.String()),
-  // config.apply, update.run
+  // config.apply, config.patch, update.run
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
   restartDelayMs: Type.Optional(Type.Number()),
@@ -56,7 +57,7 @@ export function createGatewayTool(opts?: {
     label: "Gateway",
     name: "gateway",
     description:
-      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.apply/update.run to write config or run updates with validation and restart.",
+      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -187,6 +188,42 @@ export function createGatewayTool(opts?: {
             ? Math.floor(params.restartDelayMs)
             : undefined;
         const result = await callGatewayTool("config.apply", gatewayOpts, {
+          raw,
+          baseHash,
+          sessionKey,
+          note,
+          restartDelayMs,
+        });
+        return jsonResult({ ok: true, result });
+      }
+      if (action === "config.patch") {
+        const raw = readStringParam(params, "raw", { required: true });
+        let baseHash = readStringParam(params, "baseHash");
+        if (!baseHash) {
+          const snapshot = await callGatewayTool("config.get", gatewayOpts, {});
+          if (snapshot && typeof snapshot === "object") {
+            const hash = (snapshot as { hash?: unknown }).hash;
+            if (typeof hash === "string" && hash.trim()) {
+              baseHash = hash.trim();
+            } else {
+              const rawSnapshot = (snapshot as { raw?: unknown }).raw;
+              if (typeof rawSnapshot === "string") {
+                baseHash = crypto.createHash("sha256").update(rawSnapshot).digest("hex");
+              }
+            }
+          }
+        }
+        const sessionKey =
+          typeof params.sessionKey === "string" && params.sessionKey.trim()
+            ? params.sessionKey.trim()
+            : opts?.agentSessionKey?.trim() || undefined;
+        const note =
+          typeof params.note === "string" && params.note.trim() ? params.note.trim() : undefined;
+        const restartDelayMs =
+          typeof params.restartDelayMs === "number" && Number.isFinite(params.restartDelayMs)
+            ? Math.floor(params.restartDelayMs)
+            : undefined;
+        const result = await callGatewayTool("config.patch", gatewayOpts, {
           raw,
           baseHash,
           sessionKey,

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -27,6 +27,9 @@ export const ConfigPatchParamsSchema = Type.Object(
   {
     raw: NonEmptyString,
     baseHash: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(Type.String()),
+    note: Type.Optional(Type.String()),
+    restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -493,6 +493,7 @@ export function renderApp(state: AppViewState) {
         ${state.tab === "config"
           ? renderConfig({
               raw: state.configRaw,
+              originalRaw: state.configRawOriginal,
               valid: state.configValid,
               issues: state.configIssues,
               loading: state.configLoading,
@@ -509,7 +510,10 @@ export function renderApp(state: AppViewState) {
               searchQuery: state.configSearchQuery,
               activeSection: state.configActiveSection,
               activeSubsection: state.configActiveSubsection,
-              onRawChange: (next) => (state.configRaw = next),
+              onRawChange: (next) => {
+                state.configRaw = next;
+                state.configFormDirty = true;
+              },
               onFormModeChange: (mode) => (state.configFormMode = mode),
               onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
               onSearchChange: (query) => (state.configSearchQuery = query),

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -154,6 +154,7 @@ export class ClawdbotApp extends LitElement {
 
   @state() configLoading = false;
   @state() configRaw = "{\n}\n";
+  @state() configRawOriginal = "";
   @state() configValid: boolean | null = null;
   @state() configIssues: unknown[] = [];
   @state() configSaving = false;

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -15,6 +15,7 @@ function createState(): ConfigState {
     applySessionKey: "main",
     configLoading: false,
     configRaw: "",
+    configRawOriginal: "",
     configValid: null,
     configIssues: [],
     configSaving: false,
@@ -26,6 +27,7 @@ function createState(): ConfigState {
     configSchemaLoading: false,
     configUiHints: {},
     configForm: null,
+    configFormOriginal: null,
     configFormDirty: false,
     configFormMode: "form",
     lastError: null,
@@ -62,6 +64,37 @@ describe("applyConfigSnapshot", () => {
     });
 
     expect(state.configForm).toEqual({ gateway: { mode: "local" } });
+  });
+
+  it("sets configRawOriginal when clean for change detection", () => {
+    const state = createState();
+    applyConfigSnapshot(state, {
+      config: { gateway: { mode: "local" } },
+      valid: true,
+      issues: [],
+      raw: '{ "gateway": { "mode": "local" } }',
+    });
+
+    expect(state.configRawOriginal).toBe('{ "gateway": { "mode": "local" } }');
+    expect(state.configFormOriginal).toEqual({ gateway: { mode: "local" } });
+  });
+
+  it("preserves configRawOriginal when dirty", () => {
+    const state = createState();
+    state.configFormDirty = true;
+    state.configRawOriginal = '{ "original": true }';
+    state.configFormOriginal = { original: true };
+
+    applyConfigSnapshot(state, {
+      config: { gateway: { mode: "local" } },
+      valid: true,
+      issues: [],
+      raw: '{ "gateway": { "mode": "local" } }',
+    });
+
+    // Original values should be preserved when dirty
+    expect(state.configRawOriginal).toBe('{ "original": true }');
+    expect(state.configFormOriginal).toEqual({ original: true });
   });
 });
 

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -17,6 +17,7 @@ export type ConfigState = {
   applySessionKey: string;
   configLoading: boolean;
   configRaw: string;
+  configRawOriginal: string;
   configValid: boolean | null;
   configIssues: unknown[];
   configSaving: boolean;
@@ -98,6 +99,7 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
   if (!state.configFormDirty) {
     state.configForm = cloneConfigObject(snapshot.config ?? {});
     state.configFormOriginal = cloneConfigObject(snapshot.config ?? {});
+    state.configRawOriginal = rawFromSnapshot;
   }
 }
 

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -6,6 +6,7 @@ import { renderConfig } from "./config";
 describe("config view", () => {
   const baseProps = () => ({
     raw: "{\n}\n",
+    originalRaw: "{\n}\n",
     valid: true,
     issues: [],
     loading: false,


### PR DESCRIPTION
## Summary

- Exposes the existing `config.patch` server method to agents via the gateway tool
- Allows safe partial config updates that merge with existing config instead of replacing it entirely
- Adds restart + sentinel logic to `config.patch` server method (matching `config.apply` behavior)
- Extends `ConfigPatchParamsSchema` with `sessionKey`, `note`, `restartDelayMs` parameters

This prevents agents from accidentally wiping user configurations when they only intend to make partial updates.

Closes #1617

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Gateway tool unit tests pass (4/4 including new `config.patch` test)
- [ ] Manual testing of `config.patch` via gateway tool

🤖 Generated with [Claude Code](https://claude.ai/code)