### PR TITLE
fix(signal): replace ￼ with @uuid/@phone from mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
+- Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
 - Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.

--- a/src/signal/monitor/event-handler.mention-gating.test.ts
+++ b/src/signal/monitor/event-handler.mention-gating.test.ts
@@ -53,14 +53,12 @@ type GroupEventOpts = {
   message?: string;
   attachments?: unknown[];
   quoteText?: string;
-  mentions?:
-    | Array<{
-        uuid?: string;
-        number?: string;
-        start?: number;
-        length?: number;
-      }>
-    | null;
+  mentions?: Array<{
+    uuid?: string;
+    number?: string;
+    start?: number;
+    length?: number;
+  }> | null;
 };
 
 function makeGroupEvent(opts: GroupEventOpts) {

--- a/src/signal/monitor/event-handler.mention-gating.test.ts
+++ b/src/signal/monitor/event-handler.mention-gating.test.ts
@@ -53,6 +53,14 @@ type GroupEventOpts = {
   message?: string;
   attachments?: unknown[];
   quoteText?: string;
+  mentions?:
+    | Array<{
+        uuid?: string;
+        number?: string;
+        start?: number;
+        length?: number;
+      }>
+    | null;
 };
 
 function makeGroupEvent(opts: GroupEventOpts) {
@@ -67,6 +75,7 @@ function makeGroupEvent(opts: GroupEventOpts) {
           message: opts.message ?? "",
           attachments: opts.attachments ?? [],
           quote: opts.quoteText ? { text: opts.quoteText } : undefined,
+          mentions: opts.mentions ?? undefined,
           groupInfo: { groupId: "g1", groupName: "Test Group" },
         },
       },
@@ -202,5 +211,64 @@ describe("signal mention gating", () => {
 
     await handler(makeGroupEvent({ message: "/help" }));
     expect(capturedCtx).toBeTruthy();
+  });
+
+  it("hydrates mention placeholders before trimming so offsets stay aligned", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: false } } } },
+        },
+      }),
+    );
+
+    const placeholder = "\uFFFC";
+    const message = `\n${placeholder} hi ${placeholder}`;
+    const firstStart = message.indexOf(placeholder);
+    const secondStart = message.indexOf(placeholder, firstStart + 1);
+
+    await handler(
+      makeGroupEvent({
+        message,
+        mentions: [
+          { uuid: "123e4567", start: firstStart, length: placeholder.length },
+          { number: "+15550002222", start: secondStart, length: placeholder.length },
+        ],
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    const body = String(capturedCtx?.Body ?? "");
+    expect(body).toContain("@123e4567 hi @+15550002222");
+    expect(body).not.toContain(placeholder);
+  });
+
+  it("counts mention metadata replacements toward requireMention gating", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@123e4567"] } },
+          channels: { signal: { groups: { "*": { requireMention: true } } } },
+        },
+      }),
+    );
+
+    const placeholder = "\uFFFC";
+    const message = ` ${placeholder} ping`;
+    const start = message.indexOf(placeholder);
+
+    await handler(
+      makeGroupEvent({
+        message,
+        mentions: [{ uuid: "123e4567", start, length: placeholder.length }],
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    expect(String(capturedCtx?.Body ?? "")).toContain("@123e4567");
+    expect(capturedCtx?.WasMentioned).toBe(true);
   });
 });

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -16,10 +16,19 @@ export type SignalEnvelope = {
   reactionMessage?: SignalReactionMessage | null;
 };
 
+export type SignalMention = {
+  name?: string | null;
+  number?: string | null;
+  uuid?: string | null;
+  start?: number | null;
+  length?: number | null;
+};
+
 export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
   attachments?: Array<SignalAttachment>;
+  mentions?: Array<SignalMention> | null;
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;

--- a/src/signal/monitor/mentions.test.ts
+++ b/src/signal/monitor/mentions.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { renderSignalMentions } from "./mentions.js";
 
 const PLACEHOLDER = "\uFFFC";

--- a/src/signal/monitor/mentions.test.ts
+++ b/src/signal/monitor/mentions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { renderSignalMentions } from "./mentions.js";
+
+const PLACEHOLDER = "\uFFFC";
+
+describe("renderSignalMentions", () => {
+  it("returns the original message when no mentions are provided", () => {
+    const message = `${PLACEHOLDER} ping`;
+    expect(renderSignalMentions(message, null)).toBe(message);
+    expect(renderSignalMentions(message, [])).toBe(message);
+  });
+
+  it("replaces placeholder code points using mention metadata", () => {
+    const message = `${PLACEHOLDER} hi ${PLACEHOLDER}!`;
+    const normalized = renderSignalMentions(message, [
+      { uuid: "abc-123", start: 0, length: 1 },
+      { number: "+15550005555", start: message.lastIndexOf(PLACEHOLDER), length: 1 },
+    ]);
+
+    expect(normalized).toBe("@abc-123 hi @+15550005555!");
+  });
+
+  it("skips mentions that lack identifiers or out-of-bounds spans", () => {
+    const message = `${PLACEHOLDER} hi`;
+    const normalized = renderSignalMentions(message, [
+      { name: "ignored" },
+      { uuid: "valid", start: 0, length: 1 },
+      { number: "+1555", start: 999, length: 1 },
+    ]);
+
+    expect(normalized).toBe("@valid hi");
+  });
+});

