### PR TITLE
feat: add Rube MCP plugin for 500+ app integrations

### DIFF
--- a/extensions/rube-mcp/clawdbot.plugin.json
+++ b/extensions/rube-mcp/clawdbot.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "rube-mcp",
+  "name": "Rube MCP",
+  "description": "Connect to 500+ apps via Rube MCP - Gmail, Slack, GitHub, and more",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable Rube MCP integration",
+        "default": true
+      },
+      "oauth": {
+        "type": "object",
+        "description": "OAuth credentials (managed by 'clawdbot rube login')",
+        "properties": {
+          "accessToken": { "type": "string" },
+          "refreshToken": { "type": "string" },
+          "expiresAt": { "type": "number" },
+          "clientId": { "type": "string" }
+        },
+        "required": ["accessToken", "expiresAt", "clientId"]
+      },
+      "cachedTools": {
+        "type": "array",
+        "description": "Cached tool definitions (managed by 'clawdbot rube login/refresh')",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "inputSchema": { "type": "object" }
+          },
+          "required": ["name", "inputSchema"]
+        }
+      }
+    }
+  }
+}

--- a/extensions/rube-mcp/index.ts
+++ b/extensions/rube-mcp/index.ts
@@ -1,0 +1,53 @@
+import type { ClawdbotPluginApi } from "../../src/plugins/types.js";
+
+import type { RubeOAuthCredentials } from "./src/auth.js";
+import { wrapCachedMcpTools, type CachedMcpTool } from "./src/tool-wrapper.js";
+import { getStoredCredentials, getCachedTools, saveCredentials, createRubeCommands } from "./src/cli.js";
+
+type RubePluginConfig = {
+  enabled?: boolean;
+  oauth?: RubeOAuthCredentials;
+  cachedTools?: CachedMcpTool[];
+};
+
+export default function register(api: ClawdbotPluginApi) {
+  const config = api.pluginConfig as RubePluginConfig | undefined;
+
+  // Check if plugin is disabled
+  if (config?.enabled === false) {
+    api.logger.debug("Rube MCP plugin disabled via config");
+    return;
+  }
+
+  // Register CLI commands
+  api.registerCli(
+    ({ program }) => {
+      createRubeCommands(program, api);
+    },
+    { commands: ["rube"] },
+  );
+
+  // Get cached tools (synchronous)
+  const cachedTools = getCachedTools(api);
+
+  if (cachedTools.length === 0) {
+    api.logger.debug("Rube MCP: No cached tools. Run 'clawdbot rube login' to authenticate and cache tools.");
+    return;
+  }
+
+  // Register tools from cache (synchronous)
+  const tools = wrapCachedMcpTools(
+    cachedTools,
+    () => getStoredCredentials(api),
+    async (creds) => {
+      await saveCredentials(api, creds);
+    },
+  );
+
+  api.logger.info(`Rube MCP: Loaded ${tools.length} tools from cache`);
+
+  // Register each tool
+  for (const tool of tools) {
+    api.registerTool(tool, { name: tool.name });
+  }
+}

--- a/extensions/rube-mcp/package.json
+++ b/extensions/rube-mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@clawdbot/rube-mcp",
+  "version": "1.0.0",
+  "description": "Rube MCP integration for Clawdbot - connect to 500+ apps",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.3"
+  },
+  "devDependencies": {
+    "clawdbot": "workspace:*",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "clawdbot": "*"
+  }
+}

