### PR TITLE
docs: fix sticky navbar for desktop

### DIFF
--- a/docs/assets/terminal.css
+++ b/docs/assets/terminal.css
@@ -87,7 +87,7 @@ body {
     radial-gradient(900px 600px at 95% 10%, color-mix(in oklab, var(--accent2) 14%, transparent), transparent 60%),
     radial-gradient(900px 600px at 50% 120%, color-mix(in oklab, var(--link) 10%, transparent), transparent 55%),
     linear-gradient(180deg, var(--bg0), var(--bg1));
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 body::before,

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -1,9 +1,9 @@
 ---
 summary: "Node.js + npm install sanity: versions, PATH, and global installs"
 read_when:
-  - You installed Clawdbot but `clawdbot` is “command not found”
-  - You’re setting up Node.js/npm on a new machine
-  - `npm install -g ...` fails with permissions or PATH issues
+  - 'You installed Clawdbot but `clawdbot` is "command not found"'
+  - You're setting up Node.js/npm on a new machine
+  - '`npm install -g ...` fails with permissions or PATH issues'
 ---
 
 # Node.js + npm (PATH sanity)


### PR DESCRIPTION
- fix local dev error:
```
/clawdbot/docs/install/node.md: There is a syntax error in your frontmatter on line 4, column 4 in /install/node.md
error Failed to parse MDX files, please correct errors before continuing
```

- fix sticky navbar styles:
<table>
<thead>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
</thead>
<tbody>
<tr>
<td>

https://github.com/user-attachments/assets/579c26f2-cab9-4c61-b69b-bc22a4a38054

</td>
<td>

https://github.com/user-attachments/assets/78d7b562-f9ef-428e-ada7-5dd1a6a2d682

</td>
</tr>
</tbody>
</table>
