### PR TITLE
fix(exec-approvals): match simple command name patterns in allowlist

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -33,7 +33,7 @@ function makeTempDir() {
 }
 
 describe("exec approvals allowlist matching", () => {
-  it("ignores basename-only patterns", () => {
+  it("matches basename-only patterns case-insensitively", () => {
     const resolution = {
       rawExecutable: "rg",
       resolvedPath: "/opt/homebrew/bin/rg",
@@ -41,7 +41,7 @@ describe("exec approvals allowlist matching", () => {
     };
     const entries: ExecAllowlistEntry[] = [{ pattern: "RG" }];
     const match = matchAllowlist(entries, resolution);
-    expect(match).toBeNull();
+    expect(match?.pattern).toBe("RG");
   });
 
   it("matches by resolved path with **", () => {
@@ -66,7 +66,7 @@ describe("exec approvals allowlist matching", () => {
     expect(match).toBeNull();
   });
 
-  it("requires a resolved path", () => {
+  it("falls back to rawExecutable when resolvedPath is undefined", () => {
     const resolution = {
       rawExecutable: "bin/rg",
       resolvedPath: undefined,
@@ -74,7 +74,7 @@ describe("exec approvals allowlist matching", () => {
     };
     const entries: ExecAllowlistEntry[] = [{ pattern: "bin/rg" }];
     const match = matchAllowlist(entries, resolution);
-    expect(match).toBeNull();
+    expect(match?.pattern).toBe("bin/rg");
   });
 });
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -508,14 +508,20 @@ export function matchAllowlist(
   entries: ExecAllowlistEntry[],
   resolution: CommandResolution | null,
 ): ExecAllowlistEntry | null {
-  if (!entries.length || !resolution?.resolvedPath) return null;
+  if (!entries.length || !resolution) return null;
+  const rawExecutable = resolution.rawExecutable;
   const resolvedPath = resolution.resolvedPath;
+  const executableName = resolution.executableName;
   for (const entry of entries) {
     const pattern = entry.pattern?.trim();
     if (!pattern) continue;
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
-    if (!hasPath) continue;
-    if (matchesPattern(pattern, resolvedPath)) return entry;
+    if (hasPath) {
+      const target = resolvedPath ?? rawExecutable;
+      if (target && matchesPattern(pattern, target)) return entry;
+      continue;
+    }
+    if (executableName && matchesPattern(pattern, executableName)) return entry;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Fix `matchAllowlist()` to properly match simple command patterns like `pwd`, `ls`, `date`
- Previously, patterns without path separators were skipped entirely due to `if (!hasPath) continue;`
- Now simple patterns match against `executableName`, and path-based patterns fall back to `rawExecutable` when `resolvedPath` is undefined

## Test plan
- [x] Updated existing tests to reflect correct behavior
- [x] Verified on VPS: all 29 exec-approvals tests pass
- [x] Manual testing: `pwd`, `ls`, `date` execute without approval when allowlisted; `wget` properly blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)