### PR TITLE
fix(compaction): resolve model via runtime when ctx.model is undefined

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -79,6 +79,7 @@ export function buildEmbeddedExtensionPaths(params: {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,5 +1,8 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
+  model?: Model<Api>;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -146,8 +146,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
+      console.warn(
+        "Compaction safeguard: no model available (ctx.model and runtime.model both undefined)",
+      );
       return {
         compaction: {
           summary: fallbackSummary,
@@ -175,7 +179,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
       let messagesToSummarize = preparation.messagesToSummarize;
 
-      const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
       const maxHistoryShare = runtime?.maxHistoryShare ?? 0.5;
 
       const tokensBefore =


### PR DESCRIPTION
## Summary

When compaction runs through the embedded runner path (`createAgentSession`), `extensionRunner.initialize()` is never called, leaving `ctx.model` undefined. This causes the compaction safeguard to silently fall back to the generic "Summary unavailable" message instead of generating an actual summary.

## Root Cause

As identified in #2851 and #2656:

1. `ExtensionRunner` is created with extensions loaded ✓
2. `initialize()` is never called in the `createAgentSession` path ✗
3. `getModel` stays as `() => undefined` ✗
4. Safeguard checks `ctx.model` → gets `undefined` → returns fallback immediately
5. No API call is ever attempted for summarization

## Fix

This PR passes the model through the runtime registry (alongside `maxHistoryShare`) and uses it as a fallback when `ctx.model` is undefined:

1. **compaction-safeguard-runtime.ts** - Add `model` to the runtime type
2. **extensions.ts** - Pass `params.model` when setting up the runtime
3. **compaction-safeguard.ts** - Use `ctx.model ?? runtime?.model` with explicit warning if both are undefined

## Testing

- [x] Tested locally on active Moltbot instance
- [x] Build passes (`pnpm build`)
- [x] Linter

## AI Disclosure

🤖 This fix was developed with Claude (Opus 4.5) assistance. The code changes were reviewed and tested on a live instance before submission.

Fixes #2851
Related: #2656

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes compaction summarization in the embedded runner path by threading the selected `model` through the session-scoped runtime registry used by the compaction safeguard. `buildEmbeddedExtensionPaths` now stores `{ maxHistoryShare, model }` in the compaction runtime, and the safeguard extension uses `ctx.model ?? runtime.model` (with a warning when neither is available) so summarization can still proceed when the extension runner never called `initialize()`.

This fits into the existing pattern used by other extensions (e.g. context-pruning) that rely on a WeakMap registry keyed by `sessionManager` to pass runner-specific runtime configuration into PI extensions.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, localized change that improves model resolution for compaction safeguard.
- Changes are limited to adding `model` to an existing runtime registry and using it as a fallback when `ctx.model` is undefined. Behavior is straightforward and guarded by existing fallbacks; main residual risk is added type coupling and potential log noise from the new warning.
- src/agents/pi-extensions/compaction-safeguard-runtime.ts (type coupling), src/agents/pi-extensions/compaction-safeguard.ts (logging behavior)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->