### PR TITLE
docs(groups): clarify groupAllowFrom vs groups config

### DIFF
--- a/docs/concepts/groups.md
+++ b/docs/concepts/groups.md
@@ -19,8 +19,12 @@ Translation: allowlisted senders can trigger Clawdbot by mentioning it.
 
 > TL;DR
 > - **DM access** is controlled by `*.allowFrom`.
-> - **Group access** is controlled by `*.groupPolicy` + allowlists (`*.groups`, `*.groupAllowFrom`).
+> - **Which groups** are allowed is controlled by `*.groups` (keys are group/room IDs).
+> - **Which senders** can trigger in groups is controlled by `*.groupAllowFrom` (values are phone numbers, user IDs, or `"*"`).
+> - `*.groupPolicy` sets the overall mode (`open`/`disabled`/`allowlist`).
 > - **Reply triggering** is controlled by mention gating (`requireMention`, `/activation`).
+>
+> ⚠️ `groupAllowFrom` is a **sender** allowlist — use phone numbers/user IDs, not group IDs. To control which groups are allowed, use `groups`.
 
 Quick flow (what happens to a group message):
 ```
@@ -38,7 +42,10 @@ If you want...
 | Allow all groups but only reply on @mentions | `groups: { "*": { requireMention: true } }` |
 | Disable all group replies | `groupPolicy: "disabled"` |
 | Only specific groups | `groups: { "<group-id>": { ... } }` (no `"*"` key) |
-| Only you can trigger in groups | `groupPolicy: "allowlist"`, `groupAllowFrom: ["+1555..."]` |
+| Only you can trigger in groups | `groupPolicy: "allowlist"`, `groupAllowFrom: ["+1555..."]` (**phone numbers**, not group IDs) |
+| Anyone can trigger in allowed groups | `groupAllowFrom: ["*"]`, `groups: { "<group-id>": { ... } }` |
+
+> **Common mistake:** putting a group JID (e.g. `120363...@g.us`) in `groupAllowFrom`. That field filters **senders** by phone number/user ID — use `groups` to control which groups are allowed.
 
 ## Session keys
 - Group sessions use `agent:<agentId>:<channel>:group:<id>` session keys (rooms/channels use `agent:<agentId>:<channel>:channel:<id>`).
@@ -170,18 +177,20 @@ Control how group/room messages are handled per channel:
 
 Notes:
 - `groupPolicy` is separate from mention-gating (which requires @mentions).
-- WhatsApp/Telegram/Signal/iMessage/Microsoft Teams: use `groupAllowFrom` (fallback: explicit `allowFrom`).
+- WhatsApp/Telegram/Signal/iMessage/Microsoft Teams: use `groupAllowFrom` to restrict which **senders** (phone numbers/user IDs) can trigger the bot in groups. This is a sender filter, not a group filter — use `groups` to control which groups are allowed.
 - Discord: allowlist uses `channels.discord.guilds.<id>.channels`.
 - Slack: allowlist uses `channels.slack.channels`.
 - Matrix: allowlist uses `channels.matrix.groups` (room IDs, aliases, or names). Use `channels.matrix.groupAllowFrom` to restrict senders; per-room `users` allowlists are also supported.
 - Group DMs are controlled separately (`channels.discord.dm.*`, `channels.slack.dm.*`).
 - Telegram allowlist can match user IDs (`"123456789"`, `"telegram:123456789"`, `"tg:123456789"`) or usernames (`"@alice"` or `"alice"`); prefixes are case-insensitive.
 - Default is `groupPolicy: "allowlist"`; if your group allowlist is empty, group messages are blocked.
+- ⚠️ `groupAllowFrom` expects **sender identifiers** (phone numbers, user IDs, or `"*"` for any sender). Do not put group JIDs or room IDs here — those belong in `groups`.
 
 Quick mental model (evaluation order for group messages):
-1) `groupPolicy` (open/disabled/allowlist)
-2) group allowlists (`*.groups`, `*.groupAllowFrom`, channel-specific allowlist)
-3) mention gating (`requireMention`, `/activation`)
+1) `groupPolicy` — is group messaging enabled? (`open`/`disabled`/`allowlist`)
+2) `groups` — is this specific group allowed? (keys are group/room IDs)
+3) `groupAllowFrom` — is this sender allowed? (values are **phone numbers/user IDs**, not group IDs)
+4) mention gating — was the bot mentioned? (`requireMention`, `/activation`)
 
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.


### PR DESCRIPTION
## What

Clarifies the distinction between `groupAllowFrom` (sender allowlist) and `groups` (group allowlist) in the groups documentation.

## Why

We spent a debugging session chasing a "bug" where WhatsApp group messages silently stopped working after a restart. Turned out we'd put a group JID in `groupAllowFrom` — which expects phone numbers/user IDs. The field name is ambiguous enough that `groupAllowFrom` reads naturally as "allow from these groups".

Filed as [#1952](https://github.com/clawdbot/clawdbot/issues/1952) before we identified the real cause.

## Changes

- **TL;DR section**: Split vague "group access" bullet into three clear ones (which groups, which senders, policy mode). Added ⚠️ callout.
- **Quick-reference table**: Added "(phone numbers, not group IDs)" clarification and new "anyone can trigger" row. Added "Common mistake" callout box.
- **Evaluation order**: Expanded from 3 vague steps to 4 explicit steps with descriptions.
- **Group policy notes**: Clarified `groupAllowFrom` is a sender filter with ⚠️ warning.

## AI-assisted 🤖

Written with Claude (via Clawdbot). The misconfiguration was experienced first-hand and the docs changes were verified against the actual access-control code in `src/web/inbound/access-control.ts`.

Lightly tested (docs-only change, no code changes).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/concepts/groups.md` to clarify the distinction between `groups` (which group/room IDs are allowed) and `groupAllowFrom` (which senders are allowed to trigger inside groups), and expands the docs’ “quick reference” and “evaluation order” sections accordingly.

The main thing to double-check is internal consistency with the actual enforcement path: the “Quick flow” diagram text doesn’t include the sender allowlist step, and some examples imply `groupAllowFrom` applies on its own, even though the WhatsApp access-control implementation only consults it when `groupPolicy: "allowlist"`. The mental model also introduces a `groups` check that may be enforced outside the shown access-control layer; adding a pointer to where that happens would prevent confusion.

<h3>Confidence Score: 4/5</h3>

- This is safe to merge; it’s a docs-only change with a few likely-to-confuse inconsistencies to tighten.
- No code paths are modified. The flagged issues are documentation accuracy/consistency problems (missing sender-allowlist step in the quick flow, examples that may imply behavior not matching current enforcement, and an evaluation-order step that may be enforced elsewhere).
- docs/concepts/groups.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->