### PR TITLE
Docs: add Railway deployment guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -780,6 +780,18 @@
     {
       "source": "/plugins",
       "destination": "/plugin"
+    },
+    {
+      "source": "/railway/",
+      "destination": "/railway"
+    },
+    {
+      "source": "/install/railway",
+      "destination": "/railway"
+    },
+    {
+      "source": "/install/railway/",
+      "destination": "/railway"
     }
   ],
   "navigation": {
@@ -818,6 +830,7 @@
           "install/ansible",
           "install/nix",
           "install/docker",
+          "railway",
           "install/bun"
         ]
       },

--- a/docs/railway.mdx
+++ b/docs/railway.mdx
@@ -8,10 +8,16 @@ Deploy Clawdbot on Railway with a one-click template and finish setup in your br
 
 <a href="https://railway.com/deploy/clawdbot-railway-template" target="_blank" rel="noreferrer">Deploy on Railway</a>
 
-After deploy, open:
+After deploy, find your public URL in **Railway → your service → Settings → Domains**.
 
-- `https://<your-domain>/setup` — setup wizard (password protected)
-- `https://<your-domain>/clawdbot` — Control UI
+Railway will either:
+- give you a generated domain (often `https://<something>.up.railway.app`), or
+- use your custom domain if you attached one.
+
+Then open:
+
+- `https://<your-railway-domain>/setup` — setup wizard (password protected)
+- `https://<your-railway-domain>/clawdbot` — Control UI
 
 ## What you get
 
@@ -45,7 +51,7 @@ Set these variables on the service:
 
 ## Setup flow
 
-1) Visit `https://<your-domain>/setup` and enter your `SETUP_PASSWORD`.
+1) Visit `https://<your-railway-domain>/setup` and enter your `SETUP_PASSWORD`.
 2) Choose a model/auth provider and paste your key.
 3) (Optional) Add Telegram/Discord/Slack tokens.
 4) Click **Run setup**.
@@ -73,6 +79,6 @@ If Telegram DMs are set to pairing, the setup wizard can approve the pairing cod
 
 Download a backup at:
 
-- `https://<your-domain>/setup/export`
+- `https://<your-railway-domain>/setup/export`
 
 This exports your Clawdbot state + workspace so you can migrate to another host without losing config or memory.

--- a/docs/railway.mdx
+++ b/docs/railway.mdx
@@ -1,0 +1,78 @@
+---
+title: Deploy on Railway
+---
+
+Deploy Clawdbot on Railway with a one-click template and finish setup in your browser.
+
+## One-click deploy
+
+<a href="https://railway.com/deploy/clawdbot-railway-template" target="_blank" rel="noreferrer">Deploy on Railway</a>
+
+After deploy, open:
+
+- `https://<your-domain>/setup` — setup wizard (password protected)
+- `https://<your-domain>/clawdbot` — Control UI
+
+## What you get
+
+- Hosted Clawdbot Gateway + Control UI
+- Web setup wizard at `/setup` (no terminal commands)
+- Persistent storage via Railway Volume (`/data`) so config/credentials/workspace survive redeploys
+- Backup export at `/setup/export` to migrate off Railway later
+
+## Required Railway settings
+
+### Public Networking
+
+Enable **HTTP Proxy** for the service.
+
+- Port: `8080`
+
+### Volume (required)
+
+Attach a volume mounted at:
+
+- `/data`
+
+### Variables
+
+Set these variables on the service:
+
+- `SETUP_PASSWORD` (required)
+- `CLAWDBOT_STATE_DIR=/data/.clawdbot` (recommended)
+- `CLAWDBOT_WORKSPACE_DIR=/data/workspace` (recommended)
+- `CLAWDBOT_GATEWAY_TOKEN` (recommended; treat as an admin secret)
+
+## Setup flow
+
+1) Visit `https://<your-domain>/setup` and enter your `SETUP_PASSWORD`.
+2) Choose a model/auth provider and paste your key.
+3) (Optional) Add Telegram/Discord/Slack tokens.
+4) Click **Run setup**.
+
+If Telegram DMs are set to pairing, the setup wizard can approve the pairing code.
+
+## Getting chat tokens
+
+### Telegram bot token
+
+1) Message `@BotFather` in Telegram
+2) Run `/newbot`
+3) Copy the token (looks like `123456789:AA...`)
+4) Paste it into `/setup`
+
+### Discord bot token
+
+1) Go to https://discord.com/developers/applications
+2) **New Application** → choose a name
+3) **Bot** → **Add Bot**
+4) Copy the **Bot Token** and paste into `/setup`
+5) Invite the bot to your server (OAuth2 URL Generator; scopes: `bot`, `applications.commands`)
+
+## Backups & migration
+
+Download a backup at:
+
+- `https://<your-domain>/setup/export`
+
+This exports your Clawdbot state + workspace so you can migrate to another host without losing config or memory.


### PR DESCRIPTION
Adds a Railway deployment guide at `/railway`.

- New page: `docs/railway.mdx`
- Docs nav: adds `railway` under “Install & Updates”
- Redirects: `/install/railway` → `/railway` and `/railway/` → `/railway`

Once merged, this should appear at:
https://docs.clawd.bot/railway
