### PR TITLE
fix: enable shell mode for npm on Windows (#1963)

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -88,17 +88,14 @@ export async function runCommandWithTimeout(
   const { windowsVerbatimArguments } = options;
   const hasInput = input !== undefined;
 
-  const shouldSuppressNpmFund = (() => {
-    const cmd = path.basename(argv[0] ?? "");
-    if (cmd === "npm" || cmd === "npm.cmd" || cmd === "npm.exe") {
-      return true;
-    }
-    if (cmd === "node" || cmd === "node.exe") {
-      const script = argv[1] ?? "";
-      return script.includes("npm-cli.js");
-    }
-    return false;
-  })();
+  const cmd = path.basename(argv[0] ?? "");
+  const isNpmCommand = cmd === "npm" || cmd === "npm.cmd" || cmd === "npm.exe";
+  const isNpmViaCli =
+    (cmd === "node" || cmd === "node.exe") && (argv[1] ?? "").includes("npm-cli.js");
+  const shouldSuppressNpmFund = isNpmCommand || isNpmViaCli;
+
+  // On Windows, npm is a .cmd batch file that requires shell mode to execute
+  const useShell = process.platform === "win32" && isNpmCommand;
 
   const resolvedEnv = env ? { ...process.env, ...env } : { ...process.env };
   if (shouldSuppressNpmFund) {
@@ -116,6 +113,7 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: useShell,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Fix Windows plugin install: run npm via shell only on win32 to execute npm.cmd
- Keep default spawn behavior for other commands
- Resolves spawn npm ENOENT error on Windows

Fixes #1963

AI + Manual Review
- [x] AI-assisted (Opus 4.5, Cursor)
- [x] Fully tested locally (pnpm test, pnpm lint, pnpm build, pnpm format)
- [x] I understand what the code does
Manual sanity-check: verified the change only enables shell: true on Windows when invoking npm/npm.cmd/npm.exe, and does not affect other commands

 I understand what the code does

## Test Plan
- Existing exec.test.ts tests pass
- All CI checks validated locally before push

Fix Windows plugin install: run npm via shell only on win32 to execute npm.cmd; keep default spawn behavior for other commands.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Reviewed `src/process/exec.ts` changes intended to fix Windows `spawn npm ENOENT` by enabling `shell: true` only when invoking npm on `win32`, while keeping default spawn behavior for other commands. I checked for correctness of command detection, argument quoting/escaping, and any cross-platform behavioral changes in process execution.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- The change is narrowly scoped (Windows-only) and targets a common `spawn`/`npm.cmd` behavior difference; no broader process execution paths are affected based on the provided context.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->