### PR TITLE
fix: wire up Venice API key CLI onboarding support

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -52,7 +52,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|claude-cli|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|claude-cli|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|codex-cli|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
     )
     .option(
       "--token-provider <id>",
@@ -74,6 +74,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--zai-api-key <key>", "Z.AI API key")
     .option("--minimax-api-key <key>", "MiniMax API key")
     .option("--synthetic-api-key <key>", "Synthetic API key")
+    .option("--venice-api-key <key>", "Venice API key")
     .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
@@ -123,6 +124,7 @@ export function registerOnboardCommand(program: Command) {
             zaiApiKey: opts.zaiApiKey as string | undefined,
             minimaxApiKey: opts.minimaxApiKey as string | undefined,
             syntheticApiKey: opts.syntheticApiKey as string | undefined,
+            veniceApiKey: opts.veniceApiKey as string | undefined,
             opencodeZenApiKey: opts.opencodeZenApiKey as string | undefined,
             gatewayPort:
               typeof gatewayPort === "number" && Number.isFinite(gatewayPort)

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -20,6 +20,7 @@ import {
   applyOpencodeZenConfig,
   applyOpenrouterConfig,
   applySyntheticConfig,
+  applyVeniceConfig,
   applyVercelAiGatewayConfig,
   applyZaiConfig,
   setAnthropicApiKey,
@@ -30,6 +31,7 @@ import {
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
   setSyntheticApiKey,
+  setVeniceApiKey,
   setVercelAiGatewayApiKey,
   setZaiApiKey,
 } from "../../onboard-auth.js";
@@ -270,6 +272,25 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applySyntheticConfig(nextConfig);
+  }
+
+  if (authChoice === "venice-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "venice",
+      cfg: baseConfig,
+      flagValue: opts.veniceApiKey,
+      flagName: "--venice-api-key",
+      envVar: "VENICE_API_KEY",
+      runtime,
+    });
+    if (!resolved) return null;
+    if (resolved.source !== "profile") await setVeniceApiKey(resolved.key);
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "venice:default",
+      provider: "venice",
+      mode: "api_key",
+    });
+    return applyVeniceConfig(nextConfig);
   }
 
   if (


### PR DESCRIPTION
## Summary

Fixes missing CLI support for Venice AI provider onboarding. PR #1666 added the Venice AI provider integration but the CLI onboarding flags were not wired up, causing users to be unable to configure Venice via `clawdbot onboard`.

## Problem

After PR #1666, users trying to onboard with Venice experienced:
- `--auth-choice venice-api-key` not shown in help text
- `--venice-api-key` flag missing entirely
- Credentials not being saved even when using workarounds

## Solution

Added the missing CLI wiring by following the exact pattern used by other API key providers (synthetic, openrouter, moonshot, etc.):

1. **src/cli/program/register.onboard.ts**
   - Added `venice-api-key` to `--auth-choice` help text
   - Added `--venice-api-key <key>` CLI option
   - Wired `veniceApiKey` through to `onboardCommand`

2. **src/commands/onboard-non-interactive/local/auth-choice.ts**
   - Added imports for `setVeniceApiKey` and `applyVeniceConfig`
   - Added handler for `authChoice === "venice-api-key"`

## Testing

- [x] `pnpm build` - passes
- [x] `pnpm lint` - passes  
- [x] `pnpm format` - passes
- [x] Verified Venice API connectivity (curl test successful)
- [x] Code review: follows existing patterns exactly

## Usage

After this fix, users can onboard with Venice via:
```bash
clawdbot onboard --non-interactive --accept-risk \
  --auth-choice venice-api-key \
  --venice-api-key "YOUR_VENICE_API_KEY"
```

Fixes issue with Venice onboarding discovered while testing #1666.