### PR TITLE
feat(web-search): add model parameter for per-query Perplexity model selection

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -175,6 +175,7 @@ Search the web using your configured provider.
 - `search_lang` (optional): ISO language code for search results (e.g., "de", "en", "fr")
 - `ui_lang` (optional): ISO language code for UI elements
 - `freshness` (optional, Brave only): filter by discovery time (`pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`)
+- `model` (optional, Perplexity only): override the configured model per-query (e.g., "sonar", "sonar-pro")
 
 **Examples:**
 
@@ -199,6 +200,18 @@ await web_search({
 await web_search({
   query: "TMBG interview",
   freshness: "pw"
+});
+
+// Perplexity: use faster model for simple lookups
+await web_search({
+  query: "Nick Saban birthday",
+  model: "sonar"
+});
+
+// Perplexity: use deeper reasoning for complex analysis
+await web_search({
+  query: "compare React vs Vue performance benchmarks 2026",
+  model: "sonar-pro"
 });
 ```
 


### PR DESCRIPTION
## Summary

Adds an optional `model` parameter to the `web_search` tool that allows overriding the configured Perplexity model on a per-query basis.

- Allows choosing different models per query without config changes or restarts
- Returns error if `model` is used with Brave provider
- Falls back to configured default when not specified

Added tests for model parameter passing, config override behavior, and Brave provider rejection. Documentation updated with new parameter and examples.

Closes #2882