### PR TITLE
feat(ui): add user name and avatar customization

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -275,7 +275,10 @@ const FIELD_LABELS: Record<string, string> = {
   "commands.useAccessGroups": "Use Access Groups",
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
+  "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
+  "ui.user.name": "User Name",
+  "ui.user.avatar": "User Avatar",
   "browser.controlUrl": "Browser Control URL",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
@@ -875,9 +878,9 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
     const pluginSchema = asSchemaObject(plugin.configSchema);
     const nextConfigSchema =
       baseConfigSchema &&
-      pluginSchema &&
-      isObjectSchema(baseConfigSchema) &&
-      isObjectSchema(pluginSchema)
+        pluginSchema &&
+        isObjectSchema(baseConfigSchema) &&
+        isObjectSchema(pluginSchema)
         ? mergeObjectSchema(baseConfigSchema, pluginSchema)
         : cloneSchema(plugin.configSchema);
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -275,7 +275,6 @@ const FIELD_LABELS: Record<string, string> = {
   "commands.useAccessGroups": "Use Access Groups",
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
-  "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
   "ui.user.name": "User Name",
   "ui.user.avatar": "User Avatar",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -177,6 +177,13 @@ export const ClawdbotSchema = z
           })
           .strict()
           .optional(),
+        user: z
+          .object({
+            name: z.string().max(50).optional(),
+            avatar: z.string().max(200).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -111,6 +111,11 @@ export function renderApp(state: AppViewState) {
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
 
+  // Resolve user identity from config
+  const uiConfig = (state.configSnapshot?.config as any)?.ui;
+  const userName = uiConfig?.user?.name;
+  const userAvatar = uiConfig?.user?.avatar;
+
   return html`
     <div class="shell ${isChat ? "shell--chat" : ""} ${chatFocus ? "shell--chat-focus" : ""} ${state.settings.navCollapsed ? "shell--nav-collapsed" : ""} ${state.onboarding ? "shell--onboarding" : ""}">
       <header class="topbar">
@@ -118,10 +123,10 @@ export function renderApp(state: AppViewState) {
           <button
             class="nav-collapse-toggle"
             @click=${() =>
-              state.applySettings({
-                ...state.settings,
-                navCollapsed: !state.settings.navCollapsed,
-              })}
+      state.applySettings({
+        ...state.settings,
+        navCollapsed: !state.settings.navCollapsed,
+      })}
             title="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
             aria-label="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
           >
@@ -148,20 +153,20 @@ export function renderApp(state: AppViewState) {
       </header>
       <aside class="nav ${state.settings.navCollapsed ? "nav--collapsed" : ""}">
         ${TAB_GROUPS.map((group) => {
-          const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-          return html`
+        const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
+        const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+        return html`
             <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
               <button
                 class="nav-label"
                 @click=${() => {
-                  const next = { ...state.settings.navGroupsCollapsed };
-                  next[group.label] = !isGroupCollapsed;
-                  state.applySettings({
-                    ...state.settings,
-                    navGroupsCollapsed: next,
-                  });
-                }}
+            const next = { ...state.settings.navGroupsCollapsed };
+            next[group.label] = !isGroupCollapsed;
+            state.applySettings({
+              ...state.settings,
+              navGroupsCollapsed: next,
+            });
+          }}
                 aria-expanded=${!isGroupCollapsed}
               >
                 <span class="nav-label__text">${group.label}</span>
@@ -172,7 +177,7 @@ export function renderApp(state: AppViewState) {
               </div>
             </div>
           `;
-        })}
+      })}
         <div class="nav-group nav-group--links">
           <div class="nav-label nav-label--static">
             <span class="nav-label__text">Resources</span>
