### PR TITLE
fix: prevent infinite retry loop for images exceeding 5MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Status: unreleased.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.
 - Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -31,6 +31,7 @@ describe("classifyFailoverReason", () => {
         "messages.84.content.1.image.source.base64.data: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels",
       ),
     ).toBeNull();
+    expect(classifyFailoverReason("image exceeds 5 MB maximum")).toBeNull();
   });
   it("classifies OpenAI usage limit errors as rate_limit", () => {
     expect(classifyFailoverReason("You have hit your ChatGPT usage limit (plus plan)")).toBe(

--- a/src/agents/pi-embedded-helpers.image-size-error.test.ts
+++ b/src/agents/pi-embedded-helpers.image-size-error.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { parseImageSizeError } from "./pi-embedded-helpers.js";
+
+describe("parseImageSizeError", () => {
+  it("parses max MB values from error text", () => {
+    expect(parseImageSizeError("image exceeds 5 MB maximum")?.maxMb).toBe(5);
+    expect(parseImageSizeError("Image exceeds 5.5 MB limit")?.maxMb).toBe(5.5);
+  });
+
+  it("returns null for unrelated errors", () => {
+    expect(parseImageSizeError("context overflow")).toBeNull();
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -30,6 +30,7 @@ export {
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
   parseImageDimensionError,
+  parseImageSizeError,
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -23,6 +23,7 @@ export {
   isFailoverAssistantError,
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
+  isImageSizeError,
   isOverloadedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -401,6 +401,7 @@ const ERROR_PATTERNS = {
 const IMAGE_DIMENSION_ERROR_RE =
   /image dimensions exceed max allowed size for many-image requests:\s*(\d+)\s*pixels/i;
 const IMAGE_DIMENSION_PATH_RE = /messages\.(\d+)\.content\.(\d+)\.image/i;
+const IMAGE_SIZE_ERROR_RE = /image exceeds\s*(\d+(?:\.\d+)?)\s*mb/i;
 
 function matchesErrorPatterns(raw: string, patterns: readonly ErrorPattern[]): boolean {
   if (!raw) return false;
@@ -467,10 +468,23 @@ export function isImageDimensionErrorMessage(raw: string): boolean {
   return Boolean(parseImageDimensionError(raw));
 }
 
+export function parseImageSizeError(raw: string): {
+  maxMb?: number;
+  raw: string;
+} | null {
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  if (!lower.includes("image exceeds") || !lower.includes("mb")) return null;
+  const match = raw.match(IMAGE_SIZE_ERROR_RE);
+  return {
+    maxMb: match?.[1] ? Number.parseFloat(match[1]) : undefined,
+    raw,
+  };
+}
+
 export function isImageSizeError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
-  const lower = errorMessage.toLowerCase();
-  return lower.includes("image exceeds") && lower.includes("mb");
+  return Boolean(parseImageSizeError(errorMessage));
 }
 
 export function isCloudCodeAssistFormatError(raw: string): boolean {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -467,6 +467,12 @@ export function isImageDimensionErrorMessage(raw: string): boolean {
   return Boolean(parseImageDimensionError(raw));
 }
 
+export function isImageSizeError(errorMessage?: string): boolean {
+  if (!errorMessage) return false;
+  const lower = errorMessage.toLowerCase();
+  return lower.includes("image exceeds") && lower.includes("mb");
+}
+
 export function isCloudCodeAssistFormatError(raw: string): boolean {
   return !isImageDimensionErrorMessage(raw) && matchesErrorPatterns(raw, ERROR_PATTERNS.format);
 }
@@ -478,6 +484,7 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
 
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) return null;
+  if (isImageSizeError(raw)) return null;
   if (isRateLimitErrorMessage(raw)) return "rate_limit";
   if (isOverloadedErrorMessage(raw)) return "rate_limit";
   if (isCloudCodeAssistFormatError(raw)) return "format";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -34,7 +34,7 @@ import {
   isContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
-  isImageSizeError,
+  parseImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
   isTimeoutErrorMessage,
@@ -442,12 +442,17 @@ export async function runEmbeddedPiAgent(
               };
             }
             // Handle image size errors with a user-friendly message (no retry needed)
-            if (isImageSizeError(errorText)) {
+            const imageSizeError = parseImageSizeError(errorText);
+            if (imageSizeError) {
+              const maxMb = imageSizeError.maxMb;
+              const maxMbLabel =
+                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
               return {
                 payloads: [
                   {
                     text:
-                      "Image too large for the model (max 5MB). " +
+                      `Image too large for the model${maxBytesHint}. ` +
                       "Please compress or resize the image and try again.",
                     isError: true,
                   },

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -34,6 +34,7 @@ import {
   isContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
   isTimeoutErrorMessage,
@@ -437,6 +438,29 @@ export async function runEmbeddedPiAgent(
                   },
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "role_ordering", message: errorText },
+                },
+              };
+            }
+            // Handle image size errors with a user-friendly message (no retry needed)
+            if (isImageSizeError(errorText)) {
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Image too large for the model (max 5MB). " +
+                      "Please compress or resize the image and try again.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: {
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                  },
+                  systemPromptReport: attempt.systemPromptReport,
+                  error: { kind: "image_size", message: errorText },
                 },
               };
             }

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -20,7 +20,7 @@ export type EmbeddedPiRunMeta = {
   aborted?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   error?: {
-    kind: "context_overflow" | "compaction_failure" | "role_ordering";
+    kind: "context_overflow" | "compaction_failure" | "role_ordering" | "image_size";
     message: string;
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -1,4 +1,4 @@
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB (Anthropic API limit)
+export const MAX_IMAGE_BYTES = 6 * 1024 * 1024; // 6MB
 export const MAX_AUDIO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_VIDEO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_DOCUMENT_BYTES = 100 * 1024 * 1024; // 100MB

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -1,4 +1,4 @@
-export const MAX_IMAGE_BYTES = 6 * 1024 * 1024; // 6MB
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB (Anthropic API limit)
 export const MAX_AUDIO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_VIDEO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_DOCUMENT_BYTES = 100 * 1024 * 1024; // 100MB


### PR DESCRIPTION
## Summary

Fixes #2271 - Images >5MB cause infinite retry loop and block session completely.

## Problem

When a user sends an image larger than 5MB:
1. The image gets stored in session context
2. Anthropic API rejects it with "image exceeds 5 MB maximum"
3. The error wasn't classified as non-retriable, causing infinite retry
4. Session becomes completely blocked

## Solution

1. Align `MAX_IMAGE_BYTES` constant with Anthropic's actual 5MB limit (was incorrectly set to 6MB)
2. Detect image size errors and return a user-friendly message instead of retrying
3. Prevent failover for image size errors since they're not retriable