### PR TITLE
feat: improve /help and /commands formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.clawd.bot
 Status: unreleased.
 
 ### Changes
+- Commands: group /help and /commands output with Telegram paging. (#2504) Thanks @hougangdev.
 - macOS: limit project-local `node_modules/.bin` PATH preference to debug builds (reduce PATH hijacking risk).
 - Tools: add per-sender group tool policies and fix precedence. (#1757) Thanks @adam91holt.
 - Agents: summarize dropped messages during compaction safeguard pruning. (#2509) Thanks @jogi47.

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -2,7 +2,11 @@ import { listChannelDocks } from "../channels/dock.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { listThinkingLevels } from "./thinking.js";
 import { COMMAND_ARG_FORMATTERS } from "./commands-args.js";
-import type { ChatCommandDefinition, CommandScope } from "./commands-registry.types.js";
+import type {
+  ChatCommandDefinition,
+  CommandCategory,
+  CommandScope,
+} from "./commands-registry.types.js";
 
 type DefineChatCommandInput = {
   key: string;
@@ -16,6 +20,7 @@ type DefineChatCommandInput = {
   textAlias?: string;
   textAliases?: string[];
   scope?: CommandScope;
+  category?: CommandCategory;
 };
 
 function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefinition {
@@ -37,6 +42,7 @@ function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefiniti
     argsMenu: command.argsMenu,
     textAliases: aliases,
     scope,
+    category: command.category,
   };
 }
 
@@ -48,6 +54,7 @@ function defineDockCommand(dock: ChannelDock): ChatCommandDefinition {
     nativeName: `dock_${dock.id}`,
     description: `Switch to ${dock.id} for replies.`,
     textAliases: [`/dock-${dock.id}`, `/dock_${dock.id}`],
+    category: "docks",
   });
 }
 
@@ -124,18 +131,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "help",
       description: "Show available commands.",
       textAlias: "/help",
+      category: "status",
     }),
     defineChatCommand({
       key: "commands",
       nativeName: "commands",
       description: "List all slash commands.",
       textAlias: "/commands",
+      category: "status",
     }),
     defineChatCommand({
       key: "skill",
       nativeName: "skill",
       description: "Run a skill by name.",
       textAlias: "/skill",
+      category: "tools",
       args: [
         {
           name: "name",
@@ -156,6 +166,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "status",
       description: "Show current status.",
       textAlias: "/status",
+      category: "status",
     }),
     defineChatCommand({
       key: "allowlist",
@@ -163,6 +174,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       textAlias: "/allowlist",
       acceptsArgs: true,
       scope: "text",
+      category: "management",
     }),
     defineChatCommand({
       key: "approve",
@@ -170,6 +182,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Approve or deny exec requests.",
       textAlias: "/approve",
       acceptsArgs: true,
+      category: "management",
     }),
     defineChatCommand({
       key: "context",
@@ -177,12 +190,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Explain how context is built and used.",
       textAlias: "/context",
       acceptsArgs: true,
+      category: "status",
     }),
     defineChatCommand({
       key: "tts",
       nativeName: "tts",
       description: "Control text-to-speech (TTS).",
       textAlias: "/tts",
+      category: "media",
       args: [
         {
           name: "action",
@@ -225,12 +240,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "whoami",
       description: "Show your sender id.",
       textAlias: "/whoami",
+      category: "status",
     }),
     defineChatCommand({
       key: "subagents",
       nativeName: "subagents",
       description: "List/stop/log/info subagent runs for this session.",
       textAlias: "/subagents",
+      category: "management",
       args: [
         {
           name: "action",
@@ -257,6 +274,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "config",
       description: "Show or set config values.",
       textAlias: "/config",
+      category: "management",
       args: [
         {
           name: "action",
@@ -284,6 +302,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "debug",
       description: "Set runtime debug overrides.",
       textAlias: "/debug",
+      category: "management",
       args: [
         {
           name: "action",
@@ -311,6 +330,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "usage",
       description: "Usage footer or cost summary.",
       textAlias: "/usage",
+      category: "options",
       args: [
         {
           name: "mode",
@@ -326,18 +346,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "stop",
       description: "Stop the current run.",
       textAlias: "/stop",
+      category: "session",
     }),
     defineChatCommand({
       key: "restart",
       nativeName: "restart",
       description: "Restart Clawdbot.",
       textAlias: "/restart",
+      category: "tools",
     }),
     defineChatCommand({
       key: "activation",
       nativeName: "activation",
       description: "Set group activation mode.",
       textAlias: "/activation",
+      category: "management",
       args: [
         {
           name: "mode",
@@ -353,6 +376,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "send",
       description: "Set send policy.",
       textAlias: "/send",
+      category: "management",
       args: [
         {
           name: "mode",
@@ -369,6 +393,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Reset the current session.",
       textAlias: "/reset",
       acceptsArgs: true,
+      category: "session",
     }),
     defineChatCommand({
       key: "new",
@@ -376,12 +401,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Start a new session.",
       textAlias: "/new",
       acceptsArgs: true,
+      category: "session",
     }),
     defineChatCommand({
       key: "compact",
       description: "Compact the session context.",
       textAlias: "/compact",
       scope: "text",
+      category: "session",
       args: [
         {
           name: "instructions",
@@ -396,6 +423,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "think",
       description: "Set thinking level.",
       textAlias: "/think",
+      category: "options",
       args: [
         {
           name: "level",
@@ -411,6 +439,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "verbose",
       description: "Toggle verbose mode.",
       textAlias: "/verbose",
+      category: "options",
       args: [
         {
           name: "mode",
@@ -426,6 +455,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "reasoning",
       description: "Toggle reasoning visibility.",
       textAlias: "/reasoning",
+      category: "options",
       args: [
         {
           name: "mode",
@@ -441,6 +471,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "elevated",
       description: "Toggle elevated mode.",
       textAlias: "/elevated",
+      category: "options",
       args: [
         {
           name: "mode",
@@ -456,6 +487,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "exec",
       description: "Set exec defaults for this session.",
       textAlias: "/exec",
+      category: "options",
       args: [
         {
           name: "options",
@@ -470,6 +502,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "model",
       description: "Show or set the model.",
       textAlias: "/model",
+      category: "options",
       args: [
         {
           name: "model",
@@ -485,12 +518,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       textAlias: "/models",
       argsParsing: "none",
       acceptsArgs: true,
+      category: "options",
     }),
     defineChatCommand({
       key: "queue",
       nativeName: "queue",
       description: "Adjust queue settings.",
       textAlias: "/queue",
+      category: "options",
       args: [
         {
           name: "mode",
@@ -523,6 +558,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Run host shell commands (host-only).",
       textAlias: "/bash",
       scope: "text",
+      category: "tools",
       args: [
         {
           name: "command",

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -2,6 +2,15 @@ import type { ClawdbotConfig } from "../config/types.js";
 
 export type CommandScope = "text" | "native" | "both";
 
+export type CommandCategory =
+  | "session"
+  | "options"
+  | "status"
+  | "management"
+  | "media"
+  | "tools"
+  | "docks";
+
 export type CommandArgType = "string" | "number" | "boolean";
 
 export type CommandArgChoiceContext = {
@@ -51,6 +60,7 @@ export type ChatCommandDefinition = {
   formatArgs?: (values: CommandArgValues) => string | undefined;
   argsMenu?: CommandArgMenuSpec | "auto";
   scope: CommandScope;
+  category?: CommandCategory;
 };
 
 export type NativeCommandSpec = {

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { buildCommandsPaginationKeyboard } from "./commands-info.js";
+
+describe("buildCommandsPaginationKeyboard", () => {
+  it("adds agent id to callback data when provided", () => {
+    const keyboard = buildCommandsPaginationKeyboard(2, 3, "agent-main");
+    expect(keyboard[0]).toEqual([
+      { text: "◀ Prev", callback_data: "commands_page_1:agent-main" },
+      { text: "2/3", callback_data: "commands_page_noop:agent-main" },
+      { text: "Next ▶", callback_data: "commands_page_3:agent-main" },
+    ]);
+  });
+});

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -402,8 +402,8 @@ describe("buildCommandsMessage", () => {
     } as ClawdbotConfig);
     expect(text).toContain("/commands - List all slash commands.");
     expect(text).toContain("/skill - Run a skill by name.");
-    expect(text).toContain("/think (aliases: /thinking, /t) - Set thinking level.");
-    expect(text).toContain("/compact (text-only) - Compact the session context.");
+    expect(text).toContain("/think (/thinking, /t) - Set thinking level.");
+    expect(text).toContain("/compact [text] - Compact the session context.");
     expect(text).not.toContain("/config");
     expect(text).not.toContain("/debug");
   });
@@ -430,7 +430,8 @@ describe("buildHelpMessage", () => {
     const text = buildHelpMessage({
       commands: { config: false, debug: false },
     } as ClawdbotConfig);
-    expect(text).toContain("Skills: /skill <name> [input]");
+    expect(text).toContain("Skills");
+    expect(text).toContain("/skill <name> [input]");
     expect(text).not.toContain("/config");
     expect(text).not.toContain("/debug");
   });

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -204,47 +204,6 @@ export const registerTelegramHandlers = ({
       const callbackMessage = callback.message;
       if (!data || !callbackMessage) return;
 
-      // Handle commands pagination callback
-      const paginationMatch = data.match(/^commands_page_(\d+|noop)$/);
-      if (paginationMatch) {
-        const pageValue = paginationMatch[1];
-        if (pageValue === "noop") return; // Page number button - no action
-
-        const page = parseInt(pageValue, 10);
-        if (isNaN(page) || page < 1) return;
-
-        const skillCommands = listSkillCommandsForAgents({ cfg });
-        const result = buildCommandsMessagePaginated(cfg, skillCommands, {
-          page,
-          surface: "telegram",
-        });
-
-        const messageId = callbackMessage.message_id;
-        const chatId = callbackMessage.chat.id;
-        const keyboard =
-          result.totalPages > 1
-            ? buildInlineKeyboard(
-                buildCommandsPaginationKeyboard(result.currentPage, result.totalPages),
-              )
-            : undefined;
-
-        try {
-          await bot.api.editMessageText(
-            chatId,
-            messageId,
-            result.text,
-            keyboard ? { reply_markup: keyboard } : undefined,
-          );
-        } catch (editErr) {
-          // Ignore "message is not modified" errors (user clicked same page)
-          const errStr = String(editErr);
-          if (!errStr.includes("message is not modified")) {
-            throw editErr;
-          }
-        }
-        return;
-      }
-
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
         accountId,


### PR DESCRIPTION
## Summary

- Organize commands into categories (session, options, status, management, media, tools, docks) for better discoverability
- Refactor `/help` to show grouped sections instead of a flat list
- Add pagination for `/commands` on Telegram (8 commands per page with navigation buttons)
- Show grouped list without pagination on other channels (web, Discord, etc.)

## What changed

1. **commands-registry.types.ts** - Added `CommandCategory` type
2. **commands-registry.data.ts** - Assigned categories to all commands  
3. **status.ts** - Refactored `buildHelpMessage()` and added `buildCommandsMessagePaginated()`
4. **commands-info.ts** - Added pagination keyboard builder for Telegram
5. **bot-handlers.ts** - Handle `commands_page_N` callback queries for pagination