### PR TITLE
feat(compaction): re-inject workspace context files after compaction

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -8,6 +8,7 @@
 import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAfterCompactionEvent,
+  PluginHookAfterCompactionResult,
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
   PluginHookAgentEndEvent,
@@ -43,6 +44,7 @@ export type {
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookAfterCompactionEvent,
+  PluginHookAfterCompactionResult,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -218,12 +220,21 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
   /**
    * Run after_compaction hook.
+   * Allows plugins to return text to append to the compaction summary.
    */
   async function runAfterCompaction(
     event: PluginHookAfterCompactionEvent,
     ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("after_compaction", event, ctx);
+  ): Promise<PluginHookAfterCompactionResult | undefined> {
+    return runModifyingHook<"after_compaction", PluginHookAfterCompactionResult>(
+      "after_compaction",
+      event,
+      ctx,
+      (acc, next) => ({
+        appendToSummary:
+          [acc?.appendToSummary, next.appendToSummary].filter(Boolean).join("\n\n") || undefined,
+      }),
+    );
   }
 
   // =========================================================================

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -339,6 +339,16 @@ export type PluginHookAfterCompactionEvent = {
   messageCount: number;
   tokenCount?: number;
   compactedCount: number;
+  /** The generated summary text (read-only). */
+  summary?: string;
+  /** Agent workspace root (for reading context files). */
+  workspaceRoot?: string;
+};
+
+/** Result from after_compaction hook - allows injecting additional context into the summary. */
+export type PluginHookAfterCompactionResult = {
+  /** Additional text to append to the compaction summary. */
+  appendToSummary?: string;
 };
 
 // Message context
@@ -476,7 +486,7 @@ export type PluginHookHandlerMap = {
   after_compaction: (
     event: PluginHookAfterCompactionEvent,
     ctx: PluginHookAgentContext,
-  ) => Promise<void> | void;
+  ) => Promise<PluginHookAfterCompactionResult | void> | PluginHookAfterCompactionResult | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,


### PR DESCRIPTION
## Summary

This PR ensures that **USER.md, SOUL.md, and IDENTITY.md** are automatically re-injected into the compaction summary when context gets compressed. This solves the problem of the agent losing persona and user preferences after context compression.

## Changes

1. **compaction-safeguard.ts**: 
   - Added `buildContextRefreshSection()` function to read and format workspace context files
   - Re-inject these files into the summary after compaction

2. **Plugin hook enhancement**:
   - Modified `after_compaction` hook to support returning `appendToSummary` text
   - Allows plugins to inject additional context into the compaction summary

## Testing

- Manually verified that USER.md content is included in compaction summary
- Build passes without errors

## Related Issue

Fixes context compression causing loss of user preferences (English reply format, voice settings, etc.)