### PR TITLE
feat: add /reset prune to delete session entry and transcript

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -130,9 +130,13 @@ export async function getReplyFromConfig(
 
   // Handle /reset prune - delete session entry and transcript, then return confirmation
   if (resetTriggered && pruneRequested && previousSessionEntry) {
-    const transcriptPath = previousSessionEntry.sessionId
-      ? resolveSessionTranscriptPath(previousSessionEntry.sessionId, agentId)
-      : undefined;
+    // Prefer sessionFile from entry (includes thread suffix for topics),
+    // fall back to resolveSessionTranscriptPath for legacy sessions
+    const transcriptPath =
+      previousSessionEntry.sessionFile?.trim() ||
+      (previousSessionEntry.sessionId
+        ? resolveSessionTranscriptPath(previousSessionEntry.sessionId, agentId)
+        : undefined);
     await deleteSessionEntry({
       storePath,
       sessionKey,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -43,6 +43,8 @@ export type SessionInitResult = {
   sessionId: string;
   isNewSession: boolean;
   resetTriggered: boolean;
+  /** When true, the session entry and transcript should be deleted after reset. */
+  pruneRequested: boolean;
   systemSent: boolean;
   abortedLastRun: boolean;
   storePath: string;
@@ -125,6 +127,7 @@ export async function initSessionState(params: {
   let systemSent = false;
   let abortedLastRun = false;
   let resetTriggered = false;
+  let pruneRequested = false;
 
   let persistedThinking: string | undefined;
   let persistedVerbose: string | undefined;
@@ -184,6 +187,12 @@ export async function initSessionState(params: {
       resetTriggered = true;
       break;
     }
+  }
+
+  // Check if prune was requested (e.g., "/reset prune")
+  if (resetTriggered && bodyStripped?.toLowerCase() === "prune") {
+    pruneRequested = true;
+    bodyStripped = ""; // Clear the body since "prune" is a directive, not a message
   }
 
   sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
@@ -364,6 +373,7 @@ export async function initSessionState(params: {
     sessionId: sessionId ?? crypto.randomUUID(),
     isNewSession,
     resetTriggered,
+    pruneRequested,
     systemSent,
     abortedLastRun,
     storePath,


### PR DESCRIPTION
## Summary

When user sends `/reset prune`, the session entry is removed from the session store and the transcript `.jsonl` file is deleted.

## Motivation

This is useful when deleting Telegram DM topics - users can first prune the session to avoid orphaned session files that are hard to identify later (since the thread ID becomes meaningless after deletion).

## Changes

- Add `pruneRequested` flag to `SessionInitResult`
- Detect `prune` argument after reset trigger (e.g., `/reset prune` or `/new prune`)
- Add `deleteSessionEntry()` function to `store.ts`
- Handle prune in `get-reply.ts` before normal reset flow
- Returns `✅ Session pruned.` confirmation

## Testing

- [x] TypeScript compiles without errors