### PR TITLE
fix: print Antigravity auth URL to stdout for easier copying

### DIFF
--- a/extensions/google-antigravity-auth/index.ts
+++ b/extensions/google-antigravity-auth/index.ts
@@ -308,12 +308,13 @@ async function loginAntigravity(params: {
       [
         "Open the URL in your local browser.",
         "After signing in, copy the full redirect URL and paste it back here.",
-        "",
-        `Auth URL: ${authUrl}`,
-        `Redirect URI: ${REDIRECT_URI}`,
       ].join("\n"),
       "Google Antigravity OAuth",
     );
+    // eslint-disable-next-line no-console
+    console.log(`\nAuth URL: ${authUrl}\n`);
+    // eslint-disable-next-line no-console
+    console.log(`Redirect URI: ${REDIRECT_URI}\n`);
   }
 
   if (!needsManual) {


### PR DESCRIPTION
## Summary
Moves the Google Antigravity OAuth URL and Redirect URI out of the TUI `note` component and prints them directly to stdout using `console.log`.

## Why
The TUI `note` component wraps text with borders, making it difficult for users to select and copy the long OAuth URL without including border characters. Printing to stdout allows for easy selection and copying.

## Test plan
- Run the onboarding flow with Google Antigravity selected in a non-local environment (or force manual flow).
- Verify the Auth URL is printed plainly in the terminal.

Fixes #1632