### PR TITLE
Add Slack canvas read/create/update support

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -199,7 +199,9 @@ user scopes if you plan to configure a user token.
         "emoji:read",
         "commands",
         "files:read",
-        "files:write"
+        "files:write",
+        "canvases:read",
+        "canvases:write"
       ],
       "user": [
         "channels:history",
@@ -268,9 +270,13 @@ https://docs.slack.dev/apis/web-api/using-the-conversations-api/ for the overvie
   https://docs.slack.dev/reference/scopes/emoji.read
 - `files:write` (uploads via `files.uploadV2`)
   https://docs.slack.dev/messaging/working-with-files/#upload
+- `files:read` (download canvas file content via `url_private_download`)
+- `canvases:read`, `canvases:write` (create/update canvases)
 
 ### User token scopes (optional, read-only by default)
 Add these under **User Token Scopes** if you configure `channels.slack.userToken`.
+
+**Canvas ingestion notes:** When a message includes a Slack Canvas, Clawdbot attempts to download the canvas file via `files.info` + `url_private_download`. This requires `files:read` and the bot must have access to the canvas file. Missing scopes will show a short diagnostic in the prompt context.
 
 - `channels:history`, `groups:history`, `im:history`, `mpim:history`
 - `channels:read`, `groups:read`, `im:read`, `mpim:read`
@@ -325,7 +331,8 @@ Slack uses Socket Mode only (no HTTP webhook server). Provide both tokens:
       "messages": true,
       "pins": true,
       "memberInfo": true,
-      "emojiList": true
+      "emojiList": true,
+      "canvases": false
     },
     "slashCommand": {
       "enabled": true,
@@ -334,7 +341,9 @@ Slack uses Socket Mode only (no HTTP webhook server). Provide both tokens:
       "ephemeral": true
     },
     "textChunkLimit": 4000,
