### PR TITLE
test(config): fix gateway.bind tailnet test expectation

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -218,14 +218,14 @@ describe("legacy config detection", () => {
     expect(res.config?.gateway?.auth?.mode).toBe("token");
     expect((res.config?.gateway as { token?: string })?.token).toBeUndefined();
   });
-  it("keeps gateway.bind tailnet", async () => {
+  it("does not migrate gateway.bind tailnet", async () => {
     vi.resetModules();
     const { migrateLegacyConfig } = await import("./config.js");
     const res = migrateLegacyConfig({
       gateway: { bind: "tailnet" as const },
     });
-    expect(res.changes).not.toContain("Migrated gateway.bind from 'tailnet' to 'auto'.");
-    expect(res.config?.gateway?.bind).toBe("tailnet");
+    expect(res.changes).toHaveLength(0);
+    expect(res.config).toBeNull();
   });
   it('rejects telegram.dmPolicy="open" without allowFrom "*"', async () => {
     vi.resetModules();


### PR DESCRIPTION
## Summary

Fix incorrect test expectation for `gateway.bind: "tailnet"` migration test.

## Problem

Commit b5fd66c92 removed the `tailnet→auto` migration but updated the test to expect the config to pass through. This was incorrect - `migrateLegacyConfig` intentionally returns `null` when no migrations are applied, signaling "no changes needed."

## Fix

Update test to expect the correct behavior:
- `changes` should be empty (no migration applied)
- `config` should be `null` (no changes = nothing to return)

This matches the original design from commit c9504a6f2.