### PR TITLE
fix(tests): use icacls for Windows ACL test setup [AI-assisted]

### DIFF
--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -855,30 +855,41 @@ describe("security audit", () => {
 
     const includePath = path.join(stateDir, "extra.json5");
     await fs.writeFile(includePath, "{ logging: { redactSensitive: 'off' } }\n", "utf-8");
-    await fs.chmod(includePath, 0o644);
+    if (isWindows) {
+      // Grant "Everyone" write access to trigger the perms_writable check on Windows
+      const { execSync } = await import("node:child_process");
+      execSync(`icacls "${includePath}" /grant Everyone:W`, { stdio: "ignore" });
+    } else {
+      await fs.chmod(includePath, 0o644);
+    }
 
     const configPath = path.join(stateDir, "clawdbot.json");
     await fs.writeFile(configPath, `{ "$include": "./extra.json5" }\n`, "utf-8");
     await fs.chmod(configPath, 0o600);
 
-    const cfg: ClawdbotConfig = { logging: { redactSensitive: "off" } };
-    const res = await runSecurityAudit({
-      config: cfg,
-      includeFilesystem: true,
-      includeChannelSecurity: false,
-      stateDir,
-      configPath,
-    });
+    try {
+      const cfg: ClawdbotConfig = { logging: { redactSensitive: "off" } };
+      const res = await runSecurityAudit({
+        config: cfg,
+        includeFilesystem: true,
+        includeChannelSecurity: false,
+        stateDir,
+        configPath,
+      });
 
-    const expectedCheckId = isWindows
-      ? "fs.config_include.perms_writable"
-      : "fs.config_include.perms_world_readable";
+      const expectedCheckId = isWindows
+        ? "fs.config_include.perms_writable"
+        : "fs.config_include.perms_world_readable";
 
-    expect(res.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ checkId: expectedCheckId, severity: "critical" }),
-      ]),
-    );
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ checkId: expectedCheckId, severity: "critical" }),
+        ]),
+      );
+    } finally {
+      // Clean up temp directory with world-writable file
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it("flags extensions without plugins.allow", async () => {


### PR DESCRIPTION
## What
Fixes the `flags group/world-readable config include files` test failing on Windows CI.

## Why
The test used `chmod 0o644` to create a world-readable file, but POSIX mode bits have no effect on Windows ACLs. Files created in temp directories are owned by the current user with no "Everyone" access, so the audit correctly found no insecure permissions and the expected `fs.config_include.perms_writable` check wasn't emitted.

## Changes
- On Windows, use `icacls /grant Everyone:W` to actually set world-writable ACLs
- Add `try/finally` cleanup to remove the temp directory after the test

## Testing
- [x] Lightly tested (no local Windows env; relies on CI to verify)
- Linux/macOS path unchanged — still uses `chmod 0o644`
- Windows path uses `icacls` to grant Everyone write access

## AI Disclosure
Written with Claude. I understand the code: the fix sets actual Windows ACLs instead of relying on ineffective POSIX chmod, and cleans up the world-writable temp file afterward.