### PR TITLE
Discord: enable forum post creation via thread-create

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -279,18 +279,31 @@ export async function handleDiscordMessagingAction(
       const channelId = resolveChannelId();
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
+      // Optional initial content (required for forum posts).
+      const content = readStringParam(params, "content") ?? undefined;
+      // Optional applied tag ids (forum posts).
+      const appliedTagIds = Array.isArray(params.appliedTagIds)
+        ? params.appliedTagIds.filter((x) => typeof x === "string" && x.trim())
+        : undefined;
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
           ? autoArchiveMinutesRaw
           : undefined;
+
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes },
+            { name, messageId, autoArchiveMinutes, content, appliedTagIds },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes });
+        : await createThreadDiscord(channelId, {
+            name,
+            messageId,
+            autoArchiveMinutes,
+            content,
+            appliedTagIds,
+          });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -233,11 +233,16 @@ export async function handleDiscordMessagingAction(
       const replyTo = readStringParam(params, "replyTo");
       const embeds =
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
+      const components =
+        Array.isArray(params.components) && params.components.length > 0
+          ? params.components
+          : undefined;
       const result = await sendMessageDiscord(to, content, {
         ...(accountId ? { accountId } : {}),
         mediaUrl,
         replyTo,
         embeds,
+        components,
       });
       return jsonResult({ ok: true, result });
     }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -87,6 +87,30 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
         },
       ),
     ),
+    embeds: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific embed objects (Discord embeds, etc.). Passed through to the channel adapter when supported.",
+          },
+        ),
+      ),
+    ),
+    components: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific message components (Discord buttons/selects, etc.). Passed through when supported.",
+          },
+        ),
+      ),
+    ),
   };
   if (!options.includeButtons) delete props.buttons;
   if (!options.includeCards) delete props.card;

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -180,6 +180,10 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    // Optional initial post content (required for forum post creation).
+    const content = readStringParam(params, "message");
+    // Optional forum tag ids.
+    const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -190,6 +194,8 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
         name,
         messageId,
+        content,
+        appliedTagIds,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -37,6 +37,7 @@ export async function handleDiscordMessageAction(
     const mediaUrl = readStringParam(params, "media", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
+    const components = Array.isArray(params.components) ? params.components : undefined;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -46,6 +47,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
         embeds,
+        components,
       },
       cfg,
     );

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -94,10 +94,30 @@ export async function createThreadDiscord(
 ) {
   const rest = resolveDiscordRest(opts);
   const body: Record<string, unknown> = { name: payload.name };
+
   if (payload.autoArchiveMinutes) {
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
-  const route = Routes.threads(channelId, payload.messageId);
+
+  // Forum posts (channel type 15) require an initial message payload.
+  // If content is provided, create the thread with an initial post.
+  if (payload.content) {
+    body.message = { content: payload.content };
+    if (Array.isArray(payload.appliedTagIds) && payload.appliedTagIds.length) {
+      body.applied_tags = payload.appliedTagIds;
+    }
+    // NOTE: discord-api-types Routes doesn't currently expose a helper for
+    // POST /channels/{channel.id}/threads (it only exposes listing archived threads),
+    // so use the raw route string.
+    const route = `/channels/${channelId}/threads`;
+    return await rest.post(route, { body });
+  }
+
+  // Regular threads: create from an existing message when messageId is provided,
+  // otherwise create a standard thread in the channel.
+  const route = payload.messageId
+    ? Routes.threads(channelId, payload.messageId)
+    : `/channels/${channelId}/threads`;
   return await rest.post(route, { body });
 }
 

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -29,6 +29,7 @@ type DiscordSendOpts = {
   replyTo?: string;
   retry?: RetryConfig;
   embeds?: unknown[];
+  components?: unknown[];
 };
 
 export async function sendMessageDiscord(
@@ -63,6 +64,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     } else {
@@ -74,6 +76,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     }

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -232,6 +232,7 @@ async function sendDiscordText(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   if (!text.trim()) {
@@ -252,6 +253,7 @@ async function sendDiscordText(
             content: chunks[0],
             message_reference: messageReference,
             ...(embeds?.length ? { embeds } : {}),
+            ...(components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -268,6 +270,7 @@ async function sendDiscordText(
             content: chunk,
             message_reference: isFirst ? messageReference : undefined,
             ...(isFirst && embeds?.length ? { embeds } : {}),
+            ...(isFirst && components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -289,6 +292,7 @@ async function sendDiscordMedia(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   const media = await loadWebMedia(mediaUrl);
@@ -309,6 +313,7 @@ async function sendDiscordMedia(
           content: caption || undefined,
           message_reference: messageReference,
           ...(embeds?.length ? { embeds } : {}),
+          ...(components?.length ? { components } : {}),
           files: [
             {
               data: media.buffer,
@@ -328,6 +333,7 @@ async function sendDiscordMedia(
       undefined,
       request,
       maxLinesPerMessage,
+      undefined,
       undefined,
       chunkMode,
     );

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -67,9 +67,16 @@ export type DiscordMessageEdit = {
 };
 
 export type DiscordThreadCreate = {
+  /** Optional message id to start a thread from (for classic threads). */
   messageId?: string;
+  /** Thread / forum post title. */
   name: string;
+  /** Auto-archive duration in minutes. */
   autoArchiveMinutes?: number;
+  /** Optional initial post content (required for forum post creation). */
+  content?: string;
+  /** Optional forum tag ids (applied tags). */
+  appliedTagIds?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary
Adds support for creating Discord **Forum posts** (channel type 15) using the existing `thread-create` action.

## What changed
- Accept optional initial post `message` content for `thread-create` (required by Discord for forum posts).
- Accept optional `appliedTagIds` to apply forum tags.
- Use `POST /channels/{channelId}/threads` when creating a forum post (and as fallback when no `messageId` is provided).

## Why
Forum channels require an initial message payload. Without it, Discord returns a generic "This field is required" error and forum posts cannot be created.

## Notes
- Uses a raw route string for forum thread creation because `discord-api-types` does not currently provide a helper for the create-forum-post endpoint.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Discord messaging and thread creation to support forum posts (channel type 15) via the existing `thread-create` action. It adds optional `embeds`/`components` pass-through on message sends, and expands `DiscordThreadCreate` with `content` and `appliedTagIds`. In `createThreadDiscord`, it conditionally uses `POST /channels/{channelId}/threads` with an initial `message` payload when `content` is provided, and falls back to the same endpoint when no `messageId` is provided.

Key concern: the two entry points use different parameter names for the initial post text (`message` vs `content`), which will prevent forum post creation from working consistently.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is a functional mismatch that can break forum post creation in one code path.
- Changes are largely additive (new optional fields and routing logic), but the `thread-create` parameter name mismatch (`message` vs `content`) and the truthy check on `payload.content` can still cause forum post creation to fail with Discord’s required-field error.
- src/channels/plugins/actions/discord/handle-action.ts; src/discord/send.messages.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->