### PR TITLE
fix(security): properly test Windows ACL audit for config includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Status: unreleased.
 
 ### Fixes
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.
+- Security: properly test Windows ACL audit for config includes. (#2403) Thanks @dominicnunez.
 - BlueBubbles: coalesce inbound URL link preview messages. (#1981) Thanks @tyler6204.
 - Cron: allow payloads containing "heartbeat" in event filter. (#2219) Thanks @dwfinkelstein.
 - Agents: include memory.md when bootstrapping memory context. (#2318) Thanks @czekaj.

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -333,6 +333,7 @@ describe("runHeartbeatOnce", () => {
       const cfg: ClawdbotConfig = {
         agents: {
           defaults: {
+            workspace: tmpDir,
             heartbeat: { every: "5m", target: "whatsapp" },
           },
         },
@@ -461,6 +462,7 @@ describe("runHeartbeatOnce", () => {
       const cfg: ClawdbotConfig = {
         agents: {
           defaults: {
+            workspace: tmpDir,
             heartbeat: {
               every: "5m",
               target: "last",
@@ -542,6 +544,7 @@ describe("runHeartbeatOnce", () => {
       const cfg: ClawdbotConfig = {
         agents: {
           defaults: {
+            workspace: tmpDir,
             heartbeat: { every: "5m", target: "whatsapp" },
           },
         },
@@ -597,6 +600,7 @@ describe("runHeartbeatOnce", () => {
       const cfg: ClawdbotConfig = {
         agents: {
           defaults: {
+            workspace: tmpDir,
             heartbeat: {
               every: "5m",
               target: "whatsapp",
@@ -668,6 +672,7 @@ describe("runHeartbeatOnce", () => {
       const cfg: ClawdbotConfig = {
         agents: {
           defaults: {
+            workspace: tmpDir,
             heartbeat: {
               every: "5m",
               target: "whatsapp",
@@ -737,7 +742,7 @@ describe("runHeartbeatOnce", () => {
     try {
       const cfg: ClawdbotConfig = {
         agents: {
-          defaults: { heartbeat: { every: "5m" } },
+          defaults: { workspace: tmpDir, heartbeat: { every: "5m" } },
           list: [{ id: "work", default: true }],
         },
         channels: { whatsapp: { allowFrom: ["*"] } },


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure in the security audit test for config `$include` file permissions.

**Problem:** The test expected `fs.config_include.perms_writable` on Windows, but `chmod 0o644` has no effect on Windows ACLs - the file would remain owner-only, so the audit wouldn't detect any permission issue.

**Solution:**
- Use `icacls` to grant `Everyone:W` on Windows to actually create a world-writable file
- Stub `execIcacls` to return proper ACL output so the audit can parse permissions deterministically
- Add try/finally cleanup to remove temp directory containing world-writable test file

## Testing

- [x] Lightly tested (Linux - the fix is Windows-specific, relies on CI to verify)
- [ ] Fully tested on Windows

## Checklist

- [x] Focused PR (one fix)
- [x] Describes what & why

## AI Disclosure

- [x] AI-assisted (Claude)
- [x] Lightly tested - verified code logic and existing patterns in windows-acl.ts
- [x] I understand what the code does