### PR TITLE
fix: show sub-agent announce response in WebChat UI (#1909)

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    handleChatEvent,
+    type ChatEventPayload,
+    type ChatState,
+} from "./chat";
+
+function createState(overrides: Partial<ChatState> = {}): ChatState {
+  return {
+    client: null,
+    connected: true,
+    sessionKey: "main",
+    chatLoading: false,
+    chatMessages: [],
+    chatThinkingLevel: null,
+    chatSending: false,
+    chatMessage: "",
+    chatRunId: null,
+    chatStream: null,
+    chatStreamStartedAt: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe("handleChatEvent", () => {
+  it("returns null when payload is missing", () => {
+    const state = createState();
+    expect(handleChatEvent(state, undefined)).toBe(null);
+  });
+
+  it("returns null when sessionKey does not match", () => {
+    const state = createState({ sessionKey: "main" });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "other",
+      state: "final",
+    };
+    expect(handleChatEvent(state, payload)).toBe(null);
+  });
+
+  it("returns null for delta from another run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Hello",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+    };
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Hello");
+  });
+
+  it("returns 'final' for final from another run (e.g. sub-agent announce) without clearing state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Sub-agent findings" }],
+      },
+    };
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+
+  it("processes final from own run and clears state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Reply",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,5 +1,5 @@
-import type { GatewayBrowserClient } from "../gateway";
 import { extractText } from "../chat/message-extract";
+import type { GatewayBrowserClient } from "../gateway";
 import { generateUUID } from "../uuid";
 
 export type ChatState = {
@@ -115,8 +115,17 @@ export function handleChatEvent(
 ) {
   if (!payload) return null;
   if (payload.sessionKey !== state.sessionKey) return null;
-  if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId)
+
+  // Final from another run (e.g. sub-agent announce): refresh history to show new message.
+  // See https://github.com/clawdbot/clawdbot/issues/1909
+  if (
+    payload.runId &&
+    state.chatRunId &&
+    payload.runId !== state.chatRunId
+  ) {
+    if (payload.state === "final") return "final";
     return null;
+  }
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);


### PR DESCRIPTION
## Summary
- `handleChatEvent` was ignoring `final` events from sub-agent announce runs (different `runId`), so the UI never refreshed to show the response.
- Now it returns `"final"` for those events (same session, different run) to trigger `loadChatHistory()`.

## Test Plan
- `npm run lint` ✅
- `npm run build` ✅
- `cd ui && npm install && npx playwright install chromium`
- `npx vitest run src/ui/controllers/chat.test.ts` ✅ (5/5 passed)

## AI Disclosure
- [x] AI-assisted: **Claude Opus 4.5** + **Codex 5.2** via Cursor
- [x] **Manual review** of all generated code
- [x] Fully tested (lint, build, UI unit tests passed)
- [x] I understand what the code does: when a sub-agent completes, its "announce" is a separate agent run with a different `runId`. The fix allows `final` events from other runs (same session) to trigger a history refresh without clearing the current streaming state.

Fixes #1909