### PR TITLE
feat(android): add haptic feedback for chat messages

### DIFF
--- a/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatComposer.kt
@@ -37,6 +37,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import com.clawdbot.android.chat.ChatSessionEntry
 
@@ -61,6 +63,7 @@ fun ChatComposer(
   var input by rememberSaveable { mutableStateOf("") }
   var showThinkingMenu by remember { mutableStateOf(false) }
   var showSessionMenu by remember { mutableStateOf(false) }
+  val haptic = LocalHapticFeedback.current
 
   val sessionOptions = resolveSessionChoices(sessionKey, sessions, mainSessionKey = mainSessionKey)
   val currentSessionLabel =
@@ -165,6 +168,7 @@ fun ChatComposer(
           }
         } else {
           FilledTonalIconButton(onClick = {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
             val text = input
             input = ""
             onSend(text)

--- a/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/com/clawdbot/android/ui/chat/ChatMessageListCard.kt
@@ -16,9 +16,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import com.clawdbot.android.chat.ChatMessage
 import com.clawdbot.android.chat.ChatPendingToolCall
@@ -32,6 +38,19 @@ fun ChatMessageListCard(
   modifier: Modifier = Modifier,
 ) {
   val listState = rememberLazyListState()
+  val haptic = LocalHapticFeedback.current
+  var previousMessageCount by remember { mutableIntStateOf(messages.size) }
+
+  // Haptic feedback when a new assistant message arrives
+  LaunchedEffect(messages.size) {
+    if (messages.size > previousMessageCount) {
+      val lastMessage = messages.lastOrNull()
+      if (lastMessage != null && lastMessage.role.lowercase() == "assistant") {
+        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+      }
+    }
+    previousMessageCount = messages.size
+  }
 
   LaunchedEffect(messages.size, pendingRunCount, pendingToolCalls.size, streamingAssistantText) {
     val total =


### PR DESCRIPTION
## Summary

Adds haptic feedback to the Android chat UI for a more tactile user experience:

### Changes:
- **Send button**: Provides a `LongPress` haptic feedback when sending a message
- **Message arrival**: Provides a subtle `TextHandleMove` haptic feedback when a new assistant message arrives

### Why this matters:
- Power users like having physical confirmation of actions
- Common in modern messaging apps (Telegram, WhatsApp, iMessage)
- Enhances the feel of the app without being intrusive

### Implementation:
- Uses Compose's built-in `LocalHapticFeedback` API
- Minimal code changes (23 lines added)
- No new dependencies