### PR TITLE
fix(agents): preserve tool call/result pairing in history limiting

### DIFF
--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -10,8 +10,46 @@ function stripThreadSuffix(value: string): string {
 }
 
 /**
+ * Check if an assistant message has tool calls that need results
+ */
+function hasToolCalls(msg: AgentMessage): boolean {
+  if (msg.role !== "assistant") return false;
+  const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+  if (!Array.isArray(assistant.content)) return false;
+
+  return assistant.content.some((block) => {
+    if (!block || typeof block !== "object") return false;
+    const rec = block as { type?: unknown; id?: unknown };
+    return (
+      (rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall") &&
+      typeof rec.id === "string" &&
+      rec.id
+    );
+  });
+}
+
+/**
+ * Count consecutive tool result messages following the given index
+ */
+function countFollowingToolResults(messages: AgentMessage[], startIndex: number): number {
+  let count = 0;
+  for (let i = startIndex + 1; i < messages.length; i++) {
+    if (messages[i].role === "toolResult") {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return count;
+}
+
+/**
  * Limits conversation history to the last N user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
+ *
+ * IMPORTANT: This function is tool-call-aware. If slicing would separate an
+ * assistant message with tool calls from its tool results, it adjusts the
+ * slice boundary to include the complete assistant + tool results sequence.
  */
 export function limitHistoryTurns(
   messages: AgentMessage[],
@@ -26,7 +64,27 @@ export function limitHistoryTurns(
     if (messages[i].role === "user") {
       userCount++;
       if (userCount > limit) {
-        return messages.slice(lastUserIndex);
+        // Before slicing at lastUserIndex, check if the message immediately before
+        // the slice point is a toolResult. If so, we need to include its corresponding
+        // assistant to avoid breaking the tool call/result pairing.
+        let sliceIndex = lastUserIndex;
+
+        // Only adjust if there's actually a toolResult at the boundary
+        if (lastUserIndex > 0 && messages[lastUserIndex - 1].role === "toolResult") {
+          // Walk back through consecutive tool result messages to find the assistant
+          let j = lastUserIndex - 1;
+          while (j >= 0 && messages[j].role === "toolResult") {
+            j--;
+          }
+
+          // If we found an assistant with tool calls immediately before the tool results,
+          // we need to include it to avoid breaking the tool call/result pairing.
+          if (j >= 0 && hasToolCalls(messages[j])) {
+            sliceIndex = j;
+          }
+        }
+
+        return messages.slice(sliceIndex);
       }
       lastUserIndex = i;
     }


### PR DESCRIPTION
## Problem

The `limitHistoryTurns()` function in `src/agents/pi-embedded-runner/history.ts` was slicing conversation history without considering tool call/result pairing. When limiting history to the last N user turns, it could cut off tool results from their corresponding assistant tool calls, causing Anthropic API validation errors:

```
LLM request rejected: messages.266.content.1: unexpected tool_use_id found in tool_result blocks: toolu_01K7ZFJdfEDqTsKuikvRRfmi. Each tool_result block must have a corresponding tool_use block in the previous message.
```

## Solution

Modified `limitHistoryTurns()` to be tool-call-aware:

1. Added `hasToolCalls()` helper to detect assistants with tool calls
2. Added `countFollowingToolResults()` helper to count tool results  
3. Before slicing at a boundary, check if there's a `toolResult` message immediately before the slice point
4. If found, walk back through consecutive tool results to find the corresponding assistant
5. Adjust the slice point to include the complete assistant + tool results sequence

## Impact

This ensures tool call/result pairs stay together when limiting history via `dmHistoryLimit` config, preventing the Anthropic API validation error.

## Testing

- Existing `limithistoryturns` tests pass
- Fix verified to resolve the reported error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `limitHistoryTurns()` (`src/agents/pi-embedded-runner/history.ts`) to avoid slicing conversation history in a way that separates an assistant tool-call turn from its subsequent `toolResult` messages, which can cause strict provider validation errors.

The new logic detects when the slice boundary would start immediately after one or more trailing `toolResult` messages and moves the slice start backward to include the corresponding assistant tool-call message as well.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should reduce tool pairing validation errors, with minor edge-case coverage gaps.
- The change is localized to history slicing and doesn’t affect core execution paths beyond deciding the slice start index. Main risk is behavioral mismatch in uncommon transcript shapes (e.g., toolResult blocks not immediately adjacent to the slice boundary, or tool call detection not matching all variants), plus a small amount of dead code left behind.
- src/agents/pi-embedded-runner/history.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->