### PR TITLE
fix: enable scrolling in settings page on Windows [AI-assisted]

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -242,8 +242,10 @@
 .config-main {
   display: flex;
   flex-direction: column;
+  min-height: 0;
   min-width: 0;
   background: var(--panel);
+  overflow-y: auto;
 }
 
 /* Actions Bar */


### PR DESCRIPTION
## Summary
Fixes #1743 - Settings page can't scroll on Windows

## Problem
The `.config-layout` container has `overflow: hidden` which prevents scrolling in the settings page. Users on Windows (and potentially other platforms) cannot see settings below the fold.

Regression confirmed by multiple users - v2026.1.22 worked, v2026.1.23 broken.

## Solution
Added `min-height: 0` and `overflow-y: auto` to `.config-main`:

```css
.config-main {
  min-height: 0;      /* allows shrinking in grid/flex */
  overflow-y: auto;   /* enables scroll */
}
```

This is a standard CSS pattern for nested scroll containers within Grid/Flexbox layouts.

## Changes
```diff
 .config-main {
   display: flex;
   flex-direction: column;
+  min-height: 0;
   min-width: 0;
   background: var(--panel);
+  overflow-y: auto;
 }
```

## Testing
- ✅ `npm run lint` - PASSED (0 warnings, 0 errors)
- ✅ `npm run build` - PASSED
- ⚠️ Manual UI testing needed on Windows
- **Testing level:** lightly tested (lint + build pass, no Windows for manual test)

---

### 🤖 AI-Assisted

This PR was created with assistance from:
- **OpenAI Codex CLI** - Analyzed the CSS scroll issue and identified the fix
- **Clawdbot (Claude Opus 4.5)** - PR creation, testing, and workflow

The fix follows standard CSS scroll container patterns (`min-height: 0` trick for Grid/Flexbox).