### PR TITLE
feat: include full date with day of week in system prompt

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -145,6 +145,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Current: Monday, January 5th, 2026 — 3:26 PM");
     expect(prompt).toContain("Time zone: America/Chicago");
   });
 
@@ -157,6 +158,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Current: Monday, January 5th, 2026 — 15:26");
     expect(prompt).toContain("Time zone: America/Chicago");
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -49,9 +49,14 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(`Current: ${params.userTime}`);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`, "");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -459,6 +464,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Clawdbot and included below in Project Context.",


### PR DESCRIPTION
Fixes #2108

The system prompt now includes the full current date and time (e.g., 'Current: Monday, January 5th, 2026 — 3:26 PM') in addition to the timezone. This prevents the agent from incorrectly guessing the day of week.