### PR TITLE
[AI-Assisted] fix: skip tool_use blocks with stopReason error in transcript repair

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,6 +116,16 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Skip tool call extraction if the assistant turn errored/terminated.
+    // When stopReason is "error", the tool_use blocks are incomplete and were never executed,
+    // so we should not create synthetic tool_results for them.
+    const stopReason = (assistant as { stopReason?: unknown }).stopReason;
+    if (stopReason === "error") {
+      out.push(msg);
+      continue;
+    }
+
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);


### PR DESCRIPTION
## Summary

Fixes #1826

When an assistant message has `stopReason: "error"`, the tool_use blocks within it are incomplete/terminated and were never actually executed. The transcript repair mechanism was incorrectly creating synthetic tool_results for these errored tool calls, causing all subsequent API requests to fail with:

```
invalid_request_error: messages.X.content.Y: unexpected tool_use_id found in tool_result blocks: toolu_XXX. 
Each tool_result block must have a corresponding tool_use block in the previous message.
```

This breaks the session permanently until the synthetic tool_result is manually removed from the JSONL file.

## Changes

- **Check `stopReason` before extracting tool calls** in `repairToolUseResultPairing()`
- **Skip tool call extraction** when `stopReason` is `"error"`  
- **Prevents synthetic tool_results** for incomplete/terminated tool calls

## Root Cause

The issue occurred in `src/agents/session-transcript-repair.ts` at line 119:

**Before:**
```typescript
const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
const toolCalls = extractToolCallsFromAssistant(assistant);  // ❌ Extracts from errored messages too
```

**After:**
```typescript
const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;

// Skip tool call extraction if the assistant turn errored/terminated.
// When stopReason is "error", the tool_use blocks are incomplete and were never executed,
// so we should not create synthetic tool_results for them.
const stopReason = (assistant as { stopReason?: unknown }).stopReason;
if (stopReason === "error") {
  out.push(msg);
  continue;
}

const toolCalls = extractToolCallsFromAssistant(assistant);
```

## Impact

**Before this fix:**
- Tool execution error/interruption → session permanently broken
- Requires manual JSONL editing to recover
- Confusing error messages for users

**After this fix:**
- Tool execution error/interruption → session remains usable
- No manual intervention needed
- Clean recovery from errors

## Testing Status

⚠️ **Lightly tested**
- ✅ TypeScript compiles without errors
- ✅ Linter passes (oxlint)
- ⚠️ No specific test for errored tool_use scenario (would need integration test with actual API error)
- ⚠️ Needs real-world validation

## Files Changed

- `src/agents/session-transcript-repair.ts` - Added stopReason check (10 lines added)

## AI-Assisted Development

🤖 This PR was created with assistance from Claude Sonnet 4.5
- Analyzed issue #1826 and traced root cause through codebase
- Designed minimal fix following existing code patterns
- Generated fix implementation and PR
- Testing level: **lightly tested** (compiles + lints, needs integration testing)

## Checklist

- [x] Code follows existing patterns
- [x] Linter passes  
- [x] TypeScript compiles without errors
- [ ] Integration tested (needs validation with actual error scenarios)
- [x] Marked as AI-assisted
- [x] References issue #1826

---

Generated with [Claude Code](https://claude.com/claude-code)