### PR TITLE
fix: correct parameter order in ClawdbotKit Package.swift

### DIFF
--- a/apps/shared/ClawdbotKit/Package.swift
+++ b/apps/shared/ClawdbotKit/Package.swift
@@ -26,11 +26,11 @@ let package = Package(
             ]),
         .target(
             name: "MoltbotKit",
-            path: "Sources/ClawdbotKit",
             dependencies: [
                 "MoltbotProtocol",
                 .product(name: "ElevenLabsKit", package: "ElevenLabsKit"),
             ],
+            path: "Sources/ClawdbotKit",
             resources: [
                 .process("Resources"),
             ],
@@ -39,7 +39,6 @@ let package = Package(
             ]),
         .target(
             name: "MoltbotChatUI",
-            path: "Sources/ClawdbotChatUI",
             dependencies: [
                 "MoltbotKit",
                 .product(
@@ -47,6 +46,7 @@ let package = Package(
                     package: "textual",
                     condition: .when(platforms: [.macOS, .iOS])),
             ],
+            path: "Sources/ClawdbotChatUI",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),


### PR DESCRIPTION
## Summary
- Fixed parameter ordering in `Package.swift` target definitions
- Moved `path:` parameter to come after `dependencies:` for MoltbotKit and MoltbotChatUI targets

## Context
Swift Package Manager expects target parameters in a specific order. The `path:` parameter should come after `dependencies:`.

## Test plan
- [ ] Verify Package.swift builds correctly
- [ ] Check that the package resolves dependencies properly