### PR TITLE
docs: clarify auth-profiles.json format for Claude Max setup-tokens

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -44,6 +44,59 @@ Legacy import-only file (still supported, but not the main store):
 
 All of the above also respect `$CLAWDBOT_STATE_DIR` (state dir override). Full reference: [/gateway/configuration](/gateway/configuration#auth-storage-oauth--api-keys)
 
+## auth-profiles.json format
+
+The `auth-profiles.json` file stores credentials. There are three credential types:
+
+### Setup-token (for Claude Max/Pro subscriptions)
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "anthropic:default": {
+      "type": "token",
+      "provider": "anthropic",
+      "token": "sk-ant-oat01-..."
+    }
+  }
+}
+```
+
+### API key
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "anthropic:default": {
+      "type": "api_key",
+      "provider": "anthropic",
+      "key": "sk-ant-api03-..."
+    }
+  }
+}
+```
+
+### OAuth (for providers with OAuth flow)
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "openai:default": {
+      "type": "oauth",
+      "provider": "openai",
+      "accessToken": "...",
+      "refreshToken": "...",
+      "expires": 1704067200000
+    }
+  }
+}
+```
+
+**Important:** For Anthropic setup-tokens, always use `type: "token"` with `token` field. Using `type: "oauth"` with `accessToken` will fail.
+
 ## Anthropic setup-token (subscription auth)
 
 Run `claude setup-token` on any machine, then paste it into Moltbot:

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -96,6 +96,27 @@ moltbot onboard --auth-choice setup-token
 }
 ```
 
+### Manual auth-profiles.json setup
+
+If you're configuring credentials manually, the setup-token must use `type: "token"` (not `"oauth"`):
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "anthropic:default": {
+      "type": "token",
+      "provider": "anthropic",
+      "token": "sk-ant-oat01-..."
+    }
+  }
+}
+```
+
+**Common mistake:** Using `type: "oauth"` with `accessToken` will fail silently. Setup-tokens require `type: "token"` with a `token` field.
+
+File location: `~/.clawdbot/agents/<agentId>/agent/auth-profiles.json`
+
 ## Notes
 
 - Generate the setup-token with `claude setup-token` and paste it, or run `moltbot models auth setup-token` on the gateway host.


### PR DESCRIPTION
Fixes #3098

## Summary
   - Add explicit `auth-profiles.json` format examples for setup-tokens in `docs/providers/anthropic.md`
   - Add comprehensive credential type examples in `docs/concepts/oauth.md`
   - Clarify that setup-tokens require `type: "token"` (not `"oauth"`)

   ## The Problem
   When configuring `auth-profiles.json` manually for Claude Max/Pro setup-tokens, using `type: "oauth"` with
   `accessToken` fails silently. The correct format is:

   ```json
   {
     "type": "token",
     "provider": "anthropic",
     "token": "sk-ant-oat01-..."
   }
   ```

   ## Test plan
   - [x] Verify JSON examples are syntactically correct
   - [x] Cross-reference with source types in `src/agents/auth-profiles/types.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the documentation to prevent misconfigurations when manually editing per-agent `auth-profiles.json`, especially for Anthropic Claude subscription “setup-token” auth. It adds explicit JSON examples for the three credential shapes used by the auth profile store (`api_key`, `token`, and `oauth`) in `docs/concepts/oauth.md`, and adds a dedicated “Manual auth-profiles.json setup” section to `docs/providers/anthropic.md` that clarifies setup-tokens must use `type: "token"` (not `"oauth"` / `accessToken`).

These changes align with the credential union in `src/agents/auth-profiles/types.ts` and should reduce silent failures from using the wrong credential type while keeping auth storage documentation centralized under the OAuth/token-sink concept.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are documentation-only with low operational risk.
- Edits are confined to docs and largely match the existing auth profile types, with only a small potential for minor schema drift in the OAuth example fields.
- docs/concepts/oauth.md (OAuth example field names)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->