@@ -199,383 +204,385 @@ export function renderApp(state: AppViewState) {
           </div>
           <div class="page-meta">
             ${state.lastError
-              ? html`<div class="pill danger">${state.lastError}</div>`
-              : nothing}
+      ? html`<div class="pill danger">${state.lastError}</div>`
+      : nothing}
             ${isChat ? renderChatControls(state) : nothing}
           </div>
         </section>
 
         ${state.tab === "overview"
-          ? renderOverview({
-              connected: state.connected,
-              hello: state.hello,
-              settings: state.settings,
-              password: state.password,
-              lastError: state.lastError,
-              presenceCount,
-              sessionsCount,
-              cronEnabled: state.cronStatus?.enabled ?? null,
-              cronNext,
-              lastChannelsRefresh: state.channelsLastSuccess,
-              onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.resetToolStream();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-              },
-              onConnect: () => state.connect(),
-              onRefresh: () => state.loadOverview(),
-            })
-          : nothing}
+      ? renderOverview({
+        connected: state.connected,
+        hello: state.hello,
+        settings: state.settings,
+        password: state.password,
+        lastError: state.lastError,
+        presenceCount,
+        sessionsCount,
+        cronEnabled: state.cronStatus?.enabled ?? null,
+        cronNext,
+        lastChannelsRefresh: state.channelsLastSuccess,
+        onSettingsChange: (next) => state.applySettings(next),
+        onPasswordChange: (next) => (state.password = next),
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.resetToolStream();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+        },
+        onConnect: () => state.connect(),
+        onRefresh: () => state.loadOverview(),
+      })
+      : nothing}
 
         ${state.tab === "channels"
-          ? renderChannels({
-              connected: state.connected,
-              loading: state.channelsLoading,
-              snapshot: state.channelsSnapshot,
-              lastError: state.channelsError,
-              lastSuccessAt: state.channelsLastSuccess,
-              whatsappMessage: state.whatsappLoginMessage,
-              whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-              whatsappConnected: state.whatsappLoginConnected,
-              whatsappBusy: state.whatsappBusy,
-              configSchema: state.configSchema,
-              configSchemaLoading: state.configSchemaLoading,
-              configForm: state.configForm,
-              configUiHints: state.configUiHints,
-              configSaving: state.configSaving,
-              configFormDirty: state.configFormDirty,
-              nostrProfileFormState: state.nostrProfileFormState,
-              nostrProfileAccountId: state.nostrProfileAccountId,
-              onRefresh: (probe) => loadChannels(state, probe),
-              onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-              onWhatsAppWait: () => state.handleWhatsAppWait(),
-              onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-              onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onConfigSave: () => state.handleChannelConfigSave(),
-              onConfigReload: () => state.handleChannelConfigReload(),
-              onNostrProfileEdit: (accountId, profile) =>
-                state.handleNostrProfileEdit(accountId, profile),
-              onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-              onNostrProfileFieldChange: (field, value) =>
-                state.handleNostrProfileFieldChange(field, value),
-              onNostrProfileSave: () => state.handleNostrProfileSave(),
-              onNostrProfileImport: () => state.handleNostrProfileImport(),
-              onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-            })
-          : nothing}
+      ? renderChannels({
+        connected: state.connected,
+        loading: state.channelsLoading,
+        snapshot: state.channelsSnapshot,
+        lastError: state.channelsError,
+        lastSuccessAt: state.channelsLastSuccess,
+        whatsappMessage: state.whatsappLoginMessage,
+        whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+        whatsappConnected: state.whatsappLoginConnected,
+        whatsappBusy: state.whatsappBusy,
+        configSchema: state.configSchema,
+        configSchemaLoading: state.configSchemaLoading,
+        configForm: state.configForm,
+        configUiHints: state.configUiHints,
+        configSaving: state.configSaving,
+        configFormDirty: state.configFormDirty,
+        nostrProfileFormState: state.nostrProfileFormState,
+        nostrProfileAccountId: state.nostrProfileAccountId,
+        onRefresh: (probe) => loadChannels(state, probe),
+        onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+        onWhatsAppWait: () => state.handleWhatsAppWait(),
+        onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+        onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onConfigSave: () => state.handleChannelConfigSave(),
+        onConfigReload: () => state.handleChannelConfigReload(),
+        onNostrProfileEdit: (accountId, profile) =>
+          state.handleNostrProfileEdit(accountId, profile),
+        onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+        onNostrProfileFieldChange: (field, value) =>
+          state.handleNostrProfileFieldChange(field, value),
+        onNostrProfileSave: () => state.handleNostrProfileSave(),
+        onNostrProfileImport: () => state.handleNostrProfileImport(),
+        onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+      })
+      : nothing}
 
         ${state.tab === "instances"
-          ? renderInstances({
-              loading: state.presenceLoading,
-              entries: state.presenceEntries,
-              lastError: state.presenceError,
-              statusMessage: state.presenceStatus,
-              onRefresh: () => loadPresence(state),
-            })
-          : nothing}
+      ? renderInstances({
+        loading: state.presenceLoading,
+        entries: state.presenceEntries,
+        lastError: state.presenceError,
+        statusMessage: state.presenceStatus,
+        onRefresh: () => loadPresence(state),
+      })
+      : nothing}
 
         ${state.tab === "sessions"
-          ? renderSessions({
-              loading: state.sessionsLoading,
-              result: state.sessionsResult,
-              error: state.sessionsError,
-              activeMinutes: state.sessionsFilterActive,
-              limit: state.sessionsFilterLimit,
-              includeGlobal: state.sessionsIncludeGlobal,
-              includeUnknown: state.sessionsIncludeUnknown,
-              basePath: state.basePath,
-              onFiltersChange: (next) => {
-                state.sessionsFilterActive = next.activeMinutes;
-                state.sessionsFilterLimit = next.limit;
-                state.sessionsIncludeGlobal = next.includeGlobal;
-                state.sessionsIncludeUnknown = next.includeUnknown;
-	              },
-	              onRefresh: () => loadSessions(state),
-	              onPatch: (key, patch) => patchSession(state, key, patch),
-	              onDelete: (key) => deleteSession(state, key),
-	            })
-	          : nothing}
+      ? renderSessions({
+        loading: state.sessionsLoading,
+        result: state.sessionsResult,
+        error: state.sessionsError,
+        activeMinutes: state.sessionsFilterActive,
+        limit: state.sessionsFilterLimit,
+        includeGlobal: state.sessionsIncludeGlobal,
+        includeUnknown: state.sessionsIncludeUnknown,
+        basePath: state.basePath,
+        onFiltersChange: (next) => {
+          state.sessionsFilterActive = next.activeMinutes;
+          state.sessionsFilterLimit = next.limit;
+          state.sessionsIncludeGlobal = next.includeGlobal;
+          state.sessionsIncludeUnknown = next.includeUnknown;
+        },
+        onRefresh: () => loadSessions(state),
+        onPatch: (key, patch) => patchSession(state, key, patch),
+        onDelete: (key) => deleteSession(state, key),
+      })
+      : nothing}
 
         ${state.tab === "cron"
-          ? renderCron({
-              loading: state.cronLoading,
-              status: state.cronStatus,
-              jobs: state.cronJobs,
-              error: state.cronError,
-              busy: state.cronBusy,
-              form: state.cronForm,
-              channels: state.channelsSnapshot?.channelMeta?.length
-                ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                : state.channelsSnapshot?.channelOrder ?? [],
-              channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-              channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-              runsJobId: state.cronRunsJobId,
-              runs: state.cronRuns,
-              onFormChange: (patch) => (state.cronForm = { ...state.cronForm, ...patch }),
-              onRefresh: () => state.loadCron(),
-              onAdd: () => addCronJob(state),
-              onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-              onRun: (job) => runCronJob(state, job),
-              onRemove: (job) => removeCronJob(state, job),
-              onLoadRuns: (jobId) => loadCronRuns(state, jobId),
-            })
-          : nothing}
+      ? renderCron({
+        loading: state.cronLoading,
+        status: state.cronStatus,
+        jobs: state.cronJobs,
+        error: state.cronError,
+        busy: state.cronBusy,
+        form: state.cronForm,
+        channels: state.channelsSnapshot?.channelMeta?.length
+          ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+          : state.channelsSnapshot?.channelOrder ?? [],
+        channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+        channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+        runsJobId: state.cronRunsJobId,
+        runs: state.cronRuns,
+        onFormChange: (patch) => (state.cronForm = { ...state.cronForm, ...patch }),
+        onRefresh: () => state.loadCron(),
+        onAdd: () => addCronJob(state),
+        onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+        onRun: (job) => runCronJob(state, job),
+        onRemove: (job) => removeCronJob(state, job),
+        onLoadRuns: (jobId) => loadCronRuns(state, jobId),
+      })
+      : nothing}
 
         ${state.tab === "skills"
-          ? renderSkills({
-              loading: state.skillsLoading,
-              report: state.skillsReport,
-              error: state.skillsError,
-              filter: state.skillsFilter,
-              edits: state.skillEdits,
-              messages: state.skillMessages,
-              busyKey: state.skillsBusyKey,
-              onFilterChange: (next) => (state.skillsFilter = next),
-              onRefresh: () => loadSkills(state, { clearMessages: true }),
-              onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-              onEdit: (key, value) => updateSkillEdit(state, key, value),
-              onSaveKey: (key) => saveSkillApiKey(state, key),
-              onInstall: (skillKey, name, installId) =>
-                installSkill(state, skillKey, name, installId),
-            })
-          : nothing}
+      ? renderSkills({
+        loading: state.skillsLoading,
+        report: state.skillsReport,
+        error: state.skillsError,
+        filter: state.skillsFilter,
+        edits: state.skillEdits,
+        messages: state.skillMessages,
+        busyKey: state.skillsBusyKey,
+        onFilterChange: (next) => (state.skillsFilter = next),
+        onRefresh: () => loadSkills(state, { clearMessages: true }),
+        onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+        onEdit: (key, value) => updateSkillEdit(state, key, value),
+        onSaveKey: (key) => saveSkillApiKey(state, key),
+        onInstall: (skillKey, name, installId) =>
+          installSkill(state, skillKey, name, installId),
+      })
+      : nothing}
 
         ${state.tab === "nodes"
-          ? renderNodes({
-              loading: state.nodesLoading,
-              nodes: state.nodes,
-              devicesLoading: state.devicesLoading,
-              devicesError: state.devicesError,
-              devicesList: state.devicesList,
-              configForm: state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null),
-              configLoading: state.configLoading,
-              configSaving: state.configSaving,
-              configDirty: state.configFormDirty,
-              configFormMode: state.configFormMode,
-              execApprovalsLoading: state.execApprovalsLoading,
-              execApprovalsSaving: state.execApprovalsSaving,
-              execApprovalsDirty: state.execApprovalsDirty,
-              execApprovalsSnapshot: state.execApprovalsSnapshot,
-              execApprovalsForm: state.execApprovalsForm,
-              execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-              execApprovalsTarget: state.execApprovalsTarget,
-              execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-              onRefresh: () => loadNodes(state),
-              onDevicesRefresh: () => loadDevices(state),
-              onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-              onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-              onDeviceRotate: (deviceId, role, scopes) =>
-                rotateDeviceToken(state, { deviceId, role, scopes }),
-              onDeviceRevoke: (deviceId, role) =>
-                revokeDeviceToken(state, { deviceId, role }),
-              onLoadConfig: () => loadConfig(state),
-              onLoadExecApprovals: () => {
-                const target =
-                  state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                    ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                    : { kind: "gateway" as const };
-                return loadExecApprovals(state, target);
-              },
-              onBindDefault: (nodeId) => {
-                if (nodeId) {
-                  updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                } else {
-                  removeConfigFormValue(state, ["tools", "exec", "node"]);
-                }
-              },
-              onBindAgent: (agentIndex, nodeId) => {
-                const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                if (nodeId) {
-                  updateConfigFormValue(state, basePath, nodeId);
-                } else {
-                  removeConfigFormValue(state, basePath);
-                }
-              },
-              onSaveBindings: () => saveConfig(state),
-              onExecApprovalsTargetChange: (kind, nodeId) => {
-                state.execApprovalsTarget = kind;
-                state.execApprovalsTargetNodeId = nodeId;
-                state.execApprovalsSnapshot = null;
-                state.execApprovalsForm = null;
-                state.execApprovalsDirty = false;
-                state.execApprovalsSelectedAgent = null;
-              },
-              onExecApprovalsSelectAgent: (agentId) => {
-                state.execApprovalsSelectedAgent = agentId;
-              },
-              onExecApprovalsPatch: (path, value) =>
-                updateExecApprovalsFormValue(state, path, value),
-              onExecApprovalsRemove: (path) =>
-                removeExecApprovalsFormValue(state, path),
-              onSaveExecApprovals: () => {
-                const target =
-                  state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                    ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                    : { kind: "gateway" as const };
-                return saveExecApprovals(state, target);
-              },
-            })
-          : nothing}
+      ? renderNodes({
+        loading: state.nodesLoading,
+        nodes: state.nodes,
+        devicesLoading: state.devicesLoading,
+        devicesError: state.devicesError,
+        devicesList: state.devicesList,
+        configForm: state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null),
+        configLoading: state.configLoading,
+        configSaving: state.configSaving,
+        configDirty: state.configFormDirty,
+        configFormMode: state.configFormMode,
+        execApprovalsLoading: state.execApprovalsLoading,
+        execApprovalsSaving: state.execApprovalsSaving,
+        execApprovalsDirty: state.execApprovalsDirty,
+        execApprovalsSnapshot: state.execApprovalsSnapshot,
+        execApprovalsForm: state.execApprovalsForm,
+        execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+        execApprovalsTarget: state.execApprovalsTarget,
+        execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+        onRefresh: () => loadNodes(state),
+        onDevicesRefresh: () => loadDevices(state),
+        onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+        onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+        onDeviceRotate: (deviceId, role, scopes) =>
+          rotateDeviceToken(state, { deviceId, role, scopes }),
+        onDeviceRevoke: (deviceId, role) =>
+          revokeDeviceToken(state, { deviceId, role }),
+        onLoadConfig: () => loadConfig(state),
+        onLoadExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return loadExecApprovals(state, target);
+        },
+        onBindDefault: (nodeId) => {
+          if (nodeId) {
+            updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+          } else {
+            removeConfigFormValue(state, ["tools", "exec", "node"]);
+          }
+        },
+        onBindAgent: (agentIndex, nodeId) => {
+          const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+          if (nodeId) {
+            updateConfigFormValue(state, basePath, nodeId);
+          } else {
+            removeConfigFormValue(state, basePath);
+          }
+        },
+        onSaveBindings: () => saveConfig(state),
+        onExecApprovalsTargetChange: (kind, nodeId) => {
+          state.execApprovalsTarget = kind;
+          state.execApprovalsTargetNodeId = nodeId;
+          state.execApprovalsSnapshot = null;
+          state.execApprovalsForm = null;
+          state.execApprovalsDirty = false;
+          state.execApprovalsSelectedAgent = null;
+        },
+        onExecApprovalsSelectAgent: (agentId) => {
+          state.execApprovalsSelectedAgent = agentId;
+        },
+        onExecApprovalsPatch: (path, value) =>
+          updateExecApprovalsFormValue(state, path, value),
+        onExecApprovalsRemove: (path) =>
+          removeExecApprovalsFormValue(state, path),
+        onSaveExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return saveExecApprovals(state, target);
+        },
+      })
+      : nothing}
 
         ${state.tab === "chat"
-          ? renderChat({
-              sessionKey: state.sessionKey,
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.chatAttachments = [];
-                state.chatStream = null;
-                state.chatStreamStartedAt = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.resetChatScroll();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-                void loadChatHistory(state);
-                void refreshChatAvatar(state);
-              },
-              thinkingLevel: state.chatThinkingLevel,
-              showThinking,
-              loading: state.chatLoading,
-              sending: state.chatSending,
-              compactionStatus: state.compactionStatus,
-              assistantAvatarUrl: chatAvatarUrl,
-              messages: state.chatMessages,
-              toolMessages: state.chatToolMessages,
-              stream: state.chatStream,
-              streamStartedAt: state.chatStreamStartedAt,
-              draft: state.chatMessage,
-              queue: state.chatQueue,
-              connected: state.connected,
-              canSend: state.connected,
-              disabledReason: chatDisabledReason,
-              error: state.lastError,
-              sessions: state.sessionsResult,
-              focusMode: chatFocus,
-              onRefresh: () => {
-                state.resetToolStream();
-                return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-              },
-              onToggleFocusMode: () => {
-                if (state.onboarding) return;
-                state.applySettings({
-                  ...state.settings,
-                  chatFocusMode: !state.settings.chatFocusMode,
-                });
-              },
-              onChatScroll: (event) => state.handleChatScroll(event),
-              onDraftChange: (next) => (state.chatMessage = next),
-              attachments: state.chatAttachments,
-              onAttachmentsChange: (next) => (state.chatAttachments = next),
-              onSend: () => state.handleSendChat(),
-              canAbort: Boolean(state.chatRunId),
-              onAbort: () => void state.handleAbortChat(),
-              onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onNewSession: () =>
-                state.handleSendChat("/new", { restoreDraft: true }),
-              // Sidebar props for tool output viewing
-              sidebarOpen: state.sidebarOpen,
-              sidebarContent: state.sidebarContent,
-              sidebarError: state.sidebarError,
-              splitRatio: state.splitRatio,
-              onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-              onCloseSidebar: () => state.handleCloseSidebar(),
-              onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-              assistantName: state.assistantName,
-              assistantAvatar: state.assistantAvatar,
-            })
-          : nothing}
+      ? renderChat({
+        sessionKey: state.sessionKey,
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.chatAttachments = [];
+          state.chatStream = null;
+          state.chatStreamStartedAt = null;
+          state.chatRunId = null;
+          state.chatQueue = [];
+          state.resetToolStream();
+          state.resetChatScroll();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+          void loadChatHistory(state);
+          void refreshChatAvatar(state);
+        },
+        thinkingLevel: state.chatThinkingLevel,
+        showThinking,
+        loading: state.chatLoading,
+        sending: state.chatSending,
+        compactionStatus: state.compactionStatus,
+        assistantAvatarUrl: chatAvatarUrl,
+        messages: state.chatMessages,
+        toolMessages: state.chatToolMessages,
+        stream: state.chatStream,
+        streamStartedAt: state.chatStreamStartedAt,
+        draft: state.chatMessage,
+        queue: state.chatQueue,
+        connected: state.connected,
+        canSend: state.connected,
+        disabledReason: chatDisabledReason,
+        error: state.lastError,
+        sessions: state.sessionsResult,
+        focusMode: chatFocus,
+        onRefresh: () => {
+          state.resetToolStream();
+          return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+        },
+        onToggleFocusMode: () => {
+          if (state.onboarding) return;
+          state.applySettings({
+            ...state.settings,
+            chatFocusMode: !state.settings.chatFocusMode,
+          });
+        },
+        onChatScroll: (event) => state.handleChatScroll(event),
+        onDraftChange: (next) => (state.chatMessage = next),
+        attachments: state.chatAttachments,
+        onAttachmentsChange: (next) => (state.chatAttachments = next),
+        onSend: () => state.handleSendChat(),
+        canAbort: Boolean(state.chatRunId),
+        onAbort: () => void state.handleAbortChat(),
+        onQueueRemove: (id) => state.removeQueuedMessage(id),
+        onNewSession: () =>
+          state.handleSendChat("/new", { restoreDraft: true }),
+        // Sidebar props for tool output viewing
+        sidebarOpen: state.sidebarOpen,
+        sidebarContent: state.sidebarContent,
+        sidebarError: state.sidebarError,
+        splitRatio: state.splitRatio,
+        onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+        onCloseSidebar: () => state.handleCloseSidebar(),
+        onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+        assistantName: state.assistantName,
+        assistantAvatar: state.assistantAvatar,
+        userName,
+        userAvatar,
+      })
+      : nothing}
 
         ${state.tab === "config"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.configFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.configSearchQuery,
-              activeSection: state.configActiveSection,
-              activeSubsection: state.configActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onFormModeChange: (mode) => (state.configFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.configSearchQuery = query),
-              onSectionChange: (section) => {
-                state.configActiveSection = section;
-                state.configActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.configActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-            })
-          : nothing}
+      ? renderConfig({
+        raw: state.configRaw,
+        originalRaw: state.configRawOriginal,
+        valid: state.configValid,
+        issues: state.configIssues,
+        loading: state.configLoading,
+        saving: state.configSaving,
+        applying: state.configApplying,
+        updating: state.updateRunning,
+        connected: state.connected,
+        schema: state.configSchema,
+        schemaLoading: state.configSchemaLoading,
+        uiHints: state.configUiHints,
+        formMode: state.configFormMode,
+        formValue: state.configForm,
+        originalValue: state.configFormOriginal,
+        searchQuery: state.configSearchQuery,
+        activeSection: state.configActiveSection,
+        activeSubsection: state.configActiveSubsection,
+        onRawChange: (next) => {
+          state.configRaw = next;
+        },
+        onFormModeChange: (mode) => (state.configFormMode = mode),
+        onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onSearchChange: (query) => (state.configSearchQuery = query),
+        onSectionChange: (section) => {
+          state.configActiveSection = section;
+          state.configActiveSubsection = null;
+        },
+        onSubsectionChange: (section) => (state.configActiveSubsection = section),
+        onReload: () => loadConfig(state),
+        onSave: () => saveConfig(state),
+        onApply: () => applyConfig(state),
+        onUpdate: () => runUpdate(state),
+      })
+      : nothing}
 
         ${state.tab === "debug"
-          ? renderDebug({
-              loading: state.debugLoading,
-              status: state.debugStatus,
-              health: state.debugHealth,
-              models: state.debugModels,
-              heartbeat: state.debugHeartbeat,
-              eventLog: state.eventLog,
-              callMethod: state.debugCallMethod,
-              callParams: state.debugCallParams,
-              callResult: state.debugCallResult,
-              callError: state.debugCallError,
-              onCallMethodChange: (next) => (state.debugCallMethod = next),
-              onCallParamsChange: (next) => (state.debugCallParams = next),
-              onRefresh: () => loadDebug(state),
-              onCall: () => callDebugMethod(state),
-            })
-          : nothing}
+      ? renderDebug({
+        loading: state.debugLoading,
+        status: state.debugStatus,
+        health: state.debugHealth,
+        models: state.debugModels,
+        heartbeat: state.debugHeartbeat,
+        eventLog: state.eventLog,
+        callMethod: state.debugCallMethod,
+        callParams: state.debugCallParams,
+        callResult: state.debugCallResult,
+        callError: state.debugCallError,
+        onCallMethodChange: (next) => (state.debugCallMethod = next),
+        onCallParamsChange: (next) => (state.debugCallParams = next),
+        onRefresh: () => loadDebug(state),
+        onCall: () => callDebugMethod(state),
+      })
+      : nothing}
 
         ${state.tab === "logs"
-          ? renderLogs({
-              loading: state.logsLoading,
-              error: state.logsError,
-              file: state.logsFile,
-              entries: state.logsEntries,
-              filterText: state.logsFilterText,
-              levelFilters: state.logsLevelFilters,
-              autoFollow: state.logsAutoFollow,
-              truncated: state.logsTruncated,
-              onFilterTextChange: (next) => (state.logsFilterText = next),
-              onLevelToggle: (level, enabled) => {
-                state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
-              },
-              onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-              onRefresh: () => loadLogs(state, { reset: true }),
-              onExport: (lines, label) => state.exportLogs(lines, label),
-              onScroll: (event) => state.handleLogsScroll(event),
-            })
-          : nothing}
+      ? renderLogs({
+        loading: state.logsLoading,
+        error: state.logsError,
+        file: state.logsFile,
+        entries: state.logsEntries,
+        filterText: state.logsFilterText,
+        levelFilters: state.logsLevelFilters,
+        autoFollow: state.logsAutoFollow,
+        truncated: state.logsTruncated,
+        onFilterTextChange: (next) => (state.logsFilterText = next),
+        onLevelToggle: (level, enabled) => {
+          state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+        },
+        onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+        onRefresh: () => loadLogs(state, { reset: true }),
+        onExport: (lines, label) => state.exportLogs(lines, label),
+        onScroll: (event) => state.handleLogsScroll(event),
+      })
+      : nothing}
       </main>
       ${renderExecApprovalPrompt(state)}
     </div>

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -485,12 +485,11 @@ export function renderApp(state: AppViewState) {
         onDraftChange: (next) => (state.chatMessage = next),
         attachments: state.chatAttachments,
         onAttachmentsChange: (next) => (state.chatAttachments = next),
-        onSend: () => state.handleSendChat(),
+        onSend: state.handleChatSend,
         canAbort: Boolean(state.chatRunId),
-        onAbort: () => void state.handleAbortChat(),
-        onQueueRemove: (id) => state.removeQueuedMessage(id),
-        onNewSession: () =>
-          state.handleSendChat("/new", { restoreDraft: true }),
+        onAbort: state.handleChatAbort,
+        onQueueRemove: (id) => state.handleChatDropQueueItem(id),
+        onNewSession: () => state.handleChatNewSession(),
         // Sidebar props for tool output viewing
         sidebarOpen: state.sidebarOpen,
         sidebarContent: state.sidebarContent,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -7,6 +7,7 @@ import type {
   AgentsListResult,
   ChannelsStatusSnapshot,
   ConfigSnapshot,
+  ConfigUiHints,
   CronJob,
   CronRunLogEntry,
   CronStatus,
@@ -46,6 +47,7 @@ export type AppViewState = {
   assistantAvatar: string | null;
   assistantAgentId: string | null;
   sessionKey: string;
+  applySessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;
   chatMessage: string;
@@ -53,8 +55,10 @@ export type AppViewState = {
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStream: string | null;
+  chatStreamStartedAt: number | null;
   chatRunId: string | null;
   chatAvatarUrl: string | null;
+  compactionStatus: import("./app-tool-stream").CompactionStatus | null;
   chatThinkingLevel: string | null;
   chatQueue: ChatQueueItem[];
   nodesLoading: boolean;
@@ -83,11 +87,15 @@ export type AppViewState = {
   updateRunning: boolean;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown | null;
+  configSchemaVersion: string | null;
   configSchemaLoading: boolean;
-  configUiHints: Record<string, unknown>;
+  configUiHints: ConfigUiHints;
   configForm: Record<string, unknown> | null;
   configFormOriginal: Record<string, unknown> | null;
   configFormMode: "form" | "raw";
+  configSearchQuery: string;
+  configActiveSection: string | null;
+  configActiveSubsection: string | null;
   channelsLoading: boolean;
   channelsSnapshot: ChannelsStatusSnapshot | null;
   channelsError: string | null;
@@ -141,6 +149,10 @@ export type AppViewState = {
   logsError: string | null;
   logsFile: string | null;
   logsEntries: LogEntry[];
+  logsCursor: number | null;
+  logsLastFetchAt: number | null;
+  logsLimit: number;
+  logsMaxBytes: number;
   logsFilterText: string;
   logsLevelFilters: Record<LogLevel, boolean>;
   logsAutoFollow: boolean;
@@ -198,9 +210,22 @@ export type AppViewState = {
   handleChatAbort: () => Promise<void>;
   handleChatSelectQueueItem: (id: string) => void;
   handleChatDropQueueItem: (id: string) => void;
+  handleChatNewSession: () => void;
   handleChatClearQueue: () => void;
   handleLogsFilterChange: (next: string) => void;
   handleLogsLevelFilterToggle: (level: LogLevel) => void;
   handleLogsAutoFollowToggle: (next: boolean) => void;
   handleCallDebugMethod: (method: string, params: string) => Promise<void>;
+  resetToolStream: () => void;
+  resetChatScroll: () => void;
+  handleChatScroll: (e: Event) => void;
+  sidebarOpen: boolean;
+  sidebarContent: string | null;
+  sidebarError: string | null;
+  splitRatio: number;
+  handleOpenSidebar: (content: string) => void;
+  handleCloseSidebar: () => void;
+  handleSplitRatioChange: (ratio: number) => void;
+  exportLogs: (lines: string[], label: string) => void;
+  handleLogsScroll: (e: Event) => void;
 };

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -87,14 +87,14 @@ export function renderStreamingGroup(
       ${renderAvatar("assistant", assistant)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
-          {
-            role: "assistant",
-            content: [{ type: "text", text }],
-            timestamp: startedAt,
-          },
-          { isStreaming: true, showReasoning: false },
-          onOpenSidebar,
-        )}
+    {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      timestamp: startedAt,
+    },
+    { isStreaming: true, showReasoning: false },
+    onOpenSidebar,
+  )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${name}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -111,13 +111,15 @@ export function renderMessageGroup(
     showReasoning: boolean;
     assistantName?: string;
     assistantAvatar?: string | null;
+    userName?: string;
+    userAvatar?: string | null;
   },
 ) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
   const assistantName = opts.assistantName ?? "Assistant";
   const who =
     normalizedRole === "user"
-      ? "You"
+      ? (opts.userName || "You")
       : normalizedRole === "assistant"
         ? assistantName
         : normalizedRole;
@@ -135,21 +137,24 @@ export function renderMessageGroup(
   return html`
     <div class="chat-group ${roleClass}">
       ${renderAvatar(group.role, {
-        name: assistantName,
-        avatar: opts.assistantAvatar ?? null,
-      })}
+    name: assistantName,
+    avatar: opts.assistantAvatar ?? null,
+  }, {
+    name: opts.userName,
+    avatar: opts.userAvatar,
+  })}
       <div class="chat-group-messages">
         ${group.messages.map((item, index) =>
-          renderGroupedMessage(
-            item.message,
-            {
-              isStreaming:
-                group.isStreaming && index === group.messages.length - 1,
-              showReasoning: opts.showReasoning,
-            },
-            opts.onOpenSidebar,
-          ),
-        )}
+    renderGroupedMessage(
+      item.message,
+      {
+        isStreaming:
+          group.isStreaming && index === group.messages.length - 1,
+        showReasoning: opts.showReasoning,
+      },
+      opts.onOpenSidebar,
+    ),
+  )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${who}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -162,13 +167,17 @@ export function renderMessageGroup(
 function renderAvatar(
   role: string,
   assistant?: Pick<AssistantIdentity, "name" | "avatar">,
+  user?: { name?: string; avatar?: string | null },
 ) {
   const normalized = normalizeRoleForGrouping(role);
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
+  const userName = user?.name?.trim() || "You";
+  const userAvatar = user?.avatar?.trim() || "";
+
   const initial =
     normalized === "user"
-      ? "U"
+      ? (userName === "You" ? "U" : userName.charAt(0).toUpperCase())
       : normalized === "assistant"
         ? assistantName.charAt(0).toUpperCase() || "A"
         : normalized === "tool"
@@ -179,7 +188,7 @@ function renderAvatar(
       ? "user"
       : normalized === "assistant"
         ? "assistant"
-      : normalized === "tool"
+        : normalized === "tool"
           ? "tool"
           : "other";
 
@@ -192,6 +201,16 @@ function renderAvatar(
       />`;
     }
     return html`<div class="chat-avatar ${className}">${assistantAvatar}</div>`;
+  }
+
+  if (userAvatar && normalized === "user") {
+    if (isAvatarUrl(userAvatar)) {
+      return html`<img
+        class="chat-avatar ${className}"
+        src="${userAvatar}"
+        alt="${userName}"
+      />`;
+    }
   }
 
   return html`<div class="chat-avatar ${className}">${initial}</div>`;
@@ -211,7 +230,7 @@ function renderMessageImages(images: ImageBlock[]) {
   return html`
     <div class="chat-message-images">
       ${images.map(
-        (img) => html`
+    (img) => html`
           <img
             src=${img.url}
             alt=${img.alt ?? "Attached image"}
@@ -219,7 +238,7 @@ function renderMessageImages(images: ImageBlock[]) {
             @click=${() => window.open(img.url, "_blank")}
           />
         `,
-      )}
+  )}
     </div>
   `;
 }
@@ -277,13 +296,13 @@ function renderGroupedMessage(
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
       ${reasoningMarkdown
-        ? html`<div class="chat-thinking">${unsafeHTML(
-            toSanitizedMarkdownHtml(reasoningMarkdown),
-          )}</div>`
-        : nothing}
+      ? html`<div class="chat-thinking">${unsafeHTML(
+        toSanitizedMarkdownHtml(reasoningMarkdown),
+      )}</div>`
+      : nothing}
       ${markdown
-        ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
-        : nothing}
+      ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+      : nothing}
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -52,6 +52,8 @@ export type ChatProps = {
   splitRatio?: number;
   assistantName: string;
   assistantAvatar: string | null;
+  userName?: string;
+  userAvatar?: string | null;
   // Image attachments
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
@@ -147,7 +149,7 @@ function renderAttachmentPreview(props: ChatProps) {
   return html`
     <div class="chat-attachments">
       ${attachments.map(
-        (att) => html`
+    (att) => html`
           <div class="chat-attachment">
             <img
               src=${att.dataUrl}
@@ -159,17 +161,17 @@ function renderAttachmentPreview(props: ChatProps) {
               type="button"
               aria-label="Remove attachment"
               @click=${() => {
-                const next = (props.attachments ?? []).filter(
-                  (a) => a.id !== att.id,
-                );
-                props.onAttachmentsChange?.(next);
-              }}
+        const next = (props.attachments ?? []).filter(
+          (a) => a.id !== att.id,
+        );
+        props.onAttachmentsChange?.(next);
+      }}
             >
               ${icons.x}
             </button>
           </div>
         `,
-      )}
+  )}
     </div>
   `;
 }
