### PR TITLE
fix(telegram): use configured proxy for outbound API calls

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -16,6 +16,7 @@ import { isGifMedia } from "../media/mime.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramFetch } from "./fetch.js";
+import { makeProxyFetch } from "./proxy.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { splitTelegramCaption } from "./caption.js";
@@ -146,7 +147,9 @@ export async function sendMessageTelegram(
   const chatId = normalizeChatId(target.chatId);
   // Use provided api or create a new Bot instance. The nullish coalescing
   // operator ensures api is always defined (Bot.api is always non-null).
-  const fetchImpl = resolveTelegramFetch();
+  const proxyUrl = account.config.proxy;
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl as string) : undefined;
+  const fetchImpl = resolveTelegramFetch(proxyFetch);
   const timeoutSeconds =
     typeof account.config.timeoutSeconds === "number" &&
     Number.isFinite(account.config.timeoutSeconds)
@@ -390,7 +393,9 @@ export async function reactMessageTelegram(
   const token = resolveToken(opts.token, account);
   const chatId = normalizeChatId(String(chatIdInput));
   const messageId = normalizeMessageId(messageIdInput);
-  const fetchImpl = resolveTelegramFetch();
+  const proxyUrl = account.config.proxy;
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl as string) : undefined;
+  const fetchImpl = resolveTelegramFetch(proxyFetch);
   const client: ApiClientOptions | undefined = fetchImpl
     ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
     : undefined;
@@ -436,7 +441,9 @@ export async function deleteMessageTelegram(
   const token = resolveToken(opts.token, account);
   const chatId = normalizeChatId(String(chatIdInput));
   const messageId = normalizeMessageId(messageIdInput);
-  const fetchImpl = resolveTelegramFetch();
+  const proxyUrl = account.config.proxy;
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl as string) : undefined;
+  const fetchImpl = resolveTelegramFetch(proxyFetch);
   const client: ApiClientOptions | undefined = fetchImpl
     ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
     : undefined;


### PR DESCRIPTION
## Summary

Previously, outbound Telegram API calls (`sendMessage`, `setMessageReaction`, `deleteMessage`) ignored the configured proxy setting. This meant messages could bypass the proxy even when `channels.telegram.accounts.*.proxy` was set.

This fix ensures all outbound Telegram operations use the same proxy configuration as the monitor/polling code.

## Changes

- Import `makeProxyFetch` in `src/telegram/send.ts`
- Apply proxy to `sendMessageTelegram()`, `reactMessageTelegram()`, and `deleteMessageTelegram()` functions
- Uses the same pattern as existing `monitor.ts` implementation

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Verified proxy calls appear in Squid access log when proxy is configured

🤖 Generated with [Claude Code](https://claude.ai/code)