### PR TITLE
fix(telegram): prevent block replies when streaming is disabled

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -358,12 +358,13 @@ export async function runAgentTurnWithFallback(params: {
                   // Use pipeline if available (block streaming enabled), otherwise send directly
                   if (params.blockStreamingEnabled && params.blockReplyPipeline) {
                     params.blockReplyPipeline.enqueue(blockPayload);
-                  } else {
-                    // Send directly when flushing before tool execution (no streaming).
+                  } else if (params.blockStreamingEnabled) {
+                    // Send directly when flushing before tool execution (no pipeline but streaming enabled).
                     // Track sent key to avoid duplicate in final payloads.
                     directlySentBlockKeys.add(createBlockReplyPayloadKey(blockPayload));
                     await params.opts?.onBlockReply?.(blockPayload);
                   }
+                  // When streaming is disabled entirely, blocks are accumulated in final text instead.
                 }
               : undefined,
             onBlockReplyFlush:


### PR DESCRIPTION
## Summary
- Fixes issue where block replies were sent even when `disableBlockStreaming=true`
- This caused TTS audio to be sent as a separate message instead of combined with text when draft streaming was active

## Problem
When draft streaming is enabled for Telegram, `disableBlockStreaming` is set to `true`. However, the `onBlockReply` handler was still sending blocks via the else branch, causing:
1. `hadBlockReplies=true` even though streaming was supposed to be disabled
2. TTS audio being sent as a separate "audio-only" message instead of combined with the final text

## Fix
Added a check for `blockStreamingEnabled` in the else branch so blocks are only sent when streaming is explicitly enabled.

## Test plan
- [x] Enable draft streaming + TTS auto in Telegram private chat
- [x] Send a message and verify text appears in draft bubble
- [x] Verify final message has text + audio combined (not separate)