### PR TITLE
Fix TUI footer to show the actual model you're using

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -553,6 +553,7 @@ export function listSessionsFromStore(params: {
         entry?.label ??
         originLabel;
       const deliveryFields = normalizeSessionDeliveryFields(entry);
+      const resolvedModel = resolveSessionModelRef(cfg, entry);
       return {
         key,
         entry,
@@ -578,8 +579,8 @@ export function listSessionsFromStore(params: {
         outputTokens: entry?.outputTokens,
         totalTokens: total,
         responseUsage: entry?.responseUsage,
-        modelProvider: entry?.modelProvider,
-        model: entry?.model,
+        modelProvider: resolvedModel.provider,
+        model: resolvedModel.model,
         contextTokens: entry?.contextTokens,
         deliveryContext: deliveryFields.deliveryContext,
         lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,


### PR DESCRIPTION
[When you switch models via /models, the footer was still showing the old provider name instead of updating to show what you just selected. This was confusing because the token stats were live but the model name was stuck on the default.](https://github.com/moltbot/moltbot/issues/3043)
Closes #3043 

The issue was that the footer reads from the session list, which only looked at model/modelProvider fields (set after agent runs). When you manually switch models, it actually sets providerOverride/modelOverride instead, so we need to resolve the effective model considering those overrides.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway session listing to display the *effective* model/provider in the TUI footer by resolving `modelOverride`/`providerOverride` from the session entry and falling back to the configured defaults via `resolveConfiguredModelRef`. The change is localized to `src/gateway/session-utils.ts` and affects the `listSessionsFromStore` output fields `modelProvider` and `model`, which the footer uses to render the active model name.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes the footer model display, with a small type/edge-case concern around potentially undefined model/provider.
- Change is small and well-scoped, and the override resolution matches the described bug. The main concern is `resolveSessionModelRef` declaring it always returns strings while its inputs can likely yield undefined values, which could surface as missing model/provider in the UI or mismatched types downstream.
- src/gateway/session-utils.ts (resolveSessionModelRef return typing/defaulting)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->