### PR TITLE
fix(node): avoid invoke result deadlock

### DIFF
--- a/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayChannel.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayChannel.swift
@@ -574,46 +574,22 @@ public actor GatewayChannelActor {
         params: [String: AnyCodable]?,
         timeoutMs: Double? = nil) async throws -> Data
     {
-        do {
-            try await self.connect()
-        } catch {
-            throw self.wrap(error, context: "gateway connect")
-        }
-        let id = UUID().uuidString
+        try await self.connectOrThrow(context: "gateway connect")
         let effectiveTimeout = timeoutMs ?? self.defaultRequestTimeoutMs
-        // Encode request using the generated models to avoid JSONSerialization/ObjC bridging pitfalls.
-        let paramsObject: ProtoAnyCodable? = params.map { entries in
-            let dict = entries.reduce(into: [String: ProtoAnyCodable]()) { dict, entry in
-                dict[entry.key] = ProtoAnyCodable(entry.value.value)
-            }
-            return ProtoAnyCodable(dict)
-        }
-        let frame = RequestFrame(
-            type: "req",
-            id: id,
-            method: method,
-            params: paramsObject)
-        let data: Data
-        do {
-            data = try self.encoder.encode(frame)
-        } catch {
-            self.logger.error(
-                "gateway request encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            throw error
-        }
+        let payload = try self.encodeRequest(method: method, params: params, kind: "request")
         let response = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GatewayFrame, Error>) in
-            self.pending[id] = cont
+            self.pending[payload.id] = cont
             Task { [weak self] in
                 guard let self else { return }
                 try? await Task.sleep(nanoseconds: UInt64(effectiveTimeout * 1_000_000))
-                await self.timeoutRequest(id: id, timeoutMs: effectiveTimeout)
+                await self.timeoutRequest(id: payload.id, timeoutMs: effectiveTimeout)
             }
             Task {
                 do {
-                    try await self.task?.send(.data(data))
+                    try await self.task?.send(.data(payload.data))
                 } catch {
                     let wrapped = self.wrap(error, context: "gateway send \(method)")
-                    let waiter = self.pending.removeValue(forKey: id)
+                    let waiter = self.pending.removeValue(forKey: payload.id)
                     // Treat send failures as a broken socket: mark disconnected and trigger reconnect.
                     self.connected = false
                     self.task?.cancel(with: .goingAway, reason: nil)
@@ -644,31 +620,8 @@ public actor GatewayChannelActor {
     }
 
     public func send(method: String, params: [String: AnyCodable]?) async throws {
-        do {
-            try await self.connect()
-        } catch {
-            throw self.wrap(error, context: "gateway connect")
-        }
-        let id = UUID().uuidString
-        let paramsObject: ProtoAnyCodable? = params.map { entries in
-            let dict = entries.reduce(into: [String: ProtoAnyCodable]()) { dict, entry in
-                dict[entry.key] = ProtoAnyCodable(entry.value.value)
-            }
-            return ProtoAnyCodable(dict)
-        }
-        let frame = RequestFrame(
-            type: "req",
-            id: id,
-            method: method,
-            params: paramsObject)
-        let data: Data
-        do {
-            data = try self.encoder.encode(frame)
-        } catch {
-            self.logger.error(
-                "gateway send encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            throw error
-        }
+        try await self.connectOrThrow(context: "gateway connect")
+        let payload = try self.encodeRequest(method: method, params: params, kind: "send")
         guard let task = self.task else {
             throw NSError(
                 domain: "Gateway",
@@ -676,7 +629,7 @@ public actor GatewayChannelActor {
                 userInfo: [NSLocalizedDescriptionKey: "gateway socket unavailable"])
         }
         do {
-            try await task.send(.data(data))
+            try await task.send(.data(payload.data))
         } catch {
             let wrapped = self.wrap(error, context: "gateway send \(method)")
             self.connected = false
@@ -701,6 +654,42 @@ public actor GatewayChannelActor {
         let ns = error as NSError
         let desc = ns.localizedDescription.isEmpty ? "unknown" : ns.localizedDescription
         return NSError(domain: ns.domain, code: ns.code, userInfo: [NSLocalizedDescriptionKey: "\(context): \(desc)"])
+    }
+
+    private func connectOrThrow(context: String) async throws {
+        do {
+            try await self.connect()
+        } catch {
+            throw self.wrap(error, context: context)
+        }
+    }
+
+    private func encodeRequest(
+        method: String,
+        params: [String: AnyCodable]?,
+        kind: String) throws -> (id: String, data: Data)
+    {
+        let id = UUID().uuidString
+        // Encode request using the generated models to avoid JSONSerialization/ObjC bridging pitfalls.
+        let paramsObject: ProtoAnyCodable? = params.map { entries in
+            let dict = entries.reduce(into: [String: ProtoAnyCodable]()) { dict, entry in
+                dict[entry.key] = ProtoAnyCodable(entry.value.value)
+            }
+            return ProtoAnyCodable(dict)
+        }
+        let frame = RequestFrame(
+            type: "req",
+            id: id,
+            method: method,
+            params: paramsObject)
+        do {
+            let data = try self.encoder.encode(frame)
+            return (id: id, data: data)
+        } catch {
+            self.logger.error(
+                "gateway \(kind) encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
     }
 
     private func failPending(_ error: Error) async {

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayNodeSession.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotKit/GatewayNodeSession.swift
@@ -143,7 +143,7 @@ public actor GatewayNodeSession {
             "payloadJSON": AnyCodable(payloadJSON ?? NSNull()),
         ]
         do {
-            _ = try await channel.request(method: "node.event", params: params, timeoutMs: 8000)
+            try await channel.send(method: "node.event", params: params)
         } catch {
             self.logger.error("node event failed: \(error.localizedDescription, privacy: .public)")
         }
@@ -224,7 +224,7 @@ public actor GatewayNodeSession {
             ])
         }
         do {
-            _ = try await channel.request(method: "node.invoke.result", params: params, timeoutMs: 15000)
+            try await channel.send(method: "node.invoke.result", params: params)
         } catch {
             self.logger.error("node invoke result failed: \(error.localizedDescription, privacy: .public)")
         }


### PR DESCRIPTION
## Problem

Commands executed via `nodes.run` take 8-16+ seconds when they should be instant (e.g., `echo hello`, `whoami`).

## Root Cause: Actor Deadlock

The macOS Clawdbot app uses Swift actors for concurrency. The message flow was:

```
GatewayChannelActor
│
├─ listen() receives message via callback
│      └─► Task { await handle(msg); await listen() }
│                    │
│                    └─► await pushHandler(.event(...))
│                              │
│                              ▼
│                    GatewayNodeSession.handleEvent()
│                              │
│                              ├─► runs command (instant)
│                              │
│                              └─► await sendEvent("exec.finished")
│                                        │
│                                        └─► await channel.request()  ← BLOCKS HERE
│                                                   │
│                                                   ▼
│                                            Waiting for response...
│
└─── Response can only arrive when listen() runs again
     BUT listen() only runs AFTER handle() returns
     AND handle() is waiting for channel.request()
     
     🔒 DEADLOCK (times out after 8 seconds)
```

The `listen()` function uses a callback that fires for ONE message, then must be called again to receive the next. But `listen()` is only called after `handle()` completes. Since `handle()` was blocked waiting for `request()` to get a response, and the response could only arrive via `listen()`... deadlock.

**The 8-16 second delays were the timeout values:**
- `sendEvent()` had 8 second timeout
- `sendInvokeResult()` had 15 second timeout
- Commands would hit both timeouts sequentially = ~16 seconds total

## Solution

Changed `sendEvent()` and `sendInvokeResult()` to use fire-and-forget `send()` instead of blocking `request()`.

### Before
```swift
// sendEvent - blocks waiting for ack
_ = try await channel.request(method: "node.event", params: params, timeoutMs: 8000)

// sendInvokeResult - blocks waiting for ack  
_ = try await channel.request(method: "node.invoke.result", params: params, timeoutMs: 15000)
```

### After
```swift
// sendEvent - fire and forget
try await channel.send(method: "node.event", params: params)

// sendInvokeResult - fire and forget
try await channel.send(method: "node.invoke.result", params: params)
```

## Tradeoffs

**Why fire-and-forget is OK here:**

1. **`node.invoke.result`**: Gateway responds with just `{ ok: true }` - the node does not need this acknowledgment. If sending fails, the gateway times out the invoke anyway.

2. **`node.event`**: Events like `exec.started`/`exec.finished` are informational. If one gets lost, the actual result still comes through `invoke.result`.

3. **Socket errors**: If the socket is broken, the connection fails and triggers automatic reconnection.

**Worst case**: A message silently fails and you get a timeout instead of an instant error. This is better than guaranteed 8-16 second delays on every command.

## Result

Commands now execute instantly instead of taking 8-16 seconds.
