### PR TITLE
fix(scripts): use local pnpm binary in run-node.mjs if global is missing

### DIFF
--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -116,7 +116,15 @@ if (!shouldBuild()) {
 } else {
   logRunner("Building TypeScript (dist is stale).");
   const pnpmArgs = ["exec", compiler, ...projectArgs];
-  const buildCmd = process.platform === "win32" ? "cmd.exe" : "pnpm";
+
+  // PR Fix: Check for local pnpm binary if global might be missing
+  let pnpmCmd = "pnpm";
+  const localPnpm = path.join(cwd, "node_modules", ".bin", process.platform === "win32" ? "pnpm.cmd" : "pnpm");
+  if (fs.existsSync(localPnpm)) {
+    pnpmCmd = localPnpm;
+  }
+
+  const buildCmd = process.platform === "win32" ? "cmd.exe" : pnpmCmd;
   const buildArgs =
     process.platform === "win32" ? ["/d", "/s", "/c", "pnpm", ...pnpmArgs] : pnpmArgs;
   const build = spawn(buildCmd, buildArgs, {


### PR DESCRIPTION
## Summary
- Use local pnpm binary from node_modules/.bin as a fallback when global pnpm is missing
- Improves bootstrap reliability in restricted environments

## Testing
- Not run (script change only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `scripts/run-node.mjs` to prefer a local `pnpm` binary from `node_modules/.bin` when available, improving the reliability of the TypeScript build step in environments without a global pnpm install. The change affects the “dist is stale” build path that spawns pnpm to run the configured TS compiler before running the built entrypoint.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the intended pnpm fallback is currently ineffective on Windows.
- Change is small and localized to the build-spawn path, but there is a functional gap on Windows where `cmd.exe /c pnpm ...` still requires a global pnpm and ignores the computed local pnpm path; non-Windows behavior should work as intended.
- scripts/run-node.mjs (Windows spawn args)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->