### PR TITLE
docs: tighten fly private deployment steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 Status: unreleased.
 
 ### Changes
+- Docs: tighten Fly private deployment steps. (#2289) Thanks @dguido.
 - Gateway: warn on hook tokens via query params; document header auth preference. (#2200) Thanks @YuriNachos.
 - Doctor: warn on gateway exposure without auth. (#2016) Thanks @Alex-Alaniz.
 - Discord: add configurable privileged gateway intents for presences/members. (#2266) Thanks @kentaro.

--- a/docs/platforms/fly.md
+++ b/docs/platforms/fly.md
@@ -372,6 +372,10 @@ fly ips list -a my-clawdbot
 fly ips release <public-ipv4> -a my-clawdbot
 fly ips release <public-ipv6> -a my-clawdbot
 
+# Switch to private config so future deploys don't re-allocate public IPs
+# (remove [http_service] or deploy with the private template)
+fly deploy -c fly.private.toml
+
 # Allocate private-only IPv6
 fly ips allocate-v6 --private -a my-clawdbot
 ```

--- a/fly.private.toml
+++ b/fly.private.toml
@@ -9,7 +9,7 @@
 #
 # See https://fly.io/docs/reference/configuration/
 
-app = "clawdbot"
+app = "my-clawdbot"  # change to your app name
 primary_region = "iad"  # change to your closest region
 
 [build]


### PR DESCRIPTION
Follow-up fixes for the Fly private deployment guide (config switch step + template app placeholder).