### PR TITLE
security(fix): extract hardcoded secrets to .env

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -188,9 +188,9 @@ export async function ensureAgentWorkspace(params?: {
   };
 }
 
-async function resolveMemoryBootstrapEntries(resolvedDir: string): Promise<
-  Array<{ name: WorkspaceBootstrapFileName; filePath: string }>
-> {
+async function resolveMemoryBootstrapEntries(
+  resolvedDir: string,
+): Promise<Array<{ name: WorkspaceBootstrapFileName; filePath: string }>> {
   const candidates: WorkspaceBootstrapFileName[] = [
     DEFAULT_MEMORY_FILENAME,
     DEFAULT_MEMORY_ALT_FILENAME,

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -105,6 +105,20 @@ export function registerSecurityCli(program: Command) {
             else if (action.skipped) lines.push(muted(`  skip ${command} (${action.skipped})`));
             else if (action.error) lines.push(muted(`  ${command} failed: ${action.error}`));
           }
+          if (fixResult.secretsExtracted && fixResult.secretsExtracted.length > 0) {
+            lines.push("");
+            lines.push(
+              muted(
+                `  Extracted ${fixResult.secretsExtracted.length} secret(s) to ${shortenHomePath(fixResult.envPath ?? "")}`,
+              ),
+            );
+            for (const s of fixResult.secretsExtracted) {
+              lines.push(muted(`    ${s.path.join(".")} → \${${s.envVar}}`));
+            }
+            lines.push("");
+            lines.push(muted("  ⚠️  Add .env to your backup exclusions"));
+            lines.push(muted("  ⚠️  Restart gateway: clawdbot gateway restart"));
+          }
           if (fixResult.errors.length > 0) {
             for (const err of fixResult.errors) {
               lines.push(muted(`  error: ${shortenHomeInString(err)}`));


### PR DESCRIPTION
## Summary

When running `clawdbot security audit --fix`, automatically detect hardcoded secrets in the config and:

1. Extract them to `~/.clawdbot/.env` with secure permissions (0600)
2. Replace config values with `${ENV_VAR}` references
3. Display which secrets were extracted

Uses existing redact patterns from `logging/redact.ts` plus high-entropy fallback for unknown formats.

**Example output:**
```
FIX
  extracted 4 secret(s) to ~/.clawdbot/.env
  
  Extracted 4 secret(s) to ~/.clawdbot/.env
    channels.discord.accounts.main.token → ${CLAWDBOT_DISCORD_MAIN_TOKEN}
    channels.telegram.accounts.bot.botToken → ${CLAWDBOT_TELEGRAM_BOT_BOT_TOKEN}
    gateway.auth.token → ${CLAWDBOT_GATEWAY_AUTH_TOKEN}
    models.providers.anthropic.apiKey → ${CLAWDBOT_MODELS_ANTHROPIC_API_KEY}

  ⚠️  Add .env to your backup exclusions
  ⚠️  Restart gateway: clawdbot gateway restart
```

Closes #2320

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm lint` passes  
- [ ] Manual: create config with hardcoded tokens, run `clawdbot security audit --fix`
- [ ] Verify .env created with correct values
- [ ] Verify config updated with `${VAR}` references
- [ ] Verify gateway restarts and reads from .env