### PR TITLE
WhatsApp: preserve document filenames

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -38,9 +38,10 @@ export function createWebSendApi(params: {
             ...(gifPlayback ? { gifPlayback: true } : {}),
           };
         } else {
+          const fileName = sendOptions?.fileName?.trim() || "file";
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName,
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -131,7 +131,9 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -44,11 +44,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -69,10 +71,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
-            accountId,
+            ...(accountId ? { accountId } : {}),
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
           }
         : undefined;
     const result = sendOptions


### PR DESCRIPTION
## Summary
- Preserve original filenames when sending WhatsApp document attachments
- Thread filename through web outbound send options to the send API payload

## Testing
- Not run (not requested)

## AI Assistance
- AI-assisted: Codex (ChatGPT)
- Session logs available on request
- I understand these changes and their impact

Fixes #2008
