### PR TITLE
docs: add Hostinger platform documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1084,6 +1084,7 @@
           "platforms/linux",
           "platforms/fly",
           "platforms/hetzner",
+          "platforms/hostinger",
           "platforms/gcp",
           "platforms/exe-dev"
         ]

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -19,12 +19,14 @@ If you want a $0/month option and don’t mind ARM + provider-specific setup, se
 |----------|------|-------|----------|-------|
 | Oracle Cloud | Always Free ARM | up to 4 OCPU, 24GB RAM | $0 | ARM, limited capacity / signup quirks |
 | Hetzner | CX22 | 2 vCPU, 4GB RAM | €3.79 (~$4) | Cheapest paid option |
+| Hostinger | KVM 1 | 1 vCPU, 4GB RAM | ~$5 | UI-based, Docker catalog |
 | DigitalOcean | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
 | Vultr | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
 | Linode | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
 
 **Picking a provider:**
-- DigitalOcean: simplest UX + predictable setup (this guide)
+- Hostinger: simplest setup with UI-based Docker catalog (see [Hostinger guide](/platforms/hostinger))
+- DigitalOcean: easy UX + predictable setup (this guide)
 - Hetzner: good price/perf (see [Hetzner guide](/platforms/hetzner))
 - Oracle Cloud: can be $0/month, but is more finicky and ARM-only (see [Oracle guide](/platforms/oracle))
 
@@ -237,7 +239,9 @@ free -h
 
 ## See Also
 
+- [Hostinger guide](/platforms/hostinger) — simplest UI-based setup
 - [Hetzner guide](/platforms/hetzner) — cheaper, more powerful
+- [Oracle guide](/platforms/oracle) — free tier option
 - [Docker install](/install/docker) — containerized setup
 - [Tailscale](/gateway/tailscale) — secure remote access
 - [Configuration](/gateway/configuration) — full config reference

--- a/docs/platforms/hetzner.md
+++ b/docs/platforms/hetzner.md
@@ -323,3 +323,13 @@ All long-lived state must survive restarts, rebuilds, and reboots.
 | Node runtime | Container filesystem | Docker image | Rebuilt every image build |
 | OS packages | Container filesystem | Docker image | Do not install at runtime |
 | Docker container | Ephemeral | Restartable | Safe to destroy |
+
+---
+
+## See Also
+
+- [DigitalOcean guide](/platforms/digitalocean) — CLI-based alternative
+- [Oracle guide](/platforms/oracle) — free tier option
+- [Hostinger guide](/platforms/hostinger) — simplest UI-based setup
+- [Docker install](/install/docker) — generic Docker setup
+- [Gateway configuration](/gateway/configuration) — all config options

