### PR TITLE
feat(telegram): add forum topic management actions

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -188,6 +188,27 @@ function buildGatewaySchema() {
   };
 }
 
+function buildForumTopicSchema() {
+  return {
+    iconColor: Type.Optional(
+      Type.Number({
+        description:
+          "Topic icon color in RGB (e.g. 0x6FB9F0). Only for Telegram forum topic-create.",
+      }),
+    ),
+    iconCustomEmojiId: Type.Optional(
+      Type.String({
+        description: "Custom emoji id for the topic icon. For Telegram topic-create/topic-edit.",
+      }),
+    ),
+    messageThreadId: Type.Optional(
+      Type.Number({
+        description: "Forum topic thread id. For Telegram topic-edit/close/reopen/delete.",
+      }),
+    ),
+  };
+}
+
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
@@ -220,6 +241,7 @@ function buildMessageToolSchemaProps(options: { includeButtons: boolean; include
     ...buildModerationSchema(),
     ...buildGatewaySchema(),
     ...buildChannelManagementSchema(),
+    ...buildForumTopicSchema(),
   };
 }
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -2,9 +2,14 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { MoltbotConfig } from "../../config/config.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import {
+  closeForumTopicTelegram,
+  createForumTopicTelegram,
+  deleteForumTopicTelegram,
   deleteMessageTelegram,
+  editForumTopicTelegram,
   editMessageTelegram,
   reactMessageTelegram,
+  reopenForumTopicTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
 } from "../../telegram/send.js";
@@ -316,6 +321,147 @@ export async function handleTelegramAction(
   if (action === "stickerCacheStats") {
     const stats = getCacheStats();
     return jsonResult({ ok: true, ...stats });
+  }
+
+  if (action === "createForumTopic") {
+    if (!isActionEnabled("forumTopics", false)) {
+      throw new Error(
+        "Telegram forum topic actions are disabled. Set channels.telegram.actions.forumTopics to true.",
+      );
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const name = readStringParam(params, "name", { required: true });
+    const iconColor = readNumberParam(params, "iconColor", { integer: true });
+    const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await createForumTopicTelegram(chatId ?? "", name, {
+      token,
+      accountId: accountId ?? undefined,
+      iconColor: iconColor ?? undefined,
+      iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+    });
+    return jsonResult({
+      ok: true,
+      messageThreadId: result.messageThreadId,
+      name: result.name,
+      iconColor: result.iconColor,
+      iconCustomEmojiId: result.iconCustomEmojiId,
+    });
+  }
+
+  if (action === "editForumTopic") {
+    if (!isActionEnabled("forumTopics", false)) {
+      throw new Error(
+        "Telegram forum topic actions are disabled. Set channels.telegram.actions.forumTopics to true.",
+      );
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      required: true,
+      integer: true,
+    });
+    const name = readStringParam(params, "name");
+    const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await editForumTopicTelegram(chatId ?? "", messageThreadId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+      name: name ?? undefined,
+      iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+    });
+    return jsonResult({ ok: true, edited: true });
+  }
+
+  if (action === "closeForumTopic") {
+    if (!isActionEnabled("forumTopics", false)) {
+      throw new Error(
+        "Telegram forum topic actions are disabled. Set channels.telegram.actions.forumTopics to true.",
+      );
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      required: true,
+      integer: true,
+    });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await closeForumTopicTelegram(chatId ?? "", messageThreadId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+    });
+    return jsonResult({ ok: true, closed: true });
+  }
+
+  if (action === "reopenForumTopic") {
+    if (!isActionEnabled("forumTopics", false)) {
+      throw new Error(
+        "Telegram forum topic actions are disabled. Set channels.telegram.actions.forumTopics to true.",
+      );
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      required: true,
+      integer: true,
+    });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await reopenForumTopicTelegram(chatId ?? "", messageThreadId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+    });
+    return jsonResult({ ok: true, reopened: true });
+  }
+
+  if (action === "deleteForumTopic") {
+    if (!isActionEnabled("forumTopics", false)) {
+      throw new Error(
+        "Telegram forum topic actions are disabled. Set channels.telegram.actions.forumTopics to true.",
+      );
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      required: true,
+      integer: true,
+    });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await deleteForumTopicTelegram(chatId ?? "", messageThreadId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+    });
+    return jsonResult({ ok: true, deleted: true });
   }
 
   throw new Error(`Unsupported Telegram action: ${action}`);

