### PR TITLE
docs: publish formal verification page in docs index

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -956,6 +956,7 @@
           "gateway/doctor",
           "gateway/logging",
           "gateway/security",
+          "gateway/security/formal-verification",
           "gateway/sandbox-vs-tool-policy-vs-elevated",
           "gateway/sandboxing",
           "gateway/troubleshooting",


### PR DESCRIPTION
Mintlify (docs.clawd.bot) uses `docs/docs.json` to define routable pages. The formal verification page exists in `docs/gateway/security/formal-verification.md` but was not included in the docs index, causing a Mintlify 404.

This PR adds `gateway/security/formal-verification` to the `Gateway & Ops` navigation list so the route is published.
