### PR TITLE
docs: update Hetzner guide command (--allow-unconfigured)

### DIFF
--- a/docs/platforms/hetzner.md
+++ b/docs/platforms/hetzner.md
@@ -188,7 +188,8 @@ services:
         "--bind",
         "${CLAWDBOT_GATEWAY_BIND}",
         "--port",
-        "${CLAWDBOT_GATEWAY_PORT}"
+        "${CLAWDBOT_GATEWAY_PORT}",
+        "--allow-unconfigured"
       ]
 ```
 


### PR DESCRIPTION
**What?**
Documentation: add missing "--allow-unconfigured" flag to clawdbot gateway command in the Hetzner guide.

**Why?**
It seems this flag is missing from the Hetzner doc. I followed the guide but could only run my clawdbot on Hetzner successfully after adding the flag.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Hetzner VPS Docker guide’s `docker-compose.yml` example to include the missing `--allow-unconfigured` flag in the `clawdbot gateway` command array, ensuring the documented startup command matches what’s needed to run successfully on an uninitialized config.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, localized documentation fix with low regression risk.
- Only a single docs file is changed, and the edit corrects a missing CLI flag in an example command array without affecting runtime code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->