### PR TITLE
fix(cron): anchor 'every' jobs to lastRunAtMs instead of now

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -61,7 +61,13 @@ export function recomputeNextRuns(state: CronServiceState) {
       );
       job.state.runningAtMs = undefined;
     }
-    job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+    // For "every" jobs, anchor to lastRunAtMs to prevent schedule drift.
+    // For other job types (at, cron), use current time.
+    const baseTime =
+      job.schedule.kind === "every" && typeof job.state.lastRunAtMs === "number"
+        ? job.state.lastRunAtMs
+        : now;
+    job.state.nextRunAtMs = computeJobNextRunAtMs(job, baseTime);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes #1972

For jobs with `schedule.kind="every"`, `nextRunAtMs` was calculated from the current time (`now`) instead of `lastRunAtMs`, causing schedule drift when job state was updated.

## Problem

When a job with `everyMs: 3600000` (1 hour) runs successfully:
- `lastRunAtMs`: 1769372901882 (3:28 PM)
- Expected `nextRunAtMs`: 1769376501882 (4:28 PM = lastRun + 1hr)
- Actual stored `nextRunAtMs`: 1769381650482 (5:54 PM) = **+85 min drift**

Each time the job state was touched (e.g., via patch), `recomputeNextRuns()` recalculated `nextRunAtMs` from the current moment, pushing the schedule further into the future.

## Solution

Modified `recomputeNextRuns()` in `src/cron/service/jobs.ts` to:
- For `kind: "every"` jobs: anchor to `lastRunAtMs` (if available)
- For `kind: "at"` and `kind: "cron"` jobs: continue using current time

This preserves the original schedule for interval-based jobs while maintaining existing behavior for other job types.

## Testing
- All 50 cron-related tests pass
- Linting passes for modified files

## Impact
Interval-based cron jobs (`everyMs`) now maintain consistent schedules regardless of state updates.

---

AI-assisted PR. Changes were tested with `pnpm test src/cron/` and linted with `pnpm exec oxlint`.