### PR TITLE
[AI-Assisted] fix: preserve pending tasks when subagent completes

### DIFF
--- a/src/auto-reply/reply/queue/state.store.ts
+++ b/src/auto-reply/reply/queue/state.store.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+
+import { STATE_DIR } from "../../../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../../../infra/json-file.js";
+import type { FollowupQueueState } from "./state.js";
+
+export type PersistedFollowupQueueVersion = 1;
+
+type PersistedFollowupQueueRegistry = {
+  version: 1;
+  queues: Record<string, PersistedFollowupQueueState>;
+};
+
+type PersistedFollowupQueueState = FollowupQueueState;
+
+const REGISTRY_VERSION = 1 as const;
+
+export function resolveFollowupQueueRegistryPath(): string {
+  return path.join(STATE_DIR, "followup-queues", "queues.json");
+}
+
+export function loadFollowupQueuesFromDisk(): Map<string, FollowupQueueState> {
+  const pathname = resolveFollowupQueueRegistryPath();
+  const raw = loadJsonFile(pathname);
+  if (!raw || typeof raw !== "object") return new Map();
+  const record = raw as Partial<PersistedFollowupQueueRegistry>;
+  if (record.version !== 1) return new Map();
+  const queuesRaw = record.queues;
+  if (!queuesRaw || typeof queuesRaw !== "object") return new Map();
+  const out = new Map<string, FollowupQueueState>();
+  for (const [key, entry] of Object.entries(queuesRaw)) {
+    if (!entry || typeof entry !== "object") continue;
+    // Reset draining state on restore - will be restarted if items exist
+    const restored: FollowupQueueState = {
+      ...entry,
+      draining: false,
+    };
+    out.set(key, restored);
+  }
+  return out;
+}
+
+export function saveFollowupQueuesToDisk(queues: Map<string, FollowupQueueState>) {
+  const pathname = resolveFollowupQueueRegistryPath();
+  const serialized: Record<string, PersistedFollowupQueueState> = {};
+  for (const [key, entry] of queues.entries()) {
+    // Only persist queues that have items or have been used recently
+    if (entry.items.length > 0 || entry.droppedCount > 0 || entry.lastEnqueuedAt > 0) {
+      serialized[key] = entry;
+    }
+  }
+  const out: PersistedFollowupQueueRegistry = {
+    version: REGISTRY_VERSION,
+    queues: serialized,
+  };
+  saveJsonFile(pathname, out);
+}


### PR DESCRIPTION
## Summary

Fixes #3031

When a subagent completes and announces its result back to the main agent, the main agent's pending tasks were being lost due to a race condition between the followup queue drain and the announce flow.

## Changes

- **Add persistence layer** for followup queues (similar to subagent runs persistence pattern)
- **Implement 30-second grace period** before deleting empty queues to handle subagent announce race conditions
- **Persist queue state** after enqueue/dequeue operations
- **Track `emptyAt` timestamp** to prevent premature queue deletion
- **Add periodic cleanup** for expired empty queues

This ensures that when a subagent completes and triggers a new main agent invocation, any pending tasks in the followup queue are preserved and restored from disk.

## Files Changed

- `src/auto-reply/reply/queue/state.store.ts` (new) - Persistence layer for followup queues
- `src/auto-reply/reply/queue/state.ts` - Add persistence calls and restore logic
- `src/auto-reply/reply/queue/enqueue.ts` - Persist after enqueue operations
- `src/auto-reply/reply/queue/drain.ts` - Grace period logic and persist after drain

## Testing Status

⚠️ **Lightly tested**
- ✅ TypeScript compiles without errors
- ✅ Linter passes (oxlint)
- ⚠️ No integration tests yet for the specific race condition scenario
- ⚠️ Needs real-world validation with live moltbot instance

## AI-Assisted Development

🤖 This PR was created with assistance from Claude Sonnet 4.5
- Analyzed the codebase to identify root cause
- Designed fix following existing persistence patterns (subagent-registry.ts)
- Generated issue #3031 and implementation code
- Testing level: **lightly tested** (compiles + lints, needs integration testing)

## Checklist

- [x] Code follows existing patterns (persistence similar to `subagentRuns`)
- [x] Linter passes
- [x] TypeScript compiles without errors
- [ ] Integration tested (needs validation)
- [x] Marked as AI-assisted
- [x] References issue #3031

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds on-disk persistence for followup queues to prevent pending tasks being lost when a subagent completion triggers a new main-agent invocation. The change introduces a `state.store.ts` JSON registry under `STATE_DIR`, restores queues on first access, persists after enqueue/dequeue/clear operations, and adds a 30s grace period plus periodic cleanup before deleting empty queues to avoid the announce/drain race described in #3031.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small risk of leaving empty queues around longer than intended due to a timestamp edge case.
- Changes are localized and follow existing persistence patterns, but there is at least one concrete logic issue (`emptyAt` cleared before confirming enqueue) that can defeat the cleanup mechanism, plus some extra steady-state disk I/O and lack of validation on restored JSON.
- src/auto-reply/reply/queue/enqueue.ts, src/auto-reply/reply/queue/drain.ts, src/auto-reply/reply/queue/state.store.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->