### PR TITLE
security: add mDNS discovery config to reduce information disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Status: unreleased.
 
 ### Fixes
 - Security: harden Tailscale Serve auth by validating identity via local tailscaled before trusting headers.
+- Security: add mDNS discovery mode with minimal default to reduce information disclosure. (#1882) Thanks @orlyjamie.
 - Web UI: improve WebChat image paste previews and allow image-only sends. (#1925) Thanks @smartprogrammer93.
 - Gateway: default auth now fail-closed (token/password required; Tailscale Serve identity remains allowed).
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3175,6 +3175,20 @@ Auto-generated certs require `openssl` on PATH; if generation fails, the bridge 
 }
 ```
 
+### `discovery.mdns` (Bonjour / mDNS broadcast mode)
+
+Controls LAN mDNS discovery broadcasts (`_clawdbot-gw._tcp`).
+
+- `minimal` (default): omit `cliPath` + `sshPort` from TXT records
+- `full`: include `cliPath` + `sshPort` in TXT records
+- `off`: disable mDNS broadcasts entirely
+
+```json5
+{
+  discovery: { mdns: { mode: "minimal" } }
+}
+```
+
 ### `discovery.wideArea` (Wide-Area Bonjour / unicast DNS‑SD)
 
 When enabled, the Gateway writes a unicast DNS-SD zone for `_clawdbot-bridge._tcp` under `~/.clawdbot/dns/` using the standard discovery domain `clawdbot.internal.`

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -338,6 +338,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.signal.account": "Signal Account",
   "channels.imessage.cliPath": "iMessage CLI Path",
   "agents.list[].identity.avatar": "Agent Avatar",
+  "discovery.mdns.mode": "mDNS Discovery Mode",
   "plugins.enabled": "Enable Plugins",
   "plugins.allow": "Plugin Allowlist",
   "plugins.deny": "Plugin Denylist",
@@ -369,6 +370,8 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.remote.sshIdentity": "Optional SSH identity file path (passed to ssh -i).",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
+  "discovery.mdns.mode":
+    'mDNS broadcast mode ("minimal" default, "full" includes cliPath/sshPort, "off" disables mDNS).',
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -17,8 +17,21 @@ export type WideAreaDiscoveryConfig = {
   enabled?: boolean;
 };
 
+export type MdnsDiscoveryMode = "off" | "minimal" | "full";
+
+export type MdnsDiscoveryConfig = {
+  /**
+   * mDNS/Bonjour discovery broadcast mode (default: minimal).
+   * - off: disable mDNS entirely
+   * - minimal: omit cliPath/sshPort from TXT records
+   * - full: include cliPath/sshPort in TXT records
+   */
+  mode?: MdnsDiscoveryMode;
+};
+
 export type DiscoveryConfig = {
   wideArea?: WideAreaDiscoveryConfig;
+  mdns?: MdnsDiscoveryConfig;
 };
 
 export type CanvasHostConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -272,6 +272,12 @@ export const ClawdbotSchema = z
           })
           .strict()
           .optional(),
+        mdns: z
+          .object({
+            mode: z.enum(["off", "minimal", "full"]).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -14,36 +14,46 @@ export async function startGatewayDiscovery(params: {
   canvasPort?: number;
   wideAreaDiscoveryEnabled: boolean;
   tailscaleMode: "off" | "serve" | "funnel";
+  /** mDNS/Bonjour discovery mode (default: minimal). */
+  mdnsMode?: "off" | "minimal" | "full";
   logDiscovery: { info: (msg: string) => void; warn: (msg: string) => void };
 }) {
   let bonjourStop: (() => Promise<void>) | null = null;
+  const mdnsMode = params.mdnsMode ?? "minimal";
+  // mDNS can be disabled via config (mdnsMode: off) or env var.
   const bonjourEnabled =
+    mdnsMode !== "off" &&
     process.env.CLAWDBOT_DISABLE_BONJOUR !== "1" &&
     process.env.NODE_ENV !== "test" &&
     !process.env.VITEST;
+  const mdnsMinimal = mdnsMode !== "full";
   const tailscaleEnabled = params.tailscaleMode !== "off";
   const needsTailnetDns = bonjourEnabled || params.wideAreaDiscoveryEnabled;
   const tailnetDns = needsTailnetDns
     ? await resolveTailnetDnsHint({ enabled: tailscaleEnabled })
     : undefined;
-  const sshPortEnv = process.env.CLAWDBOT_SSH_PORT?.trim();
+  const sshPortEnv = mdnsMinimal ? undefined : process.env.CLAWDBOT_SSH_PORT?.trim();
   const sshPortParsed = sshPortEnv ? Number.parseInt(sshPortEnv, 10) : NaN;
   const sshPort = Number.isFinite(sshPortParsed) && sshPortParsed > 0 ? sshPortParsed : undefined;
+  const cliPath = mdnsMinimal ? undefined : resolveBonjourCliPath();
 
-  try {
-    const bonjour = await startGatewayBonjourAdvertiser({
-      instanceName: formatBonjourInstanceName(params.machineDisplayName),
-      gatewayPort: params.port,
-      gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
-      gatewayTlsFingerprintSha256: params.gatewayTls?.fingerprintSha256,
-      canvasPort: params.canvasPort,
-      sshPort,
-      tailnetDns,
-      cliPath: resolveBonjourCliPath(),
-    });
-    bonjourStop = bonjour.stop;
-  } catch (err) {
-    params.logDiscovery.warn(`bonjour advertising failed: ${String(err)}`);
+  if (bonjourEnabled) {
+    try {
+      const bonjour = await startGatewayBonjourAdvertiser({
+        instanceName: formatBonjourInstanceName(params.machineDisplayName),
+        gatewayPort: params.port,
+        gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
+        gatewayTlsFingerprintSha256: params.gatewayTls?.fingerprintSha256,
+        canvasPort: params.canvasPort,
+        sshPort,
+        tailnetDns,
+        cliPath,
+        minimal: mdnsMinimal,
+      });
+      bonjourStop = bonjour.stop;
+    } catch (err) {
+      params.logDiscovery.warn(`bonjour advertising failed: ${String(err)}`);
+    }
   }
 
   if (params.wideAreaDiscoveryEnabled) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -352,7 +352,6 @@ export async function startGatewayServer(
       : undefined,
     wideAreaDiscoveryEnabled: cfgAtStart.discovery?.wideArea?.enabled === true,
     tailscaleMode,
-    tailscaleMode,
     mdnsMode: cfgAtStart.discovery?.mdns?.mode,
     logDiscovery,
   });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -352,6 +352,8 @@ export async function startGatewayServer(
       : undefined,
     wideAreaDiscoveryEnabled: cfgAtStart.discovery?.wideArea?.enabled === true,
     tailscaleMode,
+    tailscaleMode,
+    mdnsMode: cfgAtStart.discovery?.mdns?.mode,
     logDiscovery,
   });
   bonjourStop = discovery.bonjourStop;


### PR DESCRIPTION
mDNS broadcasts can expose sensitive operational details like filesystem paths (cliPath) and SSH availability (sshPort) to anyone on the local network. This information aids reconnaissance and should be minimized for gateways exposed beyond trusted networks.

Example..

https://www.shodan.io/search?query=clawdbot
<img width="1233" height="680" alt="image" src="https://github.com/user-attachments/assets/06bb1815-6929-4850-b5c8-11f5864dda8a" />


Changes:
- Add discovery.mdns.enabled config option to disable mDNS entirely
- Add discovery.mdns.minimal option to omit cliPath/sshPort from TXT records
- Update security docs with operational security guidance

Minimal mode still broadcasts enough for device discovery (role, gatewayPort, transport) while omitting details that help map the host environment. Apps that need CLI path can fetch it via the authenticated WebSocket.