### PR TITLE
feat(slack): add channel-info and mark-read actions for unread tracking

### DIFF
--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -33,6 +33,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "role-add",
   "role-remove",
   "channel-info",
+  "mark-read",
   "channel-list",
   "channel-create",
   "channel-edit",

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -46,6 +46,10 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
       }
       if (isActionEnabled("memberInfo")) actions.add("member-info");
       if (isActionEnabled("emojiList")) actions.add("emoji-list");
+      if (isActionEnabled("channelInfo")) {
+        actions.add("channel-info");
+        actions.add("mark-read");
+      }
       return Array.from(actions);
     },
     extractToolSend: ({ args }): ChannelToolSend | null => {
@@ -200,6 +204,30 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
       if (action === "emoji-list") {
         return await handleSlackAction(
           { action: "emojiList", accountId: accountId ?? undefined },
+          cfg,
+        );
+      }
+
+      if (action === "channel-info") {
+        return await handleSlackAction(
+          {
+            action: "channelInfo",
+            channelId: resolveChannelId(),
+            accountId: accountId ?? undefined,
+          },
+          cfg,
+        );
+      }
+
+      if (action === "mark-read") {
+        const timestamp = readStringParam(params, "timestamp", { required: true });
+        return await handleSlackAction(
+          {
+            action: "markRead",
+            channelId: resolveChannelId(),
+            timestamp,
+            accountId: accountId ?? undefined,
+          },
           cfg,
         );
       }

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -38,6 +38,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     "role-add": "none",
     "role-remove": "none",
     "channel-info": "channelId",
+    "mark-read": "channelId",
     "channel-list": "none",
     "channel-create": "none",
     "channel-edit": "channelId",


### PR DESCRIPTION
## Summary

Adds two new Slack actions to support unread message tracking:

- **`channel-info`**: Returns channel metadata including `lastRead` timestamp, `unreadCount`, and `unreadCountDisplay`. Enables bots to know what messages they haven't processed yet.

- **`mark-read`**: Updates the bot's read cursor for a channel to a specific timestamp. Allows bots to mark messages as processed.

## Use Case

AI assistants that need to catch up on missed messages after context compaction or session restart. By tracking the read position, they can fetch only new messages and avoid reprocessing.

### Example Workflow

1. Call `channel-info` to get `lastRead` timestamp
2. Call `read` with `after=lastRead` to get unread messages
3. Process messages
4. Call `mark-read` with the latest message timestamp

## Changes

- `src/slack/actions.ts`: Added `getSlackChannelInfo` and `markSlackChannelRead` functions
- `src/agents/tools/slack-actions.ts`: Added handlers for `channelInfo` and `markRead` actions
- `src/channels/plugins/slack.actions.ts`: Wired up `channel-info` and `mark-read` to the Slack plugin
- `src/channels/plugins/message-action-names.ts`: Added `mark-read` to action names
- `src/infra/outbound/message-action-spec.ts`: Added target mode for `mark-read`

## Configuration

Both actions are gated by the `channelInfo` action flag (default: enabled).

```yaml
channels:
  slack:
    actions:
      channelInfo: true  # enables both channel-info and mark-read
```

## Testing

- [x] Type-checked (builds without errors related to these changes)
- [ ] Runtime tested

---

🤖 **AI-assisted**: Built with Claude (Opus 4.5) via Clawdbot