### PR TITLE
feat(system-prompt): add formatted date with day of week

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -49,9 +49,14 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(params.userTime);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`, "");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -297,6 +302,7 @@ export function buildAgentSystemPrompt(params: {
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
+  const userTime = params.userTime?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const heartbeatPromptLine = heartbeatPrompt
@@ -459,6 +465,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Clawdbot and included below in Project Context.",


### PR DESCRIPTION
## Summary
Fixes #1897

The system prompt now includes the full formatted date (e.g., "Sunday, January 25th, 2026 — 12:40 PM") above the timezone, so agents no longer have to guess what day it is.

## Changes
- Modified `buildTimeSection()` in `src/agents/system-prompt.ts` to accept and display `userTime`
- The `userTime` value was already being computed by `formatUserTime()` — it just wasn't being passed through

### Before
```
## Current Date & Time
Time zone: America/Chicago
```

### After
```
## Current Date & Time
Sunday, January 25th, 2026 — 12:40 PM
Time zone: America/Chicago
```

## AI Disclosure
- [x] AI-assisted: Generated with **Claude Opus 4.5**
- [x] Testing: Lightly tested (lint passes, code review)
- [x] I understand what this code does

## Testing
- `npm run lint` ✅ passes
- Manual code review ✅