### PR TITLE
fix(auth): add copyable raw URL below ASCII box for Google auth

### DIFF
--- a/extensions/google-antigravity-auth/index.ts
+++ b/extensions/google-antigravity-auth/index.ts
@@ -281,6 +281,7 @@ async function loginAntigravity(params: {
   openUrl: (url: string) => Promise<void>;
   prompt: (message: string) => Promise<string>;
   note: (message: string, title?: string) => Promise<void>;
+  log: (message: string) => void;
   progress: { update: (msg: string) => void; stop: (msg?: string) => void };
 }): Promise<{
   access: string;
@@ -314,6 +315,11 @@ async function loginAntigravity(params: {
       ].join("\n"),
       "Google Antigravity OAuth",
     );
+    // Output raw URL below the box for easy copying (fixes #1772)
+    params.log("");
+    params.log("Copy this URL:");
+    params.log(authUrl);
+    params.log("");
   }
 
   if (!needsManual) {
@@ -382,6 +388,7 @@ const antigravityPlugin = {
                 openUrl: ctx.openUrl,
                 prompt: async (message) => String(await ctx.prompter.text({ message })),
                 note: ctx.prompter.note,
+                log: (message) => ctx.runtime.log(message),
                 progress: spin,
               });
 


### PR DESCRIPTION
## Summary
Output the unformatted authentication URL below the ASCII-rendered box to enable standard terminal text selection without capturing border characters or line breaks.

## Problem
When users authenticate with Google Antigravity, the auth URL is displayed inside an ASCII table box. When trying to copy the URL from the terminal, line breaks and │ border characters get included in the selection, making it difficult to copy the URL correctly.

## Solution
Added raw URL output below the ASCII box so users can easily copy it using standard terminal text selection.

The output now looks like:
```
┌ Google Antigravity OAuth ─────────────────────────────┐
│                                                        │
│ Open the URL in your local browser.                    │
│ ...                                                    │
│ Auth URL: https://accounts.google.com/o/oauth2/...     │
│ Redirect URI: http://localhost:51121/oauth-callback    │
│                                                        │
└────────────────────────────────────────────────────────┘

Copy this URL:
https://accounts.google.com/o/oauth2/v2/auth?client_id=...
```

Fixes #1772

---

## 🤖 AI-Assisted PR

- [x] AI-assisted (Claude Opus 4.5 via Clawdbot)
- [x] Testing: Lightly tested (code review, not runtime tested)
- [x] I understand what this code does

**What the code does:** Adds a `log` parameter to `loginAntigravity()` and uses it to output the raw auth URL below the ASCII box when in manual OAuth mode (VPS/WSL2 environments where the browser cannot auto-open).