### PR TITLE
feat(signal): add reaction support via message tool

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -18,11 +18,18 @@ import {
   setAccountEnabledInConfigSection,
   signalOnboardingAdapter,
   SignalConfigSchema,
+  type ChannelMessageActionAdapter,
   type ChannelPlugin,
   type ResolvedSignalAccount,
 } from "clawdbot/plugin-sdk";
 
 import { getSignalRuntime } from "./runtime.js";
+
+const signalMessageActions: ChannelMessageActionAdapter = {
+  listActions: (ctx) => getSignalRuntime().channel.signal.messageActions.listActions(ctx),
+  handleAction: async (ctx) =>
+    await getSignalRuntime().channel.signal.messageActions.handleAction(ctx),
+};
 
 const meta = getChatChannelMeta("signal");
 
@@ -42,7 +49,9 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
   capabilities: {
     chatTypes: ["direct", "group"],
     media: true,
+    reactions: true,
   },
+  actions: signalMessageActions,
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
   },

--- a/src/channels/plugins/actions/signal.ts
+++ b/src/channels/plugins/actions/signal.ts
@@ -1,0 +1,89 @@
+import { createActionGate, jsonResult, readStringParam } from "../../../agents/tools/common.js";
+import { listSignalAccountIds, resolveSignalAccount } from "../../../signal/accounts.js";
+import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
+import { sendReactionSignal, removeReactionSignal } from "../../../signal/send-reactions.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
+
+const providerId = "signal";
+
+export const signalMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const accountIds = listSignalAccountIds(cfg);
+    if (accountIds.length === 0) return [];
+
+    const hasConfigured = accountIds.some((accountId) => {
+      const account = resolveSignalAccount({ cfg, accountId });
+      return account.configured;
+    });
+    if (!hasConfigured) return [];
+
+    const gate = createActionGate(cfg.channels?.signal?.actions);
+    const actions = new Set<ChannelMessageActionName>(["send"]);
+
+    if (gate("reactions")) {
+      actions.add("react");
+    }
+
+    return Array.from(actions);
+  },
+
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action === "send") {
+      throw new Error("Send should be handled by outbound, not actions handler.");
+    }
+
+    if (action === "react") {
+      // Check reaction level first
+      const reactionLevelInfo = resolveSignalReactionLevel({
+        cfg,
+        accountId: accountId ?? undefined,
+      });
+      if (!reactionLevelInfo.agentReactionsEnabled) {
+        throw new Error(
+          `Signal agent reactions disabled (reactionLevel="${reactionLevelInfo.level}"). ` +
+            `Set channels.signal.reactionLevel to "minimal" or "extensive" to enable.`,
+        );
+      }
+
+      // Also check the action gate for backward compatibility
+      const isActionEnabled = createActionGate(cfg.channels?.signal?.actions);
+      if (!isActionEnabled("reactions")) {
+        throw new Error("Signal reactions are disabled via actions.reactions.");
+      }
+
+      const recipient =
+        readStringParam(params, "recipient") ??
+        readStringParam(params, "to", {
+          required: true,
+          label: "recipient (UUID or phone number)",
+        });
+
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId (timestamp)",
+      });
+
+      const emoji = readStringParam(params, "emoji", { allowEmpty: true });
+      const remove = typeof params.remove === "boolean" ? params.remove : undefined;
+
+      const timestamp = parseInt(messageId, 10);
+      if (!Number.isFinite(timestamp)) {
+        throw new Error(`Invalid messageId: ${messageId}. Expected numeric timestamp.`);
+      }
+
+      if (remove) {
+        if (!emoji) throw new Error("Emoji required to remove reaction.");
+        await removeReactionSignal(recipient, timestamp, emoji, {
+          accountId: accountId ?? undefined,
+        });
+        return jsonResult({ ok: true, removed: emoji });
+      }
+
+      if (!emoji) throw new Error("Emoji required to add reaction.");
+      await sendReactionSignal(recipient, timestamp, emoji, { accountId: accountId ?? undefined });
+      return jsonResult({ ok: true, added: emoji });
+    }
+
+    throw new Error(`Action ${action} not supported for ${providerId}.`);
+  },
+};

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -22,9 +22,14 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   return normalized.toLowerCase();
 }
 
+// UUID pattern for signal-cli recipient IDs
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function looksLikeSignalTargetId(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) return false;
   if (/^(signal:)?(group:|username:|u:)/i.test(trimmed)) return true;
+  // Accept UUIDs (used by signal-cli for reactions)
+  if (UUID_PATTERN.test(trimmed)) return true;
   return /^\+?\d{3,}$/.test(trimmed);
 }

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -8,6 +8,7 @@ import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
 
 export type SignalAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
