### PR TITLE
fix: include stable entry ID in chat.history messages

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -23,7 +23,7 @@ export function readSessionMessages(
     try {
       const parsed = JSON.parse(line);
       if (parsed?.message) {
-        messages.push(parsed.message);
+        messages.push({ ...parsed.message, id: parsed.id });
       }
     } catch {
       // ignore bad lines


### PR DESCRIPTION
## Summary

Include the JSONL entry `id` in messages returned by `readSessionMessages()`, providing stable unique identifiers for each message.

## Problem

The `chat.history` gateway method returns messages without unique identifiers. Downstream consumers (custom dashboards, external integrations, MCP clients) must fall back to array indices for message IDs, which are unstable when messages are filtered, compacted, or new messages arrive.

This causes issues for chat UIs that:
- Deduplicate messages by ID (indices shift when messages are added/removed)
- Use message IDs as rendering keys (causes unnecessary re-renders and state loss)
- Track "seen" messages across polling intervals (false positives/negatives)

## Solution

Changed `messages.push(parsed.message)` to `messages.push({ ...parsed.message, id: parsed.id })` in `src/gateway/session-utils.fs.ts`.

Each JSONL transcript entry already has a unique `id` field. This change spreads that ID onto the message object, making it available to `chat.history` consumers.

## Testing

- [x] **Live tested** - Running in production with a custom chat integration for ~1 week
- [x] Confirmed understanding of the code and impact
- [x] Added unit tests for `readSessionMessages` to verify `id` is included

The unit tests verify:
- Messages with stable IDs are preserved
- Messages without IDs handle gracefully (id: undefined)
- Invalid JSON and empty lines are skipped
- Message content and metadata are preserved
- Nonexistent files return empty array

## Notes

- Non-breaking change - adds an optional `id` field to returned messages
- Consumers that don't use `id` are unaffected
- Single line change in production code + comprehensive test coverage

---

## AI-Assisted PR

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing: **live tested** in production + unit tests added
- [x] Confirm I understand what the code does

This PR was AI-assisted using Claude. The fix spreads the JSONL entry ID onto message objects to provide stable identifiers for chat history consumers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `readSessionMessages()` to include the JSONL transcript entry `id` on each returned message object, and adds a new `readSessionMessages` test suite to validate IDs are present, malformed lines are skipped, and missing files return an empty array.

The change fits into the gateway transcript utilities by making `chat.history` consumers able to reference a stable, per-entry identifier rather than relying on array indices.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge; main risk is identifier collision/overwrite semantics.
- The production change is small and well-covered by basic tests, but it unconditionally overwrites any existing `message.id` with the transcript entry ID, which could break consumers if message objects already carry their own IDs. No other functional issues were observed in the changed files.
- src/gateway/session-utils.fs.ts (id overwrite semantics)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->