### PR TITLE
[WIP] feat: Add tool hooks bridge for external UI visibility

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { MoltbotConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "tool";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;

--- a/src/infra/agent-hook-bridge.test.ts
+++ b/src/infra/agent-hook-bridge.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  startAgentHookBridge,
+  stopAgentHookBridge,
+  type SessionMeta,
+  type ToolHookEvent,
+} from "./agent-hook-bridge.js";
+import { emitAgentEvent } from "./agent-events.js";
+import {
+  clearInternalHooks,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "../hooks/internal-hooks.js";
+
+describe("agent-hook-bridge", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+    stopAgentHookBridge();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+    stopAgentHookBridge();
+  });
+
+  describe("startAgentHookBridge", () => {
+    it("should emit tool:start events to hooks", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool:start", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123456",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-1",
+          args: { command: "npm test" },
+        },
+      });
+
+      // Allow async hook to process
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("tool");
+      expect(events[0].action).toBe("start");
+      expect(events[0].context).toMatchObject({
+        runId: "run-1",
+        toolName: "exec",
+        toolCallId: "tool-1",
+        args: { command: "npm test" },
+      });
+    });
+
+    it("should emit tool:update events to hooks", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool:update", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:telegram:dm:user123",
+        data: {
+          phase: "update",
+          name: "exec",
+          toolCallId: "tool-1",
+          partialResult: "Building...",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      expect(events[0].action).toBe("update");
+      expect(events[0].context).toMatchObject({
+        toolName: "exec",
+        partialResult: "Building...",
+      });
+    });
+
+    it("should emit tool:result events to hooks", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool:result", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:slack:channel:C123",
+        data: {
+          phase: "result",
+          name: "read",
+          toolCallId: "tool-2",
+          result: { content: "file contents" },
+          isError: false,
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      expect(events[0].action).toBe("result");
+      expect(events[0].context).toMatchObject({
+        toolName: "read",
+        result: { content: "file contents" },
+        isError: false,
+      });
+    });
+
+    it("should parse sessionMeta correctly", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123456789",
+        data: {
+          phase: "start",
+          name: "browser",
+          toolCallId: "tool-3",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const sessionMeta = (events[0].context as { sessionMeta: SessionMeta }).sessionMeta;
+      expect(sessionMeta).toEqual({
+        agentId: "main",
+        platform: "discord",
+        channelType: "channel",
+        channelId: "123456789",
+        raw: "discord:channel:123456789",
+      });
+    });
+
+    it("should handle channelIds with colons (e.g., Matrix)", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:matrix:room:!abc:matrix.org",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-4",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const sessionMeta = (events[0].context as { sessionMeta: SessionMeta }).sessionMeta;
+      expect(sessionMeta.channelId).toBe("!abc:matrix.org");
+    });
+
+    it("should not emit events for non-tool streams", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "lifecycle",
+        sessionKey: "agent:main:discord:channel:123",
+        data: { phase: "start" },
+      });
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "assistant",
+        sessionKey: "agent:main:discord:channel:123",
+        data: { text: "Hello" },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("should not emit events for unknown phases", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123",
+        data: {
+          phase: "unknown",
+          name: "exec",
+          toolCallId: "tool-5",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("should prevent double-subscription", () => {
+      const unsub1 = startAgentHookBridge();
+      const unsub2 = startAgentHookBridge();
+
+      // Should return the same cleanup function
+      expect(unsub1).toBe(unsub2);
+    });
+
+    it("should handle malformed session keys gracefully", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      // Missing parts
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-7",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      const sessionMeta = (events[0].context as { sessionMeta: SessionMeta }).sessionMeta;
+      expect(sessionMeta.agentId).toBeNull();
+      expect(sessionMeta.platform).toBeNull();
+    });
+
+    it("should handle empty session keys", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-8",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      const sessionMeta = (events[0].context as { sessionMeta: SessionMeta }).sessionMeta;
+      expect(sessionMeta).toEqual({
+        agentId: null,
+        platform: null,
+        channelType: null,
+        channelId: null,
+        raw: null,
+      });
+    });
+
+    it("should normalize empty channelId to null", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      // Trailing colon resulting in empty channelId
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-9",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(1);
+      const sessionMeta = (events[0].context as { sessionMeta: SessionMeta }).sessionMeta;
+      expect(sessionMeta.channelId).toBeNull();
+    });
+
+    it("should ignore events with missing toolCallId", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123",
+        data: {
+          phase: "start",
+          name: "exec",
+          // Missing toolCallId
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("should ignore events with missing name", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123",
+        data: {
+          phase: "start",
+          toolCallId: "tool-10",
+          // Missing name
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe("stopAgentHookBridge", () => {
+    it("should stop emitting events after stop", async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("tool", async (evt) => {
+        events.push(evt);
+      });
+
+      startAgentHookBridge();
+      stopAgentHookBridge();
+
+      emitAgentEvent({
+        runId: "run-1",
+        stream: "tool",
+        sessionKey: "agent:main:discord:channel:123",
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "tool-6",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(events).toHaveLength(0);
+    });
+  });
+});

--- a/src/infra/agent-hook-bridge.test.ts
+++ b/src/infra/agent-hook-bridge.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   startAgentHookBridge,
   stopAgentHookBridge,
   type SessionMeta,
-  type ToolHookEvent,
 } from "./agent-hook-bridge.js";
 import { emitAgentEvent } from "./agent-events.js";
 import {

--- a/src/infra/agent-hook-bridge.ts
+++ b/src/infra/agent-hook-bridge.ts
@@ -1,0 +1,188 @@
+/**
+ * Agent Hook Bridge
+ *
+ * Bridges agent runtime events (tool lifecycle) to the internal hooks system,
+ * enabling workspace hooks to react to tool execution.
+ *
+ * Events emitted:
+ * - tool:start   - Tool execution begins (includes args)
+ * - tool:update  - Streaming output during execution
+ * - tool:result  - Tool execution completes (includes result, isError)
+ *
+ * IMPORTANT: tool:update events can fire at high frequency (token-level streaming).
+ * Hook scripts are responsible for implementing their own throttling/debouncing
+ * if targeting rate-limited APIs like Discord. This design allows different hooks
+ * to handle updates differently (e.g., real-time WebSocket vs throttled Discord).
+ *
+ * @see https://github.com/moltbot/moltbot/issues/2904
+ */
+
+import { onAgentEvent, type AgentEventPayload } from "./agent-events.js";
+import { triggerInternalHook, type InternalHookEvent } from "../hooks/internal-hooks.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+
+export type ToolHookPhase = "start" | "update" | "result";
+
+export type SessionMeta = {
+  agentId: string | null;
+  platform: string | null;
+  channelType: string | null;
+  channelId: string | null;
+  raw: string | null;
+};
+
+export type ToolHookContext = {
+  runId: string;
+  toolName: string;
+  toolCallId: string;
+  args?: unknown;
+  result?: unknown;
+  partialResult?: unknown;
+  isError?: boolean;
+  meta: Record<string, unknown>;
+  sessionMeta: SessionMeta;
+};
+
+export type ToolHookEvent = Omit<InternalHookEvent, "type" | "action" | "context"> & {
+  type: "tool";
+  action: ToolHookPhase;
+  context: ToolHookContext;
+};
+
+/**
+ * Parse session key into structured metadata for hook convenience.
+ *
+ * Session keys look like: `agent:main:discord:channel:123456789`
+ * The `rest` field contains: `discord:channel:123456789`
+ */
+function parseSessionMeta(sessionKey: string | undefined | null): SessionMeta {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return {
+      agentId: null,
+      platform: null,
+      channelType: null,
+      channelId: null,
+      raw: null,
+    };
+  }
+
+  const { agentId, rest } = parsed;
+  const parts = rest.split(":");
+
+  // Handle IDs that might contain colons (e.g., Matrix IDs)
+  const rawChannelId = parts.length > 2 ? parts.slice(2).join(":") : null;
+  // Normalize empty strings to null
+  const channelId = rawChannelId && rawChannelId.trim() ? rawChannelId : null;
+
+  return {
+    agentId,
+    platform: parts[0] ?? null,
+    channelType: parts[1] ?? null,
+    channelId,
+    raw: rest,
+  };
+}
+
+/**
+ * Type guard for tool event data
+ */
+function isToolEventData(
+  data: Record<string, unknown> | undefined,
+): data is {
+  phase: string;
+  name: string;
+  toolCallId: string;
+  args?: unknown;
+  result?: unknown;
+  partialResult?: unknown;
+  isError?: boolean;
+  meta?: Record<string, unknown>;
+} {
+  if (!data) return false;
+  return (
+    typeof data.phase === "string" &&
+    typeof data.name === "string" &&
+    typeof data.toolCallId === "string"
+  );
+}
+
+/**
+ * Check if a phase is a valid tool hook phase
+ */
+function isToolHookPhase(phase: string): phase is ToolHookPhase {
+  return phase === "start" || phase === "update" || phase === "result";
+}
+
+let unsubscribe: (() => void) | null = null;
+
+/**
+ * Start the agent hook bridge.
+ *
+ * Subscribes to agent events and translates tool lifecycle events
+ * to internal hook events. Should be called during gateway startup
+ * after hooks have been loaded.
+ *
+ * @returns Cleanup function to stop the bridge
+ */
+export function startAgentHookBridge(): () => void {
+  // Prevent double-subscription
+  if (unsubscribe) {
+    return unsubscribe;
+  }
+
+  unsubscribe = onAgentEvent((evt: AgentEventPayload) => {
+    // Only care about tool streams
+    if (evt.stream !== "tool") return;
+
+    // Validate event data structure
+    if (!isToolEventData(evt.data)) return;
+
+    const { phase, name, toolCallId, args, result, partialResult, isError, meta } = evt.data;
+
+    // Only bridge known phases
+    if (!isToolHookPhase(phase)) return;
+
+    const hookPayload: ToolHookEvent = {
+      type: "tool",
+      action: phase,
+      sessionKey: evt.sessionKey ?? "",
+      timestamp: new Date(evt.ts),
+      // Explicitly undefined to signal this isn't a chat message event
+      messages: [],
+      context: {
+        runId: evt.runId,
+        toolName: name,
+        toolCallId,
+        // Only include relevant data per phase to reduce payload size
+        args: phase === "start" ? args : undefined,
+        result: phase === "result" ? result : undefined,
+        partialResult: phase === "update" ? partialResult : undefined,
+        isError: phase === "result" ? isError : undefined,
+        meta: meta ?? {},
+        // Parsed session metadata so hooks don't need to parse session keys
+        sessionMeta: parseSessionMeta(evt.sessionKey),
+      },
+    };
+
+    // Fire and forget - don't block tool execution on hook processing
+    void triggerInternalHook(hookPayload as InternalHookEvent);
+  });
+
+  return () => {
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  };
+}
+
+/**
+ * Stop the agent hook bridge if running.
+ */
+export function stopAgentHookBridge(): void {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+}

--- a/src/infra/agent-hook-bridge.ts
+++ b/src/infra/agent-hook-bridge.ts
@@ -87,9 +87,7 @@ function parseSessionMeta(sessionKey: string | undefined | null): SessionMeta {
 /**
  * Type guard for tool event data
  */
-function isToolEventData(
-  data: Record<string, unknown> | undefined,
-): data is {
+function isToolEventData(data: Record<string, unknown> | undefined): data is {
   phase: string;
   name: string;
   toolCallId: string;


### PR DESCRIPTION
## Summary

This PR adds a bridge that connects agent runtime tool events to the internal hooks system, enabling workspace hooks to react to tool execution lifecycle events.

**Closes #2904**

## Problem

When an agent session is churning through tool calls (long-running exec, polling background processes, etc.), external UIs like Discord go silent even though the agent is actively working. There was no visibility into what the agent was doing.

## Solution

Introduces a **Tool Hook Bridge** (`src/infra/agent-hook-bridge.ts`) that:

1. Subscribes to agent events via `onAgentEvent()`
2. Filters for `stream: "tool"` events
3. Translates them to internal hook events (`type: "tool"`)
4. Triggers hooks with `tool:start`, `tool:update`, `tool:result` actions

### Hook Event Structure

```typescript
{
  type: "tool",
  action: "start" | "update" | "result",
  sessionKey: "agent:main:discord:channel:123456",
  timestamp: Date,
  context: {
    runId: string,
    toolName: string,
    toolCallId: string,
    args?: unknown,           // on start
    partialResult?: unknown,  // on update
    result?: unknown,         // on result
    isError?: boolean,        // on result
    meta: object,
    sessionMeta: {            // Parsed for convenience
      agentId: string,
      platform: string,       // discord, telegram, etc.
      channelType: string,
      channelId: string,
    }
  }
}
```

## Key Design Decisions

1. **Update events NOT throttled at bridge level** — Hook scripts handle their own rate limiting. This allows both throttled Discord updates AND real-time WebSocket streaming.

2. **Fire-and-forget** — `void triggerInternalHook()` so tool execution isn't blocked by slow hooks.

3. **Reuses existing utilities** — Uses `parseAgentSessionKey` from session-key-utils.js

4. **Dedicated module** — Keeps gateway startup clean, follows existing patterns.

## Changes

- **NEW:** `src/infra/agent-hook-bridge.ts` - The bridge implementation
- **NEW:** `src/infra/agent-hook-bridge.test.ts` - Comprehensive tests
- **MODIFIED:** `src/hooks/internal-hooks.ts` - Adds `"tool"` to `InternalHookEventType`
- **MODIFIED:** `src/gateway/server-startup.ts` - Starts bridge when hooks are enabled

## Testing

Added tests for:
- tool:start, tool:update, tool:result events
- sessionMeta parsing (including colons in IDs like Matrix)
- Malformed/empty session keys
- Missing required fields (toolCallId, name)
- Non-tool streams ignored
- Unknown phases ignored
- Double-subscription prevention
- Stop functionality

## Example Hook Script

```javascript
// hooks/tool-visibility/handler.js
const activeTools = new Map();

export default async function(event) {
    if (event.type !== 'tool') return;
    
    const { sessionMeta, toolCallId, toolName } = event.context;
    if (sessionMeta.platform !== 'discord') return;
    
    if (event.action === 'start') {
        const msgId = await postEmbed({ title: `⚙️ ${toolName}` });
        activeTools.set(toolCallId, { msgId, startTime: Date.now() });
    }
    
    if (event.action === 'result') {
        const tracked = activeTools.get(toolCallId);
        if (tracked) {
            await updateEmbed(tracked.msgId, { title: `✅ ${toolName}` });
            activeTools.delete(toolCallId);
        }
    }
}
```

## Review Notes

- Architecture reviewed by external agent (Gemini 3 Pro) - approved with minor suggestions which have been addressed
- This is a shallow clone, so diff against main might show false conflicts
