### PR TITLE
security(memory): fix workspace escape via path prefix collision [AI-assisted]

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -401,7 +401,8 @@ export class MemoryIndexManager {
       throw new Error("path required");
     }
     const absPath = path.resolve(this.workspaceDir, relPath);
-    if (!absPath.startsWith(this.workspaceDir)) {
+    const rel = path.relative(this.workspaceDir, absPath);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error("path escapes workspace");
     }
     const content = await fs.readFile(absPath, "utf-8");


### PR DESCRIPTION
## Summary
Prevent memory workspace escapes caused by path prefix collisions.

## Problem
The workspace boundary check used a string prefix match:

```ts
if (!absPath.startsWith(this.workspaceDir)) {
  throw new Error("path escapes workspace");
}
```

If `workspaceDir` is `/root/work`, a path like `/root/workspace/secrets.txt` passes because `/root/workspace` starts with `/root/work`.

## Solution
Use `path.relative()` to validate the resolved path is within the workspace:

```ts
const rel = path.relative(this.workspaceDir, absPath);
if (rel.startsWith("..") || path.isAbsolute(rel)) {
  throw new Error("path escapes workspace");
}
```

This correctly flags `/root/workspace/...` as escaping because the relative path is `../workspace/...`.

## Changes
- `src/memory/manager.ts`: replace `startsWith` boundary check with `path.relative` validation.

## Testing
- ✅ Build passes
- ⚠️ Lightly tested (manual verification)

## AI Disclosure
- **AI-assisted:** Yes (Claude/Clawdbot)
- **Testing level:** Lightly tested
- **Understanding confirmed:** Yes

Fixes #3277 (partial)
