### PR TITLE
fix(error): Fix OpenAI's Rate Limit error being classified as Context Overflow error

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -32,6 +32,8 @@ const CONTEXT_OVERFLOW_HINT_RE =
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) return false;
+  // Rate limit errors should not be classified as context overflow
+  if (isRateLimitErrorMessage(errorMessage)) return false;
   if (isContextOverflowError(errorMessage)) return true;
   return CONTEXT_OVERFLOW_HINT_RE.test(errorMessage);
 }


### PR DESCRIPTION
Currently OpenAI's RateLimit error is being classified as a ContextLimit error resulting in undefined behaviors. 

This is because 'Request Rate limit reached for gpt-5.2 in organization org-xxx on tokens per min (TPM): Limit 500000, Used 362512, Requested 153920. Please try again in 1.971s' is matching CONTEXT_OVERFLOW_HINT_RE. 

The fix is simple, we should exclude RateLimit errors from ContextLimit errors

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents OpenAI rate-limit errors (e.g., TPM quota messages) from being misclassified as context overflow by adding an early `isRateLimitErrorMessage` guard in `isLikelyContextOverflowError`.

This fits into the existing error-classification helpers in `src/agents/pi-embedded-helpers/errors.ts`, which normalize raw provider error strings into higher-level categories (context overflow, rate limit, overloaded, timeout, etc.) used for UI messaging and failover decisions.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and narrowly scoped to error classification.
- Change is a simple early-return guard with low blast radius, but correctness depends on how `isContextOverflowError` and the hint regex interact with provider error strings; no tests were added here to lock behavior in.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->