### PR TITLE
feat(plugins): wire up before_tool_call hook for pre-execution validation

### DIFF
--- a/src/agents/pi-tools.before-call-hook.ts
+++ b/src/agents/pi-tools.before-call-hook.ts
@@ -1,0 +1,91 @@
+/**
+ * Tool wrapper that invokes the before_tool_call plugin hook.
+ *
+ * This wrapper intercepts tool execution to allow plugins to:
+ * - Validate and audit tool calls before execution
+ * - Modify tool parameters
+ * - Block tool execution with a custom reason
+ */
+
+import type { HookRunner } from "../plugins/hooks.js";
+import type { PluginHookToolContext } from "../plugins/hooks.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+export interface BeforeCallHookContext {
+  hookRunner: HookRunner;
+  agentId?: string;
+  sessionKey?: string;
+}
+
+/**
+ * Wraps a tool to invoke the before_tool_call hook before execution.
+ *
+ * If the hook returns `block: true`, the tool execution is skipped and
+ * an error message is returned instead.
+ *
+ * If the hook returns modified `params`, those are passed to the actual
+ * tool execute function.
+ */
+export function wrapToolWithBeforeCallHook(
+  tool: AnyAgentTool,
+  ctx: BeforeCallHookContext,
+): AnyAgentTool {
+  const { hookRunner, agentId, sessionKey } = ctx;
+  const execute = tool.execute;
+
+  // If no execute function or no hooks registered, return tool unchanged
+  if (!execute || !hookRunner.hasHooks("before_tool_call")) {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const toolName = tool.name;
+
+      // Build hook context
+      const hookCtx: PluginHookToolContext = {
+        agentId,
+        sessionKey,
+        toolName,
+        toolCallId,
+      };
+
+      // Run the before_tool_call hook
+      const hookResult = await hookRunner.runBeforeToolCall(
+        {
+          toolName,
+          toolCallId,
+          params: params as Record<string, unknown>,
+        },
+        hookCtx,
+      );
+
+      // Check if the hook blocked the tool call
+      if (hookResult?.block) {
+        const reason = hookResult.blockReason ?? "Tool call blocked by policy";
+        // Return a structured error that the agent can understand
+        return {
+          type: "text" as const,
+          text: `Error: ${reason}`,
+        };
+      }
+
+      // Use modified params if provided, otherwise use original
+      const effectiveParams = hookResult?.params ?? params;
+
+      // Execute the actual tool
+      return await execute(toolCallId, effectiveParams, signal, onUpdate);
+    },
+  };
+}
+
+/**
+ * Wraps all tools in the array with the before_tool_call hook.
+ */
+export function wrapToolsWithBeforeCallHook(
+  tools: AnyAgentTool[],
+  ctx: BeforeCallHookContext,
+): AnyAgentTool[] {
+  return tools.map((tool) => wrapToolWithBeforeCallHook(tool, ctx));
+}

--- a/src/agents/pi-tools.before-call-hook.ts
+++ b/src/agents/pi-tools.before-call-hook.ts
@@ -63,10 +63,11 @@ export function wrapToolWithBeforeCallHook(
       // Check if the hook blocked the tool call
       if (hookResult?.block) {
         const reason = hookResult.blockReason ?? "Tool call blocked by policy";
-        // Return a properly structured AgentToolResult error
+        // Return a properly structured AgentToolResult error with status="error"
+        // so downstream error detection (isToolResultError) recognizes it as an error
         const blockedResult: AgentToolResult<unknown> = {
           content: [{ type: "text", text: `Error: ${reason}` }],
-          details: { blocked: true, reason },
+          details: { status: "error", error: reason, blocked: true },
         };
         return blockedResult;
       }


### PR DESCRIPTION
## Summary

Adds the missing wiring for the `before_tool_call` plugin hook, enabling plugins to intercept, validate, modify, or block tool calls **before** execution.

The hook infrastructure (types, runner, handler merging) already existed in `src/plugins/hooks.ts` but was never actually invoked in the tool execution path. This PR adds the missing piece.

## Changes

- **New file:** `src/agents/pi-tools.before-call-hook.ts`
  - `wrapToolWithBeforeCallHook()` - wraps a single tool
  - `wrapToolsWithBeforeCallHook()` - wraps all tools in array
  
- **Modified:** `src/agents/pi-embedded-runner/run/attempt.ts`
  - Wraps tools after sanitization if `before_tool_call` hooks are registered
  - Only wraps if hooks exist (zero overhead when no plugins use this hook)

## Hook Behavior

Plugins can register a `before_tool_call` handler via `api.on("before_tool_call", ...)` to:

1. **Allow** (default) - tool executes normally
2. **Modify params** - return `{ params: modifiedParams }` to change tool arguments
3. **Block** - return `{ block: true, blockReason: "..." }` to prevent execution

## Example Plugin Usage

```typescript
api.on("before_tool_call", (event, ctx) => {
  const { toolName, params } = event;
  
  // Block dangerous commands
  if (toolName === "exec" && params.command?.includes("rm -rf /")) {
    return { block: true, blockReason: "Refusing to delete root filesystem" };
  }
  
  // Allow everything else
  return {};
});
```

## Test Plan

- [ ] Verify existing `tool_result_persist` hook still works
- [ ] Test plugin with `before_tool_call` handler can log tool calls
- [ ] Test plugin can block tool calls with custom reason
- [ ] Test plugin can modify tool parameters
- [ ] Verify no performance impact when no hooks registered

Closes #1733

---

Generated with [Claude Code](https://claude.com/claude-code)