### PR TITLE
fix: search WhatsApp account subdirs for LID mapping files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,28 @@ function resolveLidMappingDirs(opts?: JidToE164Options): string[] {
   addDir(opts?.authDir);
   for (const dir of opts?.lidMappingDirs ?? []) addDir(dir);
   addDir(resolveOAuthDir());
-  addDir(path.join(CONFIG_DIR, "credentials"));
+  const credentialsDir = path.join(CONFIG_DIR, "credentials");
+  addDir(credentialsDir);
+
+  // Also search WhatsApp account subdirectories for LID mappings
+  const waDir = path.join(credentialsDir, "whatsapp");
+  try {
+    if (fs.existsSync(waDir) && fs.statSync(waDir).isDirectory()) {
+      for (const account of fs.readdirSync(waDir)) {
+        const accountDir = path.join(waDir, account);
+        try {
+          if (fs.statSync(accountDir).isDirectory()) {
+            dirs.add(accountDir);
+          }
+        } catch {
+          // Skip if can't stat
+        }
+      }
+    }
+  } catch {
+    // Skip if whatsapp dir doesn't exist or can't be read
+  }
+
   return [...dirs];
 }
 


### PR DESCRIPTION
## Summary

Fixes #2771

When `jidToE164()` is called without `opts.authDir` (e.g., from `extract.ts` in `describeReplyContext()`), the LID reverse mapping lookup fails because `resolveLidMappingDirs()` only searches the top-level credentials directory, not the `whatsapp/<accountId>/` subdirectories where the mapping files are actually stored.

This causes the reply-to-bot trigger in groups to fail when the bot's JID uses the WhatsApp LID format, as the implicit mention comparison can't resolve the LID to an E164 phone number.

## Changes

Updated `resolveLidMappingDirs()` in `src/utils.ts` to also search WhatsApp account subdirectories (`~/.clawdbot/credentials/whatsapp/*/`).

## Testing

1. Set up WhatsApp with a number using LID format
2. Join a group with `/activation mention`
3. Reply to bot's message without @mentioning
4. Bot now correctly responds (implicit mention via reply-to-bot)

Verified working on Clawdbot 2026.1.24-3.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Investigated the change to `resolveLidMappingDirs()` in `src/utils.ts`, which extends LID reverse-mapping discovery to also search WhatsApp account subdirectories under the credentials directory (e.g. `credentials/whatsapp/*/`). This aligns the implicit `jidToE164()` lookup behavior with where mapping files are actually stored when `opts.authDir` isn’t provided (notably in reply-context flows).

No correctness issues were found in the change given the PR’s stated intent; it is a narrowly-scoped path discovery adjustment that should restore LID resolution in group reply-to-bot scenarios without affecting unrelated auth directory usage.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; it’s a small, targeted directory-discovery change.
- Only a single utility function is adjusted to search additional subdirectories for mapping files; the change is limited in scope and consistent with reported bug behavior. Confidence isn’t 5 because this review did not execute runtime tests across different OS/path layouts and credential directory configurations.
- src/utils.ts (directory traversal logic)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->