--- a/extensions/rube-mcp/src/auth.ts
+++ b/extensions/rube-mcp/src/auth.ts
@@ -1,0 +1,303 @@
+import { createHash, randomBytes } from "node:crypto";
+import http from "node:http";
+
+// Rube OAuth endpoints (from .well-known/oauth-authorization-server)
+export const RUBE_ISSUER = "https://login.composio.dev";
+export const RUBE_REGISTRATION_ENDPOINT = "https://rube.app/api/auth/mcp/register";
+export const RUBE_AUTHORIZE_ENDPOINT = "https://rube.app/api/auth/mcp/authorize";
+export const RUBE_TOKEN_ENDPOINT = "https://rube.app/api/auth/mcp/token";
+
+const REDIRECT_PORT = 19876;
+const REDIRECT_URI = `http://127.0.0.1:${REDIRECT_PORT}/callback`;
+const SCOPES = ["email", "offline_access", "openid", "profile"];
+const EXPIRES_BUFFER_MS = 5 * 60 * 1000;
+
+export type RubePkce = { verifier: string; challenge: string };
+
+export type RubeOAuthCredentials = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  clientId: string;
+};
+
+export type RubeDcrResponse = {
+  client_id: string;
+  client_id_issued_at: number;
+  client_name: string;
+};
+
+/**
+ * Generate PKCE code verifier and challenge (S256)
+ */
+export function generatePkce(): RubePkce {
+  const verifier = randomBytes(32).toString("hex");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+/**
+ * Dynamic Client Registration with Rube
+ */
+export async function registerClient(fetchFn = fetch): Promise<string> {
+  const response = await fetchFn(RUBE_REGISTRATION_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: "Clawdbot",
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Rube DCR failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as RubeDcrResponse;
+  if (!data.client_id) {
+    throw new Error("Rube DCR returned no client_id");
+  }
+
+  return data.client_id;
+}
+
+/**
+ * Build the authorization URL for the OAuth flow
+ */
+export function buildAuthorizationUrl(params: {
+  clientId: string;
+  pkce: RubePkce;
+  state: string;
+}): string {
+  const url = new URL(RUBE_AUTHORIZE_ENDPOINT);
+  url.searchParams.set("client_id", params.clientId);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", SCOPES.join(" "));
+  url.searchParams.set("state", params.state);
+  url.searchParams.set("code_challenge", params.pkce.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url.toString();
+}
+
+/**
+ * Exchange authorization code for tokens
+ */
+export async function exchangeCodeForTokens(params: {
+  clientId: string;
+  code: string;
+  codeVerifier: string;
+  fetchFn?: typeof fetch;
+  now?: number;
+}): Promise<RubeOAuthCredentials> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const now = params.now ?? Date.now();
+
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: params.clientId,
+    code: params.code,
+    redirect_uri: REDIRECT_URI,
+    code_verifier: params.codeVerifier,
+  });
+
+  const response = await fetchFn(RUBE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Rube token exchange failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+
+  const accessToken = data.access_token?.trim();
+  const refreshToken = data.refresh_token?.trim() ?? "";
+  const expiresIn = data.expires_in ?? 3600;
+
+  if (!accessToken) throw new Error("Rube token exchange returned no access_token");
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: now + expiresIn * 1000 - EXPIRES_BUFFER_MS,
+    clientId: params.clientId,
+  };
+}
+
+/**
+ * Refresh access token using refresh token
+ */
+export async function refreshTokens(params: {
+  credentials: RubeOAuthCredentials;
+  fetchFn?: typeof fetch;
+  now?: number;
+}): Promise<RubeOAuthCredentials> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const now = params.now ?? Date.now();
+
+  if (!params.credentials.refreshToken) {
+    throw new Error("No refresh token available - please re-authenticate with 'clawdbot rube login'");
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: params.credentials.clientId,
+    refresh_token: params.credentials.refreshToken,
+  });
+
+  const response = await fetchFn(RUBE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Rube token refresh failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+
+  const accessToken = data.access_token?.trim();
+  const newRefreshToken = data.refresh_token?.trim();
+  const expiresIn = data.expires_in ?? 3600;
+
+  if (!accessToken) throw new Error("Rube token refresh returned no access_token");
+
+  return {
+    accessToken,
+    refreshToken: newRefreshToken || params.credentials.refreshToken,
+    expiresAt: now + expiresIn * 1000 - EXPIRES_BUFFER_MS,
+    clientId: params.credentials.clientId,
+  };
+}
+
+/**
+ * Start local server to receive OAuth callback
+ */
+export function startCallbackServer(params: {
+  state: string;
+  timeoutMs?: number;
+}): Promise<{ code: string; cleanup: () => void }> {
+  const timeoutMs = params.timeoutMs ?? 120_000;
+
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+
+    const server = http.createServer((req, res) => {
+      if (resolved) {
+        res.writeHead(400);
+        res.end("Already processed");
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", `http://127.0.0.1:${REDIRECT_PORT}`);
+
+      if (url.pathname !== "/callback") {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      const error = url.searchParams.get("error");
+      const errorDescription = url.searchParams.get("error_description");
+
+      if (error) {
+        // Escape error description to prevent HTML injection
+        const safeDesc = (errorDescription || error).replace(/[&<>"']/g, (c) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c
+        );
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end(`<html><body><h1>Authentication failed</h1><p>${safeDesc}</p></body></html>`);
+        resolved = true;
+        cleanup();
+        reject(new Error(`OAuth error: ${errorDescription || error}`));
+        return;
+      }
+
+      if (!code) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end("<html><body><h1>Missing authorization code</h1></body></html>");
+        resolved = true;
+        cleanup();
+        reject(new Error("OAuth callback missing authorization code"));
+        return;
+      }
+
+      if (state !== params.state) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end("<html><body><h1>Invalid state parameter</h1></body></html>");
+        resolved = true;
+        cleanup();
+        reject(new Error("OAuth callback received invalid state parameter"));
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`
+        <html>
+          <body style="font-family: system-ui; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+            <div style="text-align: center;">
+              <h1>Rube Connected!</h1>
+              <p>You can close this window and return to Clawdbot.</p>
+            </div>
+          </body>
+        </html>
+      `);
+
+      resolved = true;
+      cleanup();
+      resolve({ code, cleanup: () => {} });
+    });
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      server.close();
+    };
+
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(new Error("OAuth callback timed out"));
+      }
+    }, timeoutMs);
+
+    server.listen(REDIRECT_PORT, "127.0.0.1", () => {
+      // Server ready
+    });
+
+    server.on("error", (err) => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(new Error(`Failed to start callback server: ${err.message}`));
+      }
+    });
+  });
+}
+
+/**
+ * Check if credentials are expired or about to expire
+ */
+export function isExpired(credentials: RubeOAuthCredentials, now = Date.now()): boolean {
+  return now >= credentials.expiresAt;
+}

