### PR TITLE
fix: align minimax base url and discord target typing

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -17,7 +17,7 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<MoltbotConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
-const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
+const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;

--- a/src/discord/targets.ts
+++ b/src/discord/targets.ts
@@ -5,12 +5,11 @@ import {
   type MessagingTarget,
   type MessagingTargetKind,
   type MessagingTargetParseOptions,
-  type DirectoryConfigParams,
-  type ChannelDirectoryEntry,
 } from "../channels/targets.js";
 
+import type { DirectoryConfigParams } from "../channels/plugins/directory-config.js";
+
 import { listDiscordDirectoryPeersLive } from "./directory-live.js";
-import { resolveDiscordAccount } from "./accounts.js";
 
 export type DiscordTargetKind = MessagingTargetKind;
 
@@ -76,7 +75,7 @@ export function resolveDiscordChannelId(raw: string): string {
  */
 export async function resolveDiscordTarget(
   raw: string,
-  options: DirectoryConfigParams,
+  options: DirectoryConfigParams & DiscordTargetParseOptions,
 ): Promise<MessagingTarget | undefined> {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
@@ -101,7 +100,7 @@ export async function resolveDiscordTarget(
       const userId = match.id.replace(/^user:/, "");
       return buildMessagingTarget("user", userId, trimmed);
     }
-  } catch (error) {
+  } catch {
     // Directory lookup failed - fall through to parse as-is
     // This preserves existing behavior for channel names
   }

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -13,8 +13,12 @@ describe("resolveTelegramForumThreadId", () => {
   });
 
   it("returns undefined for non-forum groups without messageThreadId", () => {
-    expect(resolveTelegramForumThreadId({ isForum: false, messageThreadId: undefined })).toBeUndefined();
-    expect(resolveTelegramForumThreadId({ isForum: undefined, messageThreadId: 99 })).toBeUndefined();
+    expect(
+      resolveTelegramForumThreadId({ isForum: false, messageThreadId: undefined }),
+    ).toBeUndefined();
+    expect(
+      resolveTelegramForumThreadId({ isForum: undefined, messageThreadId: 99 }),
+    ).toBeUndefined();
   });
 
   it("returns General topic (1) for forum groups without messageThreadId", () => {


### PR DESCRIPTION
## Summary
- align MiniMax default base URL to the Anthropic-compatible endpoint
- fix Discord target typing/imports after directory lookup change

## Testing
- pnpm lint
- pnpm test
- pnpm build
