### PR TITLE
fix(cron): warn when isolated job won't deliver output

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -177,6 +177,19 @@ export function registerCronAddCommand(cron: Command) {
             throw new Error("Isolated jobs require --message (agentTurn).");
           }
 
+          // Warn if isolated job won't deliver output anywhere
+          if (
+            sessionTarget === "isolated" &&
+            payload.kind === "agentTurn" &&
+            !payload.deliver &&
+            !payload.to
+          ) {
+            defaultRuntime.error(
+              "warning: isolated job has --message but no --deliver or --to; agent output will not be sent.\n" +
+                "Add --deliver --channel <channel> --to <dest> if you want proactive message delivery.",
+            );
+          }
+
           const isolation =
             sessionTarget === "isolated"
               ? {


### PR DESCRIPTION
## Summary

When creating an isolated cron job with `--message` but without `--deliver` or `--to`, the job runs but the agent output goes nowhere. This is a common mistake that's hard to debug - the job appears to succeed but nothing is actually delivered.

This was discovered when an LLM agent (running on clawdbot) created hourly check-in jobs that never sent messages. The agent assumed `--message` meant the message would be sent, but without `--deliver --channel --to`, the output just disappears.

## Changes

- Add a warning when creating isolated jobs without delivery configuration
- Suggests adding `--deliver --channel <channel> --to <dest>` for proactive delivery

## Example

Before (silent failure):
```bash
clawdbot cron add --name "reminder" --at +10m --session isolated --message "Check email"
# Job runs, output goes nowhere, no indication of the problem
```

After (helpful warning):
```bash
clawdbot cron add --name "reminder" --at +10m --session isolated --message "Check email"
# warning: isolated job has --message but no --deliver or --to; agent output will not be sent.
# Add --deliver --channel <channel> --to <dest> if you want proactive message delivery.
```

## Test plan

- [x] Existing tests pass (`vitest run src/cli/cron-cli.test.ts`)
- [x] Lint passes
- [ ] Manual test: create isolated job without delivery, verify warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a CLI-side warning when creating an **isolated** cron job using `--message` but without any delivery configuration (`--deliver` or `--to`), to help users avoid jobs that run successfully but never proactively send their output anywhere. The check is implemented in `src/cli/cron-cli/register.cron-add.ts` after validating the session/payload pairing, and emits a guidance message suggesting `--deliver --channel <channel> --to <dest>`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk.
- Change is small, localized to CLI argument handling, and only adds a warning without altering the request payload sent to the gateway. Main consideration is how emitting warnings on stderr may impact scripting/automation expectations.
- src/cli/cron-cli/register.cron-add.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->