--- a/extensions/rube-mcp/src/cli.ts
+++ b/extensions/rube-mcp/src/cli.ts
@@ -1,0 +1,288 @@
+import type { Command } from "commander";
+import { randomBytes } from "node:crypto";
+
+import type { ClawdbotPluginApi } from "../../../src/plugins/types.js";
+import type { RubeOAuthCredentials } from "./auth.js";
+import {
+  generatePkce,
+  registerClient,
+  buildAuthorizationUrl,
+  startCallbackServer,
+  exchangeCodeForTokens,
+} from "./auth.js";
+import { RubeMcpClient } from "./mcp-client.js";
+import type { CachedMcpTool } from "./tool-wrapper.js";
+
+// Storage key for credentials in plugin config
+export const RUBE_CREDENTIALS_KEY = "oauth";
+
+type RubePluginConfig = {
+  enabled?: boolean;
+  oauth?: RubeOAuthCredentials;
+  cachedTools?: CachedMcpTool[];
+};
+
+/**
+ * Get stored Rube credentials from plugin config
+ */
+export function getStoredCredentials(api: ClawdbotPluginApi): RubeOAuthCredentials | null {
+  // pluginConfig comes from plugins.entries["rube-mcp"].config
+  const config = api.pluginConfig as RubePluginConfig | undefined;
+  return config?.oauth ?? null;
+}
+
+/**
+ * Get cached tool definitions from plugin config
+ */
+export function getCachedTools(api: ClawdbotPluginApi): CachedMcpTool[] {
+  const config = api.pluginConfig as RubePluginConfig | undefined;
+  return config?.cachedTools ?? [];
+}
+
+/**
+ * Save Rube credentials to plugin config
+ */
+export async function saveCredentials(
+  api: ClawdbotPluginApi,
+  credentials: RubeOAuthCredentials | null,
+): Promise<void> {
+  // Load current config through runtime
+  const config = await api.runtime.config.loadConfig();
+
+  // Ensure plugins.entries section exists
+  config.plugins = config.plugins ?? {};
+  config.plugins.entries = config.plugins.entries ?? {};
+  config.plugins.entries["rube-mcp"] = config.plugins.entries["rube-mcp"] ?? {};
+  config.plugins.entries["rube-mcp"].config = config.plugins.entries["rube-mcp"].config ?? {};
+
+  if (credentials) {
+    (config.plugins.entries["rube-mcp"].config as Record<string, unknown>).oauth = credentials;
+  } else {
+    delete (config.plugins.entries["rube-mcp"].config as Record<string, unknown>).oauth;
+  }
+
+  // Write back through runtime
+  await api.runtime.config.writeConfigFile(config);
+}
+
+/**
+ * Save cached tools to plugin config
+ */
+export async function saveCachedTools(
+  api: ClawdbotPluginApi,
+  tools: CachedMcpTool[] | null,
+): Promise<void> {
+  const config = await api.runtime.config.loadConfig();
+
+  config.plugins = config.plugins ?? {};
+  config.plugins.entries = config.plugins.entries ?? {};
+  config.plugins.entries["rube-mcp"] = config.plugins.entries["rube-mcp"] ?? {};
+  config.plugins.entries["rube-mcp"].config = config.plugins.entries["rube-mcp"].config ?? {};
+
+  if (tools && tools.length > 0) {
+    (config.plugins.entries["rube-mcp"].config as Record<string, unknown>).cachedTools = tools;
+  } else {
+    delete (config.plugins.entries["rube-mcp"].config as Record<string, unknown>).cachedTools;
+  }
+
+  await api.runtime.config.writeConfigFile(config);
+}
+
+/**
+ * Fetch and cache tool definitions from Rube MCP
+ */
+async function refreshToolCache(api: ClawdbotPluginApi): Promise<CachedMcpTool[]> {
+  const credentials = getStoredCredentials(api);
+  if (!credentials) {
+    throw new Error("Not authenticated. Run 'clawdbot rube login' first.");
+  }
+
+  const client = new RubeMcpClient({
+    credentials,
+    onCredentialsRefreshed: async (creds) => saveCredentials(api, creds),
+  });
+
+  try {
+    const mcpTools = await client.listTools();
+
+    // Convert to cached format (serializable)
+    const cachedTools: CachedMcpTool[] = mcpTools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+
+    await saveCachedTools(api, cachedTools);
+
+    return cachedTools;
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Create Rube CLI commands on the given program
+ */
+export function createRubeCommands(program: Command, api: ClawdbotPluginApi): void {
+    const rube = program.command("rube").description("Rube MCP integration - connect to 500+ apps");
+
+    rube
+      .command("login")
+      .description("Authenticate with Rube")
+      .action(async () => {
+        const { openUrl } = await import("../../../src/commands/onboard-helpers.js");
+
+        console.log("Starting Rube authentication...\n");
+
+        // Step 1: Dynamic Client Registration
+        console.log("Registering client...");
+        const clientId = await registerClient();
+        console.log("Client registered.\n");
+
+        // Step 2: Generate PKCE and state
+        const pkce = generatePkce();
+        const state = randomBytes(16).toString("hex");
+
+        // Step 3: Start callback server
+        console.log("Starting local callback server...");
+        const callbackPromise = startCallbackServer({ state, timeoutMs: 120_000 });
+
+        // Step 4: Open browser
+        const authUrl = buildAuthorizationUrl({ clientId, pkce, state });
+        console.log("\nOpening browser for authentication...");
+        console.log(`If browser doesn't open, visit:\n${authUrl}\n`);
+
+        await openUrl(authUrl);
+
+        // Step 5: Wait for callback
+        console.log("Waiting for authentication...");
+        const { code } = await callbackPromise;
+        console.log("\nReceived authorization code.\n");
+
+        // Step 6: Exchange code for tokens
+        console.log("Exchanging code for tokens...");
+        const credentials = await exchangeCodeForTokens({
+          clientId,
+          code,
+          codeVerifier: pkce.verifier,
+        });
+
+        // Step 7: Save credentials
+        await saveCredentials(api, credentials);
+
+        // Step 8: Cache tool definitions
+        console.log("Fetching tool definitions...");
+        try {
+          const tools = await refreshToolCache(api);
+          console.log(`Cached ${tools.length} tools.\n`);
+        } catch (err) {
+          console.log(`Warning: Could not cache tools: ${err instanceof Error ? err.message : String(err)}`);
+          console.log("Run 'clawdbot rube refresh' to try again.\n");
+        }
+
+        console.log("Rube authentication successful!");
+        console.log("Restart the gateway to make Rube tools available.\n");
+      });
+
+    rube
+      .command("logout")
+      .description("Disconnect from Rube")
+      .action(async () => {
+        await saveCredentials(api, null);
+        await saveCachedTools(api, null);
+        console.log("Rube credentials and cached tools removed.");
+      });
+
+    rube
+      .command("refresh")
+      .description("Refresh cached tool definitions from Rube")
+      .action(async () => {
+        console.log("Refreshing tool cache...\n");
+        try {
+          const tools = await refreshToolCache(api);
+          console.log(`Cached ${tools.length} tools.`);
+          console.log("Restart the gateway to use updated tools.\n");
+        } catch (err) {
+          console.error(`Failed to refresh: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      });
+
+    rube
+      .command("status")
+      .description("Show Rube connection status")
+      .action(async () => {
+        const credentials = getStoredCredentials(api);
+
+        if (!credentials) {
+          console.log("Status: Not connected");
+          console.log("\nRun 'clawdbot rube login' to authenticate.");
+          return;
+        }
+
+        const now = Date.now();
+        const isExpired = now >= credentials.expiresAt;
+        const expiresIn = Math.max(0, Math.round((credentials.expiresAt - now) / 1000 / 60));
+
+        console.log("Status: Connected");
+        console.log(`Token expires: ${isExpired ? "Expired (will refresh on next use)" : `in ${expiresIn} minutes`}`);
+
+        // Try to list tools
+        let client: RubeMcpClient | null = null;
+        try {
+          console.log("\nFetching available tools...");
+          client = new RubeMcpClient({
+            credentials,
+            onCredentialsRefreshed: async (creds) => saveCredentials(api, creds),
+          });
+          const tools = await client.listTools();
+          console.log(`Available tools: ${tools.length}`);
+
+          if (tools.length > 0) {
+            console.log("\nSample tools:");
+            for (const tool of tools.slice(0, 5)) {
+              console.log(`  - ${tool.name}: ${tool.description?.slice(0, 60) ?? ""}...`);
+            }
+            if (tools.length > 5) {
+              console.log(`  ... and ${tools.length - 5} more`);
+            }
+          }
+        } catch (err) {
+          console.log(`\nFailed to fetch tools: ${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+          await client?.close();
+        }
+      });
+
+    rube
+      .command("tools")
+      .description("List all available Rube tools")
+      .action(async () => {
+        const credentials = getStoredCredentials(api);
+
+        if (!credentials) {
+          console.log("Not connected. Run 'clawdbot rube login' first.");
+          return;
+        }
+
+        const client = new RubeMcpClient({
+          credentials,
+          onCredentialsRefreshed: async (creds) => saveCredentials(api, creds),
+        });
+
+        try {
+          console.log("Fetching tools from Rube...\n");
+          const tools = await client.listTools();
+
+          console.log(`Found ${tools.length} tools:\n`);
+          for (const tool of tools) {
+            console.log(`${tool.name}`);
+            if (tool.description) {
+              console.log(`  ${tool.description}`);
+            }
+            console.log();
+          }
+        } finally {
+          await client.close();
+        }
+      });
+}

--- a/extensions/rube-mcp/src/mcp-client.ts
+++ b/extensions/rube-mcp/src/mcp-client.ts
@@ -1,0 +1,163 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ListToolsResultSchema, CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+
+import type { RubeOAuthCredentials } from "./auth.js";
+import { isExpired, refreshTokens } from "./auth.js";
+
+export const RUBE_MCP_ENDPOINT = "https://rube.app/mcp";
+
+export type McpTool = {
+  name: string;
+  description?: string;
+  inputSchema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+};
+
+export type McpToolCallResponse = {
+  content: Array<{
+    type: string;
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  isError?: boolean;
+};
+
+/**
+ * MCP client for Rube using the official MCP SDK
+ */
+export class RubeMcpClient {
+  private credentials: RubeOAuthCredentials;
+  private client: Client | null = null;
+  private transport: StreamableHTTPClientTransport | null = null;
+  private fetchFn: typeof fetch;
+  private onCredentialsRefreshed?: (creds: RubeOAuthCredentials) => Promise<void>;
+
+  constructor(params: {
+    credentials: RubeOAuthCredentials;
+    fetchFn?: typeof fetch;
+    onCredentialsRefreshed?: (creds: RubeOAuthCredentials) => Promise<void>;
+  }) {
+    this.credentials = params.credentials;
+    this.fetchFn = params.fetchFn ?? fetch;
+    this.onCredentialsRefreshed = params.onCredentialsRefreshed;
+  }
+
+  /**
+   * Ensure we have a valid access token, refreshing if needed
+   */
+  private async ensureValidToken(): Promise<string> {
+    if (isExpired(this.credentials)) {
+      this.credentials = await refreshTokens({
+        credentials: this.credentials,
+        fetchFn: this.fetchFn,
+      });
+      await this.onCredentialsRefreshed?.(this.credentials);
+      // Reconnect with new token
+      this.client = null;
+      this.transport = null;
+    }
+    return this.credentials.accessToken;
+  }
+
+  /**
+   * Get or create the MCP client connection
+   */
+  private async getClient(): Promise<Client> {
+    // Always check token expiry before reusing client (may invalidate existing client)
+    const token = await this.ensureValidToken();
+
+    if (this.client) {
+      return this.client;
+    }
+
+    this.client = new Client(
+      {
+        name: "clawdbot-rube",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      }
+    );
+
+    // Create HTTP transport with auth headers
+    this.transport = new StreamableHTTPClientTransport(
+      new URL(RUBE_MCP_ENDPOINT),
+      {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      }
+    );
+
+    await this.client.connect(this.transport);
+
+    return this.client;
+  }
+
+  /**
+   * List available tools from Rube MCP
+   */
+  async listTools(): Promise<McpTool[]> {
+    const client = await this.getClient();
+
+    const result = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema
+    );
+
+    return (result.tools ?? []).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema as McpTool["inputSchema"],
+    }));
+  }
+
+  /**
+   * Call a tool on Rube MCP
+   */
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResponse> {
+    const client = await this.getClient();
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: { name, arguments: args },
+      },
+      CallToolResultSchema
+    );
+
+    return {
+      content: result.content.map((c) => ({
+        type: c.type,
+        text: "text" in c ? c.text : undefined,
+        ...c,
+      })),
+      isError: result.isError,
+    };
+  }
+
+  /**
+   * Close the MCP connection
+   */
+  async close(): Promise<void> {
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+      this.transport = null;
+    }
+  }
+
+  /**
+   * Get current credentials (may have been refreshed)
+   */
+  getCredentials(): RubeOAuthCredentials {
+    return this.credentials;
+  }
+}

