### PR TITLE
fix(telegram): include AccountId in native command context for multi-agent routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Status: beta.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.
 - Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.
+- Telegram: include AccountId in native command context for multi-agent routing. (#2942) Thanks @Chloe-VP.
 - Telegram: handle video note attachments in media extraction. (#2905) Thanks @mylukin.
 - TTS: read OPENAI_TTS_BASE_URL at runtime instead of module load to honor config.env. (#3341) Thanks @hclsys.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -468,6 +468,7 @@ export const registerTelegramNativeCommands = ({
             CommandAuthorized: commandAuthorized,
             CommandSource: "native" as const,
             SessionKey: `telegram:slash:${senderId || chatId}`,
+            AccountId: route.accountId,
             CommandTargetSessionKey: sessionKey,
             MessageThreadId: threadIdForSend,
             IsForum: isForum,


### PR DESCRIPTION
## Problem

When running multiple Clawdbot agents with the same Telegram bot token (multi-agent setup), native commands like `/start` were not being routed to the correct agent. The `AccountId` was not being passed through the command context, causing the routing logic to fail.

## Solution

Added `AccountId` to the context object passed to native command handlers in the Telegram channel plugin. This ensures multi-agent routing works correctly for native commands, consistent with how regular messages are handled.

## Changes

- `src/channels/telegram/telegram-plugin.ts`: Include `AccountId` in the context object passed to `handleNativeCommand()`

## Testing

Tested in a multi-agent environment where two agents share the same Telegram bot token. Native commands now route correctly to the appropriate agent based on AccountId.