### PR TITLE
docs: update exe.dev install instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Status: beta.
 - Telegram: support plugin sendPayload channelData (media/buttons) and validate plugin commands. (#1917) Thanks @JoshuaLelon.
 - Telegram: avoid block replies when streaming is disabled. (#1885) Thanks @ivancasco.
 - Docs: keep docs header sticky so navbar stays visible while scrolling. (#2445) Thanks @chenyuan99.
+- Docs: update exe.dev install instructions. (#https://github.com/moltbot/moltbot/pull/3047) Thanks @zackerthescar.
 - Security: use Windows ACLs for permission audits and fixes on Windows. (#1957)
 - Auth: show copyable Google auth URL after ASCII prompt. (#1787) Thanks @robbyczgw-cla.
 - Routing: precompile session key regexes. (#1697) Thanks @Ray0907.

--- a/docs/platforms/exe-dev.md
+++ b/docs/platforms/exe-dev.md
@@ -103,8 +103,8 @@ server {
 
 ## 5) Access Moltbot and grant privileges
 
-Access `https//<vm-name>.exe.xyz/?token=YOUR-TOKEN-FROM-TERMINAL`. Approve
-devices with `clawdbot device list` and `clawdbot device accept`. When in doubt,
+Access `https://<vm-name>.exe.xyz/?token=YOUR-TOKEN-FROM-TERMINAL`. Approve
+devices with `moltbot devices list` and `moltbot device approve`. When in doubt,
 use Shelley from your browser!
 
 ## Remote Access


### PR DESCRIPTION
Hello! I'm from exe.dev and we just improved Moltbot's install flow on our platform. It's literally as easy as clicking a link now. Also adding manual instructions that go into (some) detail about installing on our VMs. 

Disclaimer: I work for exe.dev