### PR TITLE
feat: add global proxy support and use configured model for slug generation

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
+import { initGlobalProxy } from "../infra/global-proxy.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureClawdbotCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
@@ -27,6 +28,7 @@ export async function runCli(argv: string[] = process.argv) {
   const normalizedArgv = stripWindowsNodeExec(argv);
   loadDotEnv({ quiet: true });
   normalizeEnv();
+  initGlobalProxy();
   ensureClawdbotCliOnPath();
 
   // Enforce the minimum supported runtime before doing any work.

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,7 +11,10 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
+  resolveAgentModelPrimary,
 } from "../agents/agent-scope.js";
+import { parseModelRef } from "../agents/model-selection.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -38,6 +41,12 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    // Use the user's configured model instead of hardcoded defaults
+    const primaryModel = resolveAgentModelPrimary(params.cfg, agentId);
+    const modelRef = primaryModel ? parseModelRef(primaryModel, DEFAULT_PROVIDER) : null;
+    const provider = modelRef?.provider ?? DEFAULT_PROVIDER;
+    const model = modelRef?.model ?? DEFAULT_MODEL;
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -45,6 +54,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       workspaceDir,
       agentDir,
       config: params.cfg,
+      provider,
+      model,
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,

--- a/src/infra/global-proxy.ts
+++ b/src/infra/global-proxy.ts
@@ -1,0 +1,35 @@
+import process from "node:process";
+import { ProxyAgent, setGlobalDispatcher } from "undici";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("proxy");
+
+let initialized = false;
+
+/**
+ * Configures a global proxy dispatcher for Node.js native fetch.
+ * This enables HTTP_PROXY/HTTPS_PROXY/http_proxy/https_proxy environment
+ * variables to work with fetch() calls, including the Vercel AI SDK.
+ *
+ * Should be called early in the CLI/gateway startup.
+ */
+export function initGlobalProxy(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  if (!proxyUrl) return;
+
+  try {
+    const agent = new ProxyAgent(proxyUrl);
+    setGlobalDispatcher(agent);
+    log.info(`global proxy configured: ${proxyUrl}`);
+  } catch (err) {
+    log.warn(`failed to configure global proxy: ${err instanceof Error ? err.message : err}`);
+  }
+}


### PR DESCRIPTION
## Summary
 
This PR adds two improvements:
 
1. **Global proxy support** - Configures a global proxy dispatcher for Node.js native fetch using `undici`. This enables `HTTP_PROXY`/`HTTPS_PROXY`/`http_proxy`/`https_proxy` environment variables to work with `fetch()` calls, including the Vercel AI SDK.
 
2. **Use configured model for slug generation** - The LLM slug generator now uses the user's configured primary model instead of hardcoded defaults.
 
## Changes
 
- New file: [src/infra/global-proxy.ts](cci:7://file:///home/qi/Documents/github/clawdbot/src/infra/global-proxy.ts:0:0-0:0) - proxy initialization logic
- `src/cli/run-main.ts` - calls [initGlobalProxy()](cci:1://file:///home/qi/Documents/github/clawdbot/src/infra/global-proxy.ts:8:0-34:1) at CLI startup
- `src/hooks/llm-slug-generator.ts` - resolves user's configured model for slug generation
```**
