### PR TITLE
fix(slack): route DM replies to original channel, not App Home

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -437,7 +437,10 @@ export async function prepareSlackMessage(params: {
     });
   }
 
-  const slackTo = isDirectMessage ? `user:${message.user}` : `channel:${message.channel}`;
+  // Always use channel ID for replies - user:X triggers conversations.open which
+  // creates a bot↔user DM (App Home) instead of posting to the original channel.
+  // This broke @mentions in DMs between two other users. See #2412.
+  const slackTo = `channel:${message.channel}`;
 
   const channelDescription = [channelInfo?.topic, channelInfo?.purpose]
     .map((entry) => entry?.trim())


### PR DESCRIPTION
Fixes #2412

## Problem
When @mentioned in a DM between two other users (User A ↔ User B), the bot replies to App Home instead of the original DM.

## Root Cause
`prepare.ts:440` sets `slackTo = user:${message.user}` for DMs.

In `send.ts:81`, `user:X` targets trigger:
```typescript
await client.conversations.open({ users: recipient.id })
```
This opens a **new** bot↔user DM (App Home), not the original channel.

## Fix
Always use `channel:${message.channel}` — the Slack API accepts channel IDs for all conversation types (channels, DMs, MPIMs).

`lastRoute` tracking (line 538) intentionally still uses `user:X` for identity/session purposes.

## Testing
- [x] Verified code path in `send.ts` confirms `user:` prefix triggers `conversations.open`
- [x] Manual test: @mention bot in DM between two other users

Co-Authored-By: Warp <agent@warp.dev>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack DM reply routing by always setting `To`/`OriginatingTo` to `channel:${message.channel}` in `src/slack/monitor/message-handler/prepare.ts`, preventing the downstream Slack sender from treating DMs as `user:` targets (which triggers `conversations.open` and creates a new bot↔user DM/App Home). Session/identity tracking via `lastRoute` remains keyed by `user:${message.user}` for DM contexts.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to Slack inbound message preparation and aligns with Slack’s API expectations: replies are now always sent to the original channel ID, avoiding the unintended `conversations.open` path that created a new bot↔user DM. No broader behavior changes beyond DM routing are apparent.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->