### PR TITLE
security(audit): detect API keys in auth profile names

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -188,9 +188,9 @@ export async function ensureAgentWorkspace(params?: {
   };
 }
 
-async function resolveMemoryBootstrapEntries(resolvedDir: string): Promise<
-  Array<{ name: WorkspaceBootstrapFileName; filePath: string }>
-> {
+async function resolveMemoryBootstrapEntries(
+  resolvedDir: string,
+): Promise<Array<{ name: WorkspaceBootstrapFileName; filePath: string }>> {
   const candidates: WorkspaceBootstrapFileName[] = [
     DEFAULT_MEMORY_FILENAME,
     DEFAULT_MEMORY_ALT_FILENAME,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -9,6 +9,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { probeGateway } from "../gateway/probe.js";
 import {
+  collectApiKeyInProfileNameFindings,
   collectAttackSurfaceSummaryFindings,
   collectExposureMatrixFindings,
   collectHooksHardeningFindings,
@@ -911,6 +912,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectElevatedFindings(cfg));
   findings.push(...collectHooksHardeningFindings(cfg));
   findings.push(...collectSecretsInConfigFindings(cfg));
+  findings.push(...collectApiKeyInProfileNameFindings(cfg));
   findings.push(...collectModelHygieneFindings(cfg));
   findings.push(...collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...collectExposureMatrixFindings(cfg));


### PR DESCRIPTION
## Summary

- Adds comprehensive secret pattern detection for auth profile names
- Introduces shared `src/security/secret-patterns.ts` with patterns for 40+ services (Anthropic, OpenAI, Google, GitHub, Slack, AWS, Stripe, Twilio, etc.)
- Audit now warns when profile names contain what looks like an actual API key

Profile names appear in logs, UI dropdowns, and error messages—they shouldn't contain secrets.

Closes #2321

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test src/security/` passes
- [ ] Manual: create auth profile with API key as name, run `clawdbot security audit`, verify warning appears