### PR TITLE
added cerebras as a model provider.

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -114,8 +114,12 @@ Clawdbot ships with the pi‑ai catalog. These providers require **no**
 - xAI: `xai` (`XAI_API_KEY`)
 - Groq: `groq` (`GROQ_API_KEY`)
 - Cerebras: `cerebras` (`CEREBRAS_API_KEY`)
-  - GLM models on Cerebras use ids `zai-glm-4.7` and `zai-glm-4.6`.
-  - OpenAI-compatible base URL: `https://api.cerebras.ai/v1`.
+  - Ultra-fast inference with custom AI accelerator chips
+  - Native models: `llama3.1-8b`, `llama-3.3-70b`, `gpt-oss-120b`, `qwen-3-32b`, `qwen-3-235b-a22b-instruct-2507`, `zai-glm-4.7`
+  - Example: `cerebras/llama3.1-8b`
+  - OpenAI-compatible base URL: `https://api.cerebras.ai/v1`
+  - CLI: `clawdbot onboard --auth-choice cerebras-api-key`
+  - See [/providers/cerebras](/providers/cerebras) for full setup
 - Mistral: `mistral` (`MISTRAL_API_KEY`)
 - GitHub Copilot: `github-copilot` (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`)
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2556,9 +2556,35 @@ Notes:
 - Available model: `MiniMax-M2.1` (default).
 - Update pricing in `models.json` if you need exact cost tracking.
 
-### Cerebras (GLM 4.6 / 4.7)
+### Cerebras (Llama + GLM models)
 
-Use Cerebras via their OpenAI-compatible endpoint:
+Cerebras provides ultra-fast inference with Llama models and GLM models via their OpenAI-compatible endpoint.
+
+**Quick setup with native Llama models:**
+
+```bash
+clawdbot onboard --auth-choice cerebras-api-key
+```
+
+**Config snippet (Llama models):**
+
+```json5
+{
+  env: { CEREBRAS_API_KEY: "..." },
+  agents: {
+    defaults: {
+      model: { primary: "cerebras/llama3.1-8b" },
+      models: {
+        "cerebras/llama3.1-8b": { alias: "Llama 3.1 8B" },
+        "cerebras/llama3.1-70b": { alias: "Llama 3.1 70B" },
+        "cerebras/llama-3.3-70b": { alias: "Llama 3.3 70B" }
+      }
+    }
+  }
+}
+```
+
+**Advanced: GLM models via Cerebras:**
 
 ```json5
 {
@@ -2593,8 +2619,11 @@ Use Cerebras via their OpenAI-compatible endpoint:
 ```
 
 Notes:
+- Native Llama models: `cerebras/llama3.1-8b`, `cerebras/llama3.1-70b`, `cerebras/llama-3.3-70b`
 - Use `cerebras/zai-glm-4.7` for Cerebras; use `zai/glm-4.7` for Z.AI direct.
 - Set `CEREBRAS_API_KEY` in the environment or config.
+- Get your API key at [cloud.cerebras.ai](https://cloud.cerebras.ai/).
+- See [/providers/cerebras](/providers/cerebras) for more details.
 
 Notes:
 - Supported APIs: `openai-completions`, `openai-responses`, `anthropic-messages`,

--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -1,0 +1,49 @@
+---
+summary: "Use Cerebras ultra-fast inference for LLaMA, Qwen, GLM models via OpenAI-compatible API"
+read_when:
+  - You want to use Cerebras inference
+  - You need ultra-fast model responses
+---
+# Cerebras
+
+Cerebras provides **ultra-fast inference** using their custom AI accelerator chips, delivering industry-leading speed for popular open-source models through an OpenAI-compatible API.
+
+## CLI setup
+
+```bash
+clawdbot onboard --auth-choice cerebras-api-key
+# or non-interactive
+clawdbot onboard --cerebras-api-key "$CEREBRAS_API_KEY"
+```
+
+## Config snippet
+
+```json5
+{
+  env: { CEREBRAS_API_KEY: "csk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "cerebras/llama3.1-8b" }
+    }
+  }
+}
+```
+
+## Available models
+
+All models run at FP16 or FP16/FP8 precision:
+
+- `cerebras/llama3.1-8b` - LLaMA 3.1 8B (FP16)
+- `cerebras/llama-3.3-70b` - LLaMA 3.3 70B (FP16)
+- `cerebras/gpt-oss-120b` - GPT OSS 120B (FP16/FP8)
+- `cerebras/qwen-3-32b` - Qwen 3 32B (FP16)
+- `cerebras/qwen-3-235b-a22b-instruct-2507` - Qwen 3 235B (FP16/FP8)
+- `cerebras/zai-glm-4.7` - GLM 4.7 (FP16/FP8)
+
+## Notes
+
+- Base URL: `https://api.cerebras.ai/v1`
+- OpenAI-compatible API (drop-in replacement)
+- Model refs use `cerebras/<model>` format
+- Get API key at: https://cloud.cerebras.ai/
+- For more model options, see [/concepts/model-providers](/concepts/model-providers)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -45,6 +45,7 @@ See [Venice AI](/providers/venice).
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
 - [Venius (Venice AI, privacy-focused)](/providers/venice)
+- [Cerebras (ultra-fast inference, Llama/Qwen/GLM)](/providers/cerebras)
 - [Ollama (local models)](/providers/ollama)
 
 ## Transcription providers

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -75,6 +75,16 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1";
+const CEREBRAS_DEFAULT_CONTEXT_WINDOW = 128000;
+const CEREBRAS_DEFAULT_MAX_TOKENS = 8192;
+const CEREBRAS_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -359,6 +369,69 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   };
 }
 
