### PR TITLE
fix(ui): auto-expand chat textarea on input (Fixes #2939)

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { SessionsListResult } from "../types";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types";
@@ -70,6 +71,11 @@ export type ChatProps = {
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
+
+function adjustTextareaHeight(el: HTMLTextAreaElement) {
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+}
 
 function renderCompactionIndicator(status: CompactionIndicatorStatus | null | undefined) {
   if (!status) return nothing;
@@ -327,6 +333,7 @@ export function renderChat(props: ChatProps) {
           <label class="field chat-compose__field">
             <span>Message</span>
             <textarea
+              ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
               .value=${props.draft}
               ?disabled=${!props.connected}
               @keydown=${(e: KeyboardEvent) => {
@@ -337,8 +344,11 @@ export function renderChat(props: ChatProps) {
                 e.preventDefault();
                 if (canCompose) props.onSend();
               }}
-              @input=${(e: Event) =>
-                props.onDraftChange((e.target as HTMLTextAreaElement).value)}
+              @input=${(e: Event) => {
+                const target = e.target as HTMLTextAreaElement;
+                adjustTextareaHeight(target);
+                props.onDraftChange(target.value);
+              }}
               @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
               placeholder=${composePlaceholder}
             ></textarea>


### PR DESCRIPTION
### Summary
This PR fixes an issue where the chat input textarea had a fixed height, causing long messages to be hidden. The input now auto-expands vertically as the user types, improving visibility and the editing experience.

### Fixes
Closes #2939

### Changes
- Updated directive on the textarea.
- Added helper to dynamically set `style.height` based on `scrollHeight`.
- Ensures height resets correctly when the message is sent.

---
### 🤖 AI Contribution Info
- **AI-Assisted**: Yes
- **Testing Level**: Lightly tested (Verified logic locally)
- **Understanding**: I confirm I understand the code changes. It uses the standard `scrollHeight` technique to expand the box and the  directive to ensure it resets when the Lit component state changes (e.g. after sending).

