### PR TITLE
feat (Discord): add direct Dev Portal new application link to onboarding

### DIFF
--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -45,6 +45,7 @@ async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
   await prompter.note(
     [
       "1) Discord Developer Portal → Applications → New Application",
+      "   https://discord.com/developers/applications?new_application=true",
       "2) Bot → Add Bot → Reset Token → copy token",
       "3) OAuth2 → URL Generator → scope 'bot' → invite to your server",
       "Tip: enable Message Content Intent if you need message text. (Bot → Privileged Gateway Intents → Message Content Intent)",


### PR DESCRIPTION
AI-assisted: yes

  Reason:
  Setting up Clawdbot for a friend, he got hung up at this step, and it was hard to find on Discord's website.

  Change:
  Adds the direct Discord Developer Portal new application URL to the CLI onboarding hint.

  Testing:
  - pnpm lint
  - pnpm build
  - pnpm test (repo has unrelated browser test failures)