### PR TITLE
[AI] Webchat: distinguish system messages

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -18,6 +18,21 @@
   justify-content: flex-start;
 }
 
+.chat-group.system {
+  justify-content: center;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.chat-group.system .chat-group-messages {
+  align-items: center;
+  max-width: min(820px, 90%);
+}
+
+.chat-group.system .chat-group-footer {
+  justify-content: center;
+}
+
 .chat-group-messages {
   display: flex;
   flex-direction: column;
@@ -87,6 +102,10 @@
 .chat-avatar.tool {
   background: var(--secondary);
   color: var(--muted);
+}
+
+.chat-group.system .chat-avatar {
+  display: none;
 }
 
 /* Image avatar support */
@@ -226,6 +245,21 @@ img.chat-avatar {
 .chat-group.user .chat-bubble {
   background: var(--accent-subtle);
   border-color: transparent;
+}
+
+.chat-group.system .chat-bubble {
+  background: var(--bg-muted);
+  border-color: var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 12px;
+  text-align: center;
+}
+
+:root[data-theme="light"] .chat-group.system .chat-bubble {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
 }
 
 :root[data-theme="light"] .chat-group.user .chat-bubble {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -78,12 +78,16 @@ export function renderMessageGroup(
       ? "You"
       : normalizedRole === "assistant"
         ? assistantName
+        : normalizedRole === "system"
+          ? "System"
         : normalizedRole;
   const roleClass =
     normalizedRole === "user"
       ? "user"
       : normalizedRole === "assistant"
         ? "assistant"
+        : normalizedRole === "system"
+          ? "system"
         : "other";
   const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
     hour: "numeric",
@@ -129,6 +133,8 @@ function renderAvatar(
       ? "U"
       : normalized === "assistant"
         ? assistantName.charAt(0).toUpperCase() || "A"
+        : normalized === "system"
+          ? "!"
         : normalized === "tool"
           ? "⚙"
           : "?";
@@ -137,6 +143,8 @@ function renderAvatar(
       ? "user"
       : normalized === "assistant"
         ? "assistant"
+      : normalized === "system"
+          ? "system"
       : normalized === "tool"
           ? "tool"
           : "other";

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -7,6 +7,7 @@ import { icons } from "../icons";
 import {
   normalizeMessage,
   normalizeRoleForGrouping,
+  splitSystemPreface,
 } from "../chat/message-normalizer";
 import {
   renderMessageGroup,
@@ -337,10 +338,23 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
+    const split = splitSystemPreface(normalized);
+    if (split.systemMessage) {
+      items.push({
+        kind: "message",
+        key: `system:${messageKey(msg, i)}`,
+        message: split.systemMessage,
+      });
+    }
+
+    if (split.systemMessage && split.message.content.length === 0) {
+      continue;
+    }
+
     items.push({
       kind: "message",
       key: messageKey(msg, i),
-      message: msg,
+      message: split.systemMessage ? split.message : msg,
     });
   }
   if (props.showThinking) {


### PR DESCRIPTION
## Summary
- Split system-prefixed lines out of user messages into separate system entries in the Control UI
- Render system messages centered with muted styling to avoid looking like user chat
- Skip rendering an empty user bubble when a message contains only system lines

## Testing
- pnpm --dir ui test -- ui/src/ui/chat/message-normalizer.test.ts
  - Note: UI test suite reports existing failures in ui/src/ui/navigation.test.ts (icon expectations), unrelated to this change.

## AI Assistance
- [x] AI-assisted (Codex / ChatGPT)
- [x] Testing level noted
- [x] Prompts/logs available on request
- [x] I understand these changes and their impact

Fixes #2001
