### PR TITLE
bugfix: Docker build fails on main: .dockerignore excludes required A2UI paths (apps/shared/ClawdbotKit/Tools/CanvasA2UI, vendor/a2ui/renderers/lit)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,10 +39,17 @@ apps/ios/build
 **/*.trace
 
 # large app trees not needed for CLI build
-apps/
+apps/*
+!apps/shared/
+!apps/shared/ClawdbotKit/
+!apps/shared/ClawdbotKit/Tools/
+!apps/shared/ClawdbotKit/Tools/CanvasA2UI/**
 assets/
 Peekaboo/
 Swabble/
 Core/
 Users/
-vendor/
+vendor/*
+!vendor/a2ui/
+!vendor/a2ui/renderers/
+!vendor/a2ui/renderers/lit/**


### PR DESCRIPTION
What happened
Running ./docker-setup.sh (or docker build ...) fails at RUN pnpm build
Error mentions missing:
/app/apps/shared/ClawdbotKit/Tools/CanvasA2UI
/app/vendor/a2ui/renderers/lit
<img width="784" height="445" alt="image" src="https://github.com/user-attachments/assets/0b48a663-99ab-4c53-973d-fb799e1fc495" />

Why
.dockerignore ignores apps/ and vendor/ entirely  ￼
But scripts/bundle-a2ui.sh requires those paths as inputs  ￼
Dockerfile copies repo with COPY . ., so ignored paths never enter build context  

Reproduction
git clone https://github.com/clawdbot/clawdbot.git
cd clawdbot
./docker-setup.sh
# or: docker build -t clawdbot:local .

Environment
•OS: Ubuntu 22.04 (Vultr VPS)
•Docker / Docker Compose versions: 
<img width="635" height="614" alt="image" src="https://github.com/user-attachments/assets/c1029f59-8af4-4d8b-85f3-c41d77eee3bd" />
Docker Compose version v5.0.2

Commit/branch: 
main e79dd527b

Expected
Docker build succeeds on main

Proposed fix
Adjust .dockerignore to not exclude required A2UI paths, or re-include them using negation patterns, or change Dockerfile/build pipeline to fetch/build A2UI deps in-image.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.dockerignore` to keep the Docker build context small while re-including the specific A2UI inputs needed by `scripts/bundle-a2ui.sh` (used by `pnpm build`). Concretely, it changes broad excludes for `apps/` and `vendor/` into `apps/*` / `vendor/*` plus negation patterns to bring back `apps/shared/ClawdbotKit/Tools/CanvasA2UI/**` and `vendor/a2ui/renderers/lit/**`, which should address the reported missing-path build failure when running `docker build` / `./docker-setup.sh`.

Main thing to double-check is that all *transitive* inputs required by the rolldown config and the `lit` tsconfig are still included; the current negations are very narrow and could still miss referenced files outside those exact subtrees.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported Docker build failure, but could still miss transitive A2UI inputs depending on config references.
- The change is limited to `.dockerignore` and aligns with the failure mode described (build context missing required A2UI paths). The remaining uncertainty is whether `rolldown.config.mjs` and `vendor/a2ui/renderers/lit/tsconfig.json` reference files outside the narrowly re-included directories; if they do, Docker builds may still fail.
- .dockerignore (ensure negation patterns cover all transitive inputs for A2UI bundling)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->