### PR TITLE
fix: sanitize incomplete tool calls with partialJson

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import {
+  sanitizeToolUseResultPairing,
+  sanitizePartialToolCalls,
+} from "./session-transcript-repair.js";
 
 describe("sanitizeToolUseResultPairing", () => {
   it("moves tool results directly after tool calls and inserts missing results", () => {
@@ -108,5 +111,134 @@ describe("sanitizeToolUseResultPairing", () => {
     const out = sanitizeToolUseResultPairing(input);
     expect(out.some((m) => m.role === "toolResult")).toBe(false);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("removes incomplete tool calls with partialJson and drops their orphaned results", () => {
+    // This simulates a terminated request where tool call was incomplete
+    // Note: arguments is undefined/missing when truly incomplete
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me write that file:" },
+          {
+            type: "toolCall",
+            id: "call_incomplete",
+            name: "write",
+            // arguments is missing - only partialJson exists
+            partialJson: '{"path": "/tmp/test.md", "content": "# Hello',
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_incomplete",
+        toolName: "write",
+        content: [{ type: "text", text: "[clawdbot] synthetic error result" }],
+        isError: true,
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    // The incomplete tool call should be removed from content
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content[0]).toEqual({ type: "text", text: "Let me write that file:" });
+    // The orphaned tool result should also be dropped
+    expect(out.filter((m) => m.role === "toolResult")).toHaveLength(0);
+  });
+
+  it("keeps complete tool calls even if partialJson was captured", () => {
+    // If arguments is complete, the tool call should be kept
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_complete",
+            name: "read",
+            arguments: { path: "/tmp/test.md" },
+            partialJson: '{"path": "/tmp/test.md"}', // partialJson exists but args complete
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_complete",
+        toolName: "read",
+        content: [{ type: "text", text: "file contents" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.role).toBe("assistant");
+    expect(out[1]?.role).toBe("toolResult");
+  });
+});
+
+describe("sanitizePartialToolCalls", () => {
+  it("removes tool calls with partialJson but no arguments", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Working on it" },
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "write",
+            partialJson: '{"path": "/tmp/file.md", "content": "partial...',
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizePartialToolCalls(input);
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toHaveLength(1);
+    expect((assistant.content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("removes tool calls with partialJson and empty arguments", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "write",
+            arguments: {},
+            partialJson: '{"path": "/tmp',
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizePartialToolCalls(input);
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toHaveLength(0);
+  });
+
+  it("preserves complete tool calls without partialJson", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "read",
+            arguments: { path: "/tmp/file.md" },
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizePartialToolCalls(input);
+    expect(out).toBe(input); // Should return same reference if unchanged
   });
 });


### PR DESCRIPTION
## Problem

When a request is terminated mid-stream (e.g., timeout, user interrupt), tool call blocks may be written to the session with `partialJson` but incomplete/missing `arguments`. 

The existing repair mechanism adds synthetic tool_result entries for these incomplete tool calls, but the Anthropic API rejects them because:
1. The tool_use block exists but is malformed (partialJson without complete args)
2. The orphaned tool_result references a tool_use_id that doesn't properly exist

Error message:
```
messages.36.content.5: unexpected tool_use_id found in tool_result blocks: toolu_xxx. 
Each tool_result block must have a corresponding tool_use block in the previous message.
```

## Solution

This PR adds `sanitizePartialToolCalls()` which:
- Detects tool call blocks with `partialJson` but no complete `arguments`
- Removes these incomplete tool calls from assistant message content
- Updates `extractToolCallsFromAssistant()` to skip incomplete calls (so no synthetic results are added)

The function is called at the start of `sanitizeToolUseResultPairing()` so incomplete tool calls are cleaned before pairing logic runs.

## Testing

Added tests for:
- Removing tool calls with partialJson but no arguments
- Removing tool calls with partialJson and empty arguments  
- Preserving complete tool calls (with or without partialJson)
- Integration: incomplete tool calls removed AND their orphaned results dropped

All 9 tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a pre-pass to transcript repair that removes assistant tool-call blocks that were interrupted mid-stream (captured as `partialJson` without complete `arguments`), preventing downstream pairing logic from creating/dropping tool results in a way that strict providers (Anthropic-compatible) reject. It also updates tool-call extraction to ignore these incomplete calls and adds unit tests covering removal/preservation and an integration scenario where orphaned results are dropped.

The change fits into the existing `sanitizeToolUseResultPairing` pipeline, which is used by session-history sanitization (e.g. in `src/agents/pi-embedded-runner/google.ts`) to ensure tool calls/results are ordered and consistent before sending to model APIs.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the new partial-tool-call heuristic may drop valid tool calls in some real transcripts.
- The overall approach (remove interrupted tool calls before pairing) is coherent and covered by new tests, and it integrates cleanly into the existing sanitization pipeline. Main concern is the definition of "incomplete": treating `arguments: {}` as incomplete when `partialJson` exists could delete valid tool calls for tools with empty-arg schemas, which would also cause their results to be dropped. Tightening that heuristic would reduce risk.
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->