### PR TITLE
fix(macOS): keep Not configured from snapping back to remote

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -533,6 +533,15 @@ final class AppState {
                     gateway["remote"] = remote
                     changed = true
                 }
+            } else if connectionMode == .unconfigured {
+                // Prevent implicit remote-mode re-selection when the user explicitly
+                // chooses "Not configured" in the UI. Leaving gateway.remote.url
+                // behind causes applyConfigOverrides to force .remote.
+                if var remote = gateway["remote"] as? [String: Any], remote["url"] != nil {
+                    remote.removeValue(forKey: "url")
+                    gateway["remote"] = remote
+                    changed = true
+                }
             }
 
             guard changed else { return }


### PR DESCRIPTION
AI-assisted: yes

  ## What & Why
  Bug: From Remote mode, switching **Clawdbot runs → Not configured** immediately snapped back to Remote.
  Cause: `gateway.mode` was removed, but a stale `gateway.remote.url` remained. On reload, the app treated “mode unset + remote
  url present” as Remote.

  ## Fix
  When `connectionMode == .unconfigured`, clear `gateway.remote.url` during config sync so the app does not implicitly re-select
  Remote mode.

  ## Testing (fully tested locally)
  - ./scripts/restart-mac.sh --no-sign
  - cd apps/macos && swift build
  - Verified the picker stays on **Not configured** after switching from Remote.

  ## Notes
  - I understand this change clears `gateway.remote.url` when selecting “Not configured”.
