### PR TITLE
fix(gateway): improve auth error for native apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Status: unreleased.
 - Gateway: default auth now fail-closed (token/password required; Tailscale Serve identity remains allowed).
 - Gateway: treat loopback + non-local Host connections as remote unless trusted proxy headers are present.
 - Onboarding: remove unsupported gateway auth "off" choice from onboarding/configure flows and CLI flags.
+- Gateway: improve auth error message for native apps (macOS/iOS/Android) to clarify gateway.remote.token setup. (#2268)
 
 ## 2026.1.24-3
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -83,17 +83,25 @@ function formatGatewayAuthFailureMessage(params: {
   const isCli = isGatewayCliClient(client);
   const isControlUi = client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
   const isWebchat = isWebchatClient(client);
+  const isMacOsApp = client?.id === GATEWAY_CLIENT_IDS.MACOS_APP;
+  const isIosApp = client?.id === GATEWAY_CLIENT_IDS.IOS_APP;
+  const isAndroidApp = client?.id === GATEWAY_CLIENT_IDS.ANDROID_APP;
+  const isNativeApp = isMacOsApp || isIosApp || isAndroidApp;
   const uiHint = "open a tokenized dashboard URL or paste token in Control UI settings";
   const tokenHint = isCli
     ? "set gateway.remote.token to match gateway.auth.token"
-    : isControlUi || isWebchat
-      ? uiHint
-      : "provide gateway auth token";
+    : isNativeApp
+      ? "set gateway.remote.token in ~/.clawdbot/clawdbot.json to match gateway.auth.token on the server"
+      : isControlUi || isWebchat
+        ? uiHint
+        : "provide gateway auth token";
   const passwordHint = isCli
     ? "set gateway.remote.password to match gateway.auth.password"
-    : isControlUi || isWebchat
-      ? "enter the password in Control UI settings"
-      : "provide gateway auth password";
+    : isNativeApp
+      ? "set gateway.remote.password in ~/.clawdbot/clawdbot.json to match gateway.auth.password on the server"
+      : isControlUi || isWebchat
+        ? "enter the password in Control UI settings"
+        : "provide gateway auth password";
   switch (reason) {
     case "token_missing":
       return `unauthorized: gateway token missing (${tokenHint})`;


### PR DESCRIPTION
## Summary
Fixes #2268

Improves authentication error messages for macOS/iOS/Android apps to clearly indicate where to set `gateway.remote.token`.

## Problem
When native apps (macOS/iOS/Android) fail to connect due to missing auth credentials, they received a generic error message:
```
unauthorized: gateway token missing (provide gateway auth token)
```

This was confusing because it didn't specify:
- Where to set the token (`~/.clawdbot/clawdbot.json`)
- What config key to use (`gateway.remote.token`)
- That it must match the server's `gateway.auth.token`

## Solution
Enhanced `formatGatewayAuthFailureMessage` in [message-handler.ts:76-96](https://github.com/clawdbot/clawdbot/blob/main/src/gateway/server/ws-connection/message-handler.ts#L76-L96) to detect native apps and provide specific guidance:

**Before:**
```
unauthorized: gateway token missing (provide gateway auth token)
```

**After:**
```
unauthorized: gateway token missing (set gateway.remote.token in ~/.clawdbot/clawdbot.json to match gateway.auth.token on the server)
```

## Changes
- Added detection for `MACOS_APP`, `IOS_APP`, and `ANDROID_APP` client IDs
- Provided platform-specific error hints that include:
  - Config file path
  - Exact config key name
  - Requirement to match server config
- Applies to both token and password auth modes

## Testing
- Code review: logic correctly identifies native app client IDs
- Error message format matches existing CLI/Control UI patterns
- Backward compatible: other clients continue to receive appropriate hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves gateway authentication error messages for native app clients by detecting macOS/iOS/Android client IDs and returning more actionable hints (config file path and exact config keys to set). It also includes several gateway WS connection hardening tweaks (host parsing/local-client detection, additional Tailscale auth failure reasons, and Control UI device-auth bypass wiring), which aligns the WS handler with the newer `isLocalDirectRequest` logic in `src/gateway/auth.ts` and improves diagnostics and safety around proxied/loopback connections.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one logging/telemetry correctness concern to address.
- Changes are mostly user-facing messaging and refactors toward existing auth helpers, but the new `authMethod` fallback can mislabel the attempted authentication path (notably when Tailscale is attempted first), which could confuse operators when debugging auth failures.
- src/gateway/server/ws-connection/message-handler.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->