### PR TITLE
feat(telegram): add immediate 🎧 reaction for voice messages

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -417,6 +417,19 @@ export const buildTelegramMessageContext = async ({
         )
       : null;
 
+  // Voice/audio message reaction - immediate feedback while transcribing
+  const isVoiceMessage = Boolean(msg.audio || msg.voice);
+  const voiceReactionPromise =
+    isVoiceMessage && msg.message_id && reactionApi
+      ? reactionApi(chatId, msg.message_id, [{ type: "emoji", emoji: "🎧" }]).then(
+          () => true,
+          (err) => {
+            logVerbose(`telegram voice reaction failed for chat ${chatId}: ${String(err)}`);
+            return false;
+          },
+        )
+      : null;
+
   const replyTarget = describeReplyTarget(msg);
   const forwardOrigin = normalizeForwardedContext(msg);
   const replySuffix = replyTarget
@@ -587,6 +600,7 @@ export const buildTelegramMessageContext = async ({
     sendTyping,
     sendRecordVoice,
     ackReactionPromise,
+    voiceReactionPromise,
     reactionApi,
     removeAckAfterReply,
     accountId: account.accountId,


### PR DESCRIPTION
## Summary
When a voice note or audio file is received, immediately react with 🎧 emoji to provide visual feedback that the message is being processed/transcribed.

## Problem
Currently there's no feedback between sending a voice note and receiving a response - creating an awkward "dead air" UX gap.

## Solution
Add an immediate 🎧 reaction when voice/audio messages are detected, before transcription begins. This provides instant visual confirmation that the message was received and is being processed.

## Changes
- `src/telegram/bot-message-context.ts`: Added `voiceReactionPromise` that fires for `msg.audio` or `msg.voice` messages
- Exposed `voiceReactionPromise` in the context return object for potential future cleanup

## Testing
- Send a voice note to the Telegram bot
- Should immediately see 🎧 reaction
- Typing indicator shows during LLM processing
- Response arrives normally

## Notes
- 🤖 AI-assisted: This PR was developed with AI assistance (Claude)
- Lightly tested: Could not run full lint suite locally (missing oxlint)
- The change follows the existing ack reaction pattern