### PR TITLE
Docs: Fix typo in docs/tools/skills.md

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -66,7 +66,7 @@ that up as `<workspace>/skills` on the next session.
 
 ## Security notes
 
-- Treat third-party skills as **trusted code**. Read them before enabling.
+- Treat third-party skills as **untrusted code**. Read them before enabling.
 - Prefer sandboxed runs for untrusted inputs and risky tools. See [Sandboxing](/gateway/sandboxing).
 - `skills.entries.*.env` and `skills.entries.*.apiKey` inject secrets into the **host** process
   for that agent turn (not the sandbox). Keep secrets out of prompts and logs.


### PR DESCRIPTION
Probable typo: treat third-party skills as **_un_**trusted code, right?