### PR TITLE
docs: update .env.example with modern channel examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,57 @@
-# Copy to .env and fill with your Twilio credentials
-TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-TWILIO_AUTH_TOKEN=your_auth_token_here
-# Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:
-TWILIO_WHATSAPP_FROM=whatsapp:+17343367101
+# Moltbot Environment Variables Example
+# Copy this file to .env and fill in your credentials
+# Most settings can also be configured in ~/.clawdbot/moltbot.json
+
+# =============================================================================
+# CHANNELS - Configure your messaging platforms
+# =============================================================================
+
+# Telegram Bot
+# Get your bot token from @BotFather on Telegram
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+
+# Discord Bot
+# Create a bot at https://discord.com/developers/applications
+DISCORD_BOT_TOKEN=your_discord_bot_token_here
+
+# Slack Bot (requires both tokens)
+# Create a Slack app at https://api.slack.com/apps
+SLACK_BOT_TOKEN=your_slack_bot_token_here
+SLACK_APP_TOKEN=your_slack_app_token_here
+
+# =============================================================================
+# AI MODEL PROVIDERS - API keys for AI capabilities
+# =============================================================================
+
+# Anthropic (Claude) - Recommended primary model
+# Get your API key from https://console.anthropic.com/
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# OpenAI (GPT, DALL-E, Whisper)
+# Get your API key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Google Gemini (optional)
+# Get your API key from https://aistudio.google.com/apikey
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# =============================================================================
+# OPTIONAL SERVICES
+# =============================================================================
+
+# Brave Search (for web search capabilities)
+# Get your API key from https://brave.com/search/api/
+BRAVE_API_KEY=your_brave_api_key_here
+
+# ElevenLabs (for voice/TTS features)
+# Get your API key from https://elevenlabs.io/
+ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
+
+# =============================================================================
+# LEGACY / DEPRECATED
+# =============================================================================
+
+# Twilio (legacy WhatsApp integration - consider using Baileys instead)
+# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_AUTH_TOKEN=your_auth_token_here
+# TWILIO_WHATSAPP_FROM=whatsapp:+17343367101


### PR DESCRIPTION
## Summary
Updates `.env.example` from legacy Twilio-only configuration to a comprehensive modern setup guide.

## Changes
- ✨ Added examples for current primary channels: Telegram, Discord, Slack
- ✨ Added examples for AI providers: Anthropic (Claude), OpenAI, Google Gemini
- ✨ Added examples for optional services: Brave Search, ElevenLabs
- 📝 Added helpful comments with links to get API keys
- 🗑️ Marked legacy Twilio config as deprecated
- 🎨 Organized into clear sections for better readability

## Motivation
The existing `.env.example` only showed Twilio WhatsApp configuration, which is now deprecated in favor of Baileys. New users need examples for:
- Modern messaging channels (Telegram, Discord, Slack are the most popular)
- AI provider setup (Anthropic/Claude is the recommended primary model)
- Optional features like web search and TTS

This makes onboarding significantly easier by showing all available environment variables with context.

## Testing
- Verified format and structure
- All links to API key sources are valid
- Comments are clear and helpful

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change