### PR TITLE
feat(cli): add gateway wake command

### DIFF
--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -264,6 +264,30 @@ export function registerGatewayCli(program: Command) {
       });
     });
 
+  gatewayCallOpts(
+    gateway
+      .command("wake")
+      .description("Send a wake event to the Gateway (trigger agent processing)")
+      .option("--text <text>", "Wake event text (injected as system event)", "Wake event")
+      .option("--mode <mode>", "Wake mode: now (immediate) or next-heartbeat (default)", "now")
+      .action(async (opts) => {
+        await runGatewayCommand(async () => {
+          const mode = opts.mode === "next-heartbeat" ? "next-heartbeat" : "now";
+          const text = String(opts.text || "Wake event");
+          const result = await callGatewayCli("wake", opts, { mode, text });
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            return;
+          }
+          const rich = isRich();
+          defaultRuntime.log(colorize(rich, theme.heading, "Gateway Wake"));
+          defaultRuntime.log(
+            `${colorize(rich, theme.success, "OK")} · mode: ${mode} · text: "${text}"`,
+          );
+        }, "Gateway wake failed");
+      }),
+  );
+
   gateway
     .command("discover")
     .description(


### PR DESCRIPTION
## Summary

Adds `clawdbot gateway wake` CLI command to send wake events from the terminal.

## Motivation

Currently, the `cron.wake` action works internally via the agent tool interface, but there's no CLI equivalent. This makes it difficult for external processes (like Claude Code, scripts, or other automation) to wake the agent without going through the agent.

This PR adds the missing CLI command.

## Usage

```bash
# Wake immediately with custom text
clawdbot gateway wake --text 'Background task finished' --mode now

# Wake on next heartbeat
clawdbot gateway wake --text 'Check this out' --mode next-heartbeat

# With JSON output
clawdbot gateway wake --text 'Test' --json
```

## Options

- `--text <text>`: Wake event text (injected as system event, default: 'Wake event')
- `--mode <mode>`: Wake mode: 'now' (immediate) or 'next-heartbeat' (default: 'now')
- Standard gateway call options (`--url`, `--token`, `--password`, `--timeout`, `--json`)

## Testing

Tested locally against a running gateway:
```
$ node dist/entry.js gateway wake --text 'Test wake from local dev build' --mode now
Gateway Wake
OK · mode: now · text: "Test wake from local dev build"
```

The wake event was successfully delivered and triggered agent processing.