### PR TITLE
fix: resolve Discord usernames to user IDs for outbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Status: beta.
 - Agents: guard channel tool listActions to avoid plugin crashes. (#2859) Thanks @mbelinky.
 - Providers: update MiniMax API endpoint and compatibility mode. (#3064) Thanks @hlbbbbbbb.
 - Telegram: treat more network errors as recoverable in polling. (#3013) Thanks @ryancontent.
+- Discord: resolve usernames to user IDs for outbound messages. (#2649) Thanks @nonggialiang.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -13,7 +13,7 @@ import {
   createDiscordClient,
   normalizeDiscordPollInput,
   normalizeStickerIds,
-  parseRecipient,
+  parseAndResolveRecipient,
   resolveChannelId,
   sendDiscordMedia,
   sendDiscordText,
@@ -49,7 +49,7 @@ export async function sendMessageDiscord(
   const chunkMode = resolveChunkMode(cfg, "discord", accountInfo.accountId);
   const textWithTables = convertMarkdownTables(text ?? "", tableMode);
   const { token, rest, request } = createDiscordClient(opts, cfg);
-  const recipient = parseRecipient(to);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   let result: { id: string; channel_id: string } | { id: string | null; channel_id: string };
   try {
@@ -104,7 +104,7 @@ export async function sendStickerDiscord(
 ): Promise<DiscordSendResult> {
   const cfg = loadConfig();
   const { rest, request } = createDiscordClient(opts, cfg);
-  const recipient = parseRecipient(to);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   const content = opts.content?.trim();
   const stickers = normalizeStickerIds(stickerIds);
@@ -131,7 +131,7 @@ export async function sendPollDiscord(
 ): Promise<DiscordSendResult> {
   const cfg = loadConfig();
   const { rest, request } = createDiscordClient(opts, cfg);
-  const recipient = parseRecipient(to);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   const content = opts.content?.trim();
   const payload = normalizeDiscordPollInput(poll);

--- a/src/discord/targets.test.ts
+++ b/src/discord/targets.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ClawdbotConfig } from "../config/config.js";
 import { normalizeDiscordMessagingTarget } from "../channels/plugins/normalize/discord.js";
-import { parseDiscordTarget, resolveDiscordChannelId } from "./targets.js";
+import { listDiscordDirectoryPeersLive } from "./directory-live.js";
+import { parseDiscordTarget, resolveDiscordChannelId, resolveDiscordTarget } from "./targets.js";
+
+vi.mock("./directory-live.js", () => ({
+  listDiscordDirectoryPeersLive: vi.fn(),
+}));
 
 describe("parseDiscordTarget", () => {
   it("parses user mention and prefixes", () => {
@@ -65,6 +71,38 @@ describe("resolveDiscordChannelId", () => {
 
   it("rejects user targets", () => {
     expect(() => resolveDiscordChannelId("user:123")).toThrow(/channel id is required/i);
+  });
+});
+
+describe("resolveDiscordTarget", () => {
+  const cfg = { channels: { discord: {} } } as ClawdbotConfig;
+  const listPeers = vi.mocked(listDiscordDirectoryPeersLive);
+
+  beforeEach(() => {
+    listPeers.mockReset();
+  });
+
+  it("returns a resolved user for usernames", async () => {
+    listPeers.mockResolvedValueOnce([{ kind: "user", id: "user:999", name: "Jane" } as const]);
+
+    await expect(
+      resolveDiscordTarget("jane", { cfg, accountId: "default" }),
+    ).resolves.toMatchObject({ kind: "user", id: "999", normalized: "user:999" });
+  });
+
+  it("falls back to parsing when lookup misses", async () => {
+    listPeers.mockResolvedValueOnce([]);
+    await expect(
+      resolveDiscordTarget("general", { cfg, accountId: "default" }),
+    ).resolves.toMatchObject({ kind: "channel", id: "general" });
+  });
+
+  it("does not call directory lookup for explicit user ids", async () => {
+    listPeers.mockResolvedValueOnce([]);
+    await expect(
+      resolveDiscordTarget("user:123", { cfg, accountId: "default" }),
+    ).resolves.toMatchObject({ kind: "user", id: "123" });
+    expect(listPeers).not.toHaveBeenCalled();
   });
 });
 

--- a/src/discord/targets.ts
+++ b/src/discord/targets.ts
@@ -5,7 +5,12 @@ import {
   type MessagingTarget,
   type MessagingTargetKind,
   type MessagingTargetParseOptions,
+  type DirectoryConfigParams,
+  type ChannelDirectoryEntry,
 } from "../channels/targets.js";
+
+import { listDiscordDirectoryPeersLive } from "./directory-live.js";
+import { resolveDiscordAccount } from "./accounts.js";
 
 export type DiscordTargetKind = MessagingTargetKind;
 
@@ -59,4 +64,61 @@ export function parseDiscordTarget(
 export function resolveDiscordChannelId(raw: string): string {
   const target = parseDiscordTarget(raw, { defaultKind: "channel" });
   return requireTargetKind({ platform: "Discord", target, kind: "channel" });
+}
+
+/**
+ * Resolve a Discord username to user ID using the directory lookup.
+ * This enables sending DMs by username instead of requiring explicit user IDs.
+ *
+ * @param raw - The username or raw target string (e.g., "john.doe")
+ * @param options - Directory configuration params (cfg, accountId, limit)
+ * @returns Parsed MessagingTarget with user ID, or undefined if not found
+ */
+export async function resolveDiscordTarget(
+  raw: string,
+  options: DirectoryConfigParams,
+): Promise<MessagingTarget | undefined> {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  // If already a known format, parse directly
+  const directParse = parseDiscordTarget(trimmed, options);
+  if (directParse && directParse.kind !== "channel" && !isLikelyUsername(trimmed)) {
+    return directParse;
+  }
+
+  // Try to resolve as a username via directory lookup
+  try {
+    const directoryEntries = await listDiscordDirectoryPeersLive({
+      ...options,
+      query: trimmed,
+      limit: 1,
+    });
+
+    const match = directoryEntries[0];
+    if (match && match.kind === "user") {
+      // Extract user ID from the directory entry (format: "user:<id>")
+      const userId = match.id.replace(/^user:/, "");
+      return buildMessagingTarget("user", userId, trimmed);
+    }
+  } catch (error) {
+    // Directory lookup failed - fall through to parse as-is
+    // This preserves existing behavior for channel names
+  }
+
+  // Fallback to original parsing (for channels, etc.)
+  return parseDiscordTarget(trimmed, options);
+}
+
+/**
+ * Check if a string looks like a Discord username (not a mention, prefix, or ID).
+ * Usernames typically don't start with special characters except underscore.
+ */
+function isLikelyUsername(input: string): boolean {
+  // Skip if it's already a known format
+  if (/^(user:|channel:|discord:|@|<@!?)|[\d]+$/.test(input)) {
+    return false;
+  }
+  // Likely a username if it doesn't match known patterns
+  return true;
 }


### PR DESCRIPTION
## Summary
Fixes #2627

When sending Discord messages via cron jobs or the message tool, usernames like \`john.doe\` were incorrectly treated as channel names, causing silent delivery failures.

## Problem
The Discord outbound adapter had no \`resolveTarget\` hook. The \`parseDiscordTarget()\` function fell back to treating unrecognized strings as channel names:
\`\`\`typescript
return buildMessagingTarget("channel", trimmed, trimmed);
\`\`\`

So \`john.doe\` was passed as a channel name lookup, which fails because no channel named \`john.doe\` exists.

## Solution
This fix adds a \`resolveDiscordTarget()\` function that:
- Queries Discord directory to resolve usernames to user IDs using \`listDiscordDirectoryPeersLive()\`
- Falls back to standard parsing for known formats (user:, channel:, @mentions, numeric IDs)
- Enables sending DMs by username without requiring explicit \`user:ID\` format

## Changes
- **src/discord/targets.ts**: Added \`resolveDiscordTarget()\` function with directory lookup
- **src/discord/send.shared.ts**: Added \`parseAndResolveRecipient()\` wrapper function
- **src/discord/send.outbound.ts**: Updated \`sendMessageDiscord()\`, \`sendStickerDiscord()\`, and \`sendPollDiscord()\` to use username resolution

## Testing
After this fix, cron jobs can target usernames:
\`\`\`json
{
  "to": "john.doe",
  "channel": "discord"
}
\`\`\`

The username will be resolved to a Discord user ID, and the message will be delivered as a DM.

---

Note: This is a first step. For username resolution to work, Discord directory integration must be configured and bot must have access to guild member lists.