### PR TITLE
fix(telegram): read caption param for media sends

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -13,11 +13,9 @@ const providerId = "telegram";
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
   const mediaUrl = readStringParam(params, "media", { trim: false });
-  const content =
-    readStringParam(params, "message", {
-      required: !mediaUrl,
-      allowEmpty: true,
-    }) ?? "";
+  const message = readStringParam(params, "message", { required: !mediaUrl, allowEmpty: true });
+  const caption = readStringParam(params, "caption", { allowEmpty: true });
+  const content = message || caption || "";
   const replyTo = readStringParam(params, "replyTo");
   const threadId = readStringParam(params, "threadId");
   const buttons = params.buttons;


### PR DESCRIPTION
## What
Use `caption` parameter as fallback when `message` is empty for Telegram media sends.

## Why
When an agent sends media (GIFs, images), it passes the text in the `caption` parameter, but the code only read `message`. The `caption` parameter was completely ignored.

## Testing

- Tested locally with clawdbot agent sending GIFs with captions - caption now appears