### PR TITLE
fix(agents): skip extracting tool calls from errored assistant turns

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,14 @@ type ToolCallLike = {
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
+  // Skip extracting tool calls if the assistant turn errored/terminated.
+  // Errored turns contain incomplete tool calls (often with partialJson) that
+  // were never executed. Inserting synthetic tool_results for these would cause
+  // Anthropic's API to reject subsequent requests with "unexpected tool_use_id".
+  // See: https://github.com/clawdbot/clawdbot/issues/1826
+  const stopReason = (msg as { stopReason?: unknown }).stopReason;
+  if (stopReason === "error") return [];
+
   const content = msg.content;
   if (!Array.isArray(content)) return [];
 


### PR DESCRIPTION
## Summary
Fixes #1826

When an assistant turn has `stopReason: "error"` (terminated/interrupted), the tool calls within it were never completed. The transcript repair logic was incorrectly inserting synthetic `tool_result` messages for these incomplete tool calls, causing Anthropic's API to reject all subsequent requests with "unexpected tool_use_id" errors, permanently breaking the session.

## Changes
- Modified `extractToolCallsFromAssistant()` in `session-transcript-repair.ts` to return early (empty array) when the assistant message has `stopReason: "error"`
- Added test case covering the errored/terminated assistant turn scenario

## Test Plan
- [x] Run `pnpm test src/agents/session-transcript-repair.test.ts` - all 5 tests pass
- [x] Full test suite passes (4590 passed, 1 unrelated timeout)
- [x] Lint passes
- [x] Build passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (issue-hunter-pro)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the session transcript repair logic to avoid extracting tool calls from assistant turns that ended with `stopReason: "error"`, preventing insertion of synthetic `toolResult` messages for tool calls that were never actually executed (which can cause downstream API rejections due to unexpected tool IDs). It also adds a regression test covering an errored/terminated assistant turn containing an incomplete tool call (with `partialJson`) and verifies no synthetic results are inserted.

These changes fit into `src/agents/session-transcript-repair.ts`’s role as a sanitizer that reorders/deduplicates tool results and inserts synthetic missing results to satisfy strict provider transcript rules; the new guard narrows that behavior so it doesn’t manufacture results for interrupted turns where tool execution never occurred.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should prevent a known session-breaking failure mode.
- The change is small and localized (an early return when `stopReason === "error"`), and the added regression test exercises the reported failure scenario. The main remaining risk is behavioral: skipping tool-call extraction on errored turns may leave other providers’ transcripts inconsistent if they still require results, but for the described Anthropic-compatible behavior this is the correct tradeoff.
- src/agents/session-transcript-repair.ts (the stopReason handling and assumptions about message shapes)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->