### PR TITLE
docs: fix Mintlify routing for formal verification page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -956,7 +956,7 @@
           "gateway/doctor",
           "gateway/logging",
           "gateway/security",
-          "gateway/security/formal-verification",
+          "gateway/security-formal-verification",
           "gateway/sandbox-vs-tool-policy-vs-elevated",
           "gateway/sandboxing",
           "gateway/troubleshooting",

--- a/docs/gateway/security-formal-verification.md
+++ b/docs/gateway/security-formal-verification.md
@@ -1,7 +1,7 @@
 ---
 title: Formal Verification (Security Models)
 summary: Machine-checked security models for Clawdbot’s highest-risk paths.
-permalink: /gateway/security/formal-verification/
+permalink: /gateway/security-formal-verification/
 ---
 
 # Formal Verification (Security Models)

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -7,7 +7,7 @@ read_when:
 
 ## Quick check: `clawdbot security audit`
 
-See also: [Formal Verification (Security Models)](/gateway/security/formal-verification/)
+See also: [Formal Verification (Security Models)](/gateway/security-formal-verification/)
 
 Run this regularly (especially after changing config or exposing network surfaces):
 

--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -2,4 +2,4 @@
 permalink: /security/formal-verification/
 ---
 
-This page moved to: [/gateway/security/formal-verification/](/gateway/security/formal-verification/)
+This page moved to: [/gateway/security-formal-verification/](/gateway/security-formal-verification/)


### PR DESCRIPTION
Mintlify appears to treat `docs/gateway/security.md` and `docs/gateway/security/<page>.md` as a route conflict (same `security` segment as both a page and a directory), resulting in `/gateway/security/formal-verification` rendering Mintlify's Not Found.

This PR avoids the collision by moving the page to:
- `docs/gateway/security-formal-verification.md`
- route: `/gateway/security-formal-verification`

It also:
- updates `docs/docs.json` navigation entry
- updates links in `docs/gateway/security.md`
- updates the legacy `/security/formal-verification` stub to point to the new canonical URL

Net: Mintlify should reliably publish the page while keeping it adjacent to the security docs.
