### PR TITLE
fix: wire onToolResult to dispatcher for verbose tool summaries

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -276,6 +276,13 @@ export async function dispatchReplyFromConfig(params: {
       ctx,
       {
         ...params.replyOptions,
+        onToolResult: (payload: ReplyPayload) => {
+          if (shouldRouteToOriginating) {
+            void sendPayloadAsync(payload, undefined, false);
+          } else {
+            dispatcher.sendToolResult(payload);
+          }
+        },
         onBlockReply: (payload: ReplyPayload, context) => {
           const run = async () => {
             // Accumulate block text for TTS generation after streaming


### PR DESCRIPTION
## Summary
- Previously, `onToolResult` was not connected in `dispatchReplyFromConfig`, causing verbose tool summaries to not be sent to messaging channels like Telegram
- This adds the missing `onToolResult` handler similar to `onBlockReply`

## Test plan
- [x] Enable verbose mode in Telegram with `/verbose full`
- [x] Send a message that triggers tool calls
- [x] Verify tool result summaries are now visible in the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `dispatchReplyFromConfig` to properly forward `onToolResult` callbacks through the configured `ReplyDispatcher`, matching the existing `onBlockReply` wiring so verbose tool-result summaries can reach external messaging channels (e.g., Telegram). It also introduces block-text accumulation to synthesize a TTS-only final audio reply when streaming completes without a final payload, using `resolveTtsConfig`/`maybeApplyTtsToPayload` to keep behavior consistent with existing TTS routing logic.

Overall, the PR focuses on improving reply dispatch plumbing so tool and block outputs are routed either via `routeReply` (cross-provider/originating channel) or via the dispatcher, and ensures TTS still works in streaming-only scenarios.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a small async-ordering issue in the new onToolResult routing path.
- The change is localized and follows existing patterns for block replies, but `onToolResult` currently fire-and-forgets an async route which can reorder or drop tool-result summaries relative to `waitForIdle()` and subsequent sends.
- src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->