### PR TITLE
fix(ci): resolve macOS vitest worker crash (vitest#8564)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
   checks-macos:
     if: github.event_name == 'pull_request'
     runs-on: macos-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,12 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: "2729701"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,12 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vitest/config";
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const isWindows = process.platform === "win32";
+const isMacOS = process.platform === "darwin";
 const localWorkers = Math.max(4, Math.min(16, os.cpus().length));
 const ciWorkers = isWindows ? 2 : 3;
 
@@ -19,6 +20,8 @@ export default defineConfig({
     testTimeout: 120_000,
     hookTimeout: isWindows ? 180_000 : 120_000,
     pool: "forks",
+    // Use singleFork on macOS CI to avoid vitest worker crash (vitest#8564)
+    poolOptions: isMacOS && isCI ? { forks: { singleFork: true } } : undefined,
     maxWorkers: isCI ? ciWorkers : localWorkers,
     include: [
       "src/**/*.test.ts",


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS` memory limit for macOS CI (like Windows already has)
- Use `singleFork` mode on macOS CI to avoid worker termination crash

## Problem
The macOS CI test job fails with:
```
Error: [vitest-pool]: Worker forks emitted error.
Caused by: Error: Worker exited unexpectedly
```

All 4567 tests pass, but the vitest worker crashes at teardown. This is a known bug in Vitest 4.x (vitest-dev/vitest#8564, marked p5-urgent).

## Root Cause
Per investigation using 5 parallel Opus agents:
1. **Known Vitest bug** - workers crash during termination after tests pass
2. **No memory limits** - macOS CI didn't have `NODE_OPTIONS` like Windows
3. **Native modules** (sharp, node-pty) don't clean up properly with `pool: forks`

## Fix
1. Add `NODE_OPTIONS: --max-old-space-size=4096` for macOS CI
2. Add `poolOptions: { forks: { singleFork: true } }` for macOS CI

## Test plan
- [x] Local build passes
- [ ] CI passes on this PR (meta-test)

🤖 Generated with [Claude Code](https://claude.ai/code)