### PR TITLE
fix(nextcloud-talk): sign message text instead of JSON body

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -89,8 +89,12 @@ export async function sendMessageNextcloudTalk(
   }
   const bodyStr = JSON.stringify(body);
 
+  // Nextcloud Talk verifies signature against the extracted message text,
+  // not the full JSON body. See ChecksumVerificationService.php:
+  //   hash_hmac('sha256', $random . $data, $secret)
+  // where $data is the "message" parameter, not the raw request body.
   const { random, signature } = generateNextcloudTalkSignature({
-    body: bodyStr,
+    body: message,
     secret,
   });
 
@@ -179,8 +183,9 @@ export async function sendReactionNextcloudTalk(
   const normalizedToken = normalizeRoomToken(roomToken);
 
   const body = JSON.stringify({ reaction });
+  // Sign only the reaction string, not the full JSON body
   const { random, signature } = generateNextcloudTalkSignature({
-    body,
+    body: reaction,
     secret,
   });
 


### PR DESCRIPTION
## Problem
  Nextcloud Talk bot API returns 401 authentication errors because the signature is calculated over the full JSON body instead of just the message text.

  ## Root Cause
  Nextcloud's `ChecksumVerificationService.php` verifies:
  ```php
  hash_hmac('sha256', $random . $data, $secret)
  Where $data is the extracted message text, not the raw JSON body.

  Fix

  - sendMessageNextcloudTalk: Sign only the message text
  - sendReactionNextcloudTalk: Sign only the reaction string

  Testing

  - Fully tested on self-hosted Nextcloud 30 with Talk bot
  - Messages send successfully (was getting 401 before)

  AI Disclosure

  - AI-assisted (Claude Code)
  - I understand what the code does
  - Root cause found by reading Nextcloud source code (ChecksumVerificationService.php)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Nextcloud Talk bot request signing to match Nextcloud’s server-side checksum verification: instead of signing the full JSON request body, `sendMessageNextcloudTalk` now signs the extracted message text and `sendReactionNextcloudTalk` signs the reaction string. Requests still send the same JSON bodies, but the `X-Nextcloud-Talk-Bot-*` headers are computed over the specific fields Nextcloud validates, resolving prior 401 authentication failures against Talk bot endpoints.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes a concrete interoperability/auth issue with Nextcloud Talk bot signing.
- Change is small and localized to signature input values for two outbound requests; it aligns with documented Nextcloud behavior and does not alter request payloads. No obvious runtime/type issues introduced. Main remaining uncertainty is upstream compatibility across Nextcloud Talk versions/endpoints (message vs reaction field extraction), which is mitigated by the author’s manual test on Nextcloud 30.
- extensions/nextcloud-talk/src/send.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->