### PR TITLE
security(core): fix path validation bypasses (#3277) [AI-assisted]

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -13,4 +13,8 @@ RUN apt-get update \
     ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
+RUN useradd -m -s /bin/bash -u 1000 sandbox
+USER sandbox
+WORKDIR /home/sandbox
+
 CMD ["sleep", "infinity"]

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -56,7 +56,21 @@ function resolveTranscriptPath(params: {
   sessionFile?: string;
 }): string | null {
   const { sessionId, storePath, sessionFile } = params;
-  if (sessionFile) return sessionFile;
+  if (sessionFile) {
+    if (storePath) {
+      const storeDir = path.dirname(storePath);
+      const absSessionFile = path.resolve(storeDir, sessionFile);
+      const rel = path.relative(storeDir, absSessionFile);
+      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+        throw new Error("sessionFile escapes store directory");
+      }
+      return absSessionFile;
+    }
+    if (!path.isAbsolute(sessionFile)) {
+      throw new Error("sessionFile must be absolute when storePath is not set");
+    }
+    return sessionFile;
+  }
   if (!storePath) return null;
   return path.join(path.dirname(storePath), `${sessionId}.jsonl`);
 }

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -401,7 +401,8 @@ export class MemoryIndexManager {
       throw new Error("path required");
     }
     const absPath = path.resolve(this.workspaceDir, relPath);
-    if (!absPath.startsWith(this.workspaceDir)) {
+    const rel = path.relative(this.workspaceDir, absPath);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error("path escapes workspace");
     }
     const content = await fs.readFile(absPath, "utf-8");


### PR DESCRIPTION
## Summary
Fixes multiple path validation bypasses that could allow directory escape attacks.

## Problem
Several locations use `path.startsWith(baseDir)` for path validation. This is vulnerable because:
- If `baseDir` is `/tmp/foo`, path `/tmp/foobar/evil.txt` passes the check
- The string `/tmp/foobar` starts with `/tmp/foo` even though it is a different directory!

Additionally:
- Tar extraction had **zero** path validation
- Transcript `sessionFile` parameter was returned without any validation
- Docker sandbox runs as root

## Solution
Replace `startsWith()` with `path.relative()` validation:
```typescript
function isPathWithinBase(basePath: string, targetPath: string): boolean {
  const rel = path.relative(basePath, targetPath);
  return !rel.startsWith("..") && !path.isAbsolute(rel);
}
```

This correctly handles the prefix collision case because `path.relative("/tmp/foo", "/tmp/foobar")` returns `"../foobar"` which starts with `..`.

## Changes

| File | Change |
|------|--------|
| `src/infra/archive.ts` | Added `isPathWithinBase()` helper, fixed zip validation, added tar filter |
| `src/gateway/server-methods/chat.ts` | Validate `sessionFile` within store directory |
| `src/memory/manager.ts` | Replace `startsWith()` with `path.relative()` check |
| `Dockerfile.sandbox` | Add non-root `sandbox` user (UID 1000) |

## Testing
- ✅ Build passes (`pnpm build`)
- ⚠️ Lightly tested - manual verification of path validation logic
- No existing unit tests for these specific paths

## AI Disclosure
- **AI-assisted:** Yes (Claude/Clawdbot)
- **Testing level:** Lightly tested
- **Understanding:** Yes, I understand the `startsWith` vs `path.relative` difference and why this fix works

## References
- CWE-22: Path Traversal
- CWE-250: Execution with Unnecessary Privileges

Fixes #3277

🤖 Generated with [Claude Code](https://claude.ai/code) / Clawdbot