### PR TITLE
fix(ci): increase Node heap size for checks-macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,8 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
       - name: Run ${{ matrix.task }}
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: ${{ matrix.command }}
 
   macos-app:


### PR DESCRIPTION
## Summary

The `checks-macos` test job fails with a JavaScript heap out of memory error:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
[24520:0x128018000] 35210 ms: Scavenge 2021.4 (2076.8) -> 2019.1 (2078.1) MB
```

This increases the Node.js heap size to 4GB for the macOS test runner, matching the available memory on GitHub's macOS runners.

## Test Plan

- [x] CI should pass on this PR (meta-test)