### PR TITLE
feat(agents): add MEMORY.md to bootstrap files

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -26,6 +26,7 @@ export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
 export const DEFAULT_USER_FILENAME = "USER.md";
 export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
+export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 
 const TEMPLATE_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -61,7 +62,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_IDENTITY_FILENAME
   | typeof DEFAULT_USER_FILENAME
   | typeof DEFAULT_HEARTBEAT_FILENAME
-  | typeof DEFAULT_BOOTSTRAP_FILENAME;
+  | typeof DEFAULT_BOOTSTRAP_FILENAME
+  | typeof DEFAULT_MEMORY_FILENAME;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -218,6 +220,10 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
     {
       name: DEFAULT_BOOTSTRAP_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
+    },
+    {
+      name: DEFAULT_MEMORY_FILENAME,
+      filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
     },
   ];
 


### PR DESCRIPTION
## Summary

- MEMORY.md is now loaded into context at session start, ensuring the agent has access to curated long-term memory without requiring embedding-based semantic search
- Previously, MEMORY.md was only accessible via the `memory_search` tool, which requires an embedding provider (OpenAI/Gemini API key or local model)
- When no embedding provider was configured, the agent would claim memories were empty even though MEMORY.md existed and contained data

## Changes

- Adds `DEFAULT_MEMORY_FILENAME` constant
- Includes `MEMORY.md` in `WorkspaceBootstrapFileName` type
- Loads MEMORY.md in `loadWorkspaceBootstrapFiles()`
- Does NOT add MEMORY.md to subagent allowlist (keeps user data private)
- Does NOT auto-create MEMORY.md template (user creates as needed)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Manual test: create a MEMORY.md in workspace, run `/new`, verify agent sees memory content

🤖 Generated with [Claude Code](https://claude.com/claude-code)