### PR TITLE
Agents: add per-model fallbacks support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.molt.bot
 Status: beta.
 
 ### Changes
-- Agents: add per-model fallbacks support in `agents.defaults.models[...].fallbacks` to configure model-specific fallback chains.
 - Rebrand: rename the npm package/CLI to `moltbot`, add a `moltbot` compatibility shim, and move extensions to the `@moltbot/*` scope.
 - Commands: group /help and /commands output with Telegram paging. (#2504) Thanks @hougangdev.
 - macOS: limit project-local `node_modules/.bin` PATH preference to debug builds (reduce PATH hijacking risk).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.molt.bot
 Status: beta.
 
 ### Changes
+- Agents: add per-model fallbacks support in `agents.defaults.models[...].fallbacks` to configure model-specific fallback chains.
 - Rebrand: rename the npm package/CLI to `moltbot`, add a `moltbot` compatibility shim, and move extensions to the `@moltbot/*` scope.
 - Commands: group /help and /commands output with Telegram paging. (#2504) Thanks @hougangdev.
 - macOS: limit project-local `node_modules/.bin` PATH preference to debug builds (reduce PATH hijacking risk).

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -165,11 +165,18 @@ function resolveFallbackCandidates(params: {
 
   const modelFallbacks = (() => {
     if (params.fallbacksOverride !== undefined) return params.fallbacksOverride;
-    const model = params.cfg?.agents?.defaults?.model as
+
+    // Check for per-model fallbacks first
+    const key = modelKey(provider, model);
+    const modelConfig = params.cfg?.agents?.defaults?.models?.[key];
+    if (modelConfig?.fallbacks) return modelConfig.fallbacks;
+
+    // Fall back to global model.fallbacks
+    const modelCfg = params.cfg?.agents?.defaults?.model as
       | { fallbacks?: string[] }
       | string
       | undefined;
-    if (model && typeof model === "object") return model.fallbacks ?? [];
+    if (modelCfg && typeof modelCfg === "object") return modelCfg.fallbacks ?? [];
     return [];
   })();
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -16,6 +16,8 @@ export type AgentModelEntryConfig = {
   alias?: string;
   /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
   params?: Record<string, unknown>;
+  /** Per-model fallbacks (tried before global fallbacks). */
+  fallbacks?: string[];
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -37,6 +37,8 @@ export const AgentDefaultsSchema = z
             alias: z.string().optional(),
             /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
             params: z.record(z.string(), z.unknown()).optional(),
+            /** Per-model fallbacks (tried before global fallbacks). */
+            fallbacks: z.array(z.string()).optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
## Summary
Adds per-model fallbacks support in `agents.defaults.models[...].fallbacks` to configure model-specific fallback chains without changing the global primary model.

## Changes
- Type: Added `fallbacks?: string[]` to `AgentModelEntryConfig`
- Schema: Updated Zod validation to accept per-model fallbacks
- Logic: Per-model fallbacks take precedence over global `agents.defaults.model.fallbacks`
- Tests: Added 4 test cases covering per-model fallback scenarios
- Docs: Updated CHANGELOG with feature description

## Motivation
Users want to configure fallback chains for specific models (e.g., GLM-Air → ZAI GLM-Air → Claude Haiku) without setting that model as their global primary. This enables provider-specific fallback strategies.

## Example Configuration
```json
"agents": {
  "defaults": {
    "model": {
      "primary": "zai/glm-4.7"
    },
    "models": {
      "openrouter/z-ai/glm-4.5-air:free": {
        "alias": "GLM-Air",
        "fallbacks": [
          "zai/glm-4.5-air",
          "claude-haiku-4-5-20251001"
        ]
      },
      "zai/glm-4.5-air": {},
      "claude-haiku-4-5-20251001": {}
    }
  }
}
```

## Test Plan
- ✅ All existing model-fallback tests pass (23/23)
- ✅ Per-model fallbacks correctly override global fallbacks
- ✅ Empty per-model fallbacks array disables global fallbacks
- ✅ Fallbacks respect allowlist validation
- ✅ 429 rate limit errors trigger per-model fallback chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds support for specifying `fallbacks` on individual entries in `agents.defaults.models[...]`, updates the corresponding TypeScript types and Zod schema, and expands the model fallback test suite with cases covering per-model override/precedence behavior.

The change hooks into the existing `runWithModelFallback` candidate resolution flow by reading model-specific configuration before falling back to the global `agents.defaults.model.fallbacks` list, aiming to let users define provider/model-specific fallback chains without changing the global primary model.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a precedence bug that breaks the advertised empty-array override behavior.
- `resolveFallbackCandidates` treats an empty per-model `fallbacks: []` as falsy and falls back to global fallbacks, contradicting the intended semantics and tests; there is also a likely mismatch risk when looking up per-model config by un-normalized runtime provider/model keys.
- src/agents/model-fallback.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->