### PR TITLE
Added support for trusted proxies when running behind your own SSL termination (e.g. traefik, nginx proxy manager, etc.)

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -218,4 +218,6 @@ export type GatewayConfig = {
   tls?: GatewayTlsConfig;
   http?: GatewayHttpConfig;
   nodes?: GatewayNodesConfig;
+  /** IP addresses of trusted reverse proxies (e.g. Traefik, nginx). Requests from these IPs are treated as local for pairing auto-approval. */
+  trustedProxies?: string[];
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -315,6 +315,7 @@ export const ClawdbotSchema = z
           })
           .strict()
           .optional(),
+        trustedProxies: z.array(z.string()).optional(),
         auth: z
           .object({
             mode: z.union([z.literal("token"), z.literal("password")]).optional(),


### PR DESCRIPTION
I needed this since I already have a home server managed with terraform and ansible and run Traefik in front of everything. Thanks!