### PR TITLE
fix: expose runMode force param in cron tool for on-demand job execution

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -47,6 +47,39 @@ describe("cron tool", () => {
     expect(call.params).toEqual(expectedParams);
   });
 
+  it("run passes runMode force to gateway as mode", async () => {
+    const tool = createCronTool();
+    await tool.execute("call-force", {
+      action: "run",
+      jobId: "job-1",
+      runMode: "force",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: unknown;
+    };
+    expect(call.method).toBe("cron.run");
+    expect(call.params).toEqual({ id: "job-1", mode: "force" });
+  });
+
+  it("run omits mode when runMode is not provided", async () => {
+    const tool = createCronTool();
+    await tool.execute("call-no-mode", {
+      action: "run",
+      jobId: "job-1",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: unknown;
+    };
+    expect(call.method).toBe("cron.run");
+    expect(call.params).toEqual({ id: "job-1" });
+  });
+
   it("prefers jobId over id when both are provided", async () => {
     const tool = createCronTool();
     await tool.execute("call1", {


### PR DESCRIPTION
## Summary

The gateway protocol (`CronRunParamsSchema`), server handler (`server-methods/cron.ts`), and cron service (`service/ops.ts`) already support `mode: "force"` for `cron.run`, but the agent tool (`cron-tool.ts`) never exposed or passed this parameter through. This meant agents could not force-execute cron jobs that weren't due — the tool always returned `{ ran: false, reason: "not-due" }`.

## Changes

- Add `runMode` (`"due" | "force"`) optional param to the cron tool schema
- Pass `runMode` through as `mode` in the `cron.run` gateway call
- Update tool description to mention force execution
- Add 2 tests: force mode passthrough + default omission

## Why `runMode` instead of reusing `mode`?

The existing `mode` field is typed as `"now" | "next-heartbeat"` for the `wake` action. Since the `run` action needs `"due" | "force"`, a separate `runMode` param avoids ambiguity in the flattened schema and keeps LLM tool descriptions clear about which values apply to which action.

## Testing

- [x] AI-assisted (Claude via Clawdbot agent)
- [x] 2 new unit tests added
- [ ] Could not run full CI locally (workspace dep on unpublished 2026.1.25)
- [x] I understand what the code does

## Use case

Testing cron job pipelines: when an agent or user wants to verify a cron job works end-to-end, they can now call `cron run` with `runMode: "force"` instead of waiting for the next scheduled execution.