### PR TITLE
feat: change Venice default model to GLM 4.7

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
-export const VENICE_DEFAULT_MODEL_ID = "llama-3.3-70b";
+export const VENICE_DEFAULT_MODEL_ID = "zai-org-glm-4.7";
 export const VENICE_DEFAULT_MODEL_REF = `venice/${VENICE_DEFAULT_MODEL_ID}`;
 
 // Venice uses credit-based pricing, not per-token costs.

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -344,7 +344,7 @@ export function applyVeniceProviderConfig(cfg: ClawdbotConfig): ClawdbotConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[VENICE_DEFAULT_MODEL_REF] = {
     ...models[VENICE_DEFAULT_MODEL_REF],
-    alias: models[VENICE_DEFAULT_MODEL_REF]?.alias ?? "Llama 3.3 70B",
+    alias: models[VENICE_DEFAULT_MODEL_REF]?.alias ?? "GLM 4.7",
   };
 
   const providers = { ...cfg.models?.providers };


### PR DESCRIPTION
## Summary
Changes the default model for Venice AI provider from `llama-3.3-70b` to `zai-org-glm-4.7` (GLM 4.7).

## Changes
- Updated `VENICE_DEFAULT_MODEL_ID` in `src/agents/venice-models.ts`
- Updated the default alias in `src/commands/onboard-auth.config-core.ts`

## Why GLM 4.7?
- Reasoning-capable model (better for complex tasks)
- Private mode (fully private inference, no logging)
- Large context window (202,752 tokens)
- Better general-purpose performance

## Testing
- Build passes
- Verified model exists in Venice catalog

Co-authored-by: jonisjongithub <jonisjongithub@users.noreply.github.com>
Co-authored-by: Clawdbot <bot@clawd.bot>