@@ -206,47 +208,49 @@ export function renderChat(props: ChatProps) {
     >
       ${props.loading ? html`<div class="muted">Loading chat…</div>` : nothing}
       ${repeat(buildChatItems(props), (item) => item.key, (item) => {
-        if (item.kind === "reading-indicator") {
-          return renderReadingIndicatorGroup(assistantIdentity);
-        }
+    if (item.kind === "reading-indicator") {
+      return renderReadingIndicatorGroup(assistantIdentity);
+    }
 
-        if (item.kind === "stream") {
-          return renderStreamingGroup(
-            item.text,
-            item.startedAt,
-            props.onOpenSidebar,
-            assistantIdentity,
-          );
-        }
+    if (item.kind === "stream") {
+      return renderStreamingGroup(
+        item.text,
+        item.startedAt,
+        props.onOpenSidebar,
+        assistantIdentity,
+      );
+    }
 
-        if (item.kind === "group") {
-          return renderMessageGroup(item, {
-            onOpenSidebar: props.onOpenSidebar,
-            showReasoning,
-            assistantName: props.assistantName,
-            assistantAvatar: assistantIdentity.avatar,
-          });
-        }
+    if (item.kind === "group") {
+      return renderMessageGroup(item, {
+        onOpenSidebar: props.onOpenSidebar,
+        showReasoning,
+        assistantName: props.assistantName,
+        assistantAvatar: assistantIdentity.avatar,
+        userName: props.userName,
+        userAvatar: props.userAvatar,
+      });
+    }
 
-        return nothing;
-      })}
+    return nothing;
+  })}
     </div>
   `;
 
   return html`
     <section class="card chat">
       ${props.disabledReason
-        ? html`<div class="callout">${props.disabledReason}</div>`
-        : nothing}
+      ? html`<div class="callout">${props.disabledReason}</div>`
+      : nothing}
 
       ${props.error
-        ? html`<div class="callout danger">${props.error}</div>`
-        : nothing}
+      ? html`<div class="callout danger">${props.error}</div>`
+      : nothing}
 
       ${renderCompactionIndicator(props.compactionStatus)}
 
       ${props.focusMode
-        ? html`
+      ? html`
             <button
               class="chat-focus-exit"
               type="button"
@@ -257,7 +261,7 @@ export function renderChat(props: ChatProps) {
               ${icons.x}
             </button>
           `
-        : nothing}
+      : nothing}
 
       <div
         class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}"
@@ -270,40 +274,40 @@ export function renderChat(props: ChatProps) {
         </div>
 
         ${sidebarOpen
-          ? html`
+      ? html`
               <resizable-divider
                 .splitRatio=${splitRatio}
                 @resize=${(e: CustomEvent) =>
-                  props.onSplitRatioChange?.(e.detail.splitRatio)}
+          props.onSplitRatioChange?.(e.detail.splitRatio)}
               ></resizable-divider>
               <div class="chat-sidebar">
                 ${renderMarkdownSidebar({
-                  content: props.sidebarContent ?? null,
-                  error: props.sidebarError ?? null,
-                  onClose: props.onCloseSidebar!,
-                  onViewRawText: () => {
-                    if (!props.sidebarContent || !props.onOpenSidebar) return;
-                    props.onOpenSidebar(`\`\`\`\n${props.sidebarContent}\n\`\`\``);
-                  },
-                })}
+            content: props.sidebarContent ?? null,
+            error: props.sidebarError ?? null,
+            onClose: props.onCloseSidebar!,
+            onViewRawText: () => {
+              if (!props.sidebarContent || !props.onOpenSidebar) return;
+              props.onOpenSidebar(`\`\`\`\n${props.sidebarContent}\n\`\`\``);
+            },
+          })}
               </div>
             `
-          : nothing}
+      : nothing}
       </div>
 
       ${props.queue.length
-        ? html`
+      ? html`
             <div class="chat-queue" role="status" aria-live="polite">
               <div class="chat-queue__title">Queued (${props.queue.length})</div>
               <div class="chat-queue__list">
                 ${props.queue.map(
-                  (item) => html`
+        (item) => html`
                     <div class="chat-queue__item">
                       <div class="chat-queue__text">
                         ${item.text ||
-                        (item.attachments?.length
-                          ? `Image (${item.attachments.length})`
-                          : "")}
+          (item.attachments?.length
+            ? `Image (${item.attachments.length})`
+            : "")}
                       </div>
                       <button
                         class="btn chat-queue__remove"
@@ -315,11 +319,11 @@ export function renderChat(props: ChatProps) {
                       </button>
                     </div>
                   `,
