### PR TITLE
feat(plugins): add setupGuide field for post-install guidance

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -7,6 +7,7 @@ import type { ClawdbotConfig } from "../config/config.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
+import { loadPluginManifest } from "../plugins/manifest.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
 import type { PluginRecord } from "../plugins/registry.js";
 import { buildPluginStatusReport } from "../plugins/status.js";
@@ -31,6 +32,16 @@ export type PluginUpdateOptions = {
   all?: boolean;
   dryRun?: boolean;
 };
+
+function printSetupGuideIfPresent(targetDir: string): void {
+  const manifestResult = loadPluginManifest(targetDir);
+  if (manifestResult.ok && manifestResult.manifest.setupGuide) {
+    defaultRuntime.log("");
+    defaultRuntime.log(theme.heading("Setup Guide:"));
+    defaultRuntime.log(manifestResult.manifest.setupGuide);
+    defaultRuntime.log("");
+  }
+}
 
 function formatPluginLine(plugin: PluginRecord, verbose = false): string {
   const status =
@@ -379,6 +390,7 @@ export function registerPluginsCli(program: Command) {
         await writeConfigFile(next);
         logSlotWarnings(slotResult.warnings);
         defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
+        printSetupGuideIfPresent(result.targetDir);
         defaultRuntime.log(`Restart the gateway to load plugins.`);
         return;
       }
@@ -442,6 +454,7 @@ export function registerPluginsCli(program: Command) {
       await writeConfigFile(next);
       logSlotWarnings(slotResult.warnings);
       defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
+      printSetupGuideIfPresent(result.targetDir);
       defaultRuntime.log(`Restart the gateway to load plugins.`);
     });
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -16,6 +16,7 @@ export type PluginManifest = {
   description?: string;
   version?: string;
   uiHints?: Record<string, PluginConfigUiHint>;
+  setupGuide?: string;
 };
 
 export type PluginManifestLoadResult =
@@ -75,6 +76,8 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
     uiHints = raw.uiHints as Record<string, PluginConfigUiHint>;
   }
 
+  const setupGuide = typeof raw.setupGuide === "string" ? raw.setupGuide.trim() : undefined;
+
   return {
     ok: true,
     manifest: {
@@ -88,6 +91,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
       description,
       version,
       uiHints,
+      setupGuide,
     },
     manifestPath,
   };


### PR DESCRIPTION
## Summary

Plugins can now include a `setupGuide` field in `clawdbot.plugin.json` that will be displayed after installation.

## Motivation

When a plugin is installed, users only see "Installed plugin: xxx". For plugins requiring additional configuration (like channel plugins needing API credentials), there's no built-in way to guide users through setup.

## Changes

- Add `setupGuide?: string` to `PluginManifest` type
- Parse `setupGuide` from plugin manifest
- Display after successful plugin installation

## Usage

```json
{
  "id": "my-plugin",
  "setupGuide": "Next steps:\n1. Get API key...\n2. Add to config...",
  "configSchema": { }
}
```