### PR TITLE
fix(diagnostics-otel): update to @opentelemetry/resources v2.x API

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3,7 +3,7 @@ import type { SeverityNumber } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -62,7 +62,7 @@ export function createDiagnosticsOtelService(): ClawdbotPluginService {
       const logsEnabled = otel.logs === true;
       if (!tracesEnabled && !metricsEnabled && !logsEnabled) return;
 
-      const resource = new Resource({
+      const resource = resourceFromAttributes({
         [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
       });
 


### PR DESCRIPTION
## Summary

The `diagnostics-otel` plugin fails to load with:

```
TypeError: _resources.Resource is not a constructor
```

## Root Cause

The `@opentelemetry/resources` package v2.x removed the `Resource` class export. The new API uses `resourceFromAttributes()` function instead.

From the package's index.js (v2.5.0):
```js
export { resourceFromAttributes, defaultResource, emptyResource } from './ResourceImpl';
```

Note: No `Resource` class is exported.

## Fix

- Replace `import { Resource }` with `import { resourceFromAttributes }`
- Replace `new Resource({...})` with `resourceFromAttributes({...})`

## Testing

Tested locally on macOS with Node 22.22.0 — plugin now loads successfully and exports telemetry to Honeycomb.

---

Found while debugging with Clawdbot 🤖

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the `diagnostics-otel` plugin to match `@opentelemetry/resources` v2.x by switching from the removed `Resource` class to the new `resourceFromAttributes()` API, fixing the runtime `TypeError: Resource is not a constructor` when the plugin starts.

Change is localized to `extensions/diagnostics-otel/src/service.ts`, where the constructed resource passed into `NodeSDK`/`LoggerProvider` now uses `resourceFromAttributes({ [SemanticResourceAttributes.SERVICE_NAME]: serviceName })`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward API migration (import + constructor → function call) confined to a single location, and it directly addresses the reported runtime failure. No behavioral changes beyond resource construction were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->