### PR TITLE
fix(mentions): check mentionPatterns even when explicit mention is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Status: beta.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -4,9 +4,22 @@ import { matchesMentionWithExplicit } from "./mentions.js";
 describe("matchesMentionWithExplicit", () => {
   const mentionRegexes = [/\bclawd\b/i];
 
-  it("prefers explicit mentions when other mentions are present", () => {
+  it("checks mentionPatterns even when explicit mention is available", () => {
     const result = matchesMentionWithExplicit({
       text: "@clawd hello",
+      mentionRegexes,
+      explicit: {
+        hasAnyMention: true,
+        isExplicitlyMentioned: false,
+        canResolveExplicit: true,
+      },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when explicit is false and no regex match", () => {
+    const result = matchesMentionWithExplicit({
+      text: "<@999999> hello",
       mentionRegexes,
       explicit: {
         hasAnyMention: true,

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -90,7 +90,9 @@ export function matchesMentionWithExplicit(params: {
   const explicit = params.explicit?.isExplicitlyMentioned === true;
   const explicitAvailable = params.explicit?.canResolveExplicit === true;
   const hasAnyMention = params.explicit?.hasAnyMention === true;
-  if (hasAnyMention && explicitAvailable) return explicit;
+  if (hasAnyMention && explicitAvailable) {
+    return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
+  }
   if (!cleaned) return explicit;
   return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
 }

--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
@@ -135,7 +135,7 @@ describe("discord tool result dispatch", () => {
     expect(sendMock).toHaveBeenCalledTimes(1);
   }, 20_000);
 
-  it("skips guild messages when another user is explicitly mentioned", async () => {
+  it("accepts guild messages when mentionPatterns match even if another user is mentioned", async () => {
     const { createDiscordMessageHandler } = await import("./monitor.js");
     const cfg = {
       agents: {
@@ -211,8 +211,8 @@ describe("discord tool result dispatch", () => {
       client,
     );
 
-    expect(dispatchMock).not.toHaveBeenCalled();
-    expect(sendMock).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledTimes(1);
   }, 20_000);
 
   it("accepts guild reply-to-bot messages as implicit mentions", async () => {

--- a/src/slack/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/src/slack/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -392,7 +392,7 @@ describe("monitorSlackProvider tool results", () => {
     expect(replyMock.mock.calls[0][0].WasMentioned).toBe(true);
   });
 
-  it("skips channel messages when another user is explicitly mentioned", async () => {
+  it("accepts channel messages when mentionPatterns match even if another user is mentioned", async () => {
     slackTestState.config = {
       messages: {
         responsePrefix: "PFX",
@@ -433,8 +433,8 @@ describe("monitorSlackProvider tool results", () => {
     controller.abort();
     await run;
 
-    expect(replyMock).not.toHaveBeenCalled();
-    expect(sendMock).not.toHaveBeenCalled();
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(replyMock.mock.calls[0][0].WasMentioned).toBe(true);
   });
 
   it("treats replies to bot threads as implicit mentions", async () => {

--- a/src/telegram/bot.create-telegram-bot.accepts-group-messages-mentionpatterns-match-without-botusername.test.ts
+++ b/src/telegram/bot.create-telegram-bot.accepts-group-messages-mentionpatterns-match-without-botusername.test.ts
@@ -212,7 +212,7 @@ describe("createTelegramBot", () => {
     );
   });
 
-  it("skips group messages when another user is explicitly mentioned", async () => {
+  it("accepts group messages when mentionPatterns match even if another user is mentioned", async () => {
     onSpy.mockReset();
     const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
     replySpy.mockReset();
@@ -249,7 +249,8 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(replySpy).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy.mock.calls[0][0].WasMentioned).toBe(true);
   });
 
   it("keeps group envelope headers stable (sender identity is separate)", async () => {


### PR DESCRIPTION
## Summary
- Fix `mentionPatterns` being ignored when an explicit `<@USERID>` style mention exists in the message
- Previously, L93 in `src/auto-reply/reply/mentions.ts` returned early without checking `mentionRegexes`

## Test plan
- [x] Unit tests updated and passing
- [x] Integration tests for Discord, Slack, Telegram updated
- [x] `pnpm lint && pnpm build` passes