### PR TITLE
fix: reset chat state on webchat reconnect after gateway restart

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -127,6 +127,12 @@ export function connectGateway(host: GatewayHost) {
       host.lastError = null;
       host.hello = hello;
       applySnapshot(host, hello);
+      // Reset orphaned chat run state from before disconnect.
+      // Any in-flight run's final event was lost during the disconnect window.
+      host.chatRunId = null;
+      (host as unknown as { chatStream: string | null }).chatStream = null;
+      (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
+      resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       void loadAssistantIdentity(host as unknown as ClawdbotApp);
       void loadAgents(host as unknown as ClawdbotApp);
       void loadNodes(host as unknown as ClawdbotApp, { quiet: true });


### PR DESCRIPTION
## Problem
When the gateway restarts, the WebSocket disconnects and any in-flight `chat.final` events are lost. On reconnect, `chatRunId`/`chatStream` were still set from the orphaned run, making the UI think a run was still in progress.

**Symptom:** Users had to refresh the page after a gateway restart to see completed messages.

## Fix
Reset chat streaming state in the `onHello` callback when the WebSocket reconnects:
- `chatRunId = null`
- `chatStream = null`
- `chatStreamStartedAt = null`
- Reset tool stream state

This ensures the UI properly reflects the current state after reconnection.

## Testing
1. Send a message in webchat
2. Trigger gateway restart (`clawdbot gateway restart`)
3. Send another message
4. **Before fix:** Second message doesn't appear until page refresh
5. **After fix:** Both messages appear without refresh