### PR TITLE
fix(telegram): improve sticker vision + cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Status: unreleased.
 - Telegram: keep topic IDs in restart sentinel notifications. (#1807) Thanks @hsrvc.
 - Telegram: add optional silent send flag (disable notifications). (#2382) Thanks @Suksham-sharma.
 - Telegram: support editing sent messages via message(action="edit"). (#2394) Thanks @marcelomar21.
+- Telegram: add sticker receive/send with vision caching. (#2548) Thanks @longjos.
 - Config: apply config.env before ${VAR} substitution. (#1813) Thanks @spanishflu-est1918.
 - Slack: clear ack reaction after streamed replies. (#2044) Thanks @fancyboi999.
 - macOS: keep custom SSH usernames in remote target. (#2046) Thanks @algal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Status: unreleased.
 - Telegram: keep topic IDs in restart sentinel notifications. (#1807) Thanks @hsrvc.
 - Telegram: add optional silent send flag (disable notifications). (#2382) Thanks @Suksham-sharma.
 - Telegram: support editing sent messages via message(action="edit"). (#2394) Thanks @marcelomar21.
-- Telegram: add sticker receive/send with vision caching. (#2548) Thanks @longjos.
+- Telegram: add sticker receive/send with vision caching. (#2629) Thanks @longjos.
 - Config: apply config.env before ${VAR} substitution. (#1813) Thanks @spanishflu-est1918.
 - Slack: clear ack reaction after streamed replies. (#2044) Thanks @fancyboi999.
 - macOS: keep custom SSH usernames in remote target. (#2046) Thanks @algal.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -395,10 +395,13 @@ When a user sends a sticker, Clawdbot handles it based on the sticker type:
 - **Animated stickers (TGS):** Skipped (Lottie format not supported for processing).
 - **Video stickers (WEBM):** Skipped (video format not supported for processing).
 
-Template context fields available when receiving stickers:
-- `StickerEmoji` — the emoji associated with the sticker
-- `StickerSetName` — the name of the sticker set
-- `StickerFileId` — the Telegram file ID (used for sending the same sticker back)
+Template context field available when receiving stickers:
+- `Sticker` — object with:
+  - `emoji` — emoji associated with the sticker
+  - `setName` — name of the sticker set
+  - `fileId` — Telegram file ID (send the same sticker back)
+  - `fileUniqueId` — stable ID for cache lookup
+  - `cachedDescription` — cached vision description when available
 
 ### Sticker cache
 
@@ -416,10 +419,11 @@ Stickers are processed through the AI's vision capabilities to generate descript
 ```json
 {
   "fileId": "CAACAgIAAxkBAAI...",
+  "fileUniqueId": "AgADBAADb6cxG2Y",
   "emoji": "👋",
   "setName": "CoolCats",
   "description": "A cartoon cat waving enthusiastically",
-  "addedAt": "2026-01-15T10:30:00.000Z"
+  "cachedAt": "2026-01-15T10:30:00.000Z"
 }
 ```
 
@@ -458,7 +462,7 @@ The agent can send and search stickers using the `sticker` and `sticker-search` 
 ```
 
 Parameters:
-- `fileId` (required) — the Telegram file ID of the sticker. Obtain this from `StickerFileId` when receiving a sticker, or from a `sticker-search` result.
+- `fileId` (required) — the Telegram file ID of the sticker. Obtain this from `Sticker.fileId` when receiving a sticker, or from a `sticker-search` result.
 - `replyTo` (optional) — message ID to reply to.
 - `threadId` (optional) — message thread ID for forum topics.
 
@@ -543,7 +547,7 @@ Outbound Telegram API calls retry on transient network/429 errors with exponenti
 - Tool: `telegram` with `react` action (`chatId`, `messageId`, `emoji`).
 - Tool: `telegram` with `deleteMessage` action (`chatId`, `messageId`).
 - Reaction removal semantics: see [/tools/reactions](/tools/reactions).
-- Tool gating: `channels.telegram.actions.reactions`, `channels.telegram.actions.sendMessage`, `channels.telegram.actions.deleteMessage` (default: enabled).
+- Tool gating: `channels.telegram.actions.reactions`, `channels.telegram.actions.sendMessage`, `channels.telegram.actions.deleteMessage` (default: enabled), and `channels.telegram.actions.sticker` (default: disabled).
 
 ## Reaction notifications
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -258,7 +258,7 @@ export async function handleTelegramAction(
   }
 
   if (action === "sendSticker") {
-    if (!isActionEnabled("sticker")) {
+    if (!isActionEnabled("sticker", false)) {
       throw new Error(
         "Telegram sticker actions are disabled. Set channels.telegram.actions.sticker to true.",
       );
@@ -291,7 +291,7 @@ export async function handleTelegramAction(
   }
 
   if (action === "searchSticker") {
-    if (!isActionEnabled("sticker")) {
+    if (!isActionEnabled("sticker", false)) {
       throw new Error(
         "Telegram sticker actions are disabled. Set channels.telegram.actions.sticker to true.",
       );

--- a/src/channels/plugins/actions/telegram.test.ts
+++ b/src/channels/plugins/actions/telegram.test.ts
@@ -10,6 +10,13 @@ vi.mock("../../../agents/tools/telegram-actions.js", () => ({
 }));
 
 describe("telegramMessageActions", () => {
+  it("excludes sticker actions when not enabled", () => {
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as ClawdbotConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).not.toContain("sticker");
+    expect(actions).not.toContain("sticker-search");
+  });
+
   it("allows media-only sends and passes asVoice", async () => {
     handleTelegramAction.mockClear();
     const cfg = { channels: { telegram: { botToken: "tok" } } } as ClawdbotConfig;

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -46,7 +46,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("reactions")) actions.add("react");
     if (gate("deleteMessage")) actions.add("delete");
     if (gate("editMessage")) actions.add("edit");
-    if (gate("sticker")) {
+    if (gate("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
     }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -412,6 +412,39 @@ async function resolveAutoEntries(params: {
   return [];
 }
 
+export async function resolveAutoImageModel(params: {
+  cfg: ClawdbotConfig;
+  agentDir?: string;
+  activeModel?: ActiveMediaModel;
+}): Promise<ActiveMediaModel | null> {
+  const providerRegistry = buildProviderRegistry();
+  const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
+    if (!entry || entry.type === "cli") return null;
+    const provider = entry.provider;
+    if (!provider) return null;
+    const model = entry.model ?? DEFAULT_IMAGE_MODELS[provider];
+    if (!model) return null;
+    return { provider, model };
+  };
+  const activeEntry = await resolveActiveModelEntry({
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    providerRegistry,
+    capability: "image",
+    activeModel: params.activeModel,
+  });
+  const resolvedActive = toActive(activeEntry);
+  if (resolvedActive) return resolvedActive;
+  const keyEntry = await resolveKeyEntry({
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    providerRegistry,
+    capability: "image",
+    activeModel: params.activeModel,
+  });
+  return toActive(keyEntry);
+}
+
 async function resolveActiveModelEntry(params: {
   cfg: ClawdbotConfig;
   agentDir?: string;

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -139,6 +139,7 @@ export const dispatchTelegramMessage = async ({
       imagePath: ctxPayload.MediaPath,
       cfg,
       agentDir,
+      agentId: route.agentId,
     });
     if (description) {
       // Format the description with sticker context


### PR DESCRIPTION
## Summary
- reuse model auto-selection for sticker vision
- refresh sticker cache data on cache hit
- default sticker actions off unless enabled
- docs + tests

## Testing
- pnpm lint (previous run on same commit)
- pnpm build (previous run on same commit)
- pnpm test (previous run on same commit)
