### PR TITLE
fix: exclude Linux native builds when downloading signal-cli on macOS/Windows

### DIFF
--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -53,13 +53,25 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
   if (platform === "darwin") {
     return (
       byName(/macos|osx|darwin/) ||
-      withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
+      // Fall back to JVM version, excluding platform-specific native builds
+      withName.find(
+        (asset) =>
+          looksLikeArchive(asset.name.toLowerCase()) &&
+          !asset.name.toLowerCase().includes("linux-native") &&
+          !asset.name.toLowerCase().includes("windows"),
+      )
     );
   }
 
   if (platform === "win32") {
     return (
-      byName(/windows|win/) || withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
+      byName(/windows|win/) ||
+      // Fall back to JVM version, excluding platform-specific native builds
+      withName.find(
+        (asset) =>
+          looksLikeArchive(asset.name.toLowerCase()) &&
+          !asset.name.toLowerCase().includes("linux-native"),
+      )
     );
   }
 

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -54,12 +54,14 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
     return (
       byName(/macos|osx|darwin/) ||
       // Fall back to JVM version, excluding platform-specific native builds
-      withName.find(
-        (asset) =>
-          looksLikeArchive(asset.name.toLowerCase()) &&
-          !asset.name.toLowerCase().includes("linux-native") &&
-          !asset.name.toLowerCase().includes("windows"),
-      )
+      withName.find((asset) => {
+        const name = asset.name.toLowerCase();
+        return (
+          looksLikeArchive(name) &&
+          !name.includes("linux-native") &&
+          !/windows|win/.test(name)
+        );
+      })
     );
   }
 


### PR DESCRIPTION
## Summary

- Fix signal-cli auto-install on macOS (and Windows) by excluding Linux native builds from fallback selection
- Previously, `pickAsset()` would select the first archive found when no platform-specific build existed, which could be the Linux native build
- This caused `spawn Unknown system error -8` (ENOEXEC) on macOS ARM since the Linux ELF binary cannot execute there

## Problem

On macOS ARM, running `clawdbot doctor` or setting up Signal would download `signal-cli-X.X.X-Linux-native.tar.gz` instead of the JVM version `signal-cli-X.X.X.tar.gz`. The Linux ELF binary fails to execute with error code -8 (ENOEXEC).

## Solution

Update the fallback logic in `pickAsset()` to explicitly exclude platform-specific native builds (`linux-native`, `windows`) when selecting an archive on non-matching platforms. This ensures the cross-platform JVM version is selected.

## Test plan

- [ ] Test on macOS: `clawdbot` should download `signal-cli-X.X.X.tar.gz` (JVM version)
- [ ] Test on Linux: `clawdbot` should still prefer `signal-cli-X.X.X-Linux-native.tar.gz`
- [ ] Verify signal-cli starts successfully after install on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `pickAsset()` in `src/commands/signal-install.ts` to avoid selecting Linux native `signal-cli` archives as a fallback on macOS/Windows, ensuring the cross-platform JVM archive is chosen when no platform-specific build exists. This addresses macOS ENOEXEC failures when a Linux ELF binary is accidentally downloaded and extracted.

The change fits into the existing auto-install flow by only affecting asset selection; download/extraction and binary discovery remain unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small risk of edge-case asset selection on Windows/WSL.
- The change is localized to selection logic and clearly targets a real failure mode (macOS selecting Linux-native). Main concern is the `win32` fallback still permitting Windows-native archives in some scenarios, which could break in mixed environments; otherwise behavior is unchanged.
- src/commands/signal-install.ts (asset selection logic and platform fallback behavior)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->