@@ -64,6 +65,19 @@ export type SignalAccountConfig = {
   reactionNotifications?: SignalReactionNotificationMode;
   /** Allowlist for reaction notifications when mode is allowlist. */
   reactionAllowlist?: Array<string | number>;
+  /** Action toggles for message tool capabilities. */
+  actions?: {
+    /** Enable/disable sending reactions via message tool (default: true). */
+    reactions?: boolean;
+  };
+  /**
+   * Controls agent reaction behavior:
+   * - "off": No reactions
+   * - "ack": Only automatic ack reactions (👀 when processing)
+   * - "minimal": Agent can react sparingly (default)
+   * - "extensive": Agent can react liberally
+   */
+  reactionLevel?: SignalReactionLevel;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
 };

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -429,6 +429,13 @@ export const SignalAccountSchemaBase = z
     mediaMaxMb: z.number().int().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
+    actions: z
+      .object({
+        reactions: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
   })
   .strict();

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -33,6 +33,7 @@ import { removeAckReactionAfterReply, shouldAckReaction } from "../../channels/a
 import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { discordMessageActions } from "../../channels/plugins/actions/discord.js";
+import { signalMessageActions } from "../../channels/plugins/actions/signal.js";
 import { telegramMessageActions } from "../../channels/plugins/actions/telegram.js";
 import { createWhatsAppLoginTool } from "../../channels/plugins/agent-tools/whatsapp-login.js";
 import { monitorWebChannel } from "../../channels/web/index.js";
