### PR TITLE
macOS: bump Textual to 0.3.1 to fix NSBundle.module crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Status: unreleased.
 ### Changes
 - TBD.
 
+### Fixes
+- macOS: avoid crash when rendering code blocks by bumping Textual to 0.3.1 (fixes NSBundle.module assertion in CodeTokenizer). (#1451, #1600, #1640, #1652, #1687, #1833, #1841, #1847, #1853, #1929, #2002)
+
 ## 2026.1.24-3
 
 ### Fixes

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/textual",
       "state" : {
-        "revision" : "a03c1e103d88de4ea0dd8320ea1611ec0d4b29b3",
-        "version" : "0.2.0"
+        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
+        "version" : "0.3.1"
       }
     }
   ],

--- a/apps/shared/ClawdbotKit/Package.swift
+++ b/apps/shared/ClawdbotKit/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/steipete/ElevenLabsKit", exact: "0.1.0"),
-        .package(url: "https://github.com/gonzalezreal/textual", exact: "0.2.0"),
+        .package(url: "https://github.com/gonzalezreal/textual", exact: "0.3.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
Bumps Textual to 0.3.1 to fix macOS crashes when rendering code blocks (NSBundle.module assertion in CodeTokenizer).

## Problem
SwiftPM’s generated Bundle.module for Textual fails to locate `textual_Textual.bundle` in packaged apps, causing a fatal assertion when code highlighting runs.

## Changes
- Update Textual dependency to 0.3.1 in ClawdbotKit.
- Refresh macOS Package.resolved.

## Build instructions (macOS app)
```bash
cd apps/macos
swift build -c release --arch arm64
cd ../..
BUILD_CONFIG=release scripts/package-mac-app.sh
```

If `pnpm install` fails during packaging (e.g., local extensions require a newer published clawdbot), you can package with the following *dev-only* workaround (does not affect the Swift macOS binary):
```bash
SKIP_PNPM_INSTALL=1 SKIP_TSC=1 SKIP_UI_BUILD=1 ALLOW_ADHOC_SIGNING=1 BUILD_CONFIG=release scripts/package-mac-app.sh
```

## Repro (before fix)
1) Build + package the macOS app.
2) Delete `apps/macos/.build` after packaging.
3) Launch `/Applications/Clawdbot.app`.
4) Open chat and render a fenced code block.
→ Crash: `_assertionFailure → NSBundle.module → CodeTokenizer.init`

## Validation (after fix)
- Same steps as above; no crash even with `.build` deleted.
- Local macOS build renders code blocks without crashing.

## Fixes
Fixes #1451, #1600, #1640, #1652, #1687, #1833, #1841, #1847, #1853, #1929, #2002

## AI Assistance
- AI-assisted: Yes (Codex)
- Testing: manual macOS build + runtime repro/validation
- I understand the change and its impact.
