### PR TITLE
feat(models): Update Moonshot Kimi model references to kimi-k2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Status: beta.
 - Providers: update MiniMax API endpoint and compatibility mode. (#3064) Thanks @hlbbbbbbb.
 - Telegram: treat more network errors as recoverable in polling. (#3013) Thanks @ryancontent.
 - Discord: resolve usernames to user IDs for outbound messages. (#2649) Thanks @nonggialiang.
+- Providers: update Moonshot Kimi model references to kimi-k2.5. (#2762) Thanks @MarvinCui.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -130,9 +130,10 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 
 - Provider: `moonshot`
 - Auth: `MOONSHOT_API_KEY`
-- Example model: `moonshot/kimi-k2-0905-preview`
+- Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
   {/* moonshot-kimi-k2-model-refs:start */}
+  - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
@@ -141,7 +142,7 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 ```json5
 {
   agents: {
-    defaults: { model: { primary: "moonshot/kimi-k2-0905-preview" } }
+    defaults: { model: { primary: "moonshot/kimi-k2.5" } }
   },
   models: {
     mode: "merge",
@@ -150,7 +151,7 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
         baseUrl: "https://api.moonshot.ai/v1",
         apiKey: "${MOONSHOT_API_KEY}",
         api: "openai-completions",
-        models: [{ id: "kimi-k2-0905-preview", name: "Kimi K2 0905 Preview" }]
+        models: [{ id: "kimi-k2.5", name: "Kimi K2.5" }]
       }
     }
   }

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2396,8 +2396,8 @@ Use Moonshot's OpenAI-compatible endpoint:
   env: { MOONSHOT_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "moonshot/kimi-k2-0905-preview" },
-      models: { "moonshot/kimi-k2-0905-preview": { alias: "Kimi K2" } }
+      model: { primary: "moonshot/kimi-k2.5" },
+      models: { "moonshot/kimi-k2.5": { alias: "Kimi K2.5" } }
     }
   },
   models: {
@@ -2409,8 +2409,8 @@ Use Moonshot's OpenAI-compatible endpoint:
         api: "openai-completions",
         models: [
           {
-            id: "kimi-k2-0905-preview",
-            name: "Kimi K2 0905 Preview",
+            id: "kimi-k2.5",
+            name: "Kimi K2.5",
             reasoning: false,
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -2426,7 +2426,7 @@ Use Moonshot's OpenAI-compatible endpoint:
 
 Notes:
 - Set `MOONSHOT_API_KEY` in the environment or use `moltbot onboard --auth-choice moonshot-api-key`.
-- Model ref: `moonshot/kimi-k2-0905-preview`.
+- Model ref: `moonshot/kimi-k2.5`.
 - Use `https://api.moonshot.cn/v1` if you need the China endpoint.
 
 ### Kimi Code

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -9,11 +9,12 @@ read_when:
 # Moonshot AI (Kimi)
 
 Moonshot provides the Kimi API with OpenAI-compatible endpoints. Configure the
-provider and set the default model to `moonshot/kimi-k2-0905-preview`, or use
+provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Code with `kimi-code/kimi-for-coding`.
 
 Current Kimi K2 model IDs:
 {/* moonshot-kimi-k2-ids:start */}
+- `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
@@ -39,9 +40,10 @@ Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeabl
   env: { MOONSHOT_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "moonshot/kimi-k2-0905-preview" },
+      model: { primary: "moonshot/kimi-k2.5" },
       models: {
         // moonshot-kimi-k2-aliases:start
+        "moonshot/kimi-k2.5": { alias: "Kimi K2.5" },
         "moonshot/kimi-k2-0905-preview": { alias: "Kimi K2" },
         "moonshot/kimi-k2-turbo-preview": { alias: "Kimi K2 Turbo" },
         "moonshot/kimi-k2-thinking": { alias: "Kimi K2 Thinking" },
@@ -59,6 +61,15 @@ Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeabl
         api: "openai-completions",
         models: [
           // moonshot-kimi-k2-models:start
+          {
+            id: "kimi-k2.5",
+            name: "Kimi K2.5",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 256000,
+            maxTokens: 8192
+          },
           {
             id: "kimi-k2-0905-preview",
             name: "Kimi K2 0905 Preview",

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -31,7 +31,7 @@ const MINIMAX_API_COST = {
 };
 
 const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
-const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2-0905-preview";
+const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2.5";
 const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
 const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 const MOONSHOT_DEFAULT_COST = {
@@ -275,7 +275,7 @@ function buildMoonshotProvider(): ProviderConfig {
     models: [
       {
         id: MOONSHOT_DEFAULT_MODEL_ID,
-        name: "Kimi K2 0905 Preview",
+        name: "Kimi K2.5",
         reasoning: false,
         input: ["text"],
         cost: MOONSHOT_DEFAULT_COST,


### PR DESCRIPTION
Moonshot AI (Kimi) has launched their new model today: **Kimi-k2.5**. The model information is as follows:

| Model        | Unit        | Input Price (Cache Hit) | Input Price (Cache Miss) | Output Price | Context Window |
|--------------|-------------|--------------------------|---------------------------|--------------|----------------|
| kimi-k2.5    | 1M tokens   | $0.10                    | $0.60                     | $3.00        | 262,144 tokens |

**kimi-k2.5** is Kimi's most versatile model to date, featuring a native multimodal architecture that supports both visual and text input, thinking and non-thinking modes, and dialogue and agent tasks.  
The model supports long-context reasoning with a context length of 256k tokens, enabling extended thinking and deep reasoning scenarios.  
It also supports automatic context caching, ToolCalls, JSON Mode, Partial Mode, and built-in internet search functionality.

**This PR updates Moonshot Kimi model references from the previous default kimi-k2-0905-preview naming to kimi-k2.5.**

## Scope of changes
This change focuses on keeping the project aligned with the updated Kimi model identifier. The updates include references used in configuration and documentation so that examples and defaults consistently point to kimi-k2.5.

## What was changed
The Kimi model ID references were updated to kimi-k2.5, along with the corresponding display name, to avoid confusion between preview model IDs and the current recommended model.

## Testing
This change was lightly tested. No runtime behavior was altered beyond model identifier resolution, and no functional logic outside model configuration was modified.

## AI assistance
This PR was created with the help of Warp AI. I reviewed the changes manually and understand what the modified code and configuration do.