### PR TITLE
fix(macos): menu bar activity badge not showing during agent work

### DIFF
--- a/apps/macos/Sources/Clawdbot/AgentEventsWindow.swift
+++ b/apps/macos/Sources/Clawdbot/AgentEventsWindow.swift
@@ -67,7 +67,7 @@ private struct EventRow: View {
 
     private var tint: Color {
         switch self.event.stream {
-        case "job": .blue
+        case "lifecycle": .blue
         case "tool": .orange
         case "assistant": .green
         default: .gray

--- a/apps/macos/Sources/Clawdbot/ControlChannel.swift
+++ b/apps/macos/Sources/Clawdbot/ControlChannel.swift
@@ -379,8 +379,11 @@ final class ControlChannel {
         let sessionKey = (event.data["sessionKey"]?.value as? String) ?? "main"
 
         switch event.stream.lowercased() {
-        case "job":
-            if let state = event.data["state"]?.value as? String {
+        case "lifecycle":
+            // Gateway emits phase: "start" | "end" | "error"
+            // WorkActivityStore expects state: "started" | "streaming" | (anything else = done)
+            if let phase = event.data["phase"]?.value as? String {
+                let state = phase.lowercased() == "start" ? "started" : "done"
                 WorkActivityStore.shared.handleJob(sessionKey: sessionKey, state: state)
             }
         case "tool":

--- a/apps/macos/Tests/ClawdbotIPCTests/MasterDiscoveryMenuSmokeTests.swift
+++ b/apps/macos/Tests/ClawdbotIPCTests/MasterDiscoveryMenuSmokeTests.swift
@@ -11,7 +11,7 @@ struct MasterDiscoveryMenuSmokeTests {
         discovery.statusText = "Searching…"
         discovery.gateways = []
 
-        let view = GatewayDiscoveryInlineList(discovery: discovery, currentTarget: nil, onSelect: { _ in })
+        let view = GatewayDiscoveryInlineList(discovery: discovery, currentTarget: nil, transport: .ssh, onSelect: { _ in })
         _ = view.body
     }
 
@@ -32,7 +32,7 @@ struct MasterDiscoveryMenuSmokeTests {
         ]
 
         let currentTarget = "\(NSUserName())@office.tailnet-123.ts.net:2222"
-        let view = GatewayDiscoveryInlineList(discovery: discovery, currentTarget: currentTarget, onSelect: { _ in })
+        let view = GatewayDiscoveryInlineList(discovery: discovery, currentTarget: currentTarget, transport: .ssh, onSelect: { _ in })
         _ = view.body
     }
 


### PR DESCRIPTION
## Summary

Fixes the macOS menu bar showing 'Idle' during active agent sessions.

## Problem

The gateway emits agent lifecycle events with:
- `stream: "lifecycle"`
- `data: { phase: "start" | "end" | "error" }`

But `ControlChannel.swift` was looking for:
- `stream: "job"`  
- `data: { state: "started" | "streaming" | ... }`

This protocol mismatch meant the menu bar never received activity updates, so the badge/critter animation never triggered even during active sessions.

## Changes

### ControlChannel.swift
- Changed `case "job":` to `case "lifecycle":` in `routeWorkActivity`
- Map gateway's `phase` values to `WorkActivityStore`'s expected `state` values:
  - `"start"` → `"started"`
  - `"end"` / `"error"` → `"done"`

### AgentEventsWindow.swift  
- Updated debug UI stream color mapping from `"job"` to `"lifecycle"` for consistency

## Testing

- Verified gateway emits `stream: "lifecycle"` events (checked TypeScript source)
- Verified `WorkActivityStore.handleJob` expects `"started"` / `"streaming"` states
- Code inspection confirms the fix bridges between these formats correctly

## Fixes

Closes #1932

## Related Issues

- #1916 (8s latency on system.run/notify) - investigated but root cause appears different, likely not app-side
- #1840 (Node communication in Remote mode) - may share underlying causes with #1916