### PR TITLE
feat(gateway): add HTTP health check endpoints and Cloudflare Tunnel docs

### DIFF
--- a/src/gateway/server.health.e2e.test.ts
+++ b/src/gateway/server.health.e2e.test.ts
@@ -298,4 +298,26 @@ describe("gateway server health/presence", () => {
 
     ws.close();
   });
+
+  test("HTTP /healthz endpoint returns 200 OK", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("cache-control")).toBe("no-cache, no-store");
+    const body = await res.json();
+    expect(body).toEqual({ status: "ok" });
+  });
+
+  test("HTTP /health endpoint returns 200 OK", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body).toEqual({ status: "ok" });
+  });
+
+  test("HTTP health endpoints only accept GET", async () => {
+    const postRes = await fetch(`http://127.0.0.1:${port}/healthz`, { method: "POST" });
+    expect(postRes.status).not.toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- Add unauthenticated `/healthz` and `/health` HTTP endpoints for load balancer probes
- Add Cloudflare Tunnel documentation as an alternative to Tailscale
- Add health check endpoint documentation

## Details
The health check endpoints:
- Return `{"status":"ok"}` with HTTP 200 when the gateway is running
- Do **not** require authentication (safe for external probes)
- Set `Cache-Control: no-cache, no-store` to prevent caching
- Are intentionally minimal to avoid information disclosure

## Test plan
- [x] Added e2e tests for HTTP health check endpoints
- [x] Lint passes
- [x] Build passes
- [x] Pre-review completed with no issues above 70 confidence threshold

Closes #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)