### PR TITLE
fix: follow up config.patch restarts/docs/tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.clawd.bot
 - Docs: update Fly.io guide notes.
 - Docs: add Bedrock EC2 instance role setup + IAM steps. (#1625) Thanks @sergical. https://docs.clawd.bot/bedrock
 - Exec approvals: forward approval prompts to chat with `/approve` for all channels (including plugins). (#1621) Thanks @czekaj. https://docs.clawd.bot/tools/exec-approvals https://docs.clawd.bot/tools/slash-commands
+- Gateway: expose config.patch in the gateway tool with safe partial updates + restart sentinel. (#1624) Thanks @Glucksberg.
 
 ### Fixes
 - BlueBubbles: keep part-index GUIDs in reply tags when short IDs are missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.clawd.bot
 - Docs: update Fly.io guide notes.
 - Docs: add Bedrock EC2 instance role setup + IAM steps. (#1625) Thanks @sergical. https://docs.clawd.bot/bedrock
 - Exec approvals: forward approval prompts to chat with `/approve` for all channels (including plugins). (#1621) Thanks @czekaj. https://docs.clawd.bot/tools/exec-approvals https://docs.clawd.bot/tools/slash-commands
-- Gateway: expose config.patch in the gateway tool with safe partial updates + restart sentinel. (#1624) Thanks @Glucksberg.
+- Gateway: expose config.patch in the gateway tool with safe partial updates + restart sentinel. (#1653) Thanks @Glucksberg.
 
 ### Fixes
 - BlueBubbles: keep part-index GUIDs in reply tags when short IDs are missing.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -666,7 +666,7 @@ Subcommands:
 
 Common RPCs:
 - `config.apply` (validate + write config + restart + wake)
-- `config.patch` (merge a partial update without clobbering unrelated keys)
+- `config.patch` (merge a partial update + restart + wake)
 - `update.run` (run update + restart + wake)
 
 Tip: when calling `config.set`/`config.apply`/`config.patch` directly, pass `baseHash` from

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -50,6 +50,7 @@ Params:
 - `raw` (string) — JSON5 payload for the entire config
 - `baseHash` (optional) — config hash from `config.get` (required when a config already exists)
 - `sessionKey` (optional) — last active session key for the wake-up ping
+- `note` (optional) — note to include in the restart sentinel
 - `restartDelayMs` (optional) — delay before restart (default 2000)
 
 Example (via `gateway call`):
@@ -71,10 +72,15 @@ unrelated keys. It applies JSON merge patch semantics:
 - objects merge recursively
 - `null` deletes a key
 - arrays replace
+Like `config.apply`, it validates, writes the config, stores a restart sentinel, and schedules
+the Gateway restart (with an optional wake when `sessionKey` is provided).
 
 Params:
 - `raw` (string) — JSON5 payload containing just the keys to change
 - `baseHash` (required) — config hash from `config.get`
+- `sessionKey` (optional) — last active session key for the wake-up ping
+- `note` (optional) — note to include in the restart sentinel
+- `restartDelayMs` (optional) — delay before restart (default 2000)
 
 Example:
 
@@ -82,7 +88,9 @@ Example:
 clawdbot gateway call config.get --params '{}' # capture payload.hash
 clawdbot gateway call config.patch --params '{
   "raw": "{\\n  channels: { telegram: { groups: { \\"*\\": { requireMention: false } } } }\\n}\\n",
-  "baseHash": "<hash-from-config.get>"
+  "baseHash": "<hash-from-config.get>",
+  "sessionKey": "agent:main:whatsapp:dm:+15555550123",
+  "restartDelayMs": 1000
 }'
 ```
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -368,6 +368,7 @@ Core actions:
 - `restart` (authorizes + sends `SIGUSR1` for in-process restart; `clawdbot gateway` restart in-place)
 - `config.get` / `config.schema`
 - `config.apply` (validate + write config + restart + wake)
+- `config.patch` (merge partial update + restart + wake)
 - `update.run` (run update + restart + wake)
 
 Notes:

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -74,6 +74,7 @@ export type AppViewState = {
   execApprovalError: string | null;
   configLoading: boolean;
   configRaw: string;
+  configRawOriginal: string;
   configValid: boolean | null;
   configIssues: unknown[];
   configSaving: boolean;
@@ -84,6 +85,7 @@ export type AppViewState = {
   configSchemaLoading: boolean;
   configUiHints: Record<string, unknown>;
   configForm: Record<string, unknown> | null;
+  configFormOriginal: Record<string, unknown> | null;
   configFormMode: "form" | "raw";
   channelsLoading: boolean;
   channelsSnapshot: ChannelsStatusSnapshot | null;

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -68,6 +68,34 @@ describe("config view", () => {
     expect(saveButton?.disabled).toBe(true);
   });
 
+  it("disables save and apply when raw is unchanged", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfig({
+        ...baseProps(),
+        formMode: "raw",
+        raw: "{\n}\n",
+        originalRaw: "{\n}\n",
+      }),
+      container,
+    );
+
+    const saveButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((btn) => btn.textContent?.trim() === "Save") as
+      | HTMLButtonElement
+      | undefined;
+    const applyButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((btn) => btn.textContent?.trim() === "Apply") as
+      | HTMLButtonElement
+      | undefined;
+    expect(saveButton).not.toBeUndefined();
+    expect(applyButton).not.toBeUndefined();
+    expect(saveButton?.disabled).toBe(true);
+    expect(applyButton?.disabled).toBe(true);
+  });
+
   it("switches mode via the sidebar toggle", () => {
     const container = document.createElement("div");
     const onFormModeChange = vi.fn();


### PR DESCRIPTION
## Summary
- add follow-up fixes for config.patch: restart/sentinel test + tool hash refactor + UI state typing
- document config.patch restart/wake params
- cover raw-mode save/apply gating in UI

## Testing
- pnpm lint
- pnpm build
- pnpm test
