### PR TITLE
feat(plugins): wire up compaction hooks and export stripEnvelope

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -69,6 +69,7 @@ import type { EmbeddedPiCompactResult } from "./types.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { describeUnknownError, mapThinkingLevel, resolveExecToolDefaults } from "./utils.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 
 export type CompactEmbeddedPiSessionParams = {
   sessionId: string;
@@ -424,6 +425,22 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Run before_compaction hooks
+        const hookRunner = getGlobalHookRunner();
+        const messageCountBefore = session.messages.length;
+        if (hookRunner?.hasHooks("before_compaction")) {
+          await hookRunner.runBeforeCompaction(
+            { messageCount: messageCountBefore, tokenCount: undefined },
+            {
+              agentId: sessionAgentId,
+              sessionKey: params.sessionKey,
+              workspaceDir: effectiveWorkspace,
+              messageProvider: runtimeChannel,
+            },
+          );
+        }
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -440,6 +457,27 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Run after_compaction hooks (fire-and-forget)
+        if (hookRunner?.hasHooks("after_compaction")) {
+          void hookRunner.runAfterCompaction(
+            {
+              messageCount: session.messages.length,
+              tokenCount: tokensAfter,
+              compactedCount: messageCountBefore - session.messages.length,
+              summary: result.summary,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            },
+            {
+              agentId: sessionAgentId,
+              sessionKey: params.sessionKey,
+              workspaceDir: effectiveWorkspace,
+              messageProvider: runtimeChannel,
+            },
+          );
+        }
+
         return {
           ok: true,
           compacted: true,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -369,3 +369,6 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
+
+// Chat sanitization utilities
+export { stripEnvelope } from "../gateway/chat-sanitize.js";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -339,6 +339,12 @@ export type PluginHookAfterCompactionEvent = {
   messageCount: number;
   tokenCount?: number;
   compactedCount: number;
+  /** Compacted summary text - essential for memory plugins */
+  summary: string;
+  /** Session identifier */
+  sessionId?: string;
+  /** Session key for context */
+  sessionKey?: string;
 };
 
 // Message context


### PR DESCRIPTION
## Summary

- **Compaction hooks wired up**: `before_compaction` and `after_compaction` plugin hooks are now called during session compaction in `compact.ts`. Previously these hooks were defined in the type system but never invoked, so plugins could register handlers that would never fire.
- **Extended `PluginHookAfterCompactionEvent`**: Added `summary`, `sessionId`, and `sessionKey` fields so plugins receive the compacted summary text and session context. This is critical for memory plugins that need to store or process compaction output.
- **Exported `stripEnvelope` from plugin SDK**: Plugins can now import `stripEnvelope` from `clawdbot/plugin-sdk` to sanitize channel metadata (Telegram/Discord/Slack envelope prefixes, timestamps, user IDs) from user prompts before processing.

## Motivation

The `before_compaction` and `after_compaction` hooks were defined in `src/plugins/types.ts` but never called anywhere in the compaction pipeline. This blocked plugin authors from hooking into compaction events. Memory plugins in particular need the compacted summary data to store long-term memories — without the `after_compaction` hook firing with the summary, there was no way for a plugin to capture what was compacted.

The `stripEnvelope` export enables plugins to reuse the core's channel metadata sanitization rather than reimplementing regex patterns for every messaging platform.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/compact.ts` | Call `runBeforeCompaction` before `session.compact()` and `runAfterCompaction` after (fire-and-forget) |
| `src/plugins/types.ts` | Extend `PluginHookAfterCompactionEvent` with `summary`, `sessionId`, `sessionKey` |
| `src/plugin-sdk/index.ts` | Export `stripEnvelope` from `../gateway/chat-sanitize.js` |

## Test plan

- [x] Verified compaction hooks fire correctly via gateway logs (`supermemory: stored compaction summary`)
- [x] Confirmed `after_compaction` event includes summary text, sessionId, and sessionKey
- [x] Verified `stripEnvelope` import works from plugin context (synchronous `require()` due to jiti loader)
- [x] Full test suite passes (`pnpm test` — 5,724 tests)
- [x] Tested end-to-end with Supermemory plugin in both tandem and primary modes
- [x] No regressions in existing compaction behavior (summaries still generated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)