### PR TITLE
fix(slack): remove ack reaction when block streaming replies are sent (#2003)

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -141,7 +141,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   });
   markDispatchIdle();
 
-  if (!queuedFinal) {
+  const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+
+  if (!anyReplyDelivered) {
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,


### PR DESCRIPTION
## Summary
- Remove Slack ack reactions after block streaming replies complete
- Expand the ack-removal check to include streamed block replies

## Testing
- Not run (not requested)

## AI Assistance
- [x] AI-assisted (Codex / ChatGPT)
- [x] Testing level noted
- [x] Prompts/logs available on request
- [x] I understand these changes and their impact

Fixes #2003
