### PR TITLE
feat(web_search): add optional model parameter for Perplexity provider

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { __testing } from "./web-search.js";
 
-const { inferPerplexityBaseUrlFromApiKey, resolvePerplexityBaseUrl, normalizeFreshness } =
-  __testing;
+const {
+  inferPerplexityBaseUrlFromApiKey,
+  resolvePerplexityBaseUrl,
+  normalizeFreshness,
+  resolvePerplexityRequestParams,
+  buildWebSearchCacheKey,
+} = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
   it("detects a Perplexity key prefix", () => {
@@ -67,5 +72,90 @@ describe("web_search freshness normalization", () => {
     expect(normalizeFreshness("2024-13-01to2024-01-31")).toBeUndefined();
     expect(normalizeFreshness("2024-02-30to2024-03-01")).toBeUndefined();
     expect(normalizeFreshness("2024-03-10to2024-03-01")).toBeUndefined();
+  });
+});
+
+describe("web_search model parameter", () => {
+  it("prefixes short model names for OpenRouter", () => {
+    const { effectivePerplexityModel: shortModel } = resolvePerplexityRequestParams({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "sonar",
+    });
+    expect(shortModel).toBe("perplexity/sonar");
+
+    const { effectivePerplexityModel: prefixedModel } = resolvePerplexityRequestParams({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "perplexity/sonar-pro",
+    });
+    expect(prefixedModel).toBe("perplexity/sonar-pro");
+  });
+
+  it("keeps short model names for direct Perplexity", () => {
+    const { effectivePerplexityModel } = resolvePerplexityRequestParams({
+      baseUrl: "https://api.perplexity.ai",
+      model: "sonar",
+    });
+    expect(effectivePerplexityModel).toBe("sonar");
+  });
+
+  it("differentiates cache keys by model", () => {
+    const baseParams = {
+      provider: "perplexity" as const,
+      query: "model test",
+      count: 5,
+      perplexityBaseUrl: "default",
+    };
+
+    const firstParams = resolvePerplexityRequestParams({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "sonar",
+    });
+    const secondParams = resolvePerplexityRequestParams({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "sonar-pro",
+    });
+
+    const first = buildWebSearchCacheKey({
+      ...baseParams,
+      perplexityModel: firstParams.cachePerplexityModel,
+      perplexityBaseUrl: firstParams.cachePerplexityBaseUrl,
+    });
+    const second = buildWebSearchCacheKey({
+      ...baseParams,
+      perplexityModel: secondParams.cachePerplexityModel,
+      perplexityBaseUrl: secondParams.cachePerplexityBaseUrl,
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("differentiates cache keys by baseUrl", () => {
+    const baseParams = {
+      provider: "perplexity" as const,
+      query: "base url test",
+      count: 5,
+    };
+
+    const openRouterParams = resolvePerplexityRequestParams({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "sonar",
+    });
+    const directParams = resolvePerplexityRequestParams({
+      baseUrl: "https://api.perplexity.ai",
+      model: "sonar",
+    });
+
+    const openRouter = buildWebSearchCacheKey({
+      ...baseParams,
+      perplexityModel: openRouterParams.cachePerplexityModel,
+      perplexityBaseUrl: openRouterParams.cachePerplexityBaseUrl,
+    });
+    const direct = buildWebSearchCacheKey({
+      ...baseParams,
+      perplexityModel: directParams.cachePerplexityModel,
+      perplexityBaseUrl: directParams.cachePerplexityBaseUrl,
+    });
+
+    expect(openRouter).not.toBe(direct);
   });
 });


### PR DESCRIPTION
## Summary

Adds a `model` parameter to the `web_search` tool, allowing agents to dynamically select different Perplexity models (e.g., `sonar`, `sonar-pro`, `sonar-reasoning`) per request.

## Changes

- **New `model` parameter** in the web_search schema (Perplexity provider only)
- **OpenRouter model normalization**: Short model names like `sonar` are automatically prefixed with `perplexity/` when using OpenRouter; direct Perplexity API keeps short names
- **Cache key differentiation**: Cache keys now include model and baseUrl to prevent cross-contamination between different model responses
- **Error handling**: Returns clear error when `model` is used with Brave provider
- **Refactored helpers**: Extracted `resolvePerplexityRequestParams` and `buildWebSearchCacheKey` for testability

## Tests

Added 4 new unit tests:
- OpenRouter model prefix normalization
- Direct Perplexity keeps short names
- Cache key differs by model
- Cache key differs by baseUrl

All 16 tests passing.

## Usage

```typescript
// Use sonar-reasoning for complex queries
web_search({ query: "explain quantum entanglement", model: "sonar-reasoning" })

// Use default model (configured in config)
web_search({ query: "weather today" })
```
