### PR TITLE
telegram: move /new command to first position in menu

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -127,6 +127,14 @@ let cachedNativeRegistry: ReturnType<typeof getActivePluginRegistry> | null = nu
 function buildChatCommands(): ChatCommandDefinition[] {
   const commands: ChatCommandDefinition[] = [
     defineChatCommand({
+      key: "new",
+      nativeName: "new",
+      description: "Start a new session.",
+      textAlias: "/new",
+      acceptsArgs: true,
+      category: "session",
+    }),
+    defineChatCommand({
       key: "help",
       nativeName: "help",
       description: "Show available commands.",
@@ -392,14 +400,6 @@ function buildChatCommands(): ChatCommandDefinition[] {
       nativeName: "reset",
       description: "Reset the current session.",
       textAlias: "/reset",
-      acceptsArgs: true,
-      category: "session",
-    }),
-    defineChatCommand({
-      key: "new",
-      nativeName: "new",
-      description: "Start a new session.",
-      textAlias: "/new",
       acceptsArgs: true,
       category: "session",
     }),


### PR DESCRIPTION
Moves the `/new` command to the first position in the Telegram bot commands menu.

## Changes
- Moved `/new` command definition to the beginning of the `buildChatCommands()` array in `src/auto-reply/commands-registry.data.ts`
- This ensures `/new` appears first in the Telegram bot commands menu (the button that shows available commands)

## Rationale
The `/new` command is the most frequently used command by users during daily interaction with Moltbot via Telegram. Having it at the top of the menu provides easy access to this essential functionality.

## Impact
- Affects all channels that use native commands (Telegram, Discord, Slack, etc.) for consistency
- The `/new` command will now appear at the top of the commands list in Telegram

## Testing
- No linter errors
- Ready for manual testing: restart Telegram bot and verify `/new` appears first in the menu