### PR TITLE
docs: Add Oracle Cloud (OCI) platform guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Status: unreleased.
 - Docs: add Render deployment guide. (#1975) Thanks @anurag.
 - Docs: add Claude Max API Proxy guide. (#1875) Thanks @atalovesyou.
 - Docs: add DigitalOcean deployment guide. (#1870) Thanks @0xJonHoldsCrypto.
+- Docs: add Oracle Cloud (OCI) platform guide + cross-links. (#2333) Thanks @hirefrank.
 - Docs: add Raspberry Pi install guide. (#1871) Thanks @0xJonHoldsCrypto.
 - Docs: add GCP Compute Engine deployment guide. (#1848) Thanks @hougangdev.
 - Docs: add LINE channel guide. Thanks @thewilloftheshadow.

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -205,7 +205,7 @@ Oracle Cloud offers **Always Free** ARM instances that are significantly more po
 - Signup can be finicky (retry if it fails)
 - ARM architecture — most things work, but some binaries need ARM builds
 
-For the full setup guide, see [Oracle Cloud](/platforms/oracle).
+For the full setup guide, see [Oracle Cloud](/platforms/oracle). For signup tips and troubleshooting the enrollment process, see this [community guide](https://gist.github.com/rssnyder/51e3cfedd730e7dd5f4a816143b25dbd).
 
 ---
 

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -11,7 +11,7 @@ read_when:
 
 Run a persistent Clawdbot Gateway on DigitalOcean for **$6/month** (or $4/mo with reserved pricing).
 
-If you want something even cheaper, see [Oracle Cloud (Free Tier)](#oracle-cloud-free-alternative) at the bottom — it's **actually free forever**.
+If you want something even cheaper, see the [Oracle Cloud guide](/platforms/oracle) — it's **actually free forever**.
 
 ## Cost Comparison (2026)
 
@@ -192,7 +192,7 @@ tar -czvf clawdbot-backup.tar.gz ~/.clawdbot ~/clawd
 
 ## Oracle Cloud Free Alternative
 
-Oracle Cloud offers **Always Free** ARM instances that are significantly more powerful:
+Oracle Cloud offers **Always Free** ARM instances that are significantly more powerful than any paid option here — for $0/month.
 
 | What you get | Specs |
 |--------------|-------|
@@ -201,19 +201,11 @@ Oracle Cloud offers **Always Free** ARM instances that are significantly more po
 | **200GB storage** | Block volume |
 | **Forever free** | No credit card charges |
 
-### Quick setup:
-1. Sign up at [oracle.com/cloud/free](https://www.oracle.com/cloud/free/)
-2. Create a VM.Standard.A1.Flex instance (ARM)
-3. Choose Oracle Linux or Ubuntu
-4. Allocate up to 4 OCPU / 24GB RAM within free tier
-5. Follow the same Clawdbot install steps above
-
 **Caveats:**
 - Signup can be finicky (retry if it fails)
 - ARM architecture — most things work, but some binaries need ARM builds
-- Oracle may reclaim idle instances (keep them active)
 
-For the full Oracle guide, see the [community docs](https://gist.github.com/rssnyder/51e3cfedd730e7dd5f4a816143b25dbd).
+For the full setup guide, see [Oracle Cloud](/platforms/oracle).
 
 ---
 

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -1,5 +1,5 @@
 ---
-summary: "Clawdbot on DigitalOcean (cheapest paid VPS option)"
+summary: "Clawdbot on DigitalOcean (simple paid VPS option)"
 read_when:
   - Setting up Clawdbot on DigitalOcean
   - Looking for cheap VPS hosting for Clawdbot
@@ -11,22 +11,22 @@ read_when:
 
 Run a persistent Clawdbot Gateway on DigitalOcean for **$6/month** (or $4/mo with reserved pricing).
 
-If you want something even cheaper, see the [Oracle Cloud guide](/platforms/oracle) — it's **actually free forever**.
+If you want a $0/month option and don’t mind ARM + provider-specific setup, see the [Oracle Cloud guide](/platforms/oracle).
 
 ## Cost Comparison (2026)
 
 | Provider | Plan | Specs | Price/mo | Notes |
 |----------|------|-------|----------|-------|
-| **Oracle Cloud** | Always Free ARM | 4 OCPU, 24GB RAM | **$0** | Best value, requires ARM-compatible setup |
-| **Hetzner** | CX22 | 2 vCPU, 4GB RAM | €3.79 (~$4) | Cheapest paid, EU datacenters |
-| **DigitalOcean** | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
-| **Vultr** | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
-| **Linode** | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
+| Oracle Cloud | Always Free ARM | up to 4 OCPU, 24GB RAM | $0 | ARM, limited capacity / signup quirks |
+| Hetzner | CX22 | 2 vCPU, 4GB RAM | €3.79 (~$4) | Cheapest paid option |
+| DigitalOcean | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
+| Vultr | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
+| Linode | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
 
-**Recommendation:** 
-- **Free:** Oracle Cloud ARM (if you can handle the signup process)
-- **Paid:** Hetzner CX22 (best specs per dollar) — see [Hetzner guide](/platforms/hetzner)
-- **Easy:** DigitalOcean (this guide) — beginner-friendly UI
+**Picking a provider:**
+- DigitalOcean: simplest UX + predictable setup (this guide)
+- Hetzner: good price/perf (see [Hetzner guide](/platforms/hetzner))
+- Oracle Cloud: can be $0/month, but is more finicky and ARM-only (see [Oracle guide](/platforms/oracle))
 
 ---
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -28,7 +28,7 @@ Run a persistent Clawdbot Gateway on Oracle Cloud's **Always Free** ARM tier —
 
 ## Prerequisites
 
-- Oracle Cloud account ([signup](https://www.oracle.com/cloud/free/))
+- Oracle Cloud account ([signup](https://www.oracle.com/cloud/free/)) — see [community signup guide](https://gist.github.com/rssnyder/51e3cfedd730e7dd5f4a816143b25dbd) if you hit issues
 - Tailscale account (free at [tailscale.com](https://tailscale.com))
 - ~30 minutes
 
@@ -69,7 +69,7 @@ ssh ubuntu@YOUR_PUBLIC_IP
 
 # Update system
 sudo apt update && sudo apt upgrade -y
-sudo apt install -y build-essential unzip
+sudo apt install -y build-essential
 ```
 
 **Note:** `build-essential` is required for ARM compilation of some dependencies.

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -1,0 +1,298 @@
+---
+summary: "Clawdbot on Oracle Cloud (Always Free ARM, best value)"
+read_when:
+  - Setting up Clawdbot on Oracle Cloud
+  - Looking for free VPS hosting for Clawdbot
+  - Want 24/7 Clawdbot without paying anything
+---
+
+# Clawdbot on Oracle Cloud (OCI)
+
+## Goal
+
+Run a persistent Clawdbot Gateway on Oracle Cloud's **Always Free** ARM tier — **$0/month forever** with more resources than most paid VPS options.
+
+## Cost Comparison (2026)
+
+| Provider | Plan | Specs | Price/mo | Notes |
+|----------|------|-------|----------|-------|
+| **Oracle Cloud** | Always Free ARM | 4 OCPU, 24GB RAM | **$0** | Best value, this guide |
+| **Hetzner** | CX22 | 2 vCPU, 4GB RAM | €3.79 (~$4) | Cheapest paid, EU datacenters |
+| **DigitalOcean** | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
+| **Vultr** | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
+| **Linode** | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
+
+**Why Oracle?** The Always Free tier gives you 4x the CPU and 24x the RAM of a $6 DigitalOcean droplet — for $0. The tradeoff is ARM architecture (most things work) and Oracle's signup process (can be finicky).
+
+---
+
+## Prerequisites
+
+- Oracle Cloud account ([signup](https://www.oracle.com/cloud/free/))
+- Tailscale account (free at [tailscale.com](https://tailscale.com))
+- ~30 minutes
+
+## 1) Create an OCI Instance
+
+1. Log into [Oracle Cloud Console](https://cloud.oracle.com/)
+2. Navigate to **Compute → Instances → Create Instance**
+3. Configure:
+   - **Name:** `clawdbot`
+   - **Image:** Ubuntu 24.04 (aarch64)
+   - **Shape:** `VM.Standard.A1.Flex` (Ampere ARM)
+   - **OCPUs:** 2 (or up to 4)
+   - **Memory:** 12 GB (or up to 24 GB)
+   - **Boot volume:** 50 GB (up to 200 GB free)
+   - **SSH key:** Add your public key
+4. Click **Create**
+5. Note the public IP address
+
+**Tip:** If instance creation fails with "Out of capacity", try a different availability domain or retry later. Free tier capacity is limited.
+
+## 2) Configure VCN Security (Critical)
+
+OCI's Virtual Cloud Network (VCN) acts as a firewall at the network edge — traffic is blocked before it reaches your instance. This is more secure than host-based firewalls.
+
+1. Go to **Networking → Virtual Cloud Networks**
+2. Click your VCN → **Security Lists** → Default Security List
+3. **Remove** all ingress rules except:
+   - `0.0.0.0/0 UDP 41641` (Tailscale)
+4. Keep default egress rules (allow all outbound)
+
+This blocks everything except Tailscale. You'll SSH via Tailscale, not the public IP.
+
+## 3) Connect and Update
+
+```bash
+# Initial connection via public IP (one time only)
+ssh ubuntu@YOUR_PUBLIC_IP
+
+# Update system
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y build-essential unzip
+```
+
+**Note:** `build-essential` is required for ARM compilation of some dependencies.
+
+## 4) Configure User and Hostname
+
+```bash
+# Set hostname
+sudo hostnamectl set-hostname clawdbot
+
+# Set password for ubuntu user
+sudo passwd ubuntu
+
+# Enable lingering (keeps user services running after logout)
+sudo loginctl enable-linger ubuntu
+```
+
+## 5) Install Tailscale
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --ssh --hostname=clawdbot
+```
+
+This enables Tailscale SSH, so you can connect via `ssh clawdbot` from any device on your tailnet — no public IP needed.
+
+Verify:
+```bash
+tailscale status
+```
+
+**From now on, connect via Tailscale:** `ssh ubuntu@clawdbot` (or use the Tailscale IP).
+
+## 6) Install Homebrew (ARM)
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Add to PATH
+echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
+echo 'export HOMEBREW_NO_AUTO_UPDATE=1' >> ~/.bashrc
+echo 'export HOMEBREW_NO_ENV_HINTS=1' >> ~/.bashrc
+source ~/.bashrc
+
+# Install GCC (needed for some packages on ARM)
+brew install gcc
+```
+
+## 7) Install Clawdbot
+
+```bash
+curl -fsSL https://clawd.bot/install.sh | bash
+source ~/.bashrc
+```
+
+When prompted "How do you want to hatch your bot?", select **"Do this later"**.
+
+## 8) Configure Gateway with Tailscale Serve
+
+```bash
+clawdbot config set gateway.bind loopback
+clawdbot config set gateway.tailscale.mode serve
+clawdbot config set gateway.trustedProxies '["127.0.0.1"]'
+clawdbot config set gateway.auth.allowTailscale true
+clawdbot config set gateway.controlUi.allowInsecureAuth true
+systemctl --user restart clawdbot-gateway
+```
+
+This configures:
+- Gateway binds to loopback only (127.0.0.1)
+- Tailscale Serve provides HTTPS and handles external routing
+- Authentication via Tailscale identity headers (no tokens needed)
+
+## 9) Verify
+
+```bash
+# Check version
+clawdbot --version
+
+# Check daemon status
+systemctl --user status clawdbot-gateway
+
+# Check Tailscale Serve
+tailscale serve status
+
+# Test local response
+curl http://localhost:18789
+```
+
+---
+
+## Access the Control UI
+
+From any device on your Tailscale network:
+
+```
+https://clawdbot.<tailnet-name>.ts.net/
+```
+
+Replace `<tailnet-name>` with your tailnet name (visible in `tailscale status`).
+
+No SSH tunnel needed. Tailscale provides:
+- HTTPS encryption (automatic certs)
+- Authentication via Tailscale identity
+- Access from any device on your tailnet (laptop, phone, etc.)
+
+---
+
+## Security: Why VCN + Tailscale Is Enough
+
+With the VCN configured as above (only UDP 41641 open), you have **defense in depth** that makes traditional VPS hardening redundant.
+
+**How it works:** The VCN blocks traffic at the network edge — before it reaches your instance. Combined with Tailscale SSH (which bypasses sshd entirely), there's no attack surface for typical threats.
+
+### What's Already Protected
+
+| Traditional Step | Needed? | Why |
+|------------------|---------|-----|
+| UFW firewall | No | VCN blocks before traffic reaches instance |
+| fail2ban | No | No brute force if port 22 blocked at VCN |
+| sshd hardening | No | Tailscale SSH doesn't use sshd |
+| Disable root login | No | Tailscale uses Tailscale identity, not system users |
+| SSH key-only auth | No | Tailscale authenticates via your tailnet |
+| Disable IPv6 | No | OCI free tier doesn't assign public IPv6 |
+
+### Still Recommended
+
+- **Credential permissions:** `chmod 700 ~/.clawdbot`
+- **Security audit:** `clawdbot security audit`
+- **System updates:** `sudo apt update && sudo apt upgrade` regularly
+- **Monitor Tailscale:** Review devices in [Tailscale admin console](https://login.tailscale.com/admin)
+
+### Verify Security Posture
+
+```bash
+# Confirm no public ports listening
+sudo ss -tlnp | grep -v '127.0.0.1\|::1'
+
+# Verify Tailscale SSH is active
+tailscale status | grep -q 'offers: ssh' && echo "Tailscale SSH active"
+
+# Optional: disable sshd entirely
+sudo systemctl disable --now ssh
+```
+
+---
+
+## Fallback: SSH Tunnel
+
+If Tailscale Serve isn't working, use an SSH tunnel:
+
+```bash
+# From your local machine (via Tailscale)
+ssh -L 18789:127.0.0.1:18789 ubuntu@clawdbot
+```
+
+Then open `http://localhost:18789`.
+
+---
+
+## Troubleshooting
+
+### Instance creation fails ("Out of capacity")
+Free tier ARM instances are popular. Try:
+- Different availability domain
+- Retry during off-peak hours (early morning)
+- Use the "Always Free" filter when selecting shape
+
+### Tailscale won't connect
+```bash
+# Check status
+sudo tailscale status
+
+# Re-authenticate
+sudo tailscale up --ssh --hostname=clawdbot --reset
+```
+
+### Gateway won't start
+```bash
+clawdbot gateway status
+clawdbot doctor --non-interactive
+journalctl --user -u clawdbot-gateway -n 50
+```
+
+### Can't reach Control UI
+```bash
+# Verify Tailscale Serve is running
+tailscale serve status
+
+# Check gateway is listening
+curl http://localhost:18789
+
+# Restart if needed
+systemctl --user restart clawdbot-gateway
+```
+
+### ARM binary issues
+Some tools may not have ARM builds. Check:
+```bash
+uname -m  # Should show aarch64
+```
+
+Most npm packages work fine. For binaries, look for `linux-arm64` or `aarch64` releases.
+
+---
+
+## Persistence
+
+All state lives in:
+- `~/.clawdbot/` — config, credentials, session data
+- `~/clawd/` — workspace (SOUL.md, memory, artifacts)
+
+Back up periodically:
+```bash
+tar -czvf clawdbot-backup.tar.gz ~/.clawdbot ~/clawd
+```
+
+---
+
+## See Also
+
+- [Gateway remote access](/gateway/remote) — other remote access patterns
+- [Tailscale integration](/gateway/tailscale) — full Tailscale docs
+- [Gateway configuration](/gateway/configuration) — all config options
+- [DigitalOcean guide](/platforms/digitalocean) — if you want paid + easier signup
+- [Hetzner guide](/platforms/hetzner) — Docker-based alternative

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -140,7 +140,7 @@ tailscale serve status
 curl http://localhost:18789
 ```
 
-## 9) Lock Down VCN Security
+## 8) Lock Down VCN Security
 
 Now that everything is working, lock down the VCN to block all traffic except Tailscale. OCI's Virtual Cloud Network acts as a firewall at the network edge — traffic is blocked before it reaches your instance.
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -49,22 +49,10 @@ Run a persistent Clawdbot Gateway on Oracle Cloud's **Always Free** ARM tier —
 
 **Tip:** If instance creation fails with "Out of capacity", try a different availability domain or retry later. Free tier capacity is limited.
 
-## 2) Configure VCN Security (Critical)
-
-OCI's Virtual Cloud Network (VCN) acts as a firewall at the network edge — traffic is blocked before it reaches your instance. This is more secure than host-based firewalls.
-
-1. Go to **Networking → Virtual Cloud Networks**
-2. Click your VCN → **Security Lists** → Default Security List
-3. **Remove** all ingress rules except:
-   - `0.0.0.0/0 UDP 41641` (Tailscale)
-4. Keep default egress rules (allow all outbound)
-
-This blocks everything except Tailscale. You'll SSH via Tailscale, not the public IP.
-
-## 3) Connect and Update
+## 2) Connect and Update
 
 ```bash
-# Initial connection via public IP (one time only)
+# Connect via public IP
 ssh ubuntu@YOUR_PUBLIC_IP
 
 # Update system
@@ -74,7 +62,7 @@ sudo apt install -y build-essential
 
 **Note:** `build-essential` is required for ARM compilation of some dependencies.
 
-## 4) Configure User and Hostname
+## 3) Configure User and Hostname
 
 ```bash
 # Set hostname
@@ -87,7 +75,7 @@ sudo passwd ubuntu
 sudo loginctl enable-linger ubuntu
 ```
 
-## 5) Install Tailscale
+## 4) Install Tailscale
 
 ```bash
 curl -fsSL https://tailscale.com/install.sh | sh
@@ -102,6 +90,18 @@ tailscale status
 ```
 
 **From now on, connect via Tailscale:** `ssh ubuntu@clawdbot` (or use the Tailscale IP).
+
+## 5) Lock Down VCN Security
+
+Now that Tailscale is running, lock down the VCN to block all traffic except Tailscale. OCI's Virtual Cloud Network acts as a firewall at the network edge — traffic is blocked before it reaches your instance.
+
+1. Go to **Networking → Virtual Cloud Networks** in the OCI Console
+2. Click your VCN → **Security Lists** → Default Security List
+3. **Remove** all ingress rules except:
+   - `0.0.0.0/0 UDP 41641` (Tailscale)
+4. Keep default egress rules (allow all outbound)
+
+This blocks SSH on port 22, HTTP, HTTPS, and everything else at the network edge. You'll only be able to connect via Tailscale from now on.
 
 ## 6) Install Homebrew (ARM)
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -91,19 +91,7 @@ tailscale status
 
 **From now on, connect via Tailscale:** `ssh ubuntu@clawdbot` (or use the Tailscale IP).
 
-## 5) Lock Down VCN Security
-
-Now that Tailscale is running, lock down the VCN to block all traffic except Tailscale. OCI's Virtual Cloud Network acts as a firewall at the network edge — traffic is blocked before it reaches your instance.
-
-1. Go to **Networking → Virtual Cloud Networks** in the OCI Console
-2. Click your VCN → **Security Lists** → Default Security List
-3. **Remove** all ingress rules except:
-   - `0.0.0.0/0 UDP 41641` (Tailscale)
-4. Keep default egress rules (allow all outbound)
-
-This blocks SSH on port 22, HTTP, HTTPS, and everything else at the network edge. You'll only be able to connect via Tailscale from now on.
-
-## 6) Install Homebrew (ARM)
+## 5) Install Homebrew (ARM)
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -118,7 +106,7 @@ source ~/.bashrc
 brew install gcc
 ```
 
-## 7) Install Clawdbot
+## 6) Install Clawdbot
 
 ```bash
 curl -fsSL https://clawd.bot/install.sh | bash
@@ -127,7 +115,7 @@ source ~/.bashrc
 
 When prompted "How do you want to hatch your bot?", select **"Do this later"**.
 
-## 8) Configure Gateway with Tailscale Serve
+## 7) Configure Gateway with Tailscale Serve
 
 ```bash
 clawdbot config set gateway.bind loopback
@@ -143,7 +131,7 @@ This configures:
 - Tailscale Serve provides HTTPS and handles external routing
 - Authentication via Tailscale identity headers (no tokens needed)
 
-## 9) Verify
+## 8) Verify
 
 ```bash
 # Check version
@@ -158,6 +146,18 @@ tailscale serve status
 # Test local response
 curl http://localhost:18789
 ```
+
+## 9) Lock Down VCN Security
+
+Now that everything is working, lock down the VCN to block all traffic except Tailscale. OCI's Virtual Cloud Network acts as a firewall at the network edge — traffic is blocked before it reaches your instance.
+
+1. Go to **Networking → Virtual Cloud Networks** in the OCI Console
+2. Click your VCN → **Security Lists** → Default Security List
+3. **Remove** all ingress rules except:
+   - `0.0.0.0/0 UDP 41641` (Tailscale)
+4. Keep default egress rules (allow all outbound)
+
+This blocks SSH on port 22, HTTP, HTTPS, and everything else at the network edge. From now on, you can only connect via Tailscale.
 
 ---
 
@@ -180,7 +180,7 @@ No SSH tunnel needed. Tailscale provides:
 
 ## Security: Why VCN + Tailscale Is Enough
 
-With the VCN configured as above (only UDP 41641 open), you have **defense in depth** that makes traditional VPS hardening redundant.
+With the VCN locked down (only UDP 41641 open), you have **defense in depth** that makes traditional VPS hardening redundant.
 
 **How it works:** The VCN blocks traffic at the network edge — before it reaches your instance. Combined with Tailscale SSH (which bypasses sshd entirely), there's no attack surface for typical threats.
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -1,5 +1,5 @@
 ---
-summary: "VPS hosting hub for Clawdbot (Fly/Hetzner/GCP/exe.dev)"
+summary: "VPS hosting hub for Clawdbot (Oracle/Fly/Hetzner/GCP/exe.dev)"
 read_when:
   - You want to run the Gateway in the cloud
   - You need a quick map of VPS/hosting guides
@@ -11,6 +11,7 @@ deployments work at a high level.
 
 ## Pick a provider
 
+- **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month forever, 4 OCPU + 24GB RAM (ARM)
 - **Fly.io**: [Fly.io](/platforms/fly)
 - **Hetzner (Docker)**: [Hetzner](/platforms/hetzner)
 - **GCP (Compute Engine)**: [GCP](/platforms/gcp)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -11,7 +11,7 @@ deployments work at a high level.
 
 ## Pick a provider
 
-- **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month forever, 4 OCPU + 24GB RAM (ARM)
+- **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month (Always Free, ARM; capacity/signup can be finicky)
 - **Fly.io**: [Fly.io](/platforms/fly)
 - **Hetzner (Docker)**: [Hetzner](/platforms/hetzner)
 - **GCP (Compute Engine)**: [GCP](/platforms/gcp)

--- a/src/discord/monitor/presence-cache.test.ts
+++ b/src/discord/monitor/presence-cache.test.ts
@@ -1,11 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { GatewayPresenceUpdate } from "discord-api-types/v10";
-import {
-  clearPresences,
-  getPresence,
-  presenceCacheSize,
-  setPresence,
-} from "./presence-cache.js";
+import { clearPresences, getPresence, presenceCacheSize, setPresence } from "./presence-cache.js";
 
 describe("presence-cache", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Add comprehensive guide for Oracle Cloud Always Free tier (ARM) at `docs/platforms/oracle.md`
- Cover VCN security, Tailscale Serve setup, and why traditional VPS hardening (UFW, fail2ban, sshd) is unnecessary with OCI's network-edge firewall
- Update `docs/vps.md` to list Oracle as top provider option ($0/month)

## Why Oracle Cloud?

Oracle's Always Free tier offers significantly more resources than paid alternatives:

| Provider | Specs | Price |
|----------|-------|-------|
| **Oracle Cloud** | 4 OCPU, 24GB RAM | $0/month |
| Hetzner CX22 | 2 vCPU, 4GB RAM | ~$4/month |
| DigitalOcean | 1 vCPU, 1GB RAM | $6/month |

The guide covers the unique security model where OCI's VCN blocks traffic at the network edge, making host-based firewalls redundant.

## Test plan

- [ ] Verify markdown renders correctly on docs site
- [ ] Check all internal links resolve (`/platforms/oracle`, `/gateway/tailscale`, etc.)
- [ ] Confirm YAML frontmatter matches other platform guides

---

🤖 Generated with [Claude Code](https://claude.ai/code)