### PR TITLE
feat(android): add password field to manual gateway settings

### DIFF
--- a/apps/android/app/src/main/java/com/clawdbot/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/MainViewModel.kt
@@ -51,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val manualPassword: StateFlow<String> = runtime.manualPassword
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +103,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setManualPassword(value: String) {
+    runtime.setManualPassword(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/com/clawdbot/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/NodeRuntime.kt
@@ -284,6 +284,7 @@ class NodeRuntime(context: Context) {
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
+  val manualPassword: StateFlow<String> = prefs.manualPassword
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
 
@@ -428,6 +429,10 @@ class NodeRuntime(context: Context) {
     prefs.setManualTls(value)
   }
 
+  fun setManualPassword(value: String) {
+    prefs.setManualPassword(value)
+  }
+
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
   }
@@ -563,7 +568,12 @@ class NodeRuntime(context: Context) {
     nodeStatusText = "Connecting…"
     updateStatus()
     val token = prefs.loadGatewayToken()
-    val password = prefs.loadGatewayPassword()
+    // For manual endpoints, use the manual password if set; otherwise fall back to stored password.
+    val password = if (endpoint.stableId.startsWith("manual|")) {
+      manualPassword.value.takeIf { it.isNotEmpty() } ?: prefs.loadGatewayPassword()
+    } else {
+      prefs.loadGatewayPassword()
+    }
     val tls = resolveTlsParams(endpoint)
     operatorSession.connect(endpoint, token, password, buildOperatorConnectOptions(), tls)
     nodeSession.connect(endpoint, token, password, buildNodeConnectOptions(), tls)

--- a/apps/android/app/src/main/java/com/clawdbot/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/SecurePrefs.kt
@@ -74,6 +74,10 @@ class SecurePrefs(context: Context) {
     MutableStateFlow(readBoolWithMigration("gateway.manual.tls", null, true))
   val manualTls: StateFlow<Boolean> = _manualTls
 
+  private val _manualPassword =
+    MutableStateFlow(prefs.getString("gateway.manual.password", null)?.trim() ?: "")
+  val manualPassword: StateFlow<String> = _manualPassword
+
   private val _lastDiscoveredStableId =
     MutableStateFlow(
       readStringWithMigration(
@@ -148,6 +152,12 @@ class SecurePrefs(context: Context) {
   fun setManualTls(value: Boolean) {
     prefs.edit { putBoolean("gateway.manual.tls", value) }
     _manualTls.value = value
+  }
+
+  fun setManualPassword(value: String) {
+    val trimmed = value.trim()
+    prefs.edit { putString("gateway.manual.password", trimmed) }
+    _manualPassword.value = trimmed
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/com/clawdbot/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/ui/SettingsSheet.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -82,6 +83,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val manualPassword by viewModel.manualPassword.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
   val serverName by viewModel.serverName.collectAsState()
@@ -402,6 +404,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
             label = { Text("Port") },
             modifier = Modifier.fillMaxWidth(),
             enabled = manualEnabled,
+          )
+          OutlinedTextField(
+            value = manualPassword,
+            onValueChange = viewModel::setManualPassword,
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = manualEnabled,
+            visualTransformation = PasswordVisualTransformation(),
+            singleLine = true,
           )
           ListItem(
             headlineContent = { Text("Require TLS") },


### PR DESCRIPTION
## Summary

Adds a password field to the Android app's manual gateway settings, allowing users to connect to password-protected gateways.

## Changes

- **SecurePrefs.kt** — Added `manualPassword` storage
- **NodeRuntime.kt** — Exposed password and use it for manual connections  
- **MainViewModel.kt** — Exposed password to UI
- **SettingsSheet.kt** — Added password input field in Advanced section (uses PasswordVisualTransformation)

## Testing

Tested locally with a password-protected gateway running in LAN mode.

---

*Split from #2219 which contained unrelated changes.*