### PR TITLE
fix(skills): add missing dependency declarations to github, notion, slack, discord [AI]

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: discord
 description: Use when you need to control Discord from Clawdbot via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
+metadata: {"clawdbot":{"emoji":"🎮","requires":{"config":["channels.discord"]}}}
 ---
 
 # Discord Actions

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github
 description: "Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries."
+metadata: {"clawdbot":{"emoji":"🐙","requires":{"bins":["gh"]},"install":[{"id":"brew","kind":"brew","formula":"gh","bins":["gh"],"label":"Install GitHub CLI (brew)"},{"id":"apt","kind":"apt","package":"gh","bins":["gh"],"label":"Install GitHub CLI (apt)"}]}}
 ---
 
 # GitHub Skill

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -2,7 +2,7 @@
 name: notion
 description: Notion API for creating and managing pages, databases, and blocks.
 homepage: https://developers.notion.com
-metadata: {"clawdbot":{"emoji":"📝"}}
+metadata: {"clawdbot":{"emoji":"📝","requires":{"env":["NOTION_API_KEY"]},"primaryEnv":"NOTION_API_KEY"}}
 ---
 
 # notion

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: slack
 description: Use when you need to control Slack from Clawdbot via the slack tool, including reacting to messages or pinning/unpinning items in Slack channels or DMs.
+metadata: {"clawdbot":{"emoji":"💬","requires":{"config":["channels.slack"]}}}
 ---
 
 # Slack Actions


### PR DESCRIPTION
## Summary

Skills that depend on external CLIs, env vars, or channel configuration should declare their requirements in frontmatter metadata so Clawdbot filters them out when the dependency isn't present. Without this, users see slash commands that don't work.

## Changes

| Skill | Added Requirement | Reason |
|-------|------------------|--------|
| `github` | `requires.bins: ["gh"]` | Uses `gh` CLI |
| `notion` | `requires.env: ["NOTION_API_KEY"]` | Needs API key |
| `slack` | `requires.config: ["channels.slack"]` | Uses built-in slack tool |
| `discord` | `requires.config: ["channels.discord"]` | Uses built-in discord tool |

Also added install hints for github (brew/apt).

## Schema Reference

- **Type definitions**: [`src/agents/skills/types.ts`](https://github.com/clawdbot/clawdbot/blob/main/src/agents/skills/types.ts) — `ClawdbotSkillMetadata` interface
- **Frontmatter parsing**: [`src/agents/skills/frontmatter.ts`](https://github.com/clawdbot/clawdbot/blob/main/src/agents/skills/frontmatter.ts) — `resolveClawdbotMetadata()`
- **Filtering logic**: [`src/agents/skills/config.ts`](https://github.com/clawdbot/clawdbot/blob/main/src/agents/skills/config.ts) — `shouldIncludeSkill()`

## Audit

Verified all 52 skills:
- **49 skills** now have proper `requires` declarations
- **3 skills** (bluebubbles, canvas, skill-creator) are documentation-only and don't need external dependencies

## AI Contribution 🤖

- [x] AI-assisted (Clawdbot/Claude)
- [x] Tested: Verified metadata parsing and filtering logic locally
- [x] Understand what the code does: Adding frontmatter metadata to declare skill dependencies

## Note

CI failures are unrelated to this PR — main branch has a lockfile mismatch (`@typescript/native-preview` version).
