### PR TITLE
Feat(cron): add cron sandbox policy controls for visibility, escape, and delivery

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -134,6 +134,7 @@ Delivery notes:
 - If `to` is set, cron auto-delivers the agent’s final output even if `deliver` is omitted.
 - Use `deliver: true` when you want last-route delivery without an explicit `to`.
 - Use `deliver: false` to keep output internal even if a `to` is present.
+- Sandboxed sessions may restrict delivery targets via `agents.defaults.sandbox.cron.delivery` (see [Sandboxing](/gateway/sandboxing) and [Configuration](/gateway/configuration#agentsdefaultssandbox)).
 
 Target format reminders:
 - Slack/Discord/Mattermost (plugin) targets should use explicit prefixes (e.g. `channel:<id>`, `user:<id>`) to avoid ambiguity.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2175,6 +2175,15 @@ Defaults (if enabled):
 - optional sandboxed browser (Chromium + CDP, noVNC observer)
 - hardening knobs: `network`, `user`, `pidsLimit`, `memory`, `cpus`, `ulimits`, `seccompProfile`, `apparmorProfile`
 
+Cron policy (only applies when a session is sandboxed and the `cron` tool is allowed):
+- `cron.visibility`: `"agent"` (default) scopes cron jobs to the current agent; `"all"` allows cross-agent cron visibility.
+- `cron.elevated`: `"off"` (default) never bypasses sandbox cron restrictions; `"on"` bypasses when session elevated is on/ask/full; `"full"` bypasses only when elevated is full.
+- `cron.allowMainSessionJobs`: `false` (default) blocks main-session cron jobs and wake events from sandboxed sessions.
+- `cron.delivery`: `"last-only"` (default) allows last-route delivery only (no explicit `to`; if `channel` is set it must be `last`); `"off"` disables delivery; `"explicit"` allows explicit delivery targets.
+
+Notes:
+- This does not enable the `cron` tool inside the sandbox. Cron is denied by default in sandbox tool policy; allow it via `tools.sandbox.tools` (or per-agent `agents.list[].tools.sandbox.tools`).
+
 Warning: `scope: "shared"` means a shared container and shared workspace. No
 cross-session isolation. Use `scope: "session"` for per-session isolation.
 
@@ -2193,6 +2202,12 @@ For package installs, ensure network egress, a writable root FS, and a root user
         scope: "agent", // session | agent | shared (agent is default)
         workspaceAccess: "none", // none | ro | rw
         workspaceRoot: "~/.clawdbot/sandboxes",
+        cron: {
+          visibility: "agent", // agent | all
+          elevated: "off", // off | on | full
+          allowMainSessionJobs: false,
+          delivery: "last-only" // off | last-only | explicit
+        },
         docker: {
           image: "moltbot-sandbox:bookworm-slim",
           containerPrefix: "moltbot-sbx-",

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -90,6 +90,20 @@ Available groups:
 - `group:nodes`: `nodes`
 - `group:moltbot`: all built-in Moltbot tools (excludes provider plugins)
 
+### Cron policy inside the sandbox
+
+If the `cron` tool is allowed, sandboxed sessions can still be restricted by
+`agents.defaults.sandbox.cron` (and `agents.list[].sandbox.cron`):
+- Visibility: `agents.defaults.sandbox.cron.visibility` can scope cron jobs to the current agent.
+- Main session gating: `agents.defaults.sandbox.cron.allowMainSessionJobs: false` blocks main-session cron jobs and wake events from sandboxed sessions.
+- Delivery gating: `agents.defaults.sandbox.cron.delivery` can disable delivery or restrict it to last-route delivery.
+- Elevated gate: `agents.defaults.sandbox.cron.elevated` can use the session elevated level as an escape signal for cron restrictions.
+
+Notes:
+- Elevated remains exec-only (it does not grant extra tools), but cron policy can consult the session elevated level.
+- Fix-it keys live under `agents.defaults.sandbox.cron.*` / `agents.list[].sandbox.cron.*` (see [Configuration](/gateway/configuration#agentsdefaultssandbox)).
+- This is in addition to tool policy; if `cron` is denied by sandbox tool policy, allow it via `tools.sandbox.tools` (or per-agent `agents.list[].tools.sandbox.tools`).
+
 ## Elevated: exec-only “run on host”
 
 Elevated does **not** grant extra tools; it only affects `exec`.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -145,6 +145,24 @@ globally or per-agent, sandboxing doesn’t bring it back.
 `/exec` directives only apply for authorized senders and persist per session; to hard-disable
 `exec`, use tool policy deny (see [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated)).
 
+## Cron policy (sandboxed sessions)
+
+If the `cron` tool is allowed in a sandboxed session, Clawdbot can still apply
+additional restrictions to cron access and delivery via:
+- `agents.defaults.sandbox.cron`
+- `agents.list[].sandbox.cron` (per-agent override)
+
+This is useful when you want sandboxed agents to schedule reminders but prevent:
+- cross-agent cron visibility (`visibility: "agent"`)
+- main-session jobs and wake events (`allowMainSessionJobs: false`)
+- explicit delivery targets (`delivery: "last-only"` or `"off"`)
+
+Note: this does not enable cron in the sandbox. If `cron` is denied by sandbox tool policy,
+allow it via `tools.sandbox.tools` (or per-agent `agents.list[].tools.sandbox.tools`).
+
+See [Configuration](/gateway/configuration#agentsdefaultssandbox) for the exact keys and defaults.
+If you see “blocked” errors, also check [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated).
+
 Debugging:
 - Use `moltbot sandbox explain` to inspect effective sandbox mode, tool policy, and fix-it config keys.
 - See [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for the “why is this blocked?” mental model.

--- a/docs/multi-agent-sandbox-tools.md
+++ b/docs/multi-agent-sandbox-tools.md
@@ -178,6 +178,43 @@ For debugging “why is this blocked?”, see [Sandbox vs Tool Policy vs Elevate
 
 ---
 
+### Example 4: Sandbox Cron Policy Per Agent
+
+This is useful when you want sandboxed agents to schedule cron jobs, but keep them
+scoped (and limit delivery):
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "all",
+        "cron": {
+          "visibility": "agent",
+          "elevated": "off",
+          "allowMainSessionJobs": false,
+          "delivery": "last-only"
+        }
+      }
+    },
+    "list": [
+      {
+        "id": "admin",
+        "sandbox": {
+          "cron": {
+            "visibility": "all",
+            "elevated": "full",
+            "delivery": "explicit"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
 ## Configuration Precedence
 
 When both global (`agents.defaults.*`) and agent-specific (`agents.list[].*`) configs exist:
@@ -189,12 +226,14 @@ agents.list[].sandbox.mode > agents.defaults.sandbox.mode
 agents.list[].sandbox.scope > agents.defaults.sandbox.scope
 agents.list[].sandbox.workspaceRoot > agents.defaults.sandbox.workspaceRoot
 agents.list[].sandbox.workspaceAccess > agents.defaults.sandbox.workspaceAccess
+agents.list[].sandbox.cron.* > agents.defaults.sandbox.cron.*
 agents.list[].sandbox.docker.* > agents.defaults.sandbox.docker.*
 agents.list[].sandbox.browser.* > agents.defaults.sandbox.browser.*
 agents.list[].sandbox.prune.* > agents.defaults.sandbox.prune.*
 ```
 
 **Notes:**
+- `agents.list[].sandbox.cron.*` overrides `agents.defaults.sandbox.cron.*` for that agent.
 - `agents.list[].sandbox.{docker,browser,prune}.*` overrides `agents.defaults.sandbox.{docker,browser,prune}.*` for that agent (ignored when sandbox scope resolves to `"shared"`).
 
 ### Tool Restrictions

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -361,6 +361,7 @@ Core actions:
 Notes:
 - `add` expects a full cron job object (same schema as `cron.add` RPC).
 - `update` uses `{ id, patch }`.
+- In sandboxed sessions, cron access and delivery may be further restricted by `agents.defaults.sandbox.cron` (and per-agent overrides via `agents.list[].sandbox.cron`).
 
 ### `gateway`
 Restart or apply updates to the running Gateway process (in-place).

--- a/src/agents/sandbox-merge.test.ts
+++ b/src/agents/sandbox-merge.test.ts
@@ -131,19 +131,19 @@ describe("sandbox config merges", () => {
     const resolved = resolveSandboxCronConfig({
       globalCron: {
         visibility: "all",
-        escape: "elevated",
+        elevated: "on",
         allowMainSessionJobs: true,
         delivery: "explicit",
       },
       agentCron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
       },
     });
 
     expect(resolved).toEqual({
       visibility: "agent",
-      escape: "off",
+      elevated: "off",
       allowMainSessionJobs: true,
       delivery: "explicit",
     });

--- a/src/agents/sandbox-merge.test.ts
+++ b/src/agents/sandbox-merge.test.ts
@@ -124,4 +124,35 @@ describe("sandbox config merges", () => {
     });
     expect(pruneShared).toEqual({ idleHours: 24, maxAgeDays: 7 });
   });
+
+  it("merges sandbox cron policy (agent overrides global)", async () => {
+    const { resolveSandboxCronConfig } = await import("./sandbox.js");
+
+    const resolved = resolveSandboxCronConfig({
+      globalCron: {
+        visibility: "all",
+        escape: "elevated",
+        allowMainSessionJobs: true,
+        delivery: "explicit",
+      },
+      agentCron: {
+        visibility: "agent",
+        escape: "off",
+      },
+    });
+
+    expect(resolved).toEqual({
+      visibility: "agent",
+      escape: "off",
+      allowMainSessionJobs: true,
+      delivery: "explicit",
+    });
+  });
+
+  it("uses default cron policy when none provided", async () => {
+    const { resolveSandboxCronConfig } = await import("./sandbox.js");
+    const { DEFAULT_SANDBOX_CRON_POLICY } = await import("./sandbox/constants.js");
+
+    expect(resolveSandboxCronConfig({})).toEqual(DEFAULT_SANDBOX_CRON_POLICY);
+  });
 });

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -1,6 +1,7 @@
 export {
   resolveSandboxBrowserConfig,
   resolveSandboxConfigForAgent,
+  resolveSandboxCronConfig,
   resolveSandboxDockerConfig,
   resolveSandboxPruneConfig,
   resolveSandboxScope,
@@ -32,6 +33,7 @@ export type {
   SandboxBrowserConfig,
   SandboxBrowserContext,
   SandboxConfig,
+  SandboxCronPolicy,
   SandboxContext,
   SandboxDockerConfig,
   SandboxPruneConfig,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -132,7 +132,7 @@ export function resolveSandboxCronConfig(params: {
   return {
     visibility:
       agentCron?.visibility ?? globalCron?.visibility ?? DEFAULT_SANDBOX_CRON_POLICY.visibility,
-    escape: agentCron?.escape ?? globalCron?.escape ?? DEFAULT_SANDBOX_CRON_POLICY.escape,
+    elevated: agentCron?.elevated ?? globalCron?.elevated ?? DEFAULT_SANDBOX_CRON_POLICY.elevated,
     allowMainSessionJobs:
       agentCron?.allowMainSessionJobs ??
       globalCron?.allowMainSessionJobs ??

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_CRON_POLICY,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -21,6 +22,7 @@ import type {
   SandboxDockerConfig,
   SandboxPruneConfig,
   SandboxScope,
+  SandboxCronPolicy,
 } from "./types.js";
 
 export function resolveSandboxScope(params: {
@@ -121,6 +123,24 @@ export function resolveSandboxPruneConfig(params: {
   };
 }
 
+export function resolveSandboxCronConfig(params: {
+  globalCron?: Partial<SandboxCronPolicy>;
+  agentCron?: Partial<SandboxCronPolicy>;
+}): SandboxCronPolicy {
+  const agentCron = params.agentCron;
+  const globalCron = params.globalCron;
+  return {
+    visibility:
+      agentCron?.visibility ?? globalCron?.visibility ?? DEFAULT_SANDBOX_CRON_POLICY.visibility,
+    escape: agentCron?.escape ?? globalCron?.escape ?? DEFAULT_SANDBOX_CRON_POLICY.escape,
+    allowMainSessionJobs:
+      agentCron?.allowMainSessionJobs ??
+      globalCron?.allowMainSessionJobs ??
+      DEFAULT_SANDBOX_CRON_POLICY.allowMainSessionJobs,
+    delivery: agentCron?.delivery ?? globalCron?.delivery ?? DEFAULT_SANDBOX_CRON_POLICY.delivery,
+  };
+}
+
 export function resolveSandboxConfigForAgent(cfg?: MoltbotConfig, agentId?: string): SandboxConfig {
   const agent = cfg?.agents?.defaults?.sandbox;
 
@@ -162,6 +182,10 @@ export function resolveSandboxConfigForAgent(cfg?: MoltbotConfig, agentId?: stri
       scope,
       globalPrune: agent?.prune,
       agentPrune: agentSandbox?.prune,
+    }),
+    cron: resolveSandboxCronConfig({
+      globalCron: agent?.cron,
+      agentCron: agentSandbox?.cron,
     }),
   };
 }

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -39,7 +39,7 @@ export const DEFAULT_TOOL_DENY = [
 
 export const DEFAULT_SANDBOX_CRON_POLICY = {
   visibility: "agent",
-  escape: "off",
+  elevated: "off",
   allowMainSessionJobs: false,
   delivery: "last-only",
 } as const;

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -37,9 +37,15 @@ export const DEFAULT_TOOL_DENY = [
   ...CHANNEL_IDS,
 ] as const;
 
+export const DEFAULT_SANDBOX_CRON_POLICY = {
+  visibility: "agent",
+  escape: "off",
+  allowMainSessionJobs: false,
+  delivery: "last-only",
+} as const;
+
 export const DEFAULT_SANDBOX_BROWSER_IMAGE = "moltbot-sandbox-browser:bookworm-slim";
 export const DEFAULT_SANDBOX_COMMON_IMAGE = "moltbot-sandbox-common:bookworm-slim";
-
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "moltbot-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_CDP_PORT = 9222;
 export const DEFAULT_SANDBOX_BROWSER_VNC_PORT = 5900;

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -50,7 +50,7 @@ export type SandboxScope = "session" | "agent" | "shared";
 
 export type SandboxCronPolicy = {
   visibility: "agent" | "all";
-  escape: "off" | "elevated" | "elevated-full";
+  elevated: "off" | "on" | "full";
   allowMainSessionJobs: boolean;
   delivery: "off" | "last-only" | "explicit";
 };

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -48,6 +48,13 @@ export type SandboxPruneConfig = {
 
 export type SandboxScope = "session" | "agent" | "shared";
 
+export type SandboxCronPolicy = {
+  visibility: "agent" | "all";
+  escape: "off" | "elevated" | "elevated-full";
+  allowMainSessionJobs: boolean;
+  delivery: "off" | "last-only" | "explicit";
+};
+
 export type SandboxConfig = {
   mode: "off" | "non-main" | "all";
   scope: SandboxScope;
@@ -57,6 +64,7 @@ export type SandboxConfig = {
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
   prune: SandboxPruneConfig;
+  cron: SandboxCronPolicy;
 };
 
 export type SandboxBrowserContext = {

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -5,7 +5,7 @@ const resolveSandboxRuntimeStatusMock = vi.fn(() => ({ sandboxed: false, agentId
 const resolveSandboxConfigForAgentMock = vi.fn(() => ({
   cron: {
     visibility: "agent",
-    escape: "off",
+    elevated: "off",
     allowMainSessionJobs: false,
     delivery: "last-only",
   },
@@ -43,7 +43,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: false,
         delivery: "last-only",
       },
@@ -285,7 +285,7 @@ describe("cron tool", () => {
     expect(call.params).toEqual({ includeDisabled: false, actorAgentId: "agent-123" });
   });
 
-  it("skips actor scoping when sandbox escape is elevated", async () => {
+  it("skips actor scoping when sandbox cron elevated gate is on", async () => {
     resolveSandboxRuntimeStatusMock.mockReturnValue({
       sandboxed: true,
       agentId: "agent-123",
@@ -293,7 +293,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "elevated",
+        elevated: "on",
         allowMainSessionJobs: false,
         delivery: "last-only",
       },
@@ -311,7 +311,7 @@ describe("cron tool", () => {
     expect(call.params).toEqual({ includeDisabled: false });
   });
 
-  it("keeps actor scoping when escape is elevated-full but elevated is on", async () => {
+  it("keeps actor scoping when sandbox cron elevated gate is full but elevated is on", async () => {
     resolveSandboxRuntimeStatusMock.mockReturnValue({
       sandboxed: true,
       agentId: "agent-123",
@@ -319,7 +319,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "elevated-full",
+        elevated: "full",
         allowMainSessionJobs: false,
         delivery: "last-only",
       },
@@ -337,7 +337,7 @@ describe("cron tool", () => {
     expect(call.params).toEqual({ includeDisabled: false, actorAgentId: "agent-123" });
   });
 
-  it("skips actor scoping when escape is elevated-full and elevated is full", async () => {
+  it("skips actor scoping when sandbox cron elevated gate is full and elevated is full", async () => {
     resolveSandboxRuntimeStatusMock.mockReturnValue({
       sandboxed: true,
       agentId: "agent-123",
@@ -345,7 +345,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "elevated-full",
+        elevated: "full",
         allowMainSessionJobs: false,
         delivery: "last-only",
       },
@@ -392,7 +392,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "last-only",
       },
@@ -424,7 +424,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "last-only",
       },
@@ -529,7 +529,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "all",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: false,
         delivery: "last-only",
       },
@@ -586,7 +586,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "off",
       },
@@ -615,7 +615,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "explicit",
       },
@@ -653,7 +653,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "last-only",
       },
@@ -690,7 +690,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "off",
       },
@@ -730,7 +730,7 @@ describe("cron tool", () => {
     resolveSandboxConfigForAgentMock.mockReturnValue({
       cron: {
         visibility: "agent",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "last-only",
       },

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -55,7 +55,7 @@ type CronSandboxAccess = {
   sessionKey?: string;
   policy: {
     visibility: "agent" | "all";
-    escape: "off" | "elevated" | "elevated-full";
+    elevated: "off" | "on" | "full";
     allowMainSessionJobs: boolean;
     delivery: "off" | "last-only" | "explicit";
   };
@@ -117,7 +117,7 @@ function resolveCronSandboxAccess(params: {
       sessionKey: undefined,
       policy: {
         visibility: "all",
-        escape: "off",
+        elevated: "off",
         allowMainSessionJobs: true,
         delivery: "explicit",
       },
@@ -138,16 +138,12 @@ function resolveCronSandboxAccess(params: {
   const elevatedOn = elevatedLevel !== "off";
   const elevatedFull = elevatedLevel === "full";
 
-  const escapeAllowed =
-    policy.escape === "elevated"
-      ? elevatedOn
-      : policy.escape === "elevated-full"
-        ? elevatedFull
-        : false;
+  const elevatedAllowed =
+    policy.elevated === "on" ? elevatedOn : policy.elevated === "full" ? elevatedFull : false;
 
   return {
     sandboxed: runtime.sandboxed,
-    restricted: runtime.sandboxed && !escapeAllowed,
+    restricted: runtime.sandboxed && !elevatedAllowed,
     agentId: normalizedAgentId,
     sessionKey: rawSessionKey,
     policy,

--- a/src/config/config.sandbox-cron.test.ts
+++ b/src/config/config.sandbox-cron.test.ts
@@ -10,7 +10,7 @@ describe("sandbox cron config", () => {
           sandbox: {
             cron: {
               visibility: "agent",
-              escape: "elevated",
+              elevated: "on",
               allowMainSessionJobs: false,
               delivery: "last-only",
             },
@@ -22,7 +22,7 @@ describe("sandbox cron config", () => {
             sandbox: {
               cron: {
                 visibility: "all",
-                escape: "off",
+                elevated: "off",
                 allowMainSessionJobs: true,
                 delivery: "explicit",
               },
@@ -48,7 +48,7 @@ describe("sandbox cron config", () => {
           sandbox: {
             cron: {
               visibility: "everyone",
-              escape: "nope",
+              elevated: "nope",
               delivery: "sometimes",
             },
           },
@@ -58,7 +58,7 @@ describe("sandbox cron config", () => {
     expect(res.ok).toBe(false);
   });
 
-  it("accepts elevated-full escape and allowMainSessionJobs", async () => {
+  it("accepts full elevated gate and allowMainSessionJobs", async () => {
     vi.resetModules();
     const { validateConfigObject } = await import("./config.js");
     const res = validateConfigObject({
@@ -67,7 +67,7 @@ describe("sandbox cron config", () => {
           sandbox: {
             cron: {
               visibility: "all",
-              escape: "elevated-full",
+              elevated: "full",
               allowMainSessionJobs: true,
               delivery: "explicit",
             },
@@ -78,7 +78,7 @@ describe("sandbox cron config", () => {
 
     expect(res.ok).toBe(true);
     if (res.ok) {
-      expect(res.config.agents?.defaults?.sandbox?.cron?.escape).toBe("elevated-full");
+      expect(res.config.agents?.defaults?.sandbox?.cron?.elevated).toBe("full");
       expect(res.config.agents?.defaults?.sandbox?.cron?.allowMainSessionJobs).toBe(true);
     }
   });

--- a/src/config/config.sandbox-cron.test.ts
+++ b/src/config/config.sandbox-cron.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("sandbox cron config", () => {
+  it("accepts cron policy entries for sandbox config", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            cron: {
+              visibility: "agent",
+              escape: "elevated",
+              allowMainSessionJobs: false,
+              delivery: "last-only",
+            },
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            sandbox: {
+              cron: {
+                visibility: "all",
+                escape: "off",
+                allowMainSessionJobs: true,
+                delivery: "explicit",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.cron?.visibility).toBe("agent");
+      expect(res.config.agents?.list?.[0]?.sandbox?.cron?.visibility).toBe("all");
+    }
+  });
+
+  it("rejects invalid cron policy values", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            cron: {
+              visibility: "everyone",
+              escape: "nope",
+              delivery: "sometimes",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts elevated-full escape and allowMainSessionJobs", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            cron: {
+              visibility: "all",
+              escape: "elevated-full",
+              allowMainSessionJobs: true,
+              delivery: "explicit",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.cron?.escape).toBe("elevated-full");
+      expect(res.config.agents?.defaults?.sandbox?.cron?.allowMainSessionJobs).toBe(true);
+    }
+  });
+});

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -7,6 +7,7 @@ import type {
 import type { ChannelId } from "../channels/plugins/types.js";
 import type {
   SandboxBrowserSettings,
+  SandboxCronSettings,
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
@@ -234,6 +235,8 @@ export type AgentDefaultsConfig = {
     browser?: SandboxBrowserSettings;
     /** Auto-prune sandbox containers. */
     prune?: SandboxPruneSettings;
+    /** Cron access policy for sandboxed sessions. */
+    cron?: SandboxCronSettings;
   };
 };
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -3,6 +3,7 @@ import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type {
   SandboxBrowserSettings,
+  SandboxCronSettings,
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
@@ -58,6 +59,8 @@ export type AgentConfig = {
     browser?: SandboxBrowserSettings;
     /** Auto-prune overrides for this agent. */
     prune?: SandboxPruneSettings;
+    /** Cron access policy for sandboxed sessions. */
+    cron?: SandboxCronSettings;
   };
   tools?: AgentToolsConfig;
 };

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -75,7 +75,7 @@ export type SandboxPruneSettings = {
 };
 
 export type SandboxCronVisibility = "agent" | "all";
-export type SandboxCronEscape = "off" | "elevated" | "elevated-full";
+export type SandboxCronElevated = "off" | "on" | "full";
 export type SandboxCronDelivery = "off" | "last-only" | "explicit";
 
 export type SandboxCronSettings = {
@@ -86,12 +86,12 @@ export type SandboxCronSettings = {
    */
   visibility?: SandboxCronVisibility;
   /**
-   * Escape hatch for sandboxed cron access.
-   * - "off": never escape
-   * - "elevated": allow escape when session elevated != off
-   * - "elevated-full": allow escape only when elevated=full
+   * Elevated gate for sandboxed cron restrictions.
+   * - "off": never bypass sandbox cron restrictions
+   * - "on": bypass when the session elevated level is on/ask/full
+   * - "full": bypass only when the session elevated level is full
    */
-  escape?: SandboxCronEscape;
+  elevated?: SandboxCronElevated;
   /**
    * Allow main-session cron jobs from sandboxed sessions.
    * Default: false.

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -73,3 +73,35 @@ export type SandboxPruneSettings = {
   /** Prune if older than N days (0 disables). */
   maxAgeDays?: number;
 };
+
+export type SandboxCronVisibility = "agent" | "all";
+export type SandboxCronEscape = "off" | "elevated" | "elevated-full";
+export type SandboxCronDelivery = "off" | "last-only" | "explicit";
+
+export type SandboxCronSettings = {
+  /**
+   * Cron visibility for sandboxed sessions.
+   * - "agent": only see/manage jobs for this agent
+   * - "all": full cron visibility (admin)
+   */
+  visibility?: SandboxCronVisibility;
+  /**
+   * Escape hatch for sandboxed cron access.
+   * - "off": never escape
+   * - "elevated": allow escape when session elevated != off
+   * - "elevated-full": allow escape only when elevated=full
+   */
+  escape?: SandboxCronEscape;
+  /**
+   * Allow main-session cron jobs from sandboxed sessions.
+   * Default: false.
+   */
+  allowMainSessionJobs?: boolean;
+  /**
+   * Delivery policy for sandboxed cron jobs.
+   * - "off": forbid deliver/to/channel
+   * - "last-only": allow deliver to last route only (no explicit to)
+   * - "explicit": allow explicit delivery targets
+   */
+  delivery?: SandboxCronDelivery;
+};

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -161,9 +161,7 @@ export const AgentDefaultsSchema = z
         cron: z
           .object({
             visibility: z.union([z.literal("agent"), z.literal("all")]).optional(),
-            escape: z
-              .union([z.literal("off"), z.literal("elevated"), z.literal("elevated-full")])
-              .optional(),
+            elevated: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
             allowMainSessionJobs: z.boolean().optional(),
             delivery: z
               .union([z.literal("off"), z.literal("last-only"), z.literal("explicit")])

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -158,6 +158,19 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
         workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
         sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
+        cron: z
+          .object({
+            visibility: z.union([z.literal("agent"), z.literal("all")]).optional(),
+            escape: z
+              .union([z.literal("off"), z.literal("elevated"), z.literal("elevated-full")])
+              .optional(),
+            allowMainSessionJobs: z.boolean().optional(),
+            delivery: z
+              .union([z.literal("off"), z.literal("last-only"), z.literal("explicit")])
+              .optional(),
+          })
+          .strict()
+          .optional(),
         scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
         perSession: z.boolean().optional(),
         workspaceRoot: z.string().optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -237,9 +237,7 @@ export const AgentSandboxSchema = z
     cron: z
       .object({
         visibility: z.union([z.literal("agent"), z.literal("all")]).optional(),
-        escape: z
-          .union([z.literal("off"), z.literal("elevated"), z.literal("elevated-full")])
-          .optional(),
+        elevated: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
         allowMainSessionJobs: z.boolean().optional(),
         delivery: z
           .union([z.literal("off"), z.literal("last-only"), z.literal("explicit")])

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -234,6 +234,19 @@ export const AgentSandboxSchema = z
     mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
     workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
     sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
+    cron: z
+      .object({
+        visibility: z.union([z.literal("agent"), z.literal("all")]).optional(),
+        escape: z
+          .union([z.literal("off"), z.literal("elevated"), z.literal("elevated-full")])
+          .optional(),
+        allowMainSessionJobs: z.boolean().optional(),
+        delivery: z
+          .union([z.literal("off"), z.literal("last-only"), z.literal("explicit")])
+          .optional(),
+      })
+      .strict()
+      .optional(),
     scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
     perSession: z.boolean().optional(),
     workspaceRoot: z.string().optional(),

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -122,6 +122,7 @@ export const CronJobSchema = Type.Object(
 export const CronListParamsSchema = Type.Object(
   {
     includeDisabled: Type.Optional(Type.Boolean()),
+    actorAgentId: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );
@@ -132,6 +133,7 @@ export const CronAddParamsSchema = Type.Object(
   {
     name: NonEmptyString,
     agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    actorAgentId: Type.Optional(NonEmptyString),
     description: Type.Optional(Type.String()),
     enabled: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),
@@ -166,6 +168,7 @@ export const CronUpdateParamsSchema = Type.Union([
     {
       id: NonEmptyString,
       patch: CronJobPatchSchema,
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -173,6 +176,7 @@ export const CronUpdateParamsSchema = Type.Union([
     {
       jobId: NonEmptyString,
       patch: CronJobPatchSchema,
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -182,12 +186,14 @@ export const CronRemoveParamsSchema = Type.Union([
   Type.Object(
     {
       id: NonEmptyString,
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
   Type.Object(
     {
       jobId: NonEmptyString,
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -198,6 +204,7 @@ export const CronRunParamsSchema = Type.Union([
     {
       id: NonEmptyString,
       mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -205,6 +212,7 @@ export const CronRunParamsSchema = Type.Union([
     {
       jobId: NonEmptyString,
       mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -215,6 +223,7 @@ export const CronRunsParamsSchema = Type.Union([
     {
       id: NonEmptyString,
       limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),
@@ -222,6 +231,7 @@ export const CronRunsParamsSchema = Type.Union([
     {
       jobId: NonEmptyString,
       limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
+      actorAgentId: Type.Optional(NonEmptyString),
     },
     { additionalProperties: false },
   ),

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,6 +3,31 @@ import { afterAll, afterEach, beforeEach, vi } from "vitest";
 // Ensure Vitest environment is properly set
 process.env.VITEST = "true";
 
+// Optional dependency in e2e boot path; mock to avoid module resolution failures.
+vi.mock("node-edge-tts", () => ({
+  EdgeTTS: class {
+    async ttsPromise(_text: string, _outputPath: string) {
+      return;
+    }
+  },
+}));
+
+vi.mock("@line/bot-sdk", () => ({
+  messagingApi: {
+    MessagingApiClient: class {
+      constructor(_opts: unknown) {}
+      async getBotInfo() {
+        return {
+          displayName: "mock",
+          userId: "mock",
+          basicId: "mock",
+          pictureUrl: "mock",
+        };
+      }
+    },
+  },
+}));
+
 import type {
   ChannelId,
   ChannelOutboundAdapter,


### PR DESCRIPTION
Essentially my intention was to get cron to also support nice isolation to complement sandboxed agents

This lets you scope cron visibility (`agent` vs `all`), allow escape with elevation, gate main‑session jobs (`allowMainSessionJobs`), and restrict delivery targets (`off|last-only|explicit`). 

When a session is sandboxed **and not escaped**, the cron tool enforces these rules and scopes gateway calls with `actorAgentId`; when escape is allowed (elevated or full), scoping is removed. Gateway handlers validate `actorAgentId` visibility on list/add/update/remove/run/runs. Tests cover config validation, policy merge defaults, tool enforcement (main-session/delivery/escape), and gateway actor scoping.

Example config:

```json
{
  "agents": {
    "defaults": {
      "sandbox": {
        "cron": {
          "visibility": "agent",  // sandboxed sessions can only see/manage their own jobs
          "elevated": "full",  // lift sandbox cron restrictions only when elevated=full
          "allowMainSessionJobs": false,  // block cron jobs that target the main session
          "delivery": "last-only"  // allow delivery only to the last route (no explicit to/channel)
        }
      }
    },
    "list": [
      {
        "id": "ops",
        "sandbox": {
          "cron": {
            "visibility": "all",  // ops can see/manage all cron jobs
            "elevated": "off",  // never lift restrictions via elevation
            "allowMainSessionJobs": true,  // ops may target main session jobs
            "delivery": "explicit"  // ops may deliver to explicit channel/to
          }
        }
      }
    ]
  }
}
```

Behavior:

- Default sandboxed sessions (not escaped) only see/manage their own cron jobs, can’t target main sessions, and can only deliver to the last route.
- “Ops” can see all cron jobs and explicitly route deliveries, and can target main sessions.
- If a session escapes via elevation, cron scoping is lifted.

Each knob gates a different axis:

- `visibility` only scopes **which jobs you can see/manage** (agent‑only vs all). It doesn’t say anything about *what those jobs are allowed to target*.
- `delivery` only constrains **agentTurn delivery fields** (`deliver`/`channel`/`to`) for **isolated** sessions. It does nothing for `sessionTarget: "main"` jobs (which must be `systemEvent` anyway).
- `allowMainSessionJobs` is the **only gate** that blocks/permits `sessionTarget: "main"` (and `wake`) from sandboxed sessions.
