### PR TITLE
fix(ui): improve config save UX

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -134,7 +134,10 @@ export function connectGateway(host: GatewayHost) {
     },
     onClose: ({ code, reason }) => {
       host.connected = false;
-      host.lastError = `disconnected (${code}): ${reason || "no reason"}`;
+      // Code 1012 = Service Restart (expected during config saves, don't show as error)
+      if (code !== 1012) {
+        host.lastError = `disconnected (${code}): ${reason || "no reason"}`;
+      }
     },
     onEvent: (evt) => handleGatewayEvent(host, evt),
     onGap: ({ expected, received }) => {

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -234,8 +234,9 @@ export function renderConfig(props: ConfigProps) {
   const hasChanges = props.formMode === "form" ? diff.length > 0 : hasRawChanges;
 
   // Save/apply buttons require actual changes to be enabled
+  // Note: formUnsafe warns about unsupported schema paths but shouldn't block saving
   const canSaveForm =
-    Boolean(props.formValue) && !props.loading && !formUnsafe;
+    Boolean(props.formValue) && !props.loading;
   const canSave =
     props.connected &&
     !props.saving &&


### PR DESCRIPTION
## Summary

Follow-up improvements to #1609 (main fix already merged):

1. **Remove `formUnsafe` blocker** - The previous check blocked saving even for valid configs when the schema had unsupported paths. This is a warning, not an error, and shouldn't prevent saves.

2. **Suppress disconnect error for code 1012** - During config saves, the gateway restarts (WebSocket code 1012 = Service Restart). The red "disconnected" flash was confusing since the save actually succeeded.

## Test plan

- [x] Edit config with unsupported schema paths → save button enables
- [x] Save config → no red flash error, smooth UX
- [x] Gateway reconnects automatically after save

🤖 Generated with [Claude Code](https://claude.ai/code)