### PR TITLE
fix: accept JSON string for cron.add job parameter (#1940)

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -348,10 +348,21 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }
           }
 
-          if (!params.job || typeof params.job !== "object") {
+          if (params.job === null || params.job === undefined) {
             throw new Error("job required");
           }
-          const job = normalizeCronJobCreate(params.job) ?? params.job;
+          let rawJob: unknown = params.job;
+          if (typeof rawJob === "string") {
+            try {
+              rawJob = JSON.parse(rawJob);
+            } catch {
+              throw new Error("job must be object");
+            }
+          }
+          if (!rawJob || typeof rawJob !== "object" || Array.isArray(rawJob)) {
+            throw new Error("job must be object");
+          }
+          const job = normalizeCronJobCreate(rawJob) ?? rawJob;
           if (job && typeof job === "object" && !("agentId" in job)) {
             const cfg = loadConfig();
             const agentId = opts?.agentSessionKey


### PR DESCRIPTION
gh pr create --title "fix: accept JSON string for cron.add job parameter (#1940)" --body "

## Summary
- Parse job parameter as JSON string when passed as string instead of object
- Fixes inconsistent 'must be object' error when AI tools pass job as JSON string

## Testing
- Added test: accepts cron.add job payloads as JSON strings
- All 16 cron-tool tests pass
- pnpm lint ✅
- pnpm build ✅

## AI/Vibe-Coded PR 🤖

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing: **fully tested locally**
- [x] Include prompts or session logs if possible: available on request
- [x] Confirm you understand what the code does

### AI Tools Used
- Claude Opus-4.5
- Cursor IDE
- Manual review performed

Fixes #1940"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the `cron` agent tool more tolerant of AI/client callers by accepting `job` as a JSON-encoded string for the `cron.add` action. The implementation parses `job` when it’s a string, validates it is a plain object (not null/array), then continues through existing normalization (`normalizeCronJobCreate`) and defaulting behavior before calling the gateway.

A new Vitest case covers passing `job` as a JSON string and asserts the tool still emits the same normalized `cron.add` request payload as when an object is provided.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and covered by a new test.
- The change only affects the `cron.add` branch by adding a small JSON-parse path and a stricter plain-object guard, with a new unit test validating the intended behavior. Main remaining risk is minor: the tool schema still advertises `job` as an object, so some tool runtimes may reject string input before it reaches this runtime parsing path.
- src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->