### PR TITLE
fix(memory): support symlinks in memory file discovery

### DIFF
--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -1,6 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { chunkMarkdown } from "./internal.js";
+import { chunkMarkdown, listMemoryFiles } from "./internal.js";
+
+async function makeTempDir(prefix = "moltbot-memory-test-"): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe("listMemoryFiles", () => {
+  it("includes symlinked markdown files", async () => {
+    const tempDir = await makeTempDir();
+    const memoryDir = path.join(tempDir, "memory");
+    await fs.mkdir(memoryDir);
+
+    // Create a real file outside memory/
+    const realFile = path.join(tempDir, "notes.md");
+    await fs.writeFile(realFile, "# Notes\nSome content");
+
+    // Create a symlink inside memory/ pointing to the real file
+    const symlinkPath = path.join(memoryDir, "linked-notes.md");
+    await fs.symlink(realFile, symlinkPath);
+
+    const files = await listMemoryFiles(tempDir);
+    expect(files).toContain(symlinkPath);
+
+    // Cleanup
+    await fs.rm(tempDir, { recursive: true });
+  });
+
+  it("includes files inside symlinked directories", async () => {
+    const tempDir = await makeTempDir();
+    const memoryDir = path.join(tempDir, "memory");
+    await fs.mkdir(memoryDir);
+
+    // Create a real directory with a markdown file outside memory/
+    const realDir = path.join(tempDir, "external-notes");
+    await fs.mkdir(realDir);
+    await fs.writeFile(path.join(realDir, "doc.md"), "# Doc");
+
+    // Create a symlinked directory inside memory/
+    const symlinkDir = path.join(memoryDir, "linked-dir");
+    await fs.symlink(realDir, symlinkDir);
+
+    const files = await listMemoryFiles(tempDir);
+    expect(files).toContain(path.join(symlinkDir, "doc.md"));
+
+    // Cleanup
+    await fs.rm(tempDir, { recursive: true });
+  });
+
+  it("skips dangling symlinks gracefully", async () => {
+    const tempDir = await makeTempDir();
+    const memoryDir = path.join(tempDir, "memory");
+    await fs.mkdir(memoryDir);
+
+    // Create a symlink pointing to a non-existent file
+    const danglingSymlink = path.join(memoryDir, "dangling.md");
+    await fs.symlink("/non/existent/path.md", danglingSymlink);
+
+    // Should not throw and should return empty (no valid files)
+    const files = await listMemoryFiles(tempDir);
+    expect(files).not.toContain(danglingSymlink);
+
+    // Cleanup
+    await fs.rm(tempDir, { recursive: true });
+  });
+});
 
 describe("chunkMarkdown", () => {
   it("splits overly long lines into max-sized chunks", () => {


### PR DESCRIPTION
## Summary

`walkDir` now follows symbolic links using `fs.stat()` to determine if the target is a file or directory. This enables:

- Symlinked markdown files inside `memory/` to be indexed
- Symlinked directories inside `memory/` to be traversed
- Graceful handling of dangling symlinks (silently skipped)

## Problem

The current `walkDir` implementation uses `dirent.isFile()` to check if an entry is a file. However, for symbolic links, `dirent.isFile()` returns `false` (the dirent type is "symbolic-link", not "file"), causing symlinks to be excluded from memory search indexing.

This is especially relevant for:
- Users who symlink external note directories into `memory/`
- The proposed workspace setup in #2884 that creates symlinks for identity files

## Solution

For entries that are symbolic links, we now call `fs.stat()` (which follows symlinks) to determine the actual target type:

```typescript
if (entry.isSymbolicLink()) {
  try {
    const stat = await fs.stat(full);
    isDir = stat.isDirectory();
    isFile = stat.isFile();
  } catch {
    // Dangling symlink or inaccessible target - skip silently
    continue;
  }
}
```

## Cross-platform notes

- **Linux/macOS**: Works as expected
- **Windows**: Creating symlinks may require elevated permissions, but **reading** existing symlinks works without special privileges
- Dangling symlinks are gracefully skipped (no errors thrown)

## Test plan

- [x] Added test: symlinked markdown files are discovered
- [x] Added test: files inside symlinked directories are discovered  
- [x] Added test: dangling symlinks are skipped gracefully
- [x] Existing tests unaffected

Related: #2884

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `walkDir` in `src/memory/internal.ts` to treat symlink entries specially by `stat()`ing them (following the link) so symlinked `.md` files and symlinked directories under `memory/` are included in `listMemoryFiles()` results, while dangling symlinks are skipped. It also adds Vitest coverage in `src/memory/internal.test.ts` for symlinked file discovery, symlinked directory traversal, and dangling symlink handling.


<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but needs a symlink-loop/escape guard and CI-friendly symlink tests.
- The core change is small and targeted, but following symlinks introduces a real risk of infinite recursion and unintended traversal outside `memory/` if users add cyclic or external symlinks. The added tests also directly create symlinks, which can fail on Windows or restricted CI environments, reducing confidence without conditional skipping.
- src/memory/internal.ts, src/memory/internal.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->