### PR TITLE
feat: add CIDR support for trustedProxies and Railway/cloud deployment improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,22 @@ ENV NODE_ENV=production
 # Install gosu for dropping privileges safely
 RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
 
-# Entrypoint script: fix /data permissions then drop to node user
+# Entrypoint script: fix /data permissions, create Railway config, then drop to node user
 RUN printf '#!/bin/sh\n\
 if [ -d /data ]; then\n\
   chown -R node:node /data 2>/dev/null || true\n\
+fi\n\
+# Create initial config with trustedProxies for Railway/cloud deployments\n\
+if [ -n "$CLAWDBOT_STATE_DIR" ] && [ ! -f "$CLAWDBOT_STATE_DIR/clawdbot.json" ]; then\n\
+  mkdir -p "$CLAWDBOT_STATE_DIR"\n\
+  cat > "$CLAWDBOT_STATE_DIR/clawdbot.json" << EOF\n\
+{\n\
+  "gateway": {\n\
+    "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"]\n\
+  }\n\
+}\n\
+EOF\n\
+  chown node:node "$CLAWDBOT_STATE_DIR/clawdbot.json"\n\
 fi\n\
 exec gosu node "$@"\n' > /entrypoint.sh && chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Summary                                                                                                                                
  - Add CIDR notation support for `gateway.trustedProxies` (e.g., `100.64.0.0/10`)                                                          
  - Add Dockerfile entrypoint for Railway/cloud deployments that:                                                                           
    - Fixes volume permissions for non-root container user                                                                                  
    - Creates cloud-ready default config with trustedProxies and allowInsecureAuth                                                          
                                                                                                                                            
  ## Changes                                                                                                                                
  - `src/gateway/net.ts`: Add `isIpInCidr()` function for CIDR range matching in trustedProxies                                             
  - `Dockerfile`: Add entrypoint script with gosu for permission fixes and default cloud config                                             
                                                                                                                                            
  ## Test plan                                                                                                                              
  - [ ] Deployed on Railway and verified Control UI connects with token auth                                                                
  - [ ] Verified CIDR ranges like `100.64.0.0/10` correctly match IPs like `100.64.0.3`                                                     