### PR TITLE
Fix Docker build failure caused by .dockerignore (#2593)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@
 *.mov
 *.wav
 *.mp3
+
 node_modules
 **/node_modules
 .pnpm-store
@@ -38,11 +39,20 @@ apps/macos/.build
 apps/ios/build
 **/*.trace
 
-# large app trees not needed for CLI build
-apps/
+# ignore ONLY large platform apps (not shared)
+apps/android/
+apps/ios/
+apps/macos/
+
+# DO NOT ignore apps/shared (required for build)
+# apps/shared/
+
+# DO NOT ignore vendor (required for A2UI)
+# vendor/
+
+# other unnecessary folders
 assets/
 Peekaboo/
 Swabble/
 Core/
 Users/
-vendor/


### PR DESCRIPTION
## Summary

This PR fixes the Docker build failure reported in #2593.

### Problem

Docker builds failed because `.dockerignore` excluded directories required during the A2UI bundling step:

- `apps/shared/ClawdbotKit/Tools/CanvasA2UI`
- `vendor/a2ui/renderers/lit`

This caused `pnpm build` to fail with missing file errors during Docker builds.

### Root Cause

The `.dockerignore` file ignored the entire `apps/` and `vendor/` directories, preventing required shared assets from being copied into the Docker build context.

### Fix

- Removed blanket ignores for `apps/` and `vendor/`.
- Ignored only platform-specific directories (`apps/android`, `apps/ios`, `apps/macos`).
- Ensured required shared build assets remain available during Docker builds.

### Result

- Docker build now succeeds.
- A2UI bundling works correctly.
- Build context remains optimized without excluding required files.

### Verification

Tested locally with:

```bash
docker build -t clawdbot-test .

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.dockerignore` to stop excluding the entire `apps/` and `vendor/` directories, while still ignoring large platform-specific app trees (`apps/android`, `apps/ios`, `apps/macos`). This unblocks `pnpm build` in Docker by ensuring shared assets (`apps/shared/...`) and the A2UI vendored sources remain in the Docker build context for the `COPY . .` step in `Dockerfile`.

Primary impact is on Docker build-context size/contents; runtime behavior is unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it only changes Docker ignore patterns but can affect build context size if paths don’t match as intended.
- The change is localized to `.dockerignore` and addresses a concrete Docker build failure. Main residual risk is unintentionally including large platform directories if the ignore patterns don’t match certain repo layouts (e.g., symlinks or file placeholders), which would increase build context and slow builds but not typically break correctness.
- .dockerignore

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->