### PR TITLE
fix(gateway): use canonical session key in chat.send

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -362,7 +362,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
-    const { cfg, entry } = loadSessionEntry(p.sessionKey);
+    const { cfg, entry, canonicalKey } = loadSessionEntry(p.sessionKey);
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,
@@ -449,7 +449,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         BodyForCommands: commandBody,
         RawBody: parsedMessage,
         CommandBody: commandBody,
-        SessionKey: p.sessionKey,
+        SessionKey: canonicalKey,
         Provider: INTERNAL_MESSAGE_CHANNEL,
         Surface: INTERNAL_MESSAGE_CHANNEL,
         OriginatingChannel: INTERNAL_MESSAGE_CHANNEL,


### PR DESCRIPTION
Fixes session key mismatch where `chat.send` used raw key (e.g. `"main"`) but `chat.history` used canonical key (e.g. `"agent:main:main"`), causing messages to be written to one session but read from another.

This affected:
- iOS app chat (messages not appearing in history)
- TUI chat output (no assistant responses shown)

The fix uses `canonicalKey` from `loadSessionEntry()` instead of the raw `p.sessionKey` when building the `MsgContext`.

Fixes #2493

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a session key mismatch in `chat.send` by using the canonical session key returned by `loadSessionEntry()` when constructing the `MsgContext`. This aligns `chat.send` with `chat.history`/session storage behavior so messages written during send are appended to the same session that history reads from.

The change is localized to the gateway RPC handler (`src/gateway/server-methods/chat.ts`) and affects how inbound chat messages are attributed to a session when dispatched into the auto-reply pipeline.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the change is small and fixes a real session key mismatch, with a remaining risk of inconsistent use of raw vs canonical keys in adjacent control-plane logic.
- The core fix (using `canonicalKey` for `MsgContext.SessionKey`) matches the session store’s canonicalization behavior and should resolve the reported history mismatch. Remaining concern is that other parts of `chat.send` still use the raw session key (send policy evaluation, abort/broadcast bookkeeping), which can lead to edge-case inconsistencies if callers mix alias and canonical keys.
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->