### PR TITLE
fix(test): set USERPROFILE for Windows in CONFIG_PATH test

### DIFF
--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -69,6 +69,7 @@ describe("state + config path candidates", () => {
   it("CONFIG_PATH prefers existing legacy filename when present", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-config-"));
     const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
     const previousMoltbotConfig = process.env.MOLTBOT_CONFIG_PATH;
     const previousClawdbotConfig = process.env.CLAWDBOT_CONFIG_PATH;
     const previousMoltbotState = process.env.MOLTBOT_STATE_DIR;
@@ -80,6 +81,7 @@ describe("state + config path candidates", () => {
       await fs.writeFile(legacyPath, "{}", "utf-8");
 
       process.env.HOME = root;
+      process.env.USERPROFILE = root;
       delete process.env.MOLTBOT_CONFIG_PATH;
       delete process.env.CLAWDBOT_CONFIG_PATH;
       delete process.env.MOLTBOT_STATE_DIR;
@@ -93,6 +95,11 @@ describe("state + config path candidates", () => {
         delete process.env.HOME;
       } else {
         process.env.HOME = previousHome;
+      }
+      if (previousUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = previousUserProfile;
       }
       if (previousMoltbotConfig === undefined) delete process.env.MOLTBOT_CONFIG_PATH;
       else process.env.MOLTBOT_CONFIG_PATH = previousMoltbotConfig;


### PR DESCRIPTION
## Summary

Fix Windows CI failure in `CONFIG_PATH prefers existing legacy filename when present` test by properly setting both `HOME` and `USERPROFILE` environment variables.

## Problem

The test at `src/config/paths.test.ts:69` sets `process.env.HOME` to isolate the test environment, but on Windows `os.homedir()` uses `USERPROFILE` instead of `HOME`. This caused the test to use the global test home directory (`moltbot-test-home-*`) rather than the test-local temp directory (`moltbot-config-*`), resulting in path mismatches:

```
Expected: "C:\Users\RUNNER~1\AppData\Local\Temp\moltbot-config-XXX\.clawdbot\clawdbot.json"
Received: "C:\Users\RUNNER~1\AppData\Local\Temp\moltbot-test-home-XXX\.clawdbot\moltbot.json"
```

## Solution

Added `USERPROFILE` environment variable handling to the test, following the same pattern used in `test/test-env.ts`:
- Save `previousUserProfile` before modifying environment
- Set `process.env.USERPROFILE = root` alongside `HOME`
- Restore `USERPROFILE` in the finally block

## Testing

- [x] Lightly tested (verified the fix logic matches existing patterns in codebase)
- [x] Confirmed understanding of the code and issue
- [x] Reviewed similar Windows environment handling in `test/test-env.ts`

## Notes

- This fixes a pre-existing Windows CI failure introduced in commit e2c437e
- The test has never passed on Windows since it was added
- No functional code changes - test isolation fix only

Fixes checks-windows CI failure in https://github.com/moltbot/moltbot/actions/runs/21419505042/job/61675670257

---

## AI-Assisted PR

- [x] Mark as AI-assisted in the PR title or description  
- [x] Note the degree of testing: **lightly tested** (verified fix logic, not run on actual Windows CI)
- [x] Confirm I understand what the code does

This PR was AI-assisted using Claude. The fix adds `USERPROFILE` handling to ensure Windows tests properly isolate the home directory when using `vi.resetModules()` and dynamically importing modules that call `os.homedir()`.