### PR TITLE
feat(control-ui): auto-expand chat input textarea

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -245,16 +245,18 @@
 /* Override .field textarea min-height (180px) from components.css */
 .chat-compose .chat-compose__field textarea {
   width: 100%;
-  height: 40px;
   min-height: 40px;
-  max-height: 150px;
+  max-height: 200px;
   padding: 9px 12px;
   border-radius: 8px;
-  resize: vertical;
+  resize: none; /* Disable manual resize since we auto-expand */
   white-space: pre-wrap;
   font-family: var(--font-body);
   font-size: 14px;
   line-height: 1.45;
+  overflow-y: auto;
+  box-sizing: border-box;
+  field-sizing: content; /* Modern CSS auto-sizing (Chrome 123+, Firefox 131+) */
 }
 
 .chat-compose__field textarea:disabled {


### PR DESCRIPTION
## Summary
The chat input textarea in the Control UI now automatically expands as you type multiple lines, improving the UX when composing longer messages.

## Changes
- **CSS**: Use `field-sizing: content` for modern browsers (Chrome 123+, Firefox 131+)
- **JS fallback**: Add `autoResizeTextarea()` function for older browsers  
- Disable manual resize since auto-expand handles it
- Reset height when input is cleared (after sending)

## Behavior
- Starts at minimum height (40px) when empty
- Grows automatically as content is added
- Caps at max-height (200px) with overflow scroll
- Shrinks back when content is removed

## Testing
Tested manually by typing multi-line messages in the chat input.

Fixes the single-line input issue where users had to manually resize or scroll within the tiny input box.