### PR TITLE
docs(security): add formal verification page

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -20,7 +20,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: `vignesh07/clawdbot-formal-models`.
+Models are maintained in a separate repo: <https://github.com/vignesh07/clawdbot-formal-models>.
 
 ## Important caveats
 
@@ -34,16 +34,21 @@ Today, results are reproduced by cloning the models repo locally and running TLC
 - CI-run models with public artifacts (counterexample traces, run logs)
 - a hosted “run this model” workflow for small, bounded checks
 
-From the models repo:
+Getting started:
 
 ```bash
-export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"  # or any Java 11+
+git clone https://github.com/vignesh07/clawdbot-formal-models
+cd clawdbot-formal-models
+
+# Java 11+ required (TLC runs on the JVM).
+# The repo vendors a pinned `tla2tools.jar` (TLA+ tools) and provides `bin/tlc` + Make targets.
+
 make <target>
 ```
 
 ### Gateway exposure and open gateway misconfiguration
 
-**Claim:** binding beyond loopback without auth makes remote compromise reachable; token/password blocks unauth attackers (per the model assumptions).
+**Claim:** binding beyond loopback without auth can make remote compromise possible / increases exposure; token/password blocks unauth attackers (per the model assumptions).
 
 - Green runs:
   - `make gateway-exposure-v2`

--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -13,8 +13,8 @@ intended security policy (authorization, session isolation, tool gating, and
 misconfiguration safety), under explicit assumptions.
 
 **What this is (today):** an executable, attacker-driven **security regression suite**:
-- Each claim has a runnable model-check.
-- Most claims have a paired **negative model** that produces a counterexample trace for a realistic bug class.
+- Each claim has a runnable model-check over a finite state space.
+- Many claims have a paired **negative model** that produces a counterexample trace for a realistic bug class.
 
 **What this is not (yet):** a proof that “Clawdbot is secure in all respects” or that the full TypeScript implementation is correct.
 
@@ -22,7 +22,17 @@ misconfiguration safety), under explicit assumptions.
 
 Models are maintained in a separate repo: `vignesh07/clawdbot-formal-models`.
 
+## Important caveats
+
+- These are **models**, not the full TypeScript implementation. Drift between model and code is possible.
+- Results are bounded by the state space explored by TLC; “green” does not imply security beyond the modeled assumptions and bounds.
+- Some claims rely on explicit environmental assumptions (e.g., correct deployment, correct configuration inputs).
+
 ## Reproducing results
+
+Today, results are reproduced by cloning the models repo locally and running TLC (see below). A future iteration could offer:
+- CI-run models with public artifacts (counterexample traces, run logs)
+- a hosted “run this model” workflow for small, bounded checks
 
 From the models repo:
 
@@ -31,9 +41,9 @@ export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"  # or any Java 11+
 make <target>
 ```
 
-### Gateway exposure / open gateway misconfig
+### Gateway exposure and open gateway misconfiguration
 
-**Claim:** binding beyond loopback without auth makes remote compromise reachable; token/password blocks unauth attackers.
+**Claim:** binding beyond loopback without auth makes remote compromise reachable; token/password blocks unauth attackers (per the model assumptions).
 
 - Green runs:
   - `make gateway-exposure-v2`
@@ -45,7 +55,7 @@ See also: `docs/gateway-exposure-matrix.md` in the models repo.
 
 ### Nodes.run pipeline (highest-risk capability)
 
-**Claim:** `nodes.run` requires (a) node command allowlist + declared commands and (b) live approval when configured; approvals are tokenized to prevent replay.
+**Claim:** `nodes.run` requires (a) node command allowlist plus declared commands and (b) live approval when configured; approvals are tokenized to prevent replay (in the model).
 
 - Green runs:
   - `make nodes-pipeline`


### PR DESCRIPTION
Adds a **Formal Verification (Security Models)** docs page under `docs/security/`.

What’s in the page
- Explains the goal: an attacker-driven, machine-checked security regression suite (TLA+/TLC today).
- Clearly states scope limits/caveats: models vs TypeScript implementation, bounded state spaces, explicit assumptions.
- Points readers to the external models repo (`vignesh07/clawdbot-formal-models`) where specs/configs live.
- Lists the concrete TLC `make` targets that correspond to our current coverage:
  - Gateway exposure / misconfiguration (incl. protected vs open-gateway negative)
  - nodes.run pipeline + approval/replay protections
  - Pairing store invariants (TTL + MaxPending cap) with negative counterexamples
  - Ingress gating (mention gating + control-command bypass) with a negative counterexample
  - Routing/session-key isolation with a negative counterexample

Why this matters
- Makes our security claims reproducible (anyone can run the same TLC targets).
- Provides a canonical entry point in Clawdbot docs while keeping model details in the models repo.

Follow-ups (not in this PR)
- Add CI artifacts/badges in the models repo so readers can verify results without running locally.
- Deepen fidelity: pairing-store concurrency/locking, provider-specific ingress nuances, routing identity-links/dmScope semantics.
