### PR TITLE
fix(ui): improve active button contrast in light mode

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -344,6 +344,15 @@
   color: var(--text);
 }
 
+/* Active state for icon buttons in light mode — without this override the
+   white .btn--icon background (specificity) masks the generic .btn.active
+   orange tint, making on/off states visually identical.  See #2832. */
+:root[data-theme="light"] .btn--icon.active {
+  background: rgba(245, 159, 74, 0.18);
+  border-color: rgba(245, 159, 74, 0.5);
+  color: rgba(16, 24, 40, 0.9);
+}
+
 .btn--icon svg {
   display: block;
   width: 18px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -510,6 +510,11 @@
   border-color: var(--accent);
 }
 
+:root[data-theme="light"] .btn.active {
+  background: rgba(245, 159, 74, 0.14);
+  border-color: rgba(245, 159, 74, 0.45);
+}
+
 /* ===========================================
    Utilities
    =========================================== */


### PR DESCRIPTION
## Summary

Fix the "Thinking" toggle (🧠) and other icon buttons in the dashboard chat toolbar being visually identical in on/off states when using light mode.

## Problem

In light mode, clicking the thinking toggle produces no visible change — users cannot tell whether thinking output is enabled or disabled without checking the footer status line.

**Root cause:** CSS specificity issue. The light-mode `.btn--icon` rule sets `background: rgba(255, 255, 255, 0.9)` (near-white), which overrides the generic `.btn.active` orange tint `rgba(245, 159, 74, 0.12)`. The active state also lacks a `border-color` change in light mode, removing the only other visual cue.

## Fix

Two changes:

1. **`ui/src/styles/chat/layout.css`** — Add `:root[data-theme="light"] .btn--icon.active` with explicit orange background + border, overriding the white `.btn--icon` base at the correct specificity level.

2. **`ui/src/styles/components.css`** — Add `border-color` to `:root[data-theme="light"] .btn.active` so all active buttons (not only icon buttons) have a visible border change in light mode.

## Before / After

| State | Before | After |
|-------|--------|-------|
| Light mode inactive | White bg, gray border | White bg, gray border |
| Light mode **active** | White bg, gray border ❌ (identical) | Orange tinted bg, orange border ✅ |
| Dark mode active | Orange tinted (already correct) | No change |

## Testing

- `pnpm ui:build` — ✅ builds successfully
- Lint — ✅ 0 warnings, 0 errors
- Dark mode unaffected (new rules scoped to `[data-theme="light"]`)

## Checklist

- [x] Follows CONTRIBUTING.md guidelines
- [x] Focused single-issue PR
- [x] Build verified
- [x] Lint clean

Closes #2832