### PR TITLE
fix(canvas-host): bind to loopback by default

### DIFF
--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -385,7 +385,7 @@ export async function startCanvasHost(opts: CanvasHostServerOpts): Promise<Canva
     }));
   const ownsHandler = opts.ownsHandler ?? opts.handler === undefined;
 
-  const bindHost = opts.listenHost?.trim() || "0.0.0.0";
+  const bindHost = opts.listenHost?.trim() || "127.0.0.1";
   const server: Server = http.createServer((req, res) => {
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") return;
     void (async () => {


### PR DESCRIPTION
Change default bind from 0.0.0.0 to 127.0.0.1 to prevent unintended network exposure.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the default bind address for the canvas-host HTTP server from `0.0.0.0` to `127.0.0.1` in `src/canvas-host/server.ts`, reducing the chance of unintentionally exposing the dev/test canvas UI to the local network.

The change is localized to the server startup path (`startCanvasHost`), and continues to respect an explicit `listenHost` override while defaulting to loopback when none is provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line default-value adjustment in a single file, aligns with the stated security intent (reduce network exposure), and preserves opt-in behavior via `listenHost` overrides.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->