### PR TITLE
perf(cli): use compile cache (~10% faster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Status: unreleased.
 - Config: apply config.env before ${VAR} substitution. (#1813) Thanks @spanishflu-est1918.
 - Slack: clear ack reaction after streamed replies. (#2044) Thanks @fancyboi999.
 - macOS: keep custom SSH usernames in remote target. (#2046) Thanks @algal.
+- CLI: use Node's module compile cache for faster startup. (#2808) Thanks @pi0.
 
 ### Breaking
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -42,7 +42,7 @@ moltbot acp client
 moltbot acp client --server-args --url wss://gateway-host:18789 --token <token>
 
 # Override the server command (default: moltbot)
-moltbot acp client --server "node" --server-args dist/entry.js acp --url ws://127.0.0.1:19001
+moltbot acp client --server "node" --server-args moltbot.mjs acp --url ws://127.0.0.1:19001
 ```
 
 ## How to use this

--- a/docs/debug/node-issue.md
+++ b/docs/debug/node-issue.md
@@ -55,9 +55,9 @@ node --import tsx scripts/repro/tsx-name-repro.ts
 - Use Node + tsc watch, then run compiled output:
   ```bash
   pnpm exec tsc --watch --preserveWatchOutput
-  node --watch dist/entry.js status
+  node --watch moltbot.mjs status
   ```
-- Confirmed locally: `pnpm exec tsc -p tsconfig.json` + `node dist/entry.js status` works on Node 25.
+- Confirmed locally: `pnpm exec tsc -p tsconfig.json` + `node moltbot.mjs status` works on Node 25.
 - Disable esbuild keepNames in the TS loader if possible (prevents `__name` helper insertion); tsx does not currently expose this.
 - Test Node LTS (22/24) with `tsx` to see if the issue is Node 25–specific.
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -125,7 +125,7 @@ moltbot health
 ```
 
 Notes:
-- `pnpm build` matters when you run the packaged `moltbot` binary ([`dist/entry.js`](https://github.com/moltbot/moltbot/blob/main/dist/entry.js)) or use Node to run `dist/`.
+- `pnpm build` matters when you run the packaged `moltbot` binary ([`moltbot.mjs`](https://github.com/moltbot/moltbot/blob/main/moltbot.mjs)) or use Node to run `dist/`.
 - If you run from a repo checkout without a global install, use `pnpm moltbot ...` for CLI commands.
 - If you run directly from TypeScript (`pnpm moltbot ...`), a rebuild is usually unnecessary, but **config migrations still apply** → run doctor.
 - Switching between global and git installs is easy: install the other flavor, then run `moltbot doctor` so the gateway service entrypoint is rewritten to the current install.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -20,7 +20,7 @@ When the operator says “release”, immediately do this preflight (no extra qu
 - [ ] Bump `package.json` version (e.g., `2026.1.26`).
 - [ ] Run `pnpm plugins:sync` to align extension package versions + changelogs.
 - [ ] Update CLI/version strings: [`src/cli/program.ts`](https://github.com/moltbot/moltbot/blob/main/src/cli/program.ts) and the Baileys user agent in [`src/provider-web.ts`](https://github.com/moltbot/moltbot/blob/main/src/provider-web.ts).
-- [ ] Confirm package metadata (name, description, repository, keywords, license) and `bin` map points to [`dist/entry.js`](https://github.com/moltbot/moltbot/blob/main/dist/entry.js) for `moltbot`.
+- [ ] Confirm package metadata (name, description, repository, keywords, license) and `bin` map points to [`moltbot.mjs`](https://github.com/moltbot/moltbot/blob/main/moltbot.mjs) for `moltbot`.
 - [ ] If dependencies changed, run `pnpm install` so `pnpm-lock.yaml` is current.
 
 2) **Build & artifacts**

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -180,7 +180,7 @@ If you don’t have a global install yet, run the onboarding step via `pnpm molt
 Gateway (from this repo):
 
 ```bash
-node dist/entry.js gateway --port 18789 --verbose
+node moltbot.mjs gateway --port 18789 --verbose
 ```
 
 ## 7) Verify end-to-end

--- a/moltbot.mjs
+++ b/moltbot.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import module from "node:module";
+
+// https://nodejs.org/api/module.html#module-compile-cache
+if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    module.enableCompileCache();
+  } catch {
+    // Ignore errors
+  }
+}
+
+await import("../dist/entry.js");

--- a/moltbot.mjs
+++ b/moltbot.mjs
@@ -11,4 +11,4 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   }
 }
 
-await import("../dist/entry.js");
+await import("./dist/entry.js");

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "./cli-entry": "./dist/entry.js"
   },
   "bin": {
-    "moltbot": "dist/entry.js",
-    "clawdbot": "dist/entry.js"
+    "moltbot": "./moltbot.mjs",
+    "clawdbot": "./moltbot.mjs"
   },
   "files": [
     "dist/acp/**",
@@ -56,6 +56,7 @@
     "docs/**",
     "extensions/**",
     "assets/**",
+    "moltbot.mjs",
     "skills/**",
     "patches/**",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ".": "./dist/index.js",
     "./plugin-sdk": "./dist/plugin-sdk/index.js",
     "./plugin-sdk/*": "./dist/plugin-sdk/*",
-    "./cli-entry": "./dist/entry.js"
+    "./cli-entry": "./moltbot.mjs"
   },
   "bin": {
     "moltbot": "./moltbot.mjs",

--- a/scripts/e2e/doctor-install-switch-docker.sh
+++ b/scripts/e2e/doctor-install-switch-docker.sh
@@ -81,8 +81,8 @@ LOGINCTL
   npm install -g --prefix /tmp/npm-prefix "/app/$pkg_tgz"
 
   npm_bin="/tmp/npm-prefix/bin/moltbot"
-  npm_entry="/tmp/npm-prefix/lib/node_modules/moltbot/dist/entry.js"
-  git_entry="/app/dist/entry.js"
+  npm_entry="/tmp/npm-prefix/lib/node_modules/moltbot/moltbot.mjs"
+  git_entry="/app/moltbot.mjs"
 
   assert_entrypoint() {
     local unit_path="$1"

--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -96,8 +96,8 @@ for arg in "$@"; do
       log "  CLAWDBOT_GATEWAY_WAIT_SECONDS=0  Wait time before gateway port check (unsigned only)"
       log ""
       log "Unsigned recovery:"
-      log "  node dist/entry.js daemon install --force --runtime node"
-      log "  node dist/entry.js daemon restart"
+      log "  node moltbot.mjs daemon install --force --runtime node"
+      log "  node moltbot.mjs daemon restart"
       log ""
       log "Reset unsigned overrides:"
       log "  rm ~/.clawdbot/disable-launchagent"
@@ -217,8 +217,8 @@ fi
 # When unsigned, ensure the gateway LaunchAgent targets the repo CLI (before the app launches).
 # This reduces noisy "could not connect" errors during app startup.
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node dist/entry.js daemon install --force --runtime node"
-  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node dist/entry.js daemon restart"
+  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node moltbot.mjs daemon install --force --runtime node"
+  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node moltbot.mjs daemon restart"
   if [[ "${GATEWAY_WAIT_SECONDS}" -gt 0 ]]; then
     run_step "wait for gateway (unsigned)" sleep "${GATEWAY_WAIT_SECONDS}"
   fi

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -86,7 +86,7 @@ const logRunner = (message) => {
 };
 
 const runNode = () => {
-  const nodeProcess = spawn(process.execPath, ["dist/entry.js", ...args], {
+  const nodeProcess = spawn(process.execPath, ["moltbot.mjs", ...args], {
     cwd,
     env,
     stdio: "inherit",
@@ -95,7 +95,6 @@ const runNode = () => {
   nodeProcess.on("exit", (exitCode, exitSignal) => {
     if (exitSignal) {
       process.exit(1);
-      return;
     }
     process.exit(exitCode ?? 1);
   });
@@ -128,11 +127,9 @@ if (!shouldBuild()) {
   build.on("exit", (code, signal) => {
     if (signal) {
       process.exit(1);
-      return;
     }
     if (code !== 0 && code !== null) {
       process.exit(code);
-      return;
     }
     writeBuildStamp();
     runNode();

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -29,7 +29,7 @@ const compilerProcess = spawn("pnpm", ["exec", compiler, ...watchArgs], {
   stdio: "inherit",
 });
 
-const nodeProcess = spawn(process.execPath, ["--watch", "dist/entry.js", ...args], {
+const nodeProcess = spawn(process.execPath, ["--watch", "moltbot.mjs", ...args], {
   cwd,
   env,
   stdio: "inherit",

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -72,6 +72,7 @@ function isGatewayArgv(args: string[]): boolean {
     "dist/index.js",
     "dist/index.mjs",
     "dist/entry.js",
+    "moltbot.mjs",
     "dist/entry.mjs",
     "scripts/run-node.mjs",
     "src/index.ts",


### PR DESCRIPTION
(shamefully written by a human) This PR makes CLI startup time ~10% faster (tested on Node.js 25 on MBP M4) by leveraging on disk [module compile cache](https://nodejs.org/api/module.html#module-compile-cache)

Docs updated to recommand top level `./moltbot.mjs` (instead of `dist/entry.js`)

```
hyperfine "node ./moltbot.mjs --help" "node ./dist/entry.js --help"
Benchmark 1: node ./moltbot.mjs --help
  Time (mean ± σ):     747.7 ms ±   9.3 ms    [User: 730.0 ms, System: 224.2 ms]
  Range (min … max):   734.3 ms … 763.2 ms    10 runs
 
Benchmark 2: node ./dist/entry.js --help
  Time (mean ± σ):     824.1 ms ±   5.7 ms    [User: 874.6 ms, System: 163.8 ms]
  Range (min … max):   816.2 ms … 834.1 ms    10 runs
 
Summary
  node ./moltbot.mjs --help ran
    1.10 ± 0.02 times faster than node ./dist/entry.js --help
```

