### PR TITLE
Add sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://github.com/sponsors/steipete']


### PR DESCRIPTION
This PR adds the [Sponsor] button on the projects button bar.

Noticed how [Peter mentioned that not many people find the sponsor button](https://x.com/steipete/status/2015024340031390019) (I couldn't either), so I added it to the project using FUNDING.

After merging this you would need to enable the `Sponsorships` option on the project settings

<img width="1016" height="200" alt="Screenshot 2026-01-26 at 18 28 42" src="https://github.com/user-attachments/assets/bdc549ab-fcb3-4561-9626-3a0d4b82af1d" />
