### PR TITLE
Slack: fix thread context + prevent reply spillover

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -263,7 +263,11 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       const to = typeof args.to === "string" ? args.to : undefined;
       if (!to) return null;
       const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
-      return { to, accountId };
+      const threadIdRaw = typeof args.threadId === "string" ? args.threadId.trim() : "";
+      const replyToRaw = typeof args.replyTo === "string" ? args.replyTo.trim() : "";
+      const threadTsRaw = typeof args.threadTs === "string" ? args.threadTs.trim() : "";
+      const threadId = threadIdRaw || replyToRaw || threadTsRaw || undefined;
+      return { to, accountId, threadId };
     },
     handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
       const resolveChannelId = () =>

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -16,7 +16,7 @@ Use `slack` to react, manage pins, send/edit/delete messages, and fetch member i
 - For reactions, an `emoji` (Unicode or `:name:`).
 - For message sends, a `to` target (`channel:<id>` or `user:<id>`) and `content`.
 
-Message context lines include `slack message id` and `channel` fields you can reuse directly.
+Message text no longer includes `slack message id`. Use metadata fields like `MessageSid` or `ReplyToId`.
 
 ## Actions
 

--- a/src/agents/pi-embedded-messaging.ts
+++ b/src/agents/pi-embedded-messaging.ts
@@ -5,6 +5,7 @@ export type MessagingToolSend = {
   provider: string;
   accountId?: string;
   to?: string;
+  threadId?: string | number;
 };
 
 const CORE_MESSAGING_TOOLS = new Set(["sessions_send", "message"]);

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -31,6 +31,7 @@ export function buildReplyPayloads(params: {
     typeof shouldSuppressMessagingToolReplies
   >[0]["messagingToolSentTargets"];
   originatingTo?: string;
+  originatingThreadId?: string | number;
   accountId?: string;
 }): { replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean } {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
@@ -94,6 +95,7 @@ export function buildReplyPayloads(params: {
     messageProvider: params.messageProvider,
     messagingToolSentTargets,
     originatingTo: params.originatingTo,
+    originatingThreadId: params.originatingThreadId,
     accountId: params.accountId,
   });
   const dedupedPayloads = filterMessagingToolDuplicates({

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -97,6 +97,7 @@ export function buildReplyPayloads(params: {
     originatingTo: params.originatingTo,
     originatingThreadId: params.originatingThreadId,
     accountId: params.accountId,
+    replyToMode: params.replyToMode,
   });
   const dedupedPayloads = filterMessagingToolDuplicates({
     payloads: replyTaggedPayloads,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -408,6 +408,7 @@ export async function runReplyAgent(params: {
       messagingToolSentTexts: runResult.messagingToolSentTexts,
       messagingToolSentTargets: runResult.messagingToolSentTargets,
       originatingTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
+      originatingThreadId: sessionCtx.MessageThreadId,
       accountId: sessionCtx.AccountId,
     });
     const { replyPayloads } = payloadResult;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -241,6 +241,7 @@ export function createFollowupRunner(params: {
         messageProvider: queued.run.messageProvider,
         messagingToolSentTargets: runResult.messagingToolSentTargets,
         originatingTo: queued.originatingTo,
+        originatingThreadId: queued.originatingThreadId,
         accountId: queued.run.agentAccountId,
       });
       const finalPayloads = suppressMessagingToolReplies ? [] : dedupedPayloads;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -243,6 +243,7 @@ export function createFollowupRunner(params: {
         originatingTo: queued.originatingTo,
         originatingThreadId: queued.originatingThreadId,
         accountId: queued.run.agentAccountId,
+        replyToMode,
       });
       const finalPayloads = suppressMessagingToolReplies ? [] : dedupedPayloads;
 

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -82,12 +82,22 @@ export function shouldSuppressMessagingToolReplies(params: {
   messageProvider?: string;
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
+  originatingThreadId?: string | number;
   accountId?: string;
 }): boolean {
   const provider = params.messageProvider?.trim().toLowerCase();
   if (!provider) return false;
   const originTarget = normalizeTargetForProvider(provider, params.originatingTo);
   if (!originTarget) return false;
+  const normalizeThreadId = (value?: string | number) => {
+    if (value === undefined || value === null) return undefined;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : undefined;
+    }
+    return Number.isFinite(value) ? String(value) : undefined;
+  };
+  const originThreadId = normalizeThreadId(params.originatingThreadId);
   const originAccount = normalizeAccountId(params.accountId);
   const sentTargets = params.messagingToolSentTargets ?? [];
   if (sentTargets.length === 0) return false;
@@ -95,11 +105,15 @@ export function shouldSuppressMessagingToolReplies(params: {
     if (!target?.provider) return false;
     if (target.provider.trim().toLowerCase() !== provider) return false;
     const targetKey = normalizeTargetForProvider(provider, target.to);
-    if (!targetKey) return false;
+    if (!targetKey || targetKey !== originTarget) return false;
     const targetAccount = normalizeAccountId(target.accountId);
     if (originAccount && targetAccount && originAccount !== targetAccount) {
       return false;
     }
-    return targetKey === originTarget;
+    const targetThreadId = normalizeThreadId(target.threadId);
+    if (originThreadId || targetThreadId) {
+      return originThreadId === targetThreadId;
+    }
+    return true;
   });
 }

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -62,7 +62,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     const to = typeof args.to === "string" ? args.to : undefined;
     if (!to) return null;
     const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
-    return { to, accountId };
+    const threadIdRaw = typeof args.threadId === "string" ? args.threadId.trim() : "";
+    const threadId = threadIdRaw || undefined;
+    return { to, accountId, threadId };
   },
   handleAction: async ({ action, params, cfg, accountId }) => {
     if (action === "send") {

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -54,7 +54,11 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
       const to = typeof args.to === "string" ? args.to : undefined;
       if (!to) return null;
       const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
-      return { to, accountId };
+      const threadIdRaw = typeof args.threadId === "string" ? args.threadId.trim() : "";
+      const replyToRaw = typeof args.replyTo === "string" ? args.replyTo.trim() : "";
+      const threadTsRaw = typeof args.threadTs === "string" ? args.threadTs.trim() : "";
+      const threadId = threadIdRaw || replyToRaw || threadTsRaw || undefined;
+      return { to, accountId, threadId };
     },
     handleAction: async (ctx: ChannelMessageActionContext) => {
       const { action, params, cfg } = ctx;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -300,6 +300,7 @@ export type ChannelMessageActionContext = {
 export type ChannelToolSend = {
   to: string;
   accountId?: string | null;
+  threadId?: string | number;
 };
 
 export type ChannelMessageActionAdapter = {

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -32,7 +32,9 @@ export function createSlackMessageHandler(params: {
       const senderId = entry.message.user ?? entry.message.bot_id;
       if (!senderId) return null;
       const messageTs = entry.message.ts ?? entry.message.event_ts;
-      // If Slack flags a thread reply but omits thread_ts, isolate it from root debouncing.
+      // If we get a Slack event that looks like a thread reply (has parent_user_id)
+      // but is missing thread_ts, avoid debouncing it into the channel root bucket.
+      // We'll attempt to resolve the missing thread_ts later in prepareSlackMessage.
       const threadKey = entry.message.thread_ts
         ? `${entry.message.channel}:${entry.message.thread_ts}`
         : entry.message.parent_user_id && messageTs

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -47,6 +47,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const toolThreadTs = incomingThreadTs ?? (ctx.replyToMode === "all" ? messageTs : undefined);
   let didSetStatus = false;
 
+  if (shouldLogVerbose()) {
+    logVerbose(
+      `slack threading: inbound channel=${message.channel} ts=${messageTs ?? "unknown"} thread_ts=${incomingThreadTs ?? "none"} replyToMode=${ctx.replyToMode}`,
+    );
+  }
+
   // Shared mutable ref for "replyToMode=first". Both tool + auto-reply flows
   // mark this to ensure only the first reply is threaded.
   const hasRepliedRef = { value: false };

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -44,6 +44,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
+  const toolThreadTs = incomingThreadTs ?? (ctx.replyToMode === "all" ? messageTs : undefined);
   let didSetStatus = false;
 
   // Shared mutable ref for "replyToMode=first". Both tool + auto-reply flows
@@ -101,8 +102,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     responsePrefix: prefixContext.responsePrefix,
     responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    deliver: async (payload) => {
-      const replyThreadTs = replyPlan.nextThreadTs();
+    deliver: async (payload, info) => {
+      const replyThreadTs = info.kind === "tool" ? toolThreadTs : replyPlan.nextThreadTs();
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `slack threading: deliver kind=${info.kind} target=${prepared.replyTarget} thread_ts=${replyThreadTs ?? "none"} payload.replyToId=${payload.replyToId ?? "none"}`,
+        );
+      }
       await deliverReplies({
         replies: [payload],
         target: prepared.replyTarget,
@@ -112,7 +118,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         textLimit: ctx.textLimit,
         replyThreadTs,
       });
-      replyPlan.markSent();
+      if (info.kind !== "tool") {
+        replyPlan.markSent();
+      }
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -398,7 +398,6 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       From: slackFrom,
     }) ?? (isDirectMessage ? senderName : roomLabel);
-  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
   });
@@ -411,7 +410,7 @@ export async function prepareSlackMessage(params: {
     channel: "Slack",
     from: envelopeFrom,
     timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
-    body: textWithId,
+    body: rawBody,
     chatType: isDirectMessage ? "direct" : "channel",
     sender: { name: senderName, id: senderId },
     previousTimestamp,
@@ -430,9 +429,7 @@ export async function prepareSlackMessage(params: {
           channel: "Slack",
           from: roomLabel,
           timestamp: entry.timestamp,
-          body: `${entry.body}${
-            entry.messageId ? ` [id:${entry.messageId} channel:${message.channel}]` : ""
-          }`,
+          body: entry.body,
           chatType: "channel",
           senderLabel: entry.sender,
           envelope: envelopeOptions,
@@ -466,12 +463,11 @@ export async function prepareSlackMessage(params: {
     if (starter?.text) {
       const starterUser = starter.userId ? await ctx.resolveUserName(starter.userId) : null;
       const starterName = starterUser?.name ?? starter.userId ?? "Unknown";
-      const starterWithId = `${starter.text}\n[slack message id: ${starter.ts ?? threadTs} channel: ${message.channel}]`;
       threadStarterBody = formatThreadStarterEnvelope({
         channel: "Slack",
         author: starterName,
         timestamp: starter.ts ? Math.round(Number(starter.ts) * 1000) : undefined,
-        body: starterWithId,
+        body: starter.text,
         envelope: envelopeOptions,
       });
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -1,3 +1,5 @@
+import type { WebClient as SlackWebClient } from "@slack/web-api";
+
 import { resolveAckReaction } from "../../../agents/identity.js";
 import { hasControlCommand } from "../../../auto-reply/command-detection.js";
 import { shouldHandleTextCommands } from "../../../auto-reply/commands-registry.js";
@@ -48,13 +50,41 @@ import { resolveSlackMedia, resolveSlackThreadStarter } from "../media.js";
 
 import type { PreparedSlackMessage } from "./types.js";
 
+async function resolveSlackThreadTsFromHistory(params: {
+  client: SlackWebClient;
+  channelId: string;
+  messageTs: string;
+}): Promise<string | undefined> {
+  try {
+    const response = (await params.client.conversations.history({
+      channel: params.channelId,
+      latest: params.messageTs,
+      oldest: params.messageTs,
+      inclusive: true,
+      limit: 1,
+    })) as { messages?: Array<{ ts?: string; thread_ts?: string }> };
+    const message =
+      response.messages?.find((entry) => entry.ts === params.messageTs) ?? response.messages?.[0];
+    const threadTs = message?.thread_ts?.trim();
+    return threadTs || undefined;
+  } catch (err) {
+    if (shouldLogVerbose()) {
+      logVerbose(
+        `slack inbound: failed to resolve thread_ts via conversations.history for channel=${params.channelId} ts=${params.messageTs}: ${String(err)}`,
+      );
+    }
+    return undefined;
+  }
+}
+
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
   message: SlackMessageEvent;
   opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
 }): Promise<PreparedSlackMessage | null> {
-  const { ctx, account, message, opts } = params;
+  const { ctx, account, opts } = params;
+  let message = params.message;
   const cfg = ctx.cfg;
 
   let channelInfo: {
@@ -192,6 +222,33 @@ export async function prepareSlackMessage(params: {
       id: isDirectMessage ? (message.user ?? "unknown") : message.channel,
     },
   });
+
+  // Slack occasionally delivers events that include parent_user_id (so they're thread replies)
+  // but omit thread_ts. If we don't recover the thread_ts, replies can end up in the channel root.
+  if (!message.thread_ts && message.parent_user_id && message.ts) {
+    if (shouldLogVerbose()) {
+      logVerbose(
+        `slack inbound: missing thread_ts for thread reply channel=${message.channel} ts=${message.ts} source=${opts.source}`,
+      );
+    }
+    const resolved = await resolveSlackThreadTsFromHistory({
+      client: ctx.app.client,
+      channelId: message.channel,
+      messageTs: message.ts,
+    });
+    if (resolved) {
+      message = { ...message, thread_ts: resolved };
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `slack inbound: resolved missing thread_ts channel=${message.channel} ts=${message.ts} -> thread_ts=${resolved}`,
+        );
+      }
+    } else if (shouldLogVerbose()) {
+      logVerbose(
+        `slack inbound: could not resolve missing thread_ts channel=${message.channel} ts=${message.ts}`,
+      );
+    }
+  }
 
   const baseSessionKey = route.sessionKey;
   const threadContext = resolveSlackThreadContext({ message, replyToMode: ctx.replyToMode });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -197,14 +197,17 @@ export async function prepareSlackMessage(params: {
   const threadContext = resolveSlackThreadContext({ message, replyToMode: ctx.replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
+  const autoThreadId =
+    !isThreadReply && ctx.replyToMode === "all" ? threadContext.messageThreadId : undefined;
+  const threadSessionId = isThreadReply ? threadTs : autoThreadId;
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey,
-    threadId: isThreadReply ? threadTs : undefined,
-    parentSessionKey: isThreadReply && ctx.threadInheritParent ? baseSessionKey : undefined,
+    threadId: threadSessionId,
+    parentSessionKey: threadSessionId && ctx.threadInheritParent ? baseSessionKey : undefined,
   });
   const sessionKey = threadKeys.sessionKey;
   const historyKey =
-    isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
+    threadSessionId && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
 
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
   const hasAnyMention = /<@[^>]+>/.test(message.text ?? "");
@@ -402,7 +405,7 @@ export async function prepareSlackMessage(params: {
   const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg);
   const previousTimestamp = readSessionUpdatedAt({
     storePath,
-    sessionKey: route.sessionKey,
+    sessionKey,
   });
   const body = formatInboundEnvelope({
     channel: "Slack",

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -44,7 +44,7 @@ export async function deliverReplies(params: {
         });
       }
     }
-    params.runtime.log?.(`delivered reply to ${params.target}`);
+    params.runtime.log?.(`delivered reply to ${params.target} threadTs=${threadTs ?? "none"}`);
   }
 }
 


### PR DESCRIPTION
## Problem\nSlack thread replies sometimes lose context, and tool replies can post in the wrong place. Auto-threaded tool sends could also trigger a duplicate follow-up reply.\n\n## Changes\n- Recover missing Slack thread IDs when Slack omits thread_ts\n- Keep tool replies in the correct thread\n- Prevent tool replies from consuming the first-reply thread slot\n- Treat auto-threaded Slack tool sends as the same thread for suppression\n- Make tool-reply suppression thread-aware in follow-ups\n- Stop injecting Slack message IDs into prompt text\n\n## Why it helps\n- Replies stay in the right thread\n- Fewer context leaks and confusing replies\n- Cleaner prompt input for the model

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Slack threading reliability and reply routing by (1) recovering missing `thread_ts` for inbound thread replies, (2) making reply delivery thread-aware so tool output and model replies don’t spill into the wrong thread, and (3) tightening messaging-tool dedupe/suppression by including a `threadId` dimension. It also removes Slack message IDs from the user-visible prompt body in favor of structured metadata fields, which should reduce prompt noise and accidental leakage.

Key changes span the Slack monitor pipeline (`prepareSlackMessage`/`dispatchPreparedSlackMessage`), auto-reply payload building/suppression logic, and messaging tool send extraction so downstream routing can preserve thread context consistently across Slack (and partially Telegram).

<h3>Confidence Score: 3/5</h3>

- This PR is plausibly safe to merge but has a couple threading edge cases that could mis-route or suppress replies in Slack/Telegram.
- Most changes are localized and consistent (adding `threadId` propagation and improving Slack thread_ts recovery), but the new Slack tool-delivery threading behavior can change semantics (tool sends may start threads) and the suppression heuristic can hide genuine replies when thread IDs are assumed. Telegram’s new `caption` fallback also changes precedence when `message` is intentionally empty.
- src/slack/monitor/message-handler/dispatch.ts, src/auto-reply/reply/reply-payloads.ts, src/channels/plugins/actions/telegram.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->