### PR TITLE
refactor: improve key tracking in upsert_env function

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -124,7 +124,18 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local -a seen_keys=()
+  local has_seen
+  has_seen() {
+    local candidate="$1"
+    local existing
+    for existing in "${seen_keys[@]:-}"; do
+      if [[ "$existing" == "$candidate" ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -133,7 +144,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen_keys+=("$k")
           replaced=true
           break
         fi
@@ -145,7 +156,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if ! has_seen "$k"; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
Summary

fix docker-setup.sh run failed on macOS

Root Cause

docker-setup.sh uses declare -A, which requires Bash 4+. macOS ships Bash 3.x by default, so declare -A fails.

#2781

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to avoid Bash 4-only associative arrays by replacing the `declare -A seen` usage in `upsert_env` with an array + membership helper, which addresses macOS’s default Bash 3.x limitation. It also updates defaults and compose invocations to use `moltbot-*` service/image naming (and updates the printed docs link), which changes how the script interacts with `docker-compose.yml` and the user’s workflow.

<h3>Confidence Score: 3/5</h3>

- This PR is probably safe to merge, but it includes a potentially breaking rename in a script intended as a compatibility fix.
- The Bash 3 compatibility change in `upsert_env` is small and straightforward, but the same diff also changes default image and compose service names; if the compose file/services aren’t updated in lockstep (or users rely on the old names), the script will fail. No tests cover this script, so runtime validation is manual.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->