### PR TITLE
fix: use exact match for win32 platform detection

### DIFF
--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -2,7 +2,7 @@ export function buildNodeShellCommand(command: string, platform?: string | null)
   const normalized = String(platform ?? "")
     .trim()
     .toLowerCase();
-  if (normalized.includes("win")) {
+  if (normalized === "win32") {
     return ["cmd.exe", "/d", "/s", "/c", command];
   }
   return ["/bin/sh", "-lc", command];


### PR DESCRIPTION
## Summary

The previous check used `includes("win")` which incorrectly matched "darwin" (macOS) because it contains "win". This caused `cmd.exe` to be used on macOS instead of `/bin/sh`, resulting in `spawn cmd.exe ENOENT` errors.

## Changes
- Changed `normalized.includes("win")` to `normalized === "win32"`

## Why `win32` is safe

Per [Node.js documentation](https://nodejs.org/api/process.html#processplatform), `process.platform` returns `"win32"` on Windows regardless of 32-bit or 64-bit architecture. This is a stable API.

## Testing
- [x] Tested with local Clawdbot instance on macOS (darwin)
- [x] Verified `/bin/sh` is now correctly used instead of `cmd.exe`
- [x] Ran `npm run lint` - no warnings or errors
-  Windows testing not performed (no Windows environment available)

## AI Disclosure
- AI-assisted: Yes (Claude)
- Degree of testing: Tested on macOS, not tested on Windows
- I understand what the code does: The change ensures only Windows (win32) uses cmd.exe, while all other platforms use /bin/sh