-    "mediaMaxMb": 20
+    "mediaMaxMb": 20,
+    "canvasMaxMb": 2,
+    "canvasTextMaxChars": 20000
   }
 }
 ```
@@ -351,6 +360,7 @@ ack reaction after the bot replies.
 - Outbound text is chunked to `channels.slack.textChunkLimit` (default 4000).
 - Optional newline chunking: set `channels.slack.chunkMode="newline"` to split on blank lines (paragraph boundaries) before length chunking.
 - Media uploads are capped by `channels.slack.mediaMaxMb` (default 20).
+- Canvas downloads are capped by `channels.slack.canvasMaxMb` (default 2) and truncated to `channels.slack.canvasTextMaxChars` characters (default 20000).
 
 ## Reply threading
 By default, Clawdbot replies in the main channel. Use `channels.slack.replyToMode` to control automatic threading:

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1256,6 +1256,7 @@ Slack action groups (gate `slack` tool actions):
 | pins | enabled | Pin/unpin/list |
 | memberInfo | enabled | Member info |
 | emojiList | enabled | Custom emoji list |
+| canvases | disabled | Create/update canvases |
 
 ### `channels.mattermost` (bot token)
 

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -131,10 +131,7 @@ describe("handleSlackAction", () => {
   it("requires canvases to be enabled", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as ClawdbotConfig;
     await expect(
-      handleSlackAction(
-        { action: "createCanvas", title: "Test", content: "hello" },
-        cfg,
-      ),
+      handleSlackAction({ action: "createCanvas", title: "Test", content: "hello" }, cfg),
     ).rejects.toThrow(/Slack canvases are disabled/);
   });
 
@@ -142,10 +139,7 @@ describe("handleSlackAction", () => {
     const cfg = {
       channels: { slack: { botToken: "tok", actions: { canvases: true } } },
     } as ClawdbotConfig;
-    await handleSlackAction(
-      { action: "createCanvas", title: "Test", content: "hello" },
-      cfg,
-    );
+    await handleSlackAction({ action: "createCanvas", title: "Test", content: "hello" }, cfg);
     expect(createSlackCanvas).toHaveBeenCalledWith(
       { title: "Test", content: "hello", channelId: undefined },
       undefined,
@@ -156,10 +150,7 @@ describe("handleSlackAction", () => {
     const cfg = {
       channels: { slack: { botToken: "tok", actions: { canvases: true } } },
     } as ClawdbotConfig;
-    await handleSlackAction(
-      { action: "updateCanvas", canvasId: "C123", content: "update" },
-      cfg,
-    );
+    await handleSlackAction({ action: "updateCanvas", canvasId: "C123", content: "update" }, cfg);
     expect(updateSlackCanvas).toHaveBeenCalledWith(
       { canvasId: "C123", channelId: undefined, content: "update", updateMode: undefined },
       undefined,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -47,6 +47,8 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "timeout",
   "kick",
   "ban",
+  "canvas-create",
+  "canvas-update",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -46,6 +46,10 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
       }
       if (isActionEnabled("memberInfo")) actions.add("member-info");
       if (isActionEnabled("emojiList")) actions.add("emoji-list");
+      if (isActionEnabled("canvases", false)) {
+        actions.add("canvas-create");
+        actions.add("canvas-update");
+      }
       return Array.from(actions);
     },
     extractToolSend: ({ args }): ChannelToolSend | null => {
@@ -200,6 +204,40 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
       if (action === "emoji-list") {
         return await handleSlackAction(
           { action: "emojiList", accountId: accountId ?? undefined },
+          cfg,
+        );
+      }
+
+      if (action === "canvas-create") {
+        const title = readStringParam(params, "title", { required: true });
+        const content = readStringParam(params, "content", { required: true, allowEmpty: true });
+        const channelId = readStringParam(params, "channelId");
+        return await handleSlackAction(
+          {
+            action: "createCanvas",
+            title,
+            content,
+            channelId: channelId ?? undefined,
+            accountId: accountId ?? undefined,
+          },
+          cfg,
+        );
+      }
+
+      if (action === "canvas-update") {
+        const content = readStringParam(params, "content", { required: true, allowEmpty: true });
+        const canvasId = readStringParam(params, "canvasId");
+        const channelId = readStringParam(params, "channelId");
+        const updateMode = readStringParam(params, "updateMode");
+        return await handleSlackAction(
+          {
+            action: "updateCanvas",
+            canvasId: canvasId ?? undefined,
+            channelId: channelId ?? undefined,
+            updateMode: updateMode ?? undefined,
+            content,
+            accountId: accountId ?? undefined,
+          },
           cfg,
         );
       }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -456,6 +456,10 @@ const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.canvasMaxMb": "Max MB to download for Slack canvases (default: 2).",
+  "channels.slack.canvasTextMaxChars":
+    "Max characters of Slack canvas content injected into prompts (default: 20000).",
+  "channels.slack.actions.canvases": "Enable Slack canvas actions (default: false).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -54,6 +54,7 @@ export type SlackActionConfig = {
   memberInfo?: boolean;
   channelInfo?: boolean;
   emojiList?: boolean;
+  canvases?: boolean;
 };
 
 export type SlackSlashCommandConfig = {
@@ -122,6 +123,10 @@ export type SlackAccountConfig = {
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   mediaMaxMb?: number;
+  /** Max size for downloaded Slack canvas content (MB). Default: 2. */
+  canvasMaxMb?: number;
+  /** Max characters of Slack canvas text injected into prompt (default: 20000). */
+  canvasTextMaxChars?: number;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: SlackReactionNotificationMode;
   /** Allowlist for reaction notifications when mode is allowlist. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -409,6 +409,8 @@ export const SlackAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     mediaMaxMb: z.number().positive().optional(),
+    canvasMaxMb: z.number().positive().optional(),
+    canvasTextMaxChars: z.number().int().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
@@ -424,6 +426,7 @@ export const SlackAccountSchema = z
         memberInfo: z.boolean().optional(),
         channelInfo: z.boolean().optional(),
         emojiList: z.boolean().optional(),
+        canvases: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -258,3 +258,49 @@ export async function listSlackPins(
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
 }
+
+type SlackCanvasCreatePayload = {
+  title: string;
+  document_content: string;
+  channel_id?: string;
+};
+
+type SlackCanvasEditPayload = {
+  canvas_id?: string;
+  channel_id?: string;
+  document_content: string;
+  mode?: string;
+};
+
+export async function createSlackCanvas(
+  params: { title: string; content: string; channelId?: string },
+  opts: SlackActionClientOpts = {},
+) {
+  const client = await getClient(opts);
+  const payload: SlackCanvasCreatePayload = {
+    title: params.title,
+    document_content: params.content,
+    ...(params.channelId ? { channel_id: params.channelId } : {}),
+  };
+  if (params.channelId) {
+    return await client.apiCall("conversations.canvases.create", payload);
+  }
+  return await client.apiCall("canvases.create", payload);
+}
+
+export async function updateSlackCanvas(
+  params: { canvasId?: string; channelId?: string; content: string; updateMode?: string },
+  opts: SlackActionClientOpts = {},
+) {
+  const client = await getClient(opts);
+  const payload: SlackCanvasEditPayload = {
+    ...(params.canvasId ? { canvas_id: params.canvasId } : {}),
+    ...(params.channelId ? { channel_id: params.channelId } : {}),
+    document_content: params.content,
+    ...(params.updateMode ? { mode: params.updateMode } : {}),
+  };
+  if (params.channelId && !params.canvasId) {
+    return await client.apiCall("conversations.canvases.edit", payload);
+  }
+  return await client.apiCall("canvases.edit", payload);
+}

--- a/src/slack/canvases.test.ts
+++ b/src/slack/canvases.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WebClient } from "@slack/web-api";
+
+import {
+  extractCanvasRefsFromEvent,
+  fetchSlackCanvasContent,
+  isSlackCanvasFile,
+} from "./canvases.js";
+import type { SlackMessageEvent } from "./types.js";
+
+function createClient() {
+  return {
+    files: {
+      info: vi.fn(async () => ({
+        file: {
+          id: "F123",
+          title: "Canvas Title",
+          url_private_download: "https://files.slack.com/canvas.json",
+        },
+      })),
+    },
+  } as unknown as WebClient;
+}
+
+describe("isSlackCanvasFile", () => {
+  it("detects canvas mimetype", () => {
+    expect(isSlackCanvasFile({ mimetype: "application/vnd.slack-docs" })).toBe(true);
+  });
+
+  it("detects canvas pretty_type", () => {
+    expect(isSlackCanvasFile({ pretty_type: "Canvas" })).toBe(true);
+  });
+
+  it("detects quip filetype", () => {
+    expect(isSlackCanvasFile({ filetype: "quip" })).toBe(true);
+  });
+});
+
+describe("extractCanvasRefsFromEvent", () => {
+  it("finds canvas files and URLs", () => {
+    const event: SlackMessageEvent = {
+      type: "message",
+      channel: "C1",
+      ts: "1.2",
+      text: "See https://acme.slack.com/docs/T123/F12345678",
+      files: [{ id: "F999", mimetype: "application/vnd.slack-docs" }],
+    } as SlackMessageEvent;
+
+    const refs = extractCanvasRefsFromEvent(event);
+    const ids = refs.map((ref) => ref.fileId).filter(Boolean);
+    expect(ids).toContain("F999");
+    expect(ids).toContain("F12345678");
+  });
+});
+
+describe("fetchSlackCanvasContent", () => {
+  it("downloads and parses JSON canvas content", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ text: "hello canvas" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient();
+    const result = await fetchSlackCanvasContent({
+      ref: { fileId: "F123" },
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      maxChars: 1000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.extractedText).toContain("hello canvas");
+      expect(result.rawFormat).toBe("json");
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("returns missing_scope errors", async () => {
+    const client = {
+      files: {
+        info: vi.fn(async () => {
+          const err = new Error("missing_scope");
+          (err as any).data = { error: "missing_scope", needed: "files:read" };
+          throw err;
+        }),
+      },
+    } as unknown as WebClient;
+
+    const result = await fetchSlackCanvasContent({
+      ref: { fileId: "F123" },
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      maxChars: 1000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("missing_scope");
+    }
+  });
+
+  it("handles download HTTP failures", async () => {
+    const fetchMock = vi.fn(async () => new Response("forbidden", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient();
+    const result = await fetchSlackCanvasContent({
+      ref: { fileId: "F123" },
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      maxChars: 1000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("download_http_403");
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("truncates large payloads", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ text: "1234567890" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient();
+    const result = await fetchSlackCanvasContent({
+      ref: { fileId: "F123" },
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      maxChars: 5,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.truncated).toBe(true);
+      expect(result.extractedText.length).toBeLessThanOrEqual(5);
+    }
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/slack/canvases.test.ts
+++ b/src/slack/canvases.test.ts
@@ -56,11 +56,12 @@ describe("extractCanvasRefsFromEvent", () => {
 
 describe("fetchSlackCanvasContent", () => {
   it("downloads and parses JSON canvas content", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ text: "hello canvas" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ text: "hello canvas" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -127,11 +128,12 @@ describe("fetchSlackCanvasContent", () => {
   });
 
   it("truncates large payloads", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ text: "1234567890" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ text: "1234567890" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/src/slack/canvases.ts
+++ b/src/slack/canvases.ts
@@ -1,0 +1,265 @@
+import type { WebClient as SlackWebClient } from "@slack/web-api";
+
+import { logVerbose } from "../globals.js";
+import type { SlackFile, SlackMessageEvent } from "./types.js";
+
+type CanvasUrlMatch = {
+  url: string;
+  fileId?: string;
+};
+
+export type SlackCanvasRef = {
+  fileId?: string;
+  canvasUrl?: string;
+  channelId?: string;
+  messageTs?: string;
+};
+
+export type SlackCanvasContent = {
+  title?: string;
+  extractedText: string;
+  rawFormat: "json" | "text" | "unknown";
+  truncated: boolean;
+};
+
+export type SlackCanvasFetchResult =
+  | ({ ok: true } & SlackCanvasContent)
+  | { ok: false; error: string };
+
+const SLACK_CANVAS_MIME = "application/vnd.slack-docs";
+const CANVAS_FILETYPE_HINTS = new Set(["quip"]);
+const CANVAS_PRETTY_TYPE = new Set(["canvas"]);
+
+const CANVAS_URL_RE = /https?:\/\/[^\s<>"]*slack\.com\/(docs|canvas|doc|files)\/[^\s<>"]+/gi;
+const SLACK_FILE_ID_RE = /\bF[A-Z0-9]{8,}\b/g;
+
+export function isSlackCanvasFile(file?: SlackFile | null): boolean {
+  if (!file) return false;
+  const mimetype = file.mimetype?.toLowerCase();
+  const prettyType = file.pretty_type?.toLowerCase();
+  const filetype = file.filetype?.toLowerCase();
+  if (mimetype && mimetype === SLACK_CANVAS_MIME) return true;
+  if (prettyType && CANVAS_PRETTY_TYPE.has(prettyType)) return true;
+  if (filetype && CANVAS_FILETYPE_HINTS.has(filetype)) return true;
+  return false;
+}
+
+function extractFileIdFromUrl(url: string): string | undefined {
+  const matches = url.match(SLACK_FILE_ID_RE);
+  if (!matches || matches.length === 0) return undefined;
+  return matches[0];
+}
+
+function collectUrlsFromText(text: string): CanvasUrlMatch[] {
+  const matches = text.match(CANVAS_URL_RE) ?? [];
+  return matches.map((url) => ({ url, fileId: extractFileIdFromUrl(url) }));
+}
+
+function collectUrlsFromObject(value: unknown, into: CanvasUrlMatch[], seen = new Set<string>()) {
+  if (!value) return;
+  if (typeof value === "string") {
+    for (const entry of collectUrlsFromText(value)) {
+      if (seen.has(entry.url)) continue;
+      seen.add(entry.url);
+      into.push(entry);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectUrlsFromObject(entry, into, seen);
+    return;
+  }
+  if (typeof value !== "object") return;
+  for (const entry of Object.values(value as Record<string, unknown>)) {
+    collectUrlsFromObject(entry, into, seen);
+  }
+}
+
+export function extractCanvasRefsFromEvent(event: SlackMessageEvent): SlackCanvasRef[] {
+  const refs: SlackCanvasRef[] = [];
+  const seen = new Set<string>();
+  const channelId = event.channel;
+  const messageTs = event.ts ?? event.event_ts;
+
+  for (const file of event.files ?? []) {
+    if (!isSlackCanvasFile(file)) continue;
+    const fileId = file.id;
+    if (fileId && seen.has(fileId)) continue;
+    if (fileId) seen.add(fileId);
+    refs.push({ fileId, channelId, messageTs });
+  }
+
+  const urlMatches: CanvasUrlMatch[] = [];
+  if (event.text) collectUrlsFromObject(event.text, urlMatches);
+  collectUrlsFromObject(event.blocks, urlMatches);
+  collectUrlsFromObject(event.attachments, urlMatches);
+
+  for (const match of urlMatches) {
+    const dedupeKey = match.fileId ?? match.url;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    refs.push({
+      fileId: match.fileId,
+      canvasUrl: match.url,
+      channelId,
+      messageTs,
+    });
+  }
+
+  return refs;
+}
+
+function buildErrorLabel(err: unknown): string {
+  const data = err as { data?: { error?: string; needed?: string | string[] } } | undefined;
+  const apiError = data?.data?.error ?? (err as { error?: string } | undefined)?.error;
+  if (apiError === "missing_scope") {
+    const needed = data?.data?.needed;
+    const scopeList = Array.isArray(needed) ? needed.join(", ") : needed;
+    return scopeList ? `missing_scope: ${scopeList}` : "missing_scope";
+  }
+  if (apiError === "not_allowed_token_type") return "not_allowed_token_type";
+  if (apiError === "not_in_channel") return "not_in_channel";
+  if (apiError === "channel_not_found") return "channel_not_found";
+  if (apiError && typeof apiError === "string") return apiError;
+  return err instanceof Error ? err.message : String(err);
+}
+
+function coerceToText(input: string, maxChars: number): { text: string; truncated: boolean } {
+  if (input.length <= maxChars) return { text: input, truncated: false };
+  return { text: input.slice(0, maxChars), truncated: true };
+}
+
+function collectJsonText(
+  value: unknown,
+  params: {
+    maxChars: number;
+    results: string[];
+    seen: Set<string>;
+    depth: number;
+  },
+) {
+  if (params.results.join("\n").length >= params.maxChars) return;
+  if (params.depth > 12) return;
+  if (value == null) return;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (!params.seen.has(trimmed)) {
+      params.seen.add(trimmed);
+      params.results.push(trimmed);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectJsonText(entry, { ...params, depth: params.depth + 1 });
+      if (params.results.join("\n").length >= params.maxChars) return;
+    }
+    return;
+  }
+  if (typeof value !== "object") return;
+
+  const record = value as Record<string, unknown>;
+  const preferredKeys = ["text", "plain_text", "title", "value", "name"];
+  for (const key of preferredKeys) {
+    const entry = record[key];
+    if (typeof entry === "string") {
+      collectJsonText(entry, { ...params, depth: params.depth + 1 });
+    }
+  }
+  for (const entry of Object.values(record)) {
+    collectJsonText(entry, { ...params, depth: params.depth + 1 });
+    if (params.results.join("\n").length >= params.maxChars) return;
+  }
+}
+
+function extractTextFromJson(payload: unknown, maxChars: number): { text: string; truncated: boolean } {
+  const results: string[] = [];
+  const seen = new Set<string>();
+  collectJsonText(payload, { maxChars, results, seen, depth: 0 });
+  const joined = results.join("\n");
+  if (!joined) {
+    return coerceToText(JSON.stringify(payload), maxChars);
+  }
+  return coerceToText(joined, maxChars);
+}
+
+export async function fetchSlackCanvasContent(params: {
+  ref: SlackCanvasRef;
+  client: SlackWebClient;
+  token: string;
+  maxBytes: number;
+  maxChars: number;
+}): Promise<SlackCanvasFetchResult> {
+  const { ref, client, token, maxBytes, maxChars } = params;
+  const fileId = ref.fileId ?? (ref.canvasUrl ? extractFileIdFromUrl(ref.canvasUrl) : undefined);
+  if (!fileId) {
+    return { ok: false, error: "no_file_id" };
+  }
+
+  let fileInfo: { file?: SlackFile & { title?: string; name?: string; url_private?: string; url_private_download?: string } };
+  try {
+    fileInfo = (await client.files.info({ file: fileId })) as {
+      file?: SlackFile & { title?: string; name?: string; url_private?: string; url_private_download?: string };
+    };
+  } catch (err) {
+    const label = buildErrorLabel(err);
+    logVerbose(`slack canvases: files.info failed fileId=${fileId} error=${label}`);
+    return { ok: false, error: label };
+  }
+
+  const file = fileInfo.file;
+  if (!file) {
+    return { ok: false, error: "file_not_found" };
+  }
+
+  const url = file.url_private_download ?? file.url_private;
+  if (!url) {
+    return { ok: false, error: "missing_download_url" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (err) {
+    return { ok: false, error: `download_failed: ${String(err)}` };
+  }
+
+  if (!response.ok) {
+    return { ok: false, error: `download_http_${response.status}` };
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const buffer = await response.arrayBuffer();
+  const truncatedByBytes = buffer.byteLength > maxBytes;
+  const sliced = truncatedByBytes ? buffer.slice(0, maxBytes) : buffer;
+  const text = new TextDecoder().decode(sliced);
+
+  let extracted: { text: string; truncated: boolean };
+  let rawFormat: SlackCanvasContent["rawFormat"] = "unknown";
+
+  if (contentType.includes("application/json") || text.trim().startsWith("{") || text.trim().startsWith("[")) {
+    rawFormat = "json";
+    try {
+      const payload = JSON.parse(text);
+      extracted = extractTextFromJson(payload, maxChars);
+    } catch {
+      extracted = coerceToText(text, maxChars);
+    }
+  } else {
+    rawFormat = "text";
+    extracted = coerceToText(text, maxChars);
+  }
+
+  return {
+    ok: true,
+    title: file.title ?? file.name ?? fileId,
+    extractedText: extracted.text,
+    rawFormat,
+    truncated: truncatedByBytes || extracted.truncated,
+  };
+}

--- a/src/slack/canvases.ts
+++ b/src/slack/canvases.ts
@@ -173,7 +173,10 @@ function collectJsonText(
   }
 }
 
-function extractTextFromJson(payload: unknown, maxChars: number): { text: string; truncated: boolean } {
+function extractTextFromJson(
+  payload: unknown,
+  maxChars: number,
+): { text: string; truncated: boolean } {
   const results: string[] = [];
   const seen = new Set<string>();
   collectJsonText(payload, { maxChars, results, seen, depth: 0 });
@@ -197,10 +200,22 @@ export async function fetchSlackCanvasContent(params: {
     return { ok: false, error: "no_file_id" };
   }
 
-  let fileInfo: { file?: SlackFile & { title?: string; name?: string; url_private?: string; url_private_download?: string } };
+  let fileInfo: {
+    file?: SlackFile & {
+      title?: string;
+      name?: string;
+      url_private?: string;
+      url_private_download?: string;
+    };
+  };
   try {
     fileInfo = (await client.files.info({ file: fileId })) as {
-      file?: SlackFile & { title?: string; name?: string; url_private?: string; url_private_download?: string };
+      file?: SlackFile & {
+        title?: string;
+        name?: string;
+        url_private?: string;
+        url_private_download?: string;
+      };
     };
   } catch (err) {
     const label = buildErrorLabel(err);
@@ -242,7 +257,11 @@ export async function fetchSlackCanvasContent(params: {
   let extracted: { text: string; truncated: boolean };
   let rawFormat: SlackCanvasContent["rawFormat"] = "unknown";
 
-  if (contentType.includes("application/json") || text.trim().startsWith("{") || text.trim().startsWith("[")) {
+  if (
+    contentType.includes("application/json") ||
+    text.trim().startsWith("{") ||
+    text.trim().startsWith("[")
+  ) {
     rawFormat = "json";
     try {
       const payload = JSON.parse(text);

--- a/src/slack/monitor/context.test.ts
+++ b/src/slack/monitor/context.test.ts
@@ -28,6 +28,8 @@ const baseParams = () => ({
   reactionMode: "off" as const,
   reactionAllowlist: [],
   replyToMode: "off" as const,
+  threadHistoryScope: "thread" as const,
+  threadInheritParent: false,
   slashCommand: {
     enabled: false,
     name: "clawd",
@@ -37,6 +39,8 @@ const baseParams = () => ({
   textLimit: 4000,
   ackReactionScope: "group-mentions",
   mediaMaxBytes: 1,
+  canvasMaxBytes: 1,
+  canvasTextMaxChars: 1000,
   removeAckAfterReply: false,
 });
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -86,6 +86,8 @@ export type SlackMonitorContext = {
   textLimit: number;
   ackReactionScope: string;
   mediaMaxBytes: number;
+  canvasMaxBytes: number;
+  canvasTextMaxChars: number;
   removeAckAfterReply: boolean;
 
   logger: ReturnType<typeof getChildLogger>;
@@ -147,6 +149,8 @@ export function createSlackMonitorContext(params: {
   textLimit: number;
   ackReactionScope: string;
   mediaMaxBytes: number;
+  canvasMaxBytes: number;
+  canvasTextMaxChars: number;
   removeAckAfterReply: boolean;
 }): SlackMonitorContext {
   const channelHistories = new Map<string, HistoryEntry[]>();
@@ -391,6 +395,8 @@ export function createSlackMonitorContext(params: {
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,
     mediaMaxBytes: params.mediaMaxBytes,
+    canvasMaxBytes: params.canvasMaxBytes,
+    canvasTextMaxChars: params.canvasTextMaxChars,
     removeAckAfterReply: params.removeAckAfterReply,
     logger,
     markMessageSeen,

--- a/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
+++ b/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
@@ -151,11 +151,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("appends canvas content to the inbound body", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ title: "Canvas", text: "hello canvas" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ title: "Canvas", text: "hello canvas" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -371,7 +371,8 @@ export async function prepareSlackMessage(params: {
   }
   const canvasContext = canvasBlocks.length > 0 ? canvasBlocks.join("\n\n") : "";
 
-  const baseBody = (message.text ?? "").trim() || media?.placeholder || (canvasContext ? "[Slack canvas]" : "");
+  const baseBody =
+    (message.text ?? "").trim() || media?.placeholder || (canvasContext ? "[Slack canvas]" : "");
   if (!baseBody) return null;
   const rawBody = baseBody;
   const rawBodyWithCanvas = canvasContext ? `${rawBody}\n\n${canvasContext}` : rawBody;

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -122,6 +122,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
+  const canvasMaxBytes = (slackCfg.canvasMaxMb ?? 2) * 1024 * 1024;
+  const canvasTextMaxChars = slackCfg.canvasTextMaxChars ?? 20000;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
 
   const receiver =
@@ -203,6 +205,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     textLimit,
     ackReactionScope,
     mediaMaxBytes,
+    canvasMaxBytes,
+    canvasTextMaxChars,
     removeAckAfterReply,
   });
 

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -1,7 +1,10 @@
 export type SlackFile = {
   id?: string;
   name?: string;
+  title?: string;
   mimetype?: string;
+  filetype?: string;
+  pretty_type?: string;
   size?: number;
   url_private?: string;
   url_private_download?: string;
@@ -21,6 +24,8 @@ export type SlackMessageEvent = {
   channel: string;
   channel_type?: "im" | "mpim" | "channel" | "group";
   files?: SlackFile[];
+  blocks?: unknown[];
+  attachments?: unknown[];
 };
 
 export type SlackAppMentionEvent = {


### PR DESCRIPTION
## Summary
- detect Slack Canvas shares and pull content into inbound context (best-effort)
- add Slack canvas actions (create/update) gated by channels.slack.actions.canvases
- add canvas limits config + docs updates for scopes and limits
- add canvas helper + tests for detection/fetch + inbound injection

## Testing
- not run (unit/e2e)

## Manual verification
1) Add scopes: files:read, canvases:read, canvases:write (plus existing). Reinstall the Slack app.
2) Ensure Socket Mode works (app-level token with connections:write).
3) Create/share a canvas in a channel where the bot is present.
4) Post a message with the canvas link/file. Verify Clawdbot context includes a [Slack Canvas: ...] block or a short diagnostic.
5) Ask Clawdbot to create a canvas (e.g., "create a canvas titled X with Y"). Verify canvas creation.
6) Ask Clawdbot to update a canvas (by canvasId or channelId) and verify edits.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Slack Canvas support in two places:

- **Inbound ingestion**: detects canvas shares/files on incoming Slack messages, fetches the associated file content via `files.info` + `url_private_download`, and injects a best-effort `[Slack Canvas: ...]` block into the inbound prompt context with configurable byte/char limits.
- **Outbound actions**: introduces new Slack actions for `createCanvas` / `updateCanvas`, gated behind `channels.slack.actions.canvases`, plus corresponding config schema/types and docs updates.

Overall the changes fit the existing Slack monitor + action-gating architecture (monitor context carries limits; tools route through `handleSlackAction`; channel plugins advertise actions based on config).

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge after fixing the `listPins` credential-selection bug.
- The changes are additive and follow existing Slack monitor/action patterns, with tests included for canvas detection/fetch and inbound injection. The main issue found is a concrete logic bug in `handleSlackAction` where `listPins` may ignore `readOpts` unless `writeOpts` is set, which can break expected auth behavior. Remaining notes are performance/robustness considerations rather than correctness blockers.
- src/agents/tools/slack-actions.ts (pin listing opts), src/slack/canvases.ts (recursive traversal robustness)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->