### PR TITLE
fix: use .moltbot for device identity directory

### DIFF
--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -17,7 +17,7 @@ type StoredIdentity = {
   createdAtMs: number;
 };
 
-const DEFAULT_DIR = path.join(os.homedir(), ".clawdbot", "identity");
+const DEFAULT_DIR = path.join(os.homedir(), ".moltbot", "identity");
 const DEFAULT_FILE = path.join(DEFAULT_DIR, "device.json");
 
 function ensureDir(filePath: string) {


### PR DESCRIPTION
Fixes #3198

## Summary
   Change default device identity directory from `.clawdbot` to `.moltbot`.

   ## The Problem
   `src/infra/device-identity.ts` hardcodes `.clawdbot/identity` which causes the old directory to be recreated even
   for users who migrated to `.moltbot`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the default device identity storage directory in `src/infra/device-identity.ts` from `~/.clawdbot/identity` to `~/.moltbot/identity`, preventing the legacy `.clawdbot` identity directory from being re-created after users have migrated.

The change is localized to the default path constant used by `loadOrCreateDeviceIdentity()`, which is consumed by gateway/client initialization and related tests/helpers when no explicit identity path is provided.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge, with a small behavioral edge case around state-dir overrides.
- The change is a single constant update affecting where a file is read/written by default. The main concern is consistency with the repo’s broader state directory resolution (env overrides and legacy/new preference), which could lead to surprising identity location for users who rely on `MOLTBOT_STATE_DIR`/`CLAWDBOT_STATE_DIR` or migration behavior.
- src/infra/device-identity.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->