### PR TITLE
feat(whatsapp): add per-session ackReaction override

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -244,10 +244,12 @@ The global and per-account configurations can be overridden for specific session
 - `ackReaction`: `"always" | "mentions" | "never"`
   - `"always"`: Enables reactions (overrides global off/never).
   - `"never"`: Disables reactions (overrides global on/always/mentions).
-  - `"mentions"`: Enforces mention-only reactions.
+  - `"mentions"`: Enforces **strict** mention-only reactions (requires actual @mention, ignores group activation state).
   - Useful for disabling reactions in specific DMs (`"never"`) or forcing them in specific groups.
 
 > **Note:** Setting `"mentions"` on a DM session effectively disables reactions for that DM, since direct messages don't have @mentions. Use `"always"` or `"never"` for DMs.
+>
+> **Note:** Unlike the global `group: "mentions"` setting which respects group activation state, the session-level `"mentions"` override is strict and always requires an actual @mention.
 
 **Per-account override:**
 ```json

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -239,6 +239,16 @@ WhatsApp can automatically send emoji reactions to incoming messages immediately
   - `"mentions"`: React only when bot is @mentioned
   - `"never"`: Never react in groups
 
+**Per-session override:**
+The global and per-account configurations can be overridden for specific sessions (DMs or Groups) using session configuration (in `sessions.json`).
+- `ackReaction`: `"always" | "mentions" | "never"`
+  - `"always"`: Enables reactions (overrides global off/never).
+  - `"never"`: Disables reactions (overrides global on/always/mentions).
+  - `"mentions"`: Enforces mention-only reactions.
+  - Useful for disabling reactions in specific DMs (`"never"`) or forcing them in specific groups.
+
+> **Note:** Setting `"mentions"` on a DM session effectively disables reactions for that DM, since direct messages don't have @mentions. Use `"always"` or `"never"` for DMs.
+
 **Per-account override:**
 ```json
 {

--- a/src/channels/ack-reactions.test.ts
+++ b/src/channels/ack-reactions.test.ts
@@ -281,6 +281,20 @@ describe("shouldAckReactionForWhatsApp", () => {
         sessionMode: "mentions", // Session override ON (if mentioned)
       }),
     ).toBe(true);
+
+    // Session: MENTIONS is strict - does NOT bypass via groupActivated
+    expect(
+      shouldAckReactionForWhatsApp({
+        emoji: "👀",
+        isDirect: false,
+        isGroup: true,
+        directEnabled: true,
+        groupMode: "always",
+        wasMentioned: false, // Not mentioned
+        groupActivated: true, // But group is activated
+        sessionMode: "mentions", // Explicit mentions = strict, no bypass
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/channels/ack-reactions.test.ts
+++ b/src/channels/ack-reactions.test.ts
@@ -225,6 +225,63 @@ describe("shouldAckReactionForWhatsApp", () => {
       }),
     ).toBe(false);
   });
