### PR TITLE
feat(web_search): add optional model parameter for Perplexity provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -63,6 +63,12 @@ const WebSearchSchema = Type.Object({
         "Filter results by discovery time (Brave only). Values: 'pd' (past 24h), 'pw' (past week), 'pm' (past month), 'py' (past year), or date range 'YYYY-MM-DDtoYYYY-MM-DD'.",
     }),
   ),
+  model: Type.Optional(
+    Type.String({
+      description:
+        "Perplexity model to use (Perplexity provider only). Overrides the configured default. Examples: 'sonar', 'sonar-pro', 'sonar-reasoning'.",
+    }),
+  ),
 });
 
 type WebSearchConfig = NonNullable<MoltbotConfig["tools"]>["web"] extends infer Web
@@ -450,6 +456,14 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.molt.bot/tools/web",
         });
       }
+      const modelOverride = readStringParam(params, "model");
+      if (modelOverride && provider !== "perplexity") {
+        return jsonResult({
+          error: "unsupported_model_override",
+          message: "model parameter is only supported by the Perplexity web_search provider.",
+          docs: "https://docs.molt.bot/tools/web",
+        });
+      }
       const freshness = rawFreshness ? normalizeFreshness(rawFreshness) : undefined;
       if (rawFreshness && !freshness) {
         return jsonResult({
@@ -475,7 +489,7 @@ export function createWebSearchTool(options?: {
           perplexityAuth?.source,
           perplexityAuth?.apiKey,
         ),
-        perplexityModel: resolvePerplexityModel(perplexityConfig),
+        perplexityModel: modelOverride || resolvePerplexityModel(perplexityConfig),
       });
       return jsonResult(result);
     },


### PR DESCRIPTION
## Summary

Adds an optional `model` parameter to the `web_search` tool, allowing users to override the configured Perplexity model at runtime without config changes or gateway restarts.

## Changes

- Add `model` parameter to `WebSearchSchema`
- Use override when provided, otherwise fall back to configured default
- Return descriptive error if `model` is used with Brave provider (only Perplexity supports this)

## Usage

```javascript
// Use configured default
web_search({ query: "...", })

// Override model for this query
web_search({ query: "...", model: "sonar-pro" })
web_search({ query: "...", model: "sonar-reasoning" })
```

## Testing

- [x] Existing tests pass
- [x] Lint passes
- [x] Type-checks (schema uses TypeBox)

Closes #2882