### PR TITLE
feat(channels): add systemPrompt support for WhatsApp and Signal

### DIFF
--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -8,6 +8,8 @@ export type GroupChatConfig = {
 
 export type DmConfig = {
   historyLimit?: number;
+  /** Custom system prompt for this DM conversation. */
+  systemPrompt?: string;
 };
 
 export type QueueConfig = {

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -6,9 +6,19 @@ import type {
 } from "./types.base.js";
 import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
+import type { GroupToolPolicyConfig } from "./types.tools.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
+
+export type SignalGroupConfig = {
+  /** Require explicit bot mention in group messages (default: true). */
+  requireMention?: boolean;
+  /** Tool policy overrides for this group. */
+  tools?: GroupToolPolicyConfig;
+  /** Custom system prompt for this group. */
+  systemPrompt?: string;
+};
 
 export type SignalAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
@@ -57,6 +67,8 @@ export type SignalAccountConfig = {
   dmHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
+  /** Per-group config overrides keyed by group ID. */
+  groups?: Record<string, SignalGroupConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -70,6 +70,8 @@ export type WhatsAppConfig = {
     {
       requireMention?: boolean;
       tools?: GroupToolPolicyConfig;
+      /** Custom system prompt for this group. */
+      systemPrompt?: string;
     }
   >;
   /** Acknowledgment reaction sent immediately upon message receipt. */
@@ -135,6 +137,8 @@ export type WhatsAppAccountConfig = {
     {
       requireMention?: boolean;
       tools?: GroupToolPolicyConfig;
+      /** Custom system prompt for this group. */
+      systemPrompt?: string;
     }
   >;
   /** Acknowledgment reaction sent immediately upon message receipt. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -92,6 +92,7 @@ export const GroupChatSchema = z
 export const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),
+    systemPrompt: z.string().optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -474,6 +474,14 @@ export const SlackConfigSchema = SlackAccountSchema.extend({
   }
 });
 
+export const SignalGroupSchema = z
+  .object({
+    requireMention: z.boolean().optional(),
+    tools: ToolPolicySchema,
+    systemPrompt: z.string().optional(),
+  })
+  .strict();
+
 export const SignalAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -499,6 +507,7 @@ export const SignalAccountSchemaBase = z
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+    groups: z.record(z.string(), SignalGroupSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -41,6 +41,7 @@ export const WhatsAppAccountSchema = z
           .object({
             requireMention: z.boolean().optional(),
             tools: ToolPolicySchema,
+            systemPrompt: z.string().optional(),
           })
           .strict()
           .optional(),
@@ -105,6 +106,7 @@ export const WhatsAppConfigSchema = z
           .object({
             requireMention: z.boolean().optional(),
             tools: ToolPolicySchema,
+            systemPrompt: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
Add per-group and per-DM system prompt configuration for WhatsApp and Signal channels, mirroring the existing Telegram implementation.

- Add systemPrompt to DmConfig type and schema
- Add systemPrompt to WhatsApp group config (both root and account)
- Add SignalGroupConfig type with systemPrompt and groups config
- Add resolveChannelGroupSystemPrompt() and resolveChannelDmSystemPrompt() helpers in group-policy.ts
- Pass GroupSystemPrompt to inbound context in WhatsApp and Signal handlers

More testing required.