### PR TITLE
fix: ensure most recent session metadata wins during gateway store merge

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -88,7 +88,7 @@ function resolveIdentityAvatarUrl(
   cfg: ClawdbotConfig,
   agentId: string,
   avatar: string | undefined,
-  ): string | undefined {
+): string | undefined {
   if (!avatar) return undefined;
   const trimmed = avatar.trim();
   if (!trimmed) return undefined;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -88,7 +88,7 @@ function resolveIdentityAvatarUrl(
   cfg: ClawdbotConfig,
   agentId: string,
   avatar: string | undefined,
-): string | undefined {
+  ): string | undefined {
   if (!avatar) return undefined;
   const trimmed = avatar.trim();
   if (!trimmed) return undefined;
@@ -381,6 +381,34 @@ export function resolveGatewaySessionStoreTarget(params: { cfg: ClawdbotConfig; 
   };
 }
 
+// Merge with existing entry based on latest timestamp to ensure data consistency and avoid overwriting with less complete data.
+function mergeSessionEntryIntoCombined(params: {
+  combined: Record<string, SessionEntry>;
+  entry: SessionEntry;
+  agentId: string;
+  canonicalKey: string;
+}) {
+  const { combined, entry, agentId, canonicalKey } = params;
+  const existing = combined[canonicalKey];
+
+  if (existing && (existing.updatedAt ?? 0) > (entry.updatedAt ?? 0)) {
+    combined[canonicalKey] = {
+      ...entry,
+      ...existing,
+      spawnedBy: canonicalizeSpawnedByForAgent(agentId, existing.spawnedBy ?? entry.spawnedBy),
+    };
+  } else {
+    combined[canonicalKey] = {
+      ...existing,
+      ...entry,
+      spawnedBy: canonicalizeSpawnedByForAgent(
+        agentId,
+        entry.spawnedBy ?? existing?.spawnedBy,
+      ),
+    };
+  }
+}
+
 export function loadCombinedSessionStoreForGateway(cfg: ClawdbotConfig): {
   storePath: string;
   store: Record<string, SessionEntry>;
@@ -393,10 +421,12 @@ export function loadCombinedSessionStoreForGateway(cfg: ClawdbotConfig): {
     const combined: Record<string, SessionEntry> = {};
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
-      combined[canonicalKey] = {
-        ...entry,
-        spawnedBy: canonicalizeSpawnedByForAgent(defaultAgentId, entry.spawnedBy),
-      };
+      mergeSessionEntryIntoCombined({
+        combined,
+        entry,
+        agentId: defaultAgentId,
+        canonicalKey,
+      });
     }
     return { storePath, store: combined };
   }
@@ -408,13 +438,12 @@ export function loadCombinedSessionStoreForGateway(cfg: ClawdbotConfig): {
     const store = loadSessionStore(storePath);
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
-      // Merge with existing entry if present (avoid overwriting with less complete data)
-      const existing = combined[canonicalKey];
-      combined[canonicalKey] = {
-        ...existing,
-        ...entry,
-        spawnedBy: canonicalizeSpawnedByForAgent(agentId, entry.spawnedBy ?? existing?.spawnedBy),
-      };
+      mergeSessionEntryIntoCombined({
+        combined,
+        entry,
+        agentId,
+        canonicalKey,
+      });
     }
   }
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -401,10 +401,7 @@ function mergeSessionEntryIntoCombined(params: {
     combined[canonicalKey] = {
       ...existing,
       ...entry,
-      spawnedBy: canonicalizeSpawnedByForAgent(
-        agentId,
-        entry.spawnedBy ?? existing?.spawnedBy,
-      ),
+      spawnedBy: canonicalizeSpawnedByForAgent(agentId, entry.spawnedBy ?? existing?.spawnedBy),
     };
   }
 }


### PR DESCRIPTION
## Summary
The web dashboard at `/sessions` was displaying an outdated timestamp (15d ago) for one of my sessions, while the `/status` command issued in Telegram correctly displayed "updated just now" for the session. This PR fixes this by ensuring the most recently updated session entry takes precedence.

### Initial Prompt
The `/status` command is correctly showing the main session as 'updated just now', but the web dashboard at `/sessions` is displaying an outdated 'updated 15 days ago' timestamp for the same session.

Please investigate the root cause of this discrepancy. Identify why the `/status` command and the web dashboard are displaying different updatedAt timestamps for the same session, and ensure consistent session metadata across all Clawdbot interfaces.

### Notes
- tested locally, AI-assisted