### PR TITLE
feat(tools): add Serper Google Search API as web_search provider option

### DIFF
--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -62,11 +62,12 @@ You can keep it local with `memorySearch.provider = "local"` (no API usage).
 
 See [Memory](/concepts/memory).
 
-### 4) Web search tool (Brave / Perplexity via OpenRouter)
+### 4) Web search tool (Brave / Perplexity via OpenRouter / Serper Google Search API)
 `web_search` uses API keys and may incur usage charges:
 
 - **Brave Search API**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
 - **Perplexity** (via OpenRouter): `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
+- **Serper Google Search API**: `SERPER_API_KEY` or `tools.web.search.apiKey`
 
 **Brave free tier (generous):**
 - **2,000 requests/month**

--- a/docs/serper.md
+++ b/docs/serper.md
@@ -1,0 +1,43 @@
+---
+summary: "Serper Google Search API setup for web_search"
+read_when:
+  - You want to use Serper Google Search API for web search
+  - You need a SERPER_API_KEY or plan details
+---
+
+# Serper Google Search API
+
+Clawdbot can use Serper Google Search API as a search provider for `web_search`. Serper provides fast and cost-effective access to Google Search results in structured JSON format.
+
+## Get an API key
+
+1) Create a Serper API account at https://serper.dev/
+2) Generate an API key in your dashboard
+3) Store the key in config (recommended) or set `SERPER_API_KEY` in the Gateway environment.
+
+## Config example
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "serper",
+        apiKey: "SERPER_API_KEY_HERE",
+        maxResults: 5,
+        timeoutSeconds: 30
+      }
+    }
+  }
+}
+```
+
+## Notes
+
+- Serper provides a free tier (2,500 queries) plus paid plans; check the Serper dashboard for current limits and pricing.
+- Serper is fast and cost-effective, returning traditional Google Search results (title, URL, snippet) similar to Brave Search.
+- Supports country (`country`) and language (`search_lang`) parameters for region-specific results.
+- Does not support `freshness` filtering (Brave-only feature).
+
+See [Web tools](/tools/web) for the full web_search configuration.
+

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,16 +1,17 @@
 ---
-summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter)"
+summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter, Serper Google Search API)"
 read_when:
   - You want to enable web_search or web_fetch
   - You need Brave Search API key setup
   - You want to use Perplexity Sonar for web search
+  - You want to use Serper Google Search API for web search
 ---
 
 # Web tools
 
 Clawdbot ships two lightweight web tools:
 
-- `web_search` — Search the web via Brave Search API (default) or Perplexity Sonar (direct or via OpenRouter).
+- `web_search` — Search the web via Brave Search API (default), Perplexity Sonar (direct or via OpenRouter), or Serper Google Search API.
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -21,6 +22,7 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 - `web_search` calls your configured provider and returns results.
   - **Brave** (default): returns structured results (title, URL, snippet).
   - **Perplexity**: returns AI-synthesized answers with citations from real-time web search.
+  - **Serper**: returns Google Search results (title, URL, snippet) via Serper Google Search API.
 - Results are cached by query for 15 minutes (configurable).
 - `web_fetch` does a plain HTTP GET and extracts readable content
   (HTML → markdown/text). It does **not** execute JavaScript.
@@ -32,8 +34,9 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 |----------|------|------|---------|
 | **Brave** (default) | Fast, structured results, free tier | Traditional search results | `BRAVE_API_KEY` |
 | **Perplexity** | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **Serper** | Fast, cost-effective Google Search API, good free tier | Traditional search results | `SERPER_API_KEY` |
 
-See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for provider-specific details.
+See [Brave Search setup](/brave-search), [Perplexity Sonar](/perplexity), and [Serper Google Search API](/serper) for provider-specific details.
 
 Set the provider in config:
 
@@ -42,7 +45,7 @@ Set the provider in config:
   tools: {
     web: {
       search: {
-        provider: "brave"  // or "perplexity"
+        provider: "brave"  // or "perplexity" or "serper"
       }
     }
   }
