### PR TITLE
CLI: expand versioned node argv handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Status: unreleased.
 ### Fixes
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.
 - Security: properly test Windows ACL audit for config includes. (#2403) Thanks @dominicnunez.
+- CLI: recognize versioned Node executables when parsing argv. (#2490) Thanks @David-Marsh-Photo.
 - BlueBubbles: coalesce inbound URL link preview messages. (#1981) Thanks @tyler6204.
 - Cron: allow payloads containing "heartbeat" in event filter. (#2219) Thanks @dwfinkelstein.
 - CLI: avoid loading config for global help/version while registering plugin commands. (#2212) Thanks @dial481.

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -78,6 +78,48 @@ describe("argv helpers", () => {
     });
     expect(nodeArgv).toEqual(["node", "clawdbot", "status"]);
 
+    const versionedNodeArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["node-22", "clawdbot", "status"],
+    });
+    expect(versionedNodeArgv).toEqual(["node-22", "clawdbot", "status"]);
+
+    const versionedNodeWindowsArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["node-22.2.0.exe", "clawdbot", "status"],
+    });
+    expect(versionedNodeWindowsArgv).toEqual(["node-22.2.0.exe", "clawdbot", "status"]);
+
+    const versionedNodePatchlessArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["node-22.2", "clawdbot", "status"],
+    });
+    expect(versionedNodePatchlessArgv).toEqual(["node-22.2", "clawdbot", "status"]);
+
+    const versionedNodeWindowsPatchlessArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["node-22.2.exe", "clawdbot", "status"],
+    });
+    expect(versionedNodeWindowsPatchlessArgv).toEqual(["node-22.2.exe", "clawdbot", "status"]);
+
+    const versionedNodeWithPathArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["/usr/bin/node-22.2.0", "clawdbot", "status"],
+    });
+    expect(versionedNodeWithPathArgv).toEqual(["/usr/bin/node-22.2.0", "clawdbot", "status"]);
+
+    const nodejsArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["nodejs", "clawdbot", "status"],
+    });
+    expect(nodejsArgv).toEqual(["nodejs", "clawdbot", "status"]);
+
+    const nonVersionedNodeArgv = buildParseArgv({
+      programName: "clawdbot",
+      rawArgs: ["node-dev", "clawdbot", "status"],
+    });
+    expect(nonVersionedNodeArgv).toEqual(["node", "clawdbot", "node-dev", "clawdbot", "status"]);
+
     const directArgv = buildParseArgv({
       programName: "clawdbot",
       rawArgs: ["clawdbot", "status"],

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -96,14 +96,25 @@ export function buildParseArgv(params: {
         : baseArgv;
   const executable = (normalizedArgv[0]?.split(/[/\\]/).pop() ?? "").toLowerCase();
   const looksLikeNode =
-    normalizedArgv.length >= 2 &&
-    (executable === "node" ||
-      executable === "node.exe" ||
-      executable.startsWith("node-") ||
-      executable === "bun" ||
-      executable === "bun.exe");
+    normalizedArgv.length >= 2 && (isNodeExecutable(executable) || isBunExecutable(executable));
   if (looksLikeNode) return normalizedArgv;
   return ["node", programName || "clawdbot", ...normalizedArgv];
+}
+
+const nodeExecutablePattern = /^node-\d+(?:\.\d+)*(?:\.exe)?$/;
+
+function isNodeExecutable(executable: string): boolean {
+  return (
+    executable === "node" ||
+    executable === "node.exe" ||
+    executable === "nodejs" ||
+    executable === "nodejs.exe" ||
+    nodeExecutablePattern.test(executable)
+  );
+}
+
+function isBunExecutable(executable: string): boolean {
+  return executable === "bun" || executable === "bun.exe";
 }
 
 export function shouldMigrateStateFromPath(path: string[]): boolean {


### PR DESCRIPTION
## Summary
- centralize node/bun executable detection for versioned binaries and nodejs variants
- add argv regression tests for versioned, path-based, and negative node names

## Test plan
- [x] pnpm test -- src/cli/argv.test.ts