### PR TITLE
fix(heartbeat): remove unhandled rejection crash in wake handler

### DIFF
--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -37,10 +37,10 @@ function schedule(coalesceMs: number) {
         pendingReason = reason ?? "retry";
         schedule(DEFAULT_RETRY_MS);
       }
-    } catch (err) {
+    } catch {
+      // Error is already logged by the heartbeat runner; schedule a retry.
       pendingReason = reason ?? "retry";
       schedule(DEFAULT_RETRY_MS);
-      throw err;
     } finally {
       running = false;
       if (pendingReason || scheduled) schedule(coalesceMs);


### PR DESCRIPTION
## Summary
- Fixes gateway crash caused by unhandled promise rejection in heartbeat wake handler
- The async `setTimeout` callback was re-throwing errors without a `.catch()` handler
- Error is already logged by the heartbeat runner and a retry is scheduled, so the re-throw was unnecessary

## Root Cause
In `src/infra/heartbeat-wake.ts:43`, errors were re-thrown inside an async `setTimeout` callback. Since `setTimeout` doesn't return a catchable promise, this became an unhandled rejection that triggered `process.exit(1)` via the global handler.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual test: gateway should no longer crash on transient network failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)