### PR TITLE
Friendlier Windows onboarding message

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -8,8 +8,8 @@ read_when:
 
 Moltbot on Windows is recommended **via WSL2** (Ubuntu recommended). The
 CLI + Gateway run inside Linux, which keeps the runtime consistent and makes
-tooling far more compatible (Node/Bun/pnpm, Linux binaries, skills). Native
-Windows installs are untested and more problematic.
+tooling far more compatible (Node/Bun/pnpm, Linux binaries, skills). WSL2 gives
+you the full Linux experience on Windows — one command to install: `wsl --install`.
 
 Native Windows companion apps are planned.
 

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -63,8 +63,8 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
   if (process.platform === "win32") {
     runtime.log(
       [
-        "Windows detected.",
-        "WSL2 is strongly recommended; native Windows is untested and more problematic.",
+        "Windows detected — Clawdbot runs great on WSL2!",
+        "Quick setup: wsl --install (one command, one reboot)",
         "Guide: https://docs.molt.bot/windows",
       ].join("\n"),
     );


### PR DESCRIPTION
## What

Replaces the Windows detection message during onboarding:

**Before:**
```
Windows detected.
WSL2 is strongly recommended; native Windows is untested and more problematic.
```

**After:**
```
Windows detected — Clawdbot runs great on WSL2!
Quick setup: wsl --install (one command, one reboot)
```

Also updates `docs/platforms/windows.md` with the same positive framing.

## Why

The old message reads as discouraging to Windows users. Clawdbot actually runs *great* on WSL2 — the message should reflect that and give users the one command they need to get going, rather than making them feel like they picked the wrong OS.

## Changes
- `src/commands/onboard.ts` — Updated CLI output
- `docs/platforms/windows.md` — Updated docs to match