+function buildCerebrasProvider(): ProviderConfig {
+  return {
+    baseUrl: CEREBRAS_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: "llama3.1-8b",
+        name: "Llama 3.1 8B",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "llama-3.3-70b",
+        name: "Llama 3.3 70B",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "gpt-oss-120b",
+        name: "GPT OSS 120B",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "qwen-3-32b",
+        name: "Qwen 3 32B",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "qwen-3-235b-a22b-instruct-2507",
+        name: "Qwen 3 235B A22B Instruct",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "zai-glm-4.7",
+        name: "GLM 4.7",
+        reasoning: false,
+        input: ["text"],
+        cost: CEREBRAS_DEFAULT_COST,
+        contextWindow: CEREBRAS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: CEREBRAS_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -416,6 +489,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  }
+
+  const cerebrasKey =
+    resolveEnvApiKeyVarName("cerebras") ??
+    resolveApiKeyFromProfiles({ provider: "cerebras", store: authStore });
+  if (cerebrasKey) {
+    providers.cerebras = { ...buildCerebrasProvider(), apiKey: cerebrasKey };
   }
 
   return providers;

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -76,6 +76,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--synthetic-api-key <key>", "Synthetic API key")
     .option("--venice-api-key <key>", "Venice API key")
     .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
+    .option("--cerebras-api-key <key>", "Cerebras API key")
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -20,6 +20,7 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
+  | "cerebras"
   | "qwen";
 
 export type AuthChoiceGroup = {
@@ -70,6 +71,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "Venice AI",
     hint: "Privacy-focused (uncensored models)",
     choices: ["venice-api-key"],
+  },
+  {
+    value: "cerebras",
+    label: "Cerebras",
+    hint: "Ultra-fast inference (Llama/Qwen/GLM)",
+    choices: ["cerebras-api-key"],
   },
   {
     value: "google",
@@ -146,6 +153,11 @@ export function buildAuthChoiceOptions(params: {
     value: "venice-api-key",
     label: "Venice AI API key",
     hint: "Privacy-focused inference (uncensored models)",
+  });
+  options.push({
+    value: "cerebras-api-key",
+    label: "Cerebras API key",
+    hint: "Ultra-fast inference (Llama/Qwen/GLM)",
   });
   options.push({
     value: "github-copilot",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -459,3 +459,64 @@ export function applyAuthProfileConfig(
     },
   };
 }
+
+export function applyCerebrasProviderConfig(cfg: ClawdbotConfig): ClawdbotConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models["cerebras/llama3.1-8b"] = {
+    ...models["cerebras/llama3.1-8b"],
+    alias: models["cerebras/llama3.1-8b"]?.alias ?? "Llama 3.1 8B",
+  };
+  models["cerebras/llama-3.3-70b"] = {
+    ...models["cerebras/llama-3.3-70b"],
+    alias: models["cerebras/llama-3.3-70b"]?.alias ?? "Llama 3.3 70B",
+  };
+  models["cerebras/gpt-oss-120b"] = {
+    ...models["cerebras/gpt-oss-120b"],
+    alias: models["cerebras/gpt-oss-120b"]?.alias ?? "GPT OSS 120B",
+  };
+  models["cerebras/qwen-3-32b"] = {
+    ...models["cerebras/qwen-3-32b"],
+    alias: models["cerebras/qwen-3-32b"]?.alias ?? "Qwen 3 32B",
+  };
+  models["cerebras/qwen-3-235b-a22b-instruct-2507"] = {
+    ...models["cerebras/qwen-3-235b-a22b-instruct-2507"],
+    alias: models["cerebras/qwen-3-235b-a22b-instruct-2507"]?.alias ?? "Qwen 3 235B",
+  };
+  models["cerebras/zai-glm-4.7"] = {
+    ...models["cerebras/zai-glm-4.7"],
+    alias: models["cerebras/zai-glm-4.7"]?.alias ?? "GLM 4.7",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyCerebrasConfig(cfg: ClawdbotConfig): ClawdbotConfig {
+  const next = applyCerebrasProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: "cerebras/llama3.1-8b",
+        },
+      },
+    },
+  };
+}

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,6 +115,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
+export const CEREBRAS_DEFAULT_MODEL_REF = "cerebras/llama3.1-8b";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {
   // Write to resolved agent dir so gateway finds credentials on startup.
@@ -159,6 +160,18 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     credential: {
       type: "api_key",
       provider: "opencode",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setCerebrasApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "cerebras:default",
+    credential: {
+      type: "api_key",
+      provider: "cerebras",
       key,
     },
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyCerebrasConfig,
+  applyCerebrasProviderConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
@@ -34,7 +36,9 @@ export {
 } from "./onboard-auth.config-opencode.js";
 export {
   OPENROUTER_DEFAULT_MODEL_REF,
+  CEREBRAS_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
+  setCerebrasApiKey,
   setGeminiApiKey,
   setKimiCodeApiKey,
   setMinimaxApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -8,6 +8,7 @@ import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-tok
 import { applyGoogleGeminiModelDefault } from "../../google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyCerebrasConfig,
   applyKimiCodeConfig,
   applyMinimaxApiConfig,
   applyMinimaxConfig,
@@ -19,6 +20,7 @@ import {
   applyVercelAiGatewayConfig,
   applyZaiConfig,
   setAnthropicApiKey,
+  setCerebrasApiKey,
   setGeminiApiKey,
   setKimiCodeApiKey,
   setMinimaxApiKey,
@@ -307,6 +309,25 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyVeniceConfig(nextConfig);
+  }
+
+  if (authChoice === "cerebras-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "cerebras",
+      cfg: baseConfig,
+      flagValue: opts.cerebrasApiKey,
+      flagName: "--cerebras-api-key",
+      envVar: "CEREBRAS_API_KEY",
+      runtime,
+    });
+    if (!resolved) return null;
+    if (resolved.source !== "profile") await setCerebrasApiKey(resolved.key);
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "cerebras:default",
+      provider: "cerebras",
+      mode: "api_key",
+    });
+    return applyCerebrasConfig(nextConfig);
   }
 
   if (

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -17,6 +17,7 @@ export type AuthChoice =
   | "kimi-code-api-key"
   | "synthetic-api-key"
   | "venice-api-key"
+  | "cerebras-api-key"
   | "codex-cli"
   | "apiKey"
   | "gemini-api-key"
@@ -71,6 +72,7 @@ export type OnboardOptions = {
   syntheticApiKey?: string;
   veniceApiKey?: string;
   opencodeZenApiKey?: string;
+  cerebrasApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
# Add Cerebras Provider

## Summary
Adds Cerebras as a new model provider with support for 6 ultra-fast inference models using their OpenAI-compatible API at `https://api.cerebras.ai/v1`. Also they have a free tier of about 1M tokens a day, potentially allowing us to run clawdbot for free ( for some while ). 

## Changes
- ✅ Added Cerebras provider configuration with 6 models:
  - `llama3.1-8b` (default)
  - `llama-3.3-70b`
  - `gpt-oss-120b`
  - `qwen-3-32b`
  - `qwen-3-235b-a22b-instruct-2507`
  - `zai-glm-4.7`
- ✅ Interactive onboarding support (`clawdbot onboard --auth-choice cerebras-api-key`)
- ✅ Non-interactive CLI flag (`--cerebras-api-key`)
- ✅ Documentation for setup and usage

## Files Modified
- `src/agents/models-config.providers.ts` - Provider configuration and model catalog
- `src/commands/onboard-auth.credentials.ts` - Credential management
- `src/commands/onboard-auth.config-core.ts` - Configuration helpers
- `src/commands/onboard-auth.ts` - Exported auth functions
- `src/commands/onboard-types.ts` - Type definitions
- `src/cli/program/register.onboard.ts` - CLI flag support
- `src/commands/auth-choice.apply.api-providers.ts` - Interactive auth handler
- `src/commands/onboard-non-interactive/local/auth-choice.ts` - Non-interactive auth handler
- `src/commands/auth-choice-options.ts` - Menu options and display
- `docs/providers/cerebras.md` - Provider documentation
- `docs/providers/index.md` - Provider index
- `docs/concepts/model-providers.md` - Model provider overview

## Testing
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] Cerebras appears in interactive onboarding menu
- [x] CLI flag `--cerebras-api-key` works
- [x] Live API test with `CEREBRAS_API_KEY`

From the interactive onboarding form we can select cerebras as a model provider and use this awesome tool.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Cerebras as a new model provider with 6 models (Llama, GPT OSS, Qwen, GLM), including interactive and non-interactive onboarding, CLI flag support, and documentation. The implementation closely follows existing provider patterns (Venice, Moonshot, etc.) and integrates cleanly across all required touchpoints.

- **Documentation bug**: `docs/gateway/configuration.md` references a non-existent model `cerebras/llama3.1-70b` in both the config snippet and Notes section. The actual catalog only has `llama3.1-8b` and `llama-3.3-70b`.
- **Minor**: `applyCerebrasConfig` hardcodes the primary model string instead of using the `CEREBRAS_DEFAULT_MODEL_REF` constant, breaking consistency with all other providers in the same file.
- **Note**: The new `docs/providers/cerebras.md` page is not added to `docs/docs.json` navigation, though this appears to be a pre-existing gap (Venice and Ollama are also missing).

<h3>Confidence Score: 3/5</h3>

- Code changes are safe to merge but documentation has an incorrect model ID that will mislead users.
- The source code changes follow existing patterns exactly and are functionally correct. However, the configuration docs reference a phantom model ID (cerebras/llama3.1-70b) that doesn't exist in the provider catalog, which will cause user-facing errors. The doc fix is trivial but should be addressed before merge.
- docs/gateway/configuration.md references a model ID not in the catalog; should be fixed before merge.

<sub>Last reviewed commit: e31ff45</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->