### PR TITLE
Fix: avoid double inline replies

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.handles-inline-commands-strips-it-before-agent.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.handles-inline-commands-strips-it-before-agent.e2e.test.ts
@@ -160,6 +160,35 @@ describe("trigger handling", () => {
       expect(text).toBe("ok");
     });
   });
+  it("returns a single reply for envelope-prefixed /help", async () => {
+    await withTempHome(async (home) => {
+      const blockReplies: Array<{ text?: string }> = [];
+      const res = await getReplyFromConfig(
+        {
+          Body: "[Signal] T: /help",
+          RawBody: "/help",
+          CommandBody: "/help",
+          From: "+1002",
+          To: "+2000",
+          Provider: "signal",
+          Surface: "signal",
+          SenderName: "T",
+          SenderId: "signal:+1002",
+          CommandAuthorized: true,
+        },
+        {
+          onBlockReply: async (payload) => {
+            blockReplies.push(payload);
+          },
+        },
+        makeCfg(home),
+      );
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(blockReplies.length).toBe(0);
+      expect(text).toContain("Help");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
   it("drops /status for unauthorized senders", async () => {
     await withTempHome(async (home) => {
       const cfg = {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -11,6 +11,7 @@ import type { InlineDirectives } from "./directive-handling.js";
 import { isDirectiveOnly } from "./directive-handling.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
+import { stripStructuralPrefixes } from "./mentions.js";
 import type { TypingController } from "./typing.js";
 import { listSkillCommandsForWorkspace, resolveSkillCommandInvocation } from "../skill-commands.js";
 import { logVerbose } from "../../globals.js";
@@ -297,7 +298,8 @@ export async function handleInlineActions(params: {
       skillCommands,
     });
     if (inlineResult.reply) {
-      if (!inlineCommand.cleaned) {
+      const cleanedAfterStrip = stripStructuralPrefixes(inlineCommand.cleaned);
+      if (!cleanedAfterStrip) {
         typing.cleanup();
         return { kind: "reply", reply: inlineResult.reply };
       }


### PR DESCRIPTION
 ## Summary
  This fixes a double‑reply bug for inline slash commands like `/help` when the inbound message body is wrapped with an envelope/
  sender prefix (e.g. `T: /help`).

  ## Bug
  When the body includes an envelope prefix, the inline command path matches `/help` and sends an inline reply. However, the cleaned
  body still contains only structural text (`T:` / `[Signal]`), so the normal command handler runs as well. That results in two
  identical replies for a single inbound message.

  ## Root Cause
  `extractInlineSimpleCommand` strips the `/help` token but leaves envelope scaffolding behind. The inline handler only
  short‑circuited when the cleaned body was empty, so envelope‑only leftovers caused a second command pass.

  ## Fix
  Before deciding whether to short‑circuit, the inline handler now strips structural prefixes from the cleaned body. If only envelope
  text remains, it is treated as empty and the handler returns the inline reply immediately, avoiding the second command path.

  ## Tests
  Added an e2e test that simulates an envelope‑prefixed `/help` and asserts:
  - only one reply is produced
  - no agent run is triggered
  
  Note: coded with assistance of gpt-5.2-codex. Tested by running the e2e test, and also by installing my branch into a VM and verifying that `/help` only returned one reply and not two after the change. Nothing else seemed affected. 