### PR TITLE
fix: add duplex: half for Node.js 22+ fetch compatibility

### DIFF
--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -2,18 +2,30 @@ type FetchWithPreconnect = typeof fetch & {
   preconnect: (url: string, init?: { credentials?: RequestCredentials }) => void;
 };
 
+/**
+ * Patch RequestInit for Node.js 22+ compatibility.
+ * Node.js 22 requires `duplex: 'half'` when sending a body with fetch.
+ */
+function patchInitForNodejs22(init?: RequestInit): RequestInit | undefined {
+  if (!init?.body) return init;
+  const initRecord = init as Record<string, unknown>;
+  if ("duplex" in initRecord) return init;
+  return { ...init, duplex: "half" } as RequestInit;
+}
+
 export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch {
   const wrapped = ((input: RequestInfo | URL, init?: RequestInit) => {
-    const signal = init?.signal;
-    if (!signal) return fetchImpl(input, init);
+    const patchedInit = patchInitForNodejs22(init);
+    const signal = patchedInit?.signal;
+    if (!signal) return fetchImpl(input, patchedInit);
     if (typeof AbortSignal !== "undefined" && signal instanceof AbortSignal) {
-      return fetchImpl(input, init);
+      return fetchImpl(input, patchedInit);
     }
     if (typeof AbortController === "undefined") {
-      return fetchImpl(input, init);
+      return fetchImpl(input, patchedInit);
     }
     if (typeof signal.addEventListener !== "function") {
-      return fetchImpl(input, init);
+      return fetchImpl(input, patchedInit);
     }
     const controller = new AbortController();
     const onAbort = () => controller.abort();
@@ -22,7 +34,7 @@ export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch 
     } else {
       signal.addEventListener("abort", onAbort, { once: true });
     }
-    const response = fetchImpl(input, { ...init, signal: controller.signal });
+    const response = fetchImpl(input, { ...patchedInit, signal: controller.signal });
     if (typeof signal.removeEventListener === "function") {
       void response.finally(() => {
         signal.removeEventListener("abort", onAbort);


### PR DESCRIPTION
## Summary

Fixes #1684

Node.js 22 requires `duplex: 'half'` to be set on fetch `RequestInit` when sending a body. This fixes image/file uploads via Telegram (and other channels) that were failing with:

```
TypeError: RequestInit: duplex option is required when sending a body.
```

## Changes

- Add `patchInitForNodejs22()` helper function in `src/infra/fetch.ts`
- Apply the patch in `wrapFetchWithAbortSignal()` to inject `duplex: 'half'` for requests with a body
- Preserve any existing `duplex` value if already set
- Add tests for the new behavior

## Test Plan

- [x] Added unit tests for the duplex patching logic
- [x] TypeScript compiles without errors
- [ ] Manual testing on Node.js 22 with Telegram image uploads (requires environment setup)

---
🤖 Generated with Claude Code