### PR TITLE
Fix subagent verbose leak: force verboseLevel off + strip tool summaries

### DIFF
--- a/src/agents/tools/sessions-helpers.test.ts
+++ b/src/agents/tools/sessions-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
+import {
+  extractAssistantText,
+  sanitizeTextContent,
+  stripToolMessages,
+} from "./sessions-helpers.js";
 
 describe("sanitizeTextContent", () => {
   it("strips minimax tool call XML and downgraded markers", () => {
@@ -30,5 +34,38 @@ describe("extractAssistantText", () => {
       ],
     };
     expect(extractAssistantText(message)).toBe("Hi there");
+  });
+});
+
+describe("stripToolMessages", () => {
+  it("removes toolResult entries and known tool summary prefixes", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "Tool: use cache" }] },
+      { role: "assistant", content: [{ type: "text", text: "🛠️ Exec: ls -la" }] },
+      { role: "assistant", content: [{ type: "text", text: "🧩 Tool: fallback" }] },
+      { role: "toolResult", content: [] },
+      { role: "assistant", content: [{ type: "text", text: "Kept" }] },
+    ];
+
+    const filtered = stripToolMessages(messages);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]).toMatchObject({ role: "assistant" });
+    expect(extractAssistantText(filtered[0])).toBe("Kept");
+  });
+
+  it("keeps emoji-prefixed assistant headings that are not tool summaries", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "📌 Note: keep this" }] },
+      { role: "assistant", content: [{ type: "text", text: "✅ Done: keep this too" }] },
+      { role: "assistant", content: [{ type: "text", text: "📎 Media: 2 ok" }] },
+    ];
+
+    const filtered = stripToolMessages(messages);
+    expect(filtered).toHaveLength(3);
+    expect(filtered.map((msg) => extractAssistantText(msg))).toEqual([
+      "📌 Note: keep this",
+      "✅ Done: keep this too",
+      "📎 Media: 2 ok",
+    ]);
   });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -156,6 +156,14 @@ export function createSessionsSpawnTool(opts?: {
         }
       }
       const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
+
+      // Ensure subagent runs never inherit verbose settings from the requester.
+      await callGateway({
+        method: "sessions.patch",
+        params: { key: childSessionKey, verboseLevel: "off" },
+        timeoutMs: 10_000,
+      });
+
       const spawnedByKey = requesterInternalKey;
       const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
       const resolvedModel =


### PR DESCRIPTION
## Summary
- Force subagent sessions to `verboseLevel: "off"` on spawn to prevent verbose output leaking into transcripts
- Improve transcript filtering for tool-summary-like assistant messages using actual prefixes from `tool-display.json`

## Changes
- **Force subagent sessions to `verboseLevel: "off"` on spawn**
  - `src/agents/tools/sessions-spawn-tool.ts` - Patches session immediately after generating `childSessionKey`

- **Improve transcript filtering for tool-summary-like assistant messages**
  - `src/agents/tools/sessions-helpers.ts` - `stripToolMessages()` now removes assistant messages matching:
    - `Tool: ...`
    - Emoji + label prefixes derived from `tool-display.json` (e.g. `🔧 Tool: ...`, `🛠 Sessions: ...`)
  - Uses actual tool display configuration rather than a broad regex pattern

## Validation
- `pnpm build` ✓
- `pnpm test` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)