### PR TITLE
fix(skills): skills-created definition add secrets handling guidance

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -98,6 +98,16 @@ Files not intended to be loaded into context, but rather used within the output 
 - **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
 - **Benefits**: Separates output resources from documentation, enables Codex to use files without loading them into context
 
+#### Secrets & Credentials
+
+**NEVER hardcode secrets automatically**—only if user explicitly requests it. Scripts must look up secrets dynamically: config → env → error.
+
+```bash
+VALUE=$(jq -r '.skills.entries["skill-name"].apiKey // empty' ~/.clawdbot/clawdbot.json)
+VALUE="${VALUE:-$SKILL_NAME_API_KEY}"
+[[ -z "$VALUE" ]] && echo "Error: Set skills.entries.skill-name.apiKey in config or SKILL_NAME_API_KEY env var" && exit 1
+```
+
 #### What to Not Include in a Skill
 
 A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -100,13 +100,16 @@ Files not intended to be loaded into context, but rather used within the output 
 
 #### Secrets & Credentials
 
-**NEVER hardcode secrets automatically**—only if user explicitly requests it. Scripts must look up secrets dynamically: config → env → error.
+**NEVER hardcode secrets automatically.** Look up secrets dynamically based on skill type:
 
+**Clawdbot-native skills** (no external CLI): Use config → env → error:
 ```bash
 VALUE=$(jq -r '.skills.entries["skill-name"].apiKey // empty' ~/.clawdbot/clawdbot.json)
 VALUE="${VALUE:-$SKILL_NAME_API_KEY}"
 [[ -z "$VALUE" ]] && echo "Error: Set skills.entries.skill-name.apiKey in config or SKILL_NAME_API_KEY env var" && exit 1
 ```
+
+**Skills wrapping external tools**: Source from `~/.config/<tool>/` (XDG convention). If the tool works standalone without Clawdbot, its credentials belong outside Clawdbot's config.
 
 #### What to Not Include in a Skill
 


### PR DESCRIPTION
## Summary
- Add explicit rule that skills must never hardcode secrets automatically
- Include config → env → error lookup pattern for scripts that need API keys/tokens
- Fix heading level for "What to Not Include" section

🦞 Generated with assistance from Claude Code