### PR TITLE
fix: propagate config.env.vars to LaunchAgent/systemd service environment

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -100,6 +100,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       if (json) warnings.push(message);
       else defaultRuntime.log(message);
     },
+    configEnvVars: cfg.env?.vars,
   });
 
   try {

--- a/src/commands/configure.daemon.ts
+++ b/src/commands/configure.daemon.ts
@@ -11,6 +11,7 @@ import {
 } from "./daemon-runtime.js";
 import { guardCancel } from "./onboard-helpers.js";
 import { ensureSystemdUserLingerInteractive } from "./systemd-linger.js";
+import { loadConfig } from "../config/config.js";
 
 export async function maybeInstallDaemon(params: {
   runtime: RuntimeEnv;
@@ -81,12 +82,14 @@ export async function maybeInstallDaemon(params: {
 
         progress.setLabel("Preparing Gateway service…");
 
+        const cfg = loadConfig();
         const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({
           env: process.env,
           port: params.port,
           token: params.gatewayToken,
           runtime: daemonRuntime,
           warn: (message, title) => note(message, title),
+          configEnvVars: cfg.env?.vars,
         });
 
         progress.setLabel("Installing Gateway service…");

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -161,6 +161,7 @@ export async function maybeRepairGatewayDaemon(params: {
           token: params.cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN,
           runtime: daemonRuntime,
           warn: (message, title) => note(message, title),
+          configEnvVars: params.cfg.env?.vars,
         });
         try {
           await service.install({

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -110,6 +110,7 @@ export async function maybeMigrateLegacyGatewayService(
     token: cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN,
     runtime: daemonRuntime,
     warn: (message, title) => note(message, title),
+    configEnvVars: cfg.env?.vars,
   });
   try {
     await service.install({
@@ -177,6 +178,7 @@ export async function maybeRepairGatewayServiceConfig(
     runtime: needsNodeRuntime && systemNodePath ? "node" : runtimeChoice,
     nodePath: systemNodePath ?? undefined,
     warn: (message, title) => note(message, title),
+    configEnvVars: cfg.env?.vars,
   });
   const expectedEntrypoint = findGatewayEntrypoint(programArguments);
   const currentEntrypoint = findGatewayEntrypoint(command.programArguments);

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -38,6 +38,7 @@ export async function installGatewayDaemonNonInteractive(params: {
     token: gatewayToken,
     runtime: daemonRuntimeRaw,
     warn: (message) => runtime.log(message),
+    configEnvVars: params.nextConfig.env?.vars,
   });
   try {
     await service.install({

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -169,6 +169,7 @@ export async function finalizeOnboardingWizard(options: FinalizeOnboardingOption
           token: settings.gatewayToken,
           runtime: daemonRuntime,
           warn: (message, title) => prompter.note(message, title),
+          configEnvVars: nextConfig.env?.vars,
         });
 
         progress.update("Installing Gateway service…");


### PR DESCRIPTION
## Problem

When installing the Gateway daemon via LaunchAgent (macOS) or systemd (Linux), environment variables defined in `config.env.vars` were not being included in the service environment. This caused API keys and other env vars configured in `clawdbot.json5` to be unavailable when the Gateway ran as a service.

Users had to manually edit the LaunchAgent plist (via `PlistBuddy`) to add environment variables like `GOOGLE_API_KEY`, which was error-prone and not documented.

## Root Cause

- `config/io.js` → `applyConfigEnv()` applies `env.vars` to `process.env` **at runtime** when the Gateway reads the config
- `daemon/daemon-install-helpers.ts` → `buildGatewayInstallPlan()` constructs the service environment **without reading the config**, so `env.vars` were never included in the plist/systemd unit

## Solution

Add a `configEnvVars` parameter to `buildGatewayInstallPlan()` that merges `config.env.vars` into the service environment. Service-specific variables (`CLAWDBOT_*`, `HOME`, `PATH`) take precedence over config env vars.

Updated all call sites:
- `cli/daemon-cli/install.ts`
- `commands/configure.daemon.ts`
- `commands/doctor-gateway-daemon-flow.ts`
- `commands/doctor-gateway-services.ts`
- `commands/onboard-non-interactive/local/daemon-install.ts`
- `wizard/onboarding.finalize.ts`

## Testing

Added unit tests in `daemon-install-helpers.test.ts`:
- Verifies config env vars are merged into the environment
- Verifies empty/undefined values are not included
- Verifies service environment vars take precedence

## Example

Before this fix, users with:
```json5
{
  env: {
    vars: {
      GOOGLE_API_KEY: "AIza..."
    }
  }
}
```

Would have to manually run:
```bash
/usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:GOOGLE_API_KEY string AIza..." ~/Library/LaunchAgents/com.clawdbot.gateway.plist
```

After this fix, running `clawdbot gateway install` (or `clawdbot onboard`) will automatically include these env vars in the service.