### PR TITLE
fix: revert deps to match lockfile

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -34,6 +34,6 @@
     "clawdbot": "workspace:*"
   },
   "peerDependencies": {
-    "clawdbot": ">=2026.1.25"
+    "clawdbot": ">=2026.1.24"
   }
 }

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -9,6 +9,6 @@
     ]
   },
   "peerDependencies": {
-    "clawdbot": ">=2026.1.25"
+    "clawdbot": ">=2026.1.24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/ws": "^8.18.1",
-    "@typescript/native-preview": "7.0.0-dev.20260125.1",
+    "@typescript/native-preview": "7.0.0-dev.20260124.1",
     "@vitest/coverage-v8": "^4.0.18",
     "docx-preview": "^0.3.7",
     "lit": "^3.3.2",


### PR DESCRIPTION
Buiilding from source is borked currently after 8f65424

The repo got into an invalid lockfile state due to bumping to a ts native nightly that doesnt exist yet, so your publish doc seems to have died at the `pnpm i` step in the releasing doc? https://github.com/clawdbot/clawdbot/blob/main/docs/reference/RELEASING.md

The peer-dep revert is needed bc the lockfile has `autoInstallPeers: true`, and will attempt to fetch the clawdbot version from today that doesnt exist yet. Idk if you wanna fix that another way, but that is also blocking install.

- Revert @typescript/native-preview to 7.0.0-dev.20260124.1 (7.0.0-dev.20260125.1 doesn't exist on npm)
- Revert extension peerDeps to >=2026.1.24 (2026.1.25 not published yet)

Fixes #2011