### PR TITLE
iOS: implement dual-connection gateway architecture with deadlock fix

### DIFF
--- a/apps/ios/Sources/Chat/ChatSheet.swift
+++ b/apps/ios/Sources/Chat/ChatSheet.swift
@@ -7,8 +7,13 @@ struct ChatSheet: View {
     @State private var viewModel: MoltbotChatViewModel
     private let userAccent: Color?
 
-    init(gateway: GatewayNodeSession, sessionKey: String, userAccent: Color? = nil) {
-        let transport = IOSGatewayChatTransport(gateway: gateway)
+    init(
+        gateway: GatewayOperatorSession,
+        nodeSession: GatewayNodeSession,
+        sessionKey: String,
+        userAccent: Color? = nil
+    ) {
+        let transport = IOSGatewayChatTransport(gateway: gateway, nodeSession: nodeSession)
         self._viewModel = State(
             initialValue: MoltbotChatViewModel(
                 sessionKey: sessionKey,

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -4,10 +4,13 @@ import MoltbotProtocol
 import Foundation
 
 struct IOSGatewayChatTransport: MoltbotChatTransport, Sendable {
-    private let gateway: GatewayNodeSession
+    private let gateway: GatewayOperatorSession
+    /// Node session is used for sending node.event (e.g., chat.subscribe).
+    private let nodeSession: GatewayNodeSession
 
-    init(gateway: GatewayNodeSession) {
+    init(gateway: GatewayOperatorSession, nodeSession: GatewayNodeSession) {
         self.gateway = gateway
+        self.nodeSession = nodeSession
     }
 
     func abortRun(sessionKey: String, runId: String) async throws {
@@ -36,7 +39,8 @@ struct IOSGatewayChatTransport: MoltbotChatTransport, Sendable {
         struct Subscribe: Codable { var sessionKey: String }
         let data = try JSONEncoder().encode(Subscribe(sessionKey: sessionKey))
         let json = String(data: data, encoding: .utf8)
-        await self.gateway.sendEvent(event: "chat.subscribe", payloadJSON: json)
+        // Use node session for chat.subscribe (node.event).
+        await self.nodeSession.sendEvent(event: "chat.subscribe", payloadJSON: json)
     }
 
     func requestHistory(sessionKey: String) async throws -> MoltbotChatHistoryPayload {

--- a/apps/ios/Sources/Gateway/GatewayOperatorSession.swift
+++ b/apps/ios/Sources/Gateway/GatewayOperatorSession.swift
@@ -1,0 +1,163 @@
+import MoltbotKit
+import MoltbotProtocol
+import Foundation
+
+/// Operator-role gateway session for iOS.
+///
+/// Wraps `GatewayChannelActor` to provide a similar interface to `GatewayNodeSession`
+/// but without invoke handling (operator role does not receive node.invoke requests).
+public actor GatewayOperatorSession {
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+    private var channel: GatewayChannelActor?
+    private var activeURL: URL?
+    private var activeToken: String?
+    private var activePassword: String?
+    private var serverEventSubscribers: [UUID: AsyncStream<EventFrame>.Continuation] = [:]
+
+    public init() {}
+
+    public func connect(
+        url: URL,
+        token: String?,
+        password: String?,
+        connectOptions: GatewayConnectOptions,
+        sessionBox: WebSocketSessionBox?,
+        onConnected: @escaping @Sendable () async -> Void,
+        onDisconnected: @escaping @Sendable (String) async -> Void
+    ) async throws {
+        let shouldReconnect = self.activeURL != url ||
+            self.activeToken != token ||
+            self.activePassword != password ||
+            self.channel == nil
+
+        if shouldReconnect {
+            if let existing = self.channel {
+                await existing.shutdown()
+            }
+            let channel = GatewayChannelActor(
+                url: url,
+                token: token,
+                password: password,
+                session: sessionBox,
+                pushHandler: { [weak self] push in
+                    await self?.handlePush(push, onConnected: onConnected)
+                },
+                connectOptions: connectOptions,
+                disconnectHandler: { [weak self] reason in
+                    guard self != nil else { return }
+                    await onDisconnected(reason)
+                })
+            self.channel = channel
+            self.activeURL = url
+            self.activeToken = token
+            self.activePassword = password
+        }
+
+        guard let channel = self.channel else {
+            throw NSError(domain: "Gateway", code: 0, userInfo: [
+                NSLocalizedDescriptionKey: "gateway channel unavailable",
+            ])
+        }
+
+        do {
+            try await channel.connect()
+            // onConnected is called via pushHandler when snapshot arrives
+        } catch {
+            await onDisconnected(error.localizedDescription)
+            throw error
+        }
+    }
+
+    public func disconnect() async {
+        await self.channel?.shutdown()
+        self.channel = nil
+        self.activeURL = nil
+        self.activeToken = nil
+        self.activePassword = nil
+    }
+
+    public func currentRemoteAddress() -> String? {
+        guard let url = self.activeURL else { return nil }
+        guard let host = url.host else { return url.absoluteString }
+        let port = url.port ?? (url.scheme == "wss" ? 443 : 80)
+        if host.contains(":") {
+            return "[\(host)]:\(port)"
+        }
+        return "\(host):\(port)"
+    }
+
+    public func request(method: String, paramsJSON: String?, timeoutSeconds: Int = 15) async throws -> Data {
+        guard let channel = self.channel else {
+            throw NSError(domain: "Gateway", code: 11, userInfo: [
+                NSLocalizedDescriptionKey: "not connected",
+            ])
+        }
+
+        let params = try self.decodeParamsJSON(paramsJSON)
+        return try await channel.request(
+            method: method,
+            params: params,
+            timeoutMs: Double(timeoutSeconds * 1000))
+    }
+
+    public func subscribeServerEvents(bufferingNewest: Int = 200) -> AsyncStream<EventFrame> {
+        let id = UUID()
+        let session = self
+        return AsyncStream(bufferingPolicy: .bufferingNewest(bufferingNewest)) { continuation in
+            self.serverEventSubscribers[id] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { await session.removeServerEventSubscriber(id) }
+            }
+        }
+    }
+
+    private func handlePush(
+        _ push: GatewayPush,
+        onConnected: @escaping @Sendable () async -> Void
+    ) async {
+        switch push {
+        case .snapshot:
+            await onConnected()
+        case let .event(evt):
+            self.broadcastServerEvent(evt)
+        case let .seqGap(expected, received):
+            // Broadcast a synthetic event so subscribers can handle gaps
+            let gapEvent = EventFrame(
+                type: "evt",
+                event: "seqGap",
+                payload: MoltbotProtocol.AnyCodable(["expected": expected, "received": received]),
+                seq: received,
+                stateversion: nil)
+            self.broadcastServerEvent(gapEvent)
+        }
+    }
+
+    private func broadcastServerEvent(_ evt: EventFrame) {
+        for (id, continuation) in self.serverEventSubscribers {
+            if case .terminated = continuation.yield(evt) {
+                self.serverEventSubscribers.removeValue(forKey: id)
+            }
+        }
+    }
+
+    private func removeServerEventSubscriber(_ id: UUID) {
+        self.serverEventSubscribers.removeValue(forKey: id)
+    }
+
+    private func decodeParamsJSON(_ paramsJSON: String?) throws -> [String: MoltbotKit.AnyCodable]? {
+        guard let paramsJSON, !paramsJSON.isEmpty else { return nil }
+        guard let data = paramsJSON.data(using: .utf8) else {
+            throw NSError(domain: "Gateway", code: 12, userInfo: [
+                NSLocalizedDescriptionKey: "paramsJSON not UTF-8",
+            ])
+        }
+        let raw = try JSONSerialization.jsonObject(with: data)
+        guard let dict = raw as? [String: Any] else {
+            return nil
+        }
+        return dict.reduce(into: [:]) { acc, entry in
+            acc[entry.key] = MoltbotKit.AnyCodable(entry.value)
+        }
+    }
+}

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -64,8 +64,39 @@ struct RootTabs: View {
         }
     }
 
+    private var pairingRole: StatusPill.PairingRole? {
+        switch self.appModel.gatewayPairingState {
+        case .none:
+            return nil
+        case .operatorPending:
+            return .operator
+        case .nodePending:
+            return .node
+        case .bothPending:
+            return .both
+        }
+    }
+
+    private var connectionRole: StatusPill.ConnectionRole? {
+        switch (self.appModel.operatorConnected, self.appModel.nodeConnected) {
+        case (true, true):
+            return .both
+        case (true, false):
+            return .operatorOnly
+        case (false, true):
+            return .nodeOnly
+        case (false, false):
+            return nil
+        }
+    }
+
     private var gatewayStatus: StatusPill.GatewayState {
-        if self.appModel.gatewayServerName != nil { return .connected }
+        if let pairingRole {
+            return .pairingPending(pairingRole)
+        }
+        if let connectionRole {
+            return .connected(connectionRole)
+        }
 
         let text = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.localizedCaseInsensitiveContains("connecting") ||
@@ -88,6 +119,10 @@ struct RootTabs: View {
                 title: "Foreground required",
                 systemImage: "exclamationmark.triangle.fill",
                 tint: .orange)
+        }
+
+        if self.pairingRole != nil {
+            return nil
         }
 
         let gatewayStatus = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -65,8 +65,22 @@ struct SettingsTab: View {
                 }
 
                 Section("Gateway") {
-                    LabeledContent("Discovery", value: self.gatewayController.discoveryStatusText)
+                    LabeledContent("Discovery (Bonjour)", value: self.gatewayController.discoveryStatusText)
+                    Text("Discovery stays active while Moltbot is open to find other gateways.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                     LabeledContent("Status", value: self.appModel.gatewayStatusText)
+
+                    TextField("Gateway Token", text: self.$gatewayToken)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    SecureField("Gateway Password", text: self.$gatewayPassword)
+
+                    Text("Required to pair with a gateway. Provide a token or password from the gateway settings.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
                     if let serverName = self.appModel.gatewayServerName {
                         LabeledContent("Server", value: serverName)
                         if let addr = self.appModel.gatewayRemoteAddress {
@@ -120,7 +134,7 @@ struct SettingsTab: View {
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
 
-                        TextField("Port", value: self.$manualGatewayPort, format: .number)
+                        TextField("Port", value: self.$manualGatewayPort, formatter: Self.portFormatter)
                             .keyboardType(.numberPad)
 
                         Toggle("Use TLS", isOn: self.$manualGatewayTLS)
@@ -158,12 +172,6 @@ struct SettingsTab: View {
                         }
 
                         Toggle("Debug Canvas Status", isOn: self.$canvasDebugStatusEnabled)
-
-                        TextField("Gateway Token", text: self.$gatewayToken)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-
-                        SecureField("Gateway Password", text: self.$gatewayPassword)
                     }
                 }
 
@@ -398,6 +406,13 @@ struct SettingsTab: View {
             useTLS: self.manualGatewayTLS)
     }
 
+    private static let portFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.usesGroupingSeparator = false
+        return formatter
+    }()
+
     private static func primaryIPv4Address() -> String? {
         var addrList: UnsafeMutablePointer<ifaddrs>?
         guard getifaddrs(&addrList) == 0, let first = addrList else { return nil }
@@ -458,7 +473,7 @@ struct SettingsTab: View {
         }
 
         if lines.isEmpty {
-            lines.append(gateway.debugID)
+            lines.append("Discovery details unavailable yet.")
         }
 
         return lines

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -76,4 +76,39 @@ private func withUserDefaults<T>(_ updates: [String: Any?], _ body: () throws ->
             #expect(commands.contains(MoltbotLocationCommand.get.rawValue))
         }
     }
+
+    @Test @MainActor func currentCommandsMatchGatewayIOSAllowlist() {
+        // Verify only iOS-allowlisted commands are declared.
+        // iOS allowlist per node-command-policy.ts: canvas, camera, screen, location
+        // System commands (run, which, notify, execApprovals.*) are NOT allowed on iOS.
+        withUserDefaults([
+            "node.instanceId": "ios-test",
+            "camera.enabled": true,
+            "location.enabledMode": MoltbotLocationMode.whileUsing.rawValue,
+        ]) {
+            let appModel = NodeAppModel()
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            let commands = Set(controller._test_currentCommands())
+
+            #expect(commands.contains(MoltbotCanvasCommand.present.rawValue))
+            #expect(commands.contains(MoltbotCanvasCommand.hide.rawValue))
+            #expect(commands.contains(MoltbotCanvasCommand.navigate.rawValue))
+            #expect(commands.contains(MoltbotCanvasCommand.evalJS.rawValue))
+            #expect(commands.contains(MoltbotCanvasCommand.snapshot.rawValue))
+            #expect(commands.contains(MoltbotCanvasA2UICommand.push.rawValue))
+            #expect(commands.contains(MoltbotCanvasA2UICommand.pushJSONL.rawValue))
+            #expect(commands.contains(MoltbotCanvasA2UICommand.reset.rawValue))
+            #expect(commands.contains(MoltbotScreenCommand.record.rawValue))
+            #expect(commands.contains(MoltbotCameraCommand.list.rawValue))
+            #expect(commands.contains(MoltbotCameraCommand.snap.rawValue))
+            #expect(commands.contains(MoltbotCameraCommand.clip.rawValue))
+            #expect(commands.contains(MoltbotLocationCommand.get.rawValue))
+
+            #expect(!commands.contains(MoltbotSystemCommand.notify.rawValue))
+            #expect(!commands.contains(MoltbotSystemCommand.which.rawValue))
+            #expect(!commands.contains(MoltbotSystemCommand.run.rawValue))
+            #expect(!commands.contains(MoltbotSystemCommand.execApprovalsGet.rawValue))
+            #expect(!commands.contains(MoltbotSystemCommand.execApprovalsSet.rawValue))
+        }
+    }
 }

--- a/apps/ios/Tests/GatewayDualSessionStateTests.swift
+++ b/apps/ios/Tests/GatewayDualSessionStateTests.swift
@@ -1,0 +1,52 @@
+import MoltbotKit
+import Foundation
+import Testing
+@testable import Moltbot
+
+@Suite(.serialized) struct GatewayDualSessionStateTests {
+    @Test @MainActor func connectToGatewayStartsOperatorAndNodeSessions() async {
+        let session = TestGatewayWebSocketSession()
+        let appModel = NodeAppModel(
+            gatewaySession: GatewayOperatorSession(),
+            nodeSession: GatewayNodeSession())
+
+        let operatorOptions = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read", "operator.write"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "moltbot-ios",
+            clientMode: "ui",
+            clientDisplayName: "Test")
+        // Node role should have empty scopes - operator scopes are operator-only
+        let nodeOptions = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["camera"],
+            commands: [],
+            permissions: [:],
+            clientId: "moltbot-ios",
+            clientMode: "node",
+            clientDisplayName: "Test")
+
+        appModel.connectToGateway(
+            url: URL(string: "ws://example.invalid")!,
+            gatewayStableID: "test",
+            tls: nil,
+            token: nil,
+            password: nil,
+            operatorConnectOptions: operatorOptions,
+            nodeConnectOptions: nodeOptions,
+            sessionBox: WebSocketSessionBox(session: session))
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let roles = Set(session.snapshotConnectRoles())
+        #expect(roles == ["operator", "node"])
+        #expect(appModel.gatewayStatusText == "Connected (operator + node)")
+
+        appModel.disconnectGateway()
+        #expect(appModel.gatewayStatusText == "Offline")
+    }
+}

--- a/apps/ios/Tests/GatewayPairingStateTests.swift
+++ b/apps/ios/Tests/GatewayPairingStateTests.swift
@@ -1,0 +1,146 @@
+import MoltbotKit
+import MoltbotProtocol
+import Foundation
+import Testing
+@testable import Moltbot
+
+@Suite(.serialized) struct GatewayPairingStateTests {
+    @Test @MainActor func pairingPendingTransitionsAcrossRoles() {
+        let appModel = NodeAppModel()
+
+        #expect(appModel.gatewayPairingState == .none)
+
+        appModel._test_updatePairingPending(role: .operator, reason: "Pairing required")
+        #expect(appModel.gatewayPairingState == .operatorPending)
+
+        appModel._test_updatePairingPending(role: .node, reason: "Awaiting approval")
+        #expect(appModel.gatewayPairingState == .bothPending)
+
+        appModel._test_updatePairingPending(role: .operator, reason: "Disconnected")
+        #expect(appModel.gatewayPairingState == .nodePending)
+
+        appModel._test_clearPairingPending()
+        #expect(appModel.gatewayPairingState == .none)
+    }
+
+    @Test @MainActor func pairingPendingClearsOnEmptyReason() {
+        let appModel = NodeAppModel()
+        appModel._test_setPairingPending(role: .node, pending: true)
+        #expect(appModel.gatewayPairingState == .nodePending)
+
+        appModel._test_updatePairingPending(role: .node, reason: "   ")
+        #expect(appModel.gatewayPairingState == .none)
+    }
+
+    @Test @MainActor func pairingRequestedEventSetsPendingForOperatorRole() async {
+        let appModel = NodeAppModel()
+        let myDeviceId = "test-device-123"
+
+        let payload: [String: MoltbotProtocol.AnyCodable] = [
+            "deviceId": MoltbotProtocol.AnyCodable(myDeviceId),
+            "role": MoltbotProtocol.AnyCodable("operator"),
+        ]
+        let evt = EventFrame(
+            type: "event",
+            event: "device.pair.requested",
+            payload: MoltbotProtocol.AnyCodable(payload),
+            seq: nil,
+            stateversion: nil)
+
+        await appModel._test_handlePairingEvent(evt, myDeviceId: myDeviceId)
+
+        #expect(appModel.gatewayPairingState == .operatorPending)
+    }
+
+    @Test @MainActor func pairingRequestedEventSetsPendingForNodeRole() async {
+        let appModel = NodeAppModel()
+        let myDeviceId = "test-device-456"
+
+        let payload: [String: MoltbotProtocol.AnyCodable] = [
+            "deviceId": MoltbotProtocol.AnyCodable(myDeviceId),
+            "role": MoltbotProtocol.AnyCodable("node"),
+        ]
+        let evt = EventFrame(
+            type: "event",
+            event: "device.pair.requested",
+            payload: MoltbotProtocol.AnyCodable(payload),
+            seq: nil,
+            stateversion: nil)
+
+        await appModel._test_handlePairingEvent(evt, myDeviceId: myDeviceId)
+
+        #expect(appModel.gatewayPairingState == .nodePending)
+    }
+
+    @Test @MainActor func pairingRequestedEventIgnoresOtherDevices() async {
+        let appModel = NodeAppModel()
+        let myDeviceId = "test-device-mine"
+
+        let payload: [String: MoltbotProtocol.AnyCodable] = [
+            "deviceId": MoltbotProtocol.AnyCodable("different-device"),
+            "role": MoltbotProtocol.AnyCodable("operator"),
+        ]
+        let evt = EventFrame(
+            type: "event",
+            event: "device.pair.requested",
+            payload: MoltbotProtocol.AnyCodable(payload),
+            seq: nil,
+            stateversion: nil)
+
+        await appModel._test_handlePairingEvent(evt, myDeviceId: myDeviceId)
+
+        #expect(appModel.gatewayPairingState == .none)
+    }
+
+    @Test @MainActor func pairingResolvedEventClearsPending() async {
+        let appModel = NodeAppModel()
+        let myDeviceId = "test-device-789"
+
+        // First set pending state
+        appModel._test_setPairingPending(role: .operator, pending: true)
+        appModel._test_setPairingPending(role: .node, pending: true)
+        #expect(appModel.gatewayPairingState == .bothPending)
+
+        // Receive resolved event
+        let payload: [String: MoltbotProtocol.AnyCodable] = [
+            "deviceId": MoltbotProtocol.AnyCodable(myDeviceId),
+            "decision": MoltbotProtocol.AnyCodable("approved"),
+        ]
+        let evt = EventFrame(
+            type: "event",
+            event: "device.pair.resolved",
+            payload: MoltbotProtocol.AnyCodable(payload),
+            seq: nil,
+            stateversion: nil)
+
+        await appModel._test_handlePairingEvent(evt, myDeviceId: myDeviceId)
+
+        #expect(appModel.gatewayPairingState == .none)
+    }
+
+    @Test @MainActor func pairingResolvedEventIgnoresOtherDevices() async {
+        let appModel = NodeAppModel()
+        let myDeviceId = "test-device-mine"
+
+        // Set pending state
+        appModel._test_setPairingPending(role: .operator, pending: true)
+        #expect(appModel.gatewayPairingState == .operatorPending)
+
+        // Receive resolved event for different device
+        let payload: [String: MoltbotProtocol.AnyCodable] = [
+            "deviceId": MoltbotProtocol.AnyCodable("different-device"),
+            "decision": MoltbotProtocol.AnyCodable("approved"),
+        ]
+        let evt = EventFrame(
+            type: "event",
+            event: "device.pair.resolved",
+            payload: MoltbotProtocol.AnyCodable(payload),
+            seq: nil,
+            stateversion: nil)
+
+        await appModel._test_handlePairingEvent(evt, myDeviceId: myDeviceId)
+
+        // State unchanged
+        #expect(appModel.gatewayPairingState == .operatorPending)
+    }
+}

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -4,8 +4,9 @@ import Testing
 
 @Suite struct IOSGatewayChatTransportTests {
     @Test func requestsFailFastWhenGatewayNotConnected() async {
-        let gateway = GatewayNodeSession()
-        let transport = IOSGatewayChatTransport(gateway: gateway)
+        let gateway = GatewayOperatorSession()
+        let nodeSession = GatewayNodeSession()
+        let transport = IOSGatewayChatTransport(gateway: gateway, nodeSession: nodeSession)
 
         do {
             _ = try await transport.requestHistory(sessionKey: "node-test")

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -67,8 +67,10 @@ import UIKit
 
     @Test @MainActor func chatSheetBuildsAViewHierarchy() {
         let appModel = NodeAppModel()
-        let gateway = GatewayNodeSession()
-        let root = ChatSheet(gateway: gateway, sessionKey: "test")
+        let root = ChatSheet(
+            gateway: appModel.gatewaySession,
+            nodeSession: appModel.gatewayNodeSession,
+            sessionKey: "test")
             .environment(appModel)
             .environment(appModel.voiceWake)
         _ = Self.host(root)

--- a/apps/ios/Tests/TestGatewayWebSocketSession.swift
+++ b/apps/ios/Tests/TestGatewayWebSocketSession.swift
@@ -1,0 +1,220 @@
+import MoltbotKit
+import Foundation
+import os
+
+final class TestGatewayWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    private let connectRequestID = OSAllocatedUnfairLock<String?>(initialState: nil)
+    private let connectParamsData = OSAllocatedUnfairLock<Data?>(initialState: nil)
+    private let requestMethods = OSAllocatedUnfairLock<[String]>(initialState: [])
+    private let pendingReceiveHandler =
+        OSAllocatedUnfairLock<(@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?>(
+            initialState: nil)
+    private let queuedMessages = OSAllocatedUnfairLock<[URLSessionWebSocketTask.Message]>(initialState: [])
+    private let sentChallenge = OSAllocatedUnfairLock(initialState: false)
+
+    var state: URLSessionTask.State = .suspended
+
+    func snapshotConnectParams() -> [String: Any]? {
+        guard let data = self.connectParamsData.withLock({ $0 }) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    func snapshotRequestMethods() -> [String] {
+        self.requestMethods.withLock { $0 }
+    }
+
+    func resume() {
+        self.state = .running
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        _ = (closeCode, reason)
+        self.state = .canceling
+        let handler = self.pendingReceiveHandler.withLock { handler in
+            defer { handler = nil }
+            return handler
+        }
+        handler?(Result<URLSessionWebSocketTask.Message, Error>.failure(URLError(.cancelled)))
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        let data: Data? = switch message {
+        case let .data(d): d
+        case let .string(s): s.data(using: .utf8)
+        @unknown default: nil
+        }
+        guard let data else { return }
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              obj["type"] as? String == "req",
+              let id = obj["id"] as? String,
+              let method = obj["method"] as? String
+        else { return }
+
+        if method == "connect" {
+            self.connectRequestID.withLock { $0 = id }
+            let paramsData = obj["params"].flatMap { try? JSONSerialization.data(withJSONObject: $0) }
+            self.connectParamsData.withLock { $0 = paramsData }
+            return
+        }
+
+        self.requestMethods.withLock { $0.append(method) }
+        guard let responseData = Self.responseData(for: method, id: id) else { return }
+        self.deliver(.data(responseData))
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        if self.sentChallenge.withLock({ $0 == false }) {
+            self.sentChallenge.withLock { $0 = true }
+            return .data(Self.connectChallengeData())
+        }
+        let id = self.connectRequestID.withLock { $0 } ?? "connect"
+        return .data(Self.connectOkData(id: id))
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
+    {
+        let message = self.queuedMessages.withLock { messages -> URLSessionWebSocketTask.Message? in
+            guard !messages.isEmpty else { return nil }
+            return messages.removeFirst()
+        }
+        if let message {
+            completionHandler(.success(message))
+            return
+        }
+        self.pendingReceiveHandler.withLock { $0 = completionHandler }
+    }
+
+    private func deliver(_ message: URLSessionWebSocketTask.Message) {
+        let handler = self.pendingReceiveHandler.withLock { handler -> ((@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void))? in
+            let h = handler
+            handler = nil
+            return h
+        }
+        if let handler {
+            handler(.success(message))
+        } else {
+            self.queuedMessages.withLock { $0.append(message) }
+        }
+    }
+
+    private static func connectChallengeData() -> Data {
+        let json = """
+        {
+          "type": "event",
+          "event": "connect.challenge",
+          "payload": { "nonce": "test-nonce" }
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    private static func connectOkData(id: String) -> Data {
+        let json = """
+        {
+          "type": "res",
+          "id": "\(id)",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 3,
+            "server": { "version": "test", "connId": "test" },
+            "features": { "methods": [], "events": [] },
+            "snapshot": {
+              "presence": [ { "ts": 1 } ],
+              "health": {},
+              "stateVersion": { "presence": 0, "health": 0 },
+              "uptimeMs": 0
+            },
+            "policy": { "maxPayload": 1, "maxBufferedBytes": 1, "tickIntervalMs": 30000 }
+          }
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    private static func responseData(for method: String, id: String) -> Data? {
+        switch method {
+        case "chat.send":
+            return Data("""
+            {
+              "type": "res",
+              "id": "\(id)",
+              "ok": true,
+              "payload": { "runId": "run-1", "status": "ok" }
+            }
+            """.utf8)
+        case "chat.history":
+            return Data("""
+            {
+              "type": "res",
+              "id": "\(id)",
+              "ok": true,
+              "payload": {
+                "sessionKey": "main",
+                "sessionId": null,
+                "messages": [],
+                "thinkingLevel": "low"
+              }
+            }
+            """.utf8)
+        case "health":
+            return Data("""
+            {
+              "type": "res",
+              "id": "\(id)",
+              "ok": true,
+              "payload": { "ok": true }
+            }
+            """.utf8)
+        case "config.get":
+            return Data("""
+            {
+              "type": "res",
+              "id": "\(id)",
+              "ok": true,
+              "payload": {
+                "config": {
+                  "ui": { "seamColor": "#ffffff" },
+                  "session": { "mainKey": "main" }
+                }
+              }
+            }
+            """.utf8)
+        case "voicewake.get":
+            return Data("""
+            {
+              "type": "res",
+              "id": "\(id)",
+              "ok": true,
+              "payload": { "triggers": ["clawd"] }
+            }
+            """.utf8)
+        default:
+            return nil
+        }
+    }
+}
+
+final class TestGatewayWebSocketSession: WebSocketSessioning, @unchecked Sendable {
+    private let taskLock = OSAllocatedUnfairLock<[TestGatewayWebSocketTask]>(initialState: [])
+
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        _ = url
+        let task = TestGatewayWebSocketTask()
+        self.taskLock.withLock { $0.append(task) }
+        return WebSocketTaskBox(task: task)
+    }
+
+    func snapshotConnectRoles() -> [String] {
+        self.taskLock.withLock { tasks in
+            tasks.compactMap { $0.snapshotConnectParams()?["role"] as? String }
+        }
+    }
+
+    func snapshotRequestMethods() -> [String] {
+        self.taskLock.withLock { tasks in
+            tasks.flatMap { $0.snapshotRequestMethods() }
+        }
+    }
+}

--- a/apps/shared/MoltbotKit/Sources/MoltbotChatUI/ChatViewModel.swift
+++ b/apps/shared/MoltbotKit/Sources/MoltbotChatUI/ChatViewModel.swift
@@ -408,7 +408,10 @@ public final class MoltbotChatViewModel {
     }
 
     private func handleAgentEvent(_ evt: MoltbotAgentEventPayload) {
-        if let sessionId, evt.runId != sessionId {
+        // Agent events use runId (client idempotency key), not sessionId (Pi session UUID).
+        // Match against our pending runs, not the session ID.
+        let isOurRun = self.pendingRuns.contains(evt.runId)
+        if !isOurRun {
             return
         }
 

--- a/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
+++ b/apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayNodeSession.swift
@@ -191,10 +191,10 @@ public actor GatewayNodeSession {
         self.broadcastServerEvent(evt)
         guard evt.event == "node.invoke.request" else { return }
         guard let payload = evt.payload else { return }
+        guard let onInvoke = self.onInvoke else { return }
         do {
             let data = try self.encoder.encode(payload)
             let request = try self.decoder.decode(NodeInvokeRequestPayload.self, from: data)
-            guard let onInvoke else { return }
             let req = BridgeInvokeRequest(id: request.id, command: request.command, paramsJSON: request.paramsJSON)
             let response = await Self.invokeWithTimeout(
                 request: req,

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -23,24 +23,47 @@ Availability: internal preview. The iOS app is not publicly distributed yet.
   - Tailnet via unicast DNS-SD (`moltbot.internal.`), **or**
   - Manual host/port (fallback).
 
-## Quick start (pair + connect)
+## Quick start (authenticate + pair + connect)
 
-1) Start the Gateway:
+### 1. Start the Gateway
 
 ```bash
 moltbot gateway --port 18789
 ```
 
-2) In the iOS app, open Settings and pick a discovered gateway (or enable Manual Host and enter host/port).
+### 2. Configure authentication in the iOS app
 
-3) Approve the pairing request on the gateway host:
+Open Settings in the Moltbot iOS app and configure **one** of the following:
+
+- **Gateway Token**: Paste the token from `moltbot config get gateway.token` (recommended for secure setups)
+- **Gateway Password**: Enter the password from `moltbot config get gateway.password` (simpler alternative)
+
+If neither is set on the gateway, you can set one:
 
 ```bash
-moltbot nodes pending
-moltbot nodes approve <requestId>
+moltbot config set gateway.token "your-secret-token"
+# or
+moltbot config set gateway.password "your-password"
 ```
 
-4) Verify connection:
+### 3. Select the gateway
+
+In the iOS app Settings, pick a discovered gateway from the list, or enable **Manual Host** and enter the host/port manually.
+
+### 4. Approve the pairing request
+
+The iOS app requires device pairing for both operator and node roles. On the gateway host, list and approve pending devices:
+
+```bash
+moltbot devices list
+moltbot devices approve <id>
+```
+
+You may need to approve twice (once for operator role, once for node role).
+
+> **Note**: Use `moltbot devices` for WebSocket pairing, not `moltbot nodes pending/approve`.
+
+### 5. Verify connection
 
 ```bash
 moltbot nodes status
@@ -94,8 +117,9 @@ moltbot nodes invoke --node "iOS Node" --command canvas.snapshot --params '{"max
 
 - `NODE_BACKGROUND_UNAVAILABLE`: bring the iOS app to the foreground (canvas/camera/screen commands require it).
 - `A2UI_HOST_NOT_CONFIGURED`: the Gateway did not advertise a canvas host URL; check `canvasHost` in [Gateway configuration](/gateway/configuration).
-- Pairing prompt never appears: run `moltbot nodes pending` and approve manually.
-- Reconnect fails after reinstall: the Keychain pairing token was cleared; re-pair the node.
+- **Authentication failed**: Ensure the gateway token or password in iOS Settings matches what is configured on the gateway (`moltbot config get gateway.token` or `gateway.password`).
+- **Pairing prompt never appears**: Run `moltbot devices list` to see pending requests and approve with `moltbot devices approve <id>`.
+- **Reconnect fails after reinstall**: The Keychain pairing token was cleared; re-pair the device using `moltbot devices list` and `moltbot devices approve`.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

Aligns the iOS app with the [Clawnet refactor](/docs/refactor/clawnet.md) by implementing proper role separation for gateway connections. Uses separate operator and node sessions to match the gateway's authorization requirements. Also fixes a latent deadlock in `GatewayChannelActor` that blocked requests made from `onConnected` callbacks.

**iOS chat is now working.** This is the base PR to unlock further work on the iOS app.

## Changes

### iOS App - Gateway Architecture
- **New `GatewayOperatorSession`**: Wraps `GatewayChannelActor` for operator-role RPC requests (`chat.*`, `health`, `sessions.list`) without invoke handling
- **Dual-connection architecture**: Operator session for requests, node session for `node.event` calls (e.g., `chat.subscribe`)
- **Separate websocket sessions**: Each connection now gets its own `URLSession` to prevent response cross-talk
- **Updated chat transport**: `IOSGatewayChatTransport` uses operator session for requests, node session for subscriptions

### ClawdbotKit (shared)
- **Deadlock fix in `GatewayChannel.swift`**: Moved connection finalization (`listen()`, `connected=true`, `isConnecting=false`, waiter resumption) to occur *before* calling `pushHandler`. This fixes a latent bug where requests made from `onConnected` callbacks would deadlock waiting for `isConnecting` to clear. Does not affect macOS (its callback doesn't make requests).
- **Package.swift fix**: Fixed argument order for Swift 6.2 compatibility

## Testing
- [x] iOS build succeeds
- [x] 77 iOS unit tests pass
- [x] Manual testing: chat UI connects and loads history correctly
- [x] Verified macOS is unaffected by the shared code change

## AI Disclosure
- [x] AI-assisted
- [x] Fully tested
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors the iOS gateway integration to use a dual-connection model (operator session for RPC methods like `chat.*`/`health` and node session for `node.event` subscriptions like `chat.subscribe`), introduces a new `GatewayOperatorSession` wrapper over `GatewayChannelActor`, and updates the iOS UI/state model to track operator vs node connection/pairing state separately.

In shared `MoltbotKit`, it adjusts `GatewayChannelActor`’s connect sequencing to avoid deadlocks when `onConnected` triggers nested requests, and tweaks connect-challenge timing/handling. Tests were expanded with a fake websocket session and new dual-session/pairing state coverage.

<h3>Confidence Score: 2/5</h3>

- This PR is directionally solid but has a couple of behavioral/concurrency issues that could reintroduce deadlocks or cause unexpected connect failures.
- The iOS architectural split and test additions look coherent, but `GatewayChannelActor.connect()` still appears to keep `isConnecting` true while awaiting `pushHandler` (via a `defer`), which can recreate the deadlock the PR aims to fix. Separately, `waitForConnectChallenge()` now throws on timeout instead of falling back to v1/no-nonce behavior, which can break connects depending on gateway behavior/timing. There’s also a mismatch where some node-session operations are gated only on operator connectivity, leading to silent no-ops.
- apps/shared/MoltbotKit/Sources/MoltbotKit/GatewayChannel.swift; apps/ios/Sources/Model/NodeAppModel.swift

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->