### PR TITLE
feat(discord): add configurable privileged Gateway Intents (GuildPresences, GuildMembers)

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -55,7 +55,7 @@ export async function handleDiscordGuildAction(
       const member = accountId
         ? await fetchMemberInfoDiscord(guildId, userId, { accountId })
         : await fetchMemberInfoDiscord(guildId, userId);
-      const presence = getPresence(userId);
+      const presence = getPresence(accountId, userId);
       const activities = presence?.activities ?? undefined;
       const status = presence?.status ?? undefined;
       return jsonResult({ ok: true, member, ...(presence ? { status, activities } : {}) });

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { DiscordActionConfig } from "../../config/config.js";
+import { getPresence } from "../../discord/monitor/presence-cache.js";
 import {
   addRoleDiscord,
   createChannelDiscord,
@@ -54,7 +55,10 @@ export async function handleDiscordGuildAction(
       const member = accountId
         ? await fetchMemberInfoDiscord(guildId, userId, { accountId })
         : await fetchMemberInfoDiscord(guildId, userId);
-      return jsonResult({ ok: true, member });
+      const presence = getPresence(userId);
+      const activities = presence?.activities ?? undefined;
+      const status = presence?.status ?? undefined;
+      return jsonResult({ ok: true, member, ...(presence ? { status, activities } : {}) });
     }
     case "roleInfo": {
       if (!isActionEnabled("roleInfo")) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -321,6 +321,8 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.discord.retry.maxDelayMs": "Discord Retry Max Delay (ms)",
   "channels.discord.retry.jitter": "Discord Retry Jitter",
   "channels.discord.maxLinesPerMessage": "Discord Max Lines Per Message",
+  "channels.discord.intents.presence": "Discord Presence Intent",
+  "channels.discord.intents.guildMembers": "Discord Guild Members Intent",
   "channels.slack.dm.policy": "Slack DM Policy",
   "channels.slack.allowBots": "Slack Allow Bot Messages",
   "channels.discord.token": "Discord Bot Token",
@@ -657,6 +659,10 @@ const FIELD_HELP: Record<string, string> = {
   "channels.discord.retry.maxDelayMs": "Maximum retry delay cap in ms for Discord outbound calls.",
   "channels.discord.retry.jitter": "Jitter factor (0-1) applied to Discord retry delays.",
   "channels.discord.maxLinesPerMessage": "Soft max line count per Discord message (default: 17).",
+  "channels.discord.intents.presence":
+    "Enable the Guild Presences privileged intent. Must also be enabled in the Discord Developer Portal. Allows tracking user activities (e.g. Spotify). Default: false.",
+  "channels.discord.intents.guildMembers":
+    "Enable the Guild Members privileged intent. Must also be enabled in the Discord Developer Portal. Default: false.",
   "channels.slack.dm.policy":
     'Direct message access control ("pairing" recommended). "open" requires channels.slack.dm.allowFrom=["*"].',
 };

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -72,6 +72,13 @@ export type DiscordActionConfig = {
   channels?: boolean;
 };
 
+export type DiscordIntentsConfig = {
+  /** Enable Guild Presences privileged intent (requires Portal opt-in). Default: false. */
+  presence?: boolean;
+  /** Enable Guild Members privileged intent (requires Portal opt-in). Default: false. */
+  guildMembers?: boolean;
+};
+
 export type DiscordExecApprovalConfig = {
   /** Enable exec approval forwarding to Discord DMs. Default: false. */
   enabled?: boolean;
@@ -139,6 +146,8 @@ export type DiscordAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Exec approval forwarding configuration. */
   execApprovals?: DiscordExecApprovalConfig;
+  /** Privileged Gateway Intents (must also be enabled in Discord Developer Portal). */
+  intents?: DiscordIntentsConfig;
 };
 
 export type DiscordConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -256,6 +256,13 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    intents: z
+      .object({
+        presence: z.boolean().optional(),
+        guildMembers: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/discord/monitor.slash.test.ts
+++ b/src/discord/monitor.slash.test.ts
@@ -16,6 +16,7 @@ vi.mock("@buape/carbon", () => ({
   MessageCreateListener: class {},
   MessageReactionAddListener: class {},
   MessageReactionRemoveListener: class {},
+  PresenceUpdateListener: class {},
   Row: class {
     constructor(_components: unknown[]) {}
   },

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -276,10 +276,12 @@ type PresenceUpdateEvent = Parameters<PresenceUpdateListener["handle"]>[0];
 
 export class DiscordPresenceListener extends PresenceUpdateListener {
   private logger?: Logger;
+  private accountId?: string;
 
-  constructor(logger?: Logger) {
+  constructor(params: { logger?: Logger; accountId?: string }) {
     super();
-    this.logger = logger;
+    this.logger = params.logger;
+    this.accountId = params.accountId;
   }
 
   async handle(data: PresenceUpdateEvent) {
@@ -289,7 +291,11 @@ export class DiscordPresenceListener extends PresenceUpdateListener {
           ? String(data.user.id)
           : undefined;
       if (!userId) return;
-      setPresence(userId, data as import("discord-api-types/v10").GatewayPresenceUpdate);
+      setPresence(
+        this.accountId,
+        userId,
+        data as import("discord-api-types/v10").GatewayPresenceUpdate,
+      );
     } catch (err) {
       const logger = this.logger ?? discordEventQueueLog;
       logger.error(danger(`discord presence handler failed: ${String(err)}`));

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -4,11 +4,13 @@ import {
   MessageCreateListener,
   MessageReactionAddListener,
   MessageReactionRemoveListener,
+  PresenceUpdateListener,
 } from "@buape/carbon";
 
 import { danger } from "../../globals.js";
 import { formatDurationSeconds } from "../../infra/format-duration.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { setPresence } from "./presence-cache.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
@@ -267,5 +269,30 @@ async function handleDiscordReactionEvent(params: {
     });
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
+  }
+}
+
+type PresenceUpdateEvent = Parameters<PresenceUpdateListener["handle"]>[0];
+
+export class DiscordPresenceListener extends PresenceUpdateListener {
+  private logger?: Logger;
+
+  constructor(logger?: Logger) {
+    super();
+    this.logger = logger;
+  }
+
+  async handle(data: PresenceUpdateEvent) {
+    try {
+      const userId =
+        "user" in data && data.user && typeof data.user === "object" && "id" in data.user
+          ? String(data.user.id)
+          : undefined;
+      if (!userId) return;
+      setPresence(userId, data as import("discord-api-types/v10").GatewayPresenceUpdate);
+    } catch (err) {
+      const logger = this.logger ?? discordEventQueueLog;
+      logger.error(danger(`discord presence handler failed: ${String(err)}`));
+    }
   }
 }

--- a/src/discord/monitor/presence-cache.ts
+++ b/src/discord/monitor/presence-cache.ts
@@ -4,24 +4,49 @@ import type { GatewayPresenceUpdate } from "discord-api-types/v10";
  * In-memory cache of Discord user presence data.
  * Populated by PRESENCE_UPDATE gateway events when the GuildPresences intent is enabled.
  */
-const presenceCache = new Map<string, GatewayPresenceUpdate>();
+const presenceCache = new Map<string, Map<string, GatewayPresenceUpdate>>();
+
+function resolveAccountKey(accountId?: string): string {
+  return accountId ?? "default";
+}
 
 /** Update cached presence for a user. */
-export function setPresence(userId: string, data: GatewayPresenceUpdate): void {
-  presenceCache.set(userId, data);
+export function setPresence(
+  accountId: string | undefined,
+  userId: string,
+  data: GatewayPresenceUpdate,
+): void {
+  const accountKey = resolveAccountKey(accountId);
+  let accountCache = presenceCache.get(accountKey);
+  if (!accountCache) {
+    accountCache = new Map();
+    presenceCache.set(accountKey, accountCache);
+  }
+  accountCache.set(userId, data);
 }
 
 /** Get cached presence for a user. Returns undefined if not cached. */
-export function getPresence(userId: string): GatewayPresenceUpdate | undefined {
-  return presenceCache.get(userId);
+export function getPresence(
+  accountId: string | undefined,
+  userId: string,
+): GatewayPresenceUpdate | undefined {
+  return presenceCache.get(resolveAccountKey(accountId))?.get(userId);
 }
 
-/** Clear all cached presence data. */
-export function clearPresences(): void {
+/** Clear cached presence data. */
+export function clearPresences(accountId?: string): void {
+  if (accountId) {
+    presenceCache.delete(resolveAccountKey(accountId));
+    return;
+  }
   presenceCache.clear();
 }
 
 /** Get the number of cached presence entries. */
 export function presenceCacheSize(): number {
-  return presenceCache.size;
+  let total = 0;
+  for (const accountCache of presenceCache.values()) {
+    total += accountCache.size;
+  }
+  return total;
 }

--- a/src/discord/monitor/presence-cache.ts
+++ b/src/discord/monitor/presence-cache.ts
@@ -1,0 +1,27 @@
+import type { GatewayPresenceUpdate } from "discord-api-types/v10";
+
+/**
+ * In-memory cache of Discord user presence data.
+ * Populated by PRESENCE_UPDATE gateway events when the GuildPresences intent is enabled.
+ */
+const presenceCache = new Map<string, GatewayPresenceUpdate>();
+
+/** Update cached presence for a user. */
+export function setPresence(userId: string, data: GatewayPresenceUpdate): void {
+  presenceCache.set(userId, data);
+}
+
+/** Get cached presence for a user. Returns undefined if not cached. */
+export function getPresence(userId: string): GatewayPresenceUpdate | undefined {
+  return presenceCache.get(userId);
+}
+
+/** Clear all cached presence data. */
+export function clearPresences(): void {
+  presenceCache.clear();
+}
+
+/** Get the number of cached presence entries. */
+export function presenceCacheSize(): number {
+  return presenceCache.size;
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -542,7 +542,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   );
 
   if (discordCfg.intents?.presence) {
-    registerDiscordListener(client.listeners, new DiscordPresenceListener(logger));
+    registerDiscordListener(
+      client.listeners,
+      new DiscordPresenceListener({ logger, accountId: account.accountId }),
+    );
     runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
   }
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -28,6 +28,7 @@ import { resolveDiscordUserAllowlist } from "../resolve-users.js";
 import { normalizeDiscordToken } from "../token.js";
 import {
   DiscordMessageListener,
+  DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
   registerDiscordListener,
@@ -107,6 +108,25 @@ function formatDiscordDeployErrorDetails(err: unknown): string {
     }
   }
   return details.length > 0 ? ` (${details.join(", ")})` : "";
+}
+
+function resolveDiscordGatewayIntents(
+  intentsConfig?: import("../../config/types.discord.js").DiscordIntentsConfig,
+): number {
+  let intents =
+    GatewayIntents.Guilds |
+    GatewayIntents.GuildMessages |
+    GatewayIntents.MessageContent |
+    GatewayIntents.DirectMessages |
+    GatewayIntents.GuildMessageReactions |
+    GatewayIntents.DirectMessageReactions;
+  if (intentsConfig?.presence) {
+    intents |= GatewayIntents.GuildPresences;
+  }
+  if (intentsConfig?.guildMembers) {
+    intents |= GatewayIntents.GuildMembers;
+  }
+  return intents;
 }
 
 export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
@@ -451,13 +471,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         reconnect: {
           maxAttempts: Number.POSITIVE_INFINITY,
         },
-        intents:
-          GatewayIntents.Guilds |
-          GatewayIntents.GuildMessages |
-          GatewayIntents.MessageContent |
-          GatewayIntents.DirectMessages |
-          GatewayIntents.GuildMessageReactions |
-          GatewayIntents.DirectMessageReactions,
+        intents: resolveDiscordGatewayIntents(discordCfg.intents),
         autoInteractions: true,
       }),
     ],
@@ -526,6 +540,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       logger,
     }),
   );
+
+  if (discordCfg.intents?.presence) {
+    registerDiscordListener(client.listeners, new DiscordPresenceListener(logger));
+    runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
+  }
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
 


### PR DESCRIPTION
## Summary

Add support for optionally enabling Discord privileged Gateway Intents via config, starting with **GuildPresences** and **GuildMembers**.

## Motivation

Discord's Rich Presence / Activity Status (e.g. Spotify listening activity, game status) is only available through the Gateway when the `GUILD_PRESENCES` privileged intent is enabled. Currently, Clawdbot has no way to request this intent, so `member-info` cannot return user activities even when the intent is enabled in the Discord Developer Portal.

## Changes

### Config
- New `channels.discord.intents.presence` (boolean, default `false`)
- New `channels.discord.intents.guildMembers` (boolean, default `false`)
- Both include labels and help descriptions in the config schema

### Gateway Intents
- Extracted intent computation into `resolveDiscordGatewayIntents()` 
- Base intents unchanged; privileged intents are OR'd in when config is truthy

### Presence Listener
- New `DiscordPresenceListener` extending `@buape/carbon`'s `PresenceUpdateListener`
- Registered only when `intents.presence` is enabled
- Caches `GatewayPresenceUpdate` data per user ID in a simple in-memory Map

### Member Info Enhancement
- `member-info` action now includes `status` and `activities` from the presence cache when available
- No breaking change: fields are only present when presence data is cached

## Usage

```yaml
channels:
  discord:
    intents:
      presence: true    # requires Portal opt-in
      # guildMembers: true  # also available
```

Then `member-info` will include activity data:
```json
{
  "ok": true,
  "member": { ... },
  "status": "online",
  "activities": [
    {
      "type": 2,
      "name": "Spotify",
      "details": "Song Title",
      "state": "Artist Name"
    }
  ]
}
```

## Prerequisites

Both intents must be enabled in the **Discord Developer Portal** → Bot → Privileged Gateway Intents before they can be used. If not enabled in the Portal, the gateway connection will fail with `DisallowedIntents`.

## Files Changed

| File | Change |
|------|--------|
| `src/config/types.discord.ts` | `DiscordIntentsConfig` type, added to `DiscordAccountConfig` |
| `src/config/zod-schema.providers-core.ts` | Zod schema for intents validation |
| `src/config/schema.ts` | Labels and descriptions |
| `src/discord/monitor/provider.ts` | `resolveDiscordGatewayIntents()`, conditional listener registration |
| `src/discord/monitor/listeners.ts` | `DiscordPresenceListener` class |
| `src/discord/monitor/presence-cache.ts` | In-memory presence cache (new file) |
| `src/agents/tools/discord-actions-guild.ts` | Include presence in member-info response |