### PR TITLE
[AI] fix(macos): parse SSH port correctly in remote connection test

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -403,30 +403,10 @@ final class AppState {
             self.remoteUrl = remoteUrlText
         }
 
-        let targetMode = desiredMode ?? self.connectionMode
-        if targetMode == .remote,
-           remoteTransport != .direct,
-           let host = AppState.remoteHost(from: remoteUrl)
-        {
-            self.updateRemoteTarget(host: host)
-        }
-    }
-
-    private func updateRemoteTarget(host: String) {
-        let trimmed = self.remoteTarget.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsed = CommandResolver.parseSSHTarget(trimmed) else { return }
-        let trimmedUser = parsed.user?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let user = (trimmedUser?.isEmpty ?? true) ? nil : trimmedUser
-        let port = parsed.port
-        let assembled: String
-        if let user {
-            assembled = port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
-        } else {
-            assembled = port == 22 ? host : "\(host):\(port)"
-        }
-        if assembled != self.remoteTarget {
-            self.remoteTarget = assembled
-        }
+        // Note: We intentionally do NOT auto-populate remoteTarget here.
+        // The SSH target is user-controlled via the UI; auto-populating it from
+        // gateway.remote.url would override user edits (including clearing the field).
+        // Initial population happens in init() for first-time setup only.
     }
 
     private func syncGatewayConfigIfNeeded() {

--- a/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
@@ -51,8 +51,10 @@ enum GatewayLaunchAgentManager {
 
     static func set(enabled: Bool, bundlePath: String, port: Int) async -> String? {
         _ = bundlePath
-        guard !CommandResolver.connectionModeIsRemote() else {
-            self.logger.info("launchd change skipped (remote mode)")
+        // In remote mode, never enable the local gateway, but still allow disabling it
+        // so switching from local→remote properly unloads the launchd job.
+        if enabled, CommandResolver.connectionModeIsRemote() {
+            self.logger.info("launchd enable skipped (remote mode)")
             return nil
         }
         if enabled, self.isLaunchAgentWriteDisabled() {

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2890,6 +2890,8 @@ Auth and Tailscale:
 Remote client defaults (CLI):
 - `gateway.remote.url` sets the default Gateway WebSocket URL for CLI calls when `gateway.mode = "remote"`.
 - `gateway.remote.transport` selects the macOS remote transport (`ssh` default, `direct` for ws/wss). When `direct`, `gateway.remote.url` must be `ws://` or `wss://`. `ws://host` defaults to port `18789`.
+- `gateway.remote.sshTarget` sets the SSH target for CLI probes and macOS app tunneling (`user@host` or `user@host:port`; port defaults to 22).
+- `gateway.remote.sshIdentity` sets the SSH identity file path for remote connections.
 - `gateway.remote.token` supplies the token for remote calls (leave unset for no auth).
 - `gateway.remote.password` supplies the password for remote calls (leave unset for no auth).
 
@@ -2906,6 +2908,23 @@ macOS app behavior:
       url: "ws://gateway.tailnet:18789",
       token: "your-token",
       password: "your-password"
+    }
+  }
+}
+```
+
+SSH tunnel example with non-standard SSH port (macOS app):
+
+```json5
+{
+  gateway: {
+    mode: "remote",
+    remote: {
+      transport: "ssh",
+      sshTarget: "admin@gateway.example.com:2222",
+      sshIdentity: "~/.ssh/id_ed25519",
+      url: "ws://127.0.0.1:18789",
+      token: "your-token"
     }
   }
 }

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -27,7 +27,8 @@ Remote mode supports two transports:
 1) Open *Settings → General*.
 2) Under **Clawdbot runs**, pick **Remote over SSH** and set:
    - **Transport**: **SSH tunnel** or **Direct (ws/wss)**.
-   - **SSH target**: `user@host` (optional `:port`).
+   - **SSH target**: `user@host` or `user@host:port` (port defaults to 22).
+     - Example with non-standard SSH port: `admin@gateway.example.com:2222`
      - If the gateway is on the same LAN and advertises Bonjour, pick it from the discovered list to auto-fill this field.
    - **Gateway URL** (Direct only): `wss://gateway.example.ts.net` (or `ws://...` for local/LAN).
    - **Identity file** (advanced): path to your key.

--- a/src/discord/monitor/presence-cache.test.ts
+++ b/src/discord/monitor/presence-cache.test.ts
@@ -1,11 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { GatewayPresenceUpdate } from "discord-api-types/v10";
-import {
-  clearPresences,
-  getPresence,
-  presenceCacheSize,
-  setPresence,
-} from "./presence-cache.js";
+import { clearPresences, getPresence, presenceCacheSize, setPresence } from "./presence-cache.js";
 
 describe("presence-cache", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Fix "Test Remote" button failing for non-standard SSH ports (e.g., `user@host:2222`) - Fixes #2343
- Fix SSH target field auto-repopulating after being cleared - Fixes #2344
- Fix local gateway launchd job crash-looping when switching to remote mode - Fixes #2354
- Document `gateway.remote.sshTarget` and `gateway.remote.sshIdentity` config keys
- Add non-standard SSH port example to docs

## Changes
- `GeneralSettings.swift`: Use `CommandResolver.parseSSHTarget()` to properly extract port and pass it via `-p` flag
- `AppState.swift`: Remove `updateRemoteTarget()` call from config watcher to prevent feedback loop
- `GatewayLaunchAgentManager.swift`: Allow disabling launchd job in remote mode (only block enabling)
- `docs/platforms/mac/remote.md`: Add SSH port format and example
- `docs/gateway/configuration.md`: Document `sshTarget` and `sshIdentity` keys

## Test plan
- [ ] Build macOS app and verify "Test Remote" works with `user@host:2222` format
- [ ] Verify clearing SSH target field stays cleared after saving
- [ ] Verify standard `user@host` format still works
- [ ] Switch from local to remote mode and verify no launchd crash-loop in logs

## AI disclosure
- **AI-assisted**: yes (Claude Code / Opus 4.5)
- **Testing status**: lightly tested - macOS app builds successfully; manual testing of SSH port parsing not yet performed
- **Prompts/session summary**: User reported "Test Remote" failing for SSH port 2222 and SSH target field auto-repopulating. Analyzed `GeneralSettings.swift`, `AppState.swift`, and `CommandResolver.swift` to identify root causes. Fixed port parsing to use existing `parseSSHTarget()` helper and removed config watcher feedback loop. Also discovered and fixed launchd crash-loop bug when switching to remote mode.
- **Understanding**: I understand the changes:
  - Port parsing fix reuses existing infrastructure (`CommandResolver.parseSSHTarget`) to properly extract the port and pass it via SSH's `-p` flag
  - Auto-populate fix removes a call to `updateRemoteTarget()` from the config watcher that was overwriting user edits
  - Launchd fix changes the guard in `GatewayLaunchAgentManager.set()` to only skip *enabling* in remote mode, not *disabling*

🤖 Generated with [Claude Code](https://claude.com/claude-code)