### PR TITLE
fix(telegram): clear media fields in callback query to prevent TTS inbound false positive

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -317,6 +317,15 @@ export const registerTelegramHandlers = ({
         caption: undefined,
         caption_entities: undefined,
         entities: undefined,
+        // Clear media fields to prevent TTS "inbound" mode from treating callback as voice message
+        voice: undefined,
+        audio: undefined,
+        video: undefined,
+        video_note: undefined,
+        photo: undefined,
+        document: undefined,
+        sticker: undefined,
+        animation: undefined,
       };
       const getFile = typeof ctx.getFile === "function" ? ctx.getFile.bind(ctx) : async () => ({});
       await processMessage({ message: syntheticMessage, me: ctx.me, getFile }, [], storeAllowFrom, {


### PR DESCRIPTION
## Problem

When TTS auto mode is set to `inbound`, voice replies should only trigger when the user sends an audio message. However, clicking inline buttons (e.g., `/think medium`) was incorrectly triggering TTS for the response.

## Root Cause

Inline button callbacks create a synthetic message from the original message, but media fields (`voice`, `audio`, etc.) were being inherited. This caused `isInboundAudioContext()` to return `true` even for non-audio interactions.

## Fix

Explicitly clear all media fields in the synthetic message created for callback queries:
- `voice`
- `audio`
- `video`
- `video_note`
- `photo`
- `document`
- `sticker`
- `animation`

## Testing

- Ran full test suite: 4577 passed (13 failures are pre-existing, unrelated to this change)
- Verified that original test results match after applying this fix