### PR TITLE
fix(node): reconnect stale gateway ws

### DIFF
--- a/apps/macos/Sources/Moltbot/GatewayConnection.swift
+++ b/apps/macos/Sources/Moltbot/GatewayConnection.swift
@@ -367,7 +367,8 @@ actor GatewayConnection {
             session: self.sessionBox,
             pushHandler: { [weak self] push in
                 await self?.handle(push: push)
-            })
+            },
+            loggerCategory: "gateway.control")
         self.configuredURL = url
         self.configuredToken = token
         self.configuredPassword = password

--- a/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayChannel.swift
+++ b/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayChannel.swift
@@ -109,7 +109,7 @@ private enum ConnectChallengeError: Error {
 }
 
 public actor GatewayChannelActor {
-    private let logger = Logger(subsystem: "bot.molt", category: "gateway")
+    private let logger: Logger
     private var task: WebSocketTaskBox?
     private var pending: [String: CheckedContinuation<GatewayFrame, Error>] = [:]
     private var connected = false
@@ -143,8 +143,10 @@ public actor GatewayChannelActor {
         session: WebSocketSessionBox? = nil,
         pushHandler: (@Sendable (GatewayPush) async -> Void)? = nil,
         connectOptions: GatewayConnectOptions? = nil,
+        loggerCategory: String = "gateway",
         disconnectHandler: (@Sendable (String) async -> Void)? = nil)
     {
+        self.logger = Logger(subsystem: "bot.molt", category: loggerCategory)
         self.url = url
         self.token = token
         self.password = password

--- a/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
+++ b/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
@@ -90,6 +90,7 @@ public actor GatewayNodeSession {
                     await self?.handlePush(push)
                 },
                 connectOptions: connectOptions,
+                loggerCategory: "gateway.node",
                 disconnectHandler: { [weak self] reason in
                     await self?.onDisconnected?(reason)
                 })

--- a/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
+++ b/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
@@ -107,7 +107,6 @@ public actor GatewayNodeSession {
 
         do {
             try await channel.connect()
-            await onConnected()
         } catch {
             await onDisconnected(error.localizedDescription)
             throw error


### PR DESCRIPTION
## Summary
- detect stale gateway sockets using tick age and force a reconnect
- stop reporting node connected before a hello-ok snapshot arrives
- split gateway logs into gateway.control vs gateway.node for clarity

## Testing
- Repro: MacBook Pro sleep/wake left node disconnected (paired but not connected)
- Verified fix by manually sleeping/waking and checking macOS logs for reconnection

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves gateway WebSocket resiliency and observability in the Swift clients by (1) detecting “stale” sockets using tick age and forcing reconnect, (2) deferring “connected” reporting until a hello-ok snapshot is received, and (3) splitting OSLog categories (e.g. `gateway.control` vs `gateway.node`) for cleaner log filtering. The changes are centered in `GatewayChannelActor` (connection management + tick watchdog) and are threaded through `GatewayConnection` and `GatewayNodeSession` via a new `loggerCategory` parameter.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but connection-state signaling semantics changed and could break callers depending on `onConnected` timing.
- The stale-socket reconnect and logging-category changes are localized and consistent with existing tick-based watchdog behavior. The primary risk is the behavioral change in `GatewayNodeSession.connect()` where `onConnected` is no longer called on successful `channel.connect()`, making the callback dependent on receiving a snapshot push.
- apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->