### PR TITLE
fix(matrix): decrypt encrypted media attachments in E2EE rooms

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/media.test.ts
@@ -25,10 +25,8 @@ describe("downloadMatrixMedia", () => {
 
   it("decrypts encrypted media when file payloads are present", async () => {
     const decryptMedia = vi.fn().mockResolvedValue(Buffer.from("decrypted"));
-    const downloadContent = vi.fn().mockResolvedValue(Buffer.from("encrypted"));
 
     const client = {
-      downloadContent,
       crypto: { decryptMedia },
       mxcToHttp: vi.fn().mockReturnValue("https://example/mxc"),
     } as unknown as import("matrix-bot-sdk").MatrixClient;
@@ -55,7 +53,8 @@ describe("downloadMatrixMedia", () => {
       file,
     });
 
-    expect(decryptMedia).toHaveBeenCalled();
+    // decryptMedia should be called with just the file object (it handles download internally)
+    expect(decryptMedia).toHaveBeenCalledWith(file);
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       Buffer.from("decrypted"),
       "image/png",

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -40,6 +40,7 @@ async function fetchMatrixMediaBuffer(params: {
 
 /**
  * Download and decrypt encrypted media from a Matrix room.
+ * Uses matrix-bot-sdk's decryptMedia which handles both download and decryption.
  */
 async function fetchEncryptedMediaBuffer(params: {
   client: MatrixClient;
@@ -50,18 +51,13 @@ async function fetchEncryptedMediaBuffer(params: {
     throw new Error("Cannot decrypt media: crypto not enabled");
   }
 
-  // Download the encrypted content
-  const encryptedBuffer = await params.client.downloadContent(params.file.url);
-  if (encryptedBuffer.byteLength > params.maxBytes) {
+  // decryptMedia handles downloading and decrypting the encrypted content internally
+  const decrypted = await params.client.crypto.decryptMedia(params.file);
+
+  if (decrypted.byteLength > params.maxBytes) {
     throw new Error("Matrix media exceeds configured size limit");
   }
 
-  // Decrypt using matrix-bot-sdk crypto
-  const decrypted = await params.client.crypto.decryptMedia(
-    Buffer.from(encryptedBuffer),
-    params.file,
-  );
-  
   return { buffer: decrypted };
 }
 


### PR DESCRIPTION
## Summary

Fixes encrypted media (images, audio recordings, files) not being decrypted in Matrix E2EE rooms.

Previously, when users sent images or audio recordings in encrypted Matrix rooms, the bot would fail to decrypt them. Text messages worked fine, but media attachments were broken.

## Root Cause

The `decryptMedia` function from `matrix-bot-sdk`'s `CryptoClient` was being called with incorrect parameters:

```typescript
// Before (broken) - passing 2 args
const decrypted = await params.client.crypto.decryptMedia(
  Buffer.from(encryptedBuffer),
  params.file,
);
```

However, according to the [matrix-bot-sdk documentation](https://turt2live.github.io/matrix-bot-sdk/CryptoClient.html), `decryptMedia` takes only a single `EncryptedFile` parameter and handles the download internally:

```typescript
// Correct signature
public async decryptMedia(file: EncryptedFile): Promise<Buffer>
```

## Fix

- Call `decryptMedia(file)` with just the `EncryptedFile` object
- Remove redundant manual download (the SDK handles it internally)
- Move size check to after decryption

## Testing

- Unit tests updated and passing
- Tested on live Matrix E2EE room with encrypted image attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)