### PR TITLE
feat(telegram): add linkPreview config option

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -118,6 +118,8 @@ export type TelegramAccountConfig = {
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Controls whether link previews are shown in outbound messages. Default: true. */
+  linkPreview?: boolean;
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -125,6 +125,7 @@ export const TelegramAccountSchemaBase = z
     reactionNotifications: z.enum(["off", "own", "all"]).optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    linkPreview: z.boolean().optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -151,6 +151,7 @@ export const dispatchTelegramMessage = async ({
           tableMode,
           chunkMode,
           onVoiceRecording: sendRecordVoice,
+          linkPreview: telegramCfg.linkPreview,
         });
       },
       onError: (err, info) => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -348,6 +348,7 @@ export const registerTelegramNativeCommands = ({
                   messageThreadId: resolvedThreadId,
                   tableMode,
                   chunkMode,
+                  linkPreview: telegramCfg.linkPreview,
                 });
               },
               onError: (err, info) => {

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -108,4 +108,60 @@ describe("deliverReplies", () => {
       }),
     );
   });
+
+  it("includes link_preview_options when linkPreview is false", async () => {
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 3,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    await deliverReplies({
+      replies: [{ text: "Check https://example.com" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      linkPreview: false,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.objectContaining({
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+  });
+
+  it("does not include link_preview_options when linkPreview is true", async () => {
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 4,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    await deliverReplies({
+      replies: [{ text: "Check https://example.com" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      linkPreview: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.not.objectContaining({
+        link_preview_options: expect.anything(),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #1675

Adds a `channels.telegram.linkPreview` config option to control whether link previews are shown in outbound messages. Setting it to `false` disables URL previews using Telegram's `link_preview_options.is_disabled` API parameter.

## Changes
- Add `linkPreview?: boolean` to `TelegramAccountConfig` type
- Add Zod schema validation for the new config option
- Pass `link_preview_options` to `sendMessage` API calls when `linkPreview: false`
- Propagate `linkPreview` config through `deliverReplies` and all callers
- Add unit tests for link preview behavior

## Usage
```json
{
  "channels": {
    "telegram": {
      "linkPreview": false
    }
  }
}
```

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Unit tests pass with new test cases for linkPreview behavior
- [ ] Manual testing: verify link previews are suppressed with `linkPreview: false`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)