### PR TITLE
fix: support versioned node binaries (e.g., node-22)

### DIFF
--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -99,6 +99,7 @@ export function buildParseArgv(params: {
     normalizedArgv.length >= 2 &&
     (executable === "node" ||
       executable === "node.exe" ||
+      executable.startsWith("node-") ||
       executable === "bun" ||
       executable === "bun.exe");
   if (looksLikeNode) return normalizedArgv;


### PR DESCRIPTION
## Summary

Fixes #2442

On Fedora (and potentially other distros), Node.js is installed with a version-suffixed binary (e.g., `/usr/bin/node-22`) with `/usr/bin/node` as a symlink. When Node resolves `process.execPath`, it returns the real binary path, not the symlink.

This causes `buildParseArgv` in `src/cli/argv.ts` to fail the `looksLikeNode` check, resulting in malformed argv that commander.js can't parse.

## Changes

Added `executable.startsWith("node-")` to the `looksLikeNode` condition to handle versioned node binaries.

## Testing

Tested on Fedora 43 with `/usr/bin/node-22` — all CLI commands now work correctly.