### PR TITLE
fix: add missing import and type params after browser refactor

### DIFF
--- a/src/cli/browser-cli-actions-input/register.element.ts
+++ b/src/cli/browser-cli-actions-input/register.element.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { BrowserActResponse } from "../../browser/client-actions-core.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { BrowserParentOpts } from "../browser-cli-shared.js";
@@ -27,7 +28,7 @@ export function registerBrowserElementCommands(
             .filter(Boolean)
         : undefined;
       try {
-        const result = await callBrowserAct({
+        const result = await callBrowserAct<BrowserActResponse>({
           parent,
           profile,
           body: {

--- a/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -1,9 +1,12 @@
 import type { Command } from "commander";
+import type { BrowserDownloadPayload } from "../../browser/client-actions-core.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
 import { resolveBrowserActionContext } from "./shared.js";
 import { shortenHomePath } from "../../utils.js";
+
+type BrowserDownloadResponse = { ok: true; targetId: string; download: BrowserDownloadPayload };
 
 export function registerBrowserFilesAndDownloadsCommands(
   browser: Command,
@@ -68,7 +71,7 @@ export function registerBrowserFilesAndDownloadsCommands(
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
       try {
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
-        const result = await callBrowserRequest(
+        const result = await callBrowserRequest<BrowserDownloadResponse>(
           parent,
           {
             method: "POST",
@@ -108,7 +111,7 @@ export function registerBrowserFilesAndDownloadsCommands(
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
       try {
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
-        const result = await callBrowserRequest(
+        const result = await callBrowserRequest<BrowserDownloadResponse>(
           parent,
           {
             method: "POST",

--- a/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { BrowserActResponse } from "../../browser/client-actions-core.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { BrowserParentOpts } from "../browser-cli-shared.js";
@@ -108,7 +109,7 @@ export function registerBrowserFormWaitEvalCommands(
         return;
       }
       try {
-        const result = await callBrowserAct({
+        const result = await callBrowserAct<BrowserActResponse>({
           parent,
           profile,
           body: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -2,7 +2,7 @@ import { listChannelPlugins } from "../channels/plugins/index.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { ClawdbotConfig } from "../config/config.js";
-import { resolveBrowserConfig } from "../browser/config.js";
+import { resolveBrowserConfig, resolveProfile } from "../browser/config.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { formatCliCommand } from "../cli/command-format.js";


### PR DESCRIPTION
## Summary
- Add `resolveProfile` import to `security/audit.ts`
- Add `BrowserActResponse` type param to `callBrowserAct` calls
- Add `BrowserDownloadResponse` type param to `callBrowserRequest` calls

Fixes #2560

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` (running)

🤖 Generated with [Claude Code](https://claude.ai/code)