### PR TITLE
fix(infra): use 'where' instead of 'which' on Windows for binary detection

### DIFF
--- a/src/infra/binaries.test.ts
+++ b/src/infra/binaries.test.ts
@@ -1,34 +1,86 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 import type { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { ensureBinary } from "./binaries.js";
 
+const originalPlatform = process.platform;
+
 describe("ensureBinary", () => {
-  it("passes through when binary exists", async () => {
-    const exec: typeof runExec = vi.fn().mockResolvedValue({
-      stdout: "",
-      stderr: "",
+  afterEach(() => {
+    // Restore original platform after each test
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
     });
-    const runtime: RuntimeEnv = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-    await ensureBinary("node", exec, runtime);
-    expect(exec).toHaveBeenCalledWith("which", ["node"]);
   });
 
-  it("logs and exits when missing", async () => {
-    const exec: typeof runExec = vi.fn().mockRejectedValue(new Error("missing"));
-    const error = vi.fn();
-    const exit = vi.fn(() => {
-      throw new Error("exit");
+  describe("on Unix", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+      });
     });
-    await expect(ensureBinary("ghost", exec, { log: vi.fn(), error, exit })).rejects.toThrow(
-      "exit",
-    );
-    expect(error).toHaveBeenCalledWith("Missing required binary: ghost. Please install it.");
-    expect(exit).toHaveBeenCalledWith(1);
+
+    it("passes through when binary exists", async () => {
+      const exec: typeof runExec = vi.fn().mockResolvedValue({
+        stdout: "",
+        stderr: "",
+      });
+      const runtime: RuntimeEnv = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      await ensureBinary("node", exec, runtime);
+      expect(exec).toHaveBeenCalledWith("which", ["node"]);
+    });
+
+    it("logs and exits when missing", async () => {
+      const exec: typeof runExec = vi.fn().mockRejectedValue(new Error("missing"));
+      const error = vi.fn();
+      const exit = vi.fn(() => {
+        throw new Error("exit");
+      });
+      await expect(ensureBinary("ghost", exec, { log: vi.fn(), error, exit })).rejects.toThrow(
+        "exit",
+      );
+      expect(error).toHaveBeenCalledWith("Missing required binary: ghost. Please install it.");
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("on Windows", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      });
+    });
+
+    it("passes through when binary exists", async () => {
+      const exec: typeof runExec = vi.fn().mockResolvedValue({
+        stdout: "",
+        stderr: "",
+      });
+      const runtime: RuntimeEnv = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      await ensureBinary("node", exec, runtime);
+      expect(exec).toHaveBeenCalledWith("where", ["node"]);
+    });
+
+    it("logs and exits when missing", async () => {
+      const exec: typeof runExec = vi.fn().mockRejectedValue(new Error("missing"));
+      const error = vi.fn();
+      const exit = vi.fn(() => {
+        throw new Error("exit");
+      });
+      await expect(ensureBinary("ghost", exec, { log: vi.fn(), error, exit })).rejects.toThrow(
+        "exit",
+      );
+      expect(error).toHaveBeenCalledWith("Missing required binary: ghost. Please install it.");
+      expect(exit).toHaveBeenCalledWith(1);
+    });
   });
 });

--- a/src/infra/binaries.ts
+++ b/src/infra/binaries.ts
@@ -7,7 +7,9 @@ export async function ensureBinary(
   runtime: RuntimeEnv = defaultRuntime,
 ): Promise<void> {
   // Abort early if a required CLI tool is missing.
-  await exec("which", [name]).catch(() => {
+  // Windows uses 'where', Unix uses 'which'
+  const command = process.platform === "win32" ? "where" : "which";
+  await exec(command, [name]).catch(() => {
     runtime.error(`Missing required binary: ${name}. Please install it.`);
     runtime.exit(1);
   });


### PR DESCRIPTION
## Summary
Fixes #2172

On Windows, skill detection fails for skills that require CLI binaries (e.g., blogwatcher, yt-dlp, ffmpeg) because `src/infra/binaries.ts` uses the `which` command, which is not native to Windows. Windows uses `where.exe` instead.

## Changes
- Modified `src/infra/binaries.ts` to use `process.platform === "win32" ? "where" : "which"` pattern
- This follows the existing pattern used elsewhere in the codebase:
  - `src/daemon/program-args.ts:140`
  - `src/commands/onboard-helpers.ts:304`

## Test Coverage
Added tests for both Unix and Windows platforms in `src/infra/binaries.test.ts`:
- Unix: verifies `which` is used
- Windows: verifies `where` is used

## Testing
- All 4 tests pass (2 Unix + 2 Windows)
- Linting passes for modified files

## Impact
Skills requiring binaries will now be correctly detected on Windows.

---

AI-assisted PR. Changes were tested with `pnpm test src/infra/binaries.test.ts` and linted with `pnpm exec oxlint`.