### PR TITLE
fix: preserve Telegram topic ID in gateway restart notifications

### DIFF
--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -14,6 +14,7 @@ export type AnnounceTarget = {
   channel: string;
   to: string;
   accountId?: string;
+  threadId?: string; // Forum topic/thread ID
 };
 
 export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget | null {
@@ -22,7 +23,22 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   if (parts.length < 3) return null;
   const [channelRaw, kind, ...rest] = parts;
   if (kind !== "group" && kind !== "channel") return null;
-  const id = rest.join(":").trim();
+
+  // Extract topic/thread ID from rest (supports both :topic: and :thread:)
+  // Telegram uses :topic:, other platforms use :thread:
+  let threadId: string | undefined;
+  const restJoined = rest.join(":");
+  const topicMatch = restJoined.match(/:topic:(\d+)$/);
+  const threadMatch = restJoined.match(/:thread:(\d+)$/);
+  const match = topicMatch || threadMatch;
+
+  if (match) {
+    threadId = match[1]; // Keep as string to match AgentCommandOpts.threadId
+  }
+
+  // Remove :topic:N or :thread:N suffix from ID for target
+  const id = match ? restJoined.replace(/:(topic|thread):\d+$/, "") : restJoined.trim();
+
   if (!id) return null;
   if (!channelRaw) return null;
   const normalizedChannel = normalizeAnyChannelId(channelRaw) ?? normalizeChatChannelId(channelRaw);
@@ -37,7 +53,11 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   const normalized = normalizedChannel
     ? getChannelPlugin(normalizedChannel)?.messaging?.normalizeTarget?.(kindTarget)
     : undefined;
-  return { channel, to: normalized ?? kindTarget };
+  return {
+    channel,
+    to: normalized ?? kindTarget,
+    threadId,
+  };
 }
 
 export function buildAgentToAgentMessageContext(params: {


### PR DESCRIPTION
## Problem

When gateway restarts, notifications were being sent to the wrong Telegram topic (defaulting to General topic ID 1) instead of the originating topic that triggered the restart.

## Root Causes

### 1. Missing threadId extraction in delivery chain
The `sessionKey` contains topic/thread information (e.g., `agent:main:telegram:group:-1003455795513:topic:8`), but `resolveAnnounceTargetFromKey()` was not extracting this information into the `AnnounceTarget` type, causing it to be lost during message delivery.

### 2. Inconsistent format handling
`server-restart-sentinel.ts` was only parsing `:thread:` format, but:
- **Telegram** uses `:topic:` format
- **Slack/Mattermost** use `:thread:` format

This meant restart notifications were completely broken for Telegram forum topics.

## Solution

### 1. Add threadId to AnnounceTarget type
Added `threadId?: string` field to preserve topic/thread information through the delivery chain.

### 2. Extract threadId in resolveAnnounceTargetFromKey()
Parse both `:topic:N` and `:thread:N` formats from sessionKey and include in returned `AnnounceTarget`.

### 3. Fix server-restart-sentinel.ts format handling
Updated to detect and parse **BOTH** `:topic:` and `:thread:` formats, ensuring the fix works across all platforms.

### 4. Preserve threadId through delivery
Include `parsedTarget?.threadId` in the threadId resolution chain to ensure it reaches the final delivery.

## Platform Support

This fix ensures restart notifications work correctly for:
- ✅ **Telegram** forum topics (using `:topic:` format)
- ✅ **Slack** threads (using `:thread:` format)
- ✅ **Mattermost** threads (using `:thread:` format)
- ✅ Other platforms using thread-based routing

## Testing

Verified with 2 consecutive gateway restarts that notifications now correctly route to the originating Telegram topic (Topic 8) instead of General topic (ID 1).

## Files Changed

- `src/agents/tools/sessions-send-helpers.ts` (+22 -3)
  - Add `threadId` field to `AnnounceTarget` type
  - Extract topic/thread ID from sessionKey (both formats)
- `src/gateway/server-restart-sentinel.ts` (+11 -4)
  - Parse both `:topic:` and `:thread:` formats
  - Include `parsedTarget?.threadId` in resolution chain

Total: 2 files, 33 insertions(+), 7 deletions(-)