### PR TITLE
fix: prevent false positive context overflow detection in conversation text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Errors: prevent false positive context overflow detection when conversation mentions "context overflow" topic. (#2078) Thanks @sbking.
 - Model failover: treat HTTP 400 errors as failover-eligible, enabling automatic model fallback when providers return bad request errors. (#1879) Thanks @orenyomtov.
 - Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11937)
 - Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.

--- a/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
@@ -46,4 +46,12 @@ describe("isContextOverflowError", () => {
     expect(isContextOverflowError("model not found")).toBe(false);
     expect(isContextOverflowError("authentication failed")).toBe(false);
   });
+
+  it("ignores normal conversation text mentioning context overflow", () => {
+    // These are legitimate conversation snippets, not error messages
+    expect(isContextOverflowError("Let's investigate the context overflow bug")).toBe(false);
+    expect(isContextOverflowError("The mystery context overflow errors are strange")).toBe(false);
+    expect(isContextOverflowError("We're debugging context overflow issues")).toBe(false);
+    expect(isContextOverflowError("Something is causing context overflow messages")).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -24,7 +24,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("prompt is too long") ||
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
-    lower.includes("context overflow") ||
+    lower.includes("context overflow:") ||
     (lower.includes("413") && lower.includes("too large"))
   );
 }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -278,15 +278,21 @@ function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
 }
 
 function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
-  if (!search || typeof search !== "object") return {};
+  if (!search || typeof search !== "object") {
+    return {};
+  }
   const grok = "grok" in search ? search.grok : undefined;
-  if (!grok || typeof grok !== "object") return {};
+  if (!grok || typeof grok !== "object") {
+    return {};
+  }
   return grok as GrokConfig;
 }
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   const fromConfig = normalizeApiKey(grok?.apiKey);
-  if (fromConfig) return fromConfig;
+  if (fromConfig) {
+    return fromConfig;
+  }
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -474,9 +480,7 @@ async function runWebSearch(params: {
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
       : params.provider === "perplexity"
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : params.provider === "grok"
-          ? `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`
-          : `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`,
+        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {


### PR DESCRIPTION
## Problem

The `isContextOverflowError` check was too broad — it matched any text containing 'context overflow', including legitimate conversation discussing the topic.

This caused the `sanitizeUserFacingText` function to replace normal agent responses with error messages when the agent was discussing context overflow as a topic (e.g., debugging the compaction system).

## Root Cause

Line 23 in `errors.ts`:
```typescript
lower.includes("context overflow")
```

This matches any text containing the phrase, not just actual error messages.

## Fix

Changed to require `'context overflow:'` (with colon) to only match actual error messages like:
- `"Context overflow: Summarization failed"`
- `"Context overflow: prompt too large..."`

Normal conversation like "Let's investigate the context overflow bug" will no longer trigger false positives.

## Testing

- All existing tests pass
- Added new test case to verify normal conversation text doesn't trigger false positives

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows `isContextOverflowError`’s heuristic by changing the substring match from `"context overflow"` to `"context overflow:"`, preventing `sanitizeUserFacingText` / `formatAssistantErrorText` from rewriting normal conversation that happens to mention context overflow.

It also adds a regression test ensuring conversational mentions like “investigate the context overflow bug” are not classified as overflow errors.

Overall, the change is localized to the Pi embedded helpers error classifier (`src/agents/pi-embedded-helpers/errors.ts`) and its unit tests, and it reduces false positives in downstream user-facing error sanitization.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real false-positive classification issue.
- The change is small and well-scoped (one substring match + a targeted regression test). Main risk is behavioral: requiring a colon could miss legitimate provider error strings that don’t include `context overflow:` exactly, which could reduce auto-compaction/UX handling in those cases.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->