### PR TITLE
docs: add redirect stub for /gateway/security/formal-verification

### DIFF
--- a/docs/gateway/security-formal-verification.md
+++ b/docs/gateway/security-formal-verification.md
@@ -1,0 +1,12 @@
+---
+title: Formal Verification (Security Models)
+summary: Redirect to the canonical Formal Verification page.
+permalink: /gateway/security/formal-verification/
+---
+
+This page moved to: [/security/formal-verification/](/security/formal-verification/)
+
+<script>
+  // Best-effort client-side redirect for Mintlify/Next.
+  window.location.replace("/security/formal-verification/");
+</script>


### PR DESCRIPTION
Mintlify can't serve nested /gateway/security/formal-verification when /gateway/security exists; add a lightweight stub at a non-nested source path that publishes to /gateway/security/formal-verification and forwards to /security/formal-verification.