### PR TITLE
fix: handle fetch/API errors in telegram delivery to prevent gateway crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Status: unreleased.
 - Agents: release session locks on process termination. (#2483) Thanks @janeexai.
 - Telegram: harden polling + retry behavior for transient network errors and Node 22 transport issues. (#2420) Thanks @techboss.
 - Telegram: wrap reasoning italics per line to avoid raw underscores. (#2181) Thanks @YuriNachos.
+- Telegram: log fetch/API errors in delivery to avoid unhandled rejections. (#2492) Thanks @altryne.
 - Voice Call: enforce Twilio webhook signature verification for ngrok URLs; disable ngrok free tier bypass by default.
 - Security: harden Tailscale Serve auth by validating identity via local tailscaled before trusting headers.
 - Build: align memory-core peer dependency with lockfile.

--- a/src/channels/plugins/onboarding/telegram.ts
+++ b/src/channels/plugins/onboarding/telegram.ts
@@ -80,14 +80,20 @@ async function promptTelegramAllowFrom(params: {
     if (!token) return null;
     const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
     const url = `https://api.telegram.org/bot${token}/getChat?chat_id=${encodeURIComponent(username)}`;
-    const res = await fetch(url);
-    const data = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      result?: { id?: number | string };
-    } | null;
-    const id = data?.ok ? data?.result?.id : undefined;
-    if (typeof id === "number" || typeof id === "string") return String(id);
-    return null;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) return null;
+      const data = (await res.json().catch(() => null)) as {
+        ok?: boolean;
+        result?: { id?: number | string };
+      } | null;
+      const id = data?.ok ? data?.result?.id : undefined;
+      if (typeof id === "number" || typeof id === "string") return String(id);
+      return null;
+    } catch {
+      // Network error during username lookup - return null to prompt user for numeric ID
+      return null;
+    }
   };
 
   const parseInput = (value: string) =>


### PR DESCRIPTION
## Summary

- Wrap all `bot.api.sendXxx()` media calls in `delivery.ts` with error handler that logs failures before re-throwing
- Wrap fetch() in telegram onboarding with try/catch to gracefully handle network errors

## Problem

The gateway crashes due to unhandled promise rejections from Telegram API calls. When `bot.api.sendPhoto()` (or other media sends) fails due to network issues, the error propagates as an unhandled rejection and triggers `process.exit(1)` in the global handler.

**Before:** Network failure → unhandled rejection → gateway crash  
**After:** Network failure → logged with context → error propagates to caller → graceful handling

## Changes

### `src/telegram/bot/delivery.ts`

Added `withMediaErrorHandler()` wrapper that:
1. Catches errors from media API calls
2. Logs them with context via `runtime.error()`
3. Re-throws so callers can handle appropriately

```typescript
await withMediaErrorHandler("sendPhoto", runtime, () =>
  bot.api.sendPhoto(chatId, file, { ...mediaParams }),
);
```

### `src/channels/plugins/onboarding/telegram.ts`

Wrapped the `fetch()` call for username lookup:
- Returns `null` on network errors (user can retry with numeric ID)
- Also checks `res.ok` before parsing JSON

## Test Plan

- [ ] Verify gateway doesn't crash when Telegram API times out
- [ ] Verify media sends still work normally
- [ ] Verify onboarding handles network errors gracefully

Fixes #2487
Fixes #2272

🤖 Generated with [Claude Code](https://claude.com/claude-code)