### PR TITLE
feat: Build sandbox-browser image with Chromium support

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -53,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.sandbox-browser
           platforms: linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -102,6 +103,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.sandbox-browser
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Update docker-release.yml to build Dockerfile.sandbox-browser instead of the base Dockerfile. This includes:

- Chromium browser for web automation
- Xvfb virtual framebuffer for headless display
- X11vnc + noVNC for remote browser access
- Screen capture capabilities

Required for DBA Infrastructure K8s deployment with browser control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)