### PR TITLE
docs: fix LOC guideline inconsistency and list formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 - Formatting/linting via Oxlint and Oxfmt; run `pnpm lint` before commits.
 - Add brief code comments for tricky or non-obvious logic.
 - Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
+- Aim to keep files under ~500 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
 - Naming: use **Clawdbot** for product/app/docs headings; use `clawdbot` for CLI command, package/binary, paths, and config keys.
 
 ## Release Channels (Naming)
@@ -101,7 +101,7 @@
 - Pi sessions live under `~/.clawdbot/sessions/` by default; the base directory is not configurable.
 - Environment variables: see `~/.profile`.
 - Never commit or publish real phone numbers, videos, or live configuration values. Use obviously fake placeholders in docs, tests, and examples.
- - Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
+- Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
 
 ## Troubleshooting
 - Rebrand/migration issues or legacy config/service warnings: run `clawdbot doctor` (see `docs/gateway/doctor.md`).


### PR DESCRIPTION
## Summary

- **Resolve contradictory LOC guideline**: Coding Style section stated ~700 LOC while Agent-Specific Notes stated ~500 LOC. Standardized to ~500 LOC across both references.
- **Fix list formatting**: Remove stray leading space on "Release flow" bullet in Security section that broke Markdown list rendering.

## Changes

File: `AGENTS.md` (symlinked as `CLAUDE.md`)

| Line | Before | After |
|------|--------|-------|
| 56 | `~700 LOC` | `~500 LOC` |
| 104 | `·- Release flow` | `- Release flow` |

## Test plan

- [x] Verified both LOC references now match (~500 LOC)
- [x] Confirmed Markdown list renders correctly after whitespace fix