### PR TITLE
fix: use OriginatingTo for message tool reply target

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -28,7 +28,7 @@ export function buildThreadingToolContext(params: {
   const dock = provider ? getChannelDock(provider) : undefined;
   if (!dock?.threading?.buildToolContext) {
     return {
-      currentChannelId: sessionCtx.To?.trim() || undefined,
+      currentChannelId: (sessionCtx.OriginatingTo ?? sessionCtx.To)?.trim() || undefined,
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
       hasRepliedRef,
     };


### PR DESCRIPTION
## Problem

When replying to Tlon group channel messages, the agent fails with:
```
Unknown target "~bolbex-fogdys/ops" for Tlon
```

The target is corrupted - missing the `chat/` prefix.

## Root Cause

The Tlon monitor correctly sets context as:
- `To` = `tlon:~bot-ship` (the bot's ship - message recipient)
- `OriginatingTo` = `tlon:chat/~host/channel` (the group channel - where to reply)

But when creating the message tool, `agent-runner-utils.ts` uses `To` as the default reply target:
```typescript
currentChannelId: sessionCtx.To?.trim() || undefined,
```

This gives the agent `tlon:~bot-ship` instead of the correct group channel, leading to corrupted targets when the agent tries to reply.

## Solution

Use `OriginatingTo` first (semantically correct reply target), with fallback to `To` for backward compatibility:

```typescript
currentChannelId: (sessionCtx.OriginatingTo ?? sessionCtx.To)?.trim() || undefined,
```

## Impact

- **Tlon**: Fixes group message replies ✅
- **Other channels without custom `buildToolContext`**: Also improved (Telegram, Signal, Discord, iMessage, WhatsApp)
  - For DMs: `OriginatingTo` = `To` (no change)
  - For groups: `OriginatingTo` = group channel (correct)
- **Channels with custom `buildToolContext`**: Not affected (Slack, MS Teams, Matrix, etc.)

## Testing Status

- [x] Root cause identified
- [x] Fix implemented
- [x] Applied locally and tested
- [ ] Developer review pending