### PR TITLE
[AI-assisted] fix(history): add LRU eviction for groupHistories to prevent memory leak

### DIFF
--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -3,6 +3,26 @@ import { CURRENT_MESSAGE_MARKER } from "./mentions.js";
 export const HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - for context]";
 export const DEFAULT_GROUP_HISTORY_LIMIT = 50;
 
+/** Maximum number of group history keys to retain (LRU eviction when exceeded). */
+export const MAX_HISTORY_KEYS = 1000;
+
+/**
+ * Evict oldest keys from a history map when it exceeds MAX_HISTORY_KEYS.
+ * Uses Map's insertion order for LRU-like behavior.
+ */
+export function evictOldHistoryKeys<T>(
+  historyMap: Map<string, T[]>,
+  maxKeys: number = MAX_HISTORY_KEYS,
+): void {
+  if (historyMap.size <= maxKeys) return;
+  const keysToDelete = historyMap.size - maxKeys;
+  const iterator = historyMap.keys();
+  for (let i = 0; i < keysToDelete; i++) {
+    const key = iterator.next().value;
+    if (key !== undefined) historyMap.delete(key);
+  }
+}
+
 export type HistoryEntry = {
   sender: string;
   body: string;
@@ -35,6 +55,8 @@ export function appendHistoryEntry<T extends HistoryEntry>(params: {
   history.push(entry);
   while (history.length > params.limit) history.shift();
   historyMap.set(historyKey, history);
+  // Evict oldest keys if map exceeds max size to prevent unbounded memory growth
+  evictOldHistoryKeys(historyMap);
   return history;
 }
 

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -54,6 +54,10 @@ export function appendHistoryEntry<T extends HistoryEntry>(params: {
   const history = historyMap.get(historyKey) ?? [];
   history.push(entry);
   while (history.length > params.limit) history.shift();
+  if (historyMap.has(historyKey)) {
+    // Refresh insertion order so eviction keeps recently used histories.
+    historyMap.delete(historyKey);
+  }
   historyMap.set(historyKey, history);
   // Evict oldest keys if map exceeds max size to prevent unbounded memory growth
   evictOldHistoryKeys(historyMap);


### PR DESCRIPTION
## Summary

Adds automatic LRU-style eviction to history maps to prevent unbounded memory growth in long-running instances.

## Problem

The `groupHistories` Map (and similar maps in Signal, WhatsApp, iMessage monitors) grows unbounded as users interact with more groups over time:

```typescript
const groupHistories = new Map<string, HistoryEntry[]>();
```

While `clearHistoryEntries()` empties values, **keys are never deleted**. Growth is O(unique groups), causing slow but steady memory accumulation.

## Solution

Added to `src/auto-reply/reply/history.ts`:

```typescript
export const MAX_HISTORY_KEYS = 1000;

export function evictOldHistoryKeys<T>(
  historyMap: Map<string, T[]>,
  maxKeys: number = MAX_HISTORY_KEYS,
): void {
  if (historyMap.size <= maxKeys) return;
  const keysToDelete = historyMap.size - maxKeys;
  const iterator = historyMap.keys();
  for (let i = 0; i < keysToDelete; i++) {
    const key = iterator.next().value;
    if (key !== undefined) historyMap.delete(key);
  }
}
```

Called automatically in `appendHistoryEntry()` to bound map size. Uses Map's insertion order for LRU-like behavior.

## Benefits

- ✅ Bounds memory growth to ~1000 groups maximum
- ✅ Minimal overhead (only runs when threshold exceeded)
- ✅ Uses existing Map insertion order (no extra data structures)
- ✅ Applies to all channel monitors using the shared history functions

## Testing

- ✅ Build passes (`pnpm build`)
- ✅ Lint passes (`pnpm lint`)
- 🔍 Lightly tested - verified eviction logic with manual testing

## AI Disclosure

This PR was AI-assisted (Claude/Codex). The issue was discovered through automated code analysis comparing memory patterns across long-running instances.

Fixes #2384