### PR TITLE
feat(nostr): add NIP-17 private direct messages support

### DIFF
--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -32,7 +32,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
     selectionLabel: "Nostr",
     docsPath: "/channels/nostr",
     docsLabel: "nostr",
-    blurb: "Decentralized DMs via Nostr relays (NIP-04)",
+    blurb: "Decentralized DMs via Nostr relays (NIP-04/NIP-17)",
     order: 100,
   },
   capabilities: {
@@ -218,21 +218,88 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         accountId: account.accountId,
         privateKey: account.privateKey,
         relays: account.relays,
-        onMessage: async (senderPubkey, text, reply) => {
+        dmProtocol: account.dmProtocol,
+        onMessage: async (senderPubkey, text, replyFn) => {
           ctx.log?.debug(`[${account.accountId}] DM from ${senderPubkey}: ${text.slice(0, 50)}...`);
 
-          // Forward to clawdbot's message pipeline
-          await runtime.channel.reply.handleInboundMessage({
-            channel: "nostr",
-            accountId: account.accountId,
-            senderId: senderPubkey,
-            chatType: "direct",
-            chatId: senderPubkey, // For DMs, chatId is the sender's pubkey
-            text,
-            reply: async (responseText: string) => {
-              await reply(responseText);
-            },
-          });
+          try {
+            // Load config for routing and session handling
+            const config = runtime.config.loadConfig();
+
+            // Resolve agent route for this DM
+            const route = runtime.channel.routing.resolveAgentRoute({
+              cfg: config,
+              channel: "nostr",
+              accountId: account.accountId,
+              peer: { kind: "dm", id: senderPubkey },
+            });
+
+            // Resolve store path for session recording
+            const storePath = runtime.channel.session.resolveStorePath(config.session?.store, {
+              agentId: route.agentId,
+            });
+
+            // Build the inbound context payload (no envelope - pass raw text)
+            const fromLabel = `nostr:${senderPubkey.slice(0, 8)}`;
+            const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+              Body: text,
+              RawBody: text,
+              CommandBody: text,
+              From: `nostr:${senderPubkey}`,
+              To: `nostr:${account.publicKey}`,
+              SessionKey: route.sessionKey,
+              AccountId: account.accountId,
+              ChatType: "direct",
+              ConversationLabel: fromLabel,
+              SenderName: undefined,
+              SenderId: senderPubkey,
+              Provider: "nostr" as const,
+              Surface: "nostr" as const,
+              MessageSid: `nostr-${Date.now()}`,
+              OriginatingChannel: "nostr" as const,
+              OriginatingTo: `nostr:${account.publicKey}`,
+            });
+
+            // Record the inbound session
+            await runtime.channel.session.recordInboundSession({
+              storePath,
+              sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+              ctx: ctxPayload,
+              onRecordError: (err) => {
+                ctx.log?.error(`[${account.accountId}] Failed to record session: ${String(err)}`);
+              },
+            });
+
+            // Resolve table mode for reply formatting
+            const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+              cfg: config,
+              channel: "nostr",
+              accountId: account.accountId,
+            });
+
+            // Dispatch the reply through the agent pipeline
+            await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+              ctx: ctxPayload,
+              cfg: config,
+              dispatcherOptions: {
+                deliver: async (payload) => {
+                  const replyText = runtime.channel.text.convertMarkdownTables(
+                    payload.text ?? "",
+                    tableMode
+                  );
+                  if (replyText.trim()) {
+                    await replyFn(replyText);
+                    ctx.setStatus({ lastOutboundAt: Date.now() });
+                  }
+                },
+                onError: (err, info) => {
+                  ctx.log?.error(`[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`);
+                },
+              },
+            });
+          } catch (err) {
+            ctx.log?.error(`[${account.accountId}] onMessage error: ${String(err)}`);
+          }
         },
         onError: (error, context) => {
           ctx.log?.error(`[${account.accountId}] Nostr error (${context}): ${error.message}`);

--- a/extensions/nostr/src/config-schema.ts
+++ b/extensions/nostr/src/config-schema.ts
@@ -75,6 +75,14 @@ export const NostrConfigSchema = z.object({
   /** DM access policy: pairing, allowlist, open, or disabled */
   dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
 
+  /**
+   * DM protocol preference:
+   * - "dual" (default): Accept both NIP-04 and NIP-17, send using NIP-17
+   * - "nip17": NIP-17 only (private DMs with gift wrap)
+   * - "nip04": NIP-04 only (legacy encrypted DMs)
+   */
+  dmProtocol: z.enum(["dual", "nip17", "nip04"]).optional(),
+
   /** Allowed sender pubkeys (npub or hex format) */
   allowFrom: z.array(allowFromEntry).optional(),
 

--- a/extensions/nostr/src/nostr-profile.ts
+++ b/extensions/nostr/src/nostr-profile.ts
@@ -150,7 +150,8 @@ export async function publishProfileEvent(
         setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
       });
 
-      await Promise.race([pool.publish([relay], event), timeoutPromise]);
+      // pool.publish returns Promise<string>[], get the first promise
+      await Promise.race([pool.publish([relay], event)[0], timeoutPromise]);
 
       successes.push(relay);
     } catch (err) {

--- a/extensions/nostr/src/types.ts
+++ b/extensions/nostr/src/types.ts
@@ -1,5 +1,5 @@
 import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
-import { getPublicKeyFromPrivate } from "./nostr-bus.js";
+import { getPublicKeyFromPrivate, type DmProtocol } from "./nostr-bus.js";
 import { DEFAULT_RELAYS } from "./nostr-bus.js";
 import type { NostrProfile } from "./config-schema.js";
 
@@ -9,6 +9,7 @@ export interface NostrAccountConfig {
   privateKey?: string;
   relays?: string[];
   dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  dmProtocol?: DmProtocol;
   allowFrom?: Array<string | number>;
   profile?: NostrProfile;
 }
@@ -21,6 +22,7 @@ export interface ResolvedNostrAccount {
   privateKey: string;
   publicKey: string;
   relays: string[];
+  dmProtocol: DmProtocol;
   profile?: NostrProfile;
   config: NostrAccountConfig;
 }
@@ -85,6 +87,7 @@ export function resolveNostrAccount(opts: {
     privateKey,
     publicKey,
     relays: nostrCfg?.relays ?? DEFAULT_RELAYS,
+    dmProtocol: nostrCfg?.dmProtocol ?? "dual",
     profile: nostrCfg?.profile,
     config: {
       enabled: nostrCfg?.enabled,
@@ -92,6 +95,7 @@ export function resolveNostrAccount(opts: {
       privateKey: nostrCfg?.privateKey,
       relays: nostrCfg?.relays,
       dmPolicy: nostrCfg?.dmPolicy,
+      dmProtocol: nostrCfg?.dmProtocol,
       allowFrom: nostrCfg?.allowFrom,
       profile: nostrCfg?.profile,
     },


### PR DESCRIPTION
## Summary

Adds NIP-17 (Private Direct Messages) with NIP-59 (Gift Wrap) support to the Nostr extension, enabling modern private messaging alongside the legacy NIP-04 protocol.

## Nostr DM Protocol Background

### NIP-04 (Legacy Encrypted DMs)
- **Kind 4** events with NIP-04 encryption
- Metadata leakage: sender, recipient, and timing are visible on relays
- Simple encryption using shared secret (ECDH + AES-CBC)
- Widely supported but considered deprecated for privacy reasons

### NIP-17 (Private Direct Messages) 
- **Kind 14** rumor wrapped in **Kind 13** seal, then **Kind 1059** gift wrap
- Privacy-preserving: sender pubkey hidden inside encrypted layers
- Timestamps randomized ±48 hours to prevent timing analysis
- Uses NIP-44 encryption (XChaCha20-Poly1305, more secure than NIP-04)
- Recommended standard for new implementations

### Protocol Comparison

| Aspect | NIP-04 | NIP-17 |
|--------|--------|--------|
| Event Kind | 4 | 1059 (gift wrap) → 13 (seal) → 14 (rumor) |
| Sender Visible | Yes | No (encrypted in seal) |
| Recipient Visible | Yes | Yes (in gift wrap `p` tag) |
| Timestamps | Real | Randomized ±48 hours |
| Encryption | AES-CBC | XChaCha20-Poly1305 |
| Privacy | Low | High |

## Changes

### Dual Protocol Support
- Subscribe to both kind:4 (NIP-04) and kind:1059 (GiftWrap) events
- Use 48-hour lookback window for NIP-17 (due to randomized timestamps)
- Unwrap gift wraps using `nostr-tools/nip59` to extract the inner rumor

### Configuration
New `dmProtocol` option in channel config:
- `"dual"` (default): Accept both NIP-04 and NIP-17, send using NIP-17
- `"nip17"`: NIP-17 only (maximum privacy)
- `"nip04"`: NIP-04 only (legacy compatibility)

### Sending
- When `dmProtocol` is `"dual"` or `"nip17"`, replies use NIP-17 gift wrapping
- Creates both sender and recipient wrapped copies per spec
- Falls back to NIP-04 when `dmProtocol` is `"nip04"`

### Other Fixes
- Fix `pool.publish()` calls (returns `Promise<string>[]`, need to await `[0]`)
- Pass raw message text to agent (no envelope formatting)

## Test Plan

- [x] Gateway starts and connects to relays
- [x] NIP-04 DMs received and processed
- [x] NIP-17 gift-wrapped DMs received and unwrapped
- [x] Replies sent using NIP-17 protocol
- [x] `dmProtocol` config option saves correctly in UI

## References

- [NIP-04: Encrypted Direct Message](https://github.com/nostr-protocol/nips/blob/master/04.md)
- [NIP-17: Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)
- [NIP-44: Versioned Encryption](https://github.com/nostr-protocol/nips/blob/master/44.md)

---

🤖 Generated with [Claude Code](https://claude.ai/code)