### PR TITLE
feat(providers): Add ZenMux as an AI Provider 🦞  [AI-Assisted]

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -277,6 +277,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     cerebras: "CEREBRAS_API_KEY",
     xai: "XAI_API_KEY",
     openrouter: "OPENROUTER_API_KEY",
+    zenmux: "ZENMUX_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
     "kimi-code": "KIMICODE_API_KEY",

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -20,7 +20,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "zenmux";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -113,6 +114,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "API key",
     choices: ["opencode-zen"],
   },
+  {
+    value: "zenmux",
+    label: "ZenMux",
+    hint: "API key",
+    choices: ["zenmux-api-key"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -183,6 +190,7 @@ export function buildAuthChoiceOptions(params: {
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
   });
+  options.push({ value: "zenmux-api-key", label: "ZenMux API key" });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });
   }

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -28,6 +28,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   minimax: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
+  "zenmux-api-key": "zenmux",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -15,6 +15,7 @@ import {
   OPENROUTER_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   ZAI_DEFAULT_MODEL_REF,
+  ZENMUX_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";
 import {
   buildKimiCodeModelDefinition,
@@ -131,6 +132,47 @@ export function applyOpenrouterConfig(cfg: MoltbotConfig): MoltbotConfig {
               }
             : undefined),
           primary: OPENROUTER_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+}
+
+export function applyZenmuxProviderConfig(cfg: MoltbotConfig): MoltbotConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[ZENMUX_DEFAULT_MODEL_REF] = {
+    ...models[ZENMUX_DEFAULT_MODEL_REF],
+    alias: models[ZENMUX_DEFAULT_MODEL_REF]?.alias ?? "ZenMux",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyZenmuxConfig(cfg: MoltbotConfig): MoltbotConfig {
+  const next = applyZenmuxProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: ZENMUX_DEFAULT_MODEL_REF,
         },
       },
     },

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -114,6 +114,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const ZENMUX_DEFAULT_MODEL_REF = "zenmux/openai/gpt-5.2";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {
@@ -135,6 +136,18 @@ export async function setOpenrouterApiKey(key: string, agentDir?: string) {
     credential: {
       type: "api_key",
       provider: "openrouter",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setZenmuxApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "zenmux:default",
+    credential: {
+      type: "api_key",
+      provider: "zenmux",
       key,
     },
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -18,6 +18,8 @@ export {
   applyVercelAiGatewayConfig,
   applyVercelAiGatewayProviderConfig,
   applyZaiConfig,
+  applyZenmuxConfig,
+  applyZenmuxProviderConfig,
 } from "./onboard-auth.config-core.js";
 export {
   applyMinimaxApiConfig,
@@ -45,9 +47,11 @@ export {
   setVeniceApiKey,
   setVercelAiGatewayApiKey,
   setZaiApiKey,
+  setZenmuxApiKey,
   writeOAuthCredentials,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   ZAI_DEFAULT_MODEL_REF,
+  ZENMUX_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";
 export {
   buildKimiCodeModelDefinition,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -31,6 +31,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "zenmux-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -71,6 +72,7 @@ export type OnboardOptions = {
   syntheticApiKey?: string;
   veniceApiKey?: string;
   opencodeZenApiKey?: string;
+  zenmuxApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
Adds https://zenmux.ai/ as a new AI provider with automatic model discovery, authentication, and onboarding support.                                                                                                
                                                                                                                                                                                                                      
  What is ZenMux?                                                                                                                                                                                                     
                                                                                                                                                                                                                      
  ZenMux is an AI model gateway/aggregator that provides unified access to multiple AI models through a single API. It offers:                                                                                        
  - Access to various AI models from different providers                                                                                                                                                              
  - Unified API compatible with OpenAI's format                                                                                                                                                                       
  - Transparent pricing with per-token costs                                                                                                                                                                          
  - Support for advanced features like reasoning, vision, and caching                                                                                                                                                 
                                                                                                                                                                                                                      
  What's New                                                                                                                                                                                                          
                                                                                                                                                                                                                      
  - Fetch available models from ZenMux API with pricing & capabilities                                                                                                                                                
  - ZenMux option in onboarding wizard                                                                                                                                                                                
  - Support as preferred provider                                                                                                                                                                                     
                                                                                                                                                                                                                      
  Testing                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - Onboarding flow with ZenMux selection                                                                                                                                                                             
  - Chat conversations using ZenMux models                                                                                                                                                                            
  - Discord channel message sending                                                                                                                                                                                   
                                                                                                                                                                                                                      
  AI-Assisted PR 🤖                                                                                                                                                                                                   
                                                                                                                                                                                                                      
  This PR was almost entirely written by Claude (Opus 4.5). Human provided requirements, reviewed code, and performed testing. The AI handled:                                                                        
  - ZenMux API integration & model discovery                                                                                                                                                                          
  - Pricing extraction logic                                                                                                                                                                                          
  - Onboarding flow modifications                                                                                                                                                                                     
  - Provider configuration wiring                                                                                                                                                                                     
                                                                                                                                                                                                                      
  All AI-generated code has been carefully reviewed to ensure correctness, security, and consistency with the codebase style. I understand what the code does and have verified it works end-to-end.                  
                                                                                                                                                                                                                      
  Key Prompts Used                                                                                                                                                                                                    
                                                                                                                                                                                                                      
  Initial request:                                                                                                                                                                                                    
  "I would like to add ZenMux as a 'Model/auth provider'. Reference to 'src/commands/auth-choice-prompt.ts' line 26, start your work."                                                                                
                                                                                                                                                                                                                      
  Model discovery:                                                                                                                                                                                                    
  "ZenMux does have an endpoint call 'https://zenmux.ai/api/v1/models'. The response format is like '{"data":[{"id":"...","display_name":"...","context_length":256000,"pricings":{...}}]}'"                          
                                                                                                                                                                                                                      
  Refinement:                                                                                                                                                                                                         
  "You did very well. But I just added the typings for 'pricing', so you can improve the 'cost' field"                                                                                                                
                                                                                                                                                                                                                      
  Testing:                                                                                                                                                                                                            
  "How do I test discord bot?"                                                                                                                                                                                        
                                                                                                                                                                                                                      
  "Send a test message to discord"                                                                                                                                                                                    
                                                                                                                                                                                                                      
  Code quality:                                                                                                                                                                                                       
  "Now 'ZenMux' is ranked before existing providers. It is more polite to put it at the end due to first come first serve rule" → "fix the code now"   