@@ -138,6 +141,45 @@ If no base URL is set, Clawdbot chooses a default based on the API key source:
 | `perplexity/sonar-pro` (default) | Multi-step reasoning with web search | Complex questions |
 | `perplexity/sonar-reasoning-pro` | Chain-of-thought analysis | Deep research |
 
+## Using Serper Google Search API
+
+Serper Google Search API provides access to Google Search results in structured JSON format. It's a fast and cost-effective option for getting traditional search results with good free tier limits.
+
+### Getting a Serper API key
+
+1) Create an account at https://serper.dev/
+2) Generate an API key in your dashboard
+3) Run `clawdbot configure --section web` to store the key in config (recommended), or set `SERPER_API_KEY` in your environment.
+
+Serper provides a generous free tier (2,500 queries) and affordable paid plans.
+
+### Setting up Serper search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        enabled: true,
+        provider: "serper",
+        apiKey: "SERPER_API_KEY_HERE"  // optional if SERPER_API_KEY is set
+      }
+    }
+  }
+}
+```
+
+**Environment alternative:** set `SERPER_API_KEY` in the Gateway environment. For a gateway install, put it in `~/.clawdbot/.env`.
+
+### Where to set the key (recommended)
+
+**Recommended:** run `clawdbot configure --section web`. It stores the key in
+`~/.clawdbot/clawdbot.json` under `tools.web.search.apiKey`.
+
+**Environment alternative:** set `SERPER_API_KEY` in the Gateway process
+environment. For a gateway install, put it in `~/.clawdbot/.env` (or your
+service environment). See [Env vars](/help/faq#how-does-clawdbot-load-environment-variables).
+
 ## web_search
 
 Search the web using your configured provider.
@@ -148,6 +190,7 @@ Search the web using your configured provider.
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Perplexity**: `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **Serper**: `SERPER_API_KEY` or `tools.web.search.apiKey`
 
 ### Config
 
@@ -174,7 +217,7 @@ Search the web using your configured provider.
 - `country` (optional): 2-letter country code for region-specific results (e.g., "DE", "US", "ALL"). If omitted, Brave chooses its default region.
 - `search_lang` (optional): ISO language code for search results (e.g., "de", "en", "fr")
 - `ui_lang` (optional): ISO language code for UI elements
-- `freshness` (optional, Brave only): filter by discovery time (`pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`)
+- `freshness` (optional, Brave only): filter by discovery time (`pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`). Not supported by Perplexity or Serper.
 
 **Examples:**
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -340,7 +340,9 @@ async function runSerperSearch(params: {
   country?: string;
   search_lang?: string;
   timeoutSeconds: number;
-}): Promise<{ results: Array<{ title: string; url: string; description: string; siteName?: string }> }> {
+}): Promise<{
+  results: Array<{ title: string; url: string; description: string; siteName?: string }>;
+}> {
   const body: Record<string, unknown> = {
     q: params.query,
     num: params.count,

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -22,4 +22,20 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts serper provider and config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "serper",
+            apiKey: "test-key",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -434,7 +434,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "serper").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -332,8 +332,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "serper"). */
+      provider?: "brave" | "perplexity" | "serper";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -168,7 +168,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("serper")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

Adds Serper Google Search API as a third search provider option for `web_search`.

## Changes

- Added `serper` to search providers with full API integration
- Implemented Serper API client (`runSerperSearch`) with support for country and language parameters
- Added API key resolution from config (`tools.web.search.apiKey`) or `SERPER_API_KEY` environment variable
- Updated config types and schema to include `serper` as a provider option
- Added comprehensive documentation:
  - Updated `docs/tools/web.md` with Serper in provider comparison and setup instructions
  - Created `docs/serper.md` with provider-specific documentation

## User-facing changes

Users can now configure Serper as their search provider:

```js
{
  tools: {
    web: {
      search: {
        provider: "serper",
        apiKey: "SERPER_API_KEY_HERE"  // or set SERPER_API_KEY env var
      }
    }
  }
}
```