--- a/extensions/rube-mcp/src/tool-wrapper.ts
+++ b/extensions/rube-mcp/src/tool-wrapper.ts
@@ -1,0 +1,195 @@
+import { Type, type TObject, type TProperties, type TSchema } from "@sinclair/typebox";
+
+import type { McpTool, RubeMcpClient } from "./mcp-client.js";
+import type { RubeOAuthCredentials } from "./auth.js";
+import { RubeMcpClient as RubeMcpClientClass } from "./mcp-client.js";
+
+export type CachedMcpTool = {
+  name: string;
+  description?: string;
+  inputSchema: McpTool["inputSchema"];
+};
+
+type ClawdbotTool = {
+  name: string;
+  description: string;
+  parameters: TObject<TProperties>;
+  execute: (id: string, params: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>;
+};
+
+/**
+ * Convert JSON Schema type to TypeBox type
+ */
+function jsonSchemaToTypebox(schema: unknown, required = false): unknown {
+  if (!schema || typeof schema !== "object") {
+    return required ? Type.Unknown() : Type.Optional(Type.Unknown());
+  }
+
+  const s = schema as Record<string, unknown>;
+  const type = s.type as string | undefined;
+  const description = s.description as string | undefined;
+
+  let result: unknown;
+
+  switch (type) {
+    case "string":
+      result = Type.String({ description });
+      break;
+    case "number":
+      result = Type.Number({ description });
+      break;
+    case "integer":
+      result = Type.Integer({ description });
+      break;
+    case "boolean":
+      result = Type.Boolean({ description });
+      break;
+    case "array": {
+      const items = s.items as unknown;
+      const itemType = jsonSchemaToTypebox(items, true) as TSchema;
+      result = Type.Array(itemType, { description });
+      break;
+    }
+    case "object": {
+      const properties = (s.properties ?? {}) as Record<string, unknown>;
+      const requiredProps = (s.required ?? []) as string[];
+      const props: Record<string, TSchema> = {};
+
+      for (const [key, propSchema] of Object.entries(properties)) {
+        props[key] = jsonSchemaToTypebox(propSchema, requiredProps.includes(key)) as TSchema;
+      }
+
+      result = Type.Object(props as TProperties, { description });
+      break;
+    }
+    default:
+      result = Type.Unknown({ description });
+  }
+
+  return required ? result : Type.Optional(result as TSchema);
+}
+
+/**
+ * Convert MCP input schema to TypeBox parameters
+ */
+function mcpSchemaToTypebox(inputSchema: McpTool["inputSchema"]): TObject<TProperties> {
+  const properties = inputSchema.properties ?? {};
+  const required = inputSchema.required ?? [];
+
+  const props: Record<string, unknown> = {};
+
+  for (const [key, propSchema] of Object.entries(properties)) {
+    props[key] = jsonSchemaToTypebox(propSchema, required.includes(key));
+  }
+
+  return Type.Object(props as TProperties);
+}
+
+/**
+ * Wrap an MCP tool as a Clawdbot tool
+ */
+export function wrapMcpTool(mcpTool: McpTool, client: RubeMcpClient): ClawdbotTool {
+  const toolName = `rube_${mcpTool.name.toLowerCase().replace(/[^a-z0-9]/g, "_")}`;
+
+  return {
+    name: toolName,
+    description: mcpTool.description ?? `Rube MCP tool: ${mcpTool.name}`,
+    parameters: mcpSchemaToTypebox(mcpTool.inputSchema),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const result = await client.callTool(mcpTool.name, params);
+
+      // Convert MCP response to Clawdbot tool response
+      const textContent = result.content
+        .filter((c) => c.type === "text" && typeof c.text === "string")
+        .map((c) => c.text as string)
+        .join("\n");
+
+      if (result.isError) {
+        throw new Error(textContent || "Rube tool execution failed");
+      }
+
+      return {
+        content: [{ type: "text", text: textContent || JSON.stringify(result.content) }],
+      };
+    },
+  };
+}
+
+/**
+ * Wrap all MCP tools from a client as Clawdbot tools
+ */
+export async function wrapAllMcpTools(client: RubeMcpClient): Promise<ClawdbotTool[]> {
+  const mcpTools = await client.listTools();
+  return mcpTools.map((tool) => wrapMcpTool(tool, client));
+}
+
+/**
+ * Normalize tool name to be a valid identifier (alphanumeric + underscores)
+ */
+function normalizeToolName(name: string): string {
+  return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
+/**
+ * Wrap a cached MCP tool definition, creating a client lazily on execute
+ */
+export function wrapCachedMcpTool(
+  cachedTool: CachedMcpTool,
+  getCredentials: () => RubeOAuthCredentials | null,
+  onCredentialsRefreshed?: (creds: RubeOAuthCredentials) => Promise<void>,
+): ClawdbotTool {
+  const toolName = `mcp__rube__${normalizeToolName(cachedTool.name)}`;
+
+  return {
+    name: toolName,
+    description: cachedTool.description ?? `Rube MCP tool: ${cachedTool.name}`,
+    parameters: mcpSchemaToTypebox(cachedTool.inputSchema),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const credentials = getCredentials();
+      if (!credentials) {
+        throw new Error("Rube MCP: Not authenticated. Run 'clawdbot rube login' first.");
+      }
+
+      const client = new RubeMcpClientClass({
+        credentials,
+        onCredentialsRefreshed,
+      });
+
+      try {
+        const result = await client.callTool(cachedTool.name, params);
+
+        const textContent = result.content
+          .filter((c) => c.type === "text" && typeof c.text === "string")
+          .map((c) => c.text as string)
+          .join("\n");
+
+        if (result.isError) {
+          throw new Error(textContent || "Rube tool execution failed");
+        }
+
+        return {
+          content: [{ type: "text", text: textContent || JSON.stringify(result.content) }],
+        };
+      } finally {
+        await client.close();
+      }
+    },
+  };
+}
+
+/**
+ * Wrap all cached MCP tool definitions as Clawdbot tools
+ */
+export function wrapCachedMcpTools(
+  cachedTools: CachedMcpTool[],
+  getCredentials: () => RubeOAuthCredentials | null,
+  onCredentialsRefreshed?: (creds: RubeOAuthCredentials) => Promise<void>,
+): ClawdbotTool[] {
+  return cachedTools.map((tool) =>
+    wrapCachedMcpTool(tool, getCredentials, onCredentialsRefreshed)
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,13 +39,13 @@ importers:
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
         specifier: 0.49.3
-        version: 0.49.3(ws@8.19.0)(zod@4.3.6)
+        version: 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.49.3
-        version: 0.49.3(ws@8.19.0)(zod@4.3.6)
+        version: 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.49.3
-        version: 0.49.3(ws@8.19.0)(zod@4.3.6)
+        version: 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.49.3
         version: 0.49.3
@@ -349,7 +349,7 @@ importers:
     dependencies:
       clawdbot:
         specifier: '>=2026.1.23-1'
-        version: 2026.1.23-1(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3)
+        version: 2026.1.23-1(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3)
 
   extensions/memory-lancedb:
     dependencies:
@@ -399,6 +399,19 @@ importers:
         version: 4.3.6
 
   extensions/open-prose: {}
+
+  extensions/rube-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.25.3
+        version: 1.25.3(hono@4.11.4)(zod@4.3.6)
+    devDependencies:
+      clawdbot:
+        specifier: workspace:*
+        version: link:../..
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   extensions/signal: {}
 
@@ -1411,6 +1424,16 @@ packages:
 
   '@mistralai/mistralai@1.10.0':
     resolution: {integrity: sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==}
+
+  '@modelcontextprotocol/sdk@1.25.3':
+    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
@@ -3218,6 +3241,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
@@ -3424,9 +3451,23 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -3862,6 +3903,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -3887,6 +3931,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -4582,6 +4629,10 @@ packages:
   pixelmatch@7.1.0:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.58.0:
     resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
@@ -6487,10 +6538,12 @@ snapshots:
 
   '@glideapps/ts-necessities@2.2.3': {}
 
-  '@google/genai@1.34.0':
+  '@google/genai@1.34.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.5.0
       ws: 8.19.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.4)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6538,7 +6591,6 @@ snapshots:
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:
       hono: 4.11.4
-    optional: true
 
   '@huggingface/jinja@0.5.3':
     optional: true
@@ -6824,9 +6876,9 @@ snapshots:
     transitivePeerDependencies:
       - tailwindcss
 
-  '@mariozechner/pi-agent-core@0.49.3(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.49.3
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -6837,11 +6889,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.49.3(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.972.0
-      '@google/genai': 1.34.0
+      '@google/genai': 1.34.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.47
       ajv: 8.17.1
@@ -6859,12 +6911,12 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.49.3(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/clipboard': 0.3.0
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.49.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -6940,6 +6992,28 @@ snapshots:
     dependencies:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+
+  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.4)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - hono
+      - supports-color
 
   '@mozilla/readability@0.6.0': {}
 
@@ -8839,7 +8913,7 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
-  clawdbot@2026.1.23-1(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3):
+  clawdbot@2026.1.23-1(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3):
     dependencies:
       '@agentclientprotocol/sdk': 0.13.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.975.0
@@ -8849,9 +8923,9 @@ snapshots:
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.39.3)
       '@homebridge/ciao': 1.3.4
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.49.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.49.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.49.3
       '@mozilla/readability': 0.6.0
       '@sinclair/typebox': 0.34.47
@@ -9025,6 +9099,11 @@ snapshots:
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   croner@9.1.0: {}
 
@@ -9219,7 +9298,17 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
 
   express@4.22.1:
     dependencies:
@@ -9775,6 +9864,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  jose@6.1.3: {}
+
   js-base64@3.7.8: {}
 
   js-tokens@9.0.1: {}
@@ -9795,6 +9886,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -10543,6 +10636,8 @@ snapshots:
   pixelmatch@7.1.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.58.0: {}
 

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -183,6 +183,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "rube",
+    description: "Rube MCP integration - connect to 500+ apps",
+    register: async (program) => {
+      const { registerPluginCliCommands } = await import("../../plugins/cli.js");
+      registerPluginCliCommands(program, await loadConfig());
+    },
+  },
+  {
     name: "channels",
     description: "Channel management",
     register: async (program) => {


### PR DESCRIPTION
## Summary
- Adds a new plugin extension that integrates with [Rube MCP](https://rube.app) to provide access to 500+ apps via the Model Context Protocol
- OAuth 2.0 authentication with Dynamic Client Registration (DCR) and PKCE
- Tool caching system for synchronous plugin registration
- CLI commands: `rube login`, `rube logout`, `rube status`, `rube tools`, `rube refresh`

## Features
- **Gmail, Slack, GitHub, and 500+ more apps** available as tools
- Uses official `@modelcontextprotocol/sdk` for MCP communication
- Tools are cached during login and loaded synchronously at startup
- Automatic token refresh when expired

## Test plan
- [x] Manual testing of OAuth login flow
- [x] Verified tools are cached after login (`clawdbot rube status` shows 11 tools)
- [x] Verified `clawdbot rube refresh` updates tool cache
- [x] Code review passed via Codex
- [x] Test tool execution in TUI after gateway restart

## AI-assisted development
This PR was developed with Claude Opus 4.5. The code has been:
- Reviewed and approved by Codex automated review
- Tested locally for OAuth flow and tool caching
- I understand what the code does

🤖 Generated with [Claude Code](https://claude.ai/code)