### PR TITLE
fix: wire onToolResult callback for verbose tool summaries

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -288,6 +288,16 @@ export async function dispatchReplyFromConfig(params: {
           };
           return run();
         },
+        onToolResult: (payload: ReplyPayload) => {
+          const run = async () => {
+            if (shouldRouteToOriginating) {
+              await sendPayloadAsync(payload, undefined, false);
+            } else {
+              dispatcher.sendBlockReply(payload);
+            }
+          };
+          return run();
+        },
       },
       cfg,
     );


### PR DESCRIPTION
## HOTFIX

Tool summaries were not being sent to chat channels when verbose mode was enabled (`/verbose on`).

### Problem
The `onToolResult` callback was defined in the types but never wired up in `dispatch-from-config.ts`. This meant that even with verbose mode enabled, tool summaries were silently dropped instead of being sent to WhatsApp, Telegram, and other chat channels.

### Solution
Added the missing `onToolResult` callback alongside `onBlockReply`, using the same `dispatcher.sendBlockReply()` path to deliver tool summaries.

### Testing
- Tested on WhatsApp with `/verbose on`
- Tool summaries now appear as separate messages when tools are invoked

### Changes
- `src/auto-reply/reply/dispatch-from-config.ts`: Wire up `onToolResult` callback (+10 lines)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the previously-declared `onToolResult` callback into `dispatchReplyFromConfig`, ensuring verbose tool summaries are forwarded to external chat dispatchers (or routed to an originating channel when cross-provider routing is active). It mirrors the existing `onBlockReply` pathway by reusing `dispatcher.sendBlockReply(...)` / `sendPayloadAsync(...)`, which fits the current reply dispatch architecture where final/block replies are emitted via the dispatcher and optional route-reply bridging.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one behavior gap around cancellation for verbose tool-summary dispatch.
- The change is small and localized (adds a missing callback wiring) and follows the existing dispatcher/routing pattern. The main concern is that `onToolResult` lacks access to an abort signal, so summaries can still be sent after an aborted run, potentially causing confusing out-of-order messages in chat channels.
- src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->