### PR TITLE
feat(security): add gateway network exposure check to doctor

### DIFF
--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ClawdbotConfig } from "../config/config.js";
+
+const note = vi.hoisted(() => vi.fn());
+
+vi.mock("../terminal/note.js", () => ({
+  note,
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [],
+}));
+
+import { noteSecurityWarnings } from "./doctor-security.js";
+
+describe("noteSecurityWarnings gateway exposure", () => {
+  let prevToken: string | undefined;
+  let prevPassword: string | undefined;
+
+  beforeEach(() => {
+    note.mockClear();
+    prevToken = process.env.CLAWDBOT_GATEWAY_TOKEN;
+    prevPassword = process.env.CLAWDBOT_GATEWAY_PASSWORD;
+    delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+    delete process.env.CLAWDBOT_GATEWAY_PASSWORD;
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+    else process.env.CLAWDBOT_GATEWAY_TOKEN = prevToken;
+    if (prevPassword === undefined) delete process.env.CLAWDBOT_GATEWAY_PASSWORD;
+    else process.env.CLAWDBOT_GATEWAY_PASSWORD = prevPassword;
+  });
+
+  const lastMessage = () => String(note.mock.calls.at(-1)?.[0] ?? "");
+
+  it("warns when exposed without auth", async () => {
+    const cfg = { gateway: { bind: "lan" } } as ClawdbotConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("CRITICAL");
+    expect(message).toContain("without authentication");
+  });
+
+  it("uses env token to avoid critical warning", async () => {
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "token-123";
+    const cfg = { gateway: { bind: "lan" } } as ClawdbotConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("WARNING");
+    expect(message).not.toContain("CRITICAL");
+  });
+
+  it("treats whitespace token as missing", async () => {
+    const cfg = {
+      gateway: { bind: "lan", auth: { mode: "token", token: "   " } },
+    } as ClawdbotConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("CRITICAL");
+  });
+
+  it("skips warning for loopback bind", async () => {
+    const cfg = { gateway: { bind: "loopback" } } as ClawdbotConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("No channel security warnings detected");
+    expect(message).not.toContain("Gateway bound");
+  });
+});


### PR DESCRIPTION
## Summary

Adds security check to `clawdbot doctor` that warns users when their gateway is bound to a network interface without proper authentication.

**923 Clawdbot instances are currently exposed on Shodan with no auth.**

## The Problem

While Clawdbot's onboarding flow has safeguards (defaulting to `loopback` and forcing auth when exposed), these checks:

1. **Only run during `clawdbot onboard`** - not on config edits or startup
2. **Can be bypassed** via CLI flags (`--bind all`) or manual config editing
3. **Don't warn existing users** who may have misconfigured setups

## Changes

Adds to `src/commands/doctor-security.ts`:
- **CRITICAL warning** if `bind ∈ {all, lan, 0.0.0.0}` AND `auth.mode == off`
- **CRITICAL warning** if exposed with empty token/password
- **WARNING** if exposed with auth (reminder to keep credentials secure)
- Provides actionable fix commands in warning messages

## Test Plan

```bash
# Test with dangerous config
clawdbot config set gateway.bind all
clawdbot config set gateway.auth.mode off
clawdbot doctor
# Expected: CRITICAL warning about network exposure

# Test with safe config
clawdbot config set gateway.bind loopback
clawdbot doctor
# Expected: No network exposure warning

# Test with exposed but auth'd
clawdbot config set gateway.bind all
clawdbot config set gateway.auth.mode token
clawdbot doctor --fix  # Should generate token
clawdbot doctor
# Expected: WARNING (not critical) about network exposure
```

## Related

- Fixes #2015
- Shodan results: https://www.shodan.io/search?query=%22clawdbot%22+port%3A18789
- Tweet: https://x.com/AlexDotEth/status/2015587937660841992

---

🤖 Generated with [Claude Code](https://claude.ai/code)