### PR TITLE
fix(telegram): notify users when agent returns empty response

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -199,6 +199,7 @@ export const dispatchTelegramMessage = async ({
           chunkMode,
           onVoiceRecording: sendRecordVoice,
           linkPreview: telegramCfg.linkPreview,
+          notifyEmptyResponse: info.kind === "final",
         });
       },
       onError: (err, info) => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -484,7 +484,7 @@ export const registerTelegramNativeCommands = ({
             cfg,
             dispatcherOptions: {
               responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId).responsePrefix,
-              deliver: async (payload) => {
+              deliver: async (payload, info) => {
                 await deliverReplies({
                   replies: [payload],
                   chatId: String(chatId),
@@ -497,6 +497,7 @@ export const registerTelegramNativeCommands = ({
                   tableMode,
                   chunkMode,
                   linkPreview: telegramCfg.linkPreview,
+                  notifyEmptyResponse: info.kind === "final",
                 });
               },
               onError: (err, info) => {


### PR DESCRIPTION
## Summary
- When AI model returns empty content blocks, users now see "No response generated. Please try again." instead of silence

## When this happens
- Some models (e.g., Minimax) occasionally return 0 content blocks
- Previously: user sends message → agent processes → empty response → nothing delivered → user waits indefinitely
- Now: user sees fallback message immediately

## Changes
- `delivery.ts`: Add `notifyEmptyResponse` param and fallback message logic
- `bot-message-dispatch.ts`: Enable for final replies
- `bot-native-commands.ts`: Enable for slash command final replies

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Normal messages still delivered correctly
- [ ] Empty response triggers fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)