### PR TITLE
fix: avoid daemon runtime prompt under spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Status: unreleased.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.
 - Security: properly test Windows ACL audit for config includes. (#2403) Thanks @dominicnunez.
 - CLI: recognize versioned Node executables when parsing argv. (#2490) Thanks @David-Marsh-Photo.
+- CLI: avoid prompting for gateway runtime under the spinner. (#2874)
 - BlueBubbles: coalesce inbound URL link preview messages. (#1981) Thanks @tyler6204.
 - Cron: allow payloads containing "heartbeat" in event filter. (#2219) Thanks @dwfinkelstein.
 - CLI: avoid loading config for global help/version while registering plugin commands. (#2212) Thanks @dial481.

--- a/src/commands/configure.daemon.ts
+++ b/src/commands/configure.daemon.ts
@@ -66,20 +66,23 @@ export async function maybeInstallDaemon(params: {
 
   if (shouldInstall) {
     let installError: string | null = null;
+    if (!params.daemonRuntime) {
+      if (GATEWAY_DAEMON_RUNTIME_OPTIONS.length === 1) {
+        daemonRuntime = GATEWAY_DAEMON_RUNTIME_OPTIONS[0]?.value ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
+      } else {
+        daemonRuntime = guardCancel(
+          await select({
+            message: "Gateway service runtime",
+            options: GATEWAY_DAEMON_RUNTIME_OPTIONS,
+            initialValue: DEFAULT_GATEWAY_DAEMON_RUNTIME,
+          }),
+          params.runtime,
+        ) as GatewayDaemonRuntime;
+      }
+    }
     await withProgress(
       { label: "Gateway service", indeterminate: true, delayMs: 0 },
       async (progress) => {
-        if (!params.daemonRuntime) {
-          daemonRuntime = guardCancel(
-            await select({
-              message: "Gateway service runtime",
-              options: GATEWAY_DAEMON_RUNTIME_OPTIONS,
-              initialValue: DEFAULT_GATEWAY_DAEMON_RUNTIME,
-            }),
-            params.runtime,
-          ) as GatewayDaemonRuntime;
-        }
-
         progress.setLabel("Preparing Gateway service…");
 
         const cfg = loadConfig();


### PR DESCRIPTION
Summary: move runtime selection outside progress spinner; auto-select Node when only option.