### PR TITLE
fix: normalize toolCall arguments to prevent Anthropic API rejection

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -53,4 +53,8 @@ export {
 export type { EmbeddedContextFile, FailoverReason } from "./pi-embedded-helpers/types.js";
 
 export type { ToolCallIdMode } from "./tool-call-id.js";
-export { isValidCloudCodeAssistToolId, sanitizeToolCallId } from "./tool-call-id.js";
+export {
+  isValidCloudCodeAssistToolId,
+  sanitizeToolCallId,
+  normalizeToolCallArguments,
+} from "./tool-call-id.js";

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isValidCloudCodeAssistToolId,
+  normalizeToolCallArguments,
   sanitizeToolCallIdsForCloudCodeAssist,
 } from "./tool-call-id.js";
 
@@ -264,5 +265,111 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect(r1.toolCallId).toBe(a.id);
       expect(r2.toolCallId).toBe(b.id);
     });
+  });
+});
+
+describe("normalizeToolCallArguments", () => {
+  it("is a no-op when arguments are already present", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "read", arguments: { path: "/tmp" } }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).toBe(input);
+  });
+
+  it("normalizes undefined arguments to empty object", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "memory_status" }],
+      },
+    ] as AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: unknown };
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("normalizes null arguments to empty object", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "memory_status", arguments: null }],
+      },
+    ] as AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: unknown };
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("handles multiple toolCalls in single message", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call1", name: "memory_status" },
+          { type: "toolCall", id: "call2", name: "read", arguments: { path: "/tmp" } },
+          { type: "toolCall", id: "call3", name: "load_memory" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const call1 = assistant.content?.[0] as { arguments?: unknown };
+    const call2 = assistant.content?.[1] as { arguments?: unknown };
+    const call3 = assistant.content?.[2] as { arguments?: unknown };
+    expect(call1.arguments).toEqual({});
+    expect(call2.arguments).toEqual({ path: "/tmp" });
+    expect(call3.arguments).toEqual({});
+  });
+
+  it("handles toolUse and functionCall types", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "call1", name: "status" },
+          { type: "functionCall", id: "call2", name: "ping" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const call1 = assistant.content?.[0] as { arguments?: unknown };
+    const call2 = assistant.content?.[1] as { arguments?: unknown };
+    expect(call1.arguments).toEqual({});
+    expect(call2.arguments).toEqual({});
+  });
+
+  it("does not modify user or toolResult messages", () => {
+    const input = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "toolResult",
+        toolCallId: "call1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).toBe(input);
   });
 });

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -186,3 +186,43 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
 
   return changed ? out : messages;
 }
+
+/**
+ * Normalize toolCall arguments to ensure they are always an object.
+ * Some models (e.g., via google-antigravity) may omit the `arguments` field
+ * for tools with no required parameters. Anthropic API requires `input` to be present.
+ */
+export function normalizeToolCallArguments(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const out = messages.map((msg) => {
+    if (!msg || typeof msg !== "object") return msg;
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") return msg;
+
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    const content = assistant.content;
+    if (!Array.isArray(content)) return msg;
+
+    let contentChanged = false;
+    const nextContent = content.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const rec = block as { type?: unknown; arguments?: unknown };
+      const type = rec.type;
+      if (type !== "functionCall" && type !== "toolUse" && type !== "toolCall") {
+        return block;
+      }
+      // Normalize missing or undefined arguments to empty object
+      if (rec.arguments === undefined || rec.arguments === null) {
+        contentChanged = true;
+        return { ...(block as unknown as Record<string, unknown>), arguments: {} };
+      }
+      return block;
+    });
+
+    if (!contentChanged) return msg;
+    changed = true;
+    return { ...assistant, content: nextContent as typeof assistant.content };
+  });
+
+  return changed ? out : messages;
+}


### PR DESCRIPTION
## Problem

Some models (e.g., via google-antigravity) omit the `arguments` field for tools with no required parameters. When this happens, pi-ai passes `undefined` to Anthropic's `input` field, causing API rejection:

```
messages.N.content.M.tool_use.input: Field required
```

## Solution

Added `normalizeToolCallArguments()` which ensures `arguments` is always an object (defaulting to `{}`) before messages reach the API.

## Affected tools

- `memory_status`
- `load_memory` (without trigger)
- Any tool with optional-only or no parameters

## Testing

Added tests in `tool-call-id.test.ts` covering:
- Already-present arguments (no-op)
- Undefined arguments → `{}`
- Null arguments → `{}`
- Multiple toolCalls in single message
- Different tool types (toolCall, toolUse, functionCall)
- Non-assistant messages unchanged

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `normalizeToolCallArguments()` to ensure assistant tool-call blocks always have an object-valued `arguments` field (defaulting missing/`null` to `{}`), preventing downstream providers (notably Anthropic) from rejecting messages where tool input is required but omitted by upstream models. The normalization is exported via `pi-embedded-helpers` and applied in the Google transcript sanitization pipeline (`sanitizeSessionHistory`), and a dedicated vitest suite is added to validate behavior across tool block types and message roles.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and should fix the reported provider rejection scenario.
- Changes are small and localized (pure normalization + wiring + tests). The main risk is scope/semantics (normalizing tool-call arguments for all providers) and a slightly misleading comment; no functional regressions were evident from code inspection, but I couldn’t run the test suite in this environment (pnpm unavailable).
- src/agents/pi-embedded-runner/google.ts (ensure the intended scope of normalization/comment matches behavior)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->