@@ -259,6 +260,7 @@ export function createPluginRuntime(): PluginRuntime {
         probeSignal,
         sendMessageSignal,
         monitorSignalProvider,
+        messageActions: signalMessageActions,
       },
       imessage: {
         monitorIMessageProvider,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -120,6 +120,8 @@ type TelegramMessageActions =
 type ProbeSignal = typeof import("../../signal/probe.js").probeSignal;
 type SendMessageSignal = typeof import("../../signal/send.js").sendMessageSignal;
 type MonitorSignalProvider = typeof import("../../signal/index.js").monitorSignalProvider;
+type SignalMessageActions =
+  typeof import("../../channels/plugins/actions/signal.js").signalMessageActions;
 type MonitorIMessageProvider = typeof import("../../imessage/monitor.js").monitorIMessageProvider;
 type ProbeIMessage = typeof import("../../imessage/probe.js").probeIMessage;
 type SendMessageIMessage = typeof import("../../imessage/send.js").sendMessageIMessage;
@@ -272,6 +274,7 @@ export type PluginRuntime = {
       probeSignal: ProbeSignal;
       sendMessageSignal: SendMessageSignal;
       monitorSignalProvider: MonitorSignalProvider;
+      messageActions: SignalMessageActions;
     };
     imessage: {
       monitorIMessageProvider: MonitorIMessageProvider;

--- a/src/signal/index.ts
+++ b/src/signal/index.ts
@@ -1,3 +1,5 @@
 export { monitorSignalProvider } from "./monitor.js";
 export { probeSignal } from "./probe.js";
 export { sendMessageSignal } from "./send.js";
+export { sendReactionSignal, removeReactionSignal } from "./send-reactions.js";
+export { resolveSignalReactionLevel } from "./reaction-level.js";

--- a/src/signal/reaction-level.ts
+++ b/src/signal/reaction-level.ts
@@ -1,0 +1,71 @@
+import type { ClawdbotConfig } from "../config/config.js";
+import { resolveSignalAccount } from "./accounts.js";
+
+export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
+
+export type ResolvedSignalReactionLevel = {
+  level: SignalReactionLevel;
+  /** Whether ACK reactions (e.g., 👀 when processing) are enabled. */
+  ackEnabled: boolean;
+  /** Whether agent-controlled reactions are enabled. */
+  agentReactionsEnabled: boolean;
+  /** Guidance level for agent reactions (minimal = sparse, extensive = liberal). */
+  agentReactionGuidance?: "minimal" | "extensive";
+};
+
+/**
+ * Resolve the effective reaction level and its implications for Signal.
+ *
+ * Levels:
+ * - "off": No reactions at all
+ * - "ack": Only automatic ack reactions (👀 when processing), no agent reactions
+ * - "minimal": Agent can react, but sparingly (default)
+ * - "extensive": Agent can react liberally
+ */
+export function resolveSignalReactionLevel(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string;
+}): ResolvedSignalReactionLevel {
+  const account = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const level = (account.config.reactionLevel ?? "minimal") as SignalReactionLevel;
+
+  switch (level) {
+    case "off":
+      return {
+        level,
+        ackEnabled: false,
+        agentReactionsEnabled: false,
+      };
+    case "ack":
+      return {
+        level,
+        ackEnabled: true,
+        agentReactionsEnabled: false,
+      };
+    case "minimal":
+      return {
+        level,
+        ackEnabled: false,
+        agentReactionsEnabled: true,
+        agentReactionGuidance: "minimal",
+      };
+    case "extensive":
+      return {
+        level,
+        ackEnabled: false,
+        agentReactionsEnabled: true,
+        agentReactionGuidance: "extensive",
+      };
+    default:
+      // Fallback to minimal behavior
+      return {
+        level: "minimal",
+        ackEnabled: false,
+        agentReactionsEnabled: true,
+        agentReactionGuidance: "minimal",
+      };
+  }
+}

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -1,0 +1,138 @@
+/**
+ * Signal reactions via signal-cli JSON-RPC API
+ */
+
+import { loadConfig } from "../config/config.js";
+import { resolveSignalAccount } from "./accounts.js";
+import { signalRpcRequest } from "./client.js";
+
+export type SignalReactionOpts = {
+  baseUrl?: string;
+  account?: string;
+  accountId?: string;
+  timeoutMs?: number;
+};
+
+export type SignalReactionResult = {
+  ok: boolean;
+  timestamp?: number;
+};
+
+function resolveReactionRpcContext(
+  opts: SignalReactionOpts,
+  accountInfo?: ReturnType<typeof resolveSignalAccount>,
+) {
+  const hasBaseUrl = Boolean(opts.baseUrl?.trim());
+  const hasAccount = Boolean(opts.account?.trim());
+  const resolvedAccount =
+    accountInfo ||
+    (!hasBaseUrl || !hasAccount
+      ? resolveSignalAccount({
+          cfg: loadConfig(),
+          accountId: opts.accountId,
+        })
+      : undefined);
+  const baseUrl = opts.baseUrl?.trim() || resolvedAccount?.baseUrl;
+  if (!baseUrl) {
+    throw new Error("Signal base URL is required");
+  }
+  const account = opts.account?.trim() || resolvedAccount?.config.account?.trim();
+  return { baseUrl, account };
+}
+
+/**
+ * Send a Signal reaction to a message
+ * @param recipient - UUID or E.164 phone number of the message author
+ * @param targetTimestamp - Message ID (timestamp) to react to
+ * @param emoji - Emoji to react with
+ * @param opts - Optional account/connection overrides
+ */
+export async function sendReactionSignal(
+  recipient: string,
+  targetTimestamp: number,
+  emoji: string,
+  opts: SignalReactionOpts = {},
+): Promise<SignalReactionResult> {
+  const accountInfo = resolveSignalAccount({
+    cfg: loadConfig(),
+    accountId: opts.accountId,
+  });
+  const { baseUrl, account } = resolveReactionRpcContext(opts, accountInfo);
+
+  if (!recipient?.trim()) {
+    throw new Error("Recipient is required for Signal reaction");
+  }
+  if (!Number.isFinite(targetTimestamp) || targetTimestamp <= 0) {
+    throw new Error("Valid targetTimestamp is required for Signal reaction");
+  }
+  if (!emoji?.trim()) {
+    throw new Error("Emoji is required for Signal reaction");
+  }
+
+  const params: Record<string, unknown> = {
+    recipient: recipient.trim(),
+    emoji: emoji.trim(),
+    targetAuthor: recipient.trim(), // Author of the message being reacted to
+    targetTimestamp,
+  };
+  if (account) params.account = account;
+
+  const result = await signalRpcRequest<{ timestamp?: number }>("sendReaction", params, {
+    baseUrl,
+    timeoutMs: opts.timeoutMs,
+  });
+
+  return {
+    ok: true,
+    timestamp: result?.timestamp,
+  };
+}
+
+/**
+ * Remove a Signal reaction from a message
+ * @param recipient - UUID or E.164 phone number of the message author
+ * @param targetTimestamp - Message ID (timestamp) to remove reaction from
+ * @param emoji - Emoji to remove
+ * @param opts - Optional account/connection overrides
+ */
+export async function removeReactionSignal(
+  recipient: string,
+  targetTimestamp: number,
+  emoji: string,
+  opts: SignalReactionOpts = {},
+): Promise<SignalReactionResult> {
+  const accountInfo = resolveSignalAccount({
+    cfg: loadConfig(),
+    accountId: opts.accountId,
+  });
+  const { baseUrl, account } = resolveReactionRpcContext(opts, accountInfo);
+
+  if (!recipient?.trim()) {
+    throw new Error("Recipient is required for Signal reaction removal");
+  }
+  if (!Number.isFinite(targetTimestamp) || targetTimestamp <= 0) {
+    throw new Error("Valid targetTimestamp is required for Signal reaction removal");
+  }
+  if (!emoji?.trim()) {
+    throw new Error("Emoji is required for Signal reaction removal");
+  }
+
+  const params: Record<string, unknown> = {
+    recipient: recipient.trim(),
+    emoji: emoji.trim(),
+    targetAuthor: recipient.trim(),
+    targetTimestamp,
+    remove: true,
+  };
+  if (account) params.account = account;
+
+  const result = await signalRpcRequest<{ timestamp?: number }>("sendReaction", params, {
+    baseUrl,
+    timeoutMs: opts.timeoutMs,
+  });
+
+  return {
+    ok: true,
+    timestamp: result?.timestamp,
+  };
+}


### PR DESCRIPTION
adds ability to send/remove reactions on signal messages through the message tool's react action, plus reactionLevel config for agent guidance.

features:
- sendReactionSignal() and removeReactionSignal() APIs
- message tool action handler for signal reactions
- reactionLevel config (off|ack|minimal|extensive)
- UUID pattern recognition for signal targets

usage:
  message action=react channel=signal to=<uuid> messageId=<timestamp> emoji=🔥

config:
  channels.signal.reactionLevel: minimal (default) channels.signal.actions.reactions: true (default)

tested on live signal connection.