--- a/src/signal/monitor/mentions.ts
+++ b/src/signal/monitor/mentions.ts
@@ -1,0 +1,42 @@
+import type { SignalMention } from "./event-handler.types.js";
+
+const OBJECT_REPLACEMENT = "\uFFFC";
+
+function isValidMention(mention: SignalMention | null | undefined): mention is SignalMention {
+  if (!mention) return false;
+  if (!(mention.uuid || mention.number)) return false;
+  if (typeof mention.start !== "number" || Number.isNaN(mention.start)) return false;
+  if (typeof mention.length !== "number" || Number.isNaN(mention.length)) return false;
+  return mention.length > 0;
+}
+
+function clampBounds(start: number, length: number, textLength: number) {
+  const safeStart = Math.max(0, Math.trunc(start));
+  const safeLength = Math.max(0, Math.trunc(length));
+  const safeEnd = Math.min(textLength, safeStart + safeLength);
+  return { start: safeStart, end: safeEnd };
+}
+
+export function renderSignalMentions(message: string, mentions?: SignalMention[] | null) {
+  if (!message || !mentions?.length) {
+    return message;
+  }
+
+  let normalized = message;
+  const candidates = mentions.filter(isValidMention).sort((a, b) => b.start! - a.start!);
+
+  for (const mention of candidates) {
+    const identifier = mention.uuid ?? mention.number;
+    if (!identifier) continue;
+
+    const { start, end } = clampBounds(mention.start!, mention.length!, normalized.length);
+    if (start >= end) continue;
+    const slice = normalized.slice(start, end);
+
+    if (!slice.includes(OBJECT_REPLACEMENT)) continue;
+
+    normalized = normalized.slice(0, start) + `@${identifier}` + normalized.slice(end);
+  }
+
+  return normalized;
+}

--- a/src/signal/monitor/mentions.ts
+++ b/src/signal/monitor/mentions.ts
@@ -3,10 +3,18 @@ import type { SignalMention } from "./event-handler.types.js";
 const OBJECT_REPLACEMENT = "\uFFFC";
 
 function isValidMention(mention: SignalMention | null | undefined): mention is SignalMention {
-  if (!mention) return false;
-  if (!(mention.uuid || mention.number)) return false;
-  if (typeof mention.start !== "number" || Number.isNaN(mention.start)) return false;
-  if (typeof mention.length !== "number" || Number.isNaN(mention.length)) return false;
+  if (!mention) {
+    return false;
+  }
+  if (!(mention.uuid || mention.number)) {
+    return false;
+  }
+  if (typeof mention.start !== "number" || Number.isNaN(mention.start)) {
+    return false;
+  }
+  if (typeof mention.length !== "number" || Number.isNaN(mention.length)) {
+    return false;
+  }
   return mention.length > 0;
 }
 
@@ -23,17 +31,23 @@ export function renderSignalMentions(message: string, mentions?: SignalMention[]
   }
 
   let normalized = message;
-  const candidates = mentions.filter(isValidMention).sort((a, b) => b.start! - a.start!);
+  const candidates = mentions.filter(isValidMention).toSorted((a, b) => b.start! - a.start!);
 
   for (const mention of candidates) {
     const identifier = mention.uuid ?? mention.number;
-    if (!identifier) continue;
+    if (!identifier) {
+      continue;
+    }
 
     const { start, end } = clampBounds(mention.start!, mention.length!, normalized.length);
-    if (start >= end) continue;
+    if (start >= end) {
+      continue;
+    }
     const slice = normalized.slice(start, end);
 
-    if (!slice.includes(OBJECT_REPLACEMENT)) continue;
+    if (!slice.includes(OBJECT_REPLACEMENT)) {
+      continue;
+    }
 
     normalized = normalized.slice(0, start) + `@${identifier}` + normalized.slice(end);
   }


### PR DESCRIPTION
Related #1926

Signal mentions were appearing as ￼ (object replacement character) instead of readable identifiers. This caused Clawdbot to misinterpret messages and respond inappropriately.

Now parses dataMessage.mentions array and replaces the placeholder character with @{uuid} or @{phone} from the mention metadata.

It turns out it's very difficult to display the actual contact name, but displaying the UUID at least allows Clawdbot to differentiate between users who are being mentioned.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Signal inbound event handler to post-process `dataMessage.message` using `dataMessage.mentions`, replacing the object replacement character placeholders with `@{uuid}`/`@{phone}` identifiers so Clawdbot can correctly distinguish mentioned users. Adds a `SignalMention` type and wires `mentions` into `SignalDataMessage`.

This change lives in the Signal receive path (`src/signal/monitor/event-handler.ts`) just before control-command detection and message dispatch, so the normalized mention text is what downstream routing/command parsing sees.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but mention substitution can produce incorrect text in some cases.
- The change is localized and straightforward, but it relies on `mention.start`/`mention.length` aligning with the trimmed JS string; if messages have leading whitespace/newlines, replacements can target the wrong span. Existing review threads already note additional index/bounds concerns.
- src/signal/monitor/event-handler.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->