### PR TITLE
feat(ringcentral): add RingCentral Team Messaging channel plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,3 @@ USER.md
 
 # local tooling
 .serena/
-
-# RingCentral credentials (never commit)
-rc-credentials.json
-*-credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ USER.md
 
 # local tooling
 .serena/
+
+# RingCentral credentials (never commit)
+rc-credentials.json
+*-credentials.json

--- a/extensions/ringcentral/README.md
+++ b/extensions/ringcentral/README.md
@@ -77,7 +77,7 @@ export RINGCENTRAL_JWT="your-jwt-token"
 | `selfOnly` | boolean | `true` | Only respond to JWT user in Personal chat |
 | `name` | string | - | Bot display name |
 | `textChunkLimit` | number | `4000` | Maximum characters per message chunk |
-| `dmPolicy` | string | `"pairing"` | DM policy (only when `selfOnly: false`) |
+| `dmPolicy` | string | `"allowlist"` | DM policy (only when `selfOnly: false`) |
 | `groupPolicy` | string | `"allowlist"` | Group policy (only when `selfOnly: false`) |
 
 > **Note:** When `selfOnly: true` (default), the bot only responds to the JWT user in their Personal chat. All other policy settings (`dmPolicy`, `allowFrom`, `groupPolicy`, etc.) are ignored.

--- a/extensions/ringcentral/README.md
+++ b/extensions/ringcentral/README.md
@@ -74,14 +74,13 @@ export RINGCENTRAL_JWT="your-jwt-token"
 | `clientSecret` | string | - | RingCentral app client secret |
 | `jwt` | string | - | JWT token for authentication |
 | `server` | string | `https://platform.ringcentral.com` | RingCentral API server URL |
-| `selfOnly` | boolean | `true` | Only accept messages from the JWT user |
-| `allowOtherChats` | boolean | `false` | In selfOnly mode, allow chats other than Personal |
+| `selfOnly` | boolean | `true` | Only respond to JWT user in Personal chat |
 | `name` | string | - | Bot display name |
 | `textChunkLimit` | number | `4000` | Maximum characters per message chunk |
-| `dmPolicy` | string | `"pairing"` | DM policy (only applies when `selfOnly: false`) |
-| `groupPolicy` | string | `"allowlist"` | Group policy (only applies when `selfOnly: false`) |
+| `dmPolicy` | string | `"pairing"` | DM policy (only when `selfOnly: false`) |
+| `groupPolicy` | string | `"allowlist"` | Group policy (only when `selfOnly: false`) |
 
-> **Note:** When `selfOnly: true` (default), the `dmPolicy`, `allowFrom`, `groupPolicy`, and related settings are ignored. The bot only responds to the JWT user in their Personal chat.
+> **Note:** When `selfOnly: true` (default), the bot only responds to the JWT user in their Personal chat. All other policy settings (`dmPolicy`, `allowFrom`, `groupPolicy`, etc.) are ignored.
 
 ## Usage
 

--- a/extensions/ringcentral/README.md
+++ b/extensions/ringcentral/README.md
@@ -78,6 +78,10 @@ export RINGCENTRAL_JWT="your-jwt-token"
 | `allowOtherChats` | boolean | `false` | In selfOnly mode, allow chats other than Personal |
 | `name` | string | - | Bot display name |
 | `textChunkLimit` | number | `4000` | Maximum characters per message chunk |
+| `dmPolicy` | string | `"pairing"` | DM policy (only applies when `selfOnly: false`) |
+| `groupPolicy` | string | `"allowlist"` | Group policy (only applies when `selfOnly: false`) |
+
+> **Note:** When `selfOnly: true` (default), the `dmPolicy`, `allowFrom`, `groupPolicy`, and related settings are ignored. The bot only responds to the JWT user in their Personal chat.
 
 ## Usage
 

--- a/extensions/ringcentral/README.md
+++ b/extensions/ringcentral/README.md
@@ -1,6 +1,6 @@
-# Clawdbot RingCentral Channel
+# Moltbot RingCentral Channel
 
-RingCentral Team Messaging channel plugin for Clawdbot. Enables bidirectional messaging with AI assistants through RingCentral Team Messaging.
+RingCentral Team Messaging channel plugin for Moltbot. Enables bidirectional messaging with AI assistants through RingCentral Team Messaging.
 
 ## Features
 
@@ -18,13 +18,13 @@ RingCentral Team Messaging channel plugin for Clawdbot. Enables bidirectional me
 ## Installation
 
 ```bash
-clawdbot plugin install @clawdbot/ringcentral
+moltbot plugin install @moltbot/ringcentral
 ```
 
 Or install from tarball:
 
 ```bash
-clawdbot plugin install ./clawdbot-ringcentral-2026.1.25.tgz
+moltbot plugin install ./moltbot-ringcentral-2026.1.25.tgz
 ```
 
 ## RingCentral App Setup
@@ -41,7 +41,7 @@ clawdbot plugin install ./clawdbot-ringcentral-2026.1.25.tgz
 
 ## Configuration
 
-Add to `~/.clawdbot/clawdbot.json`:
+Add to `~/.moltbot/moltbot.json`:
 
 ```json
 {
@@ -84,10 +84,10 @@ export RINGCENTRAL_JWT="your-jwt-token"
 
 ## Usage
 
-1. Start the Clawdbot gateway:
+1. Start the Moltbot gateway:
 
 ```bash
