### PR TITLE
fix(docker): add Bash 4+ version check for macOS compatibility

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ((BASH_VERSINFO[0] < 4)); then
+  if [[ "$OSTYPE" == darwin* ]]; then
+    echo "Bash 4+ required. macOS ships with Bash 3.2." >&2
+    echo "Install via: brew install bash" >&2
+    echo "Then run: /opt/homebrew/bin/bash $0" >&2
+  else
+    echo "Bash 4+ required (current: ${BASH_VERSION})" >&2
+  fi
+  exit 1
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"


### PR DESCRIPTION
### **Summary**
Updated `docker-setup.sh` to include a check for Bash 4+

### **Detail**
The `docker-setup.sh` script uses associative arrays (declare -A) which require Bash 4+. macOS ships with Bash 3.2 causing the script to fail with "declare: -A: invalid option". The new code adds both a check for macOS and Bash 4+ and provides a helpful error message directing macOS users to install Bash via Homebrew.

### **Testing**
_Lightly tested on macOS 26_
Successfully demonstrated:
- [x] With shipping version of Bash -> script stops and lets the user know that they should install the latest version of bash with homebrew
- [x] With latest version of Bash -> script continues forward with no errors.

---

**AI-assisted**: Yes (drafted with Claude, tested and verified manually)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docker-setup.sh` to fail fast when run under Bash < 4, preventing macOS’s default Bash 3.2 from hitting `declare -A` errors later. The script now prints a platform-specific guidance message for darwin and exits early, keeping the rest of the Docker setup logic unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it adds an early guard with minimal behavioral impact beyond clearer failures on unsupported Bash versions.
- Change is isolated to a small, early-exit version check. Main concern is the hardcoded Homebrew Bash path on macOS, which can be incorrect on Intel machines and cause user confusion.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->