### PR TITLE
fix(telegram): send sticker pixels to vision models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Status: unreleased.
 - Telegram: add optional silent send flag (disable notifications). (#2382) Thanks @Suksham-sharma.
 - Telegram: support editing sent messages via message(action="edit"). (#2394) Thanks @marcelomar21.
 - Telegram: add sticker receive/send with vision caching. (#2629) Thanks @longjos.
+- Telegram: send sticker pixels to vision models. (#2650)
 - Config: apply config.env before ${VAR} substitution. (#1813) Thanks @spanishflu-est1918.
 - Slack: clear ack reaction after streamed replies. (#2044) Thanks @fancyboi999.
 - macOS: keep custom SSH usernames in remote target. (#2046) Thanks @algal.

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -122,7 +122,7 @@ async function resolveStickerVisionSupport(params: {
     });
     const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
     if (!entry) return false;
-    return entry.input ? modelSupportsVision(entry) : true;
+    return modelSupportsVision(entry);
   } catch {
     return false;
   }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -27,7 +27,7 @@ async function resolveStickerVisionSupport(cfg, agentId) {
     const defaultModel = resolveDefaultModelForAgent({ cfg, agentId });
     const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
     if (!entry) return false;
-    return entry.input ? modelSupportsVision(entry) : true;
+    return modelSupportsVision(entry);
   } catch {
     return false;
   }

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -165,7 +165,7 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
   try {
     catalog = await loadModelCatalog({ config: cfg });
     const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
-    const supportsVision = entry?.input ? modelSupportsVision(entry) : Boolean(entry);
+    const supportsVision = modelSupportsVision(entry);
     if (supportsVision) {
       activeModel = { provider: defaultModel.provider, model: defaultModel.model };
     }
@@ -185,8 +185,7 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
   const selectCatalogModel = (provider: string) => {
     const entries = catalog.filter(
       (entry) =>
-        entry.provider.toLowerCase() === provider.toLowerCase() &&
-        (entry.input ? modelSupportsVision(entry) : true),
+        entry.provider.toLowerCase() === provider.toLowerCase() && modelSupportsVision(entry),
     );
     if (entries.length === 0) return undefined;
     const defaultId =


### PR DESCRIPTION
## Summary
- keep sticker MediaPath when the active/default model supports images
- use cached description only for text-only models
- still cache sticker descriptions for search

## Testing
- pnpm build
