### PR TITLE
Add "Cache-Control: no-cache" header to brave api web search requests.

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -67,8 +67,8 @@ const WebSearchSchema = Type.Object({
 
 type WebSearchConfig = NonNullable<MoltbotConfig["tools"]>["web"] extends infer Web
   ? Web extends { search?: infer Search }
-    ? Search
-    : undefined
+  ? Search
+  : undefined
   : undefined;
 
 type BraveSearchResult = {
@@ -375,6 +375,7 @@ async function runWebSearch(params: {
     method: "GET",
     headers: {
       Accept: "application/json",
+      "Cache-Control": "no-cache",
       "X-Subscription-Token": params.apiKey,
     },
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -67,8 +67,8 @@ const WebSearchSchema = Type.Object({
 
 type WebSearchConfig = NonNullable<MoltbotConfig["tools"]>["web"] extends infer Web
   ? Web extends { search?: infer Search }
-  ? Search
-  : undefined
+    ? Search
+    : undefined
   : undefined;
 
 type BraveSearchResult = {


### PR DESCRIPTION
Summary
Brave API returns 422 due to missing Cache-Control header.

Changes
Add "Cache-Control: no-cache" header to brave api web search requests.

Fixes [#2476](https://github.com/clawdbot/clawdbot/issues/2476)