### PR TITLE
chore: add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,package-lock.json,vendor,*-lock.yaml,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,7 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,package-lock.json,vendor,*-lock.yaml,*.css,.codespellrc
+skip = .git*,*.svg,package-lock.json,vendor,*-lock.yaml,*.css,.codespellrc,dist,*.caf,*/a2ui/*,.cache,*.prose,.npm
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+# Ignore camelCase and PascalCase identifiers (common in code)
+ignore-regex = \b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
+ignore-words-list = inout,rouge,statics,caf,afterall,cript,fro,nd,ot,fo

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ USER.md
 
 # local tooling
 .serena/
+.npm/

--- a/docs/token-use.md
+++ b/docs/token-use.md
@@ -69,7 +69,7 @@ never show dollar cost.
 
 Provider prompt caching only applies within the cache TTL window. Clawdbot can
 optionally run **cache-ttl pruning**: it prunes the session once the cache TTL
-has expired, then resets the cache window so subsequent requests can re-use the
+has expired, then resets the cache window so subsequent requests can reuse the
 freshly cached context instead of re-caching the full history. This keeps cache
 write costs lower when a session goes idle past the TTL.
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -517,7 +517,7 @@ Notes:
   - Role snapshot options (`--interactive`, `--compact`, `--depth`, `--selector`) force a role-based snapshot with refs like `ref=e12`.
   - `--frame "<iframe selector>"` scopes role snapshots to an iframe (pairs with role refs like `e12`).
   - `--interactive` outputs a flat, easy-to-pick list of interactive elements (best for driving actions).
-  - `--labels` adds a viewport-only screenshot with overlayed ref labels (prints `MEDIA:<path>`).
+  - `--labels` adds a viewport-only screenshot with overlaid ref labels (prints `MEDIA:<path>`).
 - `click`/`type`/etc require a `ref` from `snapshot` (either numeric `12` or role ref `e12`).
   CSS selectors are intentionally not supported for actions.
 
@@ -534,7 +534,7 @@ Clawdbot supports two “snapshot” styles:
   - Output: a role-based list/tree with `[ref=e12]` (and optional `[nth=1]`).
   - Actions: `clawdbot browser click e12`, `clawdbot browser highlight e12`.
   - Internally, the ref is resolved via `getByRole(...)` (plus `nth()` for duplicates).
-  - Add `--labels` to include a viewport screenshot with overlayed `e12` labels.
+  - Add `--labels` to include a viewport screenshot with overlaid `e12` labels.
 
 Ref behavior:
 - Refs are **not stable across navigations**; if something fails, re-run `snapshot` and use a fresh ref.

--- a/extensions/open-prose/skills/prose/guidance/antipatterns.md
+++ b/extensions/open-prose/skills/prose/guidance/antipatterns.md
@@ -568,7 +568,7 @@ session "You are a helpful assistant. Analyze this code for bugs."
 # ... later ...
 session "You are a helpful assistant. Analyze this code for bugs."
 # ... even later ...
-session "You are a helpful assistent. Analyze this code for bugs."  # Typo!
+session "You are a helpful assistant. Analyze this code for bugs."  # Typo!
 ```
 
 **Why it's bad**: Inconsistency when updating. Typos go unnoticed.

--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -115,9 +115,9 @@ describe("extractModelDirective", () => {
 
   describe("edge cases", () => {
     it("absorbs path-like segments when /model includes extra slashes", () => {
-      const result = extractModelDirective("thats not /model gpt-5/tmp/hello");
+      const result = extractModelDirective("that's not /model gpt-5/tmp/hello");
       expect(result.hasDirective).toBe(true);
-      expect(result.cleaned).toBe("thats not");
+      expect(result.cleaned).toBe("that's not");
     });
 
     it("handles alias with special regex characters", () => {

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -152,33 +152,33 @@ describe("directive parsing", () => {
   });
 
   it("preserves spacing when stripping think directives before paths", () => {
-    const res = extractThinkDirective("thats not /think high/tmp/hello");
+    const res = extractThinkDirective("that's not /think high/tmp/hello");
     expect(res.hasDirective).toBe(true);
-    expect(res.cleaned).toBe("thats not /tmp/hello");
+    expect(res.cleaned).toBe("that's not /tmp/hello");
   });
 
   it("preserves spacing when stripping verbose directives before paths", () => {
-    const res = extractVerboseDirective("thats not /verbose on/tmp/hello");
+    const res = extractVerboseDirective("that's not /verbose on/tmp/hello");
     expect(res.hasDirective).toBe(true);
-    expect(res.cleaned).toBe("thats not /tmp/hello");
+    expect(res.cleaned).toBe("that's not /tmp/hello");
   });
 
   it("preserves spacing when stripping reasoning directives before paths", () => {
-    const res = extractReasoningDirective("thats not /reasoning on/tmp/hello");
+    const res = extractReasoningDirective("that's not /reasoning on/tmp/hello");
     expect(res.hasDirective).toBe(true);
-    expect(res.cleaned).toBe("thats not /tmp/hello");
+    expect(res.cleaned).toBe("that's not /tmp/hello");
   });
 
   it("preserves spacing when stripping status directives before paths", () => {
-    const res = extractStatusDirective("thats not /status:/tmp/hello");
+    const res = extractStatusDirective("that's not /status:/tmp/hello");
     expect(res.hasDirective).toBe(true);
-    expect(res.cleaned).toBe("thats not /tmp/hello");
+    expect(res.cleaned).toBe("that's not /tmp/hello");
   });
 
   it("does not treat /usage as a status directive", () => {
-    const res = extractStatusDirective("thats not /usage:/tmp/hello");
+    const res = extractStatusDirective("that's not /usage:/tmp/hello");
     expect(res.hasDirective).toBe(false);
-    expect(res.cleaned).toBe("thats not /usage:/tmp/hello");
+    expect(res.cleaned).toBe("that's not /usage:/tmp/hello");
   });
 
   it("parses queue options and modes", () => {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -65,7 +65,7 @@ export function resolveSessionKeyForRequest(opts: {
   let sessionKey: string | undefined =
     explicitSessionKey ?? (ctx ? resolveSessionKey(scope, ctx, mainKey) : undefined);
 
-  // If a session id was provided, prefer to re-use its entry (by id) even when no key was derived.
+  // If a session id was provided, prefer to reuse its entry (by id) even when no key was derived.
   if (
     !explicitSessionKey &&
     opts.sessionId &&


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.