### PR TITLE
fix(daemon): use correct service name for node install/uninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
       matrix:
         include:
           - task: test
-            command: pnpm test
+            command: pnpm canvas:a2ui:bundle && pnpm test
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,7 +18,7 @@ excluded:
   - coverage
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
-  - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  - apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
 
 analyzer_rules:
   - unused_declaration

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -73,7 +73,7 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
 }
 
 export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
-  return tools.map((tool) => {
+  return tools.map((tool): ToolDefinition => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
     return {
@@ -108,7 +108,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           });
         }
       },
-    } satisfies ToolDefinition;
+    };
   });
 }
 
@@ -119,7 +119,7 @@ export function toClientToolDefinitions(
   onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
   hookContext?: { agentId?: string; sessionKey?: string },
 ): ToolDefinition[] {
-  return tools.map((tool) => {
+  return tools.map((tool): ToolDefinition => {
     const func = tool.function;
     return {
       name: func.name,
@@ -151,6 +151,6 @@ export function toClientToolDefinitions(
           message: "Tool execution delegated to client",
         });
       },
-    } satisfies ToolDefinition;
+    };
   });
 }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -2,15 +2,15 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import type { GatewayServiceRuntime } from "./service-runtime.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import {
   formatGatewayServiceDescription,
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   resolveGatewaySystemdServiceName,
 } from "./constants.js";
-import { parseKeyValueOutput } from "./runtime-parse.js";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
 import { resolveHomeDir } from "./paths.js";