+  it("honors session overrides", () => {
+    // Session: NEVER overrides Global: ALWAYS
+    expect(
+      shouldAckReactionForWhatsApp({
+        emoji: "👀",
+        isDirect: false,
+        isGroup: true,
+        directEnabled: true,
+        groupMode: "always",
+        wasMentioned: false,
+        groupActivated: false,
+        sessionMode: "never",
+      }),
+    ).toBe(false);
+
+    // Session: ALWAYS overrides Global: NEVER
+    expect(
+      shouldAckReactionForWhatsApp({
+        emoji: "👀",
+        isDirect: false,
+        isGroup: true,
+        directEnabled: true,
+        groupMode: "never",
+        wasMentioned: false,
+        groupActivated: false,
+        sessionMode: "always",
+      }),
+    ).toBe(true);
+
+    // Session: MENTIONS in DM (effectively OFF unless mentioned, which is false)
+    expect(
+      shouldAckReactionForWhatsApp({
+        emoji: "👀",
+        isDirect: true,
+        isGroup: false,
+        directEnabled: true, // Globally enabled
+        groupMode: "mentions",
+        wasMentioned: false,
+        groupActivated: false,
+        sessionMode: "mentions", // Override to strict mentions
+      }),
+    ).toBe(false);
+
+    // Session: MENTIONS in Group (works if mentioned)
+    expect(
+      shouldAckReactionForWhatsApp({
+        emoji: "👀",
+        isDirect: false,
+        isGroup: true,
+        directEnabled: true,
+        groupMode: "never", // Global OFF
+        wasMentioned: true, // But mentioned
+        groupActivated: false,
+        sessionMode: "mentions", // Session override ON (if mentioned)
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("removeAckReactionAfterReply", () => {

--- a/src/channels/ack-reactions.ts
+++ b/src/channels/ack-reactions.ts
@@ -44,6 +44,7 @@ export function shouldAckReactionForWhatsApp(params: {
   if (params.sessionMode === "never") return false;
   if (params.sessionMode === "always") return true;
   if (params.sessionMode === "mentions") {
+    // Strict mention-only: explicit session override should not bypass via activation
     return shouldAckReaction({
       scope: "group-mentions",
       isDirect: params.isDirect,
@@ -52,7 +53,7 @@ export function shouldAckReactionForWhatsApp(params: {
       requireMention: true,
       canDetectMention: true,
       effectiveWasMentioned: params.wasMentioned,
-      shouldBypassMention: params.groupActivated,
+      // Note: intentionally not passing shouldBypassMention here
     });
   }
 

--- a/src/channels/ack-reactions.ts
+++ b/src/channels/ack-reactions.ts
@@ -36,8 +36,27 @@ export function shouldAckReactionForWhatsApp(params: {
   groupMode: WhatsAppAckReactionMode;
   wasMentioned: boolean;
   groupActivated: boolean;
+  sessionMode?: "always" | "mentions" | "never";
 }): boolean {
   if (!params.emoji) return false;
+
+  // Session override
+  if (params.sessionMode === "never") return false;
+  if (params.sessionMode === "always") return true;
+  if (params.sessionMode === "mentions") {
+    return shouldAckReaction({
+      scope: "group-mentions",
+      isDirect: params.isDirect,
+      isGroup: params.isGroup,
+      isMentionableGroup: true,
+      requireMention: true,
+      canDetectMention: true,
+      effectiveWasMentioned: params.wasMentioned,
+      shouldBypassMention: params.groupActivated,
+    });
+  }
+
+  // Config fallback
   if (params.isDirect) return params.directEnabled;
   if (!params.isGroup) return false;
   if (params.groupMode === "never") return false;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -54,6 +54,7 @@ export type SessionEntry = {
   authProfileOverride?: string;
   authProfileOverrideSource?: "auto" | "user";
   authProfileOverrideCompactionCount?: number;
+  ackReaction?: "always" | "mentions" | "never";
   groupActivation?: "mention" | "always";
   groupActivationNeedsSystemIntro?: boolean;
   sendPolicy?: "allow" | "deny";


### PR DESCRIPTION
## Summary
Allows controlling auto-reactions (ack emoji) per-session via sessions.json.

Session-level `ackReaction` can be set to `'always'`, `'mentions'`, or `'never'` to override global direct/group settings.

## Changes
- Add `sessionMode` parameter to `shouldAckReactionForWhatsApp`
- Load session config in `maybeSendAckReaction` to check for override
- Add `ackReaction` field to `SessionEntry` type
- Add tests for session override behavior
- Document per-session override in `whatsapp.md`

## Use Case
Useful for:
- Disabling reactions in specific DMs (`"never"`)
- Forcing reactions in specific groups (`"always"`)
- Enforcing mention-only reactions per-group (`"mentions"`)

## Example
```json
// sessions.json
{
  "agent:main:whatsapp:group:123456@g.us": {
    "ackReaction": "never"
  }
}
```
