### PR TITLE
fix(discord): honor threadId for thread-reply (AI-assisted)

### DIFF
--- a/src/channels/plugins/actions/discord.test.ts
+++ b/src/channels/plugins/actions/discord.test.ts
@@ -127,4 +127,30 @@ describe("handleDiscordMessageAction", () => {
       }),
     );
   });
+
+  it("accepts threadId for thread replies (tool compatibility)", async () => {
+    sendMessageDiscord.mockClear();
+    const handleDiscordMessageAction = await loadHandleDiscordMessageAction();
+
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        // The `message` tool uses `threadId`.
+        threadId: "999",
+        // Include a conflicting channelId to ensure threadId takes precedence.
+        channelId: "123",
+        message: "hi",
+      },
+      cfg: {} as ClawdbotConfig,
+      accountId: "ops",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:999",
+      "hi",
+      expect.objectContaining({
+        accountId: "ops",
+      }),
+    );
+  });
 });

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -393,11 +393,17 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     });
     const mediaUrl = readStringParam(actionParams, "media", { trim: false });
     const replyTo = readStringParam(actionParams, "replyTo");
+
+    // `message.thread-reply` (tool) uses `threadId`, while the CLI historically used `to`/`channelId`.
+    // Prefer `threadId` when present to avoid accidentally replying in the parent channel.
+    const threadId = readStringParam(actionParams, "threadId");
+    const channelId = threadId ?? resolveChannelId();
+
     return await handleDiscordAction(
       {
         action: "threadReply",
         accountId: accountId ?? undefined,
-        channelId: resolveChannelId(),
+        channelId,
         content,
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,


### PR DESCRIPTION
Fixes Discord thread replies sometimes landing in the parent channel.

Root cause
- The `message` tool uses `threadId` for `thread-reply`, but the Discord message-action handler ignored it and resolved the target from `to`/`channelId` instead.

Change
- Prefer `threadId` when present for `thread-reply`.

Tests
- Added unit test covering `threadId` precedence.
- Ran: `pnpm vitest run src/channels/plugins/actions/discord.test.ts`
- Ran: `pnpm lint src/channels/plugins/actions/discord/handle-action.guild-admin.ts src/channels/plugins/actions/discord.test.ts`

AI-assisted
- Implemented with AI assistance; code reviewed and understood; tested locally + validated live on our instance.