### PR TITLE
fix: CLI backend session resume + TUI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.clawd.bot
 ### Fixes
 - Gateway: harden reverse proxy handling for local-client detection and unauthenticated proxied connects. (#1795) Thanks @orlyjamie.
 - Security audit: flag loopback Control UI with auth disabled as critical. (#1795) Thanks @orlyjamie.
+- CLI: resume claude-cli sessions and stream CLI replies to TUI clients. (#1921) Thanks @rmorse.
 
 ## 2026.1.24-2
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -182,6 +182,7 @@ Clawdbot ships a default for `claude-cli`:
 
 - `command: "claude"`
 - `args: ["-p", "--output-format", "json", "--dangerously-skip-permissions"]`
+- `resumeArgs: ["-p", "--output-format", "json", "--dangerously-skip-permissions", "--resume", "{sessionId}"]`
 - `modelArg: "--model"`
 - `systemPromptArg: "--append-system-prompt"`
 - `sessionArg: "--session-id"`

--- a/src/agents/claude-cli-runner.test.ts
+++ b/src/agents/claude-cli-runner.test.ts
@@ -61,7 +61,7 @@ describe("runClaudeCliAgent", () => {
     expect(argv).toContain("hi");
   });
 
-  it("uses provided --session-id when a claude session id is provided", async () => {
+  it("uses --resume when a claude session id is provided", async () => {
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       stdout: JSON.stringify({ message: "ok", session_id: "sid-2" }),
       stderr: "",
@@ -83,7 +83,7 @@ describe("runClaudeCliAgent", () => {
 
     expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
     const argv = runCommandWithTimeoutMock.mock.calls[0]?.[0] as string[];
-    expect(argv).toContain("--session-id");
+    expect(argv).toContain("--resume");
     expect(argv).toContain("c9d7b831-1c31-4d22-80b9-1e50ca207d4b");
     expect(argv).toContain("hi");
   });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -28,6 +28,14 @@ const CLAUDE_MODEL_ALIASES: Record<string, string> = {
 const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   command: "claude",
   args: ["-p", "--output-format", "json", "--dangerously-skip-permissions"],
+  resumeArgs: [
+    "-p",
+    "--output-format",
+    "json",
+    "--dangerously-skip-permissions",
+    "--resume",
+    "{sessionId}",
+  ],
   output: "json",
   input: "arg",
   modelArg: "--model",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -179,6 +179,17 @@ export async function runAgentTurnWithFallback(params: {
               images: params.opts?.images,
             })
               .then((result) => {
+                // CLI backends don't emit streaming assistant events, so we need to
+                // emit one with the final text so server-chat can populate its buffer
+                // and send the response to TUI/WebSocket clients.
+                const cliText = result.payloads?.[0]?.text?.trim();
+                if (cliText) {
+                  emitAgentEvent({
+                    runId,
+                    stream: "assistant",
+                    data: { text: cliText },
+                  });
+                }
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAgentEventHandler, createChatRunState } from "./server-chat.js";
+
+describe("agent event handler", () => {
+  it("emits chat delta for assistant text-only events", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const broadcast = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const agentRunSeq = new Map<string, number>();
+    const chatRunState = createChatRunState();
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    const handler = createAgentEventHandler({
+      broadcast,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun: () => undefined,
+      clearAgentRunContext: vi.fn(),
+    });
+
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    const chatCalls = broadcast.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(payload.state).toBe("delta");
+    expect(payload.message?.content?.[0]?.text).toBe("Hello world");
+    const sessionChatCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "chat");
+    expect(sessionChatCalls).toHaveLength(1);
+    nowSpy.mockRestore();
+  });
+});

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { GatewayRequestContext } from "./types.js";
+import { agentHandlers } from "./agent.js";
+
+const mocks = vi.hoisted(() => ({
+  loadSessionEntry: vi.fn(),
+  updateSessionStore: vi.fn(),
+  agentCommand: vi.fn(),
+  registerAgentRunContext: vi.fn(),
+}));
+
+vi.mock("../session-utils.js", () => ({
+  loadSessionEntry: mocks.loadSessionEntry,
+}));
+
+vi.mock("../../config/sessions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
+    "../../config/sessions.js",
+  );
+  return {
+    ...actual,
+    updateSessionStore: mocks.updateSessionStore,
+    resolveAgentIdFromSessionKey: () => "main",
+    resolveExplicitAgentSessionKey: () => undefined,
+    resolveAgentMainSessionKey: () => "agent:main:main",
+  };
+});
+
+vi.mock("../../commands/agent.js", () => ({
+  agentCommand: mocks.agentCommand,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds: () => ["main"],
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  registerAgentRunContext: mocks.registerAgentRunContext,
+  onAgentEvent: vi.fn(),
+}));
+
+vi.mock("../../sessions/send-policy.js", () => ({
+  resolveSendPolicy: () => "allow",
+}));
+
+vi.mock("../../utils/delivery-context.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/delivery-context.js")>(
+    "../../utils/delivery-context.js",
+  );
+  return {
+    ...actual,
+    normalizeSessionDeliveryFields: () => ({}),
+  };
+});
+
+const makeContext = (): GatewayRequestContext =>
+  ({
+    dedupe: new Map(),
+    addChatRun: vi.fn(),
+    logGateway: { info: vi.fn(), error: vi.fn() },
+  }) as unknown as GatewayRequestContext;
+
+describe("gateway agent handler", () => {
+  it("preserves cliSessionIds from existing session entry", async () => {
+    const existingCliSessionIds = { "claude-cli": "abc-123-def" };
+    const existingClaudeCliSessionId = "abc-123-def";
+
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+        cliSessionIds: existingCliSessionIds,
+        claudeCliSessionId: existingClaudeCliSessionId,
+      },
+      canonicalKey: "agent:main:main",
+    });
+
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      await updater(store);
+      capturedEntry = store["agent:main:main"] as Record<string, unknown>;
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "1", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedEntry).toBeDefined();
+    expect(capturedEntry?.cliSessionIds).toEqual(existingCliSessionIds);
+    expect(capturedEntry?.claudeCliSessionId).toBe(existingClaudeCliSessionId);
+  });
+
+  it("handles missing cliSessionIds gracefully", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+        // No cliSessionIds or claudeCliSessionId
+      },
+      canonicalKey: "agent:main:main",
+    });
+
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      await updater(store);
+      capturedEntry = store["agent:main:main"] as Record<string, unknown>;
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem-2",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "2", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedEntry).toBeDefined();
+    // Should be undefined, not cause an error
+    expect(capturedEntry?.cliSessionIds).toBeUndefined();
+    expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+});

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -251,6 +251,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,
+        cliSessionIds: entry?.cliSessionIds,
+        claudeCliSessionId: entry?.claudeCliSessionId,
       };
       sessionEntry = nextEntry;
       const sendPolicy = resolveSendPolicy({


### PR DESCRIPTION
## AI-Assisted
- Code generated with Claude Code assistance
- **Testing**: Fully tested (build, lint, unit tests, manual verification)
- Changes understood and reviewed

## Summary
- Fix Claude CLI session resume not working through the gateway
- Fix TUI showing "(no output)" for CLI backend responses

## Problem 1: Session Resume

Claude CLI requires different flags for new vs resumed sessions:
- **New session**: `--session-id <id>`
- **Resume session**: `--resume <id>`

Without proper `resumeArgs`, follow-up messages would try to use `--session-id` with an existing session ID, causing:
```
Error: Session ID already in use
```

Two bugs prevented session continuity:
1. `DEFAULT_CLAUDE_BACKEND` had no `resumeArgs`, so it always used `--session-id`
2. Gateway's `agent.ts` wasn't copying `cliSessionIds`/`claudeCliSessionId` to `nextEntry`, so CLI session IDs were lost between requests

## Problem 2: TUI "(no output)"

TUI uses WebSocket streaming events. Flow:
- **Streaming providers (API)**: emit `evt.stream === "assistant"` events → buffer populated → final message has text
- **CLI backends**: no streaming → buffer stays empty → `emitChatFinal` sends undefined → TUI shows "(no output)"

## Changes

### Session Resume
- `src/agents/cli-backends.ts` - Add `resumeArgs` to Claude backend
- `src/gateway/server-methods/agent.ts` - Preserve CLI session ID fields in `nextEntry`
- `src/gateway/server-methods/agent.test.ts` - Add regression test

### TUI Output
- `src/auto-reply/reply/agent-runner-execution.ts` - Emit `assistant` event with final text before lifecycle `end` for CLI backends

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (unrelated heartbeat test failures pre-existing)
- [x] Manual: session resume works - follow-up messages maintain conversation
- [x] Manual: TUI displays CLI backend responses correctly