### PR TITLE
fix(models): inherit baseUrl and api from provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Status: unreleased.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.
 - Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.
 - Web UI: auto-expand the chat compose textarea while typing (with sensible max height). (#2950) Thanks @shivamraut101.

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -22,8 +22,70 @@ describe("buildInlineProviderModels", () => {
     const result = buildInlineProviderModels(providers);
 
     expect(result).toEqual([
-      { ...makeModel("alpha-model"), provider: "alpha" },
-      { ...makeModel("beta-model"), provider: "beta" },
+      { ...makeModel("alpha-model"), provider: "alpha", baseUrl: undefined, api: undefined },
+      { ...makeModel("beta-model"), provider: "beta", baseUrl: undefined, api: undefined },
     ]);
+  });
+
+  it("inherits baseUrl from provider when model does not specify it", () => {
+    const providers = {
+      custom: {
+        baseUrl: "http://localhost:8000",
+        models: [makeModel("custom-model")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].baseUrl).toBe("http://localhost:8000");
+  });
+
+  it("inherits api from provider when model does not specify it", () => {
+    const providers = {
+      custom: {
+        api: "anthropic-messages",
+        models: [makeModel("custom-model")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].api).toBe("anthropic-messages");
+  });
+
+  it("model-level api takes precedence over provider-level api", () => {
+    const providers = {
+      custom: {
+        api: "openai-chat",
+        models: [{ ...makeModel("custom-model"), api: "anthropic-messages" as const }],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].api).toBe("anthropic-messages");
+  });
+
+  it("inherits both baseUrl and api from provider config", () => {
+    const providers = {
+      custom: {
+        baseUrl: "http://localhost:10000",
+        api: "anthropic-messages",
+        models: [makeModel("claude-opus-4.5")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      provider: "custom",
+      baseUrl: "http://localhost:10000",
+      api: "anthropic-messages",
+      name: "claude-opus-4.5",
+    });
   });
 });


### PR DESCRIPTION
## Summary                                                                       
  - Fix bug where custom provider's `baseUrl` and `api` were not inherited by      
  inline model definitions                                                         
  - Models now correctly use the provider's endpoint and API format                
                                                                                   
  ## Problem                                                                       
  When configuring a custom provider with `baseUrl` and `api` at the provider      
  level:                                                                           
  ```json                                                                          
  "myProvider": {                                                                  
    "baseUrl": "http://localhost:10000",                                           
    "api": "anthropic-messages",                                                   
    "models": [{ "name": "claude-opus-4.5" }]                                      
  }                                                                                
  The individual models did not inherit these settings, causing requests to fail   
  with 401 or be sent to wrong endpoints.                                          
                                                                                   
  Test plan                                                                        
                                                                                   
  - Lint passes (npm run lint)                                                     
  - Unit tests pass (vitest run src/agents/pi-embedded-runner/model.test.ts)       
  - Manual test with custom provider pointing to local server 
 ```