### PR TITLE
docs: clarify mobile and companion app availability status

### DIFF
--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -8,6 +8,8 @@ read_when:
 
 # Android App (Node)
 
+> **Note:** The Android app is currently in development and not yet publicly available. Pre-built binaries are not distributed at this time. If you're interested in building from source or participating in early testing, please reach out via [Discord](https://discord.gg/clawd).
+
 ## Support snapshot
 - Role: companion node app (Android does not host the Gateway).
 - Gateway required: yes (run it on macOS, Linux, or Windows via WSL2).

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -9,9 +9,12 @@ read_when:
 Clawdbot core is written in TypeScript. **Node is the recommended runtime**.
 Bun is not recommended for the Gateway (WhatsApp/Telegram bugs).
 
-Companion apps exist for macOS (menu bar app) and mobile nodes (iOS/Android). Windows and
-Linux companion apps are planned, but the Gateway is fully supported today.
-Native companion apps for Windows are also planned; the Gateway is recommended via WSL2.
+**Companion apps:**
+- **macOS menu bar app:** Available for development builds (build from source)
+- **iOS/Android apps:** Currently in internal preview; not publicly distributed
+- **Windows/Linux companion apps:** Planned
+
+The Gateway itself is fully supported on macOS, Linux, and Windows (via WSL2) today. You can use Clawdbot's full feature set via the CLI and web interface without needing the companion apps.
 
 ## Choose your OS
 

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -7,7 +7,7 @@ read_when:
 ---
 # iOS App (Node)
 
-Availability: internal preview. The iOS app is not publicly distributed yet.
+> **Note:** The iOS app is currently in internal preview and not yet publicly available. Pre-built binaries are not distributed at this time. If you're interested in building from source or participating in early testing, please reach out via [Discord](https://discord.gg/clawd).
 
 ## What it does
 


### PR DESCRIPTION
## Summary
Adds clear availability notices to platform documentation to address user confusion about missing download links and unavailable pre-built binaries.

## Problem
Issue #1864 and Discord discussions show users are confused when they:
- Click "Download for macOS" and find no binary releases
- Read Android/iOS docs but can't find download links
- Expect publicly available apps that don't exist yet

## Changes
✅ **Android docs** - Added prominent note that pre-built binaries are not yet publicly available  
✅ **iOS docs** - Updated existing notice to match Android format and clarify build-from-source option  
✅ **Platform index** - Added structured breakdown of companion app availability:
- macOS: Available for development builds (build from source)
- iOS/Android: Internal preview; not publicly distributed  
- Windows/Linux: Planned
- Clarified that Gateway + CLI + web interface work fully without companion apps

## Impact
- Reduces confusion for new users trying to download mobile/companion apps
- Sets clear expectations about what's available now vs. planned
- Provides Discord link for users interested in early testing or building from source
- Maintains existing technical documentation while adding crucial context

Fixes #1864

---
Co-Authored-By: Warp <agent@warp.dev>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates platform documentation to reduce confusion about companion app availability by adding prominent “not publicly available / internal preview” notices to the Android and iOS node app pages, and by restructuring the platform index to clearly list what companion apps exist today vs. what’s planned. It also clarifies that the Gateway + CLI + web interface are fully usable without any companion apps, and adjusts the VPS/hosting link list (removing Railway and adding GCP).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a docs-only change with minimal behavioral risk.
- Review focused on the three edited markdown files; changes are primarily clarifying copy and link list edits. The only noteworthy risk is user-facing link rot from hardcoded Discord invites and potential unintended removal of a hosting provider link (Railway) if it was still supported.
- docs/platforms/index.md (verify Railway removal is intended), docs/platforms/android.md and docs/platforms/ios.md (verify Discord link policy/canonical invite)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->