### PR TITLE
[Bug]: Fix session_status tool validation when called with no arguments (#3226)

### DIFF
--- a/src/agents/clawdbot-tools.session-status.test.ts
+++ b/src/agents/clawdbot-tools.session-status.test.ts
@@ -104,6 +104,30 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("accepts undefined args and defaults to current session", async () => {
+    loadSessionStoreMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    loadSessionStoreMock.mockReturnValue({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = createMoltbotTools({ agentSessionKey: "main" }).find(
+      (candidate) => candidate.name === "session_status",
+    );
+    expect(tool).toBeDefined();
+    if (!tool) throw new Error("missing session_status tool");
+
+    // Test with undefined args (the issue scenario)
+    const result = await tool.execute("call1b", undefined as unknown as Record<string, unknown>);
+    const details = result.details as { ok?: boolean; statusText?: string };
+    expect(details.ok).toBe(true);
+    expect(details.statusText).toContain("Moltbot");
+    expect(details.statusText).toContain("🧠 Model:");
+  });
+
   it("errors for unknown session keys", async () => {
     loadSessionStoreMock.mockReset();
     updateSessionStoreMock.mockReset();


### PR DESCRIPTION
## Summary
Fixes #3226 - `session_status` tool now accepts calls with no arguments as documented.

## Problem
When LLM calls `session_status` without arguments, validation fails with "root: must be object" error, causing session to become unresponsive.

## Solution
- Allow `undefined` args by defaulting to empty object
- Default to current session when no sessionKey provided
- Update schema to explicitly handle empty objects
- Add test case for undefined args scenario

## Testing
- ✅ All existing tests pass
- ✅ New test added for undefined args case
- ✅ Lint and build successful

## AI-Assisted
This PR was created with AI assistance (Kiro CLI) and has been fully tested.

**Changes**: +36 lines, -8 lines
**Backward compatible**: Yes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `session_status` tool to tolerate being invoked with no arguments by defaulting `args` to `{}` inside `execute`, and adjusts sessionKey resolution to fall back to the current session when none is provided. It also tightens the TypeBox schema by disallowing additional properties, and adds a Vitest case that covers the `undefined`-args call path.

These changes fit into the existing agent tool pattern (`AnyAgentTool.execute` receiving untyped args and using `readStringParam`), while improving real-world robustness against LLM tool calls that omit parameters.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; changes are small and covered by a targeted test.
- The behavioral change is narrowly scoped (defaulting undefined args to an empty object and choosing a sensible sessionKey fallback) and matches the documented tool contract. Schema tightening to `additionalProperties: false` is consistent with existing TypeBox usage. The only notable improvement is making the new test avoid an awkward double-cast, but it doesn’t affect runtime correctness.
- src/agents/clawdbot-tools.session-status.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->