### PR TITLE
feat(skills): add grounding-lite skill for Google Maps Grounding Lite MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 Status: unreleased.
 
 ### Changes
+- Skills: add grounding-lite skill for Google Maps Grounding Lite MCP (search places, weather, routes).
 - Agents: honor tools.exec.safeBins in exec allowlist checks. (#2281)
 - Docs: tighten Fly private deployment steps. (#2289) Thanks @dguido.
 - Gateway: warn on hook tokens via query params; document header auth preference. (#2200) Thanks @YuriNachos.

--- a/skills/grounding-lite/SKILL.md
+++ b/skills/grounding-lite/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: grounding-lite
+description: Google Maps Grounding Lite MCP for AI-powered location search, weather, and routes via mcporter.
+homepage: https://developers.google.com/maps/ai/grounding-lite
+metadata: {"clawdbot":{"emoji":"🗺️","requires":{"bins":["mcporter"],"env":["GOOGLE_MAPS_API_KEY"]},"primaryEnv":"GOOGLE_MAPS_API_KEY"}}
+---
+
+# Grounding Lite
+
+Google Maps Grounding Lite provides AI-grounded location data via MCP. Use `mcporter` to call tools directly.
+
+**Status**: Experimental (pre-GA), free during preview.
+
+**Rate limits**: search_places (100 QPM, 1K QPD), lookup_weather (300 QPM), compute_routes (300 QPM).
+
+## Setup
+
+1. Install mcporter: `npm install -g mcporter`
+2. Set `GOOGLE_MAPS_API_KEY` environment variable
+3. Configure the MCP server (one-time):
+
+```bash
+mcporter config add grounding-lite \
+  --url https://mapstools.googleapis.com/mcp \
+  --header "X-Goog-Api-Key: $GOOGLE_MAPS_API_KEY"
+```
+
+### API Key Security
+
+1. **Restrict your API key** in Google Cloud Console:
+   - API restrictions: Allow only `mapstools.googleapis.com`
+   - Application restrictions: Use IP restriction if on a fixed server
+
+2. **Never hardcode keys** - use environment variables
+
+3. **For production**: Consider OAuth 2.0 (better audit trails)
+
+See: https://developers.google.com/maps/api-security-best-practices
+
+## Search Places
+
+Find places by text query with AI summaries:
+
+```bash
+mcporter call grounding-lite.search_places text_query="coffee shops near Central Park"
+```
+
+With location bias:
+
+```bash
+mcporter call grounding-lite.search_places \
+  text_query="pizza" \
+  location_bias='{"center":{"latitude":40.7829,"longitude":-73.9654},"radius":2000}'
+```
+
+JSON output:
+
+```bash
+mcporter call grounding-lite.search_places text_query="sushi in Tokyo" --output json
+```
+
+Response includes: place IDs, names, addresses, coordinates, Google Maps links, and AI summary.
+
+## Lookup Weather
+
+Get current weather:
+
+```bash
+mcporter call grounding-lite.lookup_weather location='{"address":"Tokyo, Japan"}' units_system=METRIC
+```
+
+By coordinates:
+
+```bash
+mcporter call grounding-lite.lookup_weather \
+  location='{"lat_lng":{"latitude":35.6762,"longitude":139.6503}}'
+```
+
+By place ID:
+
+```bash
+mcporter call grounding-lite.lookup_weather location='{"place_id":"ChIJ..."}'
+```
+
+Forecast for a specific date/hour:
+
+```bash
+mcporter call grounding-lite.lookup_weather \
+  location='{"address":"Paris, France"}' \
+  date='{"year":2026,"month":1,"day":28}' \
+  hour=14
+```
+
+Units: `METRIC` (Celsius, km/h) or `IMPERIAL` (Fahrenheit, mph).
+
+## Compute Routes
+
+Calculate distance and duration:
+
+```bash
+mcporter call grounding-lite.compute_routes \
+  origin='{"address":"San Francisco, CA"}' \
+  destination='{"address":"Los Angeles, CA"}' \
+  travel_mode=DRIVE
+```
+
+Walking route:
+
+```bash
+mcporter call grounding-lite.compute_routes \
+  origin='{"address":"Times Square, NYC"}' \
+  destination='{"address":"Central Park, NYC"}' \
+  travel_mode=WALK
+```
+
+Travel modes: `DRIVE` (default) or `WALK`.
+
+Note: Returns distance/duration only. No step-by-step directions or real-time traffic.
+
+## Ad-hoc Usage (without config)
+
+Call directly without configuring first:
+
+```bash
+mcporter call "https://mapstools.googleapis.com/mcp.search_places" \
+  --header "X-Goog-Api-Key: $GOOGLE_MAPS_API_KEY" \
+  text_query="restaurants near me"
+```
+
+## List Available Tools
+
+```bash
+mcporter list grounding-lite --schema
+```
+
+## vs goplaces / local-places
+
+| Feature | Grounding Lite | goplaces | local-places |
+|---------|---------------|----------|--------------|
+| Setup | mcporter + API key | Homebrew + API key | Python + API key |
+| AI Summaries | Built-in | None | None |
+| Weather | Yes | No | No |
+| Routes | Yes (basic) | No | No |
+| Place Details | Limited | Full | Full |
+| Photos/Reviews | No | Yes | Yes |
+
+Use Grounding Lite for quick AI-grounded queries. Use goplaces or local-places for detailed place info.
+
+## Notes
+
+- Free during preview; pricing TBD after GA
+- Some features may have EEA restrictions
+- Attribution required per Google Maps Platform ToS
+- Responses contain Google Maps links - include in user-facing output

--- a/skills/grounding-lite/SKILL.md
+++ b/skills/grounding-lite/SKILL.md
@@ -2,140 +2,35 @@
 name: grounding-lite
 description: Google Maps Grounding Lite MCP for AI-powered location search, weather, and routes via mcporter.
 homepage: https://developers.google.com/maps/ai/grounding-lite
-metadata: {"clawdbot":{"emoji":"🗺️","requires":{"bins":["mcporter"],"env":["GOOGLE_MAPS_API_KEY"]},"primaryEnv":"GOOGLE_MAPS_API_KEY"}}
+metadata: {"clawdbot":{"emoji":"🗺️","requires":{"bins":["mcporter"],"env":["GOOGLE_MAPS_API_KEY"]},"primaryEnv":"GOOGLE_MAPS_API_KEY","install":[{"id":"node","kind":"node","package":"mcporter","bins":["mcporter"],"label":"Install mcporter (npm)"}]}}
 ---
 
 # Grounding Lite
 
-Google Maps Grounding Lite provides AI-grounded location data via MCP. Use `mcporter` to call tools directly.
+Google Maps Grounding Lite MCP for AI-grounded location data. Experimental (pre-GA), free during preview.
 
-**Status**: Experimental (pre-GA), free during preview.
+Setup
+- Configure once: `mcporter config add grounding-lite --url https://mapstools.googleapis.com/mcp --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY"`
+- Or ad-hoc: `mcporter call "https://mapstools.googleapis.com/mcp.search_places" --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY" text_query="..."`
 
-**Rate limits**: search_places (100 QPM, 1K QPD), lookup_weather (300 QPM), compute_routes (300 QPM).
+Search places
+- `mcporter call grounding-lite.search_places text_query="coffee shops near Central Park"`
+- With bias: `mcporter call grounding-lite.search_places text_query="pizza" location_bias='{"center":{"latitude":40.7829,"longitude":-73.9654},"radius":2000}'`
 
-## Setup
+Lookup weather
+- `mcporter call grounding-lite.lookup_weather location='{"address":"San Francisco, CA"}' units_system=IMPERIAL`
+- By coords: `mcporter call grounding-lite.lookup_weather location='{"lat_lng":{"latitude":37.77,"longitude":-122.41}}'`
+- Forecast: `mcporter call grounding-lite.lookup_weather location='{"address":"New York, NY"}' date='{"year":2026,"month":1,"day":28}' hour=14`
 
-1. Install mcporter: `npm install -g mcporter`
-2. Set `GOOGLE_MAPS_API_KEY` environment variable
-3. Configure the MCP server (one-time):
+Compute routes
+- `mcporter call grounding-lite.compute_routes origin='{"address":"San Francisco, CA"}' destination='{"address":"Los Angeles, CA"}' travel_mode=DRIVE`
+- Walking: `mcporter call grounding-lite.compute_routes origin='{"address":"Times Square, NYC"}' destination='{"address":"Central Park, NYC"}' travel_mode=WALK`
 
-```bash
-mcporter config add grounding-lite \
-  --url https://mapstools.googleapis.com/mcp \
-  --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY"
-```
+List tools
+- `mcporter list grounding-lite --schema`
 
-### API Key Security
-
-1. **Restrict your API key** in Google Cloud Console:
-   - API restrictions: Allow only `mapstools.googleapis.com`
-   - Application restrictions: Use IP restriction if on a fixed server
-
-2. **Never hardcode keys** - use environment variables
-
-3. **For production**: Consider OAuth 2.0 (better audit trails)
-
-See: https://developers.google.com/maps/api-security-best-practices
-
-## Search Places
-
-Find places by text query with AI summaries:
-
-```bash
-mcporter call grounding-lite.search_places text_query="coffee shops near Central Park"
-```
-
-With location bias:
-
-```bash
-mcporter call grounding-lite.search_places \
-  text_query="pizza" \
-  location_bias='{"center":{"latitude":40.7829,"longitude":-73.9654},"radius":2000}'
-```
-
-JSON output:
-
-```bash
-mcporter call grounding-lite.search_places text_query="sushi in Tokyo" --output json
-```
-
-Response includes: place IDs, names, addresses, coordinates, Google Maps links, and AI summary.
-
-## Lookup Weather
-
-Get current weather:
-
-```bash
-mcporter call grounding-lite.lookup_weather location='{"address":"San Francisco, CA"}' units_system=IMPERIAL
-```
-
-By coordinates:
-
-```bash
-mcporter call grounding-lite.lookup_weather \
-  location='{"lat_lng":{"latitude":35.6762,"longitude":139.6503}}'
-```
-
-By place ID:
-
-```bash
-mcporter call grounding-lite.lookup_weather location='{"place_id":"ChIJ..."}'
-```
-
-Forecast for a specific date/hour:
-
-```bash
-mcporter call grounding-lite.lookup_weather \
-  location='{"address":"New York, NY"}' \
-  date='{"year":2026,"month":1,"day":28}' \
-  hour=14
-```
-
-Units: `METRIC` (Celsius, km/h) or `IMPERIAL` (Fahrenheit, mph).
-
-## Compute Routes
-
-Calculate distance and duration:
-
-```bash
-mcporter call grounding-lite.compute_routes \
-  origin='{"address":"San Francisco, CA"}' \
-  destination='{"address":"Los Angeles, CA"}' \
-  travel_mode=DRIVE
-```
-
-Walking route:
-
-```bash
-mcporter call grounding-lite.compute_routes \
-  origin='{"address":"Times Square, NYC"}' \
-  destination='{"address":"Central Park, NYC"}' \
-  travel_mode=WALK
-```
-
-Travel modes: `DRIVE` (default) or `WALK`.
-
-Note: Returns distance/duration only. No step-by-step directions or real-time traffic.
-
-## Ad-hoc Usage (without config)
-
-Call directly without configuring first:
-
-```bash
-mcporter call "https://mapstools.googleapis.com/mcp.search_places" \
-  --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY" \
-  text_query="restaurants near me"
-```
-
-## List Available Tools
-
-```bash
-mcporter list grounding-lite --schema
-```
-
-## Notes
-
-- Free during preview; pricing TBD after GA
-- Weather lookup has regional restrictions (US locations work; some international locations may not)
-- Attribution required per Google Maps Platform ToS
-- Responses contain Google Maps links - include in user-facing output
+Notes
+- Rate limits: search_places (100 QPM, 1K QPD), lookup_weather (300 QPM), compute_routes (300 QPM)
+- Weather has regional restrictions (US locations work; some international may not)
+- Responses include Google Maps links - include in user-facing output
+- API key security: restrict to `mapstools.googleapis.com` in Cloud Console

--- a/skills/grounding-lite/SKILL.md
+++ b/skills/grounding-lite/SKILL.md
@@ -22,7 +22,7 @@ Google Maps Grounding Lite provides AI-grounded location data via MCP. Use `mcpo
 ```bash
 mcporter config add grounding-lite \
   --url https://mapstools.googleapis.com/mcp \
-  --header "X-Goog-Api-Key: $GOOGLE_MAPS_API_KEY"
+  --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY"
 ```
 
 ### API Key Security
@@ -66,7 +66,7 @@ Response includes: place IDs, names, addresses, coordinates, Google Maps links, 
 Get current weather:
 
 ```bash
-mcporter call grounding-lite.lookup_weather location='{"address":"Tokyo, Japan"}' units_system=METRIC
+mcporter call grounding-lite.lookup_weather location='{"address":"San Francisco, CA"}' units_system=IMPERIAL
 ```
 
 By coordinates:
@@ -86,7 +86,7 @@ Forecast for a specific date/hour:
 
 ```bash
 mcporter call grounding-lite.lookup_weather \
-  location='{"address":"Paris, France"}' \
+  location='{"address":"New York, NY"}' \
   date='{"year":2026,"month":1,"day":28}' \
   hour=14
 ```
@@ -123,7 +123,7 @@ Call directly without configuring first:
 
 ```bash
 mcporter call "https://mapstools.googleapis.com/mcp.search_places" \
-  --header "X-Goog-Api-Key: $GOOGLE_MAPS_API_KEY" \
+  --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY" \
   text_query="restaurants near me"
 ```
 
@@ -133,22 +133,9 @@ mcporter call "https://mapstools.googleapis.com/mcp.search_places" \
 mcporter list grounding-lite --schema
 ```
 
-## vs goplaces / local-places
-
-| Feature | Grounding Lite | goplaces | local-places |
-|---------|---------------|----------|--------------|
-| Setup | mcporter + API key | Homebrew + API key | Python + API key |
-| AI Summaries | Built-in | None | None |
-| Weather | Yes | No | No |
-| Routes | Yes (basic) | No | No |
-| Place Details | Limited | Full | Full |
-| Photos/Reviews | No | Yes | Yes |
-
-Use Grounding Lite for quick AI-grounded queries. Use goplaces or local-places for detailed place info.
-
 ## Notes
 
 - Free during preview; pricing TBD after GA
-- Some features may have EEA restrictions
+- Weather lookup has regional restrictions (US locations work; some international locations may not)
 - Attribution required per Google Maps Platform ToS
 - Responses contain Google Maps links - include in user-facing output

--- a/skills/grounding-lite/SKILL.md
+++ b/skills/grounding-lite/SKILL.md
@@ -7,30 +7,55 @@ metadata: {"clawdbot":{"emoji":"🗺️","requires":{"bins":["mcporter"],"env":[
 
 # Grounding Lite
 
-Google Maps Grounding Lite MCP for AI-grounded location data. Experimental (pre-GA), free during preview.
+Google Maps Grounding Lite MCP provides AI-grounded location data. Experimental (pre-GA), free during preview.
 
-Setup
-- Configure once: `mcporter config add grounding-lite --url https://mapstools.googleapis.com/mcp --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY"`
-- Or ad-hoc: `mcporter call "https://mapstools.googleapis.com/mcp.search_places" --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY" text_query="..."`
+## When to use each tool
 
-Search places
+- **search_places**: Use when the user asks about places, businesses, restaurants, addresses, or points of interest. Returns AI-generated summaries with Google Maps links.
+- **lookup_weather**: Use when the user asks about weather conditions or forecasts for a location. Works best with US locations.
+- **compute_routes**: Use when the user asks about travel distance, duration, or directions between two locations.
+
+## Setup (one-time)
+
+```
+mcporter config add grounding-lite --url https://mapstools.googleapis.com/mcp --header "X-Goog-Api-Key=$GOOGLE_MAPS_API_KEY"
+```
+
+## Commands
+
+Search places:
 - `mcporter call grounding-lite.search_places text_query="coffee shops near Central Park"`
-- With bias: `mcporter call grounding-lite.search_places text_query="pizza" location_bias='{"center":{"latitude":40.7829,"longitude":-73.9654},"radius":2000}'`
+- With location bias: `mcporter call grounding-lite.search_places text_query="pizza" location_bias='{"center":{"latitude":40.7829,"longitude":-73.9654},"radius":2000}'`
 
-Lookup weather
+Weather lookup:
 - `mcporter call grounding-lite.lookup_weather location='{"address":"San Francisco, CA"}' units_system=IMPERIAL`
-- By coords: `mcporter call grounding-lite.lookup_weather location='{"lat_lng":{"latitude":37.77,"longitude":-122.41}}'`
-- Forecast: `mcporter call grounding-lite.lookup_weather location='{"address":"New York, NY"}' date='{"year":2026,"month":1,"day":28}' hour=14`
+- By coordinates: `mcporter call grounding-lite.lookup_weather location='{"lat_lng":{"latitude":37.77,"longitude":-122.41}}'`
 
-Compute routes
+Compute routes:
 - `mcporter call grounding-lite.compute_routes origin='{"address":"San Francisco, CA"}' destination='{"address":"Los Angeles, CA"}' travel_mode=DRIVE`
-- Walking: `mcporter call grounding-lite.compute_routes origin='{"address":"Times Square, NYC"}' destination='{"address":"Central Park, NYC"}' travel_mode=WALK`
+- Travel modes: DRIVE (default), WALK
 
-List tools
+List available tools:
 - `mcporter list grounding-lite --schema`
 
-Notes
-- Rate limits: search_places (100 QPM, 1K QPD), lookup_weather (300 QPM), compute_routes (300 QPM)
-- Weather has regional restrictions (US locations work; some international may not)
-- Responses include Google Maps links - include in user-facing output
-- API key security: restrict to `mapstools.googleapis.com` in Cloud Console
+## Parameters
+
+**search_places**:
+- `text_query` (required): Natural language search query
+- `location_bias` (optional): Prioritize results near a location
+
+**lookup_weather**:
+- `location` (required): Address, coordinates, or place_id
+- `units_system` (optional): METRIC or IMPERIAL
+- `date`, `hour` (optional): For forecasts
+
+**compute_routes**:
+- `origin`, `destination` (required): Address, coordinates, or place_id
+- `travel_mode` (optional): DRIVE or WALK
+
+## Notes
+
+- Rate limits: search_places (100 QPM), lookup_weather (300 QPM), compute_routes (300 QPM)
+- Weather has regional restrictions; US locations work reliably
+- Include Google Maps links from responses in user-facing output
+- Restrict API key to `mapstools.googleapis.com` in Cloud Console


### PR DESCRIPTION
## Summary

Add `grounding-lite` skill for [Google Maps Grounding Lite MCP](https://developers.google.com/maps/ai/grounding-lite), an experimental Google Maps Platform service that provides AI-grounded location data.

### What it does
- **search_places**: Find places by text query with AI-generated summaries and Google Maps links
- **lookup_weather**: Get current weather or forecasts by address, coordinates, or place ID
- **compute_routes**: Calculate distance and duration between locations (driving/walking)

### Architecture: Uses mcporter MCP client
The skill uses `mcporter` (the established MCP client in Clawdbot) to connect to the remote Google Maps Platform MCP server at `https://mapstools.googleapis.com/mcp`:
- Proper MCP server configuration via `mcporter config add`
- Clean tool invocation syntax: `mcporter call grounding-lite.search_places text_query="..."`
- Ad-hoc usage option for one-off calls without config
- Tool discovery via `mcporter list grounding-lite --schema`

### Why a skill (not a plugin)
The skill pattern aligns with Clawdbot architecture for external API integrations:
- Matches existing patterns (`goplaces`, `local-places`, `weather`, `gemini`)
- Uses the same `GOOGLE_MAPS_API_KEY` already configured for Places skills
- Zero code maintenance - just mcporter commands the agent adapts

### Anthropic best practices applied
Based on official Anthropic documentation:
- **"When to use each tool" section** - explains when each tool should be used (per MCP tool design guidance)
- **Parameters section** - per-parameter documentation (per MCP best practices)
- **Natural language** - no aggressive "CRITICAL/MUST" language (per Claude 4.x prompting guide)
- **Install spec** - enables auto-installation of mcporter dependency

## Test plan
- [x] Verified skill metadata format matches existing skills
- [x] Verified `install` spec for mcporter auto-installation
- [x] mcporter commands tested against Grounding Lite MCP endpoint:
  - `search_places`: Tacos in Austin, TX with AI summaries
  - `lookup_weather`: Austin 34.7°F, Sunny
  - `compute_routes`: Austin→Houston = 266km, ~2.5hrs
- [x] Remote MCP server URL verified: `https://mapstools.googleapis.com/mcp`

## Sources
- [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)
- [Claude 4 Prompting Best Practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
- [MCP Introduction Course](https://anthropic.skilljar.com/introduction-to-model-context-protocol)

## Checklist
- [x] Changelog entry added
- [x] Follows AgentSkills-compatible format
- [x] Uses mcporter for proper MCP integration
- [x] "When to use" guidance per MCP best practices
- [x] Parameter documentation per MCP best practices
- [x] Install spec for auto-installation
- [x] Rate limits documented