### PR TITLE
feat(hooks): Make session-memory message count configurable (#2681)

### DIFF
--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -74,13 +74,18 @@ clawdbot hooks disable session-memory
 Or remove it from your config:
 
 ```json
+
 {
   "hooks": {
     "internal": {
       "entries": {
-        "session-memory": { "enabled": false }
+        "session-memory": {
+          "enabled": true,
+          "messages": 100
+        }
       }
     }
   }
 }
+
 ```


### PR DESCRIPTION
### What this PR does
- Makes the `session-memory` hook message count configurable.
- Fixes filtering logic to apply filters before slicing.
- Keeps default behavior (15 messages) for backward compatibility.

### Why
Fixes issue #2681 where message count was hardcoded and filtering order caused incorrect results.

### Files changed
- Handler logic
- Config schema
- Hook documentation
- Tests added/updated

### Testing
- Added unit tests
- Verified locally with hook execution
