### PR TITLE
feat(slack): support multiple media files in a single message

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -498,7 +498,6 @@ export async function prepareSlackMessage(params: {
   }
 
   // Use thread starter media if current message has none
-  const effectiveMediaList = mediaList.length > 0 ? mediaList : threadStarterMediaList;
   const effectiveMediaPayload =
     mediaList.length > 0 ? mediaPayload : buildSlackMediaPayload(threadStarterMediaList);
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -44,7 +44,12 @@ import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-li
 import { resolveSlackEffectiveAllowFrom } from "../auth.js";
 import { resolveSlackChannelConfig } from "../channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
-import { resolveSlackMedia, resolveSlackThreadStarter } from "../media.js";
+import {
+  buildSlackMediaPayload,
+  resolveSlackMediaList,
+  resolveSlackThreadStarter,
+  type SlackMediaInfo,
+} from "../media.js";
 
 import type { PreparedSlackMessage } from "./types.js";
 
@@ -331,12 +336,13 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const media = await resolveSlackMedia({
+  const mediaList = await resolveSlackMediaList({
     files: message.files,
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
+  const mediaPayload = buildSlackMediaPayload(mediaList);
+  const rawBody = (message.text ?? "").trim() || mediaPayload.placeholder || "";
   if (!rawBody) return null;
 
   const ackReaction = resolveAckReaction(cfg, route.agentId);
@@ -453,7 +459,7 @@ export async function prepareSlackMessage(params: {
 
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
-  let threadStarterMedia: Awaited<ReturnType<typeof resolveSlackMedia>> = null;
+  let threadStarterMediaList: SlackMediaInfo[] = [];
   if (isThreadReply && threadTs) {
     const starter = await resolveSlackThreadStarter({
       channelId: message.channel,
@@ -474,15 +480,15 @@ export async function prepareSlackMessage(params: {
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
       threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
       // If current message has no files but thread starter does, fetch starter's files
-      if (!media && starter.files && starter.files.length > 0) {
-        threadStarterMedia = await resolveSlackMedia({
+      if (mediaList.length === 0 && starter.files && starter.files.length > 0) {
+        threadStarterMediaList = await resolveSlackMediaList({
           files: starter.files,
           token: ctx.botToken,
           maxBytes: ctx.mediaMaxBytes,
         });
-        if (threadStarterMedia) {
+        if (threadStarterMediaList.length > 0) {
           logVerbose(
-            `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,
+            `slack: hydrated ${threadStarterMediaList.length} thread starter file(s) from root message`,
           );
         }
       }
@@ -492,7 +498,9 @@ export async function prepareSlackMessage(params: {
   }
 
   // Use thread starter media if current message has none
-  const effectiveMedia = media ?? threadStarterMedia;
+  const effectiveMediaList = mediaList.length > 0 ? mediaList : threadStarterMediaList;
+  const effectiveMediaPayload =
+    mediaList.length > 0 ? mediaPayload : buildSlackMediaPayload(threadStarterMediaList);
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -519,9 +527,12 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: effectiveMedia?.path,
-    MediaType: effectiveMedia?.contentType,
-    MediaUrl: effectiveMedia?.path,
+    MediaPath: effectiveMediaPayload.MediaPath,
+    MediaType: effectiveMediaPayload.MediaType,
+    MediaUrl: effectiveMediaPayload.MediaUrl,
+    MediaPaths: effectiveMediaPayload.MediaPaths,
+    MediaUrls: effectiveMediaPayload.MediaUrls,
+    MediaTypes: effectiveMediaPayload.MediaTypes,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,


### PR DESCRIPTION
## Summary

Fixes #3211 - Slack messages with multiple images/files now correctly process all attachments, not just the first one.

## Changes

### `src/slack/monitor/media.ts`
- **New**: `resolveSlackMediaList()` - processes ALL files and returns an array
- **New**: `buildSlackMediaPayload()` - builds both singular (`MediaPath`) and plural (`MediaPaths`) fields
- **Deprecated**: `resolveSlackMedia()` - kept for backwards compatibility, now wraps `resolveSlackMediaList()`

### `src/slack/monitor/message-handler/prepare.ts`
- Updated to use `resolveSlackMediaList()` instead of `resolveSlackMedia()`
- Now populates `MediaPaths`, `MediaUrls`, `MediaTypes` in the context payload
- Thread starter media also uses the new array-based approach

## Testing

- All 126 existing Slack tests pass
- TypeScript compiles without errors
- Mirrors the existing Discord implementation pattern

## Backwards Compatibility

- `MediaPath` (singular) is still set to the first file for backwards compatibility
- `resolveSlackMedia()` is deprecated but still works