### PR TITLE
Add Parallel to web-search and web-fetch tools

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,17 +1,18 @@
 ---
-summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter)"
+summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter, Parallel)"
 read_when:
   - You want to enable web_search or web_fetch
   - You need Brave Search API key setup
   - You want to use Perplexity Sonar for web search
+  - You want to use Parallel for web search or content extraction
 ---
 
 # Web tools
 
 Clawdbot ships two lightweight web tools:
 
-- `web_search` — Search the web via Brave Search API (default) or Perplexity Sonar (direct or via OpenRouter).
-- `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
+- `web_search` — Search the web via Brave Search API (default), Perplexity Sonar (direct or via OpenRouter), or Parallel Search API.
+- `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text). Supports Readability, Firecrawl, and Parallel extract.
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
 [Browser tool](/tools/browser).
@@ -32,6 +33,7 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 |----------|------|------|---------|
 | **Brave** (default) | Fast, structured results, free tier | Traditional search results | `BRAVE_API_KEY` |
 | **Perplexity** | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **Parallel** | Relevant excerpts, real-time, agentic mode | Requires Parallel API access | `PARALLEL_API_KEY` |
 
 See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for provider-specific details.
 
@@ -42,7 +44,7 @@ Set the provider in config:
   tools: {
     web: {
       search: {
-        provider: "brave"  // or "perplexity"
+        provider: "brave"  // or "perplexity" or "parallel"
       }
     }
   }
@@ -138,6 +140,64 @@ If no base URL is set, Clawdbot chooses a default based on the API key source:
 | `perplexity/sonar-pro` (default) | Multi-step reasoning with web search | Complex questions |
 | `perplexity/sonar-reasoning-pro` | Chain-of-thought analysis | Deep research |
 
+## Using Parallel
+
+Parallel provides web search and content extraction APIs optimized for agentic workflows.
+Results include relevant excerpts from each page.
+
+### Getting a Parallel API key
+
+1) Sign up at https://parallel.ai/
+2) Generate an API key in your account settings
+
+### Setting up Parallel search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        enabled: true,
+        provider: "parallel",
+        parallel: {
+          // API key (optional if PARALLEL_API_KEY is set)
+          apiKey: "your-parallel-api-key",
+          // Base URL (optional, defaults to https://api.parallel.ai)
+          baseUrl: "https://api.parallel.ai"
+        }
+      }
+    }
+  }
+}
+```
+
+**Environment alternative:** set `PARALLEL_API_KEY` in the Gateway environment.
+For a gateway install, put it in `~/.clawdbot/.env`.
+
+### Using Parallel extract for web_fetch
+
+Parallel extract can be used as a content extractor for `web_fetch`, providing
+markdown content from web pages. Enable it alongside or instead of Readability/Firecrawl:
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        parallel: {
+          enabled: true,
+          // API key (optional if PARALLEL_API_KEY is set)
+          apiKey: "your-parallel-api-key"
+        }
+      }
+    }
+  }
+}
+```
+
+When enabled, Parallel extract is tried first for HTML content. If it fails,
+Clawdbot falls back to Readability and then Firecrawl (if configured).
+
 ## web_search
 
 Search the web using your configured provider.
