### PR TITLE
Security: harden gateway auth exposure

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -132,6 +132,7 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.remote.tlsFingerprint": "Remote Gateway TLS Fingerprint",
   "gateway.auth.token": "Gateway Token",
   "gateway.auth.password": "Gateway Password",
+  "gateway.auth.minLength": "Gateway Auth Minimum Length",
   "tools.media.image.enabled": "Enable Image Understanding",
   "tools.media.image.maxBytes": "Image Understanding Max Bytes",
   "tools.media.image.maxChars": "Image Understanding Max Chars",
@@ -381,6 +382,8 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
+  "gateway.auth.minLength":
+    "Minimum token/password length required for non-loopback binds (default: 24).",
   "gateway.controlUi.basePath":
     "Optional URL prefix where the Control UI is served (e.g. /moltbot).",
   "gateway.controlUi.allowInsecureAuth":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -79,6 +79,8 @@ export type GatewayAuthConfig = {
   token?: string;
   /** Shared password for password mode (consider env instead). */
   password?: string;
+  /** Minimum auth token/password length when binding beyond loopback. Default: 24. */
+  minLength?: number;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -327,6 +327,7 @@ export const MoltbotSchema = z
             mode: z.union([z.literal("token"), z.literal("password")]).optional(),
             token: z.string().optional(),
             password: z.string().optional(),
+            minLength: z.number().int().min(8).max(128).optional(),
             allowTailscale: z.boolean().optional(),
           })
           .strict()

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -25,6 +25,12 @@ export function sendUnauthorized(res: ServerResponse) {
   });
 }
 
+export function sendRateLimited(res: ServerResponse) {
+  sendJson(res, 429, {
+    error: { message: "Too many requests", type: "rate_limited" },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -11,6 +11,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -172,6 +173,10 @@ export async function handleOpenAiHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -20,6 +20,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -335,6 +336,10 @@ export async function handleOpenResponsesHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { MoltbotConfig } from "../config/config.js";
+import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
+
+describe("resolveGatewayRuntimeConfig", () => {
+  it("rejects weak auth when binding beyond loopback", async () => {
+    const cfg: MoltbotConfig = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "short-token",
+        },
+      },
+    };
+
+    await expect(
+      resolveGatewayRuntimeConfig({
+        cfg,
+        port: 18789,
+        host: "0.0.0.0",
+      }),
+    ).rejects.toThrow("weak shared secret");
+  });
+
+  it("allows custom auth minimum length", async () => {
+    const cfg: MoltbotConfig = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "long-enough-token",
+          minLength: 10,
+        },
+      },
+    };
+
+    await expect(
+      resolveGatewayRuntimeConfig({
+        cfg,
+        port: 18789,
+        host: "0.0.0.0",
+      }),
+    ).resolves.toMatchObject({
+      bindHost: "0.0.0.0",
+    });
+  });
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -115,6 +115,8 @@ function formatGatewayAuthFailureMessage(params: {
       return "unauthorized: tailscale identity check failed (use Tailscale Serve auth or gateway token/password)";
     case "tailscale_user_mismatch":
       return "unauthorized: tailscale identity mismatch (use Tailscale Serve auth or gateway token/password)";
+    case "rate_limited":
+      return "unauthorized: too many failed attempts (try again later)";
     default:
       break;
   }

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -29,6 +29,7 @@ import {
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
 } from "./http-common.js";
 
@@ -89,6 +90,10 @@ export async function handleToolsInvokeHttpRequest(
     trustedProxies: opts.trustedProxies ?? cfg.gateway?.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }


### PR DESCRIPTION
## Summary

- Add rate limiting for failed authentication attempts (10 failures within 60s triggers a 5-minute block per IP)
- Enforce minimum auth token/password length (default 24 chars) when binding beyond loopback
- Add configurable `gateway.auth.minLength` setting (8-128 chars)
- Improve startup logging to show auth strength status
- Add `sendRateLimited` (HTTP 429) response for rate-limited requests
- Extend security audit to check password length (previously only checked token)

## Test plan

- [ ] Added unit tests for `resolveGatewayRuntimeConfig` covering weak auth rejection and custom min length
- [ ] Manual testing: verify rate limiting kicks in after repeated failed auth attempts
- [ ] Manual testing: verify gateway refuses to start with short token on non-loopback bind
- [ ] Verify startup logs show auth strength (ok/weak)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens gateway auth behavior by adding per-IP rate limiting for repeated failed auth, enforcing a minimum shared-secret length (configurable via `gateway.auth.minLength`), and extending the security audit/startup logging to surface weak or missing auth configuration. HTTP handlers now return 429 for rate-limited requests, and WS/auth logic has been updated to better handle Tailscale Serve identity verification.

Most changes integrate cleanly with the existing gateway auth/config system, but there’s one likely functional mismatch around `tools.alsoAllow` not being applied early enough to influence plugin-tool discovery.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a plausible functional issue in tool allowlisting that could break intended `tools.alsoAllow` behavior for plugin tools.
- Core security hardening changes (auth length enforcement, Tailscale identity verification, 429 responses) look internally consistent, but without running tests I can’t fully validate behavior. The `tools.alsoAllow` application order appears incorrect and could cause plugin tools to remain unavailable despite being allowlisted, which is a concrete behavior regression for some configs.
- src/gateway/tools-invoke-http.ts, src/gateway/auth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->