### PR TITLE
fix(ui): visually distinguish system messages in webchat

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -34,6 +34,34 @@
   justify-content: flex-end;
 }
 
+/* System messages centered with muted styling */
+.chat-group.system {
+  justify-content: center;
+  margin-left: 16px;
+}
+
+.chat-group.system .chat-group-messages {
+  align-items: center;
+  max-width: min(600px, calc(100% - 60px));
+}
+
+.chat-group.system .chat-bubble {
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--muted);
+  padding: 8px 12px;
+}
+
+.chat-group.system .chat-group-footer {
+  justify-content: center;
+}
+
+.chat-group.system .chat-sender-name {
+  color: var(--muted);
+  opacity: 0.8;
+}
+
 /* Footer at bottom of message group (role + time) */
 .chat-group-footer {
   display: flex;
@@ -87,6 +115,12 @@
 .chat-avatar.tool {
   background: var(--secondary);
   color: var(--muted);
+}
+
+.chat-avatar.system {
+  background: var(--border);
+  color: var(--muted);
+  font-size: 16px;
 }
 
 /* Image avatar support */

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -118,9 +118,17 @@ export function renderMessageGroup(
       ? "You"
       : normalizedRole === "assistant"
         ? assistantName
-        : normalizedRole;
+        : normalizedRole === "system"
+          ? "System"
+          : normalizedRole;
   const roleClass =
-    normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
+    normalizedRole === "user"
+      ? "user"
+      : normalizedRole === "assistant"
+        ? "assistant"
+        : normalizedRole === "system"
+          ? "system"
+          : "other";
   const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",
@@ -163,7 +171,9 @@ function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" |
         ? assistantName.charAt(0).toUpperCase() || "A"
         : normalized === "tool"
           ? "⚙"
-          : "?";
+          : normalized === "system"
+            ? "ℹ"
+            : "?";
   const className =
     normalized === "user"
       ? "user"
@@ -171,7 +181,9 @@ function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" |
         ? "assistant"
         : normalized === "tool"
           ? "tool"
-          : "other";
+          : normalized === "system"
+            ? "system"
+            : "other";
 
   if (assistantAvatar && normalized === "assistant") {
     if (isAvatarUrl(assistantAvatar)) {


### PR DESCRIPTION
## Summary
- Add distinct visual styling for system messages in the webchat UI
- System messages now appear centered with muted styling, clearly differentiated from user and assistant messages
- Add info icon (ℹ) as the avatar for system messages

## Changes
- **ui/src/ui/chat/grouped-render.ts**: Add `system` role handling to `renderMessageGroup` and `renderAvatar` functions
- **ui/src/styles/chat/grouped.css**: Add CSS styles for `.chat-group.system` and `.chat-avatar.system`

## Test plan
- [ ] Open the webchat UI
- [ ] Trigger a system message (e.g., "Showing last X messages" notice when history is truncated)
- [ ] Verify system messages appear centered with muted styling
- [ ] Verify the info icon (ℹ) appears as the avatar
- [ ] Check appearance in both light and dark themes

Closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)