### PR TITLE
fix: Support nested packages in pnpm-workspace.yaml (#2745)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - .
   - ui
-  - packages/*
+  - packages/**
   - extensions/*
 
 onlyBuiltDependencies:


### PR DESCRIPTION
…ckage glob pattern from 'packages/*' to 'packages/**' to properly include all nested packages under the packages directory. This resolves ERR_PNPM_WORKSPACE_PKG_NOT_FOUND errors during builds.  Fixes #2745

This fix addresses issue #2745 where pnpm fails during builds due to workspace packages not being properly resolved. By changing the glob pattern from 'packages/*' to 'packages/**', we ensure that all nested packages are included in the workspace configuration, fixing the ERR_PNPM_WORKSPACE_PKG_NOT_FOUND error.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `pnpm-workspace.yaml` to include nested workspace packages by adding the glob `packages/**` to the `packages:` list. This ensures pnpm discovers packages in deeper subdirectories under `packages/`, addressing `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` during builds while leaving existing workspace entries (`.`, `ui`, `extensions/*`) unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single-line workspace glob addition in `pnpm-workspace.yaml`, with no code-path impact beyond package discovery; it is consistent with the stated goal of including nested packages under `packages/`.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->