### PR TITLE
Fix potential subprocess hang by discarding stderr pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Security: restrict local path extraction in media parser to prevent LFI. (#4880)
 - Gateway: prevent token defaults from becoming the literal "undefined". (#4873) Thanks @Hisleren.
 - Control UI: fix assets resolution for npm global installs. (#4909) Thanks @YuriNachos.
+- macOS: avoid stderr pipe backpressure in gateway discovery. (#3304) Thanks @abhijeet117.
 - Telegram: normalize account token lookup for non-normalized IDs. (#5055) Thanks @jasonsschin.
 - Telegram: preserve delivery thread fallback and fix threadId handling in delivery context.
 - Telegram: fix HTML nesting for overlapping styles/links. (#4578) Thanks @ThanhNguyxn.

--- a/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -222,9 +222,9 @@ enum WideAreaGatewayDiscovery {
         process.executableURL = URL(fileURLWithPath: path)
         process.arguments = args
         let outPipe = Pipe()
-        let errPipe = Pipe()
         process.standardOutput = outPipe
-        process.standardError = errPipe
+        process.standardError = FileHandle.nullDevice
+
 
         do {
             try process.run()

--- a/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -223,8 +223,8 @@ enum WideAreaGatewayDiscovery {
         process.arguments = args
         let outPipe = Pipe()
         process.standardOutput = outPipe
+        // Avoid stderr pipe backpressure; we don't consume it.
         process.standardError = FileHandle.nullDevice
-
 
         do {
             try process.run()


### PR DESCRIPTION
The run() helper was piping stderr but never reading from it.
If a subprocess produced enough stderr output, the buffer could fill and cause the process to hang.

This change redirects stderr to FileHandle.nullDevice to prevent blocking and improve reliability.
