### PR TITLE
[AI] macOS: allow non-local SSH target usernames

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -413,10 +413,17 @@ final class AppState {
     }
 
     private func updateRemoteTarget(host: String) {
-        let parsed = CommandResolver.parseSSHTarget(self.remoteTarget)
-        let user = parsed?.user ?? NSUserName()
-        let port = parsed?.port ?? 22
-        let assembled = port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
+        let trimmed = self.remoteTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = CommandResolver.parseSSHTarget(trimmed) else { return }
+        let trimmedUser = parsed.user?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let user = (trimmedUser?.isEmpty ?? true) ? nil : trimmedUser
+        let port = parsed.port
+        let assembled: String
+        if let user {
+            assembled = port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
+        } else {
+            assembled = port == 22 ? host : "\(host):\(port)"
+        }
         if assembled != self.remoteTarget {
             self.remoteTarget = assembled
         }


### PR DESCRIPTION
What

- Stop auto-injecting the macOS username when syncing the SSH target host/port.

Why

- Prevents the SSH target field from overwriting user‑entered remote usernames. This is important because if you use one user name on your Mac, and another on the remote host, then right now the app makes it very hard (maybe impossible?) to configure the correct user name on the remote.

Testing

- Manual: I ran the macOS app, set SSH target to a non‑local username, verified it persisted and connection worked.

AI disclosure

- AI-assisted: yes (Codex)
- Prompts/session summary: “Fix SSH target username overwrite in macOS remote settings.”
- Understanding: I understand the change and its impact.
