### PR TITLE
fix: Create memory directory and symlink identity files during workspace setup

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,8 +1,16 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
+  DEFAULT_MEMORY_DIR,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_USER_FILENAME,
+  ensureAgentWorkspace,
   loadWorkspaceBootstrapFiles,
 } from "./workspace.js";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
@@ -45,5 +53,64 @@ describe("loadWorkspaceBootstrapFiles", () => {
     );
 
     expect(memoryEntries).toHaveLength(0);
+  });
+});
+
+describe("ensureAgentWorkspace", () => {
+  it("creates memory directory with symlinks to identity files", async () => {
+    const tempDir = await makeTempWorkspace("moltbot-workspace-");
+
+    const result = await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+    });
+
+    // Check memory directory was created
+    expect(result.memoryDir).toBe(path.join(tempDir, DEFAULT_MEMORY_DIR));
+    const memoryDirStat = await fs.stat(result.memoryDir!);
+    expect(memoryDirStat.isDirectory()).toBe(true);
+
+    // Check symlinks exist in memory directory
+    const memoryFiles = await fs.readdir(result.memoryDir!);
+    expect(memoryFiles).toContain(DEFAULT_SOUL_FILENAME);
+    expect(memoryFiles).toContain(DEFAULT_USER_FILENAME);
+    expect(memoryFiles).toContain(DEFAULT_AGENTS_FILENAME);
+    expect(memoryFiles).toContain(DEFAULT_IDENTITY_FILENAME);
+
+    // Check symlinks point to correct files
+    const soulLink = await fs.readlink(path.join(result.memoryDir!, DEFAULT_SOUL_FILENAME));
+    expect(soulLink).toBe(`../${DEFAULT_SOUL_FILENAME}`);
+  });
+
+  it("does not create memory directory when ensureBootstrapFiles is false", async () => {
+    const tempDir = await makeTempWorkspace("moltbot-workspace-");
+
+    const result = await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: false,
+    });
+
+    expect(result.memoryDir).toBeUndefined();
+    const memoryDirPath = path.join(tempDir, DEFAULT_MEMORY_DIR);
+    await expect(fs.access(memoryDirPath)).rejects.toThrow();
+  });
+
+  it("does not overwrite existing files in memory directory", async () => {
+    const tempDir = await makeTempWorkspace("moltbot-workspace-");
+    const memoryDir = path.join(tempDir, DEFAULT_MEMORY_DIR);
+    await fs.mkdir(memoryDir, { recursive: true });
+
+    // Create an existing file in memory directory
+    const existingContent = "existing content";
+    await fs.writeFile(path.join(memoryDir, DEFAULT_SOUL_FILENAME), existingContent);
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+    });
+
+    // Check existing file was not overwritten
+    const content = await fs.readFile(path.join(memoryDir, DEFAULT_SOUL_FILENAME), "utf-8");
+    expect(content).toBe(existingContent);
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -28,6 +28,7 @@ export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
+export const DEFAULT_MEMORY_DIR = "memory";
 
 const TEMPLATE_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -120,6 +121,7 @@ export async function ensureAgentWorkspace(params?: {
   ensureBootstrapFiles?: boolean;
 }): Promise<{
   dir: string;
+  memoryDir?: string;
   agentsPath?: string;
   soulPath?: string;
   toolsPath?: string;
@@ -174,10 +176,39 @@ export async function ensureAgentWorkspace(params?: {
   if (isBrandNewWorkspace) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
+
+  // Ensure memory/ directory exists and symlink identity files for memory search indexing
+  const memoryDir = path.join(dir, DEFAULT_MEMORY_DIR);
+  await fs.mkdir(memoryDir, { recursive: true });
+
+  // Symlink identity files into memory/ so they are indexed by memory search
+  const identityFilesToSymlink = [
+    { source: soulPath, target: path.join(memoryDir, DEFAULT_SOUL_FILENAME) },
+    { source: userPath, target: path.join(memoryDir, DEFAULT_USER_FILENAME) },
+    { source: agentsPath, target: path.join(memoryDir, DEFAULT_AGENTS_FILENAME) },
+    { source: identityPath, target: path.join(memoryDir, DEFAULT_IDENTITY_FILENAME) },
+  ];
+
+  for (const { source, target } of identityFilesToSymlink) {
+    try {
+      await fs.access(target);
+      // Target already exists, skip
+    } catch {
+      // Target doesn't exist, create symlink
+      try {
+        const relativePath = path.relative(memoryDir, source);
+        await fs.symlink(relativePath, target);
+      } catch {
+        // Symlink creation failed (e.g., on Windows without privileges), skip silently
+      }
+    }
+  }
+
   await ensureGitRepo(dir, isBrandNewWorkspace);
 
   return {
     dir,
+    memoryDir,
     agentsPath,
     soulPath,
     toolsPath,


### PR DESCRIPTION
## Summary
- Creates `memory/` directory during workspace setup when `ensureBootstrapFiles` is true
- Symlinks identity files (SOUL.md, USER.md, AGENTS.md, IDENTITY.md) into `memory/` so they are indexed by memory search
- Gracefully handles symlink failures on Windows and preserves existing files

## Problem
The memory search system looks for files in `~/clawd/memory/` but workspace setup only created identity files at the workspace root. This caused:
- `clawdbot memory status` to report "no memory files found"
- The AI to incorrectly claim "I have no memories" despite having identity files
- Users having to manually create the `memory/` directory and copy/symlink files

## Solution
During `ensureAgentWorkspace()` with `ensureBootstrapFiles: true`:
1. Create `memory/` subdirectory
2. Symlink identity files into it so memory search can index them
3. Skip if files already exist (preserves user customizations)
4. Gracefully handle symlink failures (e.g., Windows without privileges)

## Test plan
- [x] Added unit tests for memory directory creation
- [x] Added test for symlink creation
- [x] Added test for not overwriting existing files
- [x] All 6 workspace tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates workspace bootstrapping (`src/agents/workspace.ts`) to create a `memory/` subdirectory during `ensureAgentWorkspace({ ensureBootstrapFiles: true })` and attempts to symlink the identity/bootstrap files (SOUL/USER/AGENTS/IDENTITY) into that directory so the memory search subsystem can index them. It also adds unit coverage in `src/agents/workspace.test.ts` for directory creation, symlink creation, and non-overwrite behavior.

Overall, the change aligns workspace setup with other parts of the codebase (e.g., the memory CLI and internal scanner) which look for `memory/` under the workspace directory. The main risks are around cross-platform symlink behavior and the fact that the new `memory/` directory is created unconditionally whenever `ensureBootstrapFiles` is enabled.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has cross-platform test fragility and some silent-failure behavior worth addressing.
- Core logic is straightforward (mkdir + best-effort symlinks) and scoped to workspace bootstrapping, but the new tests assume symlinks always work and the implementation suppresses all symlink-related errors, which can hide real failures and cause CI issues on Windows or restricted environments.
- src/agents/workspace.test.ts (symlink assertions on Windows), src/agents/workspace.ts (error swallowing / unconditional mkdir behavior)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->