### PR TITLE
feat(tts): support custom OpenAI-compatible TTS endpoints

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -109,13 +109,13 @@ describe("tts", () => {
   });
 
   describe("isValidOpenAIModel", () => {
-    it("accepts gpt-4o-mini-tts model", () => {
+    it("accepts supported models", () => {
       expect(isValidOpenAIModel("gpt-4o-mini-tts")).toBe(true);
+      expect(isValidOpenAIModel("tts-1")).toBe(true);
+      expect(isValidOpenAIModel("tts-1-hd")).toBe(true);
     });
 
-    it("rejects other models", () => {
-      expect(isValidOpenAIModel("tts-1")).toBe(false);
-      expect(isValidOpenAIModel("tts-1-hd")).toBe(false);
+    it("rejects unsupported models", () => {
       expect(isValidOpenAIModel("invalid")).toBe(false);
       expect(isValidOpenAIModel("")).toBe(false);
       expect(isValidOpenAIModel("gpt-4")).toBe(false);
@@ -123,9 +123,11 @@ describe("tts", () => {
   });
 
   describe("OPENAI_TTS_MODELS", () => {
-    it("contains only gpt-4o-mini-tts", () => {
+    it("contains supported models", () => {
       expect(OPENAI_TTS_MODELS).toContain("gpt-4o-mini-tts");
-      expect(OPENAI_TTS_MODELS).toHaveLength(1);
+      expect(OPENAI_TTS_MODELS).toContain("tts-1");
+      expect(OPENAI_TTS_MODELS).toContain("tts-1-hd");
+      expect(OPENAI_TTS_MODELS).toHaveLength(3);
     });
 
     it("is a non-empty array", () => {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -743,7 +743,9 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  * When set, model/voice validation is relaxed to allow non-OpenAI models.
  * Example: OPENAI_TTS_BASE_URL=http://localhost:8880/v1
  */
-const OPENAI_TTS_BASE_URL = (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(/\/+$/, "");
+const OPENAI_TTS_BASE_URL = (
+  process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1"
+).replace(/\/+$/, "");
 const isCustomOpenAIEndpoint = OPENAI_TTS_BASE_URL !== "https://api.openai.com/v1";
 export const OPENAI_TTS_VOICES = [
   "alloy",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -743,7 +743,7 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  * When set, model/voice validation is relaxed to allow non-OpenAI models.
  * Example: OPENAI_TTS_BASE_URL=http://localhost:8880/v1
  */
-const OPENAI_TTS_BASE_URL = process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1";
+const OPENAI_TTS_BASE_URL = (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(/\/+$/, "");
 const isCustomOpenAIEndpoint = OPENAI_TTS_BASE_URL !== "https://api.openai.com/v1";
 export const OPENAI_TTS_VOICES = [
   "alloy",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -736,7 +736,15 @@ function parseTtsDirectives(
   };
 }
 
-export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts"] as const;
+export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as const;
+
+/**
+ * Custom OpenAI-compatible TTS endpoint.
+ * When set, model/voice validation is relaxed to allow non-OpenAI models.
+ * Example: OPENAI_TTS_BASE_URL=http://localhost:8880/v1
+ */
+const OPENAI_TTS_BASE_URL = process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1";
+const isCustomOpenAIEndpoint = OPENAI_TTS_BASE_URL !== "https://api.openai.com/v1";
 export const OPENAI_TTS_VOICES = [
   "alloy",
   "ash",
@@ -752,10 +760,14 @@ export const OPENAI_TTS_VOICES = [
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
 function isValidOpenAIModel(model: string): boolean {
+  // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
+  if (isCustomOpenAIEndpoint) return true;
   return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
 }
 
 function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
+  // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
+  if (isCustomOpenAIEndpoint) return true;
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
 }
 
@@ -982,7 +994,7 @@ async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/audio/speech", {
+    const response = await fetch(`${OPENAI_TTS_BASE_URL}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
## Problem

Currently, Clawdbot's TTS only works with OpenAI's official API. Users who want to use local/self-hosted TTS services (like Kokoro, OpenedAI-Speech, or other OpenAI-compatible TTS servers) cannot do so.

This is particularly important for:
- **Privacy**: Keep voice data local
- **Cost**: Avoid per-request API fees  
- **Language support**: Use models with better support for non-English languages (Chinese, Japanese, etc.)
- **Latency**: Local inference can be faster for some use cases

## Solution

Add support for custom OpenAI-compatible TTS endpoints via environment variable:

```bash
OPENAI_TTS_BASE_URL=http://localhost:8880/v1
```

## Changes

1. **Add `OPENAI_TTS_BASE_URL` environment variable** - Defaults to OpenAI's official API when not set
2. **Relax model/voice validation** - When using a custom endpoint, allow any model/voice (enables Kokoro Chinese voices, LocalAI models, etc.)
3. **Extend model allowlist** - Added `tts-1` and `tts-1-hd` for completeness

## Example: Kokoro-FastAPI Setup

```bash
# Run Kokoro TTS server
docker run -d --name kokoro-tts -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4

# Configure Clawdbot
echo 'OPENAI_TTS_BASE_URL=http://localhost:8880/v1' >> ~/.clawdbot/.env
```

In `clawdbot.json`:
```json
{
  "messages": {
    "tts": {
      "enabled": true,
      "provider": "openai",
      "openai": {
        "model": "kokoro",
        "voice": "zm_yunxia"
      }
    }
  }
}
```

## Compatibility

- **Backward compatible**: If `OPENAI_TTS_BASE_URL` is not set, defaults to OpenAI's official API
- **Works with**: Kokoro-FastAPI, OpenedAI-Speech, LocalAI, and any OpenAI-compatible TTS server

## Testing

Tested with:
- [x] Kokoro-FastAPI v0.2.4 (Chinese voices: zm_yunxia, zf_xiaoxiao, etc.)

## Related Projects

- [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI)
- [OpenedAI-Speech](https://github.com/matatonic/openedai-speech)
- [LocalAI](https://github.com/mudler/LocalAI)