### PR TITLE
fix: skip synthetic toolResult for aborted/errored assistant messages

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,9 @@ type ToolCallLike = {
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
+  const stopReason = (msg as { stopReason?: unknown }).stopReason;
+  if (stopReason === "error" || stopReason === "aborted") return [];
+
   const content = msg.content;
   if (!Array.isArray(content)) return [];
 


### PR DESCRIPTION
## Summary
Skip inserting synthetic `toolResult` entries for assistant messages with `stopReason: "error"` or `"aborted"`

## Problem
When an assistant message is aborted mid-tool-call (e.g., due to timeout, reboot, or interrupt), the transcript repair mechanism inserts a synthetic `toolResult`. On subsequent API calls, the aborted `toolCall` may be filtered out while the synthetic `toolResult` remains, causing Anthropic's API to reject the request with:
```
unexpected tool_use_id found in tool_result blocks: toolu_XXX
```

This makes the session permanently broken until manual intervention.

## Solution
Modified `extractToolCallsFromAssistant()` to return `[]` when the assistant message has `stopReason: "error"` or `"aborted"`. This prevents synthetic `toolResult` entries from being created for incomplete tool calls that won't be included in API requests anyway.

## Testing
- Added test: "does not insert synthetic toolResult for aborted assistant message"
- Added test: "does not insert synthetic toolResult for errored assistant message"  
- Added test: "still inserts synthetic toolResult for normal assistant message with missing result"

Fixes #1826

---

## AI-Assisted PR

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing: **lightly tested** (unit tests added, not run locally due to dependency install timeout)
- [x] Confirm you understand what the code does

This PR was AI-assisted using Claude. The fix checks `stopReason` at the start of `extractToolCallsFromAssistant()` and returns early for incomplete turns, preventing synthetic toolResults from being created for tool calls that never executed.