### PR TITLE
fix(macos): auto-scroll to bottom when sending message while scrolled up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Status: unreleased.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
@@ -132,6 +132,14 @@ public struct ClawdbotChatView: View {
             self.hasPerformedInitialScroll = false
             self.isPinnedToBottom = true
         }
+        .onChange(of: self.viewModel.isSending) { _, isSending in
+            // Scroll to bottom when user sends a message, even if scrolled up.
+            guard isSending, self.hasPerformedInitialScroll else { return }
+            self.isPinnedToBottom = true
+            withAnimation(.snappy(duration: 0.22)) {
+                self.scrollPosition = self.scrollerBottomID
+            }
+        }
         .onChange(of: self.viewModel.messages.count) { _, _ in
             guard self.hasPerformedInitialScroll, self.isPinnedToBottom else { return }
             withAnimation(.snappy(duration: 0.22)) {

--- a/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
+++ b/apps/shared/ClawdbotKit/Sources/ClawdbotChatUI/ChatView.swift
@@ -13,6 +13,7 @@ public struct ClawdbotChatView: View {
     @State private var showSessions = false
     @State private var hasPerformedInitialScroll = false
     @State private var isPinnedToBottom = true
+    @State private var lastUserMessageID: UUID?
     private let showsSessionSwitcher: Bool
     private let style: Style
     private let markdownVariant: ChatMarkdownVariant
@@ -141,7 +142,19 @@ public struct ClawdbotChatView: View {
             }
         }
         .onChange(of: self.viewModel.messages.count) { _, _ in
-            guard self.hasPerformedInitialScroll, self.isPinnedToBottom else { return }
+            guard self.hasPerformedInitialScroll else { return }
+            if let lastMessage = self.viewModel.messages.last,
+               lastMessage.role.lowercased() == "user",
+               lastMessage.id != self.lastUserMessageID {
+                self.lastUserMessageID = lastMessage.id
+                self.isPinnedToBottom = true
+                withAnimation(.snappy(duration: 0.22)) {
+                    self.scrollPosition = self.scrollerBottomID
+                }
+                return
+            }
+
+            guard self.isPinnedToBottom else { return }
             withAnimation(.snappy(duration: 0.22)) {
                 self.scrollPosition = self.scrollerBottomID
             }


### PR DESCRIPTION
## Summary
- Auto-scroll to bottom when user sends a message, even if scrolled up reading history
- Uses `onChange(of: isSending)` to detect when user starts sending
- Sets `isPinnedToBottom = true` so subsequent messages also auto-scroll

## Test plan
- [x] Build ClawdbotKit package
- [x] Scroll up in chat to read old messages
- [x] Send a new message - should scroll to bottom
- [x] Response appears at bottom where user can see it

Fixes #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)