### PR TITLE
fix(voice-call): check env vars before validation errors

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -403,12 +403,12 @@ export function validateProviderConfig(config: VoiceCallConfig): {
   }
 
   if (config.provider === "telnyx") {
-    if (!config.telnyx?.apiKey) {
+    if (!config.telnyx?.apiKey && !process.env.TELNYX_API_KEY) {
       errors.push(
         "plugins.entries.voice-call.config.telnyx.apiKey is required (or set TELNYX_API_KEY env)",
       );
     }
-    if (!config.telnyx?.connectionId) {
+    if (!config.telnyx?.connectionId && !process.env.TELNYX_CONNECTION_ID) {
       errors.push(
         "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
       );
@@ -416,12 +416,12 @@ export function validateProviderConfig(config: VoiceCallConfig): {
   }
 
   if (config.provider === "twilio") {
-    if (!config.twilio?.accountSid) {
+    if (!config.twilio?.accountSid && !process.env.TWILIO_ACCOUNT_SID) {
       errors.push(
         "plugins.entries.voice-call.config.twilio.accountSid is required (or set TWILIO_ACCOUNT_SID env)",
       );
     }
-    if (!config.twilio?.authToken) {
+    if (!config.twilio?.authToken && !process.env.TWILIO_AUTH_TOKEN) {
       errors.push(
         "plugins.entries.voice-call.config.twilio.authToken is required (or set TWILIO_AUTH_TOKEN env)",
       );
@@ -429,12 +429,12 @@ export function validateProviderConfig(config: VoiceCallConfig): {
   }
 
   if (config.provider === "plivo") {
-    if (!config.plivo?.authId) {
+    if (!config.plivo?.authId && !process.env.PLIVO_AUTH_ID) {
       errors.push(
         "plugins.entries.voice-call.config.plivo.authId is required (or set PLIVO_AUTH_ID env)",
       );
     }
-    if (!config.plivo?.authToken) {
+    if (!config.plivo?.authToken && !process.env.PLIVO_AUTH_TOKEN) {
       errors.push(
         "plugins.entries.voice-call.config.plivo.authToken is required (or set PLIVO_AUTH_TOKEN env)",
       );


### PR DESCRIPTION
## Summary

- Fix `validateProviderConfig()` to check environment variables as fallback before reporting missing credentials
- Previously, validation would fail even when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, etc. were set via env vars

## Problem

The voice-call plugin's `runtime.ts` already resolves credentials from env vars as fallback (lines 40-65), but `validateProviderConfig()` in `config.ts` runs first and reports errors without checking env vars.

This meant deployments using env vars for secrets (the recommended secure approach) would see confusing validation errors like:
```
plugins.entries.voice-call.config.twilio.accountSid is required (or set TWILIO_ACCOUNT_SID env)
```
...even when `TWILIO_ACCOUNT_SID` was correctly set.

## Changes

Added `process.env.*` fallback checks for all provider credentials:
- Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`
- Telnyx: `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`
- Plivo: `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN`

## Test plan

- [ ] Deploy with credentials in env vars only (empty `twilio: {}` in config)
- [ ] Verify no validation errors on startup
- [ ] Verify calls work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the voice-call extension’s `validateProviderConfig()` to treat provider credentials as satisfied when they are present via environment variables (Twilio/Telnyx/Plivo), matching the existing runtime provider resolution logic in `extensions/voice-call/src/runtime.ts`.

Net effect: deployments that intentionally keep secrets out of config files and supply `TWILIO_*`, `TELNYX_*`, or `PLIVO_*` env vars will no longer see misleading “missing credential” validation errors during startup/registration; validation now aligns with how the runtime actually resolves credentials.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized adjustment to config validation logic and matches existing runtime behavior for resolving provider credentials from environment variables. It does not alter provider runtime wiring beyond avoiding false-negative validation errors.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->