### PR TITLE
feat: add context usage warnings at 75% and 90% thresholds

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -506,11 +506,10 @@ export async function agentCommand(
       contextWarningMessage = storeResult.contextWarning.message;
     }
 
-    // Append context warning to payloads if present
-    const payloads = result.payloads ?? [];
-    if (contextWarningMessage) {
-      payloads.push({ text: `\n\n---\n${contextWarningMessage}` });
-    }
+    // Append context warning to payloads if present (copy to avoid mutating result)
+    const payloads = contextWarningMessage
+      ? [...(result.payloads ?? []), { text: `\n\n---\n${contextWarningMessage}` }]
+      : (result.payloads ?? []);
     return await deliverAgentCommandResult({
       cfg,
       deps,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -488,8 +488,9 @@ export async function agentCommand(
     }
 
     // Update token+model fields in the session store.
+    let contextWarningMessage: string | null = null;
     if (sessionStore && sessionKey) {
-      await updateSessionStoreAfterAgentRun({
+      const storeResult = await updateSessionStoreAfterAgentRun({
         cfg,
         contextTokensOverride: agentCfg?.contextTokens,
         sessionId,
@@ -502,9 +503,14 @@ export async function agentCommand(
         fallbackModel,
         result,
       });
+      contextWarningMessage = storeResult.contextWarning.message;
     }
 
+    // Append context warning to payloads if present
     const payloads = result.payloads ?? [];
+    if (contextWarningMessage) {
+      payloads.push({ text: `\n\n---\n${contextWarningMessage}` });
+    }
     return await deliverAgentCommandResult({
       cfg,
       deps,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -506,10 +506,11 @@ export async function agentCommand(
       contextWarningMessage = storeResult.contextWarning.message;
     }
 
-    // Append context warning to payloads if present (copy to avoid mutating result)
-    const payloads = contextWarningMessage
-      ? [...(result.payloads ?? []), { text: `\n\n---\n${contextWarningMessage}` }]
-      : (result.payloads ?? []);
+    // Copy payloads to avoid mutating result
+    const payloads = [...(result.payloads ?? [])];
+    if (contextWarningMessage) {
+      payloads.push({ text: `\n\n---\n${contextWarningMessage}` });
+    }
     return await deliverAgentCommandResult({
       cfg,
       deps,

--- a/src/commands/agent/context-warnings.test.ts
+++ b/src/commands/agent/context-warnings.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkContextWarning,
+  DEFAULT_CONTEXT_WARNING_THRESHOLD_SOFT,
+  DEFAULT_CONTEXT_WARNING_THRESHOLD_URGENT,
+  formatContextWarning,
+} from "./context-warnings.js";
+
+describe("context-warnings", () => {
+  describe("checkContextWarning", () => {
+    it("returns none when below soft threshold", () => {
+      const result = checkContextWarning({
+        totalTokens: 7000,
+        contextTokens: 10000,
+      });
+      expect(result.level).toBe("none");
+      expect(result.percentUsed).toBe(70);
+      expect(result.message).toBeNull();
+    });
+
+    it("returns soft warning at 75%", () => {
+      const result = checkContextWarning({
+        totalTokens: 7500,
+        contextTokens: 10000,
+      });
+      expect(result.level).toBe("soft");
+      expect(result.percentUsed).toBe(75);
+      expect(result.message).toContain("75%");
+      expect(result.message).toContain("/compact");
+    });
+
+    it("returns urgent warning at 90%", () => {
+      const result = checkContextWarning({
+        totalTokens: 9000,
+        contextTokens: 10000,
+      });
+      expect(result.level).toBe("urgent");
+      expect(result.percentUsed).toBe(90);
+      expect(result.message).toContain("90%");
+      expect(result.message).toContain("auto-compact");
+    });
+
+    it("does not repeat warning at same level", () => {
+      const result = checkContextWarning({
+        totalTokens: 7800,
+        contextTokens: 10000,
+        previousWarningLevel: "soft",
+      });
+      expect(result.level).toBe("soft");
+      expect(result.message).toBeNull(); // No message because already warned
+    });
+
+    it("shows warning when escalating from soft to urgent", () => {
+      const result = checkContextWarning({
+        totalTokens: 9500,
+        contextTokens: 10000,
+        previousWarningLevel: "soft",
+      });
+      expect(result.level).toBe("urgent");
+      expect(result.message).not.toBeNull();
+    });
+
+    it("returns none when totalTokens is undefined", () => {
+      const result = checkContextWarning({
+        totalTokens: undefined,
+        contextTokens: 10000,
+      });
+      expect(result.level).toBe("none");
+      expect(result.percentUsed).toBe(0);
+    });
+
+    it("returns none when contextTokens is undefined", () => {
+      const result = checkContextWarning({
+        totalTokens: 5000,
+        contextTokens: undefined,
+      });
+      expect(result.level).toBe("none");
+    });
+
+    it("returns none when contextTokens is zero", () => {
+      const result = checkContextWarning({
+        totalTokens: 5000,
+        contextTokens: 0,
+      });
+      expect(result.level).toBe("none");
+    });
+
+    it("respects custom thresholds", () => {
+      const result = checkContextWarning({
+        totalTokens: 6000,
+        contextTokens: 10000,
+        thresholds: { soft: 60, urgent: 80 },
+      });
+      expect(result.level).toBe("soft");
+      expect(result.percentUsed).toBe(60);
+    });
+
+    it("shows warning again after level resets to none", () => {
+      // User was at 95%, got urgent warning
+      // Then compacted to 40%, level reset to none
+      // Now at 76%, should show soft warning again
+      const result = checkContextWarning({
+        totalTokens: 7600,
+        contextTokens: 10000,
+        previousWarningLevel: "none",
+      });
+      expect(result.level).toBe("soft");
+      expect(result.message).not.toBeNull();
+    });
+  });
+
+  describe("formatContextWarning", () => {
+    it("formats soft warning correctly", () => {
+      const msg = formatContextWarning("soft", 77);
+      expect(msg).toContain("77%");
+      expect(msg).toContain("📊");
+      expect(msg).toContain("/compact");
+      expect(msg).toContain("/new");
+    });
+
+    it("formats urgent warning correctly", () => {
+      const msg = formatContextWarning("urgent", 92);
+      expect(msg).toContain("92%");
+      expect(msg).toContain("⚠️");
+      expect(msg).toContain("auto-compact");
+    });
+
+    it("returns empty string for none", () => {
+      const msg = formatContextWarning("none", 50);
+      expect(msg).toBe("");
+    });
+  });
+
+  describe("default thresholds", () => {
+    it("has correct default values", () => {
+      expect(DEFAULT_CONTEXT_WARNING_THRESHOLD_SOFT).toBe(75);
+      expect(DEFAULT_CONTEXT_WARNING_THRESHOLD_URGENT).toBe(90);
+    });
+  });
+});

--- a/src/commands/agent/context-warnings.ts
+++ b/src/commands/agent/context-warnings.ts
@@ -1,0 +1,102 @@
+/**
+ * Context usage warnings - alerts users when approaching context limits.
+ *
+ * Thresholds:
+ * - 75%: Soft warning - "consider managing context soon"
+ * - 90%: Urgent warning - "compact now or system will auto-compact"
+ */
+
+import type { SessionEntry } from "../../config/sessions.js";
+
+export const CONTEXT_WARNING_THRESHOLD_SOFT = 75;
+export const CONTEXT_WARNING_THRESHOLD_URGENT = 90;
+
+export type ContextWarningLevel = "none" | "soft" | "urgent";
+
+export interface ContextWarningResult {
+  level: ContextWarningLevel;
+  percentUsed: number;
+  message: string | null;
+}
+
+/**
+ * Check if a context usage warning should be shown.
+ * Returns the warning level and message if applicable.
+ */
+export function checkContextWarning(params: {
+  totalTokens: number | undefined;
+  contextTokens: number | undefined;
+  previousWarningLevel?: ContextWarningLevel;
+}): ContextWarningResult {
+  const { totalTokens, contextTokens, previousWarningLevel } = params;
+
+  if (!totalTokens || !contextTokens || contextTokens <= 0) {
+    return { level: "none", percentUsed: 0, message: null };
+  }
+
+  const percentUsed = Math.round((totalTokens / contextTokens) * 100);
+
+  // Determine current warning level
+  let level: ContextWarningLevel = "none";
+  if (percentUsed >= CONTEXT_WARNING_THRESHOLD_URGENT) {
+    level = "urgent";
+  } else if (percentUsed >= CONTEXT_WARNING_THRESHOLD_SOFT) {
+    level = "soft";
+  }
+
+  // Only show warning if we've crossed into a new threshold
+  // (avoid spamming the same warning on every message)
+  if (level === "none") {
+    return { level: "none", percentUsed, message: null };
+  }
+
+  // If we're at the same level as before, don't repeat the warning
+  if (previousWarningLevel === level) {
+    return { level, percentUsed, message: null };
+  }
+
+  // Generate appropriate warning message
+  const message = formatContextWarning(level, percentUsed);
+  return { level, percentUsed, message };
+}
+
+/**
+ * Format the warning message based on level.
+ */
+export function formatContextWarning(level: ContextWarningLevel, percentUsed: number): string {
+  switch (level) {
+    case "soft":
+      return `📊 **${percentUsed}% context used** — consider \`/compact\` or \`/new\` soon`;
+    case "urgent":
+      return `⚠️ **${percentUsed}% context used** — use \`/compact\` now or system will auto-compact at limit`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Get the warning level to store in the session entry.
+ */
+export function getWarningLevelFromSession(entry: SessionEntry | undefined): ContextWarningLevel {
+  const stored = entry?.contextWarningLevel;
+  if (stored === "soft" || stored === "urgent") return stored;
+  return "none";
+}
+
+/**
+ * Check if we should append a context warning to the response.
+ */
+export function shouldShowContextWarning(params: {
+  entry: SessionEntry | undefined;
+  totalTokens: number | undefined;
+  contextTokens: number | undefined;
+}): ContextWarningResult {
+  const { entry, totalTokens, contextTokens } = params;
+  const previousLevel = getWarningLevelFromSession(entry);
+
+  return checkContextWarning({
+    totalTokens,
+    contextTokens,
+    previousWarningLevel: previousLevel,
+  });
+}

--- a/src/commands/agent/context-warnings.ts
+++ b/src/commands/agent/context-warnings.ts
@@ -41,17 +41,24 @@ export function checkContextWarning(params: {
     urgent: DEFAULT_CONTEXT_WARNING_THRESHOLD_URGENT,
   };
 
-  if (!totalTokens || !contextTokens || contextTokens <= 0) {
+  // Ensure thresholds are valid (urgent must be >= soft)
+  const validatedThresholds = {
+    soft: Math.min(thresholds.soft, thresholds.urgent),
+    urgent: Math.max(thresholds.soft, thresholds.urgent),
+  };
+
+  if (totalTokens === undefined || !contextTokens || contextTokens <= 0) {
     return { level: "none", percentUsed: 0, message: null };
   }
 
-  const percentUsed = Math.round((totalTokens / contextTokens) * 100);
+  // Cap at 100% to avoid confusing messages like "105% context used"
+  const percentUsed = Math.min(100, Math.round((totalTokens / contextTokens) * 100));
 
   // Determine current warning level
   let level: ContextWarningLevel = "none";
-  if (percentUsed >= thresholds.urgent) {
+  if (percentUsed >= validatedThresholds.urgent) {
     level = "urgent";
-  } else if (percentUsed >= thresholds.soft) {
+  } else if (percentUsed >= validatedThresholds.soft) {
     level = "soft";
   }
 

--- a/src/commands/agent/session-store.context-warnings.test.ts
+++ b/src/commands/agent/session-store.context-warnings.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ClawdbotConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { updateSessionStoreAfterAgentRun } from "./session-store.js";
+
+describe("session-store context warnings integration", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "session-store-test-"));
+    storePath = join(tmpDir, "sessions.json");
+    await writeFile(storePath, "{}");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const baseCfg = {} as ClawdbotConfig;
+  const baseResult = {
+    payloads: [],
+    meta: {
+      agentMeta: {
+        usage: { input: 7500, output: 100 },
+        model: "test-model",
+        provider: "openai",
+      },
+    },
+  };
+
+  it("returns soft warning when crossing 75% threshold", async () => {
+    const sessionStore: Record<string, SessionEntry> = {};
+
+    const result = await updateSessionStoreAfterAgentRun({
+      cfg: baseCfg,
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      storePath,
+      sessionStore,
+      defaultProvider: "openai",
+      defaultModel: "test-model",
+      contextTokensOverride: 10000,
+      result: baseResult as any,
+    });
+
+    expect(result.contextWarning.level).toBe("soft");
+    expect(result.contextWarning.message).toContain("75%");
+    expect(result.contextWarning.message).toContain("/compact");
+  });
+
+  it("returns urgent warning when crossing 90% threshold", async () => {
+    const sessionStore: Record<string, SessionEntry> = {};
+    const urgentResult = {
+      ...baseResult,
+      meta: {
+        agentMeta: {
+          usage: { input: 9200, output: 100 },
+          model: "test-model",
+          provider: "openai",
+        },
+      },
+    };
+
+    const result = await updateSessionStoreAfterAgentRun({
+      cfg: baseCfg,
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      storePath,
+      sessionStore,
+      defaultProvider: "openai",
+      defaultModel: "test-model",
+      contextTokensOverride: 10000,
+      result: urgentResult as any,
+    });
+
+    expect(result.contextWarning.level).toBe("urgent");
+    expect(result.contextWarning.message).toContain("92%");
+    expect(result.contextWarning.message).toContain("auto-compact");
+  });
+
+  it("does not repeat warning at same level", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      "test-key": {
+        sessionId: "test-session",
+        updatedAt: Date.now(),
+        contextWarningLevel: "soft",
+      },
+    };
+
+    const result = await updateSessionStoreAfterAgentRun({
+      cfg: baseCfg,
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      storePath,
+      sessionStore,
+      defaultProvider: "openai",
+      defaultModel: "test-model",
+      contextTokensOverride: 10000,
+      result: baseResult as any,
+    });
+
+    expect(result.contextWarning.level).toBe("soft");
+    expect(result.contextWarning.message).toBeNull(); // No repeat
+  });
+
+  it("escalates from soft to urgent with new message", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      "test-key": {
+        sessionId: "test-session",
+        updatedAt: Date.now(),
+        contextWarningLevel: "soft",
+      },
+    };
+    const urgentResult = {
+      ...baseResult,
+      meta: {
+        agentMeta: {
+          usage: { input: 9500, output: 100 },
+          model: "test-model",
+          provider: "openai",
+        },
+      },
+    };
+
+    const result = await updateSessionStoreAfterAgentRun({
+      cfg: baseCfg,
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      storePath,
+      sessionStore,
+      defaultProvider: "openai",
+      defaultModel: "test-model",
+      contextTokensOverride: 10000,
+      result: urgentResult as any,
+    });
+
+    expect(result.contextWarning.level).toBe("urgent");
+    expect(result.contextWarning.message).not.toBeNull();
+  });
+
+  it("persists warning level to session store", async () => {
+    const sessionStore: Record<string, SessionEntry> = {};
+
+    await updateSessionStoreAfterAgentRun({
+      cfg: baseCfg,
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      storePath,
+      sessionStore,
+      defaultProvider: "openai",
+      defaultModel: "test-model",
+      contextTokensOverride: 10000,
+      result: baseResult as any,
+    });
+
+    expect(sessionStore["test-key"]?.contextWarningLevel).toBe("soft");
+  });
+});

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import type { Skill } from "@mariozechner/pi-coding-agent";
 import type { NormalizedChatType } from "../../channels/chat-type.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
+import type { ContextWarningLevel } from "../../commands/agent/context-warnings.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 
 export type SessionScope = "per-sender" | "global";
@@ -74,7 +75,7 @@ export type SessionEntry = {
   contextTokens?: number;
   compactionCount?: number;
   /** Last context warning level shown to prevent duplicate warnings. */
-  contextWarningLevel?: "none" | "soft" | "urgent";
+  contextWarningLevel?: ContextWarningLevel;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   cliSessionIds?: Record<string, string>;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -73,6 +73,8 @@ export type SessionEntry = {
   model?: string;
   contextTokens?: number;
   compactionCount?: number;
+  /** Last context warning level shown to prevent duplicate warnings. */
+  contextWarningLevel?: "none" | "soft" | "urgent";
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   cliSessionIds?: Record<string, string>;


### PR DESCRIPTION
## Summary

Adds progressive context usage warnings to help users proactively manage their session context before hitting the limit.

### Thresholds

| Usage | Warning |
|-------|---------|
| 75% | 📊 **75% context used** — consider `/compact` or `/new` soon |
| 90% | ⚠️ **90% context used** — use `/compact` now or system will auto-compact at limit |

### Implementation

- New `context-warnings.ts` module with threshold checking logic
- Warnings only shown once per threshold crossing (no spam on every message)
- Warning level stored in `SessionEntry.contextWarningLevel` to track state
- Warning appended as footer to agent response when triggered

### Changes

- `src/commands/agent/context-warnings.ts` - New module with warning logic
- `src/commands/agent/session-store.ts` - Returns warning result after session update
- `src/commands/agent.ts` - Appends warning to response payloads
- `src/config/sessions/types.ts` - Added `contextWarningLevel` field

### Test plan

- `pnpm build` passes ✅
- `pnpm lint` passes ✅
- `pnpm test` - 4200 passed (8 failures are pre-existing memory/vector tests unrelated to this change)

### Why

Users often don't realize their context is filling up until auto-compaction kicks in unexpectedly. This gives them a heads up and the opportunity to manually compact or start a new session.

---

🤖 Generated with [Claude Code](https://claude.ai/code)