### PR TITLE
fix(discord): allow all channels when no channel allowlist is configured

### DIFF
--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -258,7 +258,8 @@ export function resolveDiscordChannelConfigWithFallback(params: {
     scope,
   } = params;
   const channels = guildInfo?.channels;
-  if (!channels) return null;
+  // Return null if channels is undefined, null, or empty object - allows all channels when no allowlist is configured
+  if (!channels || Object.keys(channels).length === 0) return null;
   const resolvedParentSlug = parentSlug ?? (parentName ? normalizeDiscordSlug(parentName) : "");
   const match = resolveDiscordChannelEntryMatch(
     channels,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -38,6 +38,7 @@ import {
   readChannelAllowFromStore,
   upsertChannelPairingRequest,
 } from "../../pairing/pairing-store.js";
+import { logVerbose } from "../../globals.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { loadWebMedia } from "../../web/media.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
@@ -656,6 +657,14 @@ async function dispatchDiscordCommandInteraction(params: {
       modeWhenAccessGroupsOff: "configured",
     });
     if (!commandAuthorized) {
+      // Log warning when no allowlist is configured to help users debug
+      const anyAuthorizerConfigured = authorizers.some((entry) => entry.configured);
+      if (!anyAuthorizerConfigured) {
+        logVerbose(
+          `discord: slash command rejected for user ${user.id} - no allowlist configured. ` +
+            `Configure channels.discord.guilds.<id>.users or channels.discord.dm.allowFrom to allow users.`,
+        );
+      }
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return;
     }


### PR DESCRIPTION
## Problem

When a guild is in the allowlist with `groupPolicy: "allowlist"` but has no `channels` configured, messages from that guild were being blocked.

### Root Cause

`resolveDiscordChannelConfigWithFallback` only checked for `!channels` (null/undefined), but when config.patch sets `channels: null`, it can result in an empty object `{}` instead. An empty object is truthy, so the function continued and returned `{ allowed: false }` when no channel match was found.

### Fix

Added check for empty object: `Object.keys(channels).length === 0`

Now both null/undefined AND empty object return `null`, which results in `channelAllowed = true` (allowing all channels when no allowlist is configured).

## Testing

- Guild in allowlist with no `channels` config → all channels allowed ✅
- Guild in allowlist with specific `channels` → only those channels allowed ✅