### PR TITLE
docs(fly): add private/hardened deployment guide

### DIFF
--- a/fly.private.toml
+++ b/fly.private.toml
@@ -1,0 +1,39 @@
+# Clawdbot Fly.io PRIVATE deployment configuration
+# Use this template for hardened deployments with no public IP exposure.
+#
+# This config is suitable when:
+# - You only make outbound calls (no inbound webhooks needed)
+# - You use ngrok/Tailscale tunnels for any webhook callbacks
+# - You access the gateway via `fly proxy` or WireGuard, not public URL
+# - You want the deployment hidden from internet scanners (Shodan, etc.)
+#
+# See https://fly.io/docs/reference/configuration/
+
+app = "clawdbot"
+primary_region = "iad"  # change to your closest region
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  CLAWDBOT_PREFER_PNPM = "1"
+  CLAWDBOT_STATE_DIR = "/data"
+  NODE_OPTIONS = "--max-old-space-size=1536"
+
+[processes]
+  app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+
+# NOTE: No [http_service] block = no public ingress allocated.
+# The gateway will only be accessible via:
+#   - fly proxy 3000:3000 -a <app-name>
+#   - fly wireguard (then access via internal IPv6)
+#   - fly ssh console
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2048mb"
+
+[mounts]
+  source = "clawdbot_data"
+  destination = "/data"


### PR DESCRIPTION
## Summary

- Add `fly.private.toml` template for deployments with no public IP exposure
- Add "Private Deployment (Hardened)" section to Fly docs
- Add security notes recommending env vars over config file for secrets

## Motivation

Clawdbot gateways deployed on Fly.io with default settings are discoverable by internet scanners (Shodan, Censys, etc.). While the gateway token provides authentication, the exposure itself is a security concern:

- Attackers can enumerate deployed instances
- Public endpoints are targets for probing/attacks
- Some deployments (outbound-only voice calls, etc.) don't need public access

## Changes

### `fly.private.toml` (new file)

A template for private-only deployments:
- No `[http_service]` block = no public ingress
- Documented when to use (outbound-only, ngrok tunnels, etc.)
- Instructions for accessing via `fly proxy`, WireGuard, or SSH

### `docs/platforms/fly.md` updates

1. Security note in config section pointing to private deployment option
2. Note recommending env vars over config file for secrets
3. New "Private Deployment (Hardened)" section covering:
   - When to use private deployment
   - Setup with `fly.private.toml` or converting existing deployment
   - Access methods (proxy, WireGuard, SSH)
   - Webhooks with ngrok tunnel
   - Security comparison table

## Test plan

- [ ] Verify `fly deploy -c fly.private.toml` works
- [ ] Verify `fly ips list` shows only private IP after setup
- [ ] Verify `fly proxy` provides access to Control UI
- [ ] Verify docs render correctly on Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)