### PR TITLE
docs: fix Mintlify MDX autolink in formal verification

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -20,7 +20,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: <https://github.com/vignesh07/clawdbot-formal-models>.
+Models are maintained in a separate repo: [vignesh07/clawdbot-formal-models](https://github.com/vignesh07/clawdbot-formal-models).
 
 ## Important caveats
 


### PR DESCRIPTION
Mintlify MDX parser fails on angle-bracket autolinks like <https://...> (interprets as JSX). Replace with standard markdown link syntax so the formal verification page renders and deploys.

Fixes:  in Mintlify deployment.