### PR TITLE
Agent tool call hooks now fire during tool execution

### DIFF
--- a/src/agents/pi-tools.hooks.ts
+++ b/src/agents/pi-tools.hooks.ts
@@ -1,0 +1,115 @@
+/**
+ * Tool Hook Wrappers
+ *
+ * Wraps tool execute methods to fire before_tool_call and after_tool_call
+ * plugin hooks around every tool invocation.
+ */
+
+import type { HookRunner } from "../plugins/hooks.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+const log = createSubsystemLogger("tools/hooks");
+
+/**
+ * Wrap a single tool's execute method to fire before_tool_call and after_tool_call hooks.
+ */
+export function wrapToolWithHooks(
+  tool: AnyAgentTool,
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): AnyAgentTool {
+  const originalExecute = tool.execute;
+  if (!originalExecute) return tool;
+
+  const toolName = tool.name;
+
+  return {
+    ...tool,
+    execute: async (
+      toolCallId: string,
+      params: unknown,
+      signal?: AbortSignal,
+      onUpdate?: (data: unknown) => void,
+    ) => {
+      const hookCtx = {
+        agentId: ctx.agentId,
+        sessionKey: ctx.sessionKey,
+        toolName,
+      };
+
+      // --- before_tool_call ---
+      let effectiveParams = params;
+      if (hookRunner.hasHooks("before_tool_call")) {
+        try {
+          const beforeResult = await hookRunner.runBeforeToolCall(
+            {
+              toolName,
+              params: (params ?? {}) as Record<string, unknown>,
+            },
+            hookCtx,
+          );
+          if (beforeResult?.block) {
+            const reason = beforeResult.blockReason ?? "Blocked by plugin hook";
+            log.debug(`before_tool_call: blocked ${toolName} — ${reason}`);
+            return `[Tool call blocked] ${reason}`;
+          }
+          if (beforeResult?.params) {
+            effectiveParams = beforeResult.params;
+          }
+        } catch (err) {
+          log.debug(`before_tool_call hook error for ${toolName}: ${String(err)}`);
+          // Hook errors must not break tool execution
+        }
+      }
+
+      // --- execute ---
+      const startMs = Date.now();
+      let result: unknown;
+      let error: string | undefined;
+      try {
+        result = await originalExecute(toolCallId, effectiveParams, signal, onUpdate);
+        return result;
+      } catch (err) {
+        error = String(err);
+        throw err;
+      } finally {
+        // --- after_tool_call (fire-and-forget) ---
+        if (hookRunner.hasHooks("after_tool_call")) {
+          hookRunner
+            .runAfterToolCall(
+              {
+                toolName,
+                params: (effectiveParams ?? {}) as Record<string, unknown>,
+                result,
+                error,
+                durationMs: Date.now() - startMs,
+              },
+              hookCtx,
+            )
+            .catch((hookErr) => {
+              log.debug(`after_tool_call hook error for ${toolName}: ${String(hookErr)}`);
+            });
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Wrap all tools in an array with before/after tool call hooks.
+ * Returns the original array unchanged if no tool call hooks are registered.
+ */
+export function wrapToolsWithHooks(
+  tools: AnyAgentTool[],
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): AnyAgentTool[] {
+  if (
+    !hookRunner.hasHooks("before_tool_call") &&
+    !hookRunner.hasHooks("after_tool_call")
+  ) {
+    return tools;
+  }
+  return tools.map((tool) => wrapToolWithHooks(tool, hookRunner, ctx));
+}


### PR DESCRIPTION
## Summary

Wire up the existing `before_tool_call` and `after_tool_call` plugin hooks so they actually fire during the agent execution loop. These hooks were defined in `src/plugins/hooks.ts` but never invoked.

## What changed

### New file: `src/agents/pi-tools.hooks.ts`

A tool wrapper module (following the same pattern as `pi-tools.abort.ts`) that wraps each tool's `execute` method to fire plugin hooks:

- **`wrapToolWithHooks(tool, hookRunner, ctx)`** — wraps a single tool
- **`wrapToolsWithHooks(tools, hookRunner, ctx)`** — wraps an array; returns the original array unchanged if no hooks are registered (zero overhead)

### Modified: `src/agents/pi-embedded-runner/run/attempt.ts`

- Moved `hookRunner` initialization earlier (before `splitSdkTools`) so it's available for tool wrapping
- Both `builtInTools` and `customTools` are wrapped before being passed to `createAgentSession`
- Extracted `hookAgentId` to avoid repeated `sessionKey.split(":")` calls

## How it works

### `before_tool_call`

Fires **before** each tool executes. Plugin handlers receive `{ toolName, params }` and can:

- **Block the call**: return `{ block: true, blockReason: "..." }` → tool is skipped, a synthetic `[Tool call blocked] ...` result is returned to the model
- **Modify params**: return `{ params: modifiedParams }` → the modified params are used instead

Handlers run sequentially in priority order. If any handler blocks, the tool is not executed.

### `after_tool_call`

Fires **after** each tool returns (or throws). Plugin handlers receive `{ toolName, params, result, error, durationMs }`.

This is fire-and-forget (void hook) — handlers run in parallel and failures are caught and logged.

## Plugin author usage

```typescript
// In a plugin's hooks registration:
{
  hookName: "before_tool_call",
  handler: async (event, ctx) => {
    // Log all tool calls
    console.log(`Tool ${event.toolName} called with`, event.params);

    // Block dangerous tools
    if (event.toolName === "exec" && isSuspicious(event.params)) {
      return { block: true, blockReason: "Blocked by security policy" };
    }

    // Or modify params
    return { params: sanitize(event.params) };
  },
}

{
  hookName: "after_tool_call",
  handler: async (event, ctx) => {
    // Post-execution logging / telemetry
    metrics.recordToolCall({
      tool: event.toolName,
      durationMs: event.durationMs,
      success: !event.error,
    });
  },
}
```

## Safety

- Hook errors never break tool execution (caught and logged)
- Tools are only wrapped when hooks are registered (no overhead otherwise)
- Follows existing patterns: same wrapper style as `wrapToolWithAbortSignal`, same hook runner access as `session-tool-result-guard-wrapper.ts`
- No refactoring of existing code — purely additive wiring

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires `before_tool_call` and `after_tool_call` plugin hooks into the embedded agent execution loop by adding a `wrapToolsWithHooks` wrapper that decorates each tool’s `execute` method. `runEmbeddedAttempt` now initializes the global `hookRunner` earlier and passes wrapped `builtInTools` and `customTools` into `createAgentSession`, and it also avoids repeated `sessionKey.split(":")` by extracting `hookAgentId`.

The change fits into the existing plugin-hook architecture (`src/plugins/hooks.ts`) similarly to other tool wrappers (e.g. abort-signal wrapping) and enables plugins to observe/block/modify tool calls and record post-execution telemetry.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the blocked-tool-call behavior may cause tool result pairing issues on strict providers.
- Core wiring is straightforward and follows existing wrapper patterns, but the new wrapper introduces subtle contract questions: returning a raw string on blocked calls and not emitting a toolResult tied to the toolCallId can break strict tool-call/tool-result pairing or downstream result parsing depending on provider/tooling expectations.
- src/agents/pi-tools.hooks.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->