-                )}
+      )}
               </div>
             </div>
           `
-        : nothing}
+      : nothing}
 
       <div class="chat-compose">
         ${renderAttachmentPreview(props)}
@@ -330,15 +334,15 @@ export function renderChat(props: ChatProps) {
               .value=${props.draft}
               ?disabled=${!props.connected}
               @keydown=${(e: KeyboardEvent) => {
-                if (e.key !== "Enter") return;
-                if (e.isComposing || e.keyCode === 229) return;
-                if (e.shiftKey) return; // Allow Shift+Enter for line breaks
-                if (!props.connected) return;
-                e.preventDefault();
-                if (canCompose) props.onSend();
-              }}
+      if (e.key !== "Enter") return;
+      if (e.isComposing || e.keyCode === 229) return;
+      if (e.shiftKey) return; // Allow Shift+Enter for line breaks
+      if (!props.connected) return;
+      e.preventDefault();
+      if (canCompose) props.onSend();
+    }}
               @input=${(e: Event) =>
-                props.onDraftChange((e.target as HTMLTextAreaElement).value)}
+      props.onDraftChange((e.target as HTMLTextAreaElement).value)}
               @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
               placeholder=${composePlaceholder}
             ></textarea>


### PR DESCRIPTION
Resolves #2110

## Summary
Adds support for customizing the user's display name and avatar in the webchat UI via
`ui.user.name` and `ui.user.avatar`.

This removes the hardcoded `"You"` label and allows proper user identity rendering.

## What Changed
### Backend
- Added `ui.user` schema validation to `zod-schema.ts`
- Added UI hints for discoverability in `schema.ts`

### Frontend
- Updated user identity propagation and rendering in:
  - `app-render.ts`
  - `chat.ts`
  - `grouped-render.ts`

## Why
This improves:
- UI personalization
- Multi-user clarity
- Demo / branding quality
- Overall UX consistency

## Configuration Example
```json
{
  "ui": {
    "user": {
      "name": "Custom Name",
      "avatar": "https://example.com/avatar.png"
    }
  }
}
