### PR TITLE
Fix smart message chunking (keep lists/headers together)

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -343,6 +343,17 @@ describe("chunkMarkdownTextWithMode", () => {
     const text = "```js\nconst a = 1;\nconst b = 2;\n```\nAfter";
     expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual([text]);
   });
+
+  it("does not split on blank lines inside a fenced code block", () => {
+    const text = "```python\ndef my_function():\n    x = 1\n\n    y = 2\n    return x + y\n```";
+    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual([text]);
+  });
+
+  it("splits on blank lines between a code fence and following paragraph", () => {
+    const fence = "```python\ndef my_function():\n    x = 1\n\n    y = 2\n    return x + y\n```";
+    const text = `${fence}\n\nAfter`;
+    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual([fence, "After"]);
+  });
 });
 
 describe("resolveChunkMode", () => {

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -310,10 +310,16 @@ describe("chunkTextWithMode", () => {
     expect(chunks).toEqual(["Line one\nLine two"]);
   });
 
-  it("uses newline-based chunking for newline mode", () => {
+  it("uses paragraph-based chunking for newline mode", () => {
     const text = "Line one\nLine two";
     const chunks = chunkTextWithMode(text, 1000, "newline");
-    expect(chunks).toEqual(["Line one", "Line two"]);
+    expect(chunks).toEqual(["Line one\nLine two"]);
+  });
+
+  it("splits on blank lines for newline mode", () => {
+    const text = "Para one\n\nPara two";
+    const chunks = chunkTextWithMode(text, 1000, "newline");
+    expect(chunks).toEqual(["Para one", "Para two"]);
   });
 });
 
@@ -323,17 +329,19 @@ describe("chunkMarkdownTextWithMode", () => {
     expect(chunkMarkdownTextWithMode(text, 1000, "length")).toEqual(chunkMarkdownText(text, 1000));
   });
 
-  it("uses newline-based chunking for newline mode", () => {
+  it("uses paragraph-based chunking for newline mode", () => {
     const text = "Line one\nLine two";
-    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual(["Line one", "Line two"]);
+    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual(["Line one\nLine two"]);
   });
 
-  it("does not split inside code fences for newline mode", () => {
+  it("splits on blank lines for newline mode", () => {
+    const text = "Para one\n\nPara two";
+    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual(["Para one", "Para two"]);
+  });
+
+  it("does not split single-newline code fences in newline mode", () => {
     const text = "```js\nconst a = 1;\nconst b = 2;\n```\nAfter";
-    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual([
-      "```js\nconst a = 1;\nconst b = 2;\n```",
-      "After",
-    ]);
+    expect(chunkMarkdownTextWithMode(text, 1000, "newline")).toEqual([text]);
   });
 });
 

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -189,11 +189,19 @@ export function chunkByParagraph(text: string, limit: number): string[] {
     return normalized.length <= limit ? [normalized] : chunkText(normalized, limit);
   }
 
+  const spans = parseFenceSpans(normalized);
+
   const parts: string[] = [];
   const re = /\n[\t ]*\n+/g; // paragraph break: blank line(s), allowing whitespace
   let lastIndex = 0;
   for (const match of normalized.matchAll(re)) {
     const idx = match.index ?? 0;
+
+    // Do not split on blank lines that occur inside fenced code blocks.
+    if (!isSafeFenceBreak(spans, idx)) {
+      continue;
+    }
+
     parts.push(normalized.slice(lastIndex, idx));
     lastIndex = idx + match[0].length;
   }

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,5 +1,5 @@
 import {
-  chunkByNewline,
+  chunkByParagraph,
   chunkMarkdownTextWithMode,
   resolveChunkMode,
   resolveTextChunkLimit,
@@ -223,14 +223,15 @@ export async function deliverOutboundPayloads(params: {
     }
     if (chunkMode === "newline") {
       const mode = handler.chunkerMode ?? "text";
-      const lineChunks =
+      const blockChunks =
         mode === "markdown"
           ? chunkMarkdownTextWithMode(text, textLimit, "newline")
-          : chunkByNewline(text, textLimit, { splitLongLines: false });
-      if (!lineChunks.length && text) lineChunks.push(text);
-      for (const lineChunk of lineChunks) {
-        const chunks = handler.chunker(lineChunk, textLimit);
-        if (!chunks.length && lineChunk) chunks.push(lineChunk);
+          : chunkByParagraph(text, textLimit);
+
+      if (!blockChunks.length && text) blockChunks.push(text);
+      for (const blockChunk of blockChunks) {
+        const chunks = handler.chunker(blockChunk, textLimit);
+        if (!chunks.length && blockChunk) chunks.push(blockChunk);
         for (const chunk of chunks) {
           throwIfAborted(abortSignal);
           results.push(await handler.sendText(chunk));


### PR DESCRIPTION
## Summary

- **Fixed `chunkMode: "newline"` behavior** to split on paragraph boundaries (blank lines) instead of every single newline
- Lists, headers, and single-newline-wrapped text now stay together as a single message
- Paragraph splitting now always runs when blank lines are present (even for short messages under the limit)
- Block streaming no longer special-cases newline mode to flush every line

## Motivation

Some channels (notably iMessage/BlueBubbles) use `chunkMode: "newline"`, which was splitting every single newline into its own outbound message. This caused markdown-style replies like bullet lists or headers followed by content to be delivered as one message per line—noisy and breaks formatting.

## Behavior examples

**Before:** Each line was a separate message
**After:** Paragraphs stay together, only blank lines trigger splits

Input:
```
**important:**
Do X
- a
- b
```
→ Now sends as a single message

Input:
```
Para 1

Para 2
```
→ Splits into 2 messages (at the blank line)

## Test plan

- [x] Updated unit tests in `chunk.test.ts`
- [x] Verified newline mode splits on blank lines, not single newlines
- [x] Verified code fences with blank lines inside don't trigger splits


Example:
<img width="1276" height="1506" alt="image" src="https://github.com/user-attachments/assets/e16ba898-aa83-434b-a919-551ef7ba12ab" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)