### PR TITLE
test: fix CLI hint assertions under CLAWDBOT_PROFILE

### DIFF
--- a/src/agents/clawdbot-gateway-tool.test.ts
+++ b/src/agents/clawdbot-gateway-tool.test.ts
@@ -47,7 +47,9 @@ describe("gateway tool", () => {
         payload?: { kind?: string; doctorHint?: string | null };
       };
       expect(parsed.payload?.kind).toBe("restart");
-      expect(parsed.payload?.doctorHint).toBe("Run: clawdbot doctor --non-interactive");
+      expect(parsed.payload?.doctorHint).toBe(
+        "Run: clawdbot --profile isolated doctor --non-interactive",
+      );
 
       expect(kill).not.toHaveBeenCalled();
       await vi.runAllTimersAsync();

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -104,7 +104,7 @@ describe("acquireSessionWriteLock", () => {
   });
   it("cleans up locks on SIGINT without removing other handlers", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-lock-"));
-    const originalKill = process.kill.bind(process);
+    const originalKill = process.kill.bind(process) as typeof process.kill;
     const killCalls: Array<NodeJS.Signals | undefined> = [];
     let otherHandlerCalled = false;
 

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -314,7 +314,7 @@ describe("gateway-cli coverage", () => {
 
     expect(startGatewayServer).toHaveBeenCalled();
     expect(runtimeErrors.join("\n")).toContain("Gateway failed to start:");
-    expect(runtimeErrors.join("\n")).toContain("clawdbot gateway stop");
+    expect(runtimeErrors.join("\n")).toContain("gateway stop");
   });
 
   it("uses env/config port when --port is omitted", async () => {

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -370,7 +370,7 @@ describe("channels command", () => {
     });
     expect(lines.join("\n")).toMatch(/Warnings:/);
     expect(lines.join("\n")).toMatch(/Message Content Intent is disabled/i);
-    expect(lines.join("\n")).toMatch(/Run: clawdbot doctor/);
+    expect(lines.join("\n")).toMatch(/Run: clawdbot( --profile isolated)? doctor/);
   });
 
   it("surfaces Discord permission audit issues in channels status output", () => {

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -234,6 +234,8 @@ describe("buildGatewayInstallPlan", () => {
 describe("gatewayInstallErrorHint", () => {
   it("returns platform-specific hints", () => {
     expect(gatewayInstallErrorHint("win32")).toContain("Run as administrator");
-    expect(gatewayInstallErrorHint("linux")).toContain("clawdbot gateway install");
+    expect(gatewayInstallErrorHint("linux")).toMatch(
+      /clawdbot( --profile isolated)? gateway install/,
+    );
   });
 });

--- a/src/commands/onboard-hooks.test.ts
+++ b/src/commands/onboard-hooks.test.ts
@@ -239,7 +239,7 @@ describe("onboard-hooks", () => {
 
       // Second note should confirm configuration
       expect(noteCalls[1][0]).toContain("Enabled 1 hook: session-memory");
-      expect(noteCalls[1][0]).toContain("clawdbot hooks list");
+      expect(noteCalls[1][0]).toMatch(/clawdbot( --profile isolated)? hooks list/);
     });
   });
 });

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -130,7 +130,7 @@ describe("sandboxListCommand", () => {
 
       expectLogContains(runtime, "⚠️");
       expectLogContains(runtime, "image mismatch");
-      expectLogContains(runtime, "clawdbot sandbox recreate --all");
+      expectLogContains(runtime, "sandbox recreate --all");
     });
 
     it("should display message when no containers found", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -312,7 +312,13 @@ describe("statusCommand", () => {
     expect(logs.some((l) => l.includes("FAQ:"))).toBe(true);
     expect(logs.some((l) => l.includes("Troubleshooting:"))).toBe(true);
     expect(logs.some((l) => l.includes("Next steps:"))).toBe(true);
-    expect(logs.some((l) => l.includes("clawdbot status --all"))).toBe(true);
+    expect(
+      logs.some(
+        (l) =>
+          l.includes("clawdbot status --all") ||
+          l.includes("clawdbot --profile isolated status --all"),
+      ),
+    ).toBe(true);
   });
 
   it("shows gateway auth when reachable", async () => {

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -36,7 +36,10 @@ describe("buildPairingReply", () => {
       const text = buildPairingReply(testCase);
       expect(text).toContain(testCase.idLine);
       expect(text).toContain(`Pairing code: ${testCase.code}`);
-      expect(text).toContain(`clawdbot pairing approve ${testCase.channel} <code>`);
+      // CLI commands should respect CLAWDBOT_PROFILE when set (most tests run with isolated profile)
+      expect(text).toContain(
+        `clawdbot --profile isolated pairing approve ${testCase.channel} <code>`,
+      );
     });
   }
 });


### PR DESCRIPTION
Fixes failing tests caused by CLI hint strings being automatically prefixed with `--profile <name>`.

- Updates several tests to accept profile-prefixed commands.
- Avoids eslint unbound-method in session-write-lock test.

This is intended as a follow-up to the docs PR merge; it restores green CI without changing runtime behavior.