### PR TITLE
fix: apply config.env before ${VAR} substitution

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -211,6 +211,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         parseJson: (raw) => deps.json5.parse(raw),
       });
 
+      // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars
+      if (resolved && typeof resolved === "object" && "env" in resolved) {
+        applyConfigEnv(resolved as ClawdbotConfig, deps.env);
+      }
+
       // Substitute ${VAR} env var references
       const substituted = resolveConfigEnvVars(resolved, deps.env);
 
@@ -363,6 +368,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           warnings: [],
           legacyIssues: [],
         };
+      }
+
+      // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars
+      if (resolved && typeof resolved === "object" && "env" in resolved) {
+        applyConfigEnv(resolved as ClawdbotConfig, deps.env);
       }
 
       // Substitute ${VAR} env var references


### PR DESCRIPTION
## Summary

- Fixes config loading order so `env` section values are available during `${VAR}` substitution
- Previously, `resolveConfigEnvVars()` ran before `applyConfigEnv()`, causing "Missing env var" errors for vars defined in config

## Problem

When config has:
```json
{
  "env": { "MINIMAX_API_KEY": "sk-..." },
  "models": {
    "providers": {
      "minimax": { "apiKey": "${MINIMAX_API_KEY}" }
    }
  }
}
```

The substitution failed because the `env` section wasn't applied to `process.env` yet.

## Test plan

- [x] Verified fix resolves the error locally
- [x] Build passes