@@ -148,6 +208,7 @@ Search the web using your configured provider.
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Perplexity**: `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **Parallel**: `PARALLEL_API_KEY` or `tools.web.search.parallel.apiKey`
 
 ### Config
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -406,7 +406,7 @@ export async function fetchParallelContent(params: {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${params.apiKey}`,
+      "x-api-key": params.apiKey,
       "parallel-beta": "search-extract-2025-10-10",
     },
     body: JSON.stringify({

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -376,7 +376,7 @@ async function runParallelSearch(params: {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${params.apiKey}`,
+      "x-api-key": params.apiKey,
       "parallel-beta": "search-extract-2025-10-10",
     },
     body: JSON.stringify({
@@ -384,7 +384,7 @@ async function runParallelSearch(params: {
       search_queries: [params.query],
       max_results: params.count,
       excerpts: {
-        max_chars_per_result: 500,
+        max_chars_per_result: 2000,
       },
       mode: "agentic",
     }),

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -35,7 +35,7 @@ export const CONFIGURE_SECTION_OPTIONS: Array<{
 }> = [
   { value: "workspace", label: "Workspace", hint: "Set workspace + sessions" },
   { value: "model", label: "Model", hint: "Pick provider + credentials" },
-  { value: "web", label: "Web tools", hint: "Configure Brave search + fetch" },
+  { value: "web", label: "Web tools", hint: "Configure web search + fetch" },
   { value: "gateway", label: "Gateway", hint: "Port, bind, auth, tailscale" },
   {
     value: "daemon",

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -125,7 +125,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
 
   if (!opts.json) {
     runtime.log(
-      `Tip: run \`${formatCliCommand("clawdbot configure --section web")}\` to store your Brave API key for web_search. Docs: https://docs.clawd.bot/tools/web`,
+      `Tip: run \`${formatCliCommand("clawdbot configure --section web")}\` to configure web_search (Brave, Perplexity, or Parallel). Docs: https://docs.clawd.bot/tools/web`,
     );
   }
 }

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -47,7 +47,7 @@ export async function runNonInteractiveOnboardingRemote(params: {
     runtime.log(`Remote gateway: ${remoteUrl}`);
     runtime.log(`Auth: ${payload.auth}`);
     runtime.log(
-      `Tip: run \`${formatCliCommand("clawdbot configure --section web")}\` to store your Brave API key for web_search. Docs: https://docs.clawd.bot/tools/web`,
+      `Tip: run \`${formatCliCommand("clawdbot configure --section web")}\` to configure web_search (Brave, Perplexity, or Parallel). Docs: https://docs.clawd.bot/tools/web`,
     );
   }
 }

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -22,4 +22,43 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts parallel provider and config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "parallel",
+            parallel: {
+              apiKey: "test-parallel-key",
+              baseUrl: "https://api.parallel.ai",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts parallel extract config for fetch", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            enabled: true,
+            parallel: {
+              enabled: true,
+              apiKey: "test-parallel-key",
+              baseUrl: "https://api.parallel.ai",
+              timeoutSeconds: 30,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -332,8 +332,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "parallel"). */
+      provider?: "brave" | "perplexity" | "parallel";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -350,6 +350,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "perplexity/sonar-pro"). */
         model?: string;
+      };
+      /** Parallel-specific configuration (used when provider="parallel"). */
+      parallel?: {
+        /** API key for Parallel (defaults to PARALLEL_API_KEY env var). */
+        apiKey?: string;
+        /** Base URL for API requests (defaults to https://api.parallel.ai). */
+        baseUrl?: string;
       };
     };
     fetch?: {
@@ -379,6 +386,17 @@ export type ToolsConfig = {
         /** Max age (ms) for cached Firecrawl content. */
         maxAgeMs?: number;
         /** Timeout in seconds for Firecrawl requests. */
+        timeoutSeconds?: number;
+      };
+      /** Parallel extract configuration (alternative to Readability/Firecrawl). */
+      parallel?: {
+        /** Enable Parallel extract (default: false). */
+        enabled?: boolean;
+        /** Parallel API key (defaults to PARALLEL_API_KEY env var). */
+        apiKey?: string;
+        /** Parallel API base URL (defaults to https://api.parallel.ai). */
+        baseUrl?: string;
+        /** Timeout in seconds for Parallel extract requests. */
         timeoutSeconds?: number;
       };
     };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -159,7 +159,8 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
   if (value.allow && value.allow.length > 0 && value.alsoAllow && value.alsoAllow.length > 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "tools policy cannot set both allow and alsoAllow in the same scope (merge alsoAllow into allow, or remove allow and use profile + alsoAllow)",
+      message:
+        "tools policy cannot set both allow and alsoAllow in the same scope (merge alsoAllow into allow, or remove allow and use profile + alsoAllow)",
     });
   }
 }).optional();
