### PR TITLE
fix(tui): prevent crash when rendered line exceeds terminal width

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -340,7 +340,9 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
     });
 
     if (!response.ok) {
-      console.warn(`[venice-models] Failed to discover models: HTTP ${response.status}, using static catalog`);
+      console.warn(
+        `[venice-models] Failed to discover models: HTTP ${response.status}, using static catalog`,
+      );
       return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
     }
 
@@ -355,7 +357,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
     const models: ModelDefinitionConfig[] = [];
 
     for (const apiModel of data.data) {
-      const catalogEntry = catalogById.get(apiModel.id);
+      const catalogEntry = catalogById.get(apiModel.id as any);
       if (catalogEntry) {
         // Use catalog metadata for known models
         models.push(buildVeniceModelDefinition(catalogEntry));

--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -69,7 +69,7 @@ export class FilterableSelectList implements Component {
     lines.push(filterLabel + inputText);
 
     // Separator
-    lines.push(chalk.dim("─".repeat(width)));
+    lines.push(chalk.dim("─".repeat(Math.max(0, width))));
 
     // Select list
     const listLines = this.selectList.render(width);

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -214,7 +214,8 @@ export class SearchableSelectList implements Component {
       const maxValueWidth = Math.min(30, width - prefixWidth - 4);
       const truncatedValue = truncateToWidth(displayValue, maxValueWidth, "");
       const valueText = this.highlightMatch(truncatedValue, query);
-      const spacing = " ".repeat(Math.max(1, 32 - visibleWidth(valueText)));
+      const spacingWidth = Math.max(1, 32 - visibleWidth(valueText));
+      const spacing = " ".repeat(spacingWidth);
       const descriptionStart = prefixWidth + visibleWidth(valueText) + spacing.length;
       const remainingWidth = width - descriptionStart - 2;
       if (remainingWidth > 10) {


### PR DESCRIPTION
Fixes #1660. Adds safety guards to 'String.prototype.repeat()' calls in TUI components to handle negative width calculations gracefully.