### PR TITLE
feat(macos): add scroll-to-bottom button in webchat

### DIFF
--- a/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
@@ -118,6 +118,29 @@ public struct ClawdbotChatView: View {
             }
 
             self.messageListOverlay
+
+            if !self.isPinnedToBottom, self.hasPerformedInitialScroll {
+                VStack {
+                    Spacer()
+                    Button {
+                        withAnimation(.snappy(duration: 0.22)) {
+                            self.scrollPosition = self.scrollerBottomID
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.primary)
+                            .frame(width: 32, height: 32)
+                            .background(.ultraThinMaterial, in: Circle())
+                            .shadow(color: .black.opacity(0.12), radius: 4, y: 2)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.bottom, 8)
+                }
+                .frame(maxWidth: .infinity)
+                .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                .animation(.easeOut(duration: 0.15), value: self.isPinnedToBottom)
+            }
         }
         // Ensure the message list claims vertical space on the first layout pass.
         .frame(maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## Summary
- Add floating scroll-to-bottom button when user scrolls up in chat
- Small circular button with down chevron icon
- Uses `.ultraThinMaterial` background with subtle shadow
- Smooth animated scroll to bottom on tap
- Fade+scale transition when appearing/disappearing

## Test plan
- [x] Build ClawdbotKit package
- [x] Build macOS app
- [x] Scroll up in chat - button appears
- [x] Tap button - scrolls to bottom
- [x] Scroll to bottom manually - button disappears

Closes #2466

🤖 Generated with [Claude Code](https://claude.com/claude-code)