### PR TITLE
feat(nano-banana-pro): add batch mode, aspect ratio, and gallery output

### DIFF
--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,30 +1,65 @@
 ---
 name: nano-banana-pro
-description: Generate or edit images via Gemini 3 Pro Image (Nano Banana Pro).
-homepage: https://ai.google.dev/
+description: Generate or edit images via Gemini image generation API (formerly Nano Banana Pro).
+homepage: https://ai.google.dev/gemini-api/docs/image-generation
 metadata: {"clawdbot":{"emoji":"🍌","requires":{"bins":["uv"],"env":["GEMINI_API_KEY"]},"primaryEnv":"GEMINI_API_KEY","install":[{"id":"uv-brew","kind":"brew","formula":"uv","bins":["uv"],"label":"Install uv (brew)"}]}}
 ---
 
-# Nano Banana Pro (Gemini 3 Pro Image)
+# Nano Banana Pro (Gemini Image Generation)
 
-Use the bundled script to generate or edit images.
+Use the bundled script to generate or edit images via Gemini's image generation API.
 
-Generate
+## Generate
+
 ```bash
-uv run {baseDir}/scripts/generate_image.py --prompt "your image description" --filename "output.png" --resolution 1K
+# Single image
+uv run {baseDir}/scripts/generate_image.py --prompt "a cute robot exploring mars" --filename robot.png
+
+# With aspect ratio and resolution
+uv run {baseDir}/scripts/generate_image.py --prompt "cyberpunk cityscape" --filename city.png --aspect-ratio 16:9 --resolution 2K
+
+# Batch generation with gallery
+uv run {baseDir}/scripts/generate_image.py --prompt "surreal landscape" --count 4 --out-dir ./images
 ```
 
-Edit
+## Edit
+
 ```bash
-uv run {baseDir}/scripts/generate_image.py --prompt "edit instructions" --filename "output.png" --input-image "/path/in.png" --resolution 2K
+uv run {baseDir}/scripts/generate_image.py --prompt "add dramatic sunset lighting" --filename edited.png --input-image /path/to/photo.jpg
 ```
 
-API key
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--prompt`, `-p` | Image description (required) | - |
+| `--filename`, `-f` | Output filename | - |
+| `--input-image`, `-i` | Input image for editing | - |
+| `--resolution`, `-r` | `1K`, `2K`, or `4K` | `1K` |
+| `--aspect-ratio`, `-a` | `1:1`, `3:4`, `4:3`, `9:16`, `16:9` | `1:1` |
+| `--count`, `-n` | Number of images (batch mode) | `1` |
+| `--out-dir`, `-o` | Output directory (creates timestamped subdir) | - |
+| `--model`, `-m` | Model name | `gemini-2.0-flash-preview-image-generation` |
+| `--no-gallery` | Skip HTML gallery in batch mode | - |
+
+## API Key
+
+Provide via:
 - `GEMINI_API_KEY` env var
-- Or set `skills."nano-banana-pro".apiKey` / `skills."nano-banana-pro".env.GEMINI_API_KEY` in `~/.clawdbot/clawdbot.json`
+- `--api-key` flag
+- `skills."nano-banana-pro".apiKey` in `~/.clawdbot/clawdbot.json`
+- `skills."nano-banana-pro".env.GEMINI_API_KEY` in config
 
-Notes
-- Resolutions: `1K` (default), `2K`, `4K`.
-- Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`.
-- The script prints a `MEDIA:` line for Clawdbot to auto-attach on supported chat providers.
-- Do not read the image back; report the saved path only.
+## Batch Mode Output
+
+When using `--count > 1`, the script creates:
+- Numbered image files (`image-001.png`, `image-002.png`, etc.)
+- `prompts.json` — metadata for each image
+- `index.html` — browsable thumbnail gallery
+
+## Notes
+
+- Auto-detects resolution from input image when editing
+- The script prints a `MEDIA:` line for Clawdbot to auto-attach on supported providers
+- Do not read the image back; report the saved path only
+- Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -7,15 +7,28 @@
 # ]
 # ///
 """
-Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
+Generate or edit images using Google's Gemini image generation API.
 
 Usage:
-    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    # Single image generation
+    uv run generate_image.py --prompt "your image description" --filename "output.png"
+    
+    # Batch generation
+    uv run generate_image.py --prompt "lobster astronaut" --count 4 --out-dir ./images
+    
+    # Image editing
+    uv run generate_image.py --prompt "make it sunset" --input-image photo.jpg --filename edited.png
+    
+    # With options
+    uv run generate_image.py --prompt "mountain landscape" --aspect-ratio 16:9 --resolution 2K
 """
 
 import argparse
