### PR TITLE
feat(tts): Convert Edge TTS MP3 to Opus for Telegram voice messages

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1152,16 +1152,42 @@ export async function textToSpeech(params: {
           }
         }
 
+        // Convert Edge TTS MP3 to Opus for Telegram voice compatibility
+        let finalAudioPath = edgeResult.audioPath;
+        let finalVoiceCompatible = isVoiceCompatibleAudio({ fileName: edgeResult.audioPath });
+        if (channelId === "telegram" && !finalVoiceCompatible) {
+          try {
+            const opusPath = edgeResult.audioPath.replace(/\.[^.]+$/, ".opus");
+            const { execSync } = await import("node:child_process");
+            execSync(
+              `ffmpeg -i "${edgeResult.audioPath}" -c:a libopus -b:a 64k -application voip "${opusPath}" -y`,
+              { stdio: "pipe" },
+            );
+            // Remove original MP3
+            try {
+              unlinkSync(edgeResult.audioPath);
+            } catch {
+              // ignore cleanup errors
+            }
+            finalAudioPath = opusPath;
+            finalVoiceCompatible = true;
+            logVerbose("TTS: Converted Edge MP3 to Opus for Telegram voice compatibility.");
+          } catch (convErr) {
+            const convError = convErr as Error;
+            logVerbose(`TTS: ffmpeg Opus conversion failed: ${convError.message}`);
+            // Fall back to original MP3
+          }
+        }
+
         scheduleCleanup(tempDir);
-        const voiceCompatible = isVoiceCompatibleAudio({ fileName: edgeResult.audioPath });
 
         return {
           success: true,
-          audioPath: edgeResult.audioPath,
+          audioPath: finalAudioPath,
           latencyMs: Date.now() - providerStart,
           provider,
-          outputFormat: edgeResult.outputFormat,
-          voiceCompatible,
+          outputFormat: finalVoiceCompatible ? "opus" : edgeResult.outputFormat,
+          voiceCompatible: finalVoiceCompatible,
         };
       }
 


### PR DESCRIPTION
## Problem

When using Edge TTS (the free provider), Telegram delivers voice messages as MP3 files. Telegram treats MP3 files as audio files rather than voice messages, which means:
- No caption/text accompanies the voice message
- The message appears as a media file rather than a native voice note

OpenAI and ElevenLabs TTS already output Opus for Telegram (via `TELEGRAM_OUTPUT`), but Edge TTS uses its default MP3 format.

## Solution

Add an ffmpeg post-processing step that converts Edge TTS MP3 output to Opus when the target channel is Telegram. This allows Edge TTS voice messages to be delivered as native Telegram voice notes with caption support.

## Changes

After Edge TTS generates the audio file, the code now:
1. Checks if the channel is Telegram and the audio isn't already voice-compatible
2. Converts MP3 to Opus using ffmpeg (`-c:a libopus -b:a 64k -application voip`)
3. Cleans up the original MP3 file
4. Updates the return values to reflect the new format

## Requirements

- ffmpeg must be installed with libopus support
- Falls back gracefully to MP3 if ffmpeg is unavailable or conversion fails

## Testing

1. Configure TTS provider as `edge`
2. Send a TTS message to Telegram
3. Verify the message arrives as a voice note with caption text visible

## Benefits

- Free TTS (Edge) now has feature parity with paid providers on Telegram
- Voice messages show accompanying text caption
- Native voice note UI in Telegram (playback waveform, etc.)
- No user configuration needed — automatic based on channel detection

Fixes #2949