### PR TITLE
fix(minimax): use correct API endpoint and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Status: beta.
 - Web UI: auto-expand the chat compose textarea while typing (with sensible max height). (#2950) Thanks @shivamraut101.
 - Gateway: prevent crashes on transient network errors (fetch failures, timeouts, DNS). Added fatal error detection to only exit on truly critical errors. Fixes #2895, #2879, #2873. (#2980) Thanks @elliotsecops.
 - Agents: guard channel tool listActions to avoid plugin crashes. (#2859) Thanks @mbelinky.
+- Providers: update MiniMax API endpoint and compatibility mode. (#3064) Thanks @hlbbbbbbb.
 - Gateway: suppress AbortError and transient network errors in unhandled rejections. (#2451) Thanks @Glucksberg.
 - TTS: keep /tts status replies on text-only commands and avoid duplicate block-stream audio. (#2451) Thanks @Glucksberg.
 - Security: pin npm overrides to keep tar@7.5.4 for install toolchains.

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -17,7 +17,7 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<MoltbotConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
-const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
+const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;
@@ -244,7 +244,7 @@ export function normalizeProviders(params: {
 function buildMinimaxProvider(): ProviderConfig {
   return {
     baseUrl: MINIMAX_API_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     models: [
       {
         id: MINIMAX_DEFAULT_MODEL_ID,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -51,7 +51,8 @@ function isOpenAiProvider(provider?: string | null): boolean {
 function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
   if (modelApi === "anthropic-messages") return true;
   const normalized = normalizeProviderId(provider ?? "");
-  return normalized === "anthropic" || normalized === "minimax";
+  // MiniMax now uses openai-completions API, not anthropic-messages
+  return normalized === "anthropic";
 }
 
 function isMistralModel(params: { provider?: string | null; modelId?: string | null }): boolean {


### PR DESCRIPTION
## Summary

MiniMax has updated their API endpoint and format. The previous configuration was broken:

- **Old endpoint**: `https://api.minimax.io/anthropic` (no longer works)
- **New endpoint**: `https://api.minimax.chat/v1`
- **Old API format**: `anthropic-messages`
- **New API format**: `openai-completions`

## Changes

- Update `MINIMAX_API_BASE_URL` to the correct endpoint
- Change API format from `anthropic-messages` to `openai-completions`
- Remove `minimax` from `isAnthropicApi()` check in transcript-policy.ts

## Testing

Tested locally with MiniMax API key - confirmed that API calls now return results correctly.