+import html
+import json
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
 
 
@@ -26,9 +39,69 @@ def get_api_key(provided_key: str | None) -> str | None:
     return os.environ.get("GEMINI_API_KEY")
 
 
+def generate_gallery_html(output_dir: Path, images: list[dict]) -> Path:
+    """Generate an HTML gallery for the images."""
+    html_path = output_dir / "index.html"
+    
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <title>Generated Images</title>
+    <style>
+        body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #eee; padding: 20px; }
+        h1 { text-align: center; color: #ffd700; }
+        .gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 20px; }
+        .card { background: #16213e; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
+        .card img { width: 100%; height: auto; display: block; }
+        .card .info { padding: 12px; }
+        .card .prompt { font-size: 14px; color: #aaa; word-wrap: break-word; }
+        .card .meta { font-size: 12px; color: #666; margin-top: 8px; }
+    </style>
+</head>
+<body>
+    <h1>🍌 Nano Banana Pro Gallery</h1>
+    <div class="gallery">
+"""]
+    
+    for img in images:
+        # Escape HTML to prevent injection
+        safe_filename = html.escape(img['filename'])
+        safe_prompt = html.escape(img['prompt'])
+        safe_resolution = html.escape(img['resolution'])
+        safe_model = html.escape(img.get('model', 'gemini-2.0-flash-preview-image-generation'))
+        prompt_preview = html.escape(img['prompt'][:50]) + ("..." if len(img['prompt']) > 50 else "")
+        
+        html_parts.append(f"""
+        <div class="card">
+            <img src="{safe_filename}" alt="{prompt_preview}">
+            <div class="info">
+                <div class="prompt">{safe_prompt}</div>
+                <div class="meta">{safe_resolution} • {safe_model}</div>
+            </div>
+        </div>
+""")
+    
+    html_parts.append("""
+    </div>
+</body>
+</html>
+""")
+    
+    html_path.write_text("".join(html_parts), encoding="utf-8")
+    return html_path
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate images using Nano Banana Pro (Gemini 3 Pro Image)"
+        description="Generate images using Gemini image generation API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --prompt "a cute robot" --filename robot.png
+  %(prog)s --prompt "mountain sunset" --count 4 --out-dir ./gallery
+  %(prog)s --prompt "add rain" --input-image photo.jpg --filename rainy.png
+  %(prog)s --prompt "cyberpunk city" --aspect-ratio 16:9 --resolution 2K
+        """
     )
     parser.add_argument(
         "--prompt", "-p",
@@ -37,8 +110,7 @@ def main():
     )
     parser.add_argument(
         "--filename", "-f",
-        required=True,
-        help="Output filename (e.g., sunset-mountains.png)"
+        help="Output filename (e.g., sunset-mountains.png). Required for single image."
     )
     parser.add_argument(
         "--input-image", "-i",
@@ -51,11 +123,46 @@ def main():
         help="Output resolution: 1K (default), 2K, or 4K"
     )
     parser.add_argument(
+        "--aspect-ratio", "-a",
+        choices=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        default="1:1",
+        help="Aspect ratio (default: 1:1 square)"
+    )
+    parser.add_argument(
+        "--count", "-n",
+        type=int,
+        default=1,
+        help="Number of images to generate (default: 1)"
+    )
+    parser.add_argument(
+        "--out-dir", "-o",
+        help="Output directory for batch generation (creates timestamped subdir)"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default="gemini-2.0-flash-preview-image-generation",
+        help="Model to use (default: gemini-2.0-flash-preview-image-generation)"
+    )
+    parser.add_argument(
         "--api-key", "-k",
         help="Gemini API key (overrides GEMINI_API_KEY env var)"
     )
+    parser.add_argument(
+        "--no-gallery",
+        action="store_true",
+        help="Skip HTML gallery generation for batch mode"
+    )
 
     args = parser.parse_args()
+
+    # Validate arguments
+    if args.count > 1 and not args.out_dir:
+        print("Error: --out-dir is required when --count > 1", file=sys.stderr)
+        sys.exit(1)
+    
+    if args.count == 1 and not args.filename and not args.out_dir:
+        print("Error: --filename or --out-dir is required", file=sys.stderr)
+        sys.exit(1)
 
     # Get API key
     api_key = get_api_key(args.api_key)
@@ -71,14 +178,19 @@ def main():
     from google.genai import types
     from PIL import Image as PILImage
 
-    # Initialise client
+    # Initialize client
     client = genai.Client(api_key=api_key)
 
-    # Set up output path
-    output_path = Path(args.filename)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Set up output directory
+    if args.out_dir:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        output_dir = Path(args.out_dir) / f"nano-banana-{timestamp}"
+        output_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        output_dir = Path(args.filename).parent
+        output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load input image if provided
+    # Load input image if provided (for editing)
     input_image = None
     output_resolution = args.resolution
     if args.input_image:
@@ -86,9 +198,8 @@ def main():
             input_image = PILImage.open(args.input_image)
             print(f"Loaded input image: {args.input_image}")
 
-            # Auto-detect resolution if not explicitly set by user
-            if args.resolution == "1K":  # Default value
-                # Map input image size to resolution
+            # Auto-detect resolution if default
+            if args.resolution == "1K":
                 width, height = input_image.size
                 max_dim = max(width, height)
                 if max_dim >= 3000:
@@ -102,67 +213,130 @@ def main():
             print(f"Error loading input image: {e}", file=sys.stderr)
             sys.exit(1)
 
-    # Build contents (image first if editing, prompt only if generating)
-    if input_image:
-        contents = [input_image, args.prompt]
-        print(f"Editing image with resolution {output_resolution}...")
-    else:
-        contents = args.prompt
-        print(f"Generating image with resolution {output_resolution}...")
+    # Generate images
+    generated_images = []
+    
+    for i in range(args.count):
+        if args.count > 1:
+            # Generate filename for batch mode
+            filename = f"image-{i+1:03d}.png"
+            output_path = output_dir / filename
+            print(f"\n[{i+1}/{args.count}] Generating...")
+        else:
+            if args.filename:
+                output_path = Path(args.filename)
+                if not output_path.is_absolute():
+                    output_path = output_dir / output_path
+            else:
+                output_path = output_dir / "image.png"
 
-    try:
-        response = client.models.generate_content(
-            model="gemini-3-pro-image-preview",
-            contents=contents,
-            config=types.GenerateContentConfig(
-                response_modalities=["TEXT", "IMAGE"],
-                image_config=types.ImageConfig(
-                    image_size=output_resolution
+        # Build contents
+        if input_image:
+            contents = [input_image, args.prompt]
+            print(f"Editing image with resolution {output_resolution}...")
+        else:
+            contents = args.prompt
+            print(f"Generating image with resolution {output_resolution}, aspect ratio {args.aspect_ratio}...")
+
+        try:
+            # Build image config - omit aspect_ratio entirely when editing
+            image_config_kwargs = {"image_size": output_resolution}
+            if not input_image:
+                image_config_kwargs["aspect_ratio"] = args.aspect_ratio
+            
+            response = client.models.generate_content(
+                model=args.model,
+                contents=contents,
+                config=types.GenerateContentConfig(
+                    response_modalities=["TEXT", "IMAGE"],
+                    image_config=types.ImageConfig(**image_config_kwargs)
                 )
             )
-        )
 
-        # Process response and convert to PNG
-        image_saved = False
-        for part in response.parts:
-            if part.text is not None:
-                print(f"Model response: {part.text}")
-            elif part.inline_data is not None:
-                # Convert inline data to PIL Image and save as PNG
-                from io import BytesIO
+            # Process response and save image
+            image_saved = False
+            model_text = None
+            
+            for part in response.parts:
+                if part.text is not None:
+                    model_text = part.text
+                    print(f"Model response: {part.text}")
+                elif part.inline_data is not None:
+                    from io import BytesIO
 
-                # inline_data.data is already bytes, not base64
-                image_data = part.inline_data.data
-                if isinstance(image_data, str):
-                    # If it's a string, it might be base64
-                    import base64
-                    image_data = base64.b64decode(image_data)
+                    image_data = part.inline_data.data
+                    if isinstance(image_data, str):
+                        import base64
+                        image_data = base64.b64decode(image_data)
 
-                image = PILImage.open(BytesIO(image_data))
+                    image = PILImage.open(BytesIO(image_data))
 
-                # Ensure RGB mode for PNG (convert RGBA to RGB with white background if needed)
-                if image.mode == 'RGBA':
-                    rgb_image = PILImage.new('RGB', image.size, (255, 255, 255))
-                    rgb_image.paste(image, mask=image.split()[3])
-                    rgb_image.save(str(output_path), 'PNG')
-                elif image.mode == 'RGB':
-                    image.save(str(output_path), 'PNG')
-                else:
-                    image.convert('RGB').save(str(output_path), 'PNG')
-                image_saved = True
+                    # Convert to RGB for PNG
+                    if image.mode == 'RGBA':
+                        rgb_image = PILImage.new('RGB', image.size, (255, 255, 255))
+                        rgb_image.paste(image, mask=image.split()[3])
+                        rgb_image.save(str(output_path), 'PNG')
+                    elif image.mode == 'RGB':
+                        image.save(str(output_path), 'PNG')
+                    else:
+                        image.convert('RGB').save(str(output_path), 'PNG')
+                    
+                    image_saved = True
+                    
+                    generated_images.append({
+                        "filename": output_path.name,
+                        "path": str(output_path.resolve()),
+                        "prompt": args.prompt,
+                        "resolution": output_resolution,
+                        "aspect_ratio": args.aspect_ratio,
+                        "model": args.model,
+                        "model_text": model_text,
+                    })
 
-        if image_saved:
-            full_path = output_path.resolve()
-            print(f"\nImage saved: {full_path}")
-            # Clawdbot parses MEDIA tokens and will attach the file on supported providers.
-            print(f"MEDIA: {full_path}")
-        else:
-            print("Error: No image was generated in the response.", file=sys.stderr)
+            if image_saved:
+                full_path = output_path.resolve()
+                print(f"Image saved: {full_path}")
+                if args.count == 1:
+                    # For single image, emit MEDIA token
+                    print(f"MEDIA: {full_path}")
+            else:
+                print(f"Error: No image was generated in response {i+1}.", file=sys.stderr)
+                if args.count == 1:
+                    sys.exit(1)
+
+        except Exception as e:
+            print(f"Error generating image: {e}", file=sys.stderr)
+            if args.count == 1:
+                sys.exit(1)
+
+    # Save metadata and generate gallery for batch mode
+    if args.count > 1:
+        if not generated_images:
+            print(f"\nError: No images were successfully generated.", file=sys.stderr)
             sys.exit(1)
-
-    except Exception as e:
-        print(f"Error generating image: {e}", file=sys.stderr)
-        sys.exit(1)
+        
+        # Save prompts.json with relative paths for portability
+        prompts_data = []
+        for img in generated_images:
+            prompts_data.append({
+                "filename": img["filename"],
+                "prompt": img["prompt"],
+                "resolution": img["resolution"],
+                "aspect_ratio": img["aspect_ratio"],
+                "model": img["model"],
+                "model_text": img.get("model_text"),
+            })
+        
+        prompts_path = output_dir / "prompts.json"
+        prompts_path.write_text(json.dumps(prompts_data, indent=2), encoding="utf-8")
+        print(f"\nMetadata saved: {prompts_path}")
+        
+        # Generate HTML gallery
+        if not args.no_gallery:
+            gallery_path = generate_gallery_html(output_dir, generated_images)
+            print(f"Gallery saved: {gallery_path}")
+        
+        print(f"\nGenerated {len(generated_images)}/{args.count} images in {output_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Improves the nano-banana-pro skill with batch generation, aspect ratio control, and HTML gallery output.

## Changes

### New Features
- **Batch generation**: `--count` and `--out-dir` flags for generating multiple images
- **Aspect ratio control**: `--aspect-ratio` flag with options 1:1, 3:4, 4:3, 9:16, 16:9
- **HTML gallery**: Generates `index.html` thumbnail gallery for batch mode
- **Metadata export**: Generates `prompts.json` with image metadata
- **Updated model**: Default model changed to `gemini-2.0-flash-preview-image-generation`

### Documentation
- Added options table to SKILL.md
- Added batch mode examples
- Clarified API key configuration

### Fixes (from Codex code review)
- Fixed HTML injection risk by escaping prompts in gallery HTML
- Fixed `aspect_ratio=None` issue by omitting field when editing images
- Exit non-zero if all batch items fail (previously exited 0)
- Use relative paths in metadata for gallery portability
- Added explicit encoding to file writes

## Testing

- [x] Syntax check passes
- [ ] Manual testing with Gemini API (requires API key)

## AI Assistance

This PR was created with assistance from Claude (Clawdbot) and reviewed by Codex CLI.

---
Co-authored-by: Codex <codex@openai.com>