--- a/src/channels/plugins/actions/telegram.test.ts
+++ b/src/channels/plugins/actions/telegram.test.ts
@@ -118,4 +118,209 @@ describe("telegramMessageActions", () => {
 
     expect(handleTelegramAction).not.toHaveBeenCalled();
   });
+
+  it("excludes forum topic actions when not enabled", () => {
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as MoltbotConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).not.toContain("topic-create");
+    expect(actions).not.toContain("topic-edit");
+    expect(actions).not.toContain("topic-close");
+    expect(actions).not.toContain("topic-reopen");
+    expect(actions).not.toContain("topic-delete");
+  });
+
+  it("includes forum topic actions when forumTopics is enabled", () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).toContain("topic-create");
+    expect(actions).toContain("topic-edit");
+    expect(actions).toContain("topic-close");
+    expect(actions).toContain("topic-reopen");
+    expect(actions).toContain("topic-delete");
+  });
+
+  it("maps topic-create action to createForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "topic-create",
+      params: {
+        to: "-1001234567890",
+        name: "My New Topic",
+        iconColor: 0x6fb9f0,
+        iconCustomEmojiId: "emoji123",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "createForumTopic",
+        chatId: "-1001234567890",
+        name: "My New Topic",
+        iconColor: 0x6fb9f0,
+        iconCustomEmojiId: "emoji123",
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("maps topic-edit action to editForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "topic-edit",
+      params: {
+        to: "-1001234567890",
+        messageThreadId: 42,
+        name: "Renamed Topic",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "editForumTopic",
+        chatId: "-1001234567890",
+        messageThreadId: 42,
+        name: "Renamed Topic",
+        iconCustomEmojiId: undefined,
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("maps topic-close action to closeForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "topic-close",
+      params: {
+        to: "-1001234567890",
+        messageThreadId: 42,
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "closeForumTopic",
+        chatId: "-1001234567890",
+        messageThreadId: 42,
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("maps topic-reopen action to reopenForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "topic-reopen",
+      params: {
+        to: "-1001234567890",
+        messageThreadId: 42,
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "reopenForumTopic",
+        chatId: "-1001234567890",
+        messageThreadId: 42,
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("maps topic-delete action to deleteForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "topic-delete",
+      params: {
+        to: "-1001234567890",
+        messageThreadId: 42,
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "deleteForumTopic",
+        chatId: "-1001234567890",
+        messageThreadId: 42,
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("requires messageThreadId for topic-edit", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await expect(
+      telegramMessageActions.handleAction({
+        action: "topic-edit",
+        params: {
+          to: "-1001234567890",
+          name: "Renamed",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow();
+
+    expect(handleTelegramAction).not.toHaveBeenCalled();
+  });
+
+  it("requires name for topic-create", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { forumTopics: true } } },
+    } as MoltbotConfig;
+
+    await expect(
+      telegramMessageActions.handleAction({
+        action: "topic-create",
+        params: {
+          to: "-1001234567890",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow();
+
+    expect(handleTelegramAction).not.toHaveBeenCalled();
+  });
 });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -52,6 +52,13 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
+    if (gate("forumTopics", false)) {
+      actions.add("topic-create");
+      actions.add("topic-edit");
+      actions.add("topic-close");
+      actions.add("topic-reopen");
+      actions.add("topic-delete");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -177,6 +184,106 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "topic-create") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringParam(params, "to", { required: true });
+      const name = readStringParam(params, "name", { required: true });
+      const iconColor = readNumberParam(params, "iconColor", { integer: true });
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "createForumTopic",
+          chatId,
+          name,
+          iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "topic-edit") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringParam(params, "to", { required: true });
+      const messageThreadId = readNumberParam(params, "messageThreadId", {
+        required: true,
+        integer: true,
+      });
+      const name = readStringParam(params, "name");
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "editForumTopic",
+          chatId,
+          messageThreadId,
+          name: name ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "topic-close") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringParam(params, "to", { required: true });
+      const messageThreadId = readNumberParam(params, "messageThreadId", {
+        required: true,
+        integer: true,
+      });
+      return await handleTelegramAction(
+        {
+          action: "closeForumTopic",
+          chatId,
+          messageThreadId,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "topic-reopen") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringParam(params, "to", { required: true });
+      const messageThreadId = readNumberParam(params, "messageThreadId", {
+        required: true,
+        integer: true,
+      });
+      return await handleTelegramAction(
+        {
+          action: "reopenForumTopic",
+          chatId,
+          messageThreadId,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "topic-delete") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringParam(params, "to", { required: true });
+      const messageThreadId = readNumberParam(params, "messageThreadId", {
+        required: true,
+        integer: true,
+      });
+      return await handleTelegramAction(
+        {
+          action: "deleteForumTopic",
+          chatId,
+          messageThreadId,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -48,6 +48,11 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "timeout",
   "kick",
   "ban",
+  "topic-create",
+  "topic-edit",
+  "topic-close",
+  "topic-reopen",
+  "topic-delete",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable forum topic management actions (create, edit, close, reopen, delete). */
+  forumTopics?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -53,6 +53,11 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     timeout: "none",
     kick: "none",
     ban: "none",
+    "topic-create": "to",
+    "topic-edit": "to",
+    "topic-close": "to",
+    "topic-reopen": "to",
+    "topic-delete": "to",
   };
 
 const ACTION_TARGET_ALIASES: Partial<Record<ChannelMessageActionName, string[]>> = {


### PR DESCRIPTION
## Summary

Add support for creating, editing, closing, reopening, and deleting Telegram forum topics via the message tool.

Closes #3056

## New Actions

| Action | Description | Required Params |
|--------|-------------|-----------------|
| `topic-create` | Create a forum topic | `target` (chat ID), `name` (1-128 chars) |
| `topic-edit` | Edit topic name/icon | `target` (chat ID), `messageThreadId` |
| `topic-close` | Close an open topic | `target` (chat ID), `messageThreadId` |
| `topic-reopen` | Reopen a closed topic | `target` (chat ID), `messageThreadId` |
| `topic-delete` | Delete topic + messages | `target` (chat ID), `messageThreadId` |

### Optional Parameters
- `iconColor`: RGB color for topic icon (topic-create only). Must be one of the Telegram-allowed values.
- `iconCustomEmojiId`: Custom emoji ID for topic icon (topic-create, topic-edit)

## Configuration

Actions are gated behind `channels.telegram.actions.forumTopics` (defaults to `false`):

```yaml
channels:
  telegram:
    actions:
      forumTopics: true
```

The bot needs `can_manage_topics` admin rights in the supergroup.

## Usage Example

```
# Create a topic
message action=topic-create target=-1001234567890 name="My Topic"
# Returns: { ok: true, messageThreadId: 123, name: "My Topic", iconColor: 7322096 }

# Edit a topic
message action=topic-edit target=-1001234567890 messageThreadId=123 name="Renamed"

# Close / reopen / delete
message action=topic-close target=-1001234567890 messageThreadId=123
message action=topic-reopen target=-1001234567890 messageThreadId=123
message action=topic-delete target=-1001234567890 messageThreadId=123
```

## Implementation

- **message-action-names.ts**: Added 5 new action names
- **message-action-spec.ts**: Added target modes (`to`) for all 5 actions
- **telegram/send.ts**: Added 5 new API wrapper functions following the existing pattern (account resolution, retry, error logging, etc.)
- **telegram-actions.ts**: Added action handlers with forumTopics gate check
- **channels/plugins/actions/telegram.ts**: Wired actions through the channel plugin adapter with param mapping
- **config/types.telegram.ts**: Added `forumTopics` to `TelegramActionConfig`
- **message-tool.ts**: Added schema properties for `iconColor`, `iconCustomEmojiId`, `messageThreadId`

## Tests

Added 9 new tests covering:
- Forum topic actions excluded when not enabled
- Forum topic actions included when `forumTopics: true`
- All 5 action mappings (topic-create through topic-delete)
- Validation: `messageThreadId` required for topic-edit
- Validation: `name` required for topic-create

All existing tests continue to pass.