### PR TITLE
[AI-Assisted] Fix ExtensionRunner initialization in embedded mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: bind ExtensionRunner in embedded mode so compaction hooks produce real summaries instead of "Summary unavailable...". (#2027) Thanks @ArtemHorik.
 - Telegram: restore draft streaming partials. (#5543) Thanks @obviyus.
 
 ## 2026.1.30


### PR DESCRIPTION
## Summary                                                                                                                            
  - Initialize `extensionRunner` in embedded mode to fix auto-compaction summaries                                                      
  - Without this, `ctx.model` remains undefined and compaction hooks fall back to "Summary unavailable..."                              
                                                                                                                                        
  ## Why                                                                                                                                
  In embedded mode (used by bots), `extensionRunner.initialize()` was never called, unlike interactive mode where the UI calls it. This caused `compaction-safeguard` to skip real summarization.                                                                             
                                                                                                                                        
  ## Changes                                                                                                                            
  - Call `extensionRunner.initialize()` after session creation in `attempt.ts`                                                          
  - `getActiveTools` returns only valid string tool names (filters undefined)                                                           
  - `setModel` validates API key and returns `Promise<boolean>`                                                                         
  - `compact` forwards `onComplete`/`onError` callbacks properly                                                                        
                                                                                                                                        
  ## Testing                                                                                                                            
  ✅ Fully tested locally with Clawdbot instance                                                                                        
  - Verified compaction now produces actual summaries instead of "Summary unavailable..."                                               
                                                                                                                                        
  ## AI Disclosure                                                                                                                      
  - Code & review: Codex, Claude Code                                                                                                   
  - ✅ Tested locally, code reviewed and understood

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded Pi runner startup so the session’s `extensionRunner` is bound in embedded mode, enabling compaction extensions that depend on `ctx.model` to generate real summaries (instead of falling back to “Summary unavailable…”). It also adds stricter handling for active tool name extraction, model setting (API key presence), and forwards compaction completion/error callbacks.

Change is localized to the embedded run attempt path (`src/agents/pi-embedded-runner/run/attempt.ts`) and a corresponding changelog entry.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should improve embedded compaction behavior, with minor concerns around stubbed extension runner state methods.
- The change is narrowly scoped and primarily wires embedded mode into an existing extension runner API. Potential issues are mostly around behavioral expectations of extensions (`isIdle`/`hasPendingMessages`) and whether `compact()` should be awaitable, but no obvious runtime errors are introduced in the diff shown.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->