+import { parseKeyValueOutput } from "./runtime-parse.js";
 import {
   enableSystemdUserLinger,
   readSystemdUserLingerStatus,

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -39,11 +39,11 @@ function resolveSystemdUnitPathForName(
 }
 
 function resolveSystemdServiceName(env: Record<string, string | undefined>): string {
-  const override = env.CLAWDBOT_SYSTEMD_UNIT?.trim();
+  const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
   if (override) {
     return override.endsWith(".service") ? override.slice(0, -".service".length) : override;
   }
-  return resolveGatewaySystemdServiceName(env.CLAWDBOT_PROFILE);
+  return resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
 }
 
 function resolveSystemdUnitPath(env: Record<string, string | undefined>): string {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -75,7 +75,9 @@ export async function readSystemdServiceExecStart(
     const environment: Record<string, string> = {};
     for (const rawLine of content.split("\n")) {
       const line = rawLine.trim();
-      if (!line || line.startsWith("#")) continue;
+      if (!line || line.startsWith("#")) {
+        continue;
+      }
       if (line.startsWith("ExecStart=")) {
         execStart = line.slice("ExecStart=".length).trim();
       } else if (line.startsWith("WorkingDirectory=")) {
@@ -83,10 +85,14 @@ export async function readSystemdServiceExecStart(
       } else if (line.startsWith("Environment=")) {
         const raw = line.slice("Environment=".length).trim();
         const parsed = parseSystemdEnvAssignment(raw);
-        if (parsed) environment[parsed.key] = parsed.value;
+        if (parsed) {
+          environment[parsed.key] = parsed.value;
+        }
       }
     }
-    if (!execStart) return null;
+    if (!execStart) {
+      return null;
+    }
     const programArguments = parseSystemdExecStart(execStart);
     return {
       programArguments,
@@ -111,21 +117,31 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   const entries = parseKeyValueOutput(output, "=");
   const info: SystemdServiceInfo = {};
   const activeState = entries.activestate;
-  if (activeState) info.activeState = activeState;
+  if (activeState) {
+    info.activeState = activeState;
+  }
   const subState = entries.substate;
-  if (subState) info.subState = subState;
+  if (subState) {
+    info.subState = subState;
+  }
   const mainPidValue = entries.mainpid;
   if (mainPidValue) {
     const pid = Number.parseInt(mainPidValue, 10);
-    if (Number.isFinite(pid) && pid > 0) info.mainPid = pid;
+    if (Number.isFinite(pid) && pid > 0) {
+      info.mainPid = pid;
+    }
   }
   const execMainStatusValue = entries.execmainstatus;
   if (execMainStatusValue) {
     const status = Number.parseInt(execMainStatusValue, 10);
-    if (Number.isFinite(status)) info.execMainStatus = status;
+    if (Number.isFinite(status)) {
+      info.execMainStatus = status;
+    }
   }
   const execMainCode = entries.execmaincode;
-  if (execMainCode) info.execMainCode = execMainCode;
+  if (execMainCode) {
+    info.execMainCode = execMainCode;
+  }
   return info;
 }
 
@@ -159,20 +175,36 @@ async function execSystemctl(
 
 export async function isSystemdUserServiceAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) return true;
+  if (res.code === 0) {
+    return true;
+  }
   const detail = `${res.stderr} ${res.stdout}`.toLowerCase();
-  if (!detail) return false;
-  if (detail.includes("not found")) return false;
-  if (detail.includes("failed to connect")) return false;
-  if (detail.includes("not been booted")) return false;
-  if (detail.includes("no such file or directory")) return false;
-  if (detail.includes("not supported")) return false;
+  if (!detail) {
+    return false;
+  }
+  if (detail.includes("not found")) {
+    return false;
+  }
+  if (detail.includes("failed to connect")) {
+    return false;
+  }
+  if (detail.includes("not been booted")) {
+    return false;
+  }
+  if (detail.includes("no such file or directory")) {
+    return false;
+  }
+  if (detail.includes("not supported")) {
+    return false;
+  }
   return false;
 }
 
 async function assertSystemdAvailable() {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) return;
+  if (res.code === 0) {
+    return;
+  }
   const detail = res.stderr || res.stdout;
   if (detail.toLowerCase().includes("not found")) {
     throw new Error("systemctl not available; systemd user services are required on Linux.");
@@ -202,8 +234,8 @@ export async function installSystemdService({
   const serviceDescription =
     description ??
     formatGatewayServiceDescription({
-      profile: env.CLAWDBOT_PROFILE,
-      version: environment?.CLAWDBOT_SERVICE_VERSION ?? env.CLAWDBOT_SERVICE_VERSION,
+      profile: env.OPENCLAW_PROFILE,
+      version: environment?.OPENCLAW_SERVICE_VERSION ?? env.OPENCLAW_SERVICE_VERSION,
     });
   const unit = buildSystemdUnit({
     description: serviceDescription,
@@ -352,8 +384,10 @@ export type LegacySystemdUnit = {
 
 async function isSystemctlAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) return true;
-  const detail = `${res.stderr || res.stdout}`.toLowerCase();
+  if (res.code === 0) {
+    return true;
+  }
+  const detail = (res.stderr || res.stdout).toLowerCase();
   return !detail.includes("not found");
 }
 
@@ -391,7 +425,9 @@ export async function uninstallLegacySystemdUnits({
   stdout: NodeJS.WritableStream;
 }): Promise<LegacySystemdUnit[]> {
   const units = await findLegacySystemdUnits(env);
-  if (units.length === 0) return units;
+  if (units.length === 0) {
+    return units;
+  }
 
   const systemctlAvailable = await isSystemctlAvailable();
   for (const unit of units) {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -2,15 +2,15 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import {
   formatGatewayServiceDescription,
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   resolveGatewaySystemdServiceName,
 } from "./constants.js";
-import { resolveHomeDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
+import type { GatewayServiceRuntime } from "./service-runtime.js";
+import { resolveHomeDir } from "./paths.js";
 import {
   enableSystemdUserLinger,
   readSystemdUserLingerStatus,
@@ -39,11 +39,11 @@ function resolveSystemdUnitPathForName(
 }
 
 function resolveSystemdServiceName(env: Record<string, string | undefined>): string {
-  const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+  const override = env.CLAWDBOT_SYSTEMD_UNIT?.trim();
   if (override) {
     return override.endsWith(".service") ? override.slice(0, -".service".length) : override;
   }
-  return resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  return resolveGatewaySystemdServiceName(env.CLAWDBOT_PROFILE);
 }
 
 function resolveSystemdUnitPath(env: Record<string, string | undefined>): string {
@@ -75,9 +75,7 @@ export async function readSystemdServiceExecStart(
     const environment: Record<string, string> = {};
     for (const rawLine of content.split("\n")) {
       const line = rawLine.trim();
-      if (!line || line.startsWith("#")) {
-        continue;
-      }
+      if (!line || line.startsWith("#")) continue;
       if (line.startsWith("ExecStart=")) {
         execStart = line.slice("ExecStart=".length).trim();
       } else if (line.startsWith("WorkingDirectory=")) {
@@ -85,14 +83,10 @@ export async function readSystemdServiceExecStart(
       } else if (line.startsWith("Environment=")) {
         const raw = line.slice("Environment=".length).trim();
         const parsed = parseSystemdEnvAssignment(raw);
-        if (parsed) {
-          environment[parsed.key] = parsed.value;
-        }
+        if (parsed) environment[parsed.key] = parsed.value;
       }
     }
-    if (!execStart) {
-      return null;
-    }
+    if (!execStart) return null;
     const programArguments = parseSystemdExecStart(execStart);
     return {
       programArguments,
@@ -117,31 +111,21 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   const entries = parseKeyValueOutput(output, "=");
   const info: SystemdServiceInfo = {};
   const activeState = entries.activestate;
-  if (activeState) {
-    info.activeState = activeState;
-  }
+  if (activeState) info.activeState = activeState;
   const subState = entries.substate;
-  if (subState) {
-    info.subState = subState;
-  }
+  if (subState) info.subState = subState;
   const mainPidValue = entries.mainpid;
   if (mainPidValue) {
     const pid = Number.parseInt(mainPidValue, 10);
-    if (Number.isFinite(pid) && pid > 0) {
-      info.mainPid = pid;
-    }
+    if (Number.isFinite(pid) && pid > 0) info.mainPid = pid;
   }
   const execMainStatusValue = entries.execmainstatus;
   if (execMainStatusValue) {
     const status = Number.parseInt(execMainStatusValue, 10);
-    if (Number.isFinite(status)) {
-      info.execMainStatus = status;
-    }
+    if (Number.isFinite(status)) info.execMainStatus = status;
   }
   const execMainCode = entries.execmaincode;
-  if (execMainCode) {
-    info.execMainCode = execMainCode;
-  }
+  if (execMainCode) info.execMainCode = execMainCode;
   return info;
 }
 
@@ -175,36 +159,20 @@ async function execSystemctl(
 
 export async function isSystemdUserServiceAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) {
-    return true;
-  }
+  if (res.code === 0) return true;
   const detail = `${res.stderr} ${res.stdout}`.toLowerCase();
-  if (!detail) {
-    return false;
-  }
-  if (detail.includes("not found")) {
-    return false;
-  }
-  if (detail.includes("failed to connect")) {
-    return false;
-  }
-  if (detail.includes("not been booted")) {
-    return false;
-  }
-  if (detail.includes("no such file or directory")) {
-    return false;
-  }
-  if (detail.includes("not supported")) {
-    return false;
-  }
+  if (!detail) return false;
+  if (detail.includes("not found")) return false;
+  if (detail.includes("failed to connect")) return false;
+  if (detail.includes("not been booted")) return false;
+  if (detail.includes("no such file or directory")) return false;
+  if (detail.includes("not supported")) return false;
   return false;
 }
 
 async function assertSystemdAvailable() {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) {
-    return;
-  }
+  if (res.code === 0) return;
   const detail = res.stderr || res.stdout;
   if (detail.toLowerCase().includes("not found")) {
     throw new Error("systemctl not available; systemd user services are required on Linux.");
@@ -234,8 +202,8 @@ export async function installSystemdService({
   const serviceDescription =
     description ??
     formatGatewayServiceDescription({
-      profile: env.OPENCLAW_PROFILE,
-      version: environment?.OPENCLAW_SERVICE_VERSION ?? env.OPENCLAW_SERVICE_VERSION,
+      profile: env.CLAWDBOT_PROFILE,
+      version: environment?.CLAWDBOT_SERVICE_VERSION ?? env.CLAWDBOT_SERVICE_VERSION,
     });
   const unit = buildSystemdUnit({
     description: serviceDescription,
@@ -245,7 +213,7 @@ export async function installSystemdService({
   });
   await fs.writeFile(unitPath, unit, "utf8");
 
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   const reload = await execSystemctl(["--user", "daemon-reload"]);
   if (reload.code !== 0) {
@@ -276,7 +244,7 @@ export async function uninstallSystemdService({
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSystemdAvailable();
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   await execSystemctl(["--user", "disable", "--now", unitName]);
 
@@ -384,10 +352,8 @@ export type LegacySystemdUnit = {
 
 async function isSystemctlAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
-  if (res.code === 0) {
-    return true;
-  }
-  const detail = (res.stderr || res.stdout).toLowerCase();
+  if (res.code === 0) return true;
+  const detail = `${res.stderr || res.stdout}`.toLowerCase();
   return !detail.includes("not found");
 }
 
@@ -425,9 +391,7 @@ export async function uninstallLegacySystemdUnits({
   stdout: NodeJS.WritableStream;
 }): Promise<LegacySystemdUnit[]> {
   const units = await findLegacySystemdUnits(env);
-  if (units.length === 0) {
-    return units;
-  }
+  if (units.length === 0) return units;
 
   const systemctlAvailable = await isSystemctlAvailable();
   for (const unit of units) {


### PR DESCRIPTION
## Summary

`clawdbot node install` was failing on headless Linux servers with:

```
Node install failed: Error: systemctl enable failed: Failed to enable unit: Unit file clawdbot-gateway.service does not exist.
```

## Root Cause

In `src/daemon/systemd.ts`, both `installSystemdService` and `uninstallSystemdService` were hardcoded to use `resolveGatewaySystemdServiceName(env.CLAWDBOT_PROFILE)` instead of `resolveSystemdServiceName(env)`.

The problem:
1. `resolveSystemdUnitPath()` correctly uses `resolveSystemdServiceName(env)` which respects the `CLAWDBOT_SYSTEMD_UNIT` environment variable
2. But when calling `systemctl enable/disable`, it was directly using `resolveGatewaySystemdServiceName()`, ignoring the override

This caused:
1. The correct unit file to be created at `~/.config/systemd/user/clawdbot-node.service`
2. But `systemctl enable clawdbot-gateway.service` to fail because that file doesn't exist

## Fix

Replace `resolveGatewaySystemdServiceName(env.CLAWDBOT_PROFILE)` with `resolveSystemdServiceName(env)` in both functions so they respect the `CLAWDBOT_SYSTEMD_UNIT` override set by the node service installer.

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm test src/daemon/systemd.test.ts` passes (10 tests)
- [x] Verified the fix logic matches the existing `stopSystemdService` and `restartSystemdService` functions which already use `resolveSystemdServiceName(env)`

Fixes #2855

---

🤖 AI-assisted: This fix was developed with Claude Opus 4.5. The bug was identified by analyzing the source code and tracing the service name resolution path.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the daemon’s systemd service installation/uninstallation logic to consistently resolve the unit name via `resolveSystemdServiceName(env)` (respecting `OPENCLAW_SYSTEMD_UNIT` overrides) instead of hardcoding the gateway service name. It also adjusts CI to build the A2UI canvas bundle before running Node-based tests on macOS, and simplifies ToolDefinition typing in the Pi tool adapter by using explicit return types rather than `satisfies`. Overall, the changes align systemd enable/disable behavior with how unit paths and restart/stop already resolve service names, preventing `systemctl enable` failures when a custom unit name is used.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and fixes a real systemd unit-name mismatch, with low behavioral risk outside the installer paths.
- Changes are small and targeted (service name resolution for install/uninstall plus minor CI/type cleanup) and align with existing usage in stop/restart; main risk is around environment-variable naming/compat expectations, but current code/tests already reference OPENCLAW_* and CI change is straightforward.
- src/daemon/systemd.ts (ensure env var names match intended public interface); .github/workflows/ci.yml (ensure A2UI bundle build is desired for all macOS node tests)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->