-clawdbot gateway run
+moltbot gateway run
 ```
 
 2. Open RingCentral app and go to your "Personal" chat (conversation with yourself)
@@ -162,7 +162,7 @@ Add **WebSocket Subscriptions** permission in your app settings. Permission chan
 
 1. Check that `selfOnly` mode matches your use case
 2. Verify you're sending messages in a "Personal" chat (conversation with yourself)
-3. Check gateway logs: `tail -f /tmp/clawdbot/clawdbot-*.log | grep ringcentral`
+3. Check gateway logs: `tail -f /tmp/moltbot/moltbot-*.log | grep ringcentral`
 
 ### Rate limit errors
 

--- a/extensions/ringcentral/README.md
+++ b/extensions/ringcentral/README.md
@@ -1,0 +1,170 @@
+# Clawdbot RingCentral Channel
+
+RingCentral Team Messaging channel plugin for Clawdbot. Enables bidirectional messaging with AI assistants through RingCentral Team Messaging.
+
+## Features
+
+- WebSocket-based real-time messaging (no public webhook required)
+- JWT authentication
+- Self-only mode (talk to AI as yourself)
+- Support for text messages and attachments
+- Typing indicators
+
+## Prerequisites
+
+1. A RingCentral account with Team Messaging enabled
+2. A RingCentral REST API App (not Bot Add-in)
+
+## Installation
+
+```bash
+clawdbot plugin install @clawdbot/ringcentral
+```
+
+Or install from tarball:
+
+```bash
+clawdbot plugin install ./clawdbot-ringcentral-2026.1.25.tgz
+```
+
+## RingCentral App Setup
+
+1. Go to [RingCentral Developer Portal](https://developers.ringcentral.com/)
+2. Create a new app:
+   - **App Type**: REST API App
+   - **Auth**: JWT auth flow
+3. Add permissions:
+   - **Team Messaging** - Read and send messages
+   - **WebSocket Subscriptions** - Real-time event subscriptions
+   - **Read Accounts** - Read user information
+4. Generate a JWT token for your user
+
+## Configuration
+
+Add to `~/.clawdbot/clawdbot.json`:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "clientId": "your-client-id",
+      "clientSecret": "your-client-secret",
+      "jwt": "your-jwt-token",
+      "server": "https://platform.ringcentral.com"
+    }
+  }
+}
+```
+
+Or use environment variables:
+
+```bash
+export RINGCENTRAL_CLIENT_ID="your-client-id"
+export RINGCENTRAL_CLIENT_SECRET="your-client-secret"
+export RINGCENTRAL_JWT="your-jwt-token"
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable the RingCentral channel |
+| `clientId` | string | - | RingCentral app client ID |
+| `clientSecret` | string | - | RingCentral app client secret |
+| `jwt` | string | - | JWT token for authentication |
+| `server` | string | `https://platform.ringcentral.com` | RingCentral API server URL |
+| `selfOnly` | boolean | `true` | Only accept messages from the JWT user |
+| `allowOtherChats` | boolean | `false` | In selfOnly mode, allow chats other than Personal |
+| `name` | string | - | Bot display name |
+| `textChunkLimit` | number | `4000` | Maximum characters per message chunk |
+
+## Usage
+
+1. Start the Clawdbot gateway:
+
+```bash
+clawdbot gateway run
+```
+
+2. Open RingCentral app and go to your "Personal" chat (conversation with yourself)
+
+3. Send a message - the AI will respond!
+
+## How It Works
+
+This plugin uses JWT authentication, which means:
+
+- **Messages appear from your own account** (not a separate bot)
+- **Default mode (`selfOnly: true`)**: Only processes messages you send to yourself
+- **Personal chat only**: By default, only responds in your "Personal" chat
+
+This is ideal for personal AI assistant use without needing to set up a separate bot account.
+
+## Advanced Configuration
+
+### Allow Group Chats
+
+To enable the bot in group chats:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "selfOnly": false,
+      "groupPolicy": "open",
+      "dmPolicy": "open"
+    }
+  }
+}
+```
+
+### Multiple Accounts
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "defaultAccount": "work",
+      "accounts": {
+        "work": {
+          "clientId": "work-client-id",
+          "clientSecret": "work-client-secret",
+          "jwt": "work-jwt-token"
+        },
+        "personal": {
+          "clientId": "personal-client-id",
+          "clientSecret": "personal-client-secret",
+          "jwt": "personal-jwt-token"
+        }
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### "Unauthorized for this grant type"
+
+Your app type is wrong. Create a **REST API App** (not Bot Add-in) with JWT auth flow.
+
+### "In order to call this API endpoint, application needs to have [WebSocket] permission"
+
+Add **WebSocket Subscriptions** permission in your app settings. Permission changes may take a few minutes to propagate.
+
+### Messages not being processed
+
+1. Check that `selfOnly` mode matches your use case
+2. Verify you're sending messages in a "Personal" chat (conversation with yourself)
+3. Check gateway logs: `tail -f /tmp/clawdbot/clawdbot-*.log | grep ringcentral`
+
+### Rate limit errors
+
+RingCentral has API rate limits. If you see "Request rate exceeded", wait a minute before retrying.
+
+## License
+
+MIT

--- a/extensions/ringcentral/clawdbot.plugin.json
+++ b/extensions/ringcentral/clawdbot.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "ringcentral",
+  "channels": [
+    "ringcentral"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/ringcentral/index.ts
+++ b/extensions/ringcentral/index.ts
@@ -1,0 +1,19 @@
+import type { ClawdbotPluginApi } from "clawdbot/plugin-sdk";
+import { emptyPluginConfigSchema } from "clawdbot/plugin-sdk";
+
+import { ringcentralDock, ringcentralPlugin } from "./src/channel.js";
+import { setRingCentralRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "ringcentral",
+  name: "RingCentral",
+  description: "Clawdbot RingCentral Team Messaging channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: ClawdbotPluginApi) {
+    setRingCentralRuntime(api.runtime);
+    api.registerChannel({ plugin: ringcentralPlugin, dock: ringcentralDock });
+    // WebSocket mode: no HTTP handler needed
+  },
+};
+
+export default plugin;

--- a/extensions/ringcentral/index.ts
+++ b/extensions/ringcentral/index.ts
@@ -1,5 +1,5 @@
-import type { ClawdbotPluginApi } from "clawdbot/plugin-sdk";
-import { emptyPluginConfigSchema } from "clawdbot/plugin-sdk";
+import type { MoltbotPluginApi } from "moltbot/plugin-sdk";
+import { emptyPluginConfigSchema } from "moltbot/plugin-sdk";
 
 import { ringcentralDock, ringcentralPlugin } from "./src/channel.js";
 import { setRingCentralRuntime } from "./src/runtime.js";
@@ -7,9 +7,9 @@ import { setRingCentralRuntime } from "./src/runtime.js";
 const plugin = {
   id: "ringcentral",
   name: "RingCentral",
-  description: "Clawdbot RingCentral Team Messaging channel plugin",
+  description: "Moltbot RingCentral Team Messaging channel plugin",
   configSchema: emptyPluginConfigSchema(),
-  register(api: ClawdbotPluginApi) {
+  register(api: MoltbotPluginApi) {
     setRingCentralRuntime(api.runtime);
     api.registerChannel({ plugin: ringcentralPlugin, dock: ringcentralDock });
     // WebSocket mode: no HTTP handler needed

--- a/extensions/ringcentral/package.json
+++ b/extensions/ringcentral/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@clawdbot/ringcentral",
+  "version": "2026.1.25",
+  "type": "module",
+  "description": "Clawdbot RingCentral Team Messaging channel plugin",
+  "clawdbot": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "ringcentral",
+      "label": "RingCentral",
+      "selectionLabel": "RingCentral Team Messaging",
+      "detailLabel": "RingCentral",
+      "docsPath": "/channels/ringcentral",
+      "docsLabel": "ringcentral",
+      "blurb": "RingCentral Team Messaging via REST API and WebSocket.",
+      "aliases": [
+        "rc",
+        "ringcentral-tm"
+      ],
+      "order": 56
+    },
+    "install": {
+      "npmSpec": "@clawdbot/ringcentral",
+      "localPath": "extensions/ringcentral",
+      "defaultChoice": "npm"
+    }
+  },
+  "dependencies": {
+    "@ringcentral/sdk": "^5.0.0",
+    "@ringcentral/subscriptions": "^5.0.0",
+    "isomorphic-ws": "^5.0.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "clawdbot": "workspace:*"
+  },
+  "peerDependencies": {
+    "clawdbot": ">=2026.1.25"
+  }
+}

--- a/extensions/ringcentral/package.json
+++ b/extensions/ringcentral/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@clawdbot/ringcentral",
+  "name": "@moltbot/ringcentral",
   "version": "2026.1.25",
   "type": "module",
-  "description": "Clawdbot RingCentral Team Messaging channel plugin",
-  "clawdbot": {
+  "description": "Moltbot RingCentral Team Messaging channel plugin",
+  "moltbot": {
     "extensions": [
       "./index.ts"
     ],
@@ -22,7 +22,7 @@
       "order": 56
     },
     "install": {
-      "npmSpec": "@clawdbot/ringcentral",
+      "npmSpec": "@moltbot/ringcentral",
       "localPath": "extensions/ringcentral",
       "defaultChoice": "npm"
     }
@@ -34,9 +34,9 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "clawdbot": "workspace:*"
+    "moltbot": "workspace:*"
   },
   "peerDependencies": {
-    "clawdbot": ">=2026.1.25"
+    "moltbot": ">=2026.1.25"
   }
 }

--- a/extensions/ringcentral/package.json
+++ b/extensions/ringcentral/package.json
@@ -1,8 +1,26 @@
 {
   "name": "@moltbot/ringcentral",
-  "version": "2026.1.25",
+  "version": "2026.1.28",
   "type": "module",
   "description": "Moltbot RingCentral Team Messaging channel plugin",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/moltbot/moltbot.git",
+    "directory": "extensions/ringcentral"
+  },
+  "keywords": [
+    "moltbot",
+    "ringcentral",
+    "team-messaging",
+    "chat",
+    "bot"
+  ],
+  "files": [
+    "src",
+    "index.ts",
+    "README.md"
+  ],
   "moltbot": {
     "extensions": [
       "./index.ts"

--- a/extensions/ringcentral/src/accounts.test.ts
+++ b/extensions/ringcentral/src/accounts.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
+import {
+  listRingCentralAccountIds,
+  resolveDefaultRingCentralAccountId,
+  resolveRingCentralAccount,
+  listEnabledRingCentralAccounts,
+} from "./accounts.js";
+
+describe("listRingCentralAccountIds", () => {
+  it("returns default account when no accounts configured", () => {
+    const cfg = { channels: {} } as ClawdbotConfig;
+    expect(listRingCentralAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns default account when ringcentral channel not configured", () => {
+    const cfg = { channels: { telegram: { enabled: true } } } as ClawdbotConfig;
+    expect(listRingCentralAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns configured account IDs sorted alphabetically", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          accounts: {
+            work: { enabled: true },
+            personal: { enabled: true },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+    expect(listRingCentralAccountIds(cfg)).toEqual(["personal", "work"]);
+  });
+});
+
+describe("resolveDefaultRingCentralAccountId", () => {
+  it("returns explicitly set default account", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          defaultAccount: "work",
+          accounts: {
+            work: {},
+            personal: {},
+          },
+        },
+      },
+    } as ClawdbotConfig;
+    expect(resolveDefaultRingCentralAccountId(cfg)).toBe("work");
+  });
+
+  it("returns default if included in accounts", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          accounts: {
+            default: {},
+            other: {},
+          },
+        },
+      },
+    } as ClawdbotConfig;
+    expect(resolveDefaultRingCentralAccountId(cfg)).toBe("default");
+  });
+
+  it("returns first account ID when no default specified", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          accounts: {
+            zebra: {},
+            alpha: {},
+          },
+        },
+      },
+    } as ClawdbotConfig;
+    expect(resolveDefaultRingCentralAccountId(cfg)).toBe("alpha");
+  });
+});
+
+describe("resolveRingCentralAccount", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("resolves account from config credentials", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
+          jwt: "test-jwt",
+          server: "https://platform.devtest.ringcentral.com",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg });
+
+    expect(account.accountId).toBe("default");
+    expect(account.enabled).toBe(true);
+    expect(account.credentialSource).toBe("config");
+    expect(account.clientId).toBe("test-client-id");
+    expect(account.clientSecret).toBe("test-client-secret");
+    expect(account.jwt).toBe("test-jwt");
+    expect(account.server).toBe("https://platform.devtest.ringcentral.com");
+  });
+
+  it("resolves account from environment variables", () => {
+    process.env.RINGCENTRAL_CLIENT_ID = "env-client-id";
+    process.env.RINGCENTRAL_CLIENT_SECRET = "env-client-secret";
+    process.env.RINGCENTRAL_JWT = "env-jwt";
+    process.env.RINGCENTRAL_SERVER = "https://platform.devtest.ringcentral.com";
+
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg });
+
+    expect(account.credentialSource).toBe("env");
+    expect(account.clientId).toBe("env-client-id");
+    expect(account.clientSecret).toBe("env-client-secret");
+    expect(account.jwt).toBe("env-jwt");
+    expect(account.server).toBe("https://platform.devtest.ringcentral.com");
+  });
+
+  it("returns none source when no credentials configured", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg });
+
+    expect(account.credentialSource).toBe("none");
+    expect(account.clientId).toBeUndefined();
+  });
+
+  it("uses default server when not specified", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
+          jwt: "test-jwt",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg });
+
+    expect(account.server).toBe("https://platform.ringcentral.com");
+  });
+
+  it("resolves specific account from accounts map", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          accounts: {
+            work: {
+              clientId: "work-client-id",
+              clientSecret: "work-client-secret",
+              jwt: "work-jwt",
+              name: "Work Account",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg, accountId: "work" });
+
+    expect(account.accountId).toBe("work");
+    expect(account.name).toBe("Work Account");
+    expect(account.clientId).toBe("work-client-id");
+  });
+
+  it("merges base config with account config", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          server: "https://base.server.com",
+          accounts: {
+            work: {
+              clientId: "work-client-id",
+              clientSecret: "work-client-secret",
+              jwt: "work-jwt",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg, accountId: "work" });
+
+    expect(account.server).toBe("https://base.server.com");
+  });
+
+  it("account config overrides base config", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          server: "https://base.server.com",
+          accounts: {
+            work: {
+              clientId: "work-client-id",
+              clientSecret: "work-client-secret",
+              jwt: "work-jwt",
+              server: "https://work.server.com",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const account = resolveRingCentralAccount({ cfg, accountId: "work" });
+
+    expect(account.server).toBe("https://work.server.com");
+  });
+});
+
+describe("listEnabledRingCentralAccounts", () => {
+  it("returns only enabled accounts", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: true,
+          clientId: "base-id",
+          clientSecret: "base-secret",
+          jwt: "base-jwt",
+          accounts: {
+            enabled1: {
+              enabled: true,
+              clientId: "e1-id",
+              clientSecret: "e1-secret",
+              jwt: "e1-jwt",
+            },
+            disabled1: {
+              enabled: false,
+              clientId: "d1-id",
+              clientSecret: "d1-secret",
+              jwt: "d1-jwt",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const accounts = listEnabledRingCentralAccounts(cfg);
+
+    expect(accounts.map((a) => a.accountId)).toContain("enabled1");
+    expect(accounts.map((a) => a.accountId)).not.toContain("disabled1");
+  });
+
+  it("returns empty array when channel is disabled", () => {
+    const cfg = {
+      channels: {
+        ringcentral: {
+          enabled: false,
+          accounts: {
+            work: { enabled: true },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const accounts = listEnabledRingCentralAccounts(cfg);
+
+    expect(accounts).toEqual([]);
+  });
+});

--- a/extensions/ringcentral/src/accounts.test.ts
+++ b/extensions/ringcentral/src/accounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
+import type { MoltbotConfig } from "moltbot/plugin-sdk";
 import {
   listRingCentralAccountIds,
   resolveDefaultRingCentralAccountId,
@@ -9,12 +9,12 @@ import {
 
 describe("listRingCentralAccountIds", () => {
   it("returns default account when no accounts configured", () => {
-    const cfg = { channels: {} } as ClawdbotConfig;
+    const cfg = { channels: {} } as MoltbotConfig;
     expect(listRingCentralAccountIds(cfg)).toEqual(["default"]);
   });
 
   it("returns default account when ringcentral channel not configured", () => {
-    const cfg = { channels: { telegram: { enabled: true } } } as ClawdbotConfig;
+    const cfg = { channels: { telegram: { enabled: true } } } as MoltbotConfig;
     expect(listRingCentralAccountIds(cfg)).toEqual(["default"]);
   });
 
@@ -28,7 +28,7 @@ describe("listRingCentralAccountIds", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
     expect(listRingCentralAccountIds(cfg)).toEqual(["personal", "work"]);
   });
 });
@@ -45,7 +45,7 @@ describe("resolveDefaultRingCentralAccountId", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
     expect(resolveDefaultRingCentralAccountId(cfg)).toBe("work");
   });
 
@@ -59,7 +59,7 @@ describe("resolveDefaultRingCentralAccountId", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
     expect(resolveDefaultRingCentralAccountId(cfg)).toBe("default");
   });
 
@@ -73,7 +73,7 @@ describe("resolveDefaultRingCentralAccountId", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
     expect(resolveDefaultRingCentralAccountId(cfg)).toBe("alpha");
   });
 });
@@ -101,7 +101,7 @@ describe("resolveRingCentralAccount", () => {
           server: "https://platform.devtest.ringcentral.com",
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg });
 
@@ -126,7 +126,7 @@ describe("resolveRingCentralAccount", () => {
           enabled: true,
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg });
 
@@ -144,7 +144,7 @@ describe("resolveRingCentralAccount", () => {
           enabled: true,
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg });
 
@@ -162,7 +162,7 @@ describe("resolveRingCentralAccount", () => {
           jwt: "test-jwt",
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg });
 
@@ -184,7 +184,7 @@ describe("resolveRingCentralAccount", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg, accountId: "work" });
 
@@ -208,7 +208,7 @@ describe("resolveRingCentralAccount", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg, accountId: "work" });
 
@@ -231,7 +231,7 @@ describe("resolveRingCentralAccount", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const account = resolveRingCentralAccount({ cfg, accountId: "work" });
 
@@ -264,7 +264,7 @@ describe("listEnabledRingCentralAccounts", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const accounts = listEnabledRingCentralAccounts(cfg);
 
@@ -282,7 +282,7 @@ describe("listEnabledRingCentralAccounts", () => {
           },
         },
       },
-    } as ClawdbotConfig;
+    } as MoltbotConfig;
 
     const accounts = listEnabledRingCentralAccounts(cfg);
 

--- a/extensions/ringcentral/src/accounts.ts
+++ b/extensions/ringcentral/src/accounts.ts
@@ -1,5 +1,5 @@
-import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "clawdbot/plugin-sdk";
+import type { MoltbotConfig } from "moltbot/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "moltbot/plugin-sdk";
 
 import type { RingCentralAccountConfig, RingCentralConfig } from "./types.js";
 
@@ -24,19 +24,19 @@ const ENV_SERVER = "RINGCENTRAL_SERVER";
 
 const DEFAULT_SERVER = "https://platform.ringcentral.com";
 
-function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
+function listConfiguredAccountIds(cfg: MoltbotConfig): string[] {
   const accounts = (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.accounts;
   if (!accounts || typeof accounts !== "object") return [];
   return Object.keys(accounts).filter(Boolean);
 }
 
-export function listRingCentralAccountIds(cfg: ClawdbotConfig): string[] {
+export function listRingCentralAccountIds(cfg: MoltbotConfig): string[] {
   const ids = listConfiguredAccountIds(cfg);
   if (ids.length === 0) return [DEFAULT_ACCOUNT_ID];
   return ids.sort((a, b) => a.localeCompare(b));
 }
 
-export function resolveDefaultRingCentralAccountId(cfg: ClawdbotConfig): string {
+export function resolveDefaultRingCentralAccountId(cfg: MoltbotConfig): string {
   const channel = cfg.channels?.ringcentral as RingCentralConfig | undefined;
   if (channel?.defaultAccount?.trim()) return channel.defaultAccount.trim();
   const ids = listRingCentralAccountIds(cfg);
@@ -45,7 +45,7 @@ export function resolveDefaultRingCentralAccountId(cfg: ClawdbotConfig): string 
 }
 
 function resolveAccountConfig(
-  cfg: ClawdbotConfig,
+  cfg: MoltbotConfig,
   accountId: string,
 ): RingCentralAccountConfig | undefined {
   const accounts = (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.accounts;
@@ -54,7 +54,7 @@ function resolveAccountConfig(
 }
 
 function mergeRingCentralAccountConfig(
-  cfg: ClawdbotConfig,
+  cfg: MoltbotConfig,
   accountId: string,
 ): RingCentralAccountConfig {
   const raw = (cfg.channels?.ringcentral ?? {}) as RingCentralConfig;
@@ -131,7 +131,7 @@ function resolveCredentialsFromConfig(params: {
 }
 
 export function resolveRingCentralAccount(params: {
-  cfg: ClawdbotConfig;
+  cfg: MoltbotConfig;
   accountId?: string | null;
 }): ResolvedRingCentralAccount {
   const accountId = normalizeAccountId(params.accountId);
@@ -155,7 +155,7 @@ export function resolveRingCentralAccount(params: {
   };
 }
 
-export function listEnabledRingCentralAccounts(cfg: ClawdbotConfig): ResolvedRingCentralAccount[] {
+export function listEnabledRingCentralAccounts(cfg: MoltbotConfig): ResolvedRingCentralAccount[] {
   return listRingCentralAccountIds(cfg)
     .map((accountId) => resolveRingCentralAccount({ cfg, accountId }))
     .filter((account) => account.enabled);

--- a/extensions/ringcentral/src/accounts.ts
+++ b/extensions/ringcentral/src/accounts.ts
@@ -1,0 +1,274 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "clawdbot/plugin-sdk";
+
+import type { RingCentralAccountConfig, RingCentralConfig } from "./types.js";
+
+export type RingCentralCredentialSource = "config" | "file" | "env" | "none";
+
+export type ResolvedRingCentralAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  config: RingCentralAccountConfig;
+  credentialSource: RingCentralCredentialSource;
+  clientId?: string;
+  clientSecret?: string;
+  jwt?: string;
+  server: string;
+};
+
+const ENV_CLIENT_ID = "RINGCENTRAL_CLIENT_ID";
+const ENV_CLIENT_SECRET = "RINGCENTRAL_CLIENT_SECRET";
+const ENV_JWT = "RINGCENTRAL_JWT";
+const ENV_SERVER = "RINGCENTRAL_SERVER";
+const ENV_CREDENTIALS_FILE = "RINGCENTRAL_CREDENTIALS_FILE";
+
+const DEFAULT_SERVER = "https://platform.ringcentral.com";
+
+// Default credential file locations to check
+const DEFAULT_CREDENTIALS_FILES = [
+  "rc-credentials.json",
+  ".clawdbot/rc-credentials.json",
+];
+
+type CredentialsFile = {
+  clientId?: string;
+  clientSecret?: string;
+  jwt?: string;
+  server?: string;
+};
+
+let cachedFileCredentials: { path: string; data: CredentialsFile } | null = null;
+
+function findCredentialsFile(configFile?: string): { path: string; data: CredentialsFile } | null {
+  // If explicitly specified, use that
+  if (configFile?.trim()) {
+    const filePath = resolve(configFile.trim());
+    if (existsSync(filePath)) {
+      try {
+        const content = readFileSync(filePath, "utf8");
+        return { path: filePath, data: JSON.parse(content) as CredentialsFile };
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // Check env var for file path
+  const envFile = process.env[ENV_CREDENTIALS_FILE]?.trim();
+  if (envFile) {
+    const filePath = resolve(envFile);
+    if (existsSync(filePath)) {
+      try {
+        const content = readFileSync(filePath, "utf8");
+        return { path: filePath, data: JSON.parse(content) as CredentialsFile };
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  // Check default locations
+  const searchPaths = [
+    ...DEFAULT_CREDENTIALS_FILES.map((f) => resolve(process.cwd(), f)),
+    ...DEFAULT_CREDENTIALS_FILES.map((f) => resolve(homedir(), f)),
+  ];
+
+  for (const filePath of searchPaths) {
+    if (existsSync(filePath)) {
+      try {
+        const content = readFileSync(filePath, "utf8");
+        return { path: filePath, data: JSON.parse(content) as CredentialsFile };
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+function loadFileCredentials(configFile?: string): CredentialsFile | null {
+  // Use cached if available and no specific file requested
+  if (!configFile && cachedFileCredentials) {
+    return cachedFileCredentials.data;
+  }
+
+  const result = findCredentialsFile(configFile);
+  if (result) {
+    if (!configFile) {
+      cachedFileCredentials = result;
+    }
+    return result.data;
+  }
+  return null;
+}
+
+function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
+  const accounts = (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.accounts;
+  if (!accounts || typeof accounts !== "object") return [];
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listRingCentralAccountIds(cfg: ClawdbotConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) return [DEFAULT_ACCOUNT_ID];
+  return ids.sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultRingCentralAccountId(cfg: ClawdbotConfig): string {
+  const channel = cfg.channels?.ringcentral as RingCentralConfig | undefined;
+  if (channel?.defaultAccount?.trim()) return channel.defaultAccount.trim();
+  const ids = listRingCentralAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) return DEFAULT_ACCOUNT_ID;
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(
+  cfg: ClawdbotConfig,
+  accountId: string,
+): RingCentralAccountConfig | undefined {
+  const accounts = (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.accounts;
+  if (!accounts || typeof accounts !== "object") return undefined;
+  return accounts[accountId] as RingCentralAccountConfig | undefined;
+}
+
+function mergeRingCentralAccountConfig(
+  cfg: ClawdbotConfig,
+  accountId: string,
+): RingCentralAccountConfig {
+  const raw = (cfg.channels?.ringcentral ?? {}) as RingCentralConfig;
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account } as RingCentralAccountConfig;
+}
+
+function resolveCredentialsFromConfig(params: {
+  accountId: string;
+  account: RingCentralAccountConfig;
+}): {
+  clientId?: string;
+  clientSecret?: string;
+  jwt?: string;
+  server: string;
+  source: RingCentralCredentialSource;
+} {
+  const { account, accountId } = params;
+
+  const configClientId = account.clientId?.trim();
+  const configClientSecret = account.clientSecret?.trim();
+  const configJwt = account.jwt?.trim();
+  const configServer = account.server?.trim() || DEFAULT_SERVER;
+
+  // 1. Check inline config first
+  if (configClientId && configClientSecret && configJwt) {
+    return {
+      clientId: configClientId,
+      clientSecret: configClientSecret,
+      jwt: configJwt,
+      server: configServer,
+      source: "config",
+    };
+  }
+
+  // 2. Check credentials file (rc-credentials.json)
+  const fileCredentials = loadFileCredentials(
+    (account as { credentialsFile?: string }).credentialsFile,
+  );
+  if (fileCredentials) {
+    const fileClientId = fileCredentials.clientId?.trim();
+    const fileClientSecret = fileCredentials.clientSecret?.trim();
+    const fileJwt = fileCredentials.jwt?.trim();
+    const fileServer = fileCredentials.server?.trim() || DEFAULT_SERVER;
+
+    if (fileClientId && fileClientSecret && fileJwt) {
+      return {
+        clientId: fileClientId,
+        clientSecret: fileClientSecret,
+        jwt: fileJwt,
+        server: fileServer,
+        source: "file",
+      };
+    }
+  }
+
+  // 3. Check environment variables (default account only)
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    const envClientId = process.env[ENV_CLIENT_ID]?.trim();
+    const envClientSecret = process.env[ENV_CLIENT_SECRET]?.trim();
+    const envJwt = process.env[ENV_JWT]?.trim();
+    const envServer = process.env[ENV_SERVER]?.trim() || DEFAULT_SERVER;
+
+    if (envClientId && envClientSecret && envJwt) {
+      return {
+        clientId: envClientId,
+        clientSecret: envClientSecret,
+        jwt: envJwt,
+        server: envServer,
+        source: "env",
+      };
+    }
+
+    // 4. Allow partial config + file + env fallback
+    const finalClientId = configClientId || fileCredentials?.clientId?.trim() || envClientId;
+    const finalClientSecret = configClientSecret || fileCredentials?.clientSecret?.trim() || envClientSecret;
+    const finalJwt = configJwt || fileCredentials?.jwt?.trim() || envJwt;
+    const finalServer = configServer !== DEFAULT_SERVER
+      ? configServer
+      : fileCredentials?.server?.trim() || envServer;
+
+    if (finalClientId && finalClientSecret && finalJwt) {
+      const source: RingCentralCredentialSource =
+        configClientId || configClientSecret || configJwt
+          ? "config"
+          : fileCredentials?.clientId || fileCredentials?.clientSecret || fileCredentials?.jwt
+            ? "file"
+            : "env";
+      return {
+        clientId: finalClientId,
+        clientSecret: finalClientSecret,
+        jwt: finalJwt,
+        server: finalServer,
+        source,
+      };
+    }
+  }
+
+  return { server: configServer, source: "none" };
+}
+
+export function resolveRingCentralAccount(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+}): ResolvedRingCentralAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled =
+    (params.cfg.channels?.ringcentral as RingCentralConfig | undefined)?.enabled !== false;
+  const merged = mergeRingCentralAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const credentials = resolveCredentialsFromConfig({ accountId, account: merged });
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    config: merged,
+    credentialSource: credentials.source,
+    clientId: credentials.clientId,
+    clientSecret: credentials.clientSecret,
+    jwt: credentials.jwt,
+    server: credentials.server,
+  };
+}
+
+export function listEnabledRingCentralAccounts(cfg: ClawdbotConfig): ResolvedRingCentralAccount[] {
+  return listRingCentralAccountIds(cfg)
+    .map((accountId) => resolveRingCentralAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/ringcentral/src/api.ts
+++ b/extensions/ringcentral/src/api.ts
@@ -1,5 +1,6 @@
 import type { ResolvedRingCentralAccount } from "./accounts.js";
 import { getRingCentralPlatform } from "./auth.js";
+import { toRingCentralMarkdown } from "./markdown.js";
 import type {
   RingCentralChat,
   RingCentralPost,
@@ -20,7 +21,7 @@ export async function sendRingCentralMessage(params: {
   const platform = await getRingCentralPlatform(account);
 
   const body: Record<string, unknown> = {};
-  if (text) body.text = text;
+  if (text) body.text = toRingCentralMarkdown(text);
   if (attachments && attachments.length > 0) {
     body.attachments = attachments;
   }
@@ -41,7 +42,7 @@ export async function updateRingCentralMessage(params: {
 
   const response = await platform.patch(
     `${TM_API_BASE}/chats/${chatId}/posts/${postId}`,
-    { text },
+    { text: toRingCentralMarkdown(text) },
   );
   const result = (await response.json()) as RingCentralPost;
   return { postId: result.id };

--- a/extensions/ringcentral/src/api.ts
+++ b/extensions/ringcentral/src/api.ts
@@ -1,0 +1,220 @@
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+import { getRingCentralPlatform } from "./auth.js";
+import type {
+  RingCentralChat,
+  RingCentralPost,
+  RingCentralUser,
+  RingCentralAttachment,
+} from "./types.js";
+
+// Team Messaging API endpoints
+const TM_API_BASE = "/team-messaging/v1";
+
+export async function sendRingCentralMessage(params: {
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+  text?: string;
+  attachments?: Array<{ id: string; type?: string }>;
+}): Promise<{ postId?: string } | null> {
+  const { account, chatId, text, attachments } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const body: Record<string, unknown> = {};
+  if (text) body.text = text;
+  if (attachments && attachments.length > 0) {
+    body.attachments = attachments;
+  }
+
+  const response = await platform.post(`${TM_API_BASE}/chats/${chatId}/posts`, body);
+  const result = (await response.json()) as RingCentralPost;
+  return result ? { postId: result.id } : null;
+}
+
+export async function updateRingCentralMessage(params: {
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+  postId: string;
+  text: string;
+}): Promise<{ postId?: string }> {
+  const { account, chatId, postId, text } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const response = await platform.patch(
+    `${TM_API_BASE}/chats/${chatId}/posts/${postId}`,
+    { text },
+  );
+  const result = (await response.json()) as RingCentralPost;
+  return { postId: result.id };
+}
+
+export async function deleteRingCentralMessage(params: {
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+  postId: string;
+}): Promise<void> {
+  const { account, chatId, postId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.delete(`${TM_API_BASE}/chats/${chatId}/posts/${postId}`);
+}
+
+export async function getRingCentralChat(params: {
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+}): Promise<RingCentralChat | null> {
+  const { account, chatId } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  try {
+    const response = await platform.get(`${TM_API_BASE}/chats/${chatId}`);
+    return (await response.json()) as RingCentralChat;
+  } catch {
+    return null;
+  }
+}
+
+export async function listRingCentralChats(params: {
+  account: ResolvedRingCentralAccount;
+  type?: string[];
+  limit?: number;
+}): Promise<RingCentralChat[]> {
+  const { account, type, limit } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const queryParams: Record<string, string> = {};
+  if (type && type.length > 0) queryParams.type = type.join(",");
+  if (limit) queryParams.recordCount = String(limit);
+
+  const response = await platform.get(`${TM_API_BASE}/chats`, queryParams);
+  const result = (await response.json()) as { records?: RingCentralChat[] };
+  return result.records ?? [];
+}
+
+export async function getRingCentralUser(params: {
+  account: ResolvedRingCentralAccount;
+  userId: string;
+}): Promise<RingCentralUser | null> {
+  const { account, userId } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  try {
+    const response = await platform.get(`${TM_API_BASE}/persons/${userId}`);
+    return (await response.json()) as RingCentralUser;
+  } catch {
+    return null;
+  }
+}
+
+export async function getCurrentRingCentralUser(params: {
+  account: ResolvedRingCentralAccount;
+}): Promise<RingCentralUser | null> {
+  const { account } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  try {
+    const response = await platform.get("/restapi/v1.0/account/~/extension/~");
+    return (await response.json()) as RingCentralUser;
+  } catch {
+    return null;
+  }
+}
+
+export async function uploadRingCentralAttachment(params: {
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+  filename: string;
+  buffer: Buffer;
+  contentType?: string;
+}): Promise<{ attachmentId?: string }> {
+  const { account, chatId, filename, buffer, contentType } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  // Create FormData for multipart upload
+  const formData = new FormData();
+  const blob = new Blob([buffer], { type: contentType || "application/octet-stream" });
+  formData.append("file", blob, filename);
+
+  const response = await platform.post(
+    `${TM_API_BASE}/chats/${chatId}/files`,
+    formData,
+  );
+  const result = (await response.json()) as RingCentralAttachment;
+  return { attachmentId: result.id };
+}
+
+export async function downloadRingCentralAttachment(params: {
+  account: ResolvedRingCentralAccount;
+  contentUri: string;
+  maxBytes?: number;
+}): Promise<{ buffer: Buffer; contentType?: string }> {
+  const { account, contentUri, maxBytes } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const response = await platform.get(contentUri);
+  const contentType = response.headers.get("content-type") ?? undefined;
+  const arrayBuffer = await response.arrayBuffer();
+  
+  if (maxBytes && arrayBuffer.byteLength > maxBytes) {
+    throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+  }
+
+  return {
+    buffer: Buffer.from(arrayBuffer),
+    contentType,
+  };
+}
+
+export async function createRingCentralWebhookSubscription(params: {
+  account: ResolvedRingCentralAccount;
+  webhookUrl: string;
+  eventFilters: string[];
+  expiresIn?: number;
+}): Promise<{ subscriptionId?: string; expiresIn?: number }> {
+  const { account, webhookUrl, eventFilters, expiresIn = 604799 } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const body = {
+    eventFilters,
+    deliveryMode: {
+      transportType: "WebHook",
+      address: webhookUrl,
+    },
+    expiresIn,
+  };
+
+  const response = await platform.post("/restapi/v1.0/subscription", body);
+  const result = (await response.json()) as { id?: string; expiresIn?: number };
+  return {
+    subscriptionId: result.id,
+    expiresIn: result.expiresIn,
+  };
+}
+
+export async function deleteRingCentralWebhookSubscription(params: {
+  account: ResolvedRingCentralAccount;
+  subscriptionId: string;
+}): Promise<void> {
+  const { account, subscriptionId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.delete(`/restapi/v1.0/subscription/${subscriptionId}`);
+}
+
+export async function probeRingCentral(
+  account: ResolvedRingCentralAccount,
+): Promise<{ ok: boolean; error?: string; elapsedMs: number }> {
+  const start = Date.now();
+  try {
+    const user = await getCurrentRingCentralUser({ account });
+    const elapsedMs = Date.now() - start;
+    if (user?.id) {
+      return { ok: true, elapsedMs };
+    }
+    return { ok: false, error: "Unable to fetch current user", elapsedMs };
+  } catch (err) {
+    const elapsedMs = Date.now() - start;
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      elapsedMs,
+    };
+  }
+}

--- a/extensions/ringcentral/src/api.ts
+++ b/extensions/ringcentral/src/api.ts
@@ -163,41 +163,6 @@ export async function downloadRingCentralAttachment(params: {
   };
 }
 
-export async function createRingCentralWebhookSubscription(params: {
-  account: ResolvedRingCentralAccount;
-  webhookUrl: string;
-  eventFilters: string[];
-  expiresIn?: number;
-}): Promise<{ subscriptionId?: string; expiresIn?: number }> {
-  const { account, webhookUrl, eventFilters, expiresIn = 604799 } = params;
-  const platform = await getRingCentralPlatform(account);
-
-  const body = {
-    eventFilters,
-    deliveryMode: {
-      transportType: "WebHook",
-      address: webhookUrl,
-    },
-    expiresIn,
-  };
-
-  const response = await platform.post("/restapi/v1.0/subscription", body);
-  const result = (await response.json()) as { id?: string; expiresIn?: number };
-  return {
-    subscriptionId: result.id,
-    expiresIn: result.expiresIn,
-  };
-}
-
-export async function deleteRingCentralWebhookSubscription(params: {
-  account: ResolvedRingCentralAccount;
-  subscriptionId: string;
-}): Promise<void> {
-  const { account, subscriptionId } = params;
-  const platform = await getRingCentralPlatform(account);
-  await platform.delete(`/restapi/v1.0/subscription/${subscriptionId}`);
-}
-
 export async function probeRingCentral(
   account: ResolvedRingCentralAccount,
 ): Promise<{ ok: boolean; error?: string; elapsedMs: number }> {

--- a/extensions/ringcentral/src/auth.ts
+++ b/extensions/ringcentral/src/auth.ts
@@ -1,0 +1,92 @@
+import { SDK } from "@ringcentral/sdk";
+
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+
+export type SDKInstance = InstanceType<typeof SDK>;
+
+const sdkCache = new Map<string, { key: string; sdk: SDKInstance; platform: ReturnType<SDKInstance["platform"]> }>();
+
+function buildAuthKey(account: ResolvedRingCentralAccount): string {
+  return `${account.clientId}:${account.server}:${account.jwt?.slice(0, 20)}`;
+}
+
+async function getSDKInstance(account: ResolvedRingCentralAccount): Promise<{
+  sdk: SDKInstance;
+  platform: ReturnType<SDKInstance["platform"]>;
+}> {
+  const key = buildAuthKey(account);
+  const cached = sdkCache.get(account.accountId);
+  
+  if (cached && cached.key === key) {
+    // Check if still logged in
+    const platform = cached.platform;
+    try {
+      const loggedIn = await platform.loggedIn();
+      if (loggedIn) {
+        return cached;
+      }
+    } catch {
+      // Token expired or invalid, need to re-login
+    }
+  }
+
+  if (!account.clientId || !account.clientSecret) {
+    throw new Error("RingCentral clientId and clientSecret are required");
+  }
+
+  if (!account.jwt) {
+    throw new Error("RingCentral JWT token is required for authentication");
+  }
+
+  const sdk = new SDK({
+    server: account.server,
+    clientId: account.clientId,
+    clientSecret: account.clientSecret,
+  });
+
+  const platform = sdk.platform();
+
+  // Login using JWT
+  await platform.login({ jwt: account.jwt });
+
+  const entry = { key, sdk, platform };
+  sdkCache.set(account.accountId, entry);
+  return entry;
+}
+
+export async function getRingCentralSDK(
+  account: ResolvedRingCentralAccount,
+): Promise<SDKInstance> {
+  const { sdk } = await getSDKInstance(account);
+  return sdk;
+}
+
+export async function getRingCentralPlatform(
+  account: ResolvedRingCentralAccount,
+): Promise<ReturnType<SDKInstance["platform"]>> {
+  const { platform } = await getSDKInstance(account);
+  return platform;
+}
+
+export async function getRingCentralAccessToken(
+  account: ResolvedRingCentralAccount,
+): Promise<string> {
+  const { platform } = await getSDKInstance(account);
+  const authData = await platform.auth().data();
+  const token = authData?.access_token;
+  if (!token) {
+    throw new Error("Missing RingCentral access token");
+  }
+  return token;
+}
+
+export async function refreshRingCentralToken(
+  account: ResolvedRingCentralAccount,
+): Promise<void> {
+  const { platform } = await getSDKInstance(account);
+  await platform.refresh();
+}
+
+export function clearRingCentralAuth(accountId: string): void {
+  sdkCache.delete(accountId);
+}

--- a/extensions/ringcentral/src/channel.ts
+++ b/extensions/ringcentral/src/channel.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
   formatPairingApproveHint,
-  getChatChannelMeta,
   migrateBaseNameToDefaultAccount,
   missingTargetError,
   normalizeAccountId,
@@ -37,10 +36,8 @@ import {
 } from "./targets.js";
 import type { RingCentralConfig } from "./types.js";
 
-const meta = getChatChannelMeta("ringcentral");
-
 const formatAllowFromEntry = (entry: string) =>
-  entry
+  (entry ?? "")
     .trim()
     .replace(/^(ringcentral|rc):/i, "")
     .replace(/^user:/i, "")
@@ -87,9 +84,11 @@ export const ringcentralDock: ChannelDock = {
 export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
   id: "ringcentral",
   meta: {
-    ...meta,
+    id: "ringcentral",
     label: "RingCentral",
     selectionLabel: "RingCentral Team Messaging",
+    docsPath: "/channels/ringcentral",
+    docsLabel: "ringcentral",
     blurb: "RingCentral Team Messaging via REST API and WebSocket.",
     order: 56,
   },

--- a/extensions/ringcentral/src/channel.ts
+++ b/extensions/ringcentral/src/channel.ts
@@ -1,0 +1,555 @@
+import {
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  getChatChannelMeta,
+  migrateBaseNameToDefaultAccount,
+  missingTargetError,
+  normalizeAccountId,
+  PAIRING_APPROVED_MESSAGE,
+  resolveChannelMediaMaxBytes,
+  setAccountEnabledInConfigSection,
+  type ChannelDock,
+  type ChannelPlugin,
+  type ClawdbotConfig,
+} from "clawdbot/plugin-sdk";
+
+import {
+  listRingCentralAccountIds,
+  resolveDefaultRingCentralAccountId,
+  resolveRingCentralAccount,
+  type ResolvedRingCentralAccount,
+} from "./accounts.js";
+import { RingCentralConfigSchema } from "./config-schema.js";
+import {
+  sendRingCentralMessage,
+  uploadRingCentralAttachment,
+  probeRingCentral,
+} from "./api.js";
+import { getRingCentralRuntime } from "./runtime.js";
+import { resolveRingCentralWebhookPath, startRingCentralMonitor } from "./monitor.js";
+import {
+  normalizeRingCentralTarget,
+  isRingCentralChatTarget,
+  parseRingCentralTarget,
+} from "./targets.js";
+import type { RingCentralConfig } from "./types.js";
+
+const meta = getChatChannelMeta("ringcentral");
+
+const formatAllowFromEntry = (entry: string) =>
+  entry
+    .trim()
+    .replace(/^(ringcentral|rc):/i, "")
+    .replace(/^user:/i, "")
+    .toLowerCase();
+
+export const ringcentralDock: ChannelDock = {
+  id: "ringcentral",
+  capabilities: {
+    chatTypes: ["direct", "group", "thread"],
+    reactions: false,
+    media: true,
+    threads: false,
+    blockStreaming: true,
+  },
+  outbound: { textChunkLimit: 4000 },
+  config: {
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId }).config.dm?.allowFrom ??
+        []
+      ).map((entry) => String(entry)),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => {
+      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId });
+      return account.config.requireMention ?? true;
+    },
+  },
+  threading: {
+    resolveReplyToMode: ({ cfg }) =>
+      (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.replyToMode ?? "off",
+    buildToolContext: ({ context, hasRepliedRef }) => ({
+      currentChannelId: context.To?.trim() || undefined,
+      currentThreadTs: undefined,
+      hasRepliedRef,
+    }),
+  },
+};
+
+export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
+  id: "ringcentral",
+  meta: {
+    ...meta,
+    label: "RingCentral",
+    selectionLabel: "RingCentral Team Messaging",
+    blurb: "RingCentral Team Messaging via REST API and webhooks.",
+    order: 56,
+  },
+  pairing: {
+    idLabel: "ringcentralUserId",
+    normalizeAllowEntry: (entry) => formatAllowFromEntry(entry),
+    notifyApproval: async ({ cfg, id }) => {
+      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig });
+      if (account.credentialSource === "none") return;
+      const target = normalizeRingCentralTarget(id) ?? id;
+      // For DM approval, we need to find/create a direct chat
+      // This is a simplified version - in production you'd need to resolve the chat ID
+      try {
+        await sendRingCentralMessage({
+          account,
+          chatId: target,
+          text: PAIRING_APPROVED_MESSAGE,
+        });
+      } catch {
+        // Approval notification failed, but pairing still succeeds
+      }
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    reactions: false,
+    threads: false,
+    media: true,
+    nativeCommands: false,
+    blockStreaming: true,
+  },
+  streaming: {
+    blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+  },
+  reload: { configPrefixes: ["channels.ringcentral"] },
+  configSchema: buildChannelConfigSchema(RingCentralConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listRingCentralAccountIds(cfg as ClawdbotConfig),
+    resolveAccount: (cfg, accountId) =>
+      resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultRingCentralAccountId(cfg as ClawdbotConfig),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg as ClawdbotConfig,
+        sectionKey: "ringcentral",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg as ClawdbotConfig,
+        sectionKey: "ringcentral",
+        accountId,
+        clearBaseFields: [
+          "clientId",
+          "clientSecret",
+          "jwt",
+          "server",
+          "webhookPath",
+          "webhookVerificationToken",
+          "name",
+        ],
+      }),
+    isConfigured: (account) => account.credentialSource !== "none",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+      server: account.server,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveRingCentralAccount({
+        cfg: cfg as ClawdbotConfig,
+        accountId,
+      }).config.dm?.allowFrom ?? []
+      ).map((entry) => String(entry)),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(
+        (cfg as ClawdbotConfig).channels?.ringcentral?.accounts?.[resolvedAccountId],
+      );
+      const allowFromPath = useAccountPath
+        ? `channels.ringcentral.accounts.${resolvedAccountId}.dm.`
+        : "channels.ringcentral.dm.";
+      return {
+        policy: account.config.dm?.policy ?? "pairing",
+        allowFrom: account.config.dm?.allowFrom ?? [],
+        allowFromPath,
+        approveHint: formatPairingApproveHint("ringcentral"),
+        normalizeEntry: (raw) => formatAllowFromEntry(raw),
+      };
+    },
+    collectWarnings: ({ account, cfg }) => {
+      const warnings: string[] = [];
+      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      if (groupPolicy === "open") {
+        warnings.push(
+          `- RingCentral chats: groupPolicy="open" allows any chat to trigger (mention-gated). Set channels.ringcentral.groupPolicy="allowlist" and configure channels.ringcentral.groups.`,
+        );
+      }
+      if (account.config.dm?.policy === "open") {
+        warnings.push(
+          `- RingCentral DMs are open to anyone. Set channels.ringcentral.dm.policy="pairing" or "allowlist".`,
+        );
+      }
+      return warnings;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => {
+      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId });
+      return account.config.requireMention ?? true;
+    },
+  },
+  threading: {
+    resolveReplyToMode: ({ cfg }) =>
+      (cfg.channels?.ringcentral as RingCentralConfig | undefined)?.replyToMode ?? "off",
+  },
+  messaging: {
+    normalizeTarget: normalizeRingCentralTarget,
+    targetResolver: {
+      looksLikeId: (raw, normalized) => {
+        const value = normalized ?? raw.trim();
+        return isRingCentralChatTarget(value);
+      },
+      hint: "<chatId>",
+    },
+  },
+  directory: {
+    self: async () => null,
+    listPeers: async ({ cfg, accountId, query, limit }) => {
+      const account = resolveRingCentralAccount({
+        cfg: cfg as ClawdbotConfig,
+        accountId,
+      });
+      const q = query?.trim().toLowerCase() || "";
+      const allowFrom = account.config.dm?.allowFrom ?? [];
+      const peers = Array.from(
+        new Set(
+          allowFrom
+            .map((entry) => String(entry).trim())
+            .filter((entry) => Boolean(entry) && entry !== "*")
+            .map((entry) => normalizeRingCentralTarget(entry) ?? entry),
+        ),
+      )
+        .filter((id) => (q ? id.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "user", id }) as const);
+      return peers;
+    },
+    listGroups: async ({ cfg, accountId, query, limit }) => {
+      const account = resolveRingCentralAccount({
+        cfg: cfg as ClawdbotConfig,
+        accountId,
+      });
+      const groups = account.config.groups ?? {};
+      const q = query?.trim().toLowerCase() || "";
+      const entries = Object.keys(groups)
+        .filter((key) => key && key !== "*")
+        .filter((key) => (q ? key.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "group", id }) as const);
+      return entries;
+    },
+  },
+  resolver: {
+    resolveTargets: async ({ inputs, kind }) => {
+      const resolved = inputs.map((input) => {
+        const parsed = parseRingCentralTarget(input);
+        if (parsed.type === "unknown" || !parsed.id) {
+          return { input, resolved: false, note: "invalid target format" };
+        }
+        if (kind === "user" && parsed.type === "user") {
+          return { input, resolved: true, id: parsed.id };
+        }
+        if (kind === "group" && parsed.type === "chat") {
+          return { input, resolved: true, id: parsed.id };
+        }
+        return {
+          input,
+          resolved: false,
+          note: "use rc:chat:<id> or rc:user:<id>",
+        };
+      });
+      return resolved;
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg: cfg as ClawdbotConfig,
+        channelKey: "ringcentral",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "RINGCENTRAL_* env vars can only be used for the default account.";
+      }
+      if (!input.useEnv && (!input.clientId || !input.clientSecret || !input.jwt)) {
+        return "RingCentral requires --client-id, --client-secret, and --jwt (or use --use-env).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg: cfg as ClawdbotConfig,
+        channelKey: "ringcentral",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({
+              cfg: namedConfig as ClawdbotConfig,
+              channelKey: "ringcentral",
+            })
+          : namedConfig;
+      const patch = input.useEnv
+        ? {}
+        : {
+            ...(input.clientId ? { clientId: input.clientId } : {}),
+            ...(input.clientSecret ? { clientSecret: input.clientSecret } : {}),
+            ...(input.jwt ? { jwt: input.jwt } : {}),
+          };
+      const server = input.server?.trim();
+      const webhookPath = input.webhookPath?.trim();
+      const configPatch = {
+        ...patch,
+        ...(server ? { server } : {}),
+        ...(webhookPath ? { webhookPath } : {}),
+      };
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            ringcentral: {
+              ...(next.channels?.ringcentral ?? {}),
+              enabled: true,
+              ...configPatch,
+            },
+          },
+        } as ClawdbotConfig;
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          ringcentral: {
+            ...(next.channels?.ringcentral ?? {}),
+            enabled: true,
+            accounts: {
+              ...(next.channels?.ringcentral?.accounts ?? {}),
+              [accountId]: {
+                ...(next.channels?.ringcentral?.accounts?.[accountId] ?? {}),
+                enabled: true,
+                ...configPatch,
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig;
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) =>
+      getRingCentralRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 4000,
+    resolveTarget: ({ to, allowFrom, mode }) => {
+      const trimmed = to?.trim() ?? "";
+      const allowListRaw = (allowFrom ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+      const allowList = allowListRaw
+        .filter((entry) => entry !== "*")
+        .map((entry) => normalizeRingCentralTarget(entry))
+        .filter((entry): entry is string => Boolean(entry));
+
+      if (trimmed) {
+        const normalized = normalizeRingCentralTarget(trimmed);
+        if (!normalized) {
+          if ((mode === "implicit" || mode === "heartbeat") && allowList.length > 0) {
+            return { ok: true, to: allowList[0] };
+          }
+          return {
+            ok: false,
+            error: missingTargetError(
+              "RingCentral",
+              "<chatId> or channels.ringcentral.dm.allowFrom[0]",
+            ),
+          };
+        }
+        return { ok: true, to: normalized };
+      }
+
+      if (allowList.length > 0) {
+        return { ok: true, to: allowList[0] };
+      }
+      return {
+        ok: false,
+        error: missingTargetError(
+          "RingCentral",
+          "<chatId> or channels.ringcentral.dm.allowFrom[0]",
+        ),
+      };
+    },
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveRingCentralAccount({
+        cfg: cfg as ClawdbotConfig,
+        accountId,
+      });
+      const result = await sendRingCentralMessage({
+        account,
+        chatId: to,
+        text,
+      });
+      return {
+        channel: "ringcentral",
+        messageId: result?.postId ?? "",
+        chatId: to,
+      };
+    },
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+      if (!mediaUrl) {
+        throw new Error("RingCentral mediaUrl is required.");
+      }
+      const account = resolveRingCentralAccount({
+        cfg: cfg as ClawdbotConfig,
+        accountId,
+      });
+      const runtime = getRingCentralRuntime();
+      const maxBytes = resolveChannelMediaMaxBytes({
+        cfg: cfg as ClawdbotConfig,
+        resolveChannelLimitMb: ({ cfg: c, accountId: aid }) =>
+          (c.channels?.ringcentral as { accounts?: Record<string, { mediaMaxMb?: number }>; mediaMaxMb?: number } | undefined)
+            ?.accounts?.[aid]?.mediaMaxMb ??
+          (c.channels?.ringcentral as { mediaMaxMb?: number } | undefined)?.mediaMaxMb,
+        accountId,
+      });
+      const loaded = await runtime.channel.media.fetchRemoteMedia(mediaUrl, {
+        maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+      });
+      const upload = await uploadRingCentralAttachment({
+        account,
+        chatId: to,
+        filename: loaded.filename ?? "attachment",
+        buffer: loaded.buffer,
+        contentType: loaded.contentType,
+      });
+      const result = await sendRingCentralMessage({
+        account,
+        chatId: to,
+        text,
+        attachments: upload.attachmentId ? [{ id: upload.attachmentId }] : undefined,
+      });
+      return {
+        channel: "ringcentral",
+        messageId: result?.postId ?? "",
+        chatId: to,
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((entry) => {
+        const accountId = String(entry.accountId ?? DEFAULT_ACCOUNT_ID);
+        const enabled = entry.enabled !== false;
+        const configured = entry.configured === true;
+        if (!enabled || !configured) return [];
+        const issues = [];
+        if (!entry.clientId) {
+          issues.push({
+            channel: "ringcentral",
+            accountId,
+            kind: "config",
+            message: "RingCentral clientId is missing.",
+            fix: "Set channels.ringcentral.clientId or use rc-credentials.json.",
+          });
+        }
+        return issues;
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      credentialSource: snapshot.credentialSource ?? "none",
+      server: snapshot.server ?? null,
+      webhookPath: snapshot.webhookPath ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ account }) => probeRingCentral(account),
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+      server: account.server,
+      clientId: account.clientId ? `${account.clientId.slice(0, 8)}...` : undefined,
+      webhookPath: account.config.webhookPath,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      dmPolicy: account.config.dm?.policy ?? "pairing",
+      probe,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.log?.info(`[${account.accountId}] starting RingCentral webhook`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+        webhookPath: resolveRingCentralWebhookPath({ account }),
+        server: account.server,
+      });
+      const unregister = await startRingCentralMonitor({
+        account,
+        config: ctx.cfg as ClawdbotConfig,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        webhookPath: account.config.webhookPath,
+        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+      });
+      return () => {
+        unregister?.();
+        ctx.setStatus({
+          accountId: account.accountId,
+          running: false,
+          lastStopAt: Date.now(),
+        });
+      };
+    },
+  },
+};

--- a/extensions/ringcentral/src/channel.ts
+++ b/extensions/ringcentral/src/channel.ts
@@ -13,8 +13,8 @@ import {
   setAccountEnabledInConfigSection,
   type ChannelDock,
   type ChannelPlugin,
-  type ClawdbotConfig,
-} from "clawdbot/plugin-sdk";
+  type MoltbotConfig,
+} from "moltbot/plugin-sdk";
 
 import {
   listRingCentralAccountIds,
@@ -58,7 +58,7 @@ export const ringcentralDock: ChannelDock = {
   outbound: { textChunkLimit: 4000 },
   config: {
     resolveAllowFrom: ({ cfg, accountId }) =>
-      (resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId }).config.dm?.allowFrom ??
+      (resolveRingCentralAccount({ cfg: cfg as MoltbotConfig, accountId }).config.dm?.allowFrom ??
         []
       ).map((entry) => String(entry)),
     formatAllowFrom: ({ allowFrom }) =>
@@ -69,7 +69,7 @@ export const ringcentralDock: ChannelDock = {
   },
   groups: {
     resolveRequireMention: ({ cfg, accountId }) => {
-      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId });
+      const account = resolveRingCentralAccount({ cfg: cfg as MoltbotConfig, accountId });
       return account.config.requireMention ?? true;
     },
   },
@@ -97,7 +97,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     idLabel: "ringcentralUserId",
     normalizeAllowEntry: (entry) => formatAllowFromEntry(entry),
     notifyApproval: async ({ cfg, id }) => {
-      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig });
+      const account = resolveRingCentralAccount({ cfg: cfg as MoltbotConfig });
       if (account.credentialSource === "none") return;
       const target = normalizeRingCentralTarget(id) ?? id;
       // For DM approval, we need to find/create a direct chat
@@ -127,13 +127,13 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
   reload: { configPrefixes: ["channels.ringcentral"] },
   configSchema: buildChannelConfigSchema(RingCentralConfigSchema),
   config: {
-    listAccountIds: (cfg) => listRingCentralAccountIds(cfg as ClawdbotConfig),
+    listAccountIds: (cfg) => listRingCentralAccountIds(cfg as MoltbotConfig),
     resolveAccount: (cfg, accountId) =>
-      resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId }),
-    defaultAccountId: (cfg) => resolveDefaultRingCentralAccountId(cfg as ClawdbotConfig),
+      resolveRingCentralAccount({ cfg: cfg as MoltbotConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultRingCentralAccountId(cfg as MoltbotConfig),
     setAccountEnabled: ({ cfg, accountId, enabled }) =>
       setAccountEnabledInConfigSection({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         sectionKey: "ringcentral",
         accountId,
         enabled,
@@ -141,7 +141,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       }),
     deleteAccount: ({ cfg, accountId }) =>
       deleteAccountFromConfigSection({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         sectionKey: "ringcentral",
         accountId,
         clearBaseFields: [
@@ -163,7 +163,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     }),
     resolveAllowFrom: ({ cfg, accountId }) =>
       (resolveRingCentralAccount({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         accountId,
       }).config.dm?.allowFrom ?? []
       ).map((entry) => String(entry)),
@@ -177,7 +177,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     resolveDmPolicy: ({ cfg, accountId, account }) => {
       const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
       const useAccountPath = Boolean(
-        (cfg as ClawdbotConfig).channels?.ringcentral?.accounts?.[resolvedAccountId],
+        (cfg as MoltbotConfig).channels?.ringcentral?.accounts?.[resolvedAccountId],
       );
       const allowFromPath = useAccountPath
         ? `channels.ringcentral.accounts.${resolvedAccountId}.dm.`
@@ -209,7 +209,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
   },
   groups: {
     resolveRequireMention: ({ cfg, accountId }) => {
-      const account = resolveRingCentralAccount({ cfg: cfg as ClawdbotConfig, accountId });
+      const account = resolveRingCentralAccount({ cfg: cfg as MoltbotConfig, accountId });
       return account.config.requireMention ?? true;
     },
   },
@@ -231,7 +231,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     self: async () => null,
     listPeers: async ({ cfg, accountId, query, limit }) => {
       const account = resolveRingCentralAccount({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         accountId,
       });
       const q = query?.trim().toLowerCase() || "";
@@ -251,7 +251,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     },
     listGroups: async ({ cfg, accountId, query, limit }) => {
       const account = resolveRingCentralAccount({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         accountId,
       });
       const groups = account.config.groups ?? {};
@@ -290,7 +290,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
     applyAccountName: ({ cfg, accountId, name }) =>
       applyAccountNameToChannelSection({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         channelKey: "ringcentral",
         accountId,
         name,
@@ -306,7 +306,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     },
     applyAccountConfig: ({ cfg, accountId, input }) => {
       const namedConfig = applyAccountNameToChannelSection({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         channelKey: "ringcentral",
         accountId,
         name: input.name,
@@ -314,7 +314,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       const next =
         accountId !== DEFAULT_ACCOUNT_ID
           ? migrateBaseNameToDefaultAccount({
-              cfg: namedConfig as ClawdbotConfig,
+              cfg: namedConfig as MoltbotConfig,
               channelKey: "ringcentral",
             })
           : namedConfig;
@@ -341,7 +341,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
               ...configPatch,
             },
           },
-        } as ClawdbotConfig;
+        } as MoltbotConfig;
       }
       return {
         ...next,
@@ -360,7 +360,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
             },
           },
         },
-      } as ClawdbotConfig;
+      } as MoltbotConfig;
     },
   },
   outbound: {
@@ -407,7 +407,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     },
     sendText: async ({ cfg, to, text, accountId }) => {
       const account = resolveRingCentralAccount({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         accountId,
       });
       const result = await sendRingCentralMessage({
@@ -426,12 +426,12 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
         throw new Error("RingCentral mediaUrl is required.");
       }
       const account = resolveRingCentralAccount({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         accountId,
       });
       const runtime = getRingCentralRuntime();
       const maxBytes = resolveChannelMediaMaxBytes({
-        cfg: cfg as ClawdbotConfig,
+        cfg: cfg as MoltbotConfig,
         resolveChannelLimitMb: ({ cfg: c, accountId: aid }) =>
           (c.channels?.ringcentral as { accounts?: Record<string, { mediaMaxMb?: number }>; mediaMaxMb?: number } | undefined)
             ?.accounts?.[aid]?.mediaMaxMb ??
@@ -529,7 +529,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       });
       const unregister = await startRingCentralMonitor({
         account,
-        config: ctx.cfg as ClawdbotConfig,
+        config: ctx.cfg as MoltbotConfig,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -42,6 +42,7 @@ const RingCentralAccountSchemaBase = z
     allowBots: z.boolean().optional(),
     botExtensionId: z.string().optional(),
     selfOnly: z.boolean().optional(),
+    useAdaptiveCards: z.boolean().optional(), // Use Adaptive Cards for code blocks (default: false)
   })
   .strict();
 

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -27,7 +27,6 @@ const RingCentralAccountSchemaBase = z
     clientSecret: z.string().optional(),
     jwt: z.string().optional(),
     server: z.string().optional(),
-    credentialsFile: z.string().optional(),
     webhookPath: z.string().optional(),
     webhookVerificationToken: z.string().optional(),
     markdown: MarkdownConfigSchema,
@@ -44,6 +43,8 @@ const RingCentralAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     allowBots: z.boolean().optional(),
     botExtensionId: z.string().optional(),
+    selfOnly: z.boolean().optional(),
+    allowOtherChats: z.boolean().optional(),
   })
   .strict();
 

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -30,7 +30,7 @@ const RingCentralAccountSchemaBase = z
     webhookPath: z.string().optional(),
     webhookVerificationToken: z.string().optional(),
     markdown: MarkdownConfigSchema,
-    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    dmPolicy: DmPolicySchema.optional().default("allowlist"),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+import {
+  BlockStreamingCoalesceSchema,
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  requireOpenAllowFrom,
+} from "clawdbot/plugin-sdk";
+
+const RingCentralGroupConfigSchema = z
+  .object({
+    chatId: z.string().optional(),
+    requireMention: z.boolean().optional(),
+    allow: z.boolean().optional(),
+    enabled: z.boolean().optional(),
+    users: z.array(z.union([z.string(), z.number()])).optional(),
+    systemPrompt: z.string().optional(),
+  })
+  .strict();
+
+const RingCentralAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    clientId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    jwt: z.string().optional(),
+    server: z.string().optional(),
+    credentialsFile: z.string().optional(),
+    webhookPath: z.string().optional(),
+    webhookVerificationToken: z.string().optional(),
+    markdown: MarkdownConfigSchema,
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groups: z.record(z.string(), RingCentralGroupConfigSchema.optional()).optional(),
+    requireMention: z.boolean().optional(),
+    mediaMaxMb: z.number().int().positive().optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+    chunkMode: z.enum(["length", "newline"]).optional(),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    allowBots: z.boolean().optional(),
+    botExtensionId: z.string().optional(),
+  })
+  .strict();
+
+const RingCentralAccountSchema = RingCentralAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.ringcentral.dmPolicy="open" requires channels.ringcentral.allowFrom to include "*"',
+  });
+});
+
+export const RingCentralConfigSchema = RingCentralAccountSchemaBase.extend({
+  accounts: z.record(z.string(), RingCentralAccountSchema.optional()).optional(),
+  defaultAccount: z.string().optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.ringcentral.dmPolicy="open" requires channels.ringcentral.allowFrom to include "*"',
+  });
+});
+
+export type { RingCentralAccountConfig, RingCentralConfig } from "./types.js";

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -44,7 +44,6 @@ const RingCentralAccountSchemaBase = z
     allowBots: z.boolean().optional(),
     botExtensionId: z.string().optional(),
     selfOnly: z.boolean().optional(),
-    allowOtherChats: z.boolean().optional(),
   })
   .strict();
 

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -6,7 +6,7 @@ import {
   GroupPolicySchema,
   MarkdownConfigSchema,
   requireOpenAllowFrom,
-} from "clawdbot/plugin-sdk";
+} from "moltbot/plugin-sdk";
 
 const RingCentralGroupConfigSchema = z
   .object({

--- a/extensions/ringcentral/src/config-schema.ts
+++ b/extensions/ringcentral/src/config-schema.ts
@@ -27,8 +27,6 @@ const RingCentralAccountSchemaBase = z
     clientSecret: z.string().optional(),
     jwt: z.string().optional(),
     server: z.string().optional(),
-    webhookPath: z.string().optional(),
-    webhookVerificationToken: z.string().optional(),
     markdown: MarkdownConfigSchema,
     dmPolicy: DmPolicySchema.optional().default("allowlist"),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/extensions/ringcentral/src/markdown.test.ts
+++ b/extensions/ringcentral/src/markdown.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { toRingCentralMarkdown, needsMarkdownConversion } from "./markdown.js";
+
+describe("toRingCentralMarkdown", () => {
+  it("converts single underscore italic to asterisk", () => {
+    expect(toRingCentralMarkdown("_italic_")).toBe("*italic*");
+    expect(toRingCentralMarkdown("This is _italic_ text")).toBe("This is *italic* text");
+  });
+
+  it("preserves double asterisk bold", () => {
+    expect(toRingCentralMarkdown("**bold**")).toBe("**bold**");
+    expect(toRingCentralMarkdown("This is **bold** text")).toBe("This is **bold** text");
+  });
+
+  it("converts double underscore to bold", () => {
+    expect(toRingCentralMarkdown("__bold__")).toBe("**bold**");
+  });
+
+  it("removes strikethrough", () => {
+    expect(toRingCentralMarkdown("~~strikethrough~~")).toBe("strikethrough");
+    expect(toRingCentralMarkdown("This is ~~deleted~~ text")).toBe("This is deleted text");
+  });
+
+  it("removes code blocks", () => {
+    expect(toRingCentralMarkdown("```\ncode\n```")).toBe("code");
+    expect(toRingCentralMarkdown("```javascript\nconst x = 1;\n```")).toBe("const x = 1;");
+  });
+
+  it("removes inline code", () => {
+    expect(toRingCentralMarkdown("`code`")).toBe("code");
+    expect(toRingCentralMarkdown("Use `npm install` to install")).toBe("Use npm install to install");
+  });
+
+  it("converts headings to bold", () => {
+    expect(toRingCentralMarkdown("# Heading 1")).toBe("**Heading 1**");
+    expect(toRingCentralMarkdown("## Heading 2")).toBe("**Heading 2**");
+    expect(toRingCentralMarkdown("### Heading 3")).toBe("**Heading 3**");
+  });
+
+  it("normalizes bullet lists", () => {
+    expect(toRingCentralMarkdown("- item")).toBe("* item");
+    expect(toRingCentralMarkdown("+ item")).toBe("* item");
+    expect(toRingCentralMarkdown("* item")).toBe("* item");
+  });
+
+  it("preserves links", () => {
+    expect(toRingCentralMarkdown("[link](https://example.com)")).toBe("[link](https://example.com)");
+  });
+
+  it("preserves blockquotes", () => {
+    expect(toRingCentralMarkdown("> quote")).toBe("> quote");
+  });
+
+  it("preserves numbered lists", () => {
+    expect(toRingCentralMarkdown("1. first\n2. second")).toBe("1. first\n2. second");
+  });
+
+  it("handles complex markdown", () => {
+    const input = `# Title
+
+This is _italic_ and **bold** text.
+
+- Item 1
+- Item 2
+
+\`\`\`
+code block
+\`\`\`
+
+Use \`inline code\` here.`;
+
+    const expected = `**Title**
+
+This is *italic* and **bold** text.
+
+* Item 1
+* Item 2
+
+code block
+
+Use inline code here.`;
+
+    expect(toRingCentralMarkdown(input)).toBe(expected);
+  });
+
+  it("does not convert underscore in URLs or paths", () => {
+    // URLs with underscores should be preserved in links
+    expect(toRingCentralMarkdown("[link](https://example.com/path_with_underscore)"))
+      .toBe("[link](https://example.com/path_with_underscore)");
+  });
+});
+
+describe("needsMarkdownConversion", () => {
+  it("returns true for text with underscore italic", () => {
+    expect(needsMarkdownConversion("_italic_")).toBe(true);
+  });
+
+  it("returns true for text with strikethrough", () => {
+    expect(needsMarkdownConversion("~~strike~~")).toBe(true);
+  });
+
+  it("returns true for text with code blocks", () => {
+    expect(needsMarkdownConversion("```code```")).toBe(true);
+  });
+
+  it("returns true for text with inline code", () => {
+    expect(needsMarkdownConversion("`code`")).toBe(true);
+  });
+
+  it("returns true for text with headings", () => {
+    expect(needsMarkdownConversion("# Heading")).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(needsMarkdownConversion("plain text")).toBe(false);
+  });
+
+  it("returns false for already compatible markdown", () => {
+    expect(needsMarkdownConversion("*italic* and **bold**")).toBe(false);
+  });
+});

