### PR TITLE
Fix a subtle bug: `modelDefault` doesn’t apply when provider === "auto"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Status: unreleased.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -121,7 +121,9 @@ function mergeConfig(
   const overrideRemote = overrides?.remote;
   const hasRemote = Boolean(defaultRemote || overrideRemote);
   const includeRemote =
-    hasRemote || provider === "openai" || provider === "gemini" || provider === "auto";
+    Boolean(overrideRemote?.baseUrl || overrideRemote?.apiKey || overrideRemote?.headers ||
+            defaultRemote?.baseUrl || defaultRemote?.apiKey || defaultRemote?.headers) ||
+    provider === "openai" || provider === "gemini" || provider === "auto";
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? true,
     wait: overrideRemote?.batch?.wait ?? defaultRemote?.batch?.wait ?? true,
@@ -146,7 +148,7 @@ function mergeConfig(
   const modelDefault =
     provider === "gemini"
       ? DEFAULT_GEMINI_MODEL
-      : provider === "openai"
+      : provider === "openai" || provider === "auto"
         ? DEFAULT_OPENAI_MODEL
         : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -119,22 +119,16 @@ function mergeConfig(
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
-
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
-      overrideRemote?.apiKey ||
-      overrideRemote?.headers ||
-      defaultRemote?.baseUrl ||
-      defaultRemote?.apiKey ||
-      defaultRemote?.headers,
+    overrideRemote?.apiKey ||
+    overrideRemote?.headers ||
+    defaultRemote?.baseUrl ||
+    defaultRemote?.apiKey ||
+    defaultRemote?.headers,
   );
-
   const includeRemote =
-    hasRemoteConfig ||
-    provider === "openai" ||
-    provider === "gemini" ||
-    provider === "auto";
-
+    hasRemoteConfig || provider === "openai" || provider === "gemini" || provider === "auto";
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? true,
     wait: overrideRemote?.batch?.wait ?? defaultRemote?.batch?.wait ?? true,
@@ -159,7 +153,7 @@ function mergeConfig(
   const modelDefault =
     provider === "gemini"
       ? DEFAULT_GEMINI_MODEL
-      : provider === "openai" || provider === "auto"
+      : provider === "openai"
         ? DEFAULT_OPENAI_MODEL
         : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -119,10 +119,22 @@ function mergeConfig(
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
+
+  const hasRemoteConfig = Boolean(
+    overrideRemote?.baseUrl ||
+      overrideRemote?.apiKey ||
+      overrideRemote?.headers ||
+      defaultRemote?.baseUrl ||
+      defaultRemote?.apiKey ||
+      defaultRemote?.headers,
+  );
+
   const includeRemote =
-    Boolean(overrideRemote?.baseUrl || overrideRemote?.apiKey || overrideRemote?.headers ||
-            defaultRemote?.baseUrl || defaultRemote?.apiKey || defaultRemote?.headers) ||
-    provider === "openai" || provider === "gemini" || provider === "auto";
+    hasRemoteConfig ||
+    provider === "openai" ||
+    provider === "gemini" ||
+    provider === "auto";
+
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? true,
     wait: overrideRemote?.batch?.wait ?? defaultRemote?.batch?.wait ?? true,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -119,7 +119,6 @@ function mergeConfig(
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
-  const hasRemote = Boolean(defaultRemote || overrideRemote);
   const includeRemote =
     Boolean(overrideRemote?.baseUrl || overrideRemote?.apiKey || overrideRemote?.headers ||
             defaultRemote?.baseUrl || defaultRemote?.apiKey || defaultRemote?.headers) ||


### PR DESCRIPTION
1.Fix bugs when provider === "auto" which can lead model end up get ""

2. Fix to only include remote if you actually have any remote fields. (Is this intentional?)

Have seen many possibly dangerous 'behave as if config is set'