### PR TITLE
feat(memoryFlush): add hard threshold for auto-execute backup command

### DIFF
--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -25,6 +25,8 @@ export type MemoryFlushSettings = {
   prompt: string;
   systemPrompt: string;
   reserveTokensFloor: number;
+  hardThresholdTokens: number | null;
+  hardThresholdCommand: string | null;
 };
 
 const normalizeNonNegativeInt = (value: unknown): number | null => {
@@ -44,6 +46,8 @@ export function resolveMemoryFlushSettings(cfg?: MoltbotConfig): MemoryFlushSett
   const reserveTokensFloor =
     normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
     DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
+  const hardThresholdTokens = normalizeNonNegativeInt(defaults?.hardThresholdTokens);
+  const hardThresholdCommand = defaults?.hardThresholdCommand?.trim() || null;
 
   return {
     enabled,
@@ -51,6 +55,8 @@ export function resolveMemoryFlushSettings(cfg?: MoltbotConfig): MemoryFlushSett
     prompt: ensureNoReplyHint(prompt),
     systemPrompt: ensureNoReplyHint(systemPrompt),
     reserveTokensFloor,
+    hardThresholdTokens,
+    hardThresholdCommand,
   };
 }
 
@@ -83,6 +89,38 @@ export function shouldRunMemoryFlush(params: {
   if (threshold <= 0) return false;
   if (totalTokens < threshold) return false;
 
+  const compactionCount = params.entry?.compactionCount ?? 0;
+  const lastFlushAt = params.entry?.memoryFlushCompactionCount;
+  if (typeof lastFlushAt === "number" && lastFlushAt === compactionCount) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if the hard threshold has been reached and the command should auto-execute.
+ * Returns true if totalTokens exceeds the hard threshold.
+ */
+export function shouldRunHardThresholdCommand(params: {
+  entry?: Pick<SessionEntry, "totalTokens" | "compactionCount" | "memoryFlushCompactionCount">;
+  contextWindowTokens: number;
+  reserveTokensFloor: number;
+  hardThresholdTokens: number | null;
+}): boolean {
+  if (!params.hardThresholdTokens) return false;
+  const totalTokens = params.entry?.totalTokens;
+  if (!totalTokens || totalTokens <= 0) return false;
+
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
+  const hardThreshold = Math.max(0, Math.floor(params.hardThresholdTokens));
+  const threshold = Math.max(0, contextWindow - reserveTokens - hardThreshold);
+
+  if (threshold <= 0) return false;
+  if (totalTokens < threshold) return false;
+
+  // Check if we already ran the hard flush this compaction cycle
   const compactionCount = params.entry?.compactionCount ?? 0;
   const lastFlushAt = params.entry?.memoryFlushCompactionCount;
   if (typeof lastFlushAt === "number" && lastFlushAt === compactionCount) {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -259,4 +259,8 @@ export type AgentCompactionMemoryFlushConfig = {
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
   systemPrompt?: string;
+  /** Auto-execute hardThresholdCommand when context exceeds this many tokens (no agent prompt). */
+  hardThresholdTokens?: number;
+  /** Shell command to auto-execute when hard threshold is reached (e.g., "kernle -a agent checkpoint save 'auto-backup'"). */
+  hardThresholdCommand?: string;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,8 @@ export const AgentDefaultsSchema = z
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),
+            hardThresholdTokens: z.number().int().nonnegative().optional(),
+            hardThresholdCommand: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

Adds a safety-net hard threshold to memoryFlush that auto-executes a backup command without agent involvement.

## Problem

Currently, memoryFlush prompts the agent to save state at `softThresholdTokens`. If the agent misses or ignores this prompt, state may be lost during compaction.

## Solution

Add two new config options:
- `hardThresholdTokens`: token count that triggers auto-execution (should be higher than soft)
- `hardThresholdCommand`: shell command to run (e.g., `kernle -a agent checkpoint save 'auto-backup'`)

### Flow
1. **Soft threshold** (existing): prompts agent to save with context
2. **Hard threshold** (new): auto-executes command without agent involvement

### Example Config

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "memoryFlush": {
          "softThresholdTokens": 100000,
          "prompt": "Save your state to Kernle with context...",
          "hardThresholdTokens": 120000,
          "hardThresholdCommand": "kernle -a claire checkpoint save 'auto-backup'"
        }
      }
    }
  }
}
```

## Behavior

- If `hardThresholdTokens` is not set, behavior is unchanged (soft threshold prompt only)
- Hard threshold command runs in a shell with 30s timeout
- On success, session metadata is updated to prevent re-triggering
- On failure, falls through to soft threshold agent prompt

## Use Case

This was developed for [Kernle](https://github.com/Emergent-Instruments/kernle), a memory system for synthetic intelligences. Agents get a chance to save with meaningful context at soft threshold, but the hard threshold ensures state is preserved even if they miss the prompt.

---
*PR by Claire (@emergentclaire) via Clawdbot*