--- a/docs/platforms/hostinger.md
+++ b/docs/platforms/hostinger.md
@@ -1,0 +1,196 @@
+---
+summary: "Clawdbot on Hostinger VPS (simplest UI-based setup)"
+read_when:
+  - Setting up Clawdbot on Hostinger VPS
+  - Looking for the easiest VPS setup with a UI
+  - Want one-click Docker deployment
+---
+
+# Clawdbot on Hostinger VPS
+
+## Goal
+
+Run a persistent Clawdbot Gateway on Hostinger VPS using their **Docker Manager** UI.
+
+This is the **simplest setup path** if you prefer a graphical interface over SSH and command-line configuration. Hostinger's hPanel includes a Docker catalog with Clawdbot pre-configured for one-click deployment.
+
+## Cost Comparison (2026)
+
+| Provider | Plan | Specs | Price/mo | Notes |
+|----------|------|-------|----------|-------|
+| Oracle Cloud | Always Free ARM | up to 4 OCPU, 24GB RAM | $0 | ARM, limited capacity / signup quirks |
+| Hetzner | CX22 | 2 vCPU, 4GB RAM | ~$4 | Cheapest paid option |
+| Hostinger | KVM 1 | 1 vCPU, 4GB RAM | ~$5 | UI-based, Docker catalog |
+| DigitalOcean | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
+| Vultr | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
+| Linode | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
+
+**Why Hostinger?**
+- Fully UI-based setup (no SSH required)
+- Docker Manager with pre-configured Clawdbot in the catalog
+- Good starting point for users less comfortable with the command line
+
+---
+
+## Prerequisites
+
+- Hostinger account ([signup](https://www.hostinger.com/docker-hosting))
+- ~10 minutes
+
+That's it. No SSH keys, no terminal experience required.
+
+---
+
+## 1) Purchase a VPS
+
+1. Go to [Hostinger VPS plans](https://www.hostinger.com/docker-hosting)
+2. Select a plan (minimum **1GB RAM** recommended, 4GB preferred)
+3. Complete checkout
+4. Wait for provisioning (typically 1-2 minutes)
+
+## 2) Install Docker Manager
+
+1. Log into [hPanel](https://hpanel.hostinger.com/)
+2. Select your VPS from the dashboard
+3. In the left sidebar, find **Docker Manager**
+4. If not already installed, click **Install**
+5. Wait 2-3 minutes for installation to complete
+
+## 3) Deploy Clawdbot from Catalog
+
+1. Open **Docker Manager** in hPanel
+2. Go to the **Catalog** section
+3. Search for **Clawdbot**
+4. Click the **Deploy** button on the Clawdbot card
+
+## 4) Configure Environment Variables
+
+The deployment wizard will show configuration options:
+
+**Required (auto-generated):**
+- `CLAWDBOT_GATEWAY_TOKEN` — Used to access the Control UI (generated automatically)
+
+You can also configure these later via the Control UI.
+
+## 5) Complete Deployment
+
+1. Review your configuration
+2. Click **Deploy**
+3. Wait for the container to reach **Running** status (1-2 minutes)
+4. Note the assigned port number shown in Docker Manager
+
+---
+
+## Access the Control UI
+
+Once deployed, access Clawdbot at:
+
+```
+http://YOUR_VPS_IP:PORT
+```
+
+Replace:
+- `YOUR_VPS_IP` with your VPS IP address (shown in hPanel dashboard)
+- `PORT` with the port assigned by Docker Manager
+
+Enter the gateway token when prompted.
+
+---
+
+## Connect Your Channels
+
+From the Control UI, you can connect messaging platforms:
+
+1. Open the Control UI in your browser
+2. Navigate to **Channels** or **Integrations**
+3. Follow the prompts to connect:
+   - **WhatsApp** — Scan QR code
+   - **Telegram** — Enter bot token
+   - **Discord** — Enter bot token
+   - **Slack** — OAuth flow
+
+See [Channels](/channels) for detailed setup guides.
+
+---
+
+## Managing Your Deployment
+
+All management happens through Docker Manager in hPanel:
+
+- **View logs:** Click on the Clawdbot container → Logs tab
+- **Restart:** Click the restart button on the container
+- **Stop/Start:** Use the container controls
+- **Update:** Pull the latest image and redeploy
+
+### Update to Latest Version
+
+1. In Docker Manager, stop the Clawdbot container
+2. Go to the Catalog and redeploy Clawdbot
+3. Your configuration persists if using volumes
+
+---
+
+## Advanced: SSH Access
+
+If you need command-line access for troubleshooting:
+
+1. In hPanel, go to **Docker Manager**
+2. Press **Terminal** button
+
+From SSH, you can use standard Clawdbot CLI commands:
+
+```bash
+# Check status
+docker ps | grep clawdbot
+
+# View logs
+docker logs -f <container_id>
+
+# Enter container shell
+docker exec -it <container_id> /bin/bash
+```
+
+---
+
+## Persistence
+
+Docker Manager configures volumes automatically. Your data persists across container restarts:
+
+- `~/.clawdbot/` — config, credentials, session data
+- `~/clawd/` — workspace (SOUL.md, memory, artifacts)
+
+---
+
+## Troubleshooting
+
+### Container won't start
+
+1. In Docker Manager, check the container logs
+2. Verify you have enough RAM (1GB minimum)
+3. Try redeploying from the Catalog
+
+### Can't access Control UI
+
+1. Verify the container is in **Running** status
+2. Check the correct port in Docker Manager
+3. Ensure your browser can reach the VPS IP
+
+### Gateway token not working
+
+1. Check the `CLAWDBOT_GATEWAY_TOKEN` in Docker Manager → Environment
+2. The token is case-sensitive
+3. Try redeploying with a new token
+
+### Need more control
+
+If you need advanced configuration (custom binaries, specific Docker options), consider using SSH access for direct Docker commands.
+
+---
+
+## See Also
+
+- [Hetzner guide](/platforms/hetzner) — Docker Compose with full control
+- [DigitalOcean guide](/platforms/digitalocean) — CLI-based setup
+- [Oracle guide](/platforms/oracle) — free tier option
+- [Docker install](/install/docker) — generic Docker setup
+- [Gateway configuration](/gateway/configuration) — all config options

--- a/docs/platforms/hostinger.md
+++ b/docs/platforms/hostinger.md
@@ -1,18 +1,18 @@
 ---
-summary: "Clawdbot on Hostinger VPS (simplest UI-based setup)"
+summary: "Moltbot on Hostinger VPS (simplest UI-based setup)"
 read_when:
-  - Setting up Clawdbot on Hostinger VPS
+  - Setting up Moltbot on Hostinger VPS
   - Looking for the easiest VPS setup with a UI
   - Want one-click Docker deployment
 ---
 
-# Clawdbot on Hostinger VPS
+# Moltbot on Hostinger VPS
 
 ## Goal
 
-Run a persistent Clawdbot Gateway on Hostinger VPS using their **Docker Manager** UI.
+Run a persistent Moltbot Gateway on Hostinger VPS using their **Docker Manager** UI.
 
-This is the **simplest setup path** if you prefer a graphical interface over SSH and command-line configuration. Hostinger's hPanel includes a Docker catalog with Clawdbot pre-configured for one-click deployment.
+This is the **simplest setup path** if you prefer a graphical interface over SSH and command-line configuration. Hostinger's hPanel includes a Docker catalog with Moltbot pre-configured for one-click deployment.
 
 ## Cost Comparison (2026)
 
@@ -27,7 +27,7 @@ This is the **simplest setup path** if you prefer a graphical interface over SSH
 
 **Why Hostinger?**
 - Fully UI-based setup (no SSH required)
-- Docker Manager with pre-configured Clawdbot in the catalog
+- Docker Manager with pre-configured Moltbot in the catalog
 - Good starting point for users less comfortable with the command line
 
 ---
@@ -56,19 +56,19 @@ That's it. No SSH keys, no terminal experience required.
 4. If not already installed, click **Install**
 5. Wait 2-3 minutes for installation to complete
 
-## 3) Deploy Clawdbot from Catalog
+## 3) Deploy Moltbot from Catalog
 
 1. Open **Docker Manager** in hPanel
 2. Go to the **Catalog** section
-3. Search for **Clawdbot**
-4. Click the **Deploy** button on the Clawdbot card
+3. Search for **Moltbot**
+4. Click the **Deploy** button on the Moltbot card
 
 ## 4) Configure Environment Variables
 
 The deployment wizard will show configuration options:
 
 **Required (auto-generated):**
-- `CLAWDBOT_GATEWAY_TOKEN` — Used to access the Control UI (generated automatically)
+- `MOLTBOT_GATEWAY_TOKEN` — Used to access the Control UI (generated automatically)
 
 You can also configure these later via the Control UI.
 
@@ -83,7 +83,7 @@ You can also configure these later via the Control UI.
 
 ## Access the Control UI
 
-Once deployed, access Clawdbot at:
+Once deployed, access Moltbot at:
 
 ```
 http://YOUR_VPS_IP:PORT
@@ -117,15 +117,15 @@ See [Channels](/channels) for detailed setup guides.
 
 All management happens through Docker Manager in hPanel:
 
-- **View logs:** Click on the Clawdbot container → Logs tab
+- **View logs:** Click on the Moltbot container → Logs tab
 - **Restart:** Click the restart button on the container
 - **Stop/Start:** Use the container controls
 - **Update:** Pull the latest image and redeploy
 
 ### Update to Latest Version
 
-1. In Docker Manager, stop the Clawdbot container
-2. Go to the Catalog and redeploy Clawdbot
+1. In Docker Manager, stop the Moltbot container
+2. Go to the Catalog and redeploy Moltbot
 3. Your configuration persists if using volumes
 
 ---
@@ -137,11 +137,11 @@ If you need command-line access for troubleshooting:
 1. In hPanel, go to **Docker Manager**
 2. Press **Terminal** button
 
-From SSH, you can use standard Clawdbot CLI commands:
+From SSH, you can use standard Moltbot CLI commands:
 
 ```bash
 # Check status
-docker ps | grep clawdbot
+docker ps | grep moltbot
 
 # View logs
 docker logs -f <container_id>
@@ -177,7 +177,7 @@ Docker Manager configures volumes automatically. Your data persists across conta
 
 ### Gateway token not working
 
-1. Check the `CLAWDBOT_GATEWAY_TOKEN` in Docker Manager → Environment
+1. Check the `MOLTBOT_GATEWAY_TOKEN` in Docker Manager → Environment
 2. The token is case-sensitive
 3. Try redeploying with a new token
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,6 +26,7 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 - VPS hub: [VPS hosting](/vps)
 - Fly.io: [Fly.io](/platforms/fly)
 - Hetzner (Docker): [Hetzner](/platforms/hetzner)
+- Hostinger (Docker, UI-based): [Hostinger](/platforms/hostinger)
 - GCP (Compute Engine): [GCP](/platforms/gcp)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/platforms/exe-dev)
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -22,7 +22,8 @@ Oracle’s free tier can be a great fit for Clawdbot (especially if you already 
 | Provider | Plan | Specs | Price/mo | Notes |
 |----------|------|-------|----------|-------|
 | Oracle Cloud | Always Free ARM | up to 4 OCPU, 24GB RAM | $0 | ARM, limited capacity |
-| Hetzner | CX22 | 2 vCPU, 4GB RAM | ~ $4 | Cheapest paid option |
+| Hetzner | CX22 | 2 vCPU, 4GB RAM | ~$4 | Cheapest paid option |
+| Hostinger | KVM 1 | 1 vCPU, 4GB RAM | ~$5 | UI-based, Docker catalog |
 | DigitalOcean | Basic | 1 vCPU, 1GB RAM | $6 | Easy UI, good docs |
 | Vultr | Cloud Compute | 1 vCPU, 1GB RAM | $6 | Many locations |
 | Linode | Nanode | 1 vCPU, 1GB RAM | $5 | Now part of Akamai |
@@ -287,5 +288,6 @@ tar -czvf clawdbot-backup.tar.gz ~/.clawdbot ~/clawd
 - [Gateway remote access](/gateway/remote) — other remote access patterns
 - [Tailscale integration](/gateway/tailscale) — full Tailscale docs
 - [Gateway configuration](/gateway/configuration) — all config options
+- [Hostinger guide](/platforms/hostinger) — simplest UI-based setup
 - [DigitalOcean guide](/platforms/digitalocean) — if you want paid + easier signup
 - [Hetzner guide](/platforms/hetzner) — Docker-based alternative

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -1,5 +1,5 @@
 ---
-summary: "VPS hosting hub for Clawdbot (Oracle/Fly/Hetzner/GCP/exe.dev)"
+summary: "VPS hosting hub for Clawdbot (Hostinger/Oracle/Fly/Hetzner/GCP/exe.dev)"
 read_when:
   - You want to run the Gateway in the cloud
   - You need a quick map of VPS/hosting guides
@@ -16,6 +16,7 @@ deployments work at a high level.
 - **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month (Always Free, ARM; capacity/signup can be finicky)
 - **Fly.io**: [Fly.io](/platforms/fly)
 - **Hetzner (Docker)**: [Hetzner](/platforms/hetzner)
+- **Hostinger**: [Hostinger](/platforms/hostinger)
 - **GCP (Compute Engine)**: [GCP](/platforms/gcp)
 - **exe.dev** (VM + HTTPS proxy): [exe.dev](/platforms/exe-dev)
 - **AWS (EC2/Lightsail/free tier)**: works well too. Video guide:


### PR DESCRIPTION
## Summary

- Add new Hostinger VPS platform documentation with UI-based Docker Manager setup
- Update cost comparison tables across all VPS platform guides to include Hostinger
- Add cross-references to Hostinger guide in related documentation

## Details

**New file:**
- `docs/platforms/hostinger.md` — Complete setup guide for Hostinger VPS using their Docker Manager UI and pre-configured Clawdbot catalog entry

**Updated files:**
- `docs/platforms/index.md` — Added Hostinger to VPS & hosting list
- `docs/vps.md` — Added Hostinger to provider list
- `docs/platforms/digitalocean.md` — Added Hostinger to cost table and See Also
- `docs/platforms/oracle.md` — Added Hostinger to cost table and See Also
- `docs/platforms/hetzner.md` — Added See Also section with Hostinger
- `docs/docs.json` — Added Hostinger to navigation