### PR TITLE
fix: skip incomplete tool calls in transcript repair [AI-assisted]

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -5,6 +5,35 @@ type ToolCallLike = {
   name?: string;
 };
 
+/**
+ * Check whether a tool call block is incomplete (terminated mid-stream).
+ *
+ * When a streaming response is interrupted (`stopReason: "error"`,
+ * `errorMessage: "terminated"`), the assistant message may contain tool call
+ * blocks with only `partialJson` and no valid `arguments`.  These were never
+ * executed, so inserting a synthetic `toolResult` for them causes Anthropic's
+ * API to reject the request with "unexpected tool_use_id".
+ *
+ * We detect incompleteness by checking:
+ *   1. `partialJson` is present (streaming was in progress), AND
+ *   2. `arguments` is missing, empty, or not a non-empty object.
+ *
+ * If `arguments` is fully populated the call completed successfully and should
+ * be treated normally, even if `partialJson` happens to be set.
+ */
+function isIncompleteToolCall(block: Record<string, unknown>): boolean {
+  if (typeof block.partialJson !== "string" || !block.partialJson) return false;
+
+  const args = block.arguments;
+  // No arguments at all → incomplete
+  if (args === undefined || args === null) return true;
+  // Empty object {} → incomplete (arguments were not parsed)
+  if (typeof args === "object" && !Array.isArray(args) && Object.keys(args as object).length === 0)
+    return true;
+
+  return false;
+}
+
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
@@ -18,6 +47,10 @@ function extractToolCallsFromAssistant(
     if (typeof rec.id !== "string" || !rec.id) continue;
 
     if (rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall") {
+      // Skip incomplete tool calls from terminated/errored streaming responses.
+      // These were never executed, so they must not receive a synthetic toolResult.
+      if (isIncompleteToolCall(rec as Record<string, unknown>)) continue;
+
       toolCalls.push({
         id: rec.id,
         name: typeof rec.name === "string" ? rec.name : undefined,
@@ -54,7 +87,7 @@ function makeMissingToolResult(params: {
   } as Extract<AgentMessage, { role: "toolResult" }>;
 }
 
-export { makeMissingToolResult };
+export { isIncompleteToolCall, makeMissingToolResult };
 
 export function sanitizeToolUseResultPairing(messages: AgentMessage[]): AgentMessage[] {
   return repairToolUseResultPairing(messages).messages;


### PR DESCRIPTION
## Summary

When a streaming response is terminated mid-tool-call (e.g. `stopReason: "error"`, `errorMessage: "terminated"`), the assistant message contains tool call blocks with `partialJson` but **no valid `arguments`**. The existing `repairToolUseResultPairing()` treats these as complete tool calls and inserts synthetic error `toolResult` messages. On the next API call, Anthropic rejects the request with **"unexpected tool_use_id"** — corrupting the session permanently.

This PR adds an `isIncompleteToolCall()` check that detects terminated tool calls by verifying:
1. `partialJson` is present (streaming was in progress), **AND**
2. `arguments` is missing, `null`, or an empty `{}` object

Incomplete tool calls are **skipped during extraction** so no synthetic result is generated, while the block itself **remains in the assistant message** — preserving conversational context for the model.

## How this differs from existing approaches

| Approach | Behavior | Trade-off |
|----------|----------|-----------|
| Skip entire assistant msg on `stopReason: "error"` (#1859) | Drops all text content from the turn | Too coarse — loses legitimate text |
| Remove incomplete block from content array (#2253) | Mutates the assistant message | Loses debugging context |
| **This PR: skip from tool call extraction only** | Block stays, no synthetic result generated | Surgical — preserves context, no mutation |

## Changes

- **`session-transcript-repair.ts`**: Added `isIncompleteToolCall()` function; modified `extractToolCallsFromAssistant()` to skip incomplete tool calls; exported `isIncompleteToolCall` for testing
- **`session-transcript-repair.test.ts`**: Added 9 new tests (5 for `sanitizeToolUseResultPairing`, 4 for `isIncompleteToolCall`)

## Test plan

- [x] All 13 tests pass (4 existing + 9 new)
- [x] Verified against real corrupted session data from production — incomplete tool calls correctly skipped, no `toolResult` emitted
- [x] Complete tool calls with `partialJson` still work normally
- [x] Mixed complete + incomplete tool calls in same assistant message handled correctly
- [x] Linter passes (`npm run lint` — 0 warnings, 0 errors)
- [ ] Reviewers: verify no regressions in transcript repair for normal tool call flows

## AI Disclosure

🤖 This PR was AI-assisted (Claude Opus 4.5 via Claude Code). The contributor understands what the code does — the fix was designed after analyzing 4 existing open PRs (#1859, #2253, #2557, #2806) and real corrupted session data. **Fully tested** — 9 new tests + verified against production session files.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the transcript repair logic so that tool-call blocks that were cut off mid-stream (identified by `partialJson` present but `arguments` missing/empty) are ignored during tool-call extraction. That prevents generating synthetic `toolResult` entries for tool calls that never actually executed, which avoids downstream provider errors like “unexpected tool_use_id”. The change is localized to `extractToolCallsFromAssistant()` in `src/agents/session-transcript-repair.ts` and is covered by new Vitest cases in `src/agents/session-transcript-repair.test.ts` for incomplete vs complete tool calls (including mixed messages).

<h3>Confidence Score: 3/5</h3>

- This PR is probably safe to merge, but the new incompleteness heuristic may drop legitimate tool calls in some schemas.
- The change is small and well-tested for the targeted “partialJson + missing args” termination scenario, but treating `arguments: {}` as incomplete based solely on `partialJson` risks false positives for tools that legitimately accept empty objects (and the existing tests commonly model tool calls that way). That could cause real tool results to be dropped as orphans in repaired transcripts.
- src/agents/session-transcript-repair.ts (incompleteness heuristic); src/agents/session-transcript-repair.test.ts (ensure coverage for tools where empty args are valid).

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->