### PR TITLE
docs(cron): improve tool description with explicit required fields

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -147,36 +147,48 @@ ACTIONS:
 
 JOB SCHEMA (for add action):
 {
-  "name": "string (optional)",
-  "schedule": { ... },      // Required: when to run
-  "payload": { ... },       // Required: what to execute
-  "sessionTarget": "main" | "isolated",  // Required
-  "enabled": true | false   // Optional, default true
+  "name": "string (optional, required for update)",
+  "schedule": { ... },                  // REQUIRED: when to run
+  "payload": { ... },                   // REQUIRED: what to execute
+  "sessionTarget": "main" | "isolated",  // REQUIRED: which session type
+  "enabled": true | false,              // OPTIONAL, default true
+  "deleteAfterRun": true | false        // OPTIONAL, default false (for one-shot jobs)
 }
 
-SCHEDULE TYPES (schedule.kind):
-- "at": One-shot at absolute time
-  { "kind": "at", "atMs": <unix-ms-timestamp> }
-- "every": Recurring interval
-  { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
-- "cron": Cron expression
-  { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-timezone>" }
+SCHEDULE TYPES (schedule.kind - choose exactly one):
+- "at": One-shot job at absolute timestamp (ms since epoch)
+  { "kind": "at", "atMs": 1699900000000 }
 
-PAYLOAD TYPES (payload.kind):
-- "systemEvent": Injects text as system event into session
-  { "kind": "systemEvent", "text": "<message>" }
-- "agentTurn": Runs agent with message (isolated sessions only)
-  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional>, "deliver": <optional-bool>, "channel": "<optional>", "to": "<optional>", "bestEffortDeliver": <optional-bool> }
+- "every": Recurring interval (milliseconds)
+  { "kind": "every", "everyMs": 3600000 }
 
-CRITICAL CONSTRAINTS:
-- sessionTarget="main" REQUIRES payload.kind="systemEvent"
-- sessionTarget="isolated" REQUIRES payload.kind="agentTurn"
+- "cron": Standard cron expression
+  { "kind": "cron", "expr": "0 9 * * 1-5", "tz": "America/New_York" }
+
+PAYLOAD TYPES (payload.kind - choose exactly one):
+- "systemEvent": Inject text as system event (for sessionTarget="main" ONLY)
+  { "kind": "systemEvent", "text": "Your reminder message" }
+  REQUIRED FIELDS: kind, text
+
+- "agentTurn": Run agent with message (for sessionTarget="isolated" ONLY)
+  { "kind": "agentTurn", "message": "Your prompt here" }
+  REQUIRED FIELDS: kind, message
+  OPTIONAL FIELDS: model, thinking, timeoutSeconds, deliver, channel, to, bestEffortDeliver
+
+SESSION TARGET (sessionTarget - choose exactly one):
+- "main": Main session - REQUIRES payload.kind="systemEvent"
+- "isolated": Sub-agent session - REQUIRES payload.kind="agentTurn"
+
+CRITICAL CONSTRAINTS (will fail validation if violated):
+1. sessionTarget="main" MUST use payload.kind="systemEvent" with text field
+2. sessionTarget="isolated" MUST use payload.kind="agentTurn" with message field
+3. Do NOT mix: main+agentTurn or isolated+systemEvent
 
 WAKE MODES (for wake action):
-- "next-heartbeat" (default): Wake on next heartbeat
-- "now": Wake immediately
+- "next-heartbeat" (default): Deliver on next heartbeat cycle
+- "now": Deliver immediately
 
-Use jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.`,
+Use jobId as the canonical identifier; id is accepted for backward compatibility. Use contextMessages (0-10) to add previous chat messages as context to reminder jobs.`,
     parameters: CronToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary
Fixes #1982

Improved cron tool description to help AI agents reliably create cron jobs without guessing enum values or failing validation.

## Problem

AI agents were failing to create cron jobs because:
1. Required fields were not explicitly marked
2. Enum values had to be guessed through trial and error
3. Cross-field constraints were not clearly documented

Example validation errors:
- `missing required property 'text'`
- `unexpected property 'message'`
- `must match a schema in anyOf`

## Solution

Enhanced the tool description with:
- **Explicit REQUIRED markers**: schedule, payload, sessionTarget
- **Required vs Optional fields** for each payload kind
- **Concrete examples** for each schedule type (at, every, cron)
- **"Choose exactly one" guidance** for enum selections
- **Numbered constraint rules** with clear failure warnings
- **Added deleteAfterRun** to the job schema documentation

## Changes
- Modified `src/agents/tools/cron-tool.ts` description field
- No code logic changes, only documentation

## Testing
- All 15 cron-tool tests pass
- Linting passes for modified files

## Impact
AI agents can now construct valid cron add payloads on the first try without guessing enum values or discovering constraints through validation failures.

---

AI-assisted PR. Changes were tested with `pnpm test src/agents/tools/cron-tool.test.ts` and linted with `pnpm exec oxlint`.