### PR TITLE
Add PLAYBOOK.md template for capturing user-taught procedures

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -46,6 +46,14 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
 
+### 📖 PLAYBOOK.md - How To Do Things
+- When your human teaches you **how** to do something, add it to `PLAYBOOK.md`
+- This is your procedure manual — step-by-step instructions for recurring tasks
+- Format: clear headers, numbered steps, any gotchas or tips
+- Examples: "How to post to Instagram", "How to check inventory", "How to contact suppliers"
+- Before asking "how do I do X?" — check the playbook first
+- Keep it updated as procedures change
+
 ## Safety
 
 - Don't exfiltrate private data. Ever.

--- a/docs/reference/templates/PLAYBOOK.md
+++ b/docs/reference/templates/PLAYBOOK.md
@@ -1,0 +1,32 @@
+---
+summary: "Workspace template for PLAYBOOK.md"
+read_when:
+  - Bootstrapping a workspace manually
+---
+# PLAYBOOK.md - How To Do Things
+
+*Step-by-step procedures your human has taught you. Check here before asking "how?"*
+
+---
+
+## Template
+
+When adding a new procedure:
+
+```markdown
+## [Task Name]
+**Added:** YYYY-MM-DD
+**Context:** Why/when to use this
+
+### Steps
+1. First step
+2. Second step
+3. Third step
+
+### Tips / Gotchas
+- Any warnings or shortcuts
+```
+
+---
+
+*Procedures will be added here as your human teaches them.*


### PR DESCRIPTION
## Summary
When users teach their agent how to do something, the agent should document it in a playbook for future reference.

## Changes
- Added `📖 PLAYBOOK.md - How To Do Things` section to AGENTS.md template
- Created PLAYBOOK.md template with format guide and examples

## Why
This helps agents:
- Remember procedures without asking twice
- Build institutional knowledge over time
- Check the playbook before asking "how do I do X?"

---
*Submitted via Clawdbot*