### PR TITLE
fix(macos): disable gateway launchd job when switching to remote mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Status: unreleased.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- macOS: disable gateway launchd job when switching to remote mode. (#2433)
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.
 - BlueBubbles: coalesce inbound URL link preview messages. (#1981) Thanks @tyler6204.
 - Agents: include memory.md when bootstrapping memory context. (#2318) Thanks @czekaj.

--- a/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
@@ -51,8 +51,10 @@ enum GatewayLaunchAgentManager {
 
     static func set(enabled: Bool, bundlePath: String, port: Int) async -> String? {
         _ = bundlePath
-        guard !CommandResolver.connectionModeIsRemote() else {
-            self.logger.info("launchd change skipped (remote mode)")
+        // In remote mode, skip enabling (the local gateway shouldn't run), but still
+        // allow disabling so the launchd job stops retrying every 10 seconds.
+        if enabled, CommandResolver.connectionModeIsRemote() {
+            self.logger.info("launchd enable skipped (remote mode)")
             return nil
         }
         if enabled, self.isLaunchAgentWriteDisabled() {

--- a/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayProcessManager.swift
@@ -129,9 +129,8 @@ final class GatewayProcessManager {
         self.lastFailureReason = nil
         self.status = .stopped
         self.logger.info("gateway stop requested")
-        if CommandResolver.connectionModeIsRemote() {
-            return
-        }
+        // Always disable the launchd job, even in remote mode. Otherwise the job
+        // keeps restarting the gateway daemon every 10 seconds (KeepAlive throttle).
         let bundlePath = Bundle.main.bundleURL.path
         Task {
             _ = await GatewayLaunchAgentManager.set(


### PR DESCRIPTION
## Summary
- Fix gateway launchd job continuing to retry every 10 seconds when in remote mode
- Remove early return in `stop()` that skipped disabling the launchd job

## Problem
When switching from local to remote mode, the `stop()` function in `GatewayProcessManager` had an early return when `connectionModeIsRemote()` was true. This skipped the code that disables the launchd job.

Since the launchd plist has `KeepAlive=true`, macOS keeps restarting the gateway daemon every 10 seconds (the default throttle interval). The daemon starts, sees `gateway.mode=remote`, logs "Gateway start blocked", and exits—then launchd restarts it again.

## Solution
Remove the early return so the launchd job gets disabled regardless of the current connection mode. When switching back to local mode, the existing `setActive(true)` and `ensureLaunchAgentEnabledIfNeeded()` calls re-enable it.

## Test plan
- [x] Swift build passes
- [x] TypeScript lint/build passes
- [ ] Manual test: switch to remote mode, verify gateway log stops showing repeated "Gateway start blocked" messages

Fixes #2433

🤖 Generated with [Claude Code](https://claude.com/claude-code)