### PR TITLE
feat(channels): allow setting config dir for signal

### DIFF
--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -31,6 +31,8 @@ export type SignalAccountConfig = {
   httpPort?: number;
   /** signal-cli binary path (default: signal-cli). */
   cliPath?: string;
+  /** Custom config/data directory for signal-cli (default: ~/.local/share/signal-cli). */
+  configDir?: string;
   /** Auto-start signal-cli daemon (default: true if httpUrl not set). */
   autoStart?: boolean;
   /** Max time to wait for signal-cli daemon startup (ms, cap 120000). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -499,6 +499,7 @@ export const SignalAccountSchemaBase = z
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),
     cliPath: ExecutableTokenSchema.optional(),
+    configDir: z.string().optional(),
     autoStart: z.boolean().optional(),
     startupTimeoutMs: z.number().int().min(1000).max(120000).optional(),
     receiveMode: z.union([z.literal("on-start"), z.literal("manual")]).optional(),

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -10,6 +10,8 @@ export type SignalDaemonOpts = {
   ignoreAttachments?: boolean;
   ignoreStories?: boolean;
   sendReadReceipts?: boolean;
+  /** Custom config/data directory for signal-cli. */
+  configDir?: string;
   runtime?: RuntimeEnv;
 };
 
@@ -30,6 +32,9 @@ export function classifySignalCliLogLine(line: string): "log" | "error" | null {
 
 function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
   const args: string[] = [];
+  if (opts.configDir) {
+    args.push("-c", opts.configDir);
+  }
   if (opts.account) {
     args.push("-a", opts.account);
   }

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -45,6 +45,8 @@ export type MonitorSignalOpts = {
   autoStart?: boolean;
   startupTimeoutMs?: number;
   cliPath?: string;
+  /** Custom config/data directory for signal-cli. */
+  configDir?: string;
   httpHost?: string;
   httpPort?: number;
   receiveMode?: "on-start" | "manual";
@@ -295,10 +297,12 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
 
   if (autoStart) {
     const cliPath = opts.cliPath ?? accountInfo.config.cliPath ?? "signal-cli";
+    const configDir = opts.configDir ?? accountInfo.config.configDir;
     const httpHost = opts.httpHost ?? accountInfo.config.httpHost ?? "127.0.0.1";
     const httpPort = opts.httpPort ?? accountInfo.config.httpPort ?? 8080;
     daemonHandle = spawnSignalDaemon({
       cliPath,
+      configDir,
       account,
       httpHost,
       httpPort,


### PR DESCRIPTION
Create a clawdbot configuration that sets the Signal config directory. This allows the config dir to be on a volume when clawdbot is running in docker.

Set the daemon to use a specified directory for the signal config like this:

```bash
clawdbot config set channels.signal.configDir ~/.clawdbot/signal-data
```

Then when you are configuring signal with signal-cli, be sure to use `-c ~/.clawdbot/signal-data` in your command so that you use the same configuration as the daemon.

I am using this on my clawdbot installation, but that's the extent of the testing I've done. It's all pretty straight forward and boilerplate-y. Oh, and I've run the linter. There was an error, but not in the code I changed.

Created with Claude Opus 4.5