### PR TITLE
Fix Bundle.module crash in syntax highlighting

### DIFF
--- a/apps/shared/ClawdbotKit/Package.swift
+++ b/apps/shared/ClawdbotKit/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/steipete/ElevenLabsKit", exact: "0.1.0"),
-        .package(url: "https://github.com/gonzalezreal/textual", exact: "0.3.1"),
+        .package(url: "https://github.com/CraftedMark/textual", branch: "main"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
Fixes #1451 - App crashes when opening UI in Remote mode (HighlightedTextFragment / CodeTokenizer)

## Root Cause
The crash originates in `SwiftUIMath` (a dependency of `Textual`), where `Bundle.module` is used directly in `FontRegistry.swift`. When the app is packaged, the resource bundle path differs from SwiftPM's expectations, causing `Bundle.module` to crash.

Stack trace:
```
HighlightedTextFragment.body → tokenize() → CodeTokenizer.init() → 
NSBundle.module initialization → 💥 assertion failure
```

## Fix
1. Created a safe `Bundle.swiftUIMath` extension that checks multiple locations for the resource bundle instead of crashing
2. Updated `FontRegistry.swift` to use the safe bundle lookup
3. Forked `swiftui-math` and `textual` with the fix applied
4. Updated ClawdbotKit to use the fixed Textual fork

## Testing
- Tested on macOS 26.3 (25D5101c) with M2 Pro (Mac Studio) and M3 Pro (MacBook Pro)
- App no longer crashes when rendering code blocks in local or remote mode

## Related PRs
- https://github.com/CraftedMark/swiftui-math/commit/1b1934f
- https://github.com/CraftedMark/textual/commit/3e04e2e