### PR TITLE
fix(slack): handle cross-origin redirects for file downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Docs: https://docs.clawd.bot
 ## 2026.1.24-3
 
 ### Fixes
+- Slack: fix image downloads failing due to missing Authorization header on cross-origin redirects. (#1936) Thanks @sanderhelgesen.
 - Gateway: harden reverse proxy handling for local-client detection and unauthenticated proxied connects. (#1795) Thanks @orlyjamie.
 - Security audit: flag loopback Control UI with auth disabled as critical. (#1795) Thanks @orlyjamie.
 

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -181,9 +181,23 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "tts",
       nativeName: "tts",
-      description: "Configure text-to-speech.",
+      description: "Control text-to-speech (TTS).",
       textAlias: "/tts",
-      acceptsArgs: true,
+      args: [
+        {
+          name: "action",
+          description: "on | off | status | provider | limit | summary | audio | help",
+          type: "string",
+          choices: ["on", "off", "status", "provider", "limit", "summary", "audio", "help"],
+        },
+        {
+          name: "value",
+          description: "Provider, limit, or text",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+      argsMenu: "auto",
     }),
     defineChatCommand({
       key: "whoami",

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -186,9 +186,18 @@ function buildChatCommands(): ChatCommandDefinition[] {
       args: [
         {
           name: "action",
-          description: "on | off | status | provider | limit | summary | audio | help",
+          description: "TTS action",
           type: "string",
-          choices: ["on", "off", "status", "provider", "limit", "summary", "audio", "help"],
+          choices: [
+            { value: "on", label: "On" },
+            { value: "off", label: "Off" },
+            { value: "status", label: "Status" },
+            { value: "provider", label: "Provider" },
+            { value: "limit", label: "Limit" },
+            { value: "summary", label: "Summary" },
+            { value: "audio", label: "Audio" },
+            { value: "help", label: "Help" },
+          ],
         },
         {
           name: "value",
@@ -197,7 +206,19 @@ function buildChatCommands(): ChatCommandDefinition[] {
           captureRemaining: true,
         },
       ],
-      argsMenu: "auto",
+      argsMenu: {
+        arg: "action",
+        title:
+          "TTS Actions:\n" +
+          "• On – Enable TTS for responses\n" +
+          "• Off – Disable TTS\n" +
+          "• Status – Show current settings\n" +
+          "• Provider – Set voice provider (edge, elevenlabs, openai)\n" +
+          "• Limit – Set max characters for TTS\n" +
+          "• Summary – Toggle AI summary for long texts\n" +
+          "• Audio – Generate TTS from custom text\n" +
+          "• Help – Show usage guide",
+      },
     }),
     defineChatCommand({
       key: "whoami",

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -1,5 +1,6 @@
 import { listChannelDocks } from "../channels/dock.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getTtsProvider, isTtsEnabled, resolveTtsConfig, resolveTtsPrefsPath } from "../tts/tts.js";
 import { listThinkingLevels } from "./thinking.js";
 import { COMMAND_ARG_FORMATTERS } from "./commands-args.js";
 import type { ChatCommandDefinition, CommandScope } from "./commands-registry.types.js";
@@ -191,7 +192,6 @@ function buildChatCommands(): ChatCommandDefinition[] {
           choices: [
             { value: "on", label: "On" },
             { value: "off", label: "Off" },
-            { value: "status", label: "Status" },
             { value: "provider", label: "Provider" },
             { value: "limit", label: "Limit" },
             { value: "summary", label: "Summary" },
@@ -208,16 +208,25 @@ function buildChatCommands(): ChatCommandDefinition[] {
       ],
       argsMenu: {
         arg: "action",
-        title:
-          "TTS Actions:\n" +
-          "• On – Enable TTS for responses\n" +
-          "• Off – Disable TTS\n" +
-          "• Status – Show current settings\n" +
-          "• Provider – Set voice provider (edge, elevenlabs, openai)\n" +
-          "• Limit – Set max characters for TTS\n" +
-          "• Summary – Toggle AI summary for long texts\n" +
-          "• Audio – Generate TTS from custom text\n" +
-          "• Help – Show usage guide",
+        title: ({ cfg }) => {
+          if (!cfg) {
+            return "🔊 TTS Actions";
+          }
+          const config = resolveTtsConfig(cfg);
+          const prefsPath = resolveTtsPrefsPath(config);
+          const enabled = isTtsEnabled(config, prefsPath);
+          const provider = getTtsProvider(config, prefsPath);
+          const statusLine = `Status: ${enabled ? "✅ On" : "❌ Off"} · Provider: ${provider}`;
+          return (
+            `🔊 TTS Actions\n${statusLine}\n\n` +
+            "• On/Off – Toggle TTS\n" +
+            "• Provider – Change voice provider\n" +
+            "• Limit – Set max characters\n" +
+            "• Summary – Toggle AI summary\n" +
+            "• Audio – Generate from text\n" +
+            "• Help – Usage guide"
+          );
+        },
       },
     }),
     defineChatCommand({

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -229,7 +229,12 @@ describe("commands registry args", () => {
 
     const menu = resolveCommandArgMenu({ command, args: undefined, cfg: {} as never });
     expect(menu?.arg.name).toBe("mode");
-    expect(menu?.choices).toEqual(["off", "tokens", "full", "cost"]);
+    expect(menu?.choices).toEqual([
+      { value: "off", label: "off" },
+      { value: "tokens", label: "tokens" },
+      { value: "full", label: "full" },
+      { value: "cost", label: "cost" },
+    ]);
   });
 
   it("does not show menus when arg already provided", () => {
@@ -284,7 +289,10 @@ describe("commands registry args", () => {
 
     const menu = resolveCommandArgMenu({ command, args: undefined, cfg: {} as never });
     expect(menu?.arg.name).toBe("level");
-    expect(menu?.choices).toEqual(["low", "high"]);
+    expect(menu?.choices).toEqual([
+      { value: "low", label: "low" },
+      { value: "high", label: "high" },
+    ]);
     expect(seen?.commandKey).toBe("think");
     expect(seen?.argName).toBe("level");
     expect(seen?.provider).toBeTruthy();

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -305,7 +305,8 @@ export function resolveCommandArgMenu(params: {
   if (!arg) return null;
   const choices = resolveCommandArgChoices({ command, arg, cfg });
   if (choices.length === 0) return null;
-  const title = argSpec !== "auto" ? argSpec.title : undefined;
+  const rawTitle = argSpec !== "auto" ? argSpec.title : undefined;
+  const title = typeof rawTitle === "function" ? rawTitle({ cfg, command }) : rawTitle;
   return { arg, choices, title };
 }
 

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -12,14 +12,16 @@ export type CommandArgChoiceContext = {
   arg: CommandArgDefinition;
 };
 
-export type CommandArgChoicesProvider = (context: CommandArgChoiceContext) => string[];
+export type CommandArgChoice = string | { value: string; label: string };
+
+export type CommandArgChoicesProvider = (context: CommandArgChoiceContext) => CommandArgChoice[];
 
 export type CommandArgDefinition = {
   name: string;
   description: string;
   type: CommandArgType;
   required?: boolean;
-  choices?: string[] | CommandArgChoicesProvider;
+  choices?: CommandArgChoice[] | CommandArgChoicesProvider;
   captureRemaining?: boolean;
 };
 

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -25,9 +25,18 @@ export type CommandArgDefinition = {
   captureRemaining?: boolean;
 };
 
+export type CommandArgMenuTitleContext = {
+  cfg?: ClawdbotConfig;
+  command: ChatCommandDefinition;
+};
+
+export type CommandArgMenuTitleProvider = (
+  context: CommandArgMenuTitleContext,
+) => string | undefined;
+
 export type CommandArgMenuSpec = {
   arg: string;
-  title?: string;
+  title?: string | CommandArgMenuTitleProvider;
 };
 
 export type CommandArgValue = string | number | boolean | bigint;

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -6,20 +6,18 @@ import {
   getTtsMaxLength,
   getTtsProvider,
   isSummarizationEnabled,
+  isTtsEnabled,
   isTtsProviderConfigured,
-  normalizeTtsAutoMode,
-  resolveTtsAutoMode,
   resolveTtsApiKey,
   resolveTtsConfig,
   resolveTtsPrefsPath,
-  resolveTtsProviderOrder,
   setLastTtsAttempt,
   setSummarizationEnabled,
+  setTtsEnabled,
   setTtsMaxLength,
   setTtsProvider,
   textToSpeech,
 } from "../../tts/tts.js";
-import { updateSessionStore } from "../../config/sessions.js";
 
 type ParsedTtsCommand = {
   action: string;
@@ -27,11 +25,11 @@ type ParsedTtsCommand = {
 };
 
 function parseTtsCommand(normalized: string): ParsedTtsCommand | null {
-  // Accept `/tts` and `/tts <action> [args]` as a single control surface.
-  if (normalized === "/tts") return { action: "status", args: "" };
+  // Accept `/tts <action> [args]` - return null for `/tts` alone to trigger inline menu.
+  if (normalized === "/tts") return null;
   if (!normalized.startsWith("/tts ")) return null;
   const rest = normalized.slice(5).trim();
-  if (!rest) return { action: "status", args: "" };
+  if (!rest) return null;
   const [action, ...tail] = rest.split(/\s+/);
   return { action: action.toLowerCase(), args: tail.join(" ").trim() };
 }
@@ -40,14 +38,27 @@ function ttsUsage(): ReplyPayload {
   // Keep usage in one place so help/validation stays consistent.
   return {
     text:
-      "⚙️ Usage: /tts <off|always|inbound|tagged|status|provider|limit|summary|audio> [value]" +
-      "\nExamples:\n" +
-      "/tts always\n" +
-      "/tts provider openai\n" +
-      "/tts provider edge\n" +
-      "/tts limit 2000\n" +
-      "/tts summary off\n" +
-      "/tts audio Hello from Clawdbot",
+      `🔊 **TTS (Text-to-Speech) Help**\n\n` +
+      `**Commands:**\n` +
+      `• /tts on — Enable automatic TTS for replies\n` +
+      `• /tts off — Disable TTS\n` +
+      `• /tts status — Show current settings\n` +
+      `• /tts provider [name] — View/change provider\n` +
+      `• /tts limit [number] — View/change text limit\n` +
+      `• /tts summary [on|off] — View/change auto-summary\n` +
+      `• /tts audio <text> — Generate audio from text\n\n` +
+      `**Providers:**\n` +
+      `• edge — Free, fast (default)\n` +
+      `• openai — High quality (requires API key)\n` +
+      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `**Text Limit (default: 1500, max: 4096):**\n` +
+      `When text exceeds the limit:\n` +
+      `• Summary ON: AI summarizes, then generates audio\n` +
+      `• Summary OFF: Truncates text, then generates audio\n\n` +
+      `**Examples:**\n` +
+      `/tts provider edge\n` +
+      `/tts limit 2000\n` +
+      `/tts audio Hello, this is a test!`,
   };
 }
 
@@ -72,35 +83,27 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     return { shouldContinue: false, reply: ttsUsage() };
   }
 
-  const requestedAuto = normalizeTtsAutoMode(
-    action === "on" ? "always" : action === "off" ? "off" : action,
-  );
-  if (requestedAuto) {
-    const entry = params.sessionEntry;
-    const sessionKey = params.sessionKey;
-    const store = params.sessionStore;
-    if (entry && store && sessionKey) {
-      entry.ttsAuto = requestedAuto;
-      entry.updatedAt = Date.now();
-      store[sessionKey] = entry;
-      if (params.storePath) {
-        await updateSessionStore(params.storePath, (store) => {
-          store[sessionKey] = entry;
-        });
-      }
-    }
-    const label = requestedAuto === "always" ? "enabled (always)" : requestedAuto;
-    return {
-      shouldContinue: false,
-      reply: {
-        text: requestedAuto === "off" ? "🔇 TTS disabled." : `🔊 TTS ${label}.`,
-      },
-    };
+  if (action === "on") {
+    setTtsEnabled(prefsPath, true);
+    return { shouldContinue: false, reply: { text: "🔊 TTS enabled." } };
+  }
+
+  if (action === "off") {
+    setTtsEnabled(prefsPath, false);
+    return { shouldContinue: false, reply: { text: "🔇 TTS disabled." } };
   }
 
   if (action === "audio") {
     if (!args.trim()) {
-      return { shouldContinue: false, reply: ttsUsage() };
+      return {
+        shouldContinue: false,
+        reply: {
+          text:
+            `🎤 Generate audio from text.\n\n` +
+            `Usage: /tts audio <text>\n` +
+            `Example: /tts audio Hello, this is a test!`,
+        },
+      };
     }
 
     const start = Date.now();
@@ -146,9 +149,6 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   if (action === "provider") {
     const currentProvider = getTtsProvider(config, prefsPath);
     if (!args.trim()) {
-      const fallback = resolveTtsProviderOrder(currentProvider)
-        .slice(1)
-        .filter((provider) => isTtsProviderConfigured(config, provider));
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
@@ -158,7 +158,6 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
           text:
             `🎙️ TTS provider\n` +
             `Primary: ${currentProvider}\n` +
-            `Fallbacks: ${fallback.join(", ") || "none"}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
@@ -173,18 +172,9 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     }
 
     setTtsProvider(prefsPath, requested);
-    const fallback = resolveTtsProviderOrder(requested)
-      .slice(1)
-      .filter((provider) => isTtsProviderConfigured(config, provider));
     return {
       shouldContinue: false,
-      reply: {
-        text:
-          `✅ TTS provider set to ${requested} (fallbacks: ${fallback.join(", ") || "none"}).` +
-          (requested === "edge"
-            ? "\nEnable Edge TTS in config: messages.tts.edge.enabled = true."
-            : ""),
-      },
+      reply: { text: `✅ TTS provider set to ${requested}.` },
     };
   }
 
@@ -193,12 +183,22 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
       const currentLimit = getTtsMaxLength(prefsPath);
       return {
         shouldContinue: false,
-        reply: { text: `📏 TTS limit: ${currentLimit} characters.` },
+        reply: {
+          text:
+            `📏 TTS limit: ${currentLimit} characters.\n\n` +
+            `Text longer than this triggers summary (if enabled).\n` +
+            `Range: 100-4096 chars (Telegram max).\n\n` +
+            `To change: /tts limit <number>\n` +
+            `Example: /tts limit 2000`,
+        },
       };
     }
     const next = Number.parseInt(args.trim(), 10);
-    if (!Number.isFinite(next) || next < 100 || next > 10_000) {
-      return { shouldContinue: false, reply: ttsUsage() };
+    if (!Number.isFinite(next) || next < 100 || next > 4096) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ Limit must be between 100 and 4096 characters." },
+      };
     }
     setTtsMaxLength(prefsPath, next);
     return {
@@ -210,9 +210,17 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   if (action === "summary") {
     if (!args.trim()) {
       const enabled = isSummarizationEnabled(prefsPath);
+      const maxLen = getTtsMaxLength(prefsPath);
       return {
         shouldContinue: false,
-        reply: { text: `📝 TTS auto-summary: ${enabled ? "on" : "off"}.` },
+        reply: {
+          text:
+            `📝 TTS auto-summary: ${enabled ? "on" : "off"}.\n\n` +
+            `When text exceeds ${maxLen} chars:\n` +
+            `• ON: summarizes text, then generates audio\n` +
+            `• OFF: truncates text, then generates audio\n\n` +
+            `To change: /tts summary on | off`,
+        },
       };
     }
     const requested = args.trim().toLowerCase();
@@ -229,27 +237,16 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   }
 
   if (action === "status") {
-    const sessionAuto = params.sessionEntry?.ttsAuto;
-    const autoMode = resolveTtsAutoMode({ config, prefsPath, sessionAuto });
-    const enabled = autoMode !== "off";
+    const enabled = isTtsEnabled(config, prefsPath);
     const provider = getTtsProvider(config, prefsPath);
     const hasKey = isTtsProviderConfigured(config, provider);
-    const providerStatus =
-      provider === "edge"
-        ? hasKey
-          ? "✅ enabled"
-          : "❌ disabled"
-        : hasKey
-          ? "✅ key"
-          : "❌ no key";
     const maxLength = getTtsMaxLength(prefsPath);
     const summarize = isSummarizationEnabled(prefsPath);
     const last = getLastTtsAttempt();
-    const autoLabel = sessionAuto ? `${autoMode} (session)` : autoMode;
     const lines = [
       "📊 TTS status",
-      `Auto: ${enabled ? autoLabel : "off"}`,
-      `Provider: ${provider} (${providerStatus})`,
+      `State: ${enabled ? "✅ enabled" : "❌ disabled"}`,
+      `Provider: ${provider} (${hasKey ? "✅ configured" : "❌ not configured"})`,
       `Text limit: ${maxLength} chars`,
       `Auto-summary: ${summarize ? "on" : "off"}`,
     ];

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -266,12 +266,26 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal, counts };
     }
 
+    // Track accumulated block text for TTS generation after streaming completes.
+    // When block streaming succeeds, there's no final reply, so we need to generate
+    // TTS audio separately from the accumulated block content.
+    let accumulatedBlockText = "";
+    let blockCount = 0;
+
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
       ctx,
       {
         ...params.replyOptions,
         onBlockReply: (payload: ReplyPayload, context) => {
           const run = async () => {
+            // Accumulate block text for TTS generation after streaming
+            if (payload.text) {
+              if (accumulatedBlockText.length > 0) {
+                accumulatedBlockText += "\n";
+              }
+              accumulatedBlockText += payload.text;
+              blockCount++;
+            }
             const ttsPayload = await maybeApplyTtsToPayload({
               payload,
               cfg,
@@ -327,6 +341,50 @@ export async function dispatchReplyFromConfig(params: {
         queuedFinal = dispatcher.sendFinalReply(ttsReply) || queuedFinal;
       }
     }
+
+    // Generate TTS-only reply after block streaming completes (when there's no final reply).
+    // This handles the case where block streaming succeeds and drops final payloads,
+    // but we still want TTS audio to be generated from the accumulated block content.
+    if (replies.length === 0 && blockCount > 0 && accumulatedBlockText.trim()) {
+      const ttsSyntheticReply = await maybeApplyTtsToPayload({
+        payload: { text: accumulatedBlockText },
+        cfg,
+        channel: ttsChannel,
+        kind: "final",
+        inboundAudio,
+        ttsAuto: sessionTtsAuto,
+      });
+      // Only send if TTS was actually applied (mediaUrl exists)
+      if (ttsSyntheticReply.mediaUrl) {
+        // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
+        const ttsOnlyPayload: ReplyPayload = {
+          mediaUrl: ttsSyntheticReply.mediaUrl,
+          audioAsVoice: ttsSyntheticReply.audioAsVoice,
+        };
+        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+          const result = await routeReply({
+            payload: ttsOnlyPayload,
+            channel: originatingChannel,
+            to: originatingTo,
+            sessionKey: ctx.SessionKey,
+            accountId: ctx.AccountId,
+            threadId: ctx.MessageThreadId,
+            cfg,
+          });
+          queuedFinal = result.ok || queuedFinal;
+          if (result.ok) routedFinalCount += 1;
+          if (!result.ok) {
+            logVerbose(
+              `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
+            );
+          }
+        } else {
+          const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
+          queuedFinal = didQueue || queuedFinal;
+        }
+      }
+    }
+
     await dispatcher.waitForIdle();
 
     const counts = dispatcher.getQueuedCounts();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -346,42 +346,48 @@ export async function dispatchReplyFromConfig(params: {
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
     if (replies.length === 0 && blockCount > 0 && accumulatedBlockText.trim()) {
-      const ttsSyntheticReply = await maybeApplyTtsToPayload({
-        payload: { text: accumulatedBlockText },
-        cfg,
-        channel: ttsChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-      });
-      // Only send if TTS was actually applied (mediaUrl exists)
-      if (ttsSyntheticReply.mediaUrl) {
-        // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
-        const ttsOnlyPayload: ReplyPayload = {
-          mediaUrl: ttsSyntheticReply.mediaUrl,
-          audioAsVoice: ttsSyntheticReply.audioAsVoice,
-        };
-        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-          const result = await routeReply({
-            payload: ttsOnlyPayload,
-            channel: originatingChannel,
-            to: originatingTo,
-            sessionKey: ctx.SessionKey,
-            accountId: ctx.AccountId,
-            threadId: ctx.MessageThreadId,
-            cfg,
-          });
-          queuedFinal = result.ok || queuedFinal;
-          if (result.ok) routedFinalCount += 1;
-          if (!result.ok) {
-            logVerbose(
-              `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
-            );
+      try {
+        const ttsSyntheticReply = await maybeApplyTtsToPayload({
+          payload: { text: accumulatedBlockText },
+          cfg,
+          channel: ttsChannel,
+          kind: "final",
+          inboundAudio,
+          ttsAuto: sessionTtsAuto,
+        });
+        // Only send if TTS was actually applied (mediaUrl exists)
+        if (ttsSyntheticReply.mediaUrl) {
+          // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
+          const ttsOnlyPayload: ReplyPayload = {
+            mediaUrl: ttsSyntheticReply.mediaUrl,
+            audioAsVoice: ttsSyntheticReply.audioAsVoice,
+          };
+          if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+            const result = await routeReply({
+              payload: ttsOnlyPayload,
+              channel: originatingChannel,
+              to: originatingTo,
+              sessionKey: ctx.SessionKey,
+              accountId: ctx.AccountId,
+              threadId: ctx.MessageThreadId,
+              cfg,
+            });
+            queuedFinal = result.ok || queuedFinal;
+            if (result.ok) routedFinalCount += 1;
+            if (!result.ok) {
+              logVerbose(
+                `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
+              );
+            }
+          } else {
+            const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
+            queuedFinal = didQueue || queuedFinal;
           }
-        } else {
-          const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
-          queuedFinal = didQueue || queuedFinal;
         }
+      } catch (err) {
+        logVerbose(
+          `dispatch-from-config: accumulated block TTS failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -93,16 +93,18 @@ function buildDiscordCommandOptions(params: {
             typeof focused?.value === "string" ? focused.value.trim().toLowerCase() : "";
           const choices = resolveCommandArgChoices({ command, arg, cfg });
           const filtered = focusValue
-            ? choices.filter((choice) => choice.toLowerCase().includes(focusValue))
+            ? choices.filter((choice) => choice.label.toLowerCase().includes(focusValue))
             : choices;
           await interaction.respond(
-            filtered.slice(0, 25).map((choice) => ({ name: choice, value: choice })),
+            filtered.slice(0, 25).map((choice) => ({ name: choice.label, value: choice.value })),
           );
         }
       : undefined;
     const choices =
       resolvedChoices.length > 0 && !autocomplete
-        ? resolvedChoices.slice(0, 25).map((choice) => ({ name: choice, value: choice }))
+        ? resolvedChoices
+            .slice(0, 25)
+            .map((choice) => ({ name: choice.label, value: choice.value }))
         : undefined;
     return {
       name: arg.name,
@@ -351,7 +353,11 @@ export function createDiscordCommandArgFallbackButton(params: DiscordCommandArgC
 
 function buildDiscordCommandArgMenu(params: {
   command: ChatCommandDefinition;
-  menu: { arg: CommandArgDefinition; choices: string[]; title?: string };
+  menu: {
+    arg: CommandArgDefinition;
+    choices: Array<{ value: string; label: string }>;
+    title?: string;
+  };
   interaction: CommandInteraction;
   cfg: ReturnType<typeof loadConfig>;
   discordConfig: DiscordConfig;
@@ -365,11 +371,11 @@ function buildDiscordCommandArgMenu(params: {
     const buttons = choices.map(
       (choice) =>
         new DiscordCommandArgButton({
-          label: choice,
+          label: choice.label,
           customId: buildDiscordCommandArgCustomId({
             command: commandLabel,
             arg: menu.arg.name,
-            value: choice,
+            value: choice.value,
             userId,
           }),
           cfg: params.cfg,

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Store original fetch
+const originalFetch = globalThis.fetch;
+let mockFetch: ReturnType<typeof vi.fn>;
+
+describe("fetchWithSlackAuth", () => {
+  beforeEach(() => {
+    // Create a new mock for each test
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    // Restore original fetch
+    globalThis.fetch = originalFetch;
+    vi.resetModules();
+  });
+
+  it("sends Authorization header on initial request with manual redirect", async () => {
+    // Import after mocking fetch
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    // Simulate direct 200 response (no redirect)
+    const mockResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    expect(result).toBe(mockResponse);
+
+    // Verify fetch was called with correct params
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("https://files.slack.com/test.jpg", {
+      headers: { Authorization: "Bearer xoxb-test-token" },
+      redirect: "manual",
+    });
+  });
+
+  it("follows redirects without Authorization header", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    // First call: redirect response from Slack
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "https://cdn.slack-edge.com/presigned-url?sig=abc123" },
+    });
+
+    // Second call: actual file content from CDN
+    const fileResponse = new Response(Buffer.from("actual image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
+
+    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    expect(result).toBe(fileResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // First call should have Authorization header and manual redirect
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "https://files.slack.com/test.jpg", {
+      headers: { Authorization: "Bearer xoxb-test-token" },
+      redirect: "manual",
+    });
+
+    // Second call should follow the redirect without Authorization
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://cdn.slack-edge.com/presigned-url?sig=abc123",
+      { redirect: "follow" },
+    );
+  });
+
+  it("handles relative redirect URLs", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    // Redirect with relative URL
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "/files/redirect-target" },
+    });
+
+    const fileResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
+
+    await fetchWithSlackAuth("https://files.slack.com/original.jpg", "xoxb-test-token");
+
+    // Second call should resolve the relative URL against the original
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://files.slack.com/files/redirect-target", {
+      redirect: "follow",
+    });
+  });
+
+  it("returns redirect response when no location header is provided", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    // Redirect without location header
+    const redirectResponse = new Response(null, {
+      status: 302,
+      // No location header
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse);
+
+    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    // Should return the redirect response directly
+    expect(result).toBe(redirectResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 4xx/5xx responses directly without following", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    const errorResponse = new Response("Not Found", {
+      status: 404,
+    });
+
+    mockFetch.mockResolvedValueOnce(errorResponse);
+
+    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    expect(result).toBe(errorResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles 301 permanent redirects", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    const redirectResponse = new Response(null, {
+      status: 301,
+      headers: { location: "https://cdn.slack.com/new-url" },
+    });
+
+    const fileResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
+
+    await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://cdn.slack.com/new-url", {
+      redirect: "follow",
+    });
+  });
+});
+
+describe("resolveSlackMedia", () => {
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.resetModules();
+  });
+
+  it("prefers url_private_download over url_private", async () => {
+    // Mock the store module
+    vi.doMock("../../media/store.js", () => ({
+      saveMediaBuffer: vi.fn().mockResolvedValue({
+        path: "/tmp/test.jpg",
+        contentType: "image/jpeg",
+      }),
+    }));
+
+    const { resolveSlackMedia } = await import("./media.js");
+
+    const mockResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    await resolveSlackMedia({
+      files: [
+        {
+          url_private: "https://files.slack.com/private.jpg",
+          url_private_download: "https://files.slack.com/download.jpg",
+          name: "test.jpg",
+        },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://files.slack.com/download.jpg",
+      expect.anything(),
+    );
+  });
+
+  it("returns null when download fails", async () => {
+    const { resolveSlackMedia } = await import("./media.js");
+
+    // Simulate a network error
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no files are provided", async () => {
+    const { resolveSlackMedia } = await import("./media.js");
+
+    const result = await resolveSlackMedia({
+      files: [],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("skips files without url_private", async () => {
+    const { resolveSlackMedia } = await import("./media.js");
+
+    const result = await resolveSlackMedia({
+      files: [{ name: "test.jpg" }], // No url_private
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls through to next file when first file returns error", async () => {
+    // Mock the store module
+    vi.doMock("../../media/store.js", () => ({
+      saveMediaBuffer: vi.fn().mockResolvedValue({
+        path: "/tmp/test.jpg",
+        contentType: "image/jpeg",
+      }),
+    }));
+
+    const { resolveSlackMedia } = await import("./media.js");
+
+    // First file: 404
+    const errorResponse = new Response("Not Found", { status: 404 });
+    // Second file: success
+    const successResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+
+    mockFetch.mockResolvedValueOnce(errorResponse).mockResolvedValueOnce(successResponse);
+
+    const result = await resolveSlackMedia({
+      files: [
+        { url_private: "https://files.slack.com/first.jpg", name: "first.jpg" },
+        { url_private: "https://files.slack.com/second.jpg", name: "second.jpg" },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -5,6 +5,38 @@ import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import type { SlackFile } from "../types.js";
 
+/**
+ * Fetches a URL with Authorization header, handling cross-origin redirects.
+ * Node.js fetch strips Authorization headers on cross-origin redirects for security.
+ * Slack's files.slack.com URLs redirect to CDN domains with pre-signed URLs that
+ * don't need the Authorization header, so we handle the initial auth request manually.
+ */
+export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
+  // Initial request with auth and manual redirect handling
+  const initialRes = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    redirect: "manual",
+  });
+
+  // If not a redirect, return the response directly
+  if (initialRes.status < 300 || initialRes.status >= 400) {
+    return initialRes;
+  }
+
+  // Handle redirect - the redirected URL should be pre-signed and not need auth
+  const redirectUrl = initialRes.headers.get("location");
+  if (!redirectUrl) {
+    return initialRes;
+  }
+
+  // Resolve relative URLs against the original
+  const resolvedUrl = new URL(redirectUrl, url).toString();
+
+  // Follow the redirect without the Authorization header
+  // (Slack's CDN URLs are pre-signed and don't need it)
+  return fetch(resolvedUrl, { redirect: "follow" });
+}
+
 export async function resolveSlackMedia(params: {
   files?: SlackFile[];
   token: string;
@@ -19,10 +51,12 @@ export async function resolveSlackMedia(params: {
     const url = file.url_private_download ?? file.url_private;
     if (!url) continue;
     try {
-      const fetchImpl: FetchLike = (input, init) => {
-        const headers = new Headers(init?.headers);
-        headers.set("Authorization", `Bearer ${params.token}`);
-        return fetch(input, { ...init, headers });
+      // Note: We ignore init options because fetchWithSlackAuth handles
+      // redirect behavior specially. fetchRemoteMedia only passes the URL.
+      const fetchImpl: FetchLike = (input) => {
+        const inputUrl =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        return fetchWithSlackAuth(inputUrl, params.token);
       };
       const fetched = await fetchRemoteMedia({
         url,

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -103,7 +103,7 @@ function buildSlackCommandArgMenuBlocks(params: {
   title: string;
   command: string;
   arg: string;
-  choices: string[];
+  choices: Array<{ value: string; label: string }>;
   userId: string;
 }) {
   const rows = chunkItems(params.choices, 5).map((choices) => ({
@@ -111,11 +111,11 @@ function buildSlackCommandArgMenuBlocks(params: {
     elements: choices.map((choice) => ({
       type: "button",
       action_id: SLACK_COMMAND_ARG_ACTION_ID,
-      text: { type: "plain_text", text: choice },
+      text: { type: "plain_text", text: choice.label },
       value: encodeSlackCommandArgValue({
         command: params.command,
         arg: params.arg,
-        value: choice,
+        value: choice.value,
         userId: params.userId,
       }),
     })),

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -247,10 +247,10 @@ export const registerTelegramNativeCommands = ({
               rows.push(
                 slice.map((choice) => {
                   const args: CommandArgs = {
-                    values: { [menu.arg.name]: choice },
+                    values: { [menu.arg.name]: choice.value },
                   };
                   return {
-                    text: choice,
+                    text: choice.label,
                     callback_data: buildCommandTextFromArgs(commandDefinition, args),
                   };
                 }),


### PR DESCRIPTION
## Summary
- Fixes Slack image downloads failing due to missing Authorization header on cross-origin redirects
- Node.js fetch strips Authorization headers on cross-origin redirects for security
- Slack's files.slack.com URLs redirect to CDN domains with pre-signed URLs

## Root Cause
When downloading files from Slack, the request flow is:
1. Request to `files.slack.com` with `Authorization: Bearer <token>`
2. Slack validates auth and returns 302 redirect to CDN (e.g., `cdn.slack-edge.com`)
3. Node.js fetch follows redirect but strips the Authorization header (security feature)
4. CDN returns HTML login page instead of file content

## Solution
Created `fetchWithSlackAuth()` function that:
1. Makes initial request with `redirect: "manual"` and Authorization header
2. For redirect responses (3xx), follows the redirect URL without auth header (CDN URLs are pre-signed)
3. Handles both absolute and relative redirect URLs

## Test Plan
- [x] Added 11 unit tests covering:
  - Direct 200 response (no redirect)
  - 302/301 redirects to CDN
  - Relative redirect URLs
  - Missing location header
  - 4xx/5xx error responses
  - Network errors
  - Multiple files fallthrough
- [x] Build passes
- [x] Lint passes
- [x] All tests pass

Closes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)