@@ -167,7 +168,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("parallel")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -177,6 +180,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    parallel: z
+      .object({
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),
@@ -192,6 +202,15 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    parallel: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -436,9 +436,11 @@ function hasWebSearchKey(cfg: ClawdbotConfig, env: NodeJS.ProcessEnv): boolean {
   return Boolean(
     search?.apiKey ||
     search?.perplexity?.apiKey ||
+    search?.parallel?.apiKey ||
     env.BRAVE_API_KEY ||
     env.PERPLEXITY_API_KEY ||
-    env.OPENROUTER_API_KEY,
+    env.OPENROUTER_API_KEY ||
+    env.PARALLEL_API_KEY,
   );
 }
 

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -432,8 +432,20 @@ export async function finalizeOnboardingWizard(options: FinalizeOnboardingOption
     );
   }
 
-  const webSearchKey = (nextConfig.tools?.web?.search?.apiKey ?? "").trim();
-  const webSearchEnv = (process.env.BRAVE_API_KEY ?? "").trim();
+  const searchConfig = nextConfig.tools?.web?.search;
+  const webSearchKey = (
+    searchConfig?.apiKey ||
+    searchConfig?.perplexity?.apiKey ||
+    searchConfig?.parallel?.apiKey ||
+    ""
+  ).trim();
+  const webSearchEnv = (
+    process.env.BRAVE_API_KEY ||
+    process.env.PERPLEXITY_API_KEY ||
+    process.env.OPENROUTER_API_KEY ||
+    process.env.PARALLEL_API_KEY ||
+    ""
+  ).trim();
   const hasWebSearchKey = Boolean(webSearchKey || webSearchEnv);
   await prompter.note(
     hasWebSearchKey
@@ -441,20 +453,20 @@ export async function finalizeOnboardingWizard(options: FinalizeOnboardingOption
           "Web search is enabled, so your agent can look things up online when needed.",
           "",
           webSearchKey
-            ? "API key: stored in config (tools.web.search.apiKey)."
-            : "API key: provided via BRAVE_API_KEY env var (Gateway environment).",
+            ? "API key: stored in config."
+            : "API key: provided via environment variable.",
           "Docs: https://docs.clawd.bot/tools/web",
         ].join("\n")
       : [
-          "If you want your agent to be able to search the web, you’ll need an API key.",
+          "If you want your agent to be able to search the web, you'll need an API key.",
           "",
-          "Clawdbot uses Brave Search for the `web_search` tool. Without a Brave Search API key, web search won’t work.",
+          "Clawdbot supports Brave Search, Perplexity, and Parallel for the `web_search` tool.",
           "",
           "Set it up interactively:",
           `- Run: ${formatCliCommand("clawdbot configure --section web")}`,
-          "- Enable web_search and paste your Brave Search API key",
+          "- Choose a provider and paste your API key",
           "",
-          "Alternative: set BRAVE_API_KEY in the Gateway environment (no config changes).",
+          "Alternative: set BRAVE_API_KEY, PERPLEXITY_API_KEY, or PARALLEL_API_KEY in the Gateway environment.",
           "Docs: https://docs.clawd.bot/tools/web",
         ].join("\n"),
     "Web search (optional)",

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -284,7 +284,13 @@ describe("runOnboardingWizard", () => {
 
   it("shows the web search hint at the end of onboarding", async () => {
     const prevBraveKey = process.env.BRAVE_API_KEY;
+    const prevPerplexityKey = process.env.PERPLEXITY_API_KEY;
+    const prevOpenRouterKey = process.env.OPENROUTER_API_KEY;
+    const prevParallelKey = process.env.PARALLEL_API_KEY;
     delete process.env.BRAVE_API_KEY;
+    delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.PARALLEL_API_KEY;
 
     try {
       const note: WizardPrompter["note"] = vi.fn(async () => {});
@@ -328,6 +334,21 @@ describe("runOnboardingWizard", () => {
         delete process.env.BRAVE_API_KEY;
       } else {
         process.env.BRAVE_API_KEY = prevBraveKey;
+      }
+      if (prevPerplexityKey === undefined) {
+        delete process.env.PERPLEXITY_API_KEY;
+      } else {
+        process.env.PERPLEXITY_API_KEY = prevPerplexityKey;
+      }
+      if (prevOpenRouterKey === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = prevOpenRouterKey;
+      }
+      if (prevParallelKey === undefined) {
+        delete process.env.PARALLEL_API_KEY;
+      } else {
+        process.env.PARALLEL_API_KEY = prevParallelKey;
       }
     }
   });


### PR DESCRIPTION
## Summary

Adds [Parallel](https://parallel.ai/) as a third web search provider (alongside Brave and Perplexity) and as a content extraction provider for `web_fetch` (alongside Readability and Firecrawl).

- **Search:** `tools.web.search.provider: "parallel"` - returns structured results with relevant excerpts
- **Extract:** `tools.web.fetch.parallel.enabled: true` - extracts markdown content from URLs

## Changes

### Core Implementation
- **Config schema** (`src/config/zod-schema.agent-runtime.ts`): Added `"parallel"` provider option and config objects for search and fetch
- **Types** (`src/config/types.tools.ts`): Added TypeScript types for Parallel configuration
- **Web search** (`src/agents/tools/web-search.ts`): Added `runParallelSearch()` using Parallel's `/v1beta/search` API
- **Web fetch** (`src/agents/tools/web-fetch.ts`): Added `fetchParallelContent()` using Parallel's `/v1beta/extract` API

### Configuration & Onboarding
Note: some of the existing onboarding only mentioned Brave and not Brave + Perplexity, so I've included Perplexity in these changes as well for parity.
- **Configure wizard** (`src/commands/configure.wizard.ts`): Updated to support provider selection (Brave/Perplexity/Parallel)
- **Onboarding** (`src/wizard/onboarding.finalize.ts`): Updated hints to mention all providers
- **Non-interactive onboarding** (`src/commands/onboard-non-interactive/local.ts`, `remote.ts`): Updated tips to mention all providers
- **Configure shared** (`src/commands/configure.shared.ts`): Updated hint text

### Security & Audit
- **Security audit** (`src/security/audit-extra.ts`): Added `PARALLEL_API_KEY` and `parallel.apiKey` to `hasWebSearchKey()` check

### Documentation
- **Web tools docs** (`docs/tools/web.md`): Added comprehensive Parallel section with setup instructions

### Tests
- **Config validation tests** (`src/config/config.web-search-provider.test.ts`): Added tests for Parallel provider and extract config
- **Web search tests** (`src/agents/tools/web-search.test.ts`): Added tests for Parallel config resolution
- **Onboarding tests** (`src/wizard/onboarding.test.ts`): Updated to clear all provider env vars

## Configuration Examples

### Search with Parallel
```json5
{
  tools: {
    web: {
      search: {
        provider: "parallel",
        parallel: {
          apiKey: "your-parallel-api-key",  // or set PARALLEL_API_KEY env var
          baseUrl: "https://api.parallel.ai"  // optional, this is the default
        }
      }
    }
  }
}
```

### Extract with Parallel
```json5
{
  tools: {
    web: {
      fetch: {
        parallel: {
          enabled: true,
          apiKey: "your-parallel-api-key",  // or set PARALLEL_API_KEY env var
          timeoutSeconds: 30  // optional
        }
      }
    }
  }
}
```

## API Implementation

Uses direct HTTP fetch calls (consistent with Brave/Perplexity implementations):

- **Search:** `POST /v1beta/search` with `parallel-beta: search-extract-2025-10-10` header
- **Extract:** `POST /v1beta/extract` with same header

No SDK dependency added - keeps the implementation lightweight and consistent with existing patterns.

Note: We provide a npm package `parallel-web` which could be used instead. However, I'm sticking with direct HTTP fetch calls since that's how the other implementations are done.

## Environment Variables

- `PARALLEL_API_KEY` - API key for Parallel services (used for both search and extract)

## Testing

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (4640 tests)
- [x] Manual testing with real API key

Example run:
<img width="1124" height="518" alt="image" src="https://github.com/user-attachments/assets/d011e03d-2469-40b9-830d-97f2d2bdbc75" />

Running `pnpm clawdbot configure --section web`:
<img width="660" height="810" alt="image" src="https://github.com/user-attachments/assets/60296fd5-9a38-4241-a68a-fb8fadb6cd64" />
(I set the API key via the Gateway).

## Docs

- https://docs.clawd.bot/tools/web

## Other

Built using the help of Claude Code. Tested manually.