### PR TITLE
feat(bluebubbles): improve reaction handling and inline reply tags

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1985,7 +1985,7 @@ describe("BlueBubbles webhook monitor", () => {
           handle: { address: "+15551234567" },
           isGroup: false,
           isFromMe: false,
-          guid: "msg-uuid-12345",
+          guid: "p:1/msg-uuid-12345",
           chatGuid: "iMessage;-;+15551234567",
           date: Date.now(),
         },
@@ -2001,7 +2001,7 @@ describe("BlueBubbles webhook monitor", () => {
       const callArgs = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
       // MessageSid should be short ID "1" instead of full UUID
       expect(callArgs.ctx.MessageSid).toBe("1");
-      expect(callArgs.ctx.MessageSidFull).toBe("msg-uuid-12345");
+      expect(callArgs.ctx.MessageSidFull).toBe("p:1/msg-uuid-12345");
     });
 
     it("resolves short ID back to UUID", async () => {
@@ -2025,7 +2025,7 @@ describe("BlueBubbles webhook monitor", () => {
           handle: { address: "+15551234567" },
           isGroup: false,
           isFromMe: false,
-          guid: "msg-uuid-12345",
+          guid: "p:1/msg-uuid-12345",
           chatGuid: "iMessage;-;+15551234567",
           date: Date.now(),
         },
@@ -2038,7 +2038,7 @@ describe("BlueBubbles webhook monitor", () => {
       await flushAsync();
 
       // The short ID "1" should resolve back to the full UUID
-      expect(resolveBlueBubblesMessageId("1")).toBe("msg-uuid-12345");
+      expect(resolveBlueBubblesMessageId("1")).toBe("p:1/msg-uuid-12345");
     });
 
     it("returns UUID unchanged when not in cache", () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1189,9 +1189,8 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.ReplyToId).toBe("msg-0");
       expect(callArgs.ctx.ReplyToBody).toBe("original message");
       expect(callArgs.ctx.ReplyToSender).toBe("+15550000000");
-      // Body uses just the ID (no sender) for token savings
-      expect(callArgs.ctx.Body).toContain("[Replying to id:msg-0]");
-      expect(callArgs.ctx.Body).toContain("original message");
+      // Body uses inline [[reply_to:N]] tag format
+      expect(callArgs.ctx.Body).toContain("[[reply_to:msg-0]]");
     });
 
     it("hydrates missing reply sender/body from the recent-message cache", async () => {
@@ -1260,9 +1259,8 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.ReplyToIdFull).toBe("cache-msg-0");
       expect(callArgs.ctx.ReplyToBody).toBe("original message (cached)");
       expect(callArgs.ctx.ReplyToSender).toBe("+15550000000");
-      // Body uses just the short ID (no sender) for token savings
-      expect(callArgs.ctx.Body).toContain("[Replying to id:1]");
-      expect(callArgs.ctx.Body).toContain("original message (cached)");
+      // Body uses inline [[reply_to:N]] tag format with short ID
+      expect(callArgs.ctx.Body).toContain("[[reply_to:1]]");
     });
 
     it("falls back to threadOriginatorGuid when reply metadata is absent", async () => {
@@ -1759,7 +1757,7 @@ describe("BlueBubbles webhook monitor", () => {
       await flushAsync();
 
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
-        expect.stringContaining("reaction added"),
+        expect.stringContaining("reacted with ❤️ [[reply_to:"),
         expect.any(Object),
       );
     });
@@ -1799,7 +1797,7 @@ describe("BlueBubbles webhook monitor", () => {
       await flushAsync();
 
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
-        expect.stringContaining("reaction removed"),
+        expect.stringContaining("removed ❤️ reaction [[reply_to:"),
         expect.any(Object),
       );
     });


### PR DESCRIPTION
## Summary

- Refactor reply formatting to use inline `[[reply_to:N]]` tags instead of multi-line blocks, reducing token usage
- Add tapback text parsing to convert iOS tapback patterns (e.g., `Loved "hello"`) into structured emoji format (`reacted with ❤️`)
- Normalize message ID handling to strip `p:N/` part index prefixes for consistent cache lookups
- Improve reaction event formatting to use cleaner inline syntax

## Changes

**Reply formatting:**
- Regular replies: prepend tag (e.g., `[[reply_to:4]] Awesome`)
- Tapbacks/reactions: append tag (e.g., `reacted with ❤️ [[reply_to:4]]`)

**Tapback text parsing:**
- Detect patterns like `Loved`, `Liked`, `Reacted 😅 to` and convert to `reacted with <emoji>`
- Extract custom emoji from "Reacted" patterns
- Handle removal patterns (`Removed a heart from`)

**Message ID normalization:**
- Strip `p:N/` prefix from BlueBubbles GUIDs for consistent cache keys
- Maintain bidirectional short ID ↔ full GUID mappings

## Test plan

- [x] Unit tests for tapback text parsing added
- [x] Existing reply context tests updated for new format
- [x] Reaction event format tests updated
- [x] Manual testing with real BlueBubbles webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)