### PR TITLE
fix(macos): prevent webchat re-bootstrap on repeated onAppear

### DIFF
--- a/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatViewModel.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatViewModel.swift
@@ -51,6 +51,7 @@ public final class ClawdbotChatViewModel {
     }
 
     private var lastHealthPollAt: Date?
+    private var hasInitiallyLoaded = false
 
     public init(sessionKey: String, transport: any ClawdbotChatTransport) {
         self.sessionKey = sessionKey
@@ -76,6 +77,7 @@ public final class ClawdbotChatViewModel {
     }
 
     public func load() {
+        guard !self.hasInitiallyLoaded else { return }
         Task { await self.bootstrap() }
     }
 
@@ -174,6 +176,7 @@ public final class ClawdbotChatViewModel {
             await self.pollHealthIfNeeded(force: true)
             await self.fetchSessions(limit: 50)
             self.errorText = nil
+            self.hasInitiallyLoaded = true
         } catch {
             self.errorText = error.localizedDescription
             chatUILogger.error("bootstrap failed \(error.localizedDescription, privacy: .public)")
@@ -329,6 +332,7 @@ public final class ClawdbotChatViewModel {
         guard !next.isEmpty else { return }
         guard next != self.sessionKey else { return }
         self.sessionKey = next
+        self.hasInitiallyLoaded = false
         await self.bootstrap()
     }
 


### PR DESCRIPTION
## Summary
- Add `hasInitiallyLoaded` flag to prevent multiple bootstrap() calls
- Guards against SwiftUI's `onAppear` firing unexpectedly during layout changes or window show/hide
- Eliminates the blank loading screen that would appear during normal chat use
- `refresh()` method still available for explicit user-initiated reloads

## Test plan
- [x] Build ClawdbotKit package
- [x] Build macOS app
- [x] Test webchat - no more random blank screens
- [x] Test window hide/show - no re-bootstrap
- [x] Session switching still works correctly

Fixes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)