### PR TITLE
feat(android): enable text selection on all chat message content

### DIFF
--- a/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatMarkdown.kt
@@ -36,25 +36,25 @@ fun ChatMarkdown(text: String, textColor: Color) {
   val blocks = remember(text) { splitMarkdown(text) }
   val inlineCodeBg = MaterialTheme.colorScheme.surfaceContainerLow
 
-  Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-    for (b in blocks) {
-      when (b) {
-        is ChatMarkdownBlock.Text -> {
-          val trimmed = b.text.trimEnd()
-          if (trimmed.isEmpty()) continue
-          Text(
-            text = parseInlineMarkdown(trimmed, inlineCodeBg = inlineCodeBg),
-            style = MaterialTheme.typography.bodyMedium,
-            color = textColor,
-          )
-        }
-        is ChatMarkdownBlock.Code -> {
-          SelectionContainer(modifier = Modifier.fillMaxWidth()) {
+  SelectionContainer {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      for (b in blocks) {
+        when (b) {
+          is ChatMarkdownBlock.Text -> {
+            val trimmed = b.text.trimEnd()
+            if (trimmed.isEmpty()) continue
+            Text(
+              text = parseInlineMarkdown(trimmed, inlineCodeBg = inlineCodeBg),
+              style = MaterialTheme.typography.bodyMedium,
+              color = textColor,
+            )
+          }
+          is ChatMarkdownBlock.Code -> {
             ChatCodeBlock(code = b.code, language = b.language)
           }
-        }
-        is ChatMarkdownBlock.InlineImage -> {
-          InlineBase64Image(base64 = b.base64, mimeType = b.mimeType)
+          is ChatMarkdownBlock.InlineImage -> {
+            InlineBase64Image(base64 = b.base64, mimeType = b.mimeType)
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
Enable text selection for all text content in Android chat messages, matching iOS behavior.

## Problem
Previously, only code blocks wrapped in `SelectionContainer` were selectable. Regular text and inline code could not be selected or copied, which was frustrating for users who wanted to copy parts of a response.

## Solution
Wrap the entire `ChatMarkdown` composable content in a single `SelectionContainer`, allowing users to select and copy:
- Regular markdown text
- Inline code
- Code blocks

This matches the iOS implementation which uses `.textSelection(.enabled)` on the message body.

## Changes
- `apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatMarkdown.kt`: Move `SelectionContainer` to wrap the entire `Column` instead of just code blocks.

## Testing
- Long-press on any text in a chat message → should show text selection handles
- Select and copy text from both regular text and code blocks