### PR TITLE
fix(security): recognize Venice-style claude-opus-45 as top-tier model

### DIFF
--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -311,7 +311,10 @@ function isClaudeModel(id: string): boolean {
 }
 
 function isClaude45OrHigher(id: string): boolean {
-  return /\bclaude-[^\s/]*?(?:-4-5\b|4\.5\b)/i.test(id);
+  // Match claude-*-4-5, claude-*-45, claude-*4.5, or opus-4-5/opus-45 variants
+  // Examples that should match:
+  //   claude-opus-4-5, claude-opus-45, claude-4.5, venice/claude-opus-45
+  return /\bclaude-[^\s/]*?(?:-4-?5\b|4\.5\b)/i.test(id);
 }
 
 export function collectModelHygieneFindings(cfg: ClawdbotConfig): SecurityAuditFinding[] {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -687,6 +687,23 @@ describe("security audit", () => {
     );
   });
 
+  it("does not warn on Venice-style opus-45 model names", async () => {
+    // Venice uses "claude-opus-45" format (no dash between 4 and 5)
+    const cfg: ClawdbotConfig = {
+      agents: { defaults: { model: { primary: "venice/claude-opus-45" } } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    // Should NOT contain weak_tier warning for opus-45
+    const weakTierFinding = res.findings.find((f) => f.checkId === "models.weak_tier");
+    expect(weakTierFinding).toBeUndefined();
+  });
+
   it("warns when hooks token looks short", async () => {
     const cfg: ClawdbotConfig = {
       hooks: { enabled: true, token: "short" },


### PR DESCRIPTION
## Problem

The security audit (`clawdbot security audit --deep`) incorrectly flags `venice/claude-opus-45` as 'Below Claude 4.5':

```
- venice/claude-opus-45 (Below Claude 4.5) @ agents.defaults.model.primary
  Fix: Use the latest, top-tier model for any bot with tools or untrusted inboxes.
```

This is a false positive - Venice's Opus 4.5 IS Claude 4.5, just with different naming.

## Root Cause

The `isClaude45OrHigher()` regex expected `-4-5` (with dash) but Venice uses `-45` (no dash between 4 and 5):

```typescript
// Before: only matched -4-5 or 4.5
/\bclaude-[^\s/]*?(?:-4-5\b|4\.5\b)/i

// After: also matches -45
/\bclaude-[^\s/]*?(?:-4-?5\b|4\.5\b)/i
```

## Changes

- Updated regex in `src/security/audit-extra.ts` to make the dash optional
- Added test case for Venice-style model names

## Testing

```javascript
// Now correctly matches all these:
'claude-opus-4-5'        // ✅ Anthropic standard
'claude-opus-45'         // ✅ Venice naming
'venice/claude-opus-45'  // ✅ Venice with provider prefix
'claude-4.5'             // ✅ Shorthand
```

Reported in Venice Discord #agentic-revolution channel.