### PR TITLE
Docs: fix /railway redirect loop

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -782,10 +782,6 @@
       "destination": "/plugin"
     },
     {
-      "source": "/railway/",
-      "destination": "/railway"
-    },
-    {
       "source": "/install/railway",
       "destination": "/railway"
     },


### PR DESCRIPTION
Fixes an infinite redirect loop on https://docs.clawd.bot/railway.

Mintlify appears to canonicalize `/railway` ↔ `/railway/`. Our explicit redirect `/railway/` → `/railway` caused `ERR_TOO_MANY_REDIRECTS`.

This PR removes that redirect and keeps the install alias redirects.
