### PR TITLE
fix: cron sessions inherit allowAgents from parent agent config

### DIFF
--- a/src/agents/clawdbot-tools.ts
+++ b/src/agents/clawdbot-tools.ts
@@ -54,6 +54,8 @@ export function createClawdbotTools(options?: {
   hasRepliedRef?: { value: boolean };
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
+  /** Explicit agent ID override for cron/hook sessions. */
+  requesterAgentIdOverride?: string;
 }): AnyAgentTool[] {
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
@@ -105,7 +107,10 @@ export function createClawdbotTools(options?: {
       agentSessionKey: options?.agentSessionKey,
       config: options?.config,
     }),
-    createAgentsListTool({ agentSessionKey: options?.agentSessionKey }),
+    createAgentsListTool({
+      agentSessionKey: options?.agentSessionKey,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
+    }),
     createSessionsListTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
@@ -129,6 +134,7 @@ export function createClawdbotTools(options?: {
       agentGroupChannel: options?.agentGroupChannel,
       agentGroupSpace: options?.agentGroupSpace,
       sandboxed: options?.sandboxed,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -313,6 +313,7 @@ export function createClawdbotCodingTools(options?: {
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
       modelHasVision: options?.modelHasVision,
+      requesterAgentIdOverride: agentId,
     }),
   ];
   const coreToolNames = new Set(

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -19,7 +19,11 @@ type AgentListEntry = {
   configured: boolean;
 };
 
-export function createAgentsListTool(opts?: { agentSessionKey?: string }): AnyAgentTool {
+export function createAgentsListTool(opts?: {
+  agentSessionKey?: string;
+  /** Explicit agent ID override for cron/hook sessions. */
+  requesterAgentIdOverride?: string;
+}): AnyAgentTool {
   return {
     label: "Agents",
     name: "agents_list",
@@ -37,7 +41,7 @@ export function createAgentsListTool(opts?: { agentSessionKey?: string }): AnyAg
             })
           : alias;
       const requesterAgentId = normalizeAgentId(
-        parseAgentSessionKey(requesterInternalKey)?.agentId ?? DEFAULT_AGENT_ID,
+        opts?.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId ?? DEFAULT_AGENT_ID,
       );
 
       const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -67,6 +67,8 @@ export function createSessionsSpawnTool(opts?: {
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
   sandboxed?: boolean;
+  /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
+  requesterAgentIdOverride?: string;
 }): AnyAgentTool {
   return {
     label: "Sessions",
@@ -129,7 +131,7 @@ export function createSessionsSpawnTool(opts?: {
       });
 
       const requesterAgentId = normalizeAgentId(
-        parseAgentSessionKey(requesterInternalKey)?.agentId,
+        opts?.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
       );
       const targetAgentId = requestedAgentId
         ? normalizeAgentId(requestedAgentId)


### PR DESCRIPTION
## Problem

When a cron job runs in isolated mode (`sessionTarget: isolated`), the `sessions_spawn` tool cannot spawn sub-agents because it fails to find the parent agent's `allowAgents` config.

The error is: `agentId is not allowed for sessions_spawn (allowed: none)`

## Root Cause

The tool relies on parsing the session key to extract the agent ID. While the session key is correctly formatted as `agent:<agentId>:cron:<jobId>`, the parsed agent ID wasn't being passed reliably through the tool creation chain.

## Solution

Added a `requesterAgentIdOverride` parameter that flows through the tool creation chain:

1. `resolveEffectiveToolPolicy()` in `pi-tools.ts` already extracts the correct `agentId` from the session key
2. This `agentId` is now passed to `createClawdbotTools` → `createSessionsSpawnTool` and `createAgentsListTool`
3. The tools use this override instead of re-parsing the session key

## Files Changed

- `src/agents/tools/sessions-spawn-tool.ts` - Added `requesterAgentIdOverride` option
- `src/agents/tools/agents-list-tool.ts` - Added `requesterAgentIdOverride` option
- `src/agents/clawdbot-tools.ts` - Added parameter and passed it through
- `src/agents/pi-tools.ts` - Passes the resolved `agentId` as the override

Fixes #1767