### PR TITLE
fix(macos): complete Clawd → Molt rename in Swift code and build scripts

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -27,15 +27,16 @@ let package = Package(
         .target(
             name: "MoltbotIPC",
             dependencies: [],
+            path: "Sources/ClawdbotIPC",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),
         .target(
             name: "MoltbotDiscovery",
             dependencies: [
-                .product(name: "MoltbotKit", package: "MoltbotKit"),
+                .product(name: "MoltbotKit", package: "ClawdbotKit"),
             ],
-            path: "Sources/MoltbotDiscovery",
+            path: "Sources/ClawdbotDiscovery",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),
@@ -44,9 +45,9 @@ let package = Package(
             dependencies: [
                 "MoltbotIPC",
                 "MoltbotDiscovery",
-                .product(name: "MoltbotKit", package: "MoltbotKit"),
-                .product(name: "MoltbotChatUI", package: "MoltbotKit"),
-                .product(name: "MoltbotProtocol", package: "MoltbotKit"),
+                .product(name: "MoltbotKit", package: "ClawdbotKit"),
+                .product(name: "MoltbotChatUI", package: "ClawdbotKit"),
+                .product(name: "MoltbotProtocol", package: "ClawdbotKit"),
                 .product(name: "SwabbleKit", package: "swabble"),
                 .product(name: "MenuBarExtraAccess", package: "MenuBarExtraAccess"),
                 .product(name: "Subprocess", package: "swift-subprocess"),
@@ -55,11 +56,12 @@ let package = Package(
                 .product(name: "PeekabooBridge", package: "Peekaboo"),
                 .product(name: "PeekabooAutomationKit", package: "Peekaboo"),
             ],
+            path: "Sources/Clawdbot",
             exclude: [
                 "Resources/Info.plist",
             ],
             resources: [
-                .copy("Resources/Moltbot.icns"),
+                .copy("Resources/Clawdbot.icns"),
                 .copy("Resources/DeviceModels"),
             ],
             swiftSettings: [
@@ -69,10 +71,10 @@ let package = Package(
             name: "MoltbotMacCLI",
             dependencies: [
                 "MoltbotDiscovery",
-                .product(name: "MoltbotKit", package: "MoltbotKit"),
-                .product(name: "MoltbotProtocol", package: "MoltbotKit"),
+                .product(name: "MoltbotKit", package: "ClawdbotKit"),
+                .product(name: "MoltbotProtocol", package: "ClawdbotKit"),
             ],
-            path: "Sources/MoltbotMacCLI",
+            path: "Sources/ClawdbotMacCLI",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),
@@ -82,9 +84,10 @@ let package = Package(
                 "MoltbotIPC",
                 "Moltbot",
                 "MoltbotDiscovery",
-                .product(name: "MoltbotProtocol", package: "MoltbotKit"),
+                .product(name: "MoltbotProtocol", package: "ClawdbotKit"),
                 .product(name: "SwabbleKit", package: "swabble"),
             ],
+            path: "Tests/ClawdbotIPCTests",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
                 .enableExperimentalFeature("SwiftTesting"),

--- a/apps/macos/Sources/Clawdbot/AnthropicOAuth.swift
+++ b/apps/macos/Sources/Clawdbot/AnthropicOAuth.swift
@@ -226,7 +226,7 @@ enum MoltbotOAuthStore {
     }
 
     static func oauthDir() -> URL {
-        if let override = ProcessInfo.processInfo.environment[self.clawdbotOAuthDirEnv]?
+        if let override = ProcessInfo.processInfo.environment[self.moltbotOAuthDirEnv]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !override.isEmpty
         {

--- a/apps/macos/Sources/Clawdbot/CLIInstallPrompter.swift
+++ b/apps/macos/Sources/Clawdbot/CLIInstallPrompter.swift
@@ -62,7 +62,7 @@ final class CLIInstallPrompter {
         SettingsTabRouter.request(tab)
         SettingsWindowOpener.shared.open()
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .clawdbotSelectSettingsTab, object: tab)
+            NotificationCenter.default.post(name: .moltbotSelectSettingsTab, object: tab)
         }
     }
 

--- a/apps/macos/Sources/Clawdbot/CommandResolver.swift
+++ b/apps/macos/Sources/Clawdbot/CommandResolver.swift
@@ -87,7 +87,7 @@ enum CommandResolver {
         // Dev-only convenience. Avoid project-local PATH hijacking in release builds.
         extras.insert(projectRoot.appendingPathComponent("node_modules/.bin").path, at: 0)
         #endif
-        let moltbotPaths = self.clawdbotManagedPaths(home: home)
+        let moltbotPaths = self.moltbotManagedPaths(home: home)
         if !moltbotPaths.isEmpty {
             extras.insert(contentsOf: moltbotPaths, at: 1)
         }
@@ -207,7 +207,7 @@ enum CommandResolver {
     }
 
     static func hasAnyMoltbotInvoker(searchPaths: [String]? = nil) -> Bool {
-        if self.clawdbotExecutable(searchPaths: searchPaths) != nil { return true }
+        if self.moltbotExecutable(searchPaths: searchPaths) != nil { return true }
         if self.findExecutable(named: "pnpm", searchPaths: searchPaths) != nil { return true }
         if self.findExecutable(named: "node", searchPaths: searchPaths) != nil,
            self.nodeCliPath() != nil
@@ -253,7 +253,7 @@ enum CommandResolver {
                 // Use --silent to avoid pnpm lifecycle banners that would corrupt JSON outputs.
                 return [pnpm, "--silent", "moltbot", subcommand] + extraArgs
             }
-            if let moltbotPath = self.clawdbotExecutable(searchPaths: searchPaths) {
+            if let moltbotPath = self.moltbotExecutable(searchPaths: searchPaths) {
                 return [moltbotPath, subcommand] + extraArgs
             }
 
@@ -275,7 +275,7 @@ enum CommandResolver {
         configRoot: [String: Any]? = nil,
         searchPaths: [String]? = nil) -> [String]
     {
-        self.clawdbotNodeCommand(
+        self.moltbotNodeCommand(
             subcommand: subcommand,
             extraArgs: extraArgs,
             defaults: defaults,

--- a/apps/macos/Sources/Clawdbot/GatewayEnvironment.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayEnvironment.swift
@@ -123,7 +123,7 @@ enum GatewayEnvironment {
                 requiredGateway: expectedString,
                 message: RuntimeLocator.describeFailure(err))
         case let .success(runtime):
-            let gatewayBin = CommandResolver.clawdbotExecutable()
+            let gatewayBin = CommandResolver.moltbotExecutable()
 
             if gatewayBin == nil, projectEntrypoint == nil {
                 return GatewayEnvironmentStatus(
@@ -181,7 +181,7 @@ enum GatewayEnvironment {
         let projectRoot = CommandResolver.projectRoot()
         let projectEntrypoint = CommandResolver.gatewayEntrypoint(in: projectRoot)
         let status = self.check()
-        let gatewayBin = CommandResolver.clawdbotExecutable()
+        let gatewayBin = CommandResolver.moltbotExecutable()
         let runtime = RuntimeLocator.resolve(searchPaths: CommandResolver.preferredPaths())
 
         guard case .ok = status.kind else {

--- a/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/Clawdbot/GatewayLaunchAgentManager.swift
@@ -143,7 +143,7 @@ extension GatewayLaunchAgentManager {
         timeout: Double,
         quiet: Bool) async -> CommandResult
     {
-        let command = CommandResolver.clawdbotCommand(
+        let command = CommandResolver.moltbotCommand(
             subcommand: "gateway",
             extraArgs: self.withJsonFlag(args),
             // Launchd management must always run locally, even if remote mode is configured.

--- a/apps/macos/Sources/Clawdbot/MenuContentView.swift
+++ b/apps/macos/Sources/Clawdbot/MenuContentView.swift
@@ -329,7 +329,7 @@ struct MenuContent: View {
         NSApp.activate(ignoringOtherApps: true)
         self.openSettings()
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .clawdbotSelectSettingsTab, object: tab)
+            NotificationCenter.default.post(name: .moltbotSelectSettingsTab, object: tab)
         }
     }
 

--- a/apps/macos/Sources/Clawdbot/NodeServiceManager.swift
+++ b/apps/macos/Sources/Clawdbot/NodeServiceManager.swift
@@ -52,7 +52,7 @@ extension NodeServiceManager {
         timeout: Double,
         quiet: Bool) async -> CommandResult
     {
-        let command = CommandResolver.clawdbotCommand(
+        let command = CommandResolver.moltbotCommand(
             subcommand: "service",
             extraArgs: self.withJsonFlag(args),
             // Service management must always run locally, even if remote mode is configured.

--- a/apps/macos/Sources/Clawdbot/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/Clawdbot/OnboardingView+Actions.swift
@@ -47,7 +47,7 @@ extension OnboardingView {
         SettingsTabRouter.request(tab)
         self.openSettings()
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .clawdbotSelectSettingsTab, object: tab)
+            NotificationCenter.default.post(name: .moltbotSelectSettingsTab, object: tab)
         }
     }
 

--- a/apps/macos/Sources/Clawdbot/SettingsRootView.swift
+++ b/apps/macos/Sources/Clawdbot/SettingsRootView.swift
@@ -77,7 +77,7 @@ struct SettingsRootView: View {
         .padding(.vertical, 22)
         .frame(width: SettingsTab.windowWidth, height: SettingsTab.windowHeight, alignment: .topLeading)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onReceive(NotificationCenter.default.publisher(for: .clawdbotSelectSettingsTab)) { note in
+        .onReceive(NotificationCenter.default.publisher(for: .moltbotSelectSettingsTab)) { note in
             if let tab = note.object as? SettingsTab {
                 withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
                     self.selectedTab = tab

--- a/apps/shared/ClawdbotKit/Package.swift
+++ b/apps/shared/ClawdbotKit/Package.swift
@@ -26,11 +26,11 @@ let package = Package(
             ]),
         .target(
             name: "MoltbotKit",
-            path: "Sources/ClawdbotKit",
             dependencies: [
                 "MoltbotProtocol",
                 .product(name: "ElevenLabsKit", package: "ElevenLabsKit"),
             ],
+            path: "Sources/ClawdbotKit",
             resources: [
                 .process("Resources"),
             ],
@@ -39,7 +39,6 @@ let package = Package(
             ]),
         .target(
             name: "MoltbotChatUI",
-            path: "Sources/ClawdbotChatUI",
             dependencies: [
                 "MoltbotKit",
                 .product(
@@ -47,6 +46,7 @@ let package = Package(
                     package: "textual",
                     condition: .when(platforms: [.macOS, .iOS])),
             ],
+            path: "Sources/ClawdbotChatUI",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -140,7 +140,7 @@ mkdir -p "$APP_ROOT/Contents/Resources"
 mkdir -p "$APP_ROOT/Contents/Frameworks"
 
 echo "📄 Copying Info.plist template"
-INFO_PLIST_SRC="$ROOT_DIR/apps/macos/Sources/Moltbot/Resources/Info.plist"
+INFO_PLIST_SRC="$ROOT_DIR/apps/macos/Sources/Clawdbot/Resources/Info.plist"
 if [ ! -f "$INFO_PLIST_SRC" ]; then
   echo "ERROR: Info.plist template missing at $INFO_PLIST_SRC" >&2
   exit 1
@@ -201,11 +201,11 @@ else
 fi
 
 echo "🖼  Copying app icon"
-cp "$ROOT_DIR/apps/macos/Sources/Moltbot/Resources/Moltbot.icns" "$APP_ROOT/Contents/Resources/Moltbot.icns"
+cp "$ROOT_DIR/apps/macos/Sources/Clawdbot/Resources/Clawdbot.icns" "$APP_ROOT/Contents/Resources/Moltbot.icns"
 
 echo "📦 Copying device model resources"
 rm -rf "$APP_ROOT/Contents/Resources/DeviceModels"
-cp -R "$ROOT_DIR/apps/macos/Sources/Moltbot/Resources/DeviceModels" "$APP_ROOT/Contents/Resources/DeviceModels"
+cp -R "$ROOT_DIR/apps/macos/Sources/Clawdbot/Resources/DeviceModels" "$APP_ROOT/Contents/Resources/DeviceModels"
 
 echo "📦 Copying model catalog"
 MODEL_CATALOG_SRC="$ROOT_DIR/node_modules/@mariozechner/pi-ai/dist/models.generated.js"


### PR DESCRIPTION
Fix incomplete rename that broke macOS app builds:

- Update Package.swift to use ClawdbotKit package identifier (SPM uses path name)
- Fix argument order in ClawdbotKit Package.swift (dependencies before path)
- Add path properties to macos Package.swift targets pointing to Clawdbot* directories
- Update notification name references (.clawdbotSelectSettingsTab → .moltbotSelectSettingsTab)
- Update CommandResolver method calls (clawdbotCommand → moltbotCommand, etc.)
- Update self.clawdbotOAuthDirEnv → self.moltbotOAuthDirEnv
- Fix resource paths in package-mac-app.sh (Sources/Moltbot → Sources/Clawdbot)
- Fix icon filename reference (Moltbot.icns → Clawdbot.icns)