### PR TITLE
fix(infra): prevent gateway crashes on transient network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,14 @@ Status: unreleased.
 ### Breaking
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
+<<<<<<< HEAD
 ### Fixes
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.
 - Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.
 - macOS: auto-scroll to bottom when sending a new message while scrolled up. (#2471) Thanks @kennyklee.
 - Web UI: auto-expand the chat compose textarea while typing (with sensible max height). (#2950) Thanks @shivamraut101.
+- Gateway: prevent crashes on transient network errors (fetch failures, timeouts, DNS). Added fatal error detection to only exit on truly critical errors. Fixes #2895, #2879, #2873. (#2980) Thanks @elliotsecops.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -125,13 +125,16 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       expect(consoleWarnSpy).toHaveBeenCalled();
     });
 
-    it("does NOT exit on generic errors without code", () => {
+    it("exits on generic errors without code", () => {
       const genericErr = new Error("Something went wrong");
 
       process.emit("unhandledRejection", genericErr, Promise.resolve());
 
-      expect(exitCalls).toEqual([]);
-      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(exitCalls).toEqual([1]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[clawdbot] Unhandled promise rejection:",
+        expect.stringContaining("Something went wrong"),
+      );
     });
 
     it("does NOT exit on connection reset errors", () => {

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -47,7 +47,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
       expect(exitCalls).toEqual([1]);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[clawdbot] FATAL unhandled rejection:",
+        "[moltbot] FATAL unhandled rejection:",
         expect.stringContaining("Out of memory"),
       );
     });
@@ -83,7 +83,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
       expect(exitCalls).toEqual([1]);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[clawdbot] CONFIGURATION ERROR - requires fix:",
+        "[moltbot] CONFIGURATION ERROR - requires fix:",
         expect.stringContaining("Invalid config"),
       );
     });
@@ -109,7 +109,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
       expect(exitCalls).toEqual([]);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[clawdbot] Non-fatal unhandled rejection (continuing):",
+        "[moltbot] Non-fatal unhandled rejection (continuing):",
         expect.stringContaining("fetch failed"),
       );
     });
@@ -132,7 +132,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
       expect(exitCalls).toEqual([1]);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[clawdbot] Unhandled promise rejection:",
+        "[moltbot] Unhandled promise rejection:",
         expect.stringContaining("Something went wrong"),
       );
     });

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import process from "node:process";
+
+import { installUnhandledRejectionHandler } from "./unhandled-rejections.js";
+
+describe("installUnhandledRejectionHandler - fatal detection", () => {
+  let exitCalls: Array<string | number | null> = [];
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let originalExit: typeof process.exit;
+
+  beforeAll(() => {
+    originalExit = process.exit;
+    installUnhandledRejectionHandler();
+  });
+
+  beforeEach(() => {
+    exitCalls = [];
+
+    vi.spyOn(process, "exit").mockImplementation((code: string | number | null | undefined) => {
+      if (code !== undefined && code !== null) {
+        exitCalls.push(code);
+      }
+    });
+
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.exit = originalExit;
+  });
+
+  describe("fatal errors", () => {
+    it("exits on ERR_OUT_OF_MEMORY", () => {
+      const oomErr = Object.assign(new Error("Out of memory"), {
+        code: "ERR_OUT_OF_MEMORY",
+      });
+
+      process.emit("unhandledRejection", oomErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([1]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[clawdbot] FATAL unhandled rejection:",
+        expect.stringContaining("Out of memory"),
+      );
+    });
+
+    it("exits on ERR_SCRIPT_EXECUTION_TIMEOUT", () => {
+      const timeoutErr = Object.assign(new Error("Script execution timeout"), {
+        code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+      });
+
+      process.emit("unhandledRejection", timeoutErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([1]);
+    });
+
+    it("exits on ERR_WORKER_OUT_OF_MEMORY", () => {
+      const workerOomErr = Object.assign(new Error("Worker out of memory"), {
+        code: "ERR_WORKER_OUT_OF_MEMORY",
+      });
+
+      process.emit("unhandledRejection", workerOomErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([1]);
+    });
+  });
+
+  describe("configuration errors", () => {
+    it("exits on INVALID_CONFIG", () => {
+      const configErr = Object.assign(new Error("Invalid config"), {
+        code: "INVALID_CONFIG",
+      });
+
+      process.emit("unhandledRejection", configErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([1]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[clawdbot] CONFIGURATION ERROR - requires fix:",
+        expect.stringContaining("Invalid config"),
+      );
+    });
+
+    it("exits on MISSING_API_KEY", () => {
+      const missingKeyErr = Object.assign(new Error("Missing API key"), {
+        code: "MISSING_API_KEY",
+      });
+
+      process.emit("unhandledRejection", missingKeyErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([1]);
+    });
+  });
+
+  describe("non-fatal errors", () => {
+    it("does NOT exit on undici fetch failures", () => {
+      const fetchErr = Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "UND_ERR_CONNECT_TIMEOUT", syscall: "connect" },
+      });
+
+      process.emit("unhandledRejection", fetchErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[clawdbot] Non-fatal unhandled rejection (continuing):",
+        expect.stringContaining("fetch failed"),
+      );
+    });
+
+    it("does NOT exit on DNS resolution failures", () => {
+      const dnsErr = Object.assign(new Error("DNS resolve failed"), {
+        code: "UND_ERR_DNS_RESOLVE_FAILED",
+      });
+
+      process.emit("unhandledRejection", dnsErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+
+    it("does NOT exit on generic errors without code", () => {
+      const genericErr = new Error("Something went wrong");
+
+      process.emit("unhandledRejection", genericErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+
+    it("does NOT exit on connection reset errors", () => {
+      const connResetErr = Object.assign(new Error("Connection reset"), {
+        code: "ECONNRESET",
+      });
+
+      process.emit("unhandledRejection", connResetErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+
+    it("does NOT exit on timeout errors", () => {
+      const timeoutErr = Object.assign(new Error("Timeout"), {
+        code: "ETIMEDOUT",
+      });
+
+      process.emit("unhandledRejection", timeoutErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Classify fatal vs config vs transient errors in unhandled-rejections handler
- Exit only on fatal/config errors; log transient errors
- Add comprehensive tests for fatal/non-fatal paths
- Update changelog (refs #2895, #2879, #2873)

## Testing
- pnpm test src/infra/unhandled-rejections.fatal-detection.test.ts
