### PR TITLE
feat(mattermost): add ws and zod dependencies

### DIFF
--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -21,5 +21,9 @@
       "localPath": "extensions/mattermost",
       "defaultChoice": "npm"
     }
+  },
+  "dependencies": {
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,7 +352,14 @@ importers:
         specifier: workspace:*
         version: link:../..
 
-  extensions/mattermost: {}
+  extensions/mattermost:
+    dependencies:
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   extensions/memory-core:
     dependencies:


### PR DESCRIPTION

Mattermost plugin: ship runtime deps for zod/ws

Optional body (if you want one):
Fixes plugin load failure when installed under ~/.clawdbot/extensions by declaring zod and ws as runtime dependencies.