### PR TITLE
fix(reasoning): wrap multiline italic text per line for Telegram

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { extractAssistantText } from "./pi-embedded-utils.js";
+import { extractAssistantText, formatReasoningMessage } from "./pi-embedded-utils.js";
 
 describe("extractAssistantText", () => {
   it("strips Minimax tool invocation XML from text", () => {
@@ -506,5 +506,30 @@ File contents here`,
 
     const result = extractAssistantText(msg);
     expect(result).toBe("StartMiddleEnd");
+  });
+});
+
+describe("formatReasoningMessage", () => {
+  it("returns empty string for empty input", () => {
+    expect(formatReasoningMessage("")).toBe("");
+    expect(formatReasoningMessage("   ")).toBe("");
+  });
+
+  it("wraps single line in italics", () => {
+    expect(formatReasoningMessage("Because it helps")).toBe("Reasoning:\n_Because it helps_");
+  });
+
+  it("wraps each line individually for multiline text", () => {
+    const input = "line one\nline two\nline three";
+    expect(formatReasoningMessage(input)).toBe("Reasoning:\n_line one_\n_line two_\n_line three_");
+  });
+
+  it("preserves empty lines without wrapping them", () => {
+    const input = "line one\n\nline three";
+    expect(formatReasoningMessage(input)).toBe("Reasoning:\n_line one_\n\n_line three_");
+  });
+
+  it("trims leading and trailing whitespace from input", () => {
+    expect(formatReasoningMessage("  text  ")).toBe("Reasoning:\n_text_");
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -209,9 +209,15 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
 export function formatReasoningMessage(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) return "";
-  // Show reasoning in italics (cursive) for markdown-friendly surfaces (Discord, etc.).
+  // Show reasoning in italics (cursive) for markdown-friendly surfaces.
+  // Wrap each line individually because many markdown parsers (Telegram, etc.)
+  // don't support underscores spanning multiple lines.
   // Keep the plain "Reasoning:" prefix so existing parsing/detection keeps working.
-  return `Reasoning:\n_${trimmed}_`;
+  const italicLines = trimmed
+    .split("\n")
+    .map((line) => (line ? `_${line}_` : ""))
+    .join("\n");
+  return `Reasoning:\n${italicLines}`;
 }
 
 type ThinkTaggedSplitBlock =


### PR DESCRIPTION
## Summary
Fixes #2060

Reasoning blocks now wrap each line individually in underscores for italic formatting, instead of wrapping the entire block in a single underscore pair. This fixes the issue where Telegram (and other markdown parsers that don't support multiline underscore spans) would display raw underscores instead of italicized text.

## Changes
- Modified `formatReasoningMessage()` in `src/agents/pi-embedded-utils.ts` to wrap each line individually
- Added tests for the new multiline behavior in `pi-embedded-utils.test.ts`

## Before
```
Reasoning:
_line one
line two
line three_
```
(Raw underscores visible on Telegram)

## After
```
Reasoning:
_line one_
_line two_
_line three_
```
(Each line renders in italics on Telegram)

## Test plan
- [x] Existing tests pass (single-line reasoning format unchanged)
- [x] Added new tests for multiline formatting behavior
- [x] Build succeeds
- [x] Lint passes

---
🤖 Generated with Claude Code