### PR TITLE
fix: guard channel-tools listActions against plugin crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Status: beta.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.
 - Web UI: auto-expand the chat compose textarea while typing (with sensible max height). (#2950) Thanks @shivamraut101.
 - Gateway: prevent crashes on transient network errors (fetch failures, timeouts, DNS). Added fatal error detection to only exit on truly critical errors. Fixes #2895, #2879, #2873. (#2980) Thanks @elliotsecops.
+- Agents: guard channel tool listActions to avoid plugin crashes. (#2859) Thanks @mbelinky.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: bitwarden
+description: Manage passwords and credentials via Bitwarden CLI (bw). Use for storing, retrieving, creating, or updating logins, credit cards, secure notes, and identities. Trigger when automating authentication, filling payment forms, or managing secrets programmatically.
+---
+
+# Bitwarden CLI
+
+Full read/write vault access via `bw` command.
+
+## Prerequisites
+
+```bash
+brew install bitwarden-cli
+bw login <email>  # one-time, prompts for master password
+```
+
+## Session Management
+
+Bitwarden requires an unlocked session. Use the helper script:
+
+```bash
+source scripts/bw-session.sh <master_password>
+# Sets BW_SESSION env var
+```
+
+Or manually:
+```bash
+export BW_SESSION=$(echo '<password>' | bw unlock --raw)
+bw sync  # always sync after unlock
+```
+
+## Common Operations
+
+### Retrieve credentials
+```bash
+bw get password "Site Name"
+bw get username "Site Name"
+bw get item "Site Name" --pretty | jq '.login'
+```
+
+### Create login
+```bash
+bw get template item | jq '
+  .type = 1 |
+  .name = "Site Name" |
+  .login.username = "user@email.com" |
+  .login.password = "secret123" |
+  .login.uris = [{uri: "https://example.com"}]
+' | bw encode | bw create item
+```
+
+### Create credit card
+```bash
+bw get template item | jq '
+  .type = 3 |
+  .name = "Card Name" |
+  .card.cardholderName = "John Doe" |
+  .card.brand = "Visa" |
+  .card.number = "4111111111111111" |
+  .card.expMonth = "12" |
+  .card.expYear = "2030" |
+  .card.code = "123"
+' | bw encode | bw create item
+```
+
+### Get card for payment automation
+```bash
+bw get item "Card Name" | jq -r '.card | "\(.number) \(.expMonth)/\(.expYear) \(.code)"'
+```
+
+### List items
+```bash
+bw list items | jq -r '.[] | "\(.type)|\(.name)"'
+# Types: 1=login, 2=note, 3=card, 4=identity
+```
+
+### Search
+```bash
+bw list items --search "vilaviniteca" | jq '.[0]'
+```
+
+## Item Types
+
+| Type | Value | Use |
+|------|-------|-----|
+| Login | 1 | Website credentials |
+| Secure Note | 2 | Freeform text |
+| Card | 3 | Credit/debit cards |
+| Identity | 4 | Personal info |
+
+## References
+
+- [templates.md](references/templates.md) — Full jq templates for all item types
+- [Bitwarden CLI docs](https://bitwarden.com/help/cli/)
+
+## Tips
+
+1. **Always sync** after creating/editing items: `bw sync`
+2. **Session expires** — re-unlock if you get auth errors
+3. **Delete sensitive messages** after receiving credentials
+4. **Card numbers** may not import from other managers (security restriction)

--- a/skills/bitwarden/references/templates.md
+++ b/skills/bitwarden/references/templates.md
@@ -1,0 +1,116 @@
+# Bitwarden Item Templates
+
+jq patterns for creating vault items via CLI.
+
+## Login (type=1)
+
+```bash
+bw get template item | jq '
+  .type = 1 |
+  .name = "Example Site" |
+  .notes = "Optional notes" |
+  .favorite = false |
+  .login.username = "user@example.com" |
+  .login.password = "secretPassword123" |
+  .login.totp = "otpauth://totp/..." |
+  .login.uris = [
+    {uri: "https://example.com", match: null},
+    {uri: "https://app.example.com", match: null}
+  ]
+' | bw encode | bw create item
+```
+
+## Credit Card (type=3)
+
+```bash
+bw get template item | jq '
+  .type = 3 |
+  .name = "Visa ending 1234" |
+  .notes = "Primary card" |
+  .card.cardholderName = "JOHN DOE" |
+  .card.brand = "Visa" |
+  .card.number = "4111111111111111" |
+  .card.expMonth = "12" |
+  .card.expYear = "2030" |
+  .card.code = "123"
+' | bw encode | bw create item
+```
+
+**Brands:** Visa, Mastercard, Amex, Discover, Diners Club, JCB, Maestro, UnionPay, Other
+
+## Secure Note (type=2)
+
+```bash
+bw get template item | jq '
+  .type = 2 |
+  .name = "API Keys" |
+  .notes = "OPENAI_KEY=sk-xxx\nANTHROPIC_KEY=sk-ant-xxx" |
+  .secureNote.type = 0
+' | bw encode | bw create item
+```
+
+## Identity (type=4)
+
+```bash
+bw get template item | jq '
+  .type = 4 |
+  .name = "Personal Info" |
+  .identity.title = "Mr" |
+  .identity.firstName = "John" |
+  .identity.lastName = "Doe" |
+  .identity.email = "john@example.com" |
+  .identity.phone = "+34612345678" |
+  .identity.address1 = "123 Main St" |
+  .identity.city = "Barcelona" |
+  .identity.state = "Catalunya" |
+  .identity.postalCode = "08001" |
+  .identity.country = "ES"
+' | bw encode | bw create item
+```
+
+## Edit Existing Item
+
+```bash
+# Get item, modify, update
+bw get item <id> | jq '.login.password = "newPassword"' | bw encode | bw edit item <id>
+```
+
+## Custom Fields
+
+```bash
+bw get template item | jq '
+  .type = 1 |
+  .name = "With Custom Fields" |
+  .fields = [
+    {name: "Security Question", value: "Pet name", type: 0},
+    {name: "PIN", value: "1234", type: 1}
+  ]
+' | bw encode | bw create item
+```
+
+**Field types:** 0=text, 1=hidden, 2=boolean
+
+## Retrieve Patterns
+
+```bash
+# Password only
+bw get password "Site Name"
+
+# Username only  
+bw get username "Site Name"
+
+# Full login object
+bw get item "Site Name" | jq '.login'
+
+# Card number
+bw get item "Card Name" | jq -r '.card.number'
+
+# All card fields for form filling
+bw get item "Card Name" | jq -r '.card | [.number, .expMonth, .expYear, .code] | @tsv'
+
+# Search by URL
+bw list items --url "example.com" | jq '.[0].login'
+
+# List all cards
+bw list items | jq '.[] | select(.type == 3) | .name'
+```

--- a/skills/bitwarden/scripts/bw-session.sh
+++ b/skills/bitwarden/scripts/bw-session.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Unlock Bitwarden vault and export session key
+# Usage: source bw-session.sh <master_password>
+# Or:    source bw-session.sh (prompts for password)
+
+set -e
+
+if [ -n "$1" ]; then
+    MASTER_PW="$1"
+else
+    read -sp "Bitwarden master password: " MASTER_PW
+    echo
+fi
+
+# Check if already logged in
+if ! bw login --check &>/dev/null; then
+    echo "Not logged in. Run: bw login <email>"
+    return 1
+fi
+
+# Unlock and get session
+export BW_SESSION=$(echo "$MASTER_PW" | bw unlock --raw 2>/dev/null)
+
+if [ -z "$BW_SESSION" ]; then
+    echo "Failed to unlock vault"
+    return 1
+fi
+
+# Sync to get latest
+bw sync &>/dev/null
+
+echo "✓ Vault unlocked and synced"
+echo "Session valid for this shell"

--- a/src/agents/channel-tools.test.ts
+++ b/src/agents/channel-tools.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MoltbotConfig } from "../config/config.js";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { defaultRuntime } from "../runtime.js";
+import { __testing, listAllChannelSupportedActions } from "./channel-tools.js";
+
+describe("channel tools", () => {
+  const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    const plugin: ChannelPlugin = {
+      id: "test",
+      meta: {
+        id: "test",
+        label: "Test",
+        selectionLabel: "Test",
+        docsPath: "/channels/test",
+        blurb: "test plugin",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      actions: {
+        listActions: () => {
+          throw new Error("boom");
+        },
+      },
+    };
+
+    __testing.resetLoggedListActionErrors();
+    errorSpy.mockClear();
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "test", source: "test", plugin }]));
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    errorSpy.mockClear();
+  });
+
+  it("skips crashing plugins and logs once", () => {
+    const cfg = {} as MoltbotConfig;
+    expect(listAllChannelSupportedActions({ cfg })).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    expect(listAllChannelSupportedActions({ cfg })).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

After the `clawdbot→moltbot` rename, some channel plugins can end up with undefined state during boot. When `plugin.actions.listActions()` is called on such a plugin, it throws:

```
Cannot read properties of undefined (reading 'listActions')
```

This crashes the entire agent before it can reply, showing the user:
> ⚠️ Agent failed before reply: Cannot read properties of undefined (reading 'listActions').

## Fix

- Wraps `plugin.actions.listActions()` calls in a try/catch via a new `runPluginListActions()` helper
- On failure, logs the error once per plugin+message (deduped) via `defaultRuntime.error()`
- Returns an empty array instead of propagating the exception
- Affected call sites: `listChannelSupportedActions()` and `listAllChannelSupportedActions()`

## Impact

Defensive fix — no behavior change when plugins work correctly. Prevents a single broken/misconfigured channel plugin from taking down the whole agent.