### PR TITLE
fix(slack): add reactionNotifications config check to reactions handler

### DIFF
--- a/src/slack/monitor/events/reactions.ts
+++ b/src/slack/monitor/events/reactions.ts
@@ -12,6 +12,26 @@ export function registerSlackReactionEvents(params: { ctx: SlackMonitorContext }
 
   const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
     try {
+      // Check reactionNotifications config (consistent with Telegram/Discord/Signal)
+      const reactionMode = ctx.reactionMode ?? "own";
+      if (reactionMode === "off") return;
+
+      // Skip bot reactions (consistent with other providers)
+      if (event.user === ctx.botUserId) return;
+
+      // For "own" mode, only process reactions on messages sent by this bot
+      if (reactionMode === "own" && event.item_user !== ctx.botUserId) return;
+
+      // For "allowlist" mode, only process reactions from allowlisted users
+      if (reactionMode === "allowlist") {
+        const allowlist = ctx.reactionAllowlist ?? [];
+        if (allowlist.length === 0) return;
+        const userAllowed = allowlist.some(
+          (entry) => String(entry).toLowerCase() === String(event.user).toLowerCase(),
+        );
+        if (!userAllowed) return;
+      }
+
       const item = event.item;
       if (!item || item.type !== "message") return;
 


### PR DESCRIPTION
## Problem

The Slack reactions handler (`src/slack/monitor/events/reactions.ts`) processes all reactions unconditionally, ignoring the `reactionNotifications` config setting. Even with `channels.slack.reactionNotifications: "own"` configured, reaction events are not routed to agent sessions.

## Root Cause

Unlike Telegram's implementation (`src/telegram/bot.ts:379-382`), the Slack handler doesn't check `ctx.reactionMode` before processing reactions.

**Telegram (working):**
```typescript
const reactionMode = telegramCfg.reactionNotifications ?? "own";
if (reactionMode === "off") return;
if (user?.is_bot) return;
if (reactionMode === "own" && !wasSentByBot(chatId, messageId)) return;
```

**Slack (missing checks):**
```typescript
const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
  // ... just processes everything
```

## Solution

Added `reactionNotifications` config filtering at the start of `handleReactionEvent`:

- Check `reactionMode` config (`off`/`own`/`all`/`allowlist`)
- Skip bot's own reactions (consistent with other providers)
- For `own` mode, only process reactions on messages sent by the bot
- For `allowlist` mode, only process reactions from allowlisted users

## Testing

Verified that `ctx.reactionMode`, `ctx.reactionAllowlist`, and `ctx.botUserId` are already available on the `SlackMonitorContext`.