--- a/extensions/ringcentral/src/markdown.ts
+++ b/extensions/ringcentral/src/markdown.ts
@@ -1,0 +1,87 @@
+/**
+ * Convert standard Markdown to RingCentral Mini-Markdown format.
+ * 
+ * RingCentral Mini-Markdown differences:
+ * - `_text_` = underline (not italic)
+ * - `*text*` = italic
+ * - `**text**` = bold
+ * - `[text](url)` = link
+ * - `> quote` = blockquote
+ * - `* item` = bullet list
+ * 
+ * Not supported: strikethrough (~~), code blocks (```), headings (#), etc.
+ */
+
+/**
+ * Convert standard markdown to RingCentral mini-markdown
+ */
+export function toRingCentralMarkdown(text: string): string {
+  let result = text;
+
+  // 1. Preserve links - temporarily replace them to avoid modifying URLs
+  const linkPlaceholders: string[] = [];
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match) => {
+    const idx = linkPlaceholders.length;
+    linkPlaceholders.push(match);
+    return `\x00LINK_${idx}\x00`;
+  });
+
+  // 2. Convert __text__ (some markdown bold) to **text**
+  result = result.replace(/__([^_]+)__/g, "**$1**");
+
+  // 3. Convert single _text_ to *text* for italic
+  //    Match _text_ but not inside words (e.g., snake_case_name)
+  result = result.replace(/(?<=^|[\s\p{P}])_([^_\n]+)_(?=$|[\s\p{P}])/gu, "*$1*");
+
+  // 4. Remove strikethrough ~~text~~ (not supported)
+  result = result.replace(/~~([^~]+)~~/g, "$1");
+
+  // 5. Convert code blocks to plain text (not well supported)
+  // Remove triple backtick code blocks
+  result = result.replace(/```[\s\S]*?```/g, (match) => {
+    // Extract content without the backticks and language identifier
+    const content = match.replace(/```\w*\n?/, "").replace(/\n?```$/, "");
+    return content;
+  });
+
+  // Convert inline code `text` to plain text
+  result = result.replace(/`([^`]+)`/g, "$1");
+
+  // 6. Convert headings to bold (# Heading -> **Heading**)
+  result = result.replace(/^#{1,6}\s+(.+)$/gm, "**$1**");
+
+  // 7. Convert horizontal rules (---, ***, ___) to simple separator
+  result = result.replace(/^[-*_]{3,}$/gm, "---");
+
+  // 8. Normalize bullet lists (-, +, *) to * for consistency
+  result = result.replace(/^(\s*)[-+]\s+/gm, "$1* ");
+
+  // 9. Restore links
+  result = result.replace(/\x00LINK_(\d+)\x00/g, (_match, idx) => {
+    return linkPlaceholders[Number(idx)];
+  });
+
+  // 10. Keep numbered lists as-is (1. item)
+  // 11. Keep blockquotes as-is (> quote)
+
+  return result;
+}
+
+/**
+ * Check if text contains markdown that needs conversion
+ */
+export function needsMarkdownConversion(text: string): boolean {
+  // Check for patterns that need conversion
+  return (
+    // Single underscore italic
+    /(?<![\\*_])_[^_\n]+_(?![_])/.test(text) ||
+    // Strikethrough
+    /~~[^~]+~~/.test(text) ||
+    // Code blocks
+    /```[\s\S]*?```/.test(text) ||
+    // Inline code
+    /`[^`]+`/.test(text) ||
+    // Headings
+    /^#{1,6}\s+.+$/m.test(text)
+  );
+}

--- a/extensions/ringcentral/src/monitor.test.ts
+++ b/extensions/ringcentral/src/monitor.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isSenderAllowed } from "./monitor.js";
+
+describe("isSenderAllowed", () => {
+  it("returns true when allowFrom contains wildcard", () => {
+    expect(isSenderAllowed("12345", ["*"])).toBe(true);
+    expect(isSenderAllowed("any-user", ["*"])).toBe(true);
+  });
+
+  it("returns true when sender ID matches exactly", () => {
+    expect(isSenderAllowed("12345", ["12345"])).toBe(true);
+    expect(isSenderAllowed("12345", ["other", "12345"])).toBe(true);
+  });
+
+  it("returns true when sender ID matches with ringcentral: prefix", () => {
+    expect(isSenderAllowed("12345", ["ringcentral:12345"])).toBe(true);
+    expect(isSenderAllowed("12345", ["RINGCENTRAL:12345"])).toBe(true);
+  });
+
+  it("returns true when sender ID matches with rc: prefix", () => {
+    expect(isSenderAllowed("12345", ["rc:12345"])).toBe(true);
+    expect(isSenderAllowed("12345", ["RC:12345"])).toBe(true);
+  });
+
+  it("returns true when sender ID matches with user: prefix", () => {
+    expect(isSenderAllowed("12345", ["user:12345"])).toBe(true);
+    expect(isSenderAllowed("12345", ["USER:12345"])).toBe(true);
+  });
+
+  it("returns false when sender ID not in allowFrom", () => {
+    expect(isSenderAllowed("12345", ["67890"])).toBe(false);
+    expect(isSenderAllowed("12345", [])).toBe(false);
+  });
+
+  it("handles case-insensitive matching", () => {
+    expect(isSenderAllowed("ABC123", ["abc123"])).toBe(true);
+    expect(isSenderAllowed("abc123", ["ABC123"])).toBe(true);
+  });
+
+  it("handles whitespace in allowFrom entries", () => {
+    expect(isSenderAllowed("12345", ["  12345  "])).toBe(true);
+  });
+
+  it("ignores empty entries in allowFrom", () => {
+    expect(isSenderAllowed("12345", ["", "12345", "  "])).toBe(true);
+  });
+});

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -162,10 +162,15 @@ async function processMessageWithPipeline(params: {
   const rawBody = messageText || (hasMedia ? "<media:attachment>" : "");
   if (!rawBody) return;
 
-  // Skip messages from self (bot)
-  if (ownerId && senderId === ownerId) {
-    logVerbose(core, runtime, "skip self-authored message");
-    return;
+  // In JWT mode (selfOnly), only accept messages from the JWT user themselves
+  // This is because the bot uses the JWT user's identity, so we're essentially
+  // having a conversation with ourselves (the AI assistant)
+  const selfOnly = account.config.selfOnly !== false; // default true
+  if (selfOnly && ownerId) {
+    if (senderId !== ownerId) {
+      logVerbose(core, runtime, `ignore message from non-owner: ${senderId} (selfOnly mode)`);
+      return;
+    }
   }
 
   // Fetch chat info to determine type

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -199,7 +199,7 @@ async function processMessageWithPipeline(params: {
   // This is because the bot uses the JWT user's identity, so we're essentially
   // having a conversation with ourselves (the AI assistant)
   const selfOnly = account.config.selfOnly !== false; // default true
-  runtime.log?.(`[${account.accountId}] Processing message: senderId=${senderId}, ownerId=${ownerId}, selfOnly=${selfOnly}, chatId=${chatId}, text=${rawBody.slice(0, 50)}`);
+  runtime.log?.(`[${account.accountId}] Processing message: senderId=${senderId}, ownerId=${ownerId}, selfOnly=${selfOnly}, chatId=${chatId}`);
   
   if (selfOnly && ownerId) {
     if (senderId !== ownerId) {

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -330,17 +330,15 @@ async function processMessageWithPipeline(params: {
     }
   }
 
-  if (!isGroup) {
+  // DM policy checks - skip entirely in selfOnly mode (owner is always allowed)
+  if (!isGroup && !selfOnly) {
     const dmEnabled = account.config.dm?.enabled !== false;
     if (dmPolicy === "disabled" || !dmEnabled) {
       logVerbose(core, runtime, `Blocked RingCentral DM from ${senderId} (dmPolicy=disabled)`);
       return;
     }
 
-    // In selfOnly mode, always allow the owner
-    const isOwner = selfOnly && ownerId && senderId === ownerId;
-    
-    if (dmPolicy !== "open" && !isOwner) {
+    if (dmPolicy !== "open") {
       const allowed = senderAllowedForCommands;
       if (!allowed) {
         if (dmPolicy === "pairing") {

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -1,7 +1,7 @@
 import { Subscriptions } from "@ringcentral/subscriptions";
 
-import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
-import { resolveMentionGatingWithBypass } from "clawdbot/plugin-sdk";
+import type { MoltbotConfig } from "moltbot/plugin-sdk";
+import { resolveMentionGatingWithBypass } from "moltbot/plugin-sdk";
 
 import type { ResolvedRingCentralAccount } from "./accounts.js";
 import { getRingCentralSDK } from "./auth.js";
@@ -41,7 +41,7 @@ function isOwnSentMessage(messageId: string): boolean {
 
 export type RingCentralMonitorOptions = {
   account: ResolvedRingCentralAccount;
-  config: ClawdbotConfig;
+  config: MoltbotConfig;
   runtime: RingCentralRuntimeEnv;
   abortSignal: AbortSignal;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
@@ -114,19 +114,19 @@ function extractMentionInfo(mentions: RingCentralMention[], botExtensionId?: str
 function resolveBotDisplayName(params: {
   accountName?: string;
   agentId: string;
-  config: ClawdbotConfig;
+  config: MoltbotConfig;
 }): string {
   const { accountName, agentId, config } = params;
   if (accountName?.trim()) return accountName.trim();
   const agent = config.agents?.list?.find((a) => a.id === agentId);
   if (agent?.name?.trim()) return agent.name.trim();
-  return "Clawdbot";
+  return "Moltbot";
 }
 
 async function processWebSocketEvent(params: {
   event: RingCentralWebhookEvent;
   account: ResolvedRingCentralAccount;
-  config: ClawdbotConfig;
+  config: MoltbotConfig;
   runtime: RingCentralRuntimeEnv;
   core: RingCentralCoreRuntime;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
@@ -162,7 +162,7 @@ async function processWebSocketEvent(params: {
 async function processMessageWithPipeline(params: {
   eventBody: RingCentralEventBody;
   account: ResolvedRingCentralAccount;
-  config: ClawdbotConfig;
+  config: MoltbotConfig;
   runtime: RingCentralRuntimeEnv;
   core: RingCentralCoreRuntime;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
@@ -533,7 +533,7 @@ async function deliverRingCentralReply(params: {
   chatId: string;
   runtime: RingCentralRuntimeEnv;
   core: RingCentralCoreRuntime;
-  config: ClawdbotConfig;
+  config: MoltbotConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingPostId?: string;
 }): Promise<void> {

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -226,14 +226,10 @@ async function processMessageWithPipeline(params: {
   const isGroup = chatType !== "Direct" && chatType !== "PersonalChat" && chatType !== "Personal";
   runtime.log?.(`[${account.accountId}] Chat type: ${chatType}, isGroup: ${isGroup}`);
 
-  // In selfOnly mode, by default only allow "Personal" chat (conversation with yourself)
-  // Set allowOtherChats: true to allow DMs and groups
-  if (selfOnly) {
-    const allowOtherChats = account.config.allowOtherChats === true; // default false
-    if (!allowOtherChats && !isPersonalChat) {
-      logVerbose(core, runtime, `ignore non-personal chat in selfOnly mode: chatType=${chatType}`);
-      return;
-    }
+  // In selfOnly mode, only allow "Personal" chat (conversation with yourself)
+  if (selfOnly && !isPersonalChat) {
+    logVerbose(core, runtime, `ignore non-personal chat in selfOnly mode: chatType=${chatType}`);
+    return;
   }
 
   const defaultGroupPolicy = config.channels?.defaults?.groupPolicy;

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -1,0 +1,690 @@
+import { Subscriptions } from "@ringcentral/subscriptions";
+
+import type { ClawdbotConfig } from "clawdbot/plugin-sdk";
+import { resolveMentionGatingWithBypass } from "clawdbot/plugin-sdk";
+
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+import { getRingCentralSDK } from "./auth.js";
+import {
+  sendRingCentralMessage,
+  updateRingCentralMessage,
+  deleteRingCentralMessage,
+  downloadRingCentralAttachment,
+  uploadRingCentralAttachment,
+  getRingCentralChat,
+} from "./api.js";
+import { getRingCentralRuntime } from "./runtime.js";
+import type {
+  RingCentralWebhookEvent,
+  RingCentralEventBody,
+  RingCentralAttachment,
+  RingCentralMention,
+} from "./types.js";
+
+export type RingCentralRuntimeEnv = {
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type RingCentralMonitorOptions = {
+  account: ResolvedRingCentralAccount;
+  config: ClawdbotConfig;
+  runtime: RingCentralRuntimeEnv;
+  abortSignal: AbortSignal;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+type RingCentralCoreRuntime = ReturnType<typeof getRingCentralRuntime>;
+
+function logVerbose(
+  core: RingCentralCoreRuntime,
+  runtime: RingCentralRuntimeEnv,
+  message: string,
+) {
+  if (core.logging.shouldLogVerbose()) {
+    runtime.log?.(`[ringcentral] ${message}`);
+  }
+}
+
+function normalizeUserId(raw?: string | null): string {
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed) return "";
+  return trimmed.toLowerCase();
+}
+
+export function isSenderAllowed(
+  senderId: string,
+  allowFrom: string[],
+): boolean {
+  if (allowFrom.includes("*")) return true;
+  const normalizedSenderId = normalizeUserId(senderId);
+  return allowFrom.some((entry) => {
+    const normalized = String(entry).trim().toLowerCase();
+    if (!normalized) return false;
+    if (normalized === normalizedSenderId) return true;
+    if (normalized.replace(/^(ringcentral|rc):/i, "") === normalizedSenderId) return true;
+    if (normalized.replace(/^user:/i, "") === normalizedSenderId) return true;
+    return false;
+  });
+}
+
+function resolveGroupConfig(params: {
+  groupId: string;
+  groupName?: string | null;
+  groups?: Record<string, { requireMention?: boolean; allow?: boolean; enabled?: boolean; users?: Array<string | number>; systemPrompt?: string }>;
+}) {
+  const { groupId, groupName, groups } = params;
+  const entries = groups ?? {};
+  const keys = Object.keys(entries);
+  if (keys.length === 0) {
+    return { entry: undefined, allowlistConfigured: false };
+  }
+  const normalizedName = groupName?.trim().toLowerCase();
+  const candidates = [groupId, groupName ?? "", normalizedName ?? ""].filter(Boolean);
+  let entry = candidates.map((candidate) => entries[candidate]).find(Boolean);
+  if (!entry && normalizedName) {
+    entry = entries[normalizedName];
+  }
+  const fallback = entries["*"];
+  return { entry: entry ?? fallback, allowlistConfigured: true, fallback };
+}
+
+function extractMentionInfo(mentions: RingCentralMention[], botExtensionId?: string | null) {
+  const personMentions = mentions.filter((entry) => entry.type === "Person");
+  const hasAnyMention = personMentions.length > 0;
+  const wasMentioned = botExtensionId
+    ? personMentions.some((entry) => entry.id === botExtensionId)
+    : false;
+  return { hasAnyMention, wasMentioned };
+}
+
+function resolveBotDisplayName(params: {
+  accountName?: string;
+  agentId: string;
+  config: ClawdbotConfig;
+}): string {
+  const { accountName, agentId, config } = params;
+  if (accountName?.trim()) return accountName.trim();
+  const agent = config.agents?.list?.find((a) => a.id === agentId);
+  if (agent?.name?.trim()) return agent.name.trim();
+  return "Clawdbot";
+}
+
+async function processWebSocketEvent(params: {
+  event: RingCentralWebhookEvent;
+  account: ResolvedRingCentralAccount;
+  config: ClawdbotConfig;
+  runtime: RingCentralRuntimeEnv;
+  core: RingCentralCoreRuntime;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  ownerId?: string;
+}): Promise<void> {
+  const { event, account, config, runtime, core, statusSink, ownerId } = params;
+  
+  const eventBody = event.body;
+  if (!eventBody) return;
+
+  const eventType = eventBody.eventType;
+  if (eventType !== "PostAdded") return;
+
+  statusSink?.({ lastInboundAt: Date.now() });
+
+  await processMessageWithPipeline({
+    eventBody,
+    account,
+    config,
+    runtime,
+    core,
+    statusSink,
+    ownerId,
+  });
+}
+
+async function processMessageWithPipeline(params: {
+  eventBody: RingCentralEventBody;
+  account: ResolvedRingCentralAccount;
+  config: ClawdbotConfig;
+  runtime: RingCentralRuntimeEnv;
+  core: RingCentralCoreRuntime;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  ownerId?: string;
+}): Promise<void> {
+  const { eventBody, account, config, runtime, core, statusSink, ownerId } = params;
+  const mediaMaxMb = account.config.mediaMaxMb ?? 20;
+  
+  const chatId = eventBody.groupId ?? "";
+  if (!chatId) return;
+
+  const senderId = eventBody.creatorId ?? "";
+  const messageText = (eventBody.text ?? "").trim();
+  const attachments = eventBody.attachments ?? [];
+  const hasMedia = attachments.length > 0;
+  const rawBody = messageText || (hasMedia ? "<media:attachment>" : "");
+  if (!rawBody) return;
+
+  // Skip messages from self (bot)
+  if (ownerId && senderId === ownerId) {
+    logVerbose(core, runtime, "skip self-authored message");
+    return;
+  }
+
+  // Fetch chat info to determine type
+  let chatType = "Group";
+  let chatName: string | undefined;
+  try {
+    const chatInfo = await getRingCentralChat({ account, chatId });
+    chatType = chatInfo?.type ?? "Group";
+    chatName = chatInfo?.name ?? undefined;
+  } catch {
+    // If we can't fetch chat info, assume it's a group
+  }
+
+  const isGroup = chatType !== "Direct" && chatType !== "PersonalChat";
+
+  const defaultGroupPolicy = config.channels?.defaults?.groupPolicy;
+  const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+  const groupConfigResolved = resolveGroupConfig({
+    groupId: chatId,
+    groupName: chatName ?? null,
+    groups: account.config.groups ?? undefined,
+  });
+  const groupEntry = groupConfigResolved.entry;
+  const groupUsers = groupEntry?.users ?? account.config.groupAllowFrom ?? [];
+  let effectiveWasMentioned: boolean | undefined;
+
+  if (isGroup) {
+    if (groupPolicy === "disabled") {
+      logVerbose(core, runtime, `drop group message (groupPolicy=disabled, chat=${chatId})`);
+      return;
+    }
+    const groupAllowlistConfigured = groupConfigResolved.allowlistConfigured;
+    const groupAllowed =
+      Boolean(groupEntry) || Boolean((account.config.groups ?? {})["*"]);
+    if (groupPolicy === "allowlist") {
+      if (!groupAllowlistConfigured) {
+        logVerbose(
+          core,
+          runtime,
+          `drop group message (groupPolicy=allowlist, no allowlist, chat=${chatId})`,
+        );
+        return;
+      }
+      if (!groupAllowed) {
+        logVerbose(core, runtime, `drop group message (not allowlisted, chat=${chatId})`);
+        return;
+      }
+    }
+    if (groupEntry?.enabled === false || groupEntry?.allow === false) {
+      logVerbose(core, runtime, `drop group message (chat disabled, chat=${chatId})`);
+      return;
+    }
+
+    if (groupUsers.length > 0) {
+      const ok = isSenderAllowed(senderId, groupUsers.map((v) => String(v)));
+      if (!ok) {
+        logVerbose(core, runtime, `drop group message (sender not allowed, ${senderId})`);
+        return;
+      }
+    }
+  }
+
+  const dmPolicy = account.config.dm?.policy ?? account.config.dmPolicy ?? "pairing";
+  const configAllowFrom = account.config.dm?.allowFrom ?? account.config.allowFrom ?? [];
+  const configAllowFromStr = configAllowFrom.map((v) => String(v));
+  const shouldComputeAuth = core.channel.commands.shouldComputeCommandAuthorized(rawBody, config);
+  const storeAllowFrom =
+    !isGroup && (dmPolicy !== "open" || shouldComputeAuth)
+      ? await core.channel.pairing.readAllowFromStore("ringcentral").catch(() => [])
+      : [];
+  const effectiveAllowFrom = [...configAllowFromStr, ...storeAllowFrom];
+  const commandAllowFrom = isGroup ? groupUsers.map((v) => String(v)) : effectiveAllowFrom;
+  const useAccessGroups = config.commands?.useAccessGroups !== false;
+  const senderAllowedForCommands = isSenderAllowed(senderId, commandAllowFrom);
+  const commandAuthorized = shouldComputeAuth
+    ? core.channel.commands.resolveCommandAuthorizedFromAuthorizers({
+        useAccessGroups,
+        authorizers: [
+          { configured: commandAllowFrom.length > 0, allowed: senderAllowedForCommands },
+        ],
+      })
+    : undefined;
+
+  if (isGroup) {
+    const requireMention = groupEntry?.requireMention ?? account.config.requireMention ?? true;
+    const mentions = eventBody.mentions ?? [];
+    const mentionInfo = extractMentionInfo(mentions, account.config.botExtensionId);
+    const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
+      cfg: config,
+      surface: "ringcentral",
+    });
+    const mentionGate = resolveMentionGatingWithBypass({
+      isGroup: true,
+      requireMention,
+      canDetectMention: Boolean(account.config.botExtensionId),
+      wasMentioned: mentionInfo.wasMentioned,
+      implicitMention: false,
+      hasAnyMention: mentionInfo.hasAnyMention,
+      allowTextCommands,
+      hasControlCommand: core.channel.text.hasControlCommand(rawBody, config),
+      commandAuthorized: commandAuthorized === true,
+    });
+    effectiveWasMentioned = mentionGate.effectiveWasMentioned;
+    if (mentionGate.shouldSkip) {
+      logVerbose(core, runtime, `drop group message (mention required, chat=${chatId})`);
+      return;
+    }
+  }
+
+  if (!isGroup) {
+    const dmEnabled = account.config.dm?.enabled !== false;
+    if (dmPolicy === "disabled" || !dmEnabled) {
+      logVerbose(core, runtime, `Blocked RingCentral DM from ${senderId} (dmPolicy=disabled)`);
+      return;
+    }
+
+    if (dmPolicy !== "open") {
+      const allowed = senderAllowedForCommands;
+      if (!allowed) {
+        if (dmPolicy === "pairing") {
+          const { code, created } = await core.channel.pairing.upsertPairingRequest({
+            channel: "ringcentral",
+            id: senderId,
+            meta: {},
+          });
+          if (created) {
+            logVerbose(core, runtime, `ringcentral pairing request sender=${senderId}`);
+            try {
+              await sendRingCentralMessage({
+                account,
+                chatId,
+                text: core.channel.pairing.buildPairingReply({
+                  channel: "ringcentral",
+                  idLine: `Your RingCentral user id: ${senderId}`,
+                  code,
+                }),
+              });
+              statusSink?.({ lastOutboundAt: Date.now() });
+            } catch (err) {
+              logVerbose(core, runtime, `pairing reply failed for ${senderId}: ${String(err)}`);
+            }
+          }
+        } else {
+          logVerbose(
+            core,
+            runtime,
+            `Blocked unauthorized RingCentral sender ${senderId} (dmPolicy=${dmPolicy})`,
+          );
+        }
+        return;
+      }
+    }
+  }
+
+  if (
+    isGroup &&
+    core.channel.commands.isControlCommandMessage(rawBody, config) &&
+    commandAuthorized !== true
+  ) {
+    logVerbose(core, runtime, `ringcentral: drop control command from ${senderId}`);
+    return;
+  }
+
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg: config,
+    channel: "ringcentral",
+    accountId: account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "dm",
+      id: chatId,
+    },
+  });
+
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
+  if (attachments.length > 0) {
+    const first = attachments[0];
+    const attachmentData = await downloadAttachment(first, account, mediaMaxMb, core);
+    if (attachmentData) {
+      mediaPath = attachmentData.path;
+      mediaType = attachmentData.contentType;
+    }
+  }
+
+  const fromLabel = isGroup
+    ? chatName || `chat:${chatId}`
+    : `user:${senderId}`;
+  const storePath = core.channel.session.resolveStorePath(config.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(config);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+  const body = core.channel.reply.formatAgentEnvelope({
+    channel: "RingCentral",
+    from: fromLabel,
+    timestamp: eventBody.creationTime ? Date.parse(eventBody.creationTime) : undefined,
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: rawBody,
+  });
+
+  const groupSystemPrompt = groupConfigResolved.entry?.systemPrompt?.trim() || undefined;
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: body,
+    RawBody: rawBody,
+    CommandBody: rawBody,
+    From: `ringcentral:${senderId}`,
+    To: `ringcentral:${chatId}`,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: isGroup ? "channel" : "direct",
+    ConversationLabel: fromLabel,
+    SenderId: senderId,
+    WasMentioned: isGroup ? effectiveWasMentioned : undefined,
+    CommandAuthorized: commandAuthorized,
+    Provider: "ringcentral",
+    Surface: "ringcentral",
+    MessageSid: eventBody.id,
+    MessageSidFull: eventBody.id,
+    MediaPath: mediaPath,
+    MediaType: mediaType,
+    MediaUrl: mediaPath,
+    GroupSpace: isGroup ? chatName ?? undefined : undefined,
+    GroupSystemPrompt: isGroup ? groupSystemPrompt : undefined,
+    OriginatingChannel: "ringcentral",
+    OriginatingTo: `ringcentral:${chatId}`,
+  });
+
+  void core.channel.session
+    .recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+    })
+    .catch((err) => {
+      runtime.error?.(`ringcentral: failed updating session meta: ${String(err)}`);
+    });
+
+  let typingPostId: string | undefined;
+
+  // Send typing indicator message
+  try {
+    const botName = resolveBotDisplayName({
+      accountName: account.config.name,
+      agentId: route.agentId,
+      config,
+    });
+    const result = await sendRingCentralMessage({
+      account,
+      chatId,
+      text: `_${botName} is typing..._`,
+    });
+    typingPostId = result?.postId;
+  } catch (err) {
+    runtime.error?.(`Failed sending typing message: ${String(err)}`);
+  }
+
+  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg: config,
+    dispatcherOptions: {
+      deliver: async (payload) => {
+        await deliverRingCentralReply({
+          payload,
+          account,
+          chatId,
+          runtime,
+          core,
+          config,
+          statusSink,
+          typingPostId,
+        });
+        typingPostId = undefined;
+      },
+      onError: (err, info) => {
+        runtime.error?.(
+          `[${account.accountId}] RingCentral ${info.kind} reply failed: ${String(err)}`,
+        );
+      },
+    },
+  });
+}
+
+async function downloadAttachment(
+  attachment: RingCentralAttachment,
+  account: ResolvedRingCentralAccount,
+  mediaMaxMb: number,
+  core: RingCentralCoreRuntime,
+): Promise<{ path: string; contentType?: string } | null> {
+  const contentUri = attachment.contentUri;
+  if (!contentUri) return null;
+  const maxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
+  const downloaded = await downloadRingCentralAttachment({ account, contentUri, maxBytes });
+  const saved = await core.channel.media.saveMediaBuffer(
+    downloaded.buffer,
+    downloaded.contentType ?? attachment.contentType,
+    "inbound",
+    maxBytes,
+    attachment.name,
+  );
+  return { path: saved.path, contentType: saved.contentType };
+}
+
+async function deliverRingCentralReply(params: {
+  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string };
+  account: ResolvedRingCentralAccount;
+  chatId: string;
+  runtime: RingCentralRuntimeEnv;
+  core: RingCentralCoreRuntime;
+  config: ClawdbotConfig;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  typingPostId?: string;
+}): Promise<void> {
+  const { payload, account, chatId, runtime, core, config, statusSink, typingPostId } = params;
+  const mediaList = payload.mediaUrls?.length
+    ? payload.mediaUrls
+    : payload.mediaUrl
+      ? [payload.mediaUrl]
+      : [];
+
+  if (mediaList.length > 0) {
+    let suppressCaption = false;
+    if (typingPostId) {
+      try {
+        await deleteRingCentralMessage({
+          account,
+          chatId,
+          postId: typingPostId,
+        });
+      } catch (err) {
+        runtime.error?.(`RingCentral typing cleanup failed: ${String(err)}`);
+        const fallbackText = payload.text?.trim()
+          ? payload.text
+          : mediaList.length > 1
+            ? "Sent attachments."
+            : "Sent attachment.";
+        try {
+          await updateRingCentralMessage({
+            account,
+            chatId,
+            postId: typingPostId,
+            text: fallbackText,
+          });
+          suppressCaption = Boolean(payload.text?.trim());
+        } catch (updateErr) {
+          runtime.error?.(`RingCentral typing update failed: ${String(updateErr)}`);
+        }
+      }
+    }
+    let first = true;
+    for (const mediaUrl of mediaList) {
+      const caption = first && !suppressCaption ? payload.text : undefined;
+      first = false;
+      try {
+        const loaded = await core.channel.media.fetchRemoteMedia(mediaUrl, {
+          maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+        });
+        const upload = await uploadRingCentralAttachment({
+          account,
+          chatId,
+          filename: loaded.filename ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+        if (!upload.attachmentId) {
+          throw new Error("missing attachment id");
+        }
+        await sendRingCentralMessage({
+          account,
+          chatId,
+          text: caption,
+          attachments: [{ id: upload.attachmentId }],
+        });
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`RingCentral attachment send failed: ${String(err)}`);
+      }
+    }
+    return;
+  }
+
+  if (payload.text) {
+    const chunkLimit = account.config.textChunkLimit ?? 4000;
+    const chunkMode = core.channel.text.resolveChunkMode(
+      config,
+      "ringcentral",
+      account.accountId,
+    );
+    const chunks = core.channel.text.chunkMarkdownTextWithMode(
+      payload.text,
+      chunkLimit,
+      chunkMode,
+    );
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      try {
+        if (i === 0 && typingPostId) {
+          await updateRingCentralMessage({
+            account,
+            chatId,
+            postId: typingPostId,
+            text: chunk,
+          });
+        } else {
+          await sendRingCentralMessage({
+            account,
+            chatId,
+            text: chunk,
+          });
+        }
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`RingCentral message send failed: ${String(err)}`);
+      }
+    }
+  }
+}
+
+export async function startRingCentralMonitor(
+  options: RingCentralMonitorOptions,
+): Promise<() => void> {
+  const { account, config, runtime, abortSignal, statusSink } = options;
+  const core = getRingCentralRuntime();
+
+  runtime.log?.(`[${account.accountId}] Starting RingCentral WebSocket subscription...`);
+
+  // Get SDK instance
+  const sdk = await getRingCentralSDK(account);
+  
+  // Create subscriptions manager
+  const subscriptions = new Subscriptions({ sdk });
+  const subscription = subscriptions.createSubscription();
+
+  // Track current user ID to filter out self messages
+  let ownerId: string | undefined;
+  try {
+    const platform = sdk.platform();
+    const response = await platform.get("/restapi/v1.0/account/~/extension/~");
+    const userInfo = await response.json();
+    ownerId = userInfo?.id?.toString();
+    runtime.log?.(`[${account.accountId}] Authenticated as extension: ${ownerId}`);
+  } catch (err) {
+    runtime.error?.(`[${account.accountId}] Failed to get current user: ${String(err)}`);
+  }
+
+  // Handle notifications
+  subscription.on(subscription.events.notification, (event: unknown) => {
+    const evt = event as RingCentralWebhookEvent;
+    processWebSocketEvent({
+      event: evt,
+      account,
+      config,
+      runtime,
+      core,
+      statusSink,
+      ownerId,
+    }).catch((err) => {
+      runtime.error?.(`[${account.accountId}] WebSocket event processing failed: ${String(err)}`);
+    });
+  });
+
+  // Handle subscription status changes
+  subscription.on(subscription.events.subscribeSuccess, () => {
+    runtime.log?.(`[${account.accountId}] WebSocket subscription active`);
+  });
+
+  subscription.on(subscription.events.subscribeError, (err: unknown) => {
+    runtime.error?.(`[${account.accountId}] WebSocket subscription error: ${String(err)}`);
+  });
+
+  subscription.on(subscription.events.renewSuccess, () => {
+    logVerbose(core, runtime, "WebSocket subscription renewed");
+  });
+
+  subscription.on(subscription.events.renewError, (err: unknown) => {
+    runtime.error?.(`[${account.accountId}] WebSocket subscription renew error: ${String(err)}`);
+  });
+
+  // Subscribe to Team Messaging events
+  // - /restapi/v1.0/glip/posts: New posts in chats
+  // - /restapi/v1.0/glip/groups: Chat/group changes
+  try {
+    await subscription
+      .setEventFilters([
+        "/restapi/v1.0/glip/posts",
+        "/restapi/v1.0/glip/groups",
+      ])
+      .register();
+    
+    runtime.log?.(`[${account.accountId}] RingCentral WebSocket subscription established`);
+  } catch (err) {
+    runtime.error?.(`[${account.accountId}] Failed to create WebSocket subscription: ${String(err)}`);
+    throw err;
+  }
+
+  // Handle abort signal
+  const cleanup = () => {
+    runtime.log?.(`[${account.accountId}] Stopping RingCentral WebSocket subscription...`);
+    subscription.reset().catch((err) => {
+      runtime.error?.(`[${account.accountId}] Failed to reset subscription: ${String(err)}`);
+    });
+  };
+
+  if (abortSignal.aborted) {
+    cleanup();
+  } else {
+    abortSignal.addEventListener("abort", cleanup, { once: true });
+  }
+
+  return cleanup;
+}
+
+// Keep the webhook path resolver for status display
+export function resolveRingCentralWebhookPath(_params: {
+  account: ResolvedRingCentralAccount;
+}): string {
+  return "(WebSocket)";
+}

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -222,8 +222,19 @@ async function processMessageWithPipeline(params: {
   }
 
   // Personal, PersonalChat, Direct are all DM types
+  const isPersonalChat = chatType === "Personal" || chatType === "PersonalChat";
   const isGroup = chatType !== "Direct" && chatType !== "PersonalChat" && chatType !== "Personal";
   runtime.log?.(`[${account.accountId}] Chat type: ${chatType}, isGroup: ${isGroup}`);
+
+  // In selfOnly mode, by default only allow "Personal" chat (conversation with yourself)
+  // Set allowOtherChats: true to allow DMs and groups
+  if (selfOnly) {
+    const allowOtherChats = account.config.allowOtherChats === true; // default false
+    if (!allowOtherChats && !isPersonalChat) {
+      logVerbose(core, runtime, `ignore non-personal chat in selfOnly mode: chatType=${chatType}`);
+      return;
+    }
+  }
 
   const defaultGroupPolicy = config.channels?.defaults?.groupPolicy;
   const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -739,10 +739,3 @@ export async function startRingCentralMonitor(
 
   return cleanup;
 }
-
-// Keep the webhook path resolver for status display
-export function resolveRingCentralWebhookPath(_params: {
-  account: ResolvedRingCentralAccount;
-}): string {
-  return "(WebSocket)";
-}

--- a/extensions/ringcentral/src/monitor.ts
+++ b/extensions/ringcentral/src/monitor.ts
@@ -680,7 +680,7 @@ export async function startRingCentralMonitor(
 
   // Handle notifications
   subscription.on(subscription.events.notification, (event: unknown) => {
-    runtime.log?.(`[${account.accountId}] WebSocket notification received: ${JSON.stringify(event).slice(0, 500)}`);
+    logVerbose(core, runtime, `WebSocket notification received: ${JSON.stringify(event).slice(0, 500)}`);
     const evt = event as RingCentralWebhookEvent;
     processWebSocketEvent({
       event: evt,

--- a/extensions/ringcentral/src/runtime.ts
+++ b/extensions/ringcentral/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "clawdbot/plugin-sdk";
+import type { PluginRuntime } from "moltbot/plugin-sdk";
 
 let runtime: PluginRuntime | null = null;
 

--- a/extensions/ringcentral/src/runtime.ts
+++ b/extensions/ringcentral/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "clawdbot/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setRingCentralRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getRingCentralRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("RingCentral runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/ringcentral/src/targets.test.ts
+++ b/extensions/ringcentral/src/targets.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeRingCentralTarget,
+  isRingCentralChatTarget,
+  isRingCentralUserTarget,
+  formatRingCentralChatTarget,
+  formatRingCentralUserTarget,
+  parseRingCentralTarget,
+} from "./targets.js";
+
+describe("normalizeRingCentralTarget", () => {
+  it("returns null for empty string", () => {
+    expect(normalizeRingCentralTarget("")).toBeNull();
+    expect(normalizeRingCentralTarget("  ")).toBeNull();
+  });
+
+  it("removes ringcentral: prefix", () => {
+    expect(normalizeRingCentralTarget("ringcentral:12345")).toBe("12345");
+    expect(normalizeRingCentralTarget("RINGCENTRAL:12345")).toBe("12345");
+  });
+
+  it("removes rc: prefix", () => {
+    expect(normalizeRingCentralTarget("rc:12345")).toBe("12345");
+    expect(normalizeRingCentralTarget("RC:12345")).toBe("12345");
+  });
+
+  it("removes chat: prefix", () => {
+    expect(normalizeRingCentralTarget("chat:12345")).toBe("12345");
+  });
+
+  it("removes user: prefix", () => {
+    expect(normalizeRingCentralTarget("user:12345")).toBe("12345");
+  });
+
+  it("removes combined prefixes", () => {
+    expect(normalizeRingCentralTarget("rc:chat:12345")).toBe("12345");
+    expect(normalizeRingCentralTarget("ringcentral:user:12345")).toBe("12345");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeRingCentralTarget("  12345  ")).toBe("12345");
+  });
+
+  it("returns plain ID as-is", () => {
+    expect(normalizeRingCentralTarget("12345")).toBe("12345");
+  });
+});
+
+describe("isRingCentralChatTarget", () => {
+  it("returns true for numeric IDs", () => {
+    expect(isRingCentralChatTarget("12345")).toBe(true);
+    expect(isRingCentralChatTarget("rc:12345")).toBe(true);
+    expect(isRingCentralChatTarget("chat:12345")).toBe(true);
+  });
+
+  it("returns false for non-numeric IDs", () => {
+    expect(isRingCentralChatTarget("abc")).toBe(false);
+    expect(isRingCentralChatTarget("12345abc")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isRingCentralChatTarget("")).toBe(false);
+  });
+});
+
+describe("isRingCentralUserTarget", () => {
+  it("returns true for numeric IDs", () => {
+    expect(isRingCentralUserTarget("12345")).toBe(true);
+    expect(isRingCentralUserTarget("rc:12345")).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isRingCentralUserTarget("")).toBe(false);
+  });
+});
+
+describe("formatRingCentralChatTarget", () => {
+  it("formats chat ID with rc:chat: prefix", () => {
+    expect(formatRingCentralChatTarget("12345")).toBe("rc:chat:12345");
+  });
+});
+
+describe("formatRingCentralUserTarget", () => {
+  it("formats user ID with rc:user: prefix", () => {
+    expect(formatRingCentralUserTarget("12345")).toBe("rc:user:12345");
+  });
+});
+
+describe("parseRingCentralTarget", () => {
+  it("parses chat: prefix", () => {
+    expect(parseRingCentralTarget("chat:12345")).toEqual({ type: "chat", id: "12345" });
+    expect(parseRingCentralTarget("rc:chat:12345")).toEqual({ type: "chat", id: "12345" });
+    expect(parseRingCentralTarget("ringcentral:chat:12345")).toEqual({ type: "chat", id: "12345" });
+  });
+
+  it("parses user: prefix", () => {
+    expect(parseRingCentralTarget("user:12345")).toEqual({ type: "user", id: "12345" });
+    expect(parseRingCentralTarget("rc:user:12345")).toEqual({ type: "user", id: "12345" });
+  });
+
+  it("parses group: prefix as chat", () => {
+    expect(parseRingCentralTarget("group:12345")).toEqual({ type: "chat", id: "12345" });
+    expect(parseRingCentralTarget("team:12345")).toEqual({ type: "chat", id: "12345" });
+  });
+
+  it("defaults numeric IDs to chat type", () => {
+    expect(parseRingCentralTarget("12345")).toEqual({ type: "chat", id: "12345" });
+    expect(parseRingCentralTarget("rc:12345")).toEqual({ type: "chat", id: "12345" });
+  });
+
+  it("returns unknown for non-numeric IDs without type prefix", () => {
+    expect(parseRingCentralTarget("abc")).toEqual({ type: "unknown", id: "abc" });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseRingCentralTarget("  chat:12345  ")).toEqual({ type: "chat", id: "12345" });
+  });
+});

--- a/extensions/ringcentral/src/targets.ts
+++ b/extensions/ringcentral/src/targets.ts
@@ -1,0 +1,70 @@
+// Target ID normalization and resolution for RingCentral
+
+export function normalizeRingCentralTarget(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Remove common prefixes
+  let normalized = trimmed
+    .replace(/^(ringcentral|rc):/i, "")
+    .replace(/^(chat|user|group|team):/i, "")
+    .trim();
+
+  if (!normalized) return null;
+  return normalized;
+}
+
+export function isRingCentralChatTarget(target: string): boolean {
+  const normalized = normalizeRingCentralTarget(target);
+  if (!normalized) return false;
+  // RingCentral chat IDs are typically numeric strings
+  return /^\d+$/.test(normalized);
+}
+
+export function isRingCentralUserTarget(target: string): boolean {
+  const normalized = normalizeRingCentralTarget(target);
+  if (!normalized) return false;
+  // User IDs can be numeric or prefixed
+  return /^\d+$/.test(normalized) || normalized.toLowerCase().startsWith("user:");
+}
+
+export function formatRingCentralChatTarget(chatId: string): string {
+  return `rc:chat:${chatId}`;
+}
+
+export function formatRingCentralUserTarget(userId: string): string {
+  return `rc:user:${userId}`;
+}
+
+export function parseRingCentralTarget(target: string): {
+  type: "chat" | "user" | "unknown";
+  id: string;
+} {
+  const trimmed = target.trim();
+  
+  // Check for explicit type prefixes
+  const chatMatch = trimmed.match(/^(?:ringcentral|rc)?:?chat:(.+)$/i);
+  if (chatMatch) {
+    return { type: "chat", id: chatMatch[1].trim() };
+  }
+
+  const userMatch = trimmed.match(/^(?:ringcentral|rc)?:?user:(.+)$/i);
+  if (userMatch) {
+    return { type: "user", id: userMatch[1].trim() };
+  }
+
+  const groupMatch = trimmed.match(/^(?:ringcentral|rc)?:?(?:group|team):(.+)$/i);
+  if (groupMatch) {
+    return { type: "chat", id: groupMatch[1].trim() };
+  }
+
+  // Remove any remaining prefix
+  const cleaned = trimmed.replace(/^(?:ringcentral|rc):/i, "").trim();
+  
+  // Default to chat for numeric IDs
+  if (/^\d+$/.test(cleaned)) {
+    return { type: "chat", id: cleaned };
+  }
+
+  return { type: "unknown", id: cleaned };
+}

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -115,6 +115,7 @@ export type RingCentralAccountConfig = {
   allowBots?: boolean;
   botExtensionId?: string;
   replyToMode?: "off" | "all";
+  selfOnly?: boolean; // JWT mode: only accept messages from the JWT user (default: true)
 };
 
 export type RingCentralConfig = RingCentralAccountConfig & {

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -53,6 +53,56 @@ export type RingCentralMention = {
   name?: string;
 };
 
+// Adaptive Cards types (Microsoft Adaptive Card schema v1.3)
+export type RingCentralAdaptiveCardElement = {
+  type: string;
+  text?: string;
+  size?: "Small" | "Default" | "Medium" | "Large" | "ExtraLarge";
+  weight?: "Lighter" | "Default" | "Bolder";
+  color?: "Default" | "Dark" | "Light" | "Accent" | "Good" | "Warning" | "Attention";
+  wrap?: boolean;
+  url?: string;
+  altText?: string;
+  columns?: RingCentralAdaptiveCardElement[];
+  items?: RingCentralAdaptiveCardElement[];
+  width?: string | number;
+  style?: string;
+  isVisible?: boolean;
+  id?: string;
+  // Input elements
+  label?: string;
+  placeholder?: string;
+  value?: string;
+  isRequired?: boolean;
+  // Action elements
+  title?: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type RingCentralAdaptiveCardAction = {
+  type: "Action.Submit" | "Action.OpenUrl" | "Action.ShowCard" | "Action.ToggleVisibility";
+  title?: string;
+  url?: string;
+  data?: Record<string, unknown>;
+  card?: RingCentralAdaptiveCard;
+  targetElements?: Array<string | { elementId: string; isVisible?: boolean }>;
+};
+
+export type RingCentralAdaptiveCard = {
+  type?: "AdaptiveCard";
+  $schema?: string;
+  version?: string;
+  body?: RingCentralAdaptiveCardElement[];
+  actions?: RingCentralAdaptiveCardAction[];
+  fallbackText?: string;
+  speak?: string;
+  lang?: string;
+  verticalContentAlignment?: "Top" | "Center" | "Bottom";
+  backgroundImage?: string | { url: string; fillMode?: string };
+  minHeight?: string;
+};
+
 export type RingCentralWebhookEvent = {
   uuid?: string;
   event?: string;
@@ -113,6 +163,7 @@ export type RingCentralAccountConfig = {
   botExtensionId?: string;
   replyToMode?: "off" | "all";
   selfOnly?: boolean; // JWT mode: only accept messages from the JWT user in Personal chat (default: true)
+  useAdaptiveCards?: boolean; // Use Adaptive Cards for messages with code blocks (default: false)
 };
 
 export type RingCentralConfig = RingCentralAccountConfig & {

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -114,8 +114,7 @@ export type RingCentralAccountConfig = {
   allowBots?: boolean;
   botExtensionId?: string;
   replyToMode?: "off" | "all";
-  selfOnly?: boolean; // JWT mode: only accept messages from the JWT user (default: true)
-  allowOtherChats?: boolean; // In selfOnly mode, allow chats other than Personal (default: false)
+  selfOnly?: boolean; // JWT mode: only accept messages from the JWT user in Personal chat (default: true)
 };
 
 export type RingCentralConfig = RingCentralAccountConfig & {

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -1,4 +1,4 @@
-import type { DmPolicy, GroupPolicy, MarkdownConfig } from "clawdbot/plugin-sdk";
+import type { DmPolicy, GroupPolicy, MarkdownConfig } from "moltbot/plugin-sdk";
 
 // RingCentral Team Messaging API types
 

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -1,0 +1,123 @@
+import type { DmPolicy, GroupPolicy, MarkdownConfig } from "clawdbot/plugin-sdk";
+
+// RingCentral Team Messaging API types
+
+export type RingCentralUser = {
+  id?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+};
+
+export type RingCentralChat = {
+  id?: string;
+  name?: string;
+  description?: string;
+  type?: "Everyone" | "Team" | "Group" | "Personal" | "Direct" | "PersonalChat";
+  status?: "Active" | "Archived";
+  members?: string[];
+  isPublic?: boolean;
+  creationTime?: string;
+  lastModifiedTime?: string;
+};
+
+export type RingCentralPost = {
+  id?: string;
+  groupId?: string;
+  type?: "TextMessage" | "PersonJoined" | "PersonsAdded";
+  text?: string;
+  creatorId?: string;
+  addedPersonIds?: string[];
+  creationTime?: string;
+  lastModifiedTime?: string;
+  attachments?: RingCentralAttachment[];
+  activity?: string;
+  title?: string;
+  iconUri?: string;
+  iconEmoji?: string;
+  mentions?: RingCentralMention[];
+};
+
+export type RingCentralAttachment = {
+  id?: string;
+  type?: string;
+  name?: string;
+  contentUri?: string;
+  contentType?: string;
+  size?: number;
+};
+
+export type RingCentralMention = {
+  id?: string;
+  type?: "Person" | "Team" | "File" | "Link" | "Event" | "Task" | "Note" | "Card";
+  name?: string;
+};
+
+export type RingCentralWebhookEvent = {
+  uuid?: string;
+  event?: string;
+  timestamp?: string;
+  subscriptionId?: string;
+  ownerId?: string;
+  body?: RingCentralEventBody;
+};
+
+export type RingCentralEventBody = {
+  id?: string;
+  groupId?: string;
+  type?: string;
+  text?: string;
+  creatorId?: string;
+  eventType?: "PostAdded" | "PostChanged" | "PostRemoved" | "GroupJoined" | "GroupLeft" | "GroupChanged";
+  creationTime?: string;
+  lastModifiedTime?: string;
+  attachments?: RingCentralAttachment[];
+  mentions?: RingCentralMention[];
+  name?: string;
+  members?: string[];
+  status?: string;
+};
+
+// Config types
+
+export type RingCentralGroupConfig = {
+  chatId?: string;
+  requireMention?: boolean;
+  allow?: boolean;
+  enabled?: boolean;
+  users?: Array<string | number>;
+  systemPrompt?: string;
+};
+
+export type RingCentralAccountConfig = {
+  enabled?: boolean;
+  name?: string;
+  clientId?: string;
+  clientSecret?: string;
+  jwt?: string;
+  server?: string;
+  credentialsFile?: string;
+  webhookPath?: string;
+  webhookVerificationToken?: string;
+  markdown?: MarkdownConfig;
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string | number>;
+  dm?: { policy?: DmPolicy; allowFrom?: Array<string | number>; enabled?: boolean };
+  groupPolicy?: GroupPolicy;
+  groups?: Record<string, RingCentralGroupConfig>;
+  groupAllowFrom?: Array<string | number>;
+  requireMention?: boolean;
+  mediaMaxMb?: number;
+  textChunkLimit?: number;
+  chunkMode?: "length" | "newline";
+  blockStreaming?: boolean;
+  blockStreamingCoalesce?: { minChars?: number; idleMs?: number };
+  allowBots?: boolean;
+  botExtensionId?: string;
+  replyToMode?: "off" | "all";
+};
+
+export type RingCentralConfig = RingCentralAccountConfig & {
+  accounts?: Record<string, RingCentralAccountConfig>;
+  defaultAccount?: string;
+};

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -115,6 +115,7 @@ export type RingCentralAccountConfig = {
   botExtensionId?: string;
   replyToMode?: "off" | "all";
   selfOnly?: boolean; // JWT mode: only accept messages from the JWT user (default: true)
+  allowOtherChats?: boolean; // In selfOnly mode, allow chats other than Personal (default: false)
 };
 
 export type RingCentralConfig = RingCentralAccountConfig & {

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -96,8 +96,6 @@ export type RingCentralAccountConfig = {
   clientSecret?: string;
   jwt?: string;
   server?: string;
-  webhookPath?: string;
-  webhookVerificationToken?: string;
   markdown?: MarkdownConfig;
   dmPolicy?: DmPolicy;
   allowFrom?: Array<string | number>;

--- a/extensions/ringcentral/src/types.ts
+++ b/extensions/ringcentral/src/types.ts
@@ -96,7 +96,6 @@ export type RingCentralAccountConfig = {
   clientSecret?: string;
   jwt?: string;
   server?: string;
-  credentialsFile?: string;
   webhookPath?: string;
   webhookVerificationToken?: string;
   markdown?: MarkdownConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5249,6 +5249,7 @@ packages:
   tar@7.5.4:
     resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,12 +383,12 @@ importers:
       '@microsoft/agents-hosting-extensions-teams':
         specifier: ^1.2.2
         version: 1.2.2
-      moltbot:
-        specifier: workspace:*
-        version: link:../..
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      moltbot:
+        specifier: workspace:*
+        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -424,7 +424,7 @@ importers:
         specifier: ^8.18.0
         version: 8.19.0
     devDependencies:
-      clawdbot:
+      moltbot:
         specifier: workspace:*
         version: link:../..
 
@@ -3252,11 +3252,6 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
-  clawdbot@2026.1.24-3:
-    resolution: {integrity: sha512-zt9BzhWXduq8ZZR4rfzQDurQWAgmijTTyPZCQGrn5ew6wCEwhxxEr2/NHG7IlCwcfRsKymsY4se9KMhoNz0JtQ==}
-    engines: {node: '>=22.12.0'}
-    hasBin: true
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -9210,84 +9205,6 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
-
-  clawdbot@2026.1.24-3(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3):
-    dependencies:
-      '@agentclientprotocol/sdk': 0.13.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.975.0
-      '@buape/carbon': 0.14.0(hono@4.11.4)
-      '@clack/prompts': 0.11.0
-      '@grammyjs/runner': 2.0.3(grammy@1.39.3)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.39.3)
-      '@homebridge/ciao': 1.3.4
-      '@line/bot-sdk': 10.6.0
-      '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.49.3
-      '@mozilla/readability': 0.6.0
-      '@sinclair/typebox': 0.34.47
-      '@slack/bolt': 4.6.0(@types/express@5.0.6)
-      '@slack/web-api': 7.13.0
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
-      ajv: 8.17.1
-      body-parser: 2.2.2
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      chromium-bidi: 13.0.1(devtools-protocol@0.0.1561482)
-      cli-highlight: 2.1.11
-      commander: 14.0.2
-      croner: 9.1.0
-      detect-libc: 2.1.2
-      discord-api-types: 0.38.37
-      dotenv: 17.2.3
-      express: 5.2.1
-      file-type: 21.3.0
-      grammy: 1.39.3
-      hono: 4.11.4
-      jiti: 2.6.1
-      json5: 2.2.3
-      jszip: 3.10.1
-      linkedom: 0.18.12
-      long: 5.3.2
-      markdown-it: 14.1.0
-      node-edge-tts: 1.2.9
-      osc-progress: 0.3.0
-      pdfjs-dist: 5.4.530
-      playwright-core: 1.58.0
-      proper-lockfile: 4.1.2
-      qrcode-terminal: 0.12.0
-      sharp: 0.34.5
-      sqlite-vec: 0.1.7-alpha.2
-      tar: 7.5.4
-      tslog: 4.10.2
-      undici: 7.19.0
-      ws: 8.19.0
-      yaml: 2.8.2
-      zod: 4.3.6
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.88
-      node-llama-cpp: 3.15.0(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@discordjs/opus'
-      - '@modelcontextprotocol/sdk'
-      - '@types/express'
-      - audio-decode
-      - aws-crt
-      - bufferutil
-      - canvas
-      - debug
-      - devtools-protocol
-      - encoding
-      - ffmpeg-static
-      - jimp
-      - link-preview-js
-      - node-opus
-      - opusscript
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   cli-cursor@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,25 @@ importers:
 
   extensions/open-prose: {}
 
+  extensions/ringcentral:
+    dependencies:
+      '@ringcentral/sdk':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@ringcentral/subscriptions':
+        specifier: ^5.0.0
+        version: 5.0.6
+      isomorphic-ws:
+        specifier: ^5.0.0
+        version: 5.0.0(ws@8.19.0)
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      clawdbot:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/signal: {}
 
   extensions/slack: {}
@@ -2101,6 +2120,15 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@rc-ex/core@1.6.17':
+    resolution: {integrity: sha512-+Bnp/cpTyfm9wAs+QP//ocK1E0lKZbS4iDdzL6qwFs3CZuiGhnokei99nU2qeS73aDgIvnLHqPb+BwSCetataQ==}
+
+  '@rc-ex/rcsdk@1.3.13':
+    resolution: {integrity: sha512-qz4YEslBsK0a1yqDnqIUY2khZGISS1Tz+NMXJPkilEzyS9vfbWHpGk+KVZAKfyciLHSizE3TIszFposQZdiMgw==}
+
+  '@rc-ex/ws@1.3.17':
+    resolution: {integrity: sha512-M4gLkdzT9UJ0WYhumvmE49VHR8gRm5aY3kOifMH6zfrkDS7vvf7bKrPA5kV07a8/3aYfp+8CcclRq7JDhOdVAA==}
+
   '@reflink/reflink-darwin-arm64@0.1.19':
     resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
     engines: {node: '>= 10'}
@@ -2152,6 +2180,14 @@ packages:
   '@reflink/reflink@0.1.19':
     resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
     engines: {node: '>= 10'}
+
+  '@ringcentral/sdk@5.0.6':
+    resolution: {integrity: sha512-748RqYpO+ot0INmyewzBkDwAZyXZpOcgNzSCRmOtbvk+cWtj5E8U2sUlCMa+astqcUXobEQiRVTlpPydDEE1fw==}
+    engines: {node: '>=4'}
+
+  '@ringcentral/subscriptions@5.0.6':
+    resolution: {integrity: sha512-yYy+efUO9MTp+juK2qRFHD+T0Wmi1n8lWUOOqUXaVCVvsWGBBPeJQftQnfvkOYPLRk1eFWdUCupTH0UkZ7tnYQ==}
+    engines: {node: '>=4'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
@@ -3144,6 +3180,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -3415,6 +3454,9 @@ packages:
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  dom-storage@2.1.0:
+    resolution: {integrity: sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -3834,9 +3876,15 @@ packages:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
 
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3908,6 +3956,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -3945,6 +3997,15 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -5358,6 +5419,9 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -5456,6 +5520,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  wait-for-async@0.7.13:
+    resolution: {integrity: sha512-sBw2C85eWcRvTWbUmtcMUdVz6KvDkDkRtE5a5YhBANSijs7M6DrHK13lHAxwkTPTcrjVRjEQ/qH9RpK7Q7vlYA==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -7741,6 +7808,28 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@rc-ex/core@1.6.17':
+    dependencies:
+      '@types/qs': 6.14.0
+      axios: 1.13.2(debug@4.4.3)
+      qs: 6.14.1
+    transitivePeerDependencies:
+      - debug
+
+  '@rc-ex/rcsdk@1.3.13': {}
+
+  '@rc-ex/ws@1.3.17':
+    dependencies:
+      '@types/ws': 8.18.1
+      http-status-codes: 2.3.0
+      hyperid: 3.3.0
+      isomorphic-ws: 5.0.0(ws@8.19.0)
+      wait-for-async: 0.7.13
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@reflink/reflink-darwin-arm64@0.1.19':
     optional: true
 
@@ -7776,6 +7865,25 @@ snapshots:
       '@reflink/reflink-win32-arm64-msvc': 0.1.19
       '@reflink/reflink-win32-x64-msvc': 0.1.19
     optional: true
+
+  '@ringcentral/sdk@5.0.6':
+    dependencies:
+      dom-storage: 2.1.0
+      is-plain-object: 2.0.4
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@ringcentral/subscriptions@5.0.6':
+    dependencies:
+      '@rc-ex/core': 1.6.17
+      '@rc-ex/rcsdk': 1.3.13
+      '@rc-ex/ws': 1.3.17
+      wait-for-async: 0.7.13
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
 
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
     optional: true
@@ -9017,6 +9125,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -9360,6 +9473,8 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.5.0
+
+  dom-storage@2.1.0: {}
 
   domelementtype@2.3.0: {}
 
@@ -9906,12 +10021,20 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
+  http-status-codes@2.3.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  hyperid@3.3.0:
+    dependencies:
+      buffer: 5.7.1
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
 
   iconv-lite@0.4.24:
     dependencies:
@@ -10004,6 +10127,10 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
   is-plain-object@5.0.0: {}
 
   is-promise@2.2.2: {}
@@ -10028,6 +10155,12 @@ snapshots:
 
   isexe@3.1.1:
     optional: true
+
+  isobject@3.0.1: {}
+
+  isomorphic-ws@5.0.0(ws@8.19.0):
+    dependencies:
+      ws: 8.19.0
 
   isstream@0.1.2: {}
 
@@ -11617,6 +11750,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid-parse@1.1.0: {}
+
   uuid@11.1.0: {}
 
   uuid@3.4.0: {}
@@ -11688,6 +11823,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  wait-for-async@0.7.13: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "clawdbot/plugin-sdk": path.join(repoRoot, "src", "plugin-sdk", "index.ts"),
-      "moltbot/plugin-sdk": path.join(repoRoot, "src", "plugin-sdk", "index.ts"),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "clawdbot/plugin-sdk": path.join(repoRoot, "src", "plugin-sdk", "index.ts"),
+      "moltbot/plugin-sdk": path.join(repoRoot, "src", "plugin-sdk", "index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
   markdown
     Add RingCentral Team Messaging channel plugin for Moltbot.

     ## Features
     - WebSocket-based real-time messaging (no public webhook required)
     - JWT authentication (messages appear from your own account)
     - Self-only mode (default): AI assistant in Personal chat
     - Support for text messages and attachments
     - Typing indicators
     - Markdown conversion (standard markdown → RingCentral Mini-Markdown)

     ## Configuration
     ```json
     {
       "channels": {
         "ringcentral": {
           "enabled": true,
           "clientId": "your-client-id",
           "clientSecret": "your-client-secret",
           "jwt": "your-jwt-token"
         }
       }
     }

   Testing
   [x] 65 unit tests passing (markdown, targets, accounts, monitor)
   [x] Build passes
   [x] Manual testing with RingCentral sandbox

   Notes
   •  Uses REST API App (not Bot Add-in) with JWT auth flow
   •  Default selfOnly: true mode only responds to JWT user in Personal chat
   •  Requires WebSocket Subscriptions permission in RingCentral app

   ──────────────────────────────────────────
   AI-assisted: Yes 
   Testing: Fully tested