### PR TITLE
fix(google-antigravity): use 127.0.0.1 instead of localhost for OAuth redirect                 

### DIFF
--- a/extensions/google-antigravity-auth/index.ts
+++ b/extensions/google-antigravity-auth/index.ts
@@ -9,7 +9,7 @@ const CLIENT_ID = decode(
   "MTA3MTAwNjA2MDU5MS10bWhzc2luMmgyMWxjcmUyMzV2dG9sb2poNGc0MDNlcC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbQ==",
 );
 const CLIENT_SECRET = decode("R09DU1BYLUs1OEZXUjQ4NkxkTEoxbUxCOHNYQzR6NnFEQWY=");
-const REDIRECT_URI = "http://localhost:51121/oauth-callback";
+const REDIRECT_URI = "http://127.0.0.1:51121/oauth-callback";
 const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const DEFAULT_PROJECT_ID = "rising-fact-p41fc";


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
  - Fix Google Antigravity OAuth authentication failure caused by Google blocking HTTP localhost redirects                                                                                                                                                    
  - Change redirect URI from `http://localhost:51121` to `http://127.0.0.1:51121`                                                                                                                                                                             
 
## Why
Google's OAuth 2.0 security policy blocks `http://localhost` redirects but explicitly allows loopback IP addresses (`127.0.0.1`) for native app flows. This is documented in [Google's OAuth 2.0 policy](https://developers.google.com/identity/protocols/oauth2/policies#secure-response-handling).                                                                                                                                                         

Fixes [#2463](https://github.com/clawdbot/clawdbot/issues/2463)

### AI Disclosure
I've used claude code for this commit, thanks

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Google Antigravity OAuth redirect URI from `http://localhost:51121/oauth-callback` to `http://127.0.0.1:51121/oauth-callback` to comply with Google’s OAuth loopback redirect policy, and adds a small UX improvement to print the raw auth URL to the terminal during manual flow.

The change is isolated to the `google-antigravity-auth` extension: it affects how the auth URL is constructed and how the local callback server is reached, without changing token exchange or credential persistence logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (string/redirect host update plus extra logging) and aligns with existing callback server binding to 127.0.0.1; no control-flow or security-sensitive logic was altered beyond the redirect URI used in OAuth requests.
- extensions/google-antigravity-auth/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->