### PR TITLE
fix: correctly resolve paths for dynamic imports using URL utilities

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -7,6 +7,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import os from "node:os";
 import type { MoltbotConfig } from "../../../config/config.js";
 import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
@@ -106,12 +107,11 @@ const saveSessionToMemory: HookHandler = async (event) => {
         // Dynamically import the LLM slug generator (avoids module caching issues)
         // When compiled, handler is at dist/hooks/bundled/session-memory/handler.js
         // Going up ../.. puts us at dist/hooks/, so just add llm-slug-generator.js
-        const moltbotRoot = path.resolve(
-          path.dirname(import.meta.url.replace("file://", "")),
-          "../..",
-        );
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = path.dirname(__filename);
+        const moltbotRoot = path.resolve(__dirname, "../..");
         const slugGenPath = path.join(moltbotRoot, "llm-slug-generator.js");
-        const { generateSlugViaLLM } = await import(slugGenPath);
+        const { generateSlugViaLLM } = await import(pathToFileURL(slugGenPath).href);
 
         // Use LLM to generate a descriptive slug
         slug = await generateSlugViaLLM({ sessionContent, cfg });


### PR DESCRIPTION
### Summary
The session-memory hook fails on Windows when saving session memory due to incorrect handling of import.meta.url. The naive .replace("file://", "") leaves a malformed path on Windows (/C:/Users/...), and the dynamic import() receives an invalid path instead of a proper file:// URL.

### Changes
Windows compatibility issue with error Only URLs with a scheme in: file, data, and node are supported

Fixes [#2256](https://github.com/moltbot/moltbot/issues/2256)