### PR TITLE
fix(matrix): check if requestOwnUserVerification exists before calling

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -250,10 +250,14 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   // If E2EE is enabled, trigger device verification
   if (auth.encryption && client.crypto) {
     try {
-      // Request verification from other sessions
-      const verificationRequest = await client.crypto.requestOwnUserVerification();
-      if (verificationRequest) {
-        logger.info("matrix: device verification requested - please verify in another client");
+      // Request verification from other sessions (if supported by SDK)
+      if (typeof client.crypto.requestOwnUserVerification === "function") {
+        const verificationRequest = await client.crypto.requestOwnUserVerification();
+        if (verificationRequest) {
+          logger.info("matrix: device verification requested - please verify in another client");
+        }
+      } else {
+        logger.debug("matrix: device verification not supported by current crypto SDK version");
       }
     } catch (err) {
       logger.debug({ error: String(err) }, "Device verification request failed (may already be verified)");


### PR DESCRIPTION
## Summary
The crypto SDK may not have the `requestOwnUserVerification` function, causing a TypeError on startup when E2EE is enabled.

## Problem
When `channels.matrix.encryption: true` is set, the code calls `client.crypto.requestOwnUserVerification()` without checking if the function exists. This causes:
```
{"error":"TypeError: client.crypto.requestOwnUserVerification is not a function"}
```

## Solution
Add a runtime check to verify the function exists before calling it. If not supported, log a debug message instead of throwing.

## Testing
- Tested with E2EE enabled on self-hosted Synapse
- Bot starts without error
- Gracefully handles missing verification support

Fixes #2901

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Matrix E2EE startup by guarding the `client.crypto.requestOwnUserVerification()` call with a runtime `typeof === "function"` check, avoiding a `TypeError` on crypto SDK versions that don’t expose that API. When unsupported, it logs a debug message and continues startup normally, keeping the monitor flow unchanged aside from the verification request branch.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it adds a narrow runtime guard to prevent a startup crash on older/alternate Matrix crypto SDK implementations.
- Change is minimal and localized: it only checks method existence before calling and adds a debug log path; no behavior changes when the method exists, and the previous try/catch remains in place for other errors.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->