### PR TITLE
fix: don't crash gateway on transient network errors

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -27,10 +27,51 @@ export function isUnhandledRejectionHandled(reason: unknown): boolean {
   return false;
 }
 
+/**
+ * Check if an error is a transient network error that shouldn't crash the gateway.
+ * These errors commonly occur during normal operation due to network instability,
+ * timeouts, or external service issues.
+ */
+function isTransientNetworkError(reason: unknown): boolean {
+  if (!(reason instanceof Error)) return false;
+
+  const message = reason.message.toLowerCase();
+  const name = reason.name;
+
+  // Abort errors from cancelled requests
+  if (name === "AbortError") return true;
+
+  // Fetch/network failures
+  if (message.includes("fetch failed")) return true;
+  if (message.includes("network request failed")) return true;
+
+  // Connection errors
+  if (message.includes("econnreset")) return true;
+  if (message.includes("econnrefused")) return true;
+  if (message.includes("etimedout")) return true;
+  if (message.includes("socket hang up")) return true;
+
+  // TLS/SSL errors
+  if (message.includes("unable to verify")) return true;
+  if (message.includes("cert")) return true;
+
+  return false;
+}
+
 export function installUnhandledRejectionHandler(): void {
   process.on("unhandledRejection", (reason, _promise) => {
     if (isUnhandledRejectionHandled(reason)) return;
-    console.error("[clawdbot] Unhandled promise rejection:", formatUncaughtError(reason));
+
+    const errorMessage = formatUncaughtError(reason);
+
+    // For transient network errors, log but don't crash
+    if (isTransientNetworkError(reason)) {
+      console.error("[clawdbot] Transient network error (non-fatal):", errorMessage);
+      return;
+    }
+
+    // For other unhandled rejections, crash to surface the bug
+    console.error("[clawdbot] Unhandled promise rejection:", errorMessage);
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary

The gateway currently crashes (`process.exit(1)`) on **any** unhandled promise rejection, including transient network errors. This causes unnecessary restarts during normal operation when external services are slow or temporarily unavailable.

**Errors that were crashing the gateway:**
```
[clawdbot] Unhandled promise rejection: TypeError: fetch failed
[clawdbot] Unhandled promise rejection: AbortError: This operation was aborted
```

## Changes

- Added `isTransientNetworkError()` function to detect common transient errors:
  - `AbortError` (cancelled requests)
  - `fetch failed` / `network request failed`
  - Connection errors: `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `socket hang up`
  - TLS/cert errors
- Transient errors are logged as non-fatal and the gateway continues running
- Unknown/serious errors still crash to surface real bugs

## Test plan

- [x] Tested locally - gateway no longer crashes on network timeouts
- [x] Verified serious errors still cause crash (maintains safety)

## AI Disclosure

🤖 This PR was generated with Claude Code (AI-assisted)
- **Testing level:** Lightly tested locally
- **Understanding:** Yes, I understand what this code does - it adds a check for transient network errors before calling process.exit()