### PR TITLE
fix: handle 400 status in failover to enable model fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Model failover: treat HTTP 400 errors as failover-eligible, enabling automatic model fallback when providers return bad request errors. (#1879) Thanks @orenyomtov.
 - Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11937)
 - Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.
 - Docs: fix language switcher ordering and Japanese locale flag in Mintlify nav. (#12023) Thanks @joshp123.

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -11,6 +11,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -160,6 +160,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
+  if (status === 400) {
+    return "format";
+  }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
   if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {


### PR DESCRIPTION
## Summary
- Fix failover system to treat HTTP 400 errors as failover-eligible, enabling automatic model fallback when providers return bad request errors

## Problem
When Anthropic (or other providers) returned a 400 error, the failover system would not attempt the fallback model because:

1. `resolveFailoverReasonFromError` only checked for status codes 401, 402, 403, 408, and 429
2. 400 errors fell through to message-based classification
3. If the error message didn't match specific patterns, `coerceToFailoverError` returned `null`
4. This caused the error to be thrown immediately without trying fallback models

## Fix
Added `status === 400` check to return `"format"` as the failover reason, consistent with the existing `resolveFailoverStatus` mapping.

## Test plan
- [x] Added test case for `{ status: 400 }` → `"format"` in HTTP status inference test
- [x] All existing failover tests pass (7 tests)
- [x] Model fallback tests pass (17 tests)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates failover error classification to treat HTTP `400` responses as a failover-eligible `format` reason (matching the existing `resolveFailoverStatus("format") -> 400` mapping). A unit test is added to ensure `{ status: 400 }` is inferred as `"format"`.

This plugs a gap where 400s could fall through to message-based classification and end up non-failover, preventing `runWithModelFallback` from trying configured fallback models when providers return a Bad Request due to request formatting issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one additional status-code mapping) and is covered by a focused unit test. It aligns with existing `format -> 400` status mapping and should only increase failover behavior for 400 responses.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->