### PR TITLE
docs: fix references from p-mono to pi-mono

### DIFF
--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -1,11 +1,11 @@
 ---
-summary: "Agent runtime (embedded p-mono), workspace contract, and session bootstrap"
+summary: "Agent runtime (embedded pi-mono), workspace contract, and session bootstrap"
 read_when:
   - Changing agent runtime, workspace bootstrap, or session behavior
 ---
 # Agent Runtime 🤖
 
-Moltbot runs a single embedded agent runtime derived from **p-mono**.
+Moltbot runs a single embedded agent runtime derived from [**pi-mono**](https://github.com/badlogic/pi-mono).
 
 ## Workspace (required)
 
@@ -59,9 +59,9 @@ Moltbot loads skills from three locations (workspace wins on name conflict):
 
 Skills can be gated by config/env (see `skills` in [Gateway configuration](/gateway/configuration)).
 
-## p-mono integration
+## pi-mono integration
 
-Moltbot reuses pieces of the p-mono codebase (models/tools), but **session management, discovery, and tool wiring are Moltbot-owned**.
+Moltbot reuses pieces of the [pi-mono](https://github.com/badlogic/pi-mono) codebase (models/tools), but **session management, discovery, and tool wiring are Moltbot-owned**.
 
 - No p-coding agent runtime.
 - No `~/.pi/agent` or `<workspace>/.pi` settings are consulted.

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -63,7 +63,7 @@ Skills can be gated by config/env (see `skills` in [Gateway configuration](/gate
 
 Moltbot reuses pieces of the [pi-mono](https://github.com/badlogic/pi-mono) codebase (models/tools), but **session management, discovery, and tool wiring are Moltbot-owned**.
 
-- No p-coding agent runtime.
+- No pi-coding agent runtime.
 - No `~/.pi/agent` or `<workspace>/.pi` settings are consulted.
 
 ## Sessions


### PR DESCRIPTION
Confused me when trying to understand the architecture.

Keep up the good work, little agents! 🤖

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the documentation in `docs/concepts/agent.md` to replace outdated references to **p-mono** with **pi-mono**, and adds links to the upstream `pi-mono` to reduce confusion about what Moltbot reuses vs. what it owns (session management, discovery, tool wiring).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only adjusts documentation text and links.
- Changes are limited to a single markdown doc and are straightforward reference corrections with no code-path impact.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->