### PR TITLE
fix: validate E.164 format for Signal account number during onboarding

### DIFF
--- a/src/channels/plugins/onboarding/signal.ts
+++ b/src/channels/plugins/onboarding/signal.ts
@@ -235,12 +235,20 @@ export const signalOnboardingAdapter: ChannelOnboardingAdapter = {
     }
 
     if (!account) {
-      account = String(
+      const rawAccount = String(
         await prompter.text({
           message: "Signal bot number (E.164)",
-          validate: (value) => (value?.trim() ? undefined : "Required"),
+          validate: (value) => {
+            const trimmed = value?.trim();
+            if (!trimmed) return "Required";
+            if (!normalizeE164(trimmed)) {
+              return "Invalid E.164 phone number (must start with + and country code, e.g. +15555550123)";
+            }
+            return undefined;
+          },
         }),
       ).trim();
+      account = normalizeE164(rawAccount) ?? rawAccount;
     }
 
     if (account) {


### PR DESCRIPTION
## Summary

- Add proper E.164 phone number validation to Signal account prompt during onboarding
- Normalize the account value before storing to ensure consistent format

## Problem

The Signal account number prompt only validated that *some* text was entered:

```typescript
validate: (value) => (value?.trim() ? undefined : "Required"),
```

This allowed invalid values like `"ok"` to be stored if a user typed it thinking they were confirming a prompt. The Signal channel would then fail with confusing errors since `"ok"` isn't a valid phone number.

## Solution

Use the existing `normalizeE164` utility to validate the input is a proper E.164 phone number, and provide a helpful error message:

```
Invalid E.164 phone number (must start with + and country code, e.g. +15555550123)
```

Also normalize the stored value to ensure consistent format.

## Test plan

- [ ] Run `clawdbot configure` and select Signal channel
- [ ] Try entering invalid values like "ok", "test", "12345" - should show validation error
- [ ] Enter valid E.164 number like "+15555550123" - should be accepted
- [ ] Verify stored value in `clawdbot.json` is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal onboarding (`src/channels/plugins/onboarding/signal.ts`) to require an E.164-formatted “Signal bot number” instead of only checking for non-empty input, and then normalizes the value before storing it.

The change fits into the existing onboarding flow by reusing the shared `normalizeE164` utility already used elsewhere to normalize phone inputs during channel setup.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the new validation does not actually reject invalid inputs.
- Although the intent is correct, `normalizeE164` always returns a `+`-prefixed string, so the added validation condition never fails and invalid values can still be stored. The net effect is likely user-visible misconfiguration rather than improved onboarding.
- src/channels/plugins/onboarding/signal.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->