### PR TITLE
fix: set WorkingDirectory in systemd service for control UI assets

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -63,6 +63,10 @@ describe("resolveGatewayProgramArguments", () => {
     // Should use the symlinked path, not the realpath-resolved versioned path
     expect(result.programArguments[1]).toBe(symlinkPath);
     expect(result.programArguments[1]).not.toContain("@2026.1.21-2");
+    // workingDirectory should point to the symlinked package root
+    expect(result.workingDirectory).toBe(
+      path.resolve("/Users/test/Library/pnpm/global/5/node_modules/moltbot"),
+    );
   });
 
   it("falls back to node_modules package dist when .bin path is not resolved", async () => {
@@ -86,5 +90,41 @@ describe("resolveGatewayProgramArguments", () => {
       "--port",
       "18789",
     ]);
+  });
+
+  it("sets workingDirectory to parent of dist for standard entrypoint", async () => {
+    const entryPath = path.resolve("/opt/moltbot/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    expect(result.workingDirectory).toBe(path.resolve("/opt/moltbot"));
+  });
+
+  it("sets correct workingDirectory when 'dist' appears earlier in path", async () => {
+    // e.g. /mnt/distcache/apps/moltbot/dist/entry.js — "dist" in the path
+    // but only the immediate parent "dist" segment should be used
+    const entryPath = path.resolve("/mnt/distcache/apps/moltbot/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    expect(result.workingDirectory).toBe(path.resolve("/mnt/distcache/apps/moltbot"));
+  });
+
+  it("returns undefined workingDirectory when entry is not directly under dist/", async () => {
+    // e.g. /opt/moltbot/dist/subdir/entry.js — dist is not the immediate parent
+    const entryPath = path.resolve("/opt/moltbot/dist/subdir/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    expect(result.workingDirectory).toBeUndefined();
   });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -68,6 +68,20 @@ async function resolveRealpathSafe(inputPath: string): Promise<string> {
   }
 }
 
+/**
+ * Derive working directory from a dist entrypoint path.
+ * E.g., /path/to/moltbot/dist/entry.js -> /path/to/moltbot
+ */
+function resolveWorkingDirectoryFromEntrypoint(entrypointPath: string): string | undefined {
+  const dir = path.dirname(entrypointPath);
+  const parts = dir.split(path.sep);
+  const distIndex = parts.lastIndexOf("dist");
+  if (distIndex > 0) {
+    return parts.slice(0, distIndex).join(path.sep);
+  }
+  return undefined;
+}
+
 function buildDistCandidates(...inputs: string[]): string[] {
   const candidates: string[] = [];
   const seen = new Set<string>();
@@ -167,6 +181,7 @@ async function resolveCliProgramArguments(params: {
     const cliEntrypointPath = await resolveCliEntrypointPathForService();
     return {
       programArguments: [nodePath, cliEntrypointPath, ...params.args],
+      workingDirectory: resolveWorkingDirectoryFromEntrypoint(cliEntrypointPath),
     };
   }
 
@@ -186,6 +201,7 @@ async function resolveCliProgramArguments(params: {
     const cliEntrypointPath = await resolveCliEntrypointPathForService();
     return {
       programArguments: [bunPath, cliEntrypointPath, ...params.args],
+      workingDirectory: resolveWorkingDirectoryFromEntrypoint(cliEntrypointPath),
     };
   }
 
@@ -194,6 +210,7 @@ async function resolveCliProgramArguments(params: {
       const cliEntrypointPath = await resolveCliEntrypointPathForService();
       return {
         programArguments: [execPath, cliEntrypointPath, ...params.args],
+        workingDirectory: resolveWorkingDirectoryFromEntrypoint(cliEntrypointPath),
       };
     } catch (error) {
       // If running under bun or another runtime that can execute TS directly

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -70,16 +70,18 @@ async function resolveRealpathSafe(inputPath: string): Promise<string> {
 
 /**
  * Derive working directory from a dist entrypoint path.
- * E.g., /path/to/moltbot/dist/entry.js -> /path/to/moltbot
+ * Only matches when "dist" is the **immediate** parent directory of the
+ * entry file (e.g. `/path/to/moltbot/dist/entry.js` → `/path/to/moltbot`).
+ * Paths where "dist" appears elsewhere (e.g. `/mnt/distcache/...`) are
+ * correctly ignored.
  */
 function resolveWorkingDirectoryFromEntrypoint(entrypointPath: string): string | undefined {
   const dir = path.dirname(entrypointPath);
-  const parts = dir.split(path.sep);
-  const distIndex = parts.lastIndexOf("dist");
-  if (distIndex > 0) {
-    return parts.slice(0, distIndex).join(path.sep);
+  if (path.basename(dir) !== "dist") {
+    return undefined;
   }
-  return undefined;
+  const parent = path.dirname(dir);
+  return parent && parent !== dir ? parent : undefined;
 }
 
 function buildDistCandidates(...inputs: string[]): string[] {


### PR DESCRIPTION
## Summary
- Fixes control UI failing with "Control UI assets not found" when gateway runs via systemd
- The systemd service was generated without WorkingDirectory, causing cwd to be user's home directory
- Now derives workingDirectory from the CLI entrypoint path for all production runtimes

## Test plan
- [x] Run `moltbot gateway install` and verify service file contains `WorkingDirectory`
- [x] Restart gateway and verify control UI loads at `http://127.0.0.1:18789/`
- [x] Run `moltbot doctor --repair` and verify WorkingDirectory persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates gateway service argument resolution to also compute a `workingDirectory` for production runtimes (node/bun/auto) by deriving it from the built CLI entrypoint path under `dist/`. That working directory then propagates into systemd unit generation so the gateway runs with a predictable CWD and can find Control UI assets (which otherwise may fall back to `process.cwd()`).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it adds a straightforward working-directory derivation for service generation.
- Change scope is small and localized to service argument construction; behavior is additive and gated to production/runtime service paths. Main residual concern is edge-case path parsing when `dist` appears multiple times in the entrypoint path, which could mis-derive the directory in uncommonLine layouts.
- src/daemon/program-args.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->