### PR TITLE
feat(cron): include delivery channel/to in finished event

### DIFF
--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -10,6 +10,10 @@ export type CronEvent = {
   error?: string;
   summary?: string;
   nextRunAtMs?: number;
+  /** Delivery channel from the job payload (for agentTurn jobs). */
+  channel?: string;
+  /** Delivery target from the job payload (for agentTurn jobs). */
+  to?: string;
 };
 
 export type Logger = {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -103,6 +103,9 @@ export async function executeJob(
       runAtMs: startedAt,
       durationMs: job.state.lastDurationMs,
       nextRunAtMs: job.state.nextRunAtMs,
+      // Include delivery target from payload for agentTurn jobs
+      channel: job.payload.kind === "agentTurn" ? job.payload.channel : undefined,
+      to: job.payload.kind === "agentTurn" ? job.payload.to : undefined,
     });
 
     if (shouldDelete && state.store) {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -240,6 +240,10 @@ export const CronRunLogEntrySchema = Type.Object(
     runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
     nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    /** Delivery channel from the job payload (for agentTurn jobs). */
+    channel: Type.Optional(Type.String()),
+    /** Delivery target from the job payload (for agentTurn jobs). */
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Summary

When a cron job with `agentTurn` payload completes, the `cron.finished` event now includes the delivery target fields (`channel` and `to`) from the original job payload. This enables gateway clients to deliver cron messages to specific channels instead of broadcasting to all user platforms.

**Use case:** When an agent schedules a reminder like "Remind me on Discord: ...", the external gateway can now deliver the message only to Discord instead of all channels.

## Changes

- Add `channel` and `to` fields to `CronEvent` type (`src/cron/service/state.ts`)
- Add `channel` and `to` fields to `CronRunLogEntrySchema` (`src/gateway/protocol/schema/cron.ts`)
- Include `channel` and `to` from `job.payload` when emitting finished event (`src/cron/service/timer.ts`)

## Backward Compatibility

Both fields are optional. Existing clients that don't use these fields will continue to work unchanged.

## Test Plan

- [x] Code review for type safety
- [ ] Unit tests (existing tests should pass)
- [ ] E2E test: Schedule cron with specific channel, verify finished event contains channel/to

🤖 Generated with [Claude Code](https://claude.ai/code)