### PR TITLE
feat: qdrant vector DB implemenation

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "@mariozechner/pi-coding-agent": "0.49.3",
     "@mariozechner/pi-tui": "0.49.3",
     "@mozilla/readability": "^0.6.0",
+    "@qdrant/qdrant-js": "^1.14.0",
     "@sinclair/typebox": "0.34.47",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1481,6 +1481,23 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
+  '@qdrant/js-client-grpc@1.14.0':
+    resolution: {integrity: sha512-A1464Ub25+jVvqOKddemTZMP377LyilGrSHoWVaTT9FtieXXr0trIfJLL1UWExgZ6hhopaURVqcc8uK3OAsP1w==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
+
+  '@qdrant/js-client-rest@1.14.0':
+    resolution: {integrity: sha512-2sM2g17FSkN2sNCSeAfqxHRr+SPEVnUQLXBjVv/whm4YQ4JjZ53Jiy1iShk95G+xBf3hKBhJdj8itRnor03IYw==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
+
+  '@qdrant/qdrant-js@1.14.0':
+    resolution: {integrity: sha512-odY6jC/yKwE5uoyFhIN4J9EEyS6aVsGtrSdMFD0DuqMGW5ZvuvGcDNw3HLkN71JT0D0gQEyHO7/sokuG/GxkwA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
+    peerDependencies:
+      typescript: '>=4.1'
+    dependencies:
+      '@qdrant/js-client-grpc': 1.14.0
+      '@qdrant/js-client-rest': 1.14.0
+
   '@napi-rs/canvas-android-arm64@0.1.88':
     resolution: {integrity: sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==}
     engines: {node: '>= 10'}
@@ -7106,6 +7123,12 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
+  '@qdrant/js-client-grpc@1.14.0': {}
+
+  '@qdrant/js-client-rest@1.14.0': {}
+
+  '@qdrant/qdrant-js@1.14.0': {}
+
   '@napi-rs/canvas-android-arm64@0.1.88':
     optional: true
 
@@ -7910,6 +7933,15 @@ snapshots:
   '@silvia-odwyer/photon-node@0.3.4': {}
 
   '@sinclair/typebox@0.34.47': {}
+
+  '@qdrant/js-client-grpc@1.14.0': {}
+
+  '@qdrant/js-client-rest@1.14.0': {}
+
+  '@qdrant/qdrant-js@1.14.0':
+    dependencies:
+      '@qdrant/js-client-grpc': 1.14.0
+      '@qdrant/js-client-rest': 1.14.0
 
   '@slack/bolt@4.6.0(@types/express@5.0.6)':
     dependencies:
@@ -9108,6 +9140,7 @@ snapshots:
       '@mariozechner/pi-coding-agent': 0.49.3(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.49.3
       '@mozilla/readability': 0.6.0
+      '@qdrant/qdrant-js': 1.14.0
       '@sinclair/typebox': 0.34.47
       '@slack/bolt': 4.6.0(@types/express@5.0.6)
       '@slack/web-api': 7.13.0

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -32,11 +32,20 @@ export type ResolvedMemorySearchConfig = {
     modelCacheDir?: string;
   };
   store: {
-    driver: "sqlite";
+    driver: "sqlite" | "qdrant";
     path: string;
     vector: {
       enabled: boolean;
       extensionPath?: string;
+    };
+    qdrant?: {
+      url?: string;
+      apiKey?: string;
+      collection?: {
+        name?: string;
+        onDisk?: boolean;
+        distance?: "Cosine" | "Euclidean" | "Dot";
+      };
     };
   };
   chunking: {
@@ -167,10 +176,12 @@ function mergeConfig(
     extensionPath:
       overrides?.store?.vector?.extensionPath ?? defaults?.store?.vector?.extensionPath,
   };
+  const qdrant = overrides?.store?.qdrant ?? defaults?.store?.qdrant;
   const store = {
     driver: overrides?.store?.driver ?? defaults?.store?.driver ?? "sqlite",
     path: resolveStorePath(agentId, overrides?.store?.path ?? defaults?.store?.path),
     vector,
+    ...(qdrant ? { qdrant } : {}),
   };
   const chunking = {
     tokens: overrides?.chunking?.tokens ?? defaults?.chunking?.tokens ?? DEFAULT_CHUNK_TOKENS,

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -263,13 +263,27 @@ export type MemorySearchConfig = {
   };
   /** Index storage configuration. */
   store?: {
-    driver?: "sqlite";
+    driver?: "sqlite" | "qdrant";
     path?: string;
     vector?: {
       /** Enable sqlite-vec extension for vector search (default: true). */
       enabled?: boolean;
       /** Optional override path to sqlite-vec extension (.dylib/.so/.dll). */
       extensionPath?: string;
+    };
+    qdrant?: {
+      /** Qdrant server URL (default: "http://localhost:6333"). */
+      url?: string;
+      /** API key for cloud Qdrant instances. */
+      apiKey?: string;
+      collection?: {
+        /** Collection name (default: auto-generated per agent/model). */
+        name?: string;
+        /** Store vectors on disk (default: true for local, false for in-memory). */
+        onDisk?: boolean;
+        /** Distance metric (default: "Cosine"). */
+        distance?: "Cosine" | "Euclidean" | "Dot";
+      };
     };
     cache?: {
       /** Enable embedding cache (default: true). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -342,12 +342,27 @@ export const MemorySearchSchema = z
       .optional(),
     store: z
       .object({
-        driver: z.literal("sqlite").optional(),
+        driver: z.enum(["sqlite", "qdrant"]).optional(),
         path: z.string().optional(),
         vector: z
           .object({
             enabled: z.boolean().optional(),
             extensionPath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        qdrant: z
+          .object({
+            url: z.string().url().optional(),
+            apiKey: z.string().optional(),
+            collection: z
+              .object({
+                name: z.string().optional(),
+                onDisk: z.boolean().optional(),
+                distance: z.enum(["Cosine", "Euclidean", "Dot"]).optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/memory/vector-store-qdrant.ts
+++ b/src/memory/vector-store-qdrant.ts
@@ -1,0 +1,282 @@
+import type { DatabaseSync } from "node:sqlite";
+import { QdrantClient } from "@qdrant/qdrant-js";
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { hashText } from "./internal.js";
+import type { VectorSearchResult, VectorStore } from "./vector-store.js";
+
+const log = createSubsystemLogger("memory");
+
+export type QdrantConfig = {
+  url?: string;
+  apiKey?: string;
+  collection?: {
+    name?: string;
+    onDisk?: boolean;
+    distance?: "Cosine" | "Euclidean" | "Dot";
+  };
+};
+
+export class QdrantStore implements VectorStore {
+  private client: QdrantClient | null = null;
+  private collectionName: string;
+  private config: Required<QdrantConfig>;
+  private available: boolean | null = null;
+  private loadError?: string;
+  private dims?: number;
+  private ready: Promise<boolean> | null = null;
+  private readonly VECTOR_LOAD_TIMEOUT_MS = 30_000;
+
+  constructor(
+    params: {
+      agentId: string;
+      providerKey: string;
+      config: QdrantConfig;
+    },
+  ) {
+    this.config = {
+      url: params.config.url ?? "http://localhost:6333",
+      apiKey: params.config.apiKey,
+      collection: {
+        name:
+          params.config.collection?.name ??
+          `clawdbot_${params.agentId}_${hashText(params.providerKey).slice(0, 16)}`,
+        onDisk: params.config.collection?.onDisk ?? true,
+        distance: params.config.collection?.distance ?? "Cosine",
+      },
+    };
+    this.collectionName = this.config.collection.name;
+  }
+
+  async ensureReady(dimensions: number): Promise<boolean> {
+    if (!this.ready) {
+      this.ready = this.withTimeout(
+        this.initialize(),
+        this.VECTOR_LOAD_TIMEOUT_MS,
+        `Qdrant initialization timed out after ${Math.round(this.VECTOR_LOAD_TIMEOUT_MS / 1000)}s`,
+      );
+    }
+    let ready = false;
+    try {
+      ready = await this.ready;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.available = false;
+      this.loadError = message;
+      this.ready = null;
+      log.warn(`Qdrant unavailable: ${message}`);
+      return false;
+    }
+    if (ready && typeof dimensions === "number" && dimensions > 0) {
+      await this.ensureCollection(dimensions);
+    }
+    return ready;
+  }
+
+  async upsert(id: string, embedding: number[]): Promise<void> {
+    if (!this.client || !this.available || !this.dims) {
+      throw new Error("Qdrant store not ready");
+    }
+    try {
+      await this.client.upsertPoints(this.collectionName, {
+        points: [
+          {
+            id: this.stringToPointId(id),
+            vector: embedding,
+          },
+        ],
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`Qdrant upsert failed: ${message}`);
+      throw err;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    if (!this.client || !this.available) return;
+    try {
+      await this.client.deletePoints(this.collectionName, {
+        points: [this.stringToPointId(id)],
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`Qdrant delete failed: ${message}`);
+    }
+  }
+
+  async deleteByPath(path: string, source: string, db: DatabaseSync): Promise<void> {
+    if (!this.client || !this.available) return;
+    try {
+      // Get all chunk IDs for this path/source from SQLite
+      const rows = db
+        .prepare(`SELECT id FROM chunks WHERE path = ? AND source = ?`)
+        .all(path, source) as Array<{ id: string }>;
+
+      if (rows.length === 0) return;
+
+      const pointIds = rows.map((row) => this.stringToPointId(row.id));
+      await this.client.deletePoints(this.collectionName, {
+        points: pointIds,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`Qdrant deleteByPath failed: ${message}`);
+    }
+  }
+
+  async search(
+    queryVec: number[],
+    limit: number,
+    filter: { model: string; sources: string[] },
+    db: DatabaseSync,
+  ): Promise<VectorSearchResult[]> {
+    if (!this.client || !this.available || queryVec.length === 0 || limit <= 0) return [];
+    if (!(await this.ensureReady(queryVec.length))) return [];
+
+    try {
+      // Build filter to match model and sources
+      // We need to get chunk IDs from SQLite that match the filter, then search Qdrant
+      // This is a limitation: Qdrant doesn't store model/source metadata, so we filter in SQLite first
+      const sourceFilter =
+        filter.sources.length === 0
+          ? { sql: "", params: [] }
+          : {
+              sql: ` AND source IN (${filter.sources.map(() => "?").join(", ")})`,
+              params: filter.sources,
+            };
+
+      const chunkRows = db
+        .prepare(
+          `SELECT id FROM chunks WHERE model = ?${sourceFilter.sql}`,
+        )
+        .all(filter.model, ...sourceFilter.params) as Array<{ id: string }>;
+
+      if (chunkRows.length === 0) return [];
+
+      const pointIds = chunkRows.map((row) => this.stringToPointId(row.id));
+
+      const results = await this.client.searchPoints(this.collectionName, {
+        vector: queryVec,
+        limit,
+        filter: {
+          must: [
+            {
+              has_id: pointIds,
+            },
+          ],
+        },
+      });
+
+      return results.points.map((point) => {
+        const id = this.pointIdToString(point.id);
+        // Convert distance to similarity score
+        // Qdrant returns distance (lower is better for Cosine/Euclidean)
+        // For Cosine: similarity = 1 - distance (when distance is normalized 0-1)
+        // For Dot: score is already similarity
+        let score = 0;
+        if (point.score !== undefined) {
+          if (this.config.collection.distance === "Cosine") {
+            score = 1 - point.score;
+          } else if (this.config.collection.distance === "Dot") {
+            score = point.score;
+          } else {
+            // Euclidean: convert to similarity using 1 / (1 + distance)
+            score = 1 / (1 + point.score);
+          }
+        }
+        return { id, score };
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`Qdrant search failed: ${message}`);
+      return [];
+    }
+  }
+
+  private async initialize(): Promise<boolean> {
+    if (this.available !== null) return this.available;
+    try {
+      const clientConfig: { url: string; apiKey?: string } = {
+        url: this.config.url,
+      };
+      if (this.config.apiKey) {
+        clientConfig.apiKey = this.config.apiKey;
+      }
+      this.client = new QdrantClient(clientConfig);
+
+      // Test connection
+      await this.client.getCollections();
+      this.available = true;
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.available = false;
+      this.loadError = message;
+      log.warn(`Qdrant connection failed: ${message}`);
+      return false;
+    }
+  }
+
+  private async ensureCollection(dimensions: number): Promise<void> {
+    if (!this.client || this.dims === dimensions) return;
+    if (this.dims && this.dims !== dimensions) {
+      await this.dropCollection();
+    }
+
+    try {
+      const collections = await this.client.getCollections();
+      const exists = collections.collections.some((c) => c.name === this.collectionName);
+
+      if (!exists) {
+        await this.client.createCollection(this.collectionName, {
+          vectors: {
+            size: dimensions,
+            distance: this.config.collection.distance,
+            on_disk: this.config.collection.onDisk,
+          },
+        });
+        log.debug(`Created Qdrant collection: ${this.collectionName}`);
+      }
+      this.dims = dimensions;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`Failed to ensure Qdrant collection: ${message}`);
+      throw err;
+    }
+  }
+
+  private async dropCollection(): Promise<void> {
+    if (!this.client) return;
+    try {
+      await this.client.deleteCollection(this.collectionName);
+      log.debug(`Dropped Qdrant collection: ${this.collectionName}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`Failed to drop Qdrant collection: ${message}`);
+    }
+  }
+
+  private stringToPointId(str: string): string | number {
+    // Qdrant supports string or integer IDs
+    // Use string IDs to match our chunk IDs
+    return str;
+  }
+
+  private pointIdToString(id: string | number): string {
+    return String(id);
+  }
+
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((_, reject) =>
+        setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs),
+      ),
+    ]);
+  }
+}

--- a/src/memory/vector-store.ts
+++ b/src/memory/vector-store.ts
@@ -1,0 +1,198 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { loadSqliteVecExtension } from "./sqlite-vec.js";
+
+const log = createSubsystemLogger("memory");
+
+export type VectorSearchResult = {
+  id: string;
+  score: number;
+};
+
+export interface VectorStore {
+  ensureReady(dimensions: number): Promise<boolean>;
+  upsert(id: string, embedding: number[]): Promise<void>;
+  delete(id: string): Promise<void>;
+  deleteByPath(path: string, source: string, db: DatabaseSync): Promise<void>;
+  search(
+    queryVec: number[],
+    limit: number,
+    filter: { model: string; sources: string[] },
+    db: DatabaseSync,
+  ): Promise<VectorSearchResult[]>;
+}
+
+const vectorToBlob = (embedding: number[]): Buffer =>
+  Buffer.from(new Float32Array(embedding).buffer);
+
+const VECTOR_TABLE = "chunks_vec";
+
+export class SqliteVecStore implements VectorStore {
+  private db: DatabaseSync;
+  private enabled: boolean;
+  private extensionPath?: string;
+  private available: boolean | null = null;
+  private loadError?: string;
+  private dims?: number;
+  private ready: Promise<boolean> | null = null;
+  private readonly VECTOR_LOAD_TIMEOUT_MS = 30_000;
+
+  constructor(params: { db: DatabaseSync; enabled: boolean; extensionPath?: string }) {
+    this.db = params.db;
+    this.enabled = params.enabled;
+    this.extensionPath = params.extensionPath;
+  }
+
+  async ensureReady(dimensions: number): Promise<boolean> {
+    if (!this.enabled) return false;
+    if (!this.ready) {
+      this.ready = this.withTimeout(
+        this.loadVectorExtension(),
+        this.VECTOR_LOAD_TIMEOUT_MS,
+        `sqlite-vec load timed out after ${Math.round(this.VECTOR_LOAD_TIMEOUT_MS / 1000)}s`,
+      );
+    }
+    let ready = false;
+    try {
+      ready = await this.ready;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.available = false;
+      this.loadError = message;
+      this.ready = null;
+      log.warn(`sqlite-vec unavailable: ${message}`);
+      return false;
+    }
+    if (ready && typeof dimensions === "number" && dimensions > 0) {
+      this.ensureVectorTable(dimensions);
+    }
+    return ready;
+  }
+
+  async upsert(id: string, embedding: number[]): Promise<void> {
+    if (!this.available || !this.dims) {
+      throw new Error("Vector store not ready");
+    }
+    try {
+      this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
+    } catch {}
+    this.db
+      .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
+      .run(id, vectorToBlob(embedding));
+  }
+
+  async delete(id: string): Promise<void> {
+    if (!this.available) return;
+    try {
+      this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
+    } catch {}
+  }
+
+  async deleteByPath(path: string, source: string, db: DatabaseSync): Promise<void> {
+    if (!this.available) return;
+    try {
+      db.prepare(
+        `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
+      ).run(path, source);
+    } catch {}
+  }
+
+  async search(
+    queryVec: number[],
+    limit: number,
+    filter: { model: string; sources: string[] },
+    db: DatabaseSync,
+  ): Promise<VectorSearchResult[]> {
+    if (!this.available || queryVec.length === 0 || limit <= 0) return [];
+    if (!(await this.ensureReady(queryVec.length))) return [];
+
+    const sourceFilter =
+      filter.sources.length === 0
+        ? { sql: "", params: [] }
+        : {
+            sql: ` AND c.source IN (${filter.sources.map(() => "?").join(", ")})`,
+            params: filter.sources,
+          };
+
+    const rows = db
+      .prepare(
+        `SELECT c.id,\n` +
+          `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
+          `  FROM ${VECTOR_TABLE} v\n` +
+          `  JOIN chunks c ON c.id = v.id\n` +
+          ` WHERE c.model = ?${sourceFilter.sql}\n` +
+          ` ORDER BY dist ASC\n` +
+          ` LIMIT ?`,
+      )
+      .all(vectorToBlob(queryVec), filter.model, ...sourceFilter.params, limit) as Array<{
+      id: string;
+      dist: number;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      score: 1 - row.dist,
+    }));
+  }
+
+  private async loadVectorExtension(): Promise<boolean> {
+    if (this.available !== null) return this.available;
+    if (!this.enabled) {
+      this.available = false;
+      return false;
+    }
+    try {
+      const resolvedPath = this.extensionPath?.trim()
+        ? this.extensionPath.trim()
+        : undefined;
+      const loaded = await loadSqliteVecExtension({ db: this.db, extensionPath: resolvedPath });
+      if (!loaded.ok) throw new Error(loaded.error ?? "unknown sqlite-vec load error");
+      this.extensionPath = loaded.extensionPath;
+      this.available = true;
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.available = false;
+      this.loadError = message;
+      log.warn(`sqlite-vec unavailable: ${message}`);
+      return false;
+    }
+  }
+
+  private ensureVectorTable(dimensions: number): void {
+    if (this.dims === dimensions) return;
+    if (this.dims && this.dims !== dimensions) {
+      this.dropVectorTable();
+    }
+    this.db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS ${VECTOR_TABLE} USING vec0(\n` +
+        `  id TEXT PRIMARY KEY,\n` +
+        `  embedding FLOAT[${dimensions}]\n` +
+        `)`,
+    );
+    this.dims = dimensions;
+  }
+
+  private dropVectorTable(): void {
+    try {
+      this.db.exec(`DROP TABLE IF NOT EXISTS ${VECTOR_TABLE}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`Failed to drop ${VECTOR_TABLE}: ${message}`);
+    }
+  }
+
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((_, reject) =>
+        setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs),
+      ),
+    ]);
+  }
+}


### PR DESCRIPTION
Features

- Backward compatible: default driver remains "sqlite"
- SQLite still used for metadata (files, chunks tables) regardless of vector driver
- Embedding cache uses SQLite regardless of vector driver
- Hybrid search (BM25 + vector) works with Qdrant
- Fallback to in-process cosine similarity if Qdrant unavailable
- Collection isolation per agent/model combination