### PR TITLE
feat(discord): add forum channel thread (post) support

### DIFF
--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -183,6 +183,10 @@ export async function handleDiscordMessageAction(
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
+    // Forum channel support
+    const content = readStringParam(params, "message");
+    const appliedTags = readStringArrayParam(params, "appliedTags");
+    const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
     return await handleDiscordAction(
       {
         action: "threadCreate",
@@ -191,6 +195,9 @@ export async function handleDiscordMessageAction(
         name,
         messageId,
         autoArchiveMinutes,
+        content,
+        appliedTags,
+        embeds,
       },
       cfg,
     );

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -97,6 +97,22 @@ export async function createThreadDiscord(
   if (payload.autoArchiveMinutes) {
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
+
+  // Forum channels require a message object for the initial post
+  if (payload.message) {
+    body.message = {
+      content: payload.message.content,
+      ...(payload.message.embeds?.length ? { embeds: payload.message.embeds } : {}),
+    };
+  }
+
+  // Forum tags
+  if (payload.appliedTags?.length) {
+    body.applied_tags = payload.appliedTags;
+  }
+
+  // For forum channels without messageId, use the channel threads endpoint
+  // For regular channels with messageId, use the message-based thread endpoint
   const route = Routes.threads(channelId, payload.messageId);
   return await rest.post(route, { body });
 }

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -66,10 +66,19 @@ export type DiscordMessageEdit = {
   content?: string;
 };
 
+export type DiscordForumMessage = {
+  content: string;
+  embeds?: unknown[];
+};
+
 export type DiscordThreadCreate = {
   messageId?: string;
   name: string;
   autoArchiveMinutes?: number;
+  /** Initial message content for forum posts (required for forum channels) */
+  message?: DiscordForumMessage;
+  /** Tag IDs to apply to forum posts */
+  appliedTags?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

Adds support for creating threads (posts) in Discord forum channels via the `message` tool's `thread-create` action.

## Problem

Discord forum channels require an initial message object when creating a post, unlike regular text channel threads. The current implementation didn't support this, making it impossible to create forum posts programmatically.

## Solution

This PR extends the `thread-create` action with forum-specific parameters:

- `message` - Initial post content (required for forum channels)
- `appliedTags` - Array of forum tag IDs to apply
- `embeds` - Optional embed objects for the initial post

## Changes

- **`src/discord/send.types.ts`**: Added `DiscordForumMessage` type and extended `DiscordThreadCreate` with `message` and `appliedTags` fields
- **`src/discord/send.messages.ts`**: Updated `createThreadDiscord` to include message and tags in API payload
- **`src/agents/tools/discord-actions-messaging.ts`**: Read new parameters and build payload accordingly
- **`src/channels/plugins/actions/discord/handle-action.ts`**: Pass through new parameters to action handler

## Usage

```
message action=thread-create channelId=<forum-channel-id> \\
  threadName='Post Title' \\
  message='Initial post content' \\
  appliedTags='["tag-id-1", "tag-id-2"]'
```

## Backward Compatibility

This change is backward compatible - the new parameters are optional. Existing thread creation for regular text channels works unchanged.

## Testing

- [ ] Creates forum posts with initial content
- [ ] Applies forum tags correctly
- [ ] Regular text channel threads still work
- [ ] Embeds in initial post work