### PR TITLE
feat (macOS): add remote gateway token field (AI-assisted)

### DIFF
--- a/apps/macos/Sources/Clawdbot/AppState.swift
+++ b/apps/macos/Sources/Clawdbot/AppState.swift
@@ -213,6 +213,10 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var remoteToken: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -278,6 +282,7 @@ final class AppState {
         let configRoot = ClawdbotConfigFile.loadDict()
         let configRemoteUrl = GatewayRemoteConfig.resolveUrlString(root: configRoot)
         let configRemoteTransport = GatewayRemoteConfig.resolveTransport(root: configRoot)
+        let configRemoteToken = Self.resolveRemoteToken(root: configRoot)
         let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
         self.remoteTransport = configRemoteTransport
         self.connectionMode = resolvedConnectionMode
@@ -293,6 +298,7 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
+        self.remoteToken = configRemoteToken
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -352,6 +358,16 @@ final class AppState {
         return trimmed
     }
 
+    private static func resolveRemoteToken(root: [String: Any]) -> String {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let token = remote["token"] as? String
+        else {
+            return ""
+        }
+        return token.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func startConfigWatcher() {
         let configUrl = ClawdbotConfigFile.url()
         self.configWatcher = ConfigFileWatcher(url: configUrl) { [weak self] in
@@ -375,6 +391,7 @@ final class AppState {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
         let remoteTransport = GatewayRemoteConfig.resolveTransport(root: root)
+        let remoteToken = Self.resolveRemoteToken(root: root)
 
         let desiredMode: ConnectionMode? = switch modeRaw {
         case "local":
@@ -401,6 +418,9 @@ final class AppState {
         let remoteUrlText = remoteUrl ?? ""
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
+        }
+        if remoteToken != self.remoteToken {
+            self.remoteToken = remoteToken
         }
 
         let targetMode = desiredMode ?? self.connectionMode
@@ -437,6 +457,7 @@ final class AppState {
         let remoteIdentity = self.remoteIdentity
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
+        let remoteToken = self.remoteToken
         let desiredMode: String? = switch connectionMode {
         case .local:
             "local"
@@ -527,6 +548,17 @@ final class AppState {
                         remote.removeValue(forKey: "sshIdentity")
                         remoteChanged = true
                     }
+                }
+
+                let trimmedToken = remoteToken.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmedToken.isEmpty {
+                    if (remote["token"] as? String) != trimmedToken {
+                        remote["token"] = trimmedToken
+                        remoteChanged = true
+                    }
+                } else if remote["token"] != nil {
+                    remote.removeValue(forKey: "token")
+                    remoteChanged = true
                 }
 
                 if remoteChanged {
@@ -684,6 +716,7 @@ extension AppState {
         state.canvasEnabled = true
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
         state.remoteIdentity = "~/.ssh/id_ed25519"
         state.remoteProjectRoot = "~/Projects/clawdbot"
         state.remoteCliPath = ""

--- a/apps/macos/Sources/Clawdbot/GeneralSettings.swift
+++ b/apps/macos/Sources/Clawdbot/GeneralSettings.swift
@@ -145,6 +145,8 @@ struct GeneralSettings: View {
                 self.remoteDirectRow
             }
 
+            self.remoteTokenRow
+
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
                 currentTarget: self.state.remoteTarget,
@@ -299,6 +301,23 @@ struct GeneralSettings: View {
                     .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
             Text("Direct mode requires a ws:// or wss:// URL (Tailscale Serve uses wss://<magicdns>).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteTokenRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("Shared gateway auth token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            Text("Must match gateway.auth.token (or gateway.remote.token) on the gateway host.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)


### PR DESCRIPTION
  AI-assisted: yes

  Testing: lightly tested
  - ./scripts/restart-mac.sh --no-sign
  - Verified the new token field appears under Settings → General → Remote (another host)
  - Verified edits persist to gateway.remote.token
  - Attempted gateway connection flow (expected improvement: token can now be provided)

  ## Summary
  - add a visible "Gateway token" field to the macOS Remote settings card
  - bind it to `gateway.remote.token` so the client can authenticate to remote gateways
  - keep the value in sync when config changes on disk

  ## Why
  Remote connection attempts can fail with “gateway token missing,” but the macOS UI previously had no place to enter the token.
  This makes remote setup look broken even when the gateway is correctly configured.

  ## Notes
  The token is entered via a `SecureField` (masked), but it is still stored in `~/.clawdbot/clawdbot.json` like the CLI.
  EOF


