### PR TITLE
feat(telegram): add media group (album) support

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -45,6 +45,11 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
       Type.String({ description: "Alias for effectId (e.g., invisible-ink, balloons)." }),
     ),
     media: Type.Optional(Type.String()),
+    mediaUrls: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Array of media URLs to send as album/group (2-10 items, Telegram only).",
+      }),
+    ),
     filename: Type.Optional(Type.String()),
     buffer: Type.Optional(
       Type.String({

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -53,7 +53,6 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   },
   sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId }) => {
     const send = deps?.sendTelegram ?? sendMessageTelegram;
-    const sendGroup = deps?.sendMediaGroupTelegram ?? sendMediaGroupTelegram;
     const replyToMessageId = parseReplyToMessageId(replyToId);
     const messageThreadId = parseThreadId(threadId);
     const telegramData = payload.channelData?.telegram as
@@ -86,7 +85,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
 
     // Use media group (album) for 2-10 images - sends as a single album
     if (mediaUrls.length >= 2 && mediaUrls.length <= 10) {
-      const groupResult = await sendGroup(to, mediaUrls, text, {
+      const groupResult = await sendMediaGroupTelegram(to, mediaUrls, text, {
         messageThreadId,
         replyToMessageId,
         accountId: accountId ?? undefined,
@@ -101,7 +100,6 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       return {
         channel: "telegram",
         messageId: groupResult.messageIds[0] ?? "unknown",
-        messageIds: groupResult.messageIds,
         chatId: groupResult.chatId,
       };
     }
@@ -118,22 +116,5 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       });
     }
     return { channel: "telegram", ...(finalResult ?? { messageId: "unknown", chatId: to }) };
-  },
-  sendMediaGroup: async ({ to, mediaUrls, caption, accountId, deps, replyToId, threadId }) => {
-    const sendGroup = deps?.sendMediaGroupTelegram ?? sendMediaGroupTelegram;
-    const replyToMessageId = parseReplyToMessageId(replyToId);
-    const messageThreadId = parseThreadId(threadId);
-    const result = await sendGroup(to, mediaUrls, caption, {
-      messageThreadId,
-      replyToMessageId,
-      accountId: accountId ?? undefined,
-    });
-    // Return first message ID as the main one
-    return {
-      channel: "telegram",
-      messageId: result.messageIds[0] ?? "unknown",
-      messageIds: result.messageIds,
-      chatId: result.chatId,
-    };
   },
 };

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -85,7 +85,8 @@ export const telegramOutbound: ChannelOutboundAdapter = {
 
     // Use media group (album) for 2-10 images - sends as a single album
     if (mediaUrls.length >= 2 && mediaUrls.length <= 10) {
-      const groupResult = await sendMediaGroupTelegram(to, mediaUrls, text, {
+      const sendGroup = deps?.sendMediaGroup ?? sendMediaGroupTelegram;
+      const groupResult = await sendGroup(to, mediaUrls, text, {
         messageThreadId,
         replyToMessageId,
         accountId: accountId ?? undefined,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -47,6 +47,12 @@ export type OutboundSendDeps = {
     text: string,
     opts?: { mediaUrl?: string },
   ) => Promise<{ messageId: string; conversationId: string }>;
+  sendMediaGroup?: (
+    to: string,
+    mediaUrls: string[],
+    caption?: string,
+    opts?: { messageThreadId?: number; replyToMessageId?: number; accountId?: string },
+  ) => Promise<{ messageIds: string[]; chatId: string }>;
 };
 
 export type OutboundDeliveryResult = {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -646,6 +646,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     mergedMediaUrls.push(trimmed);
   };
   pushMedia(mediaHint);
+  // Read mediaUrls array from tool params (for album/media group support)
+  const paramMediaUrls = readStringArrayParam(params, "mediaUrls");
+  for (const url of paramMediaUrls ?? []) pushMedia(url);
   for (const url of parsed.mediaUrls ?? []) pushMedia(url);
   pushMedia(parsed.mediaUrl);
   message = parsed.text;

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -1,4 +1,4 @@
 export { createTelegramBot, createTelegramWebhookCallback } from "./bot.js";
 export { monitorTelegramProvider } from "./monitor.js";
-export { reactMessageTelegram, sendMessageTelegram } from "./send.js";
+export { reactMessageTelegram, sendMediaGroupTelegram, sendMessageTelegram } from "./send.js";
 export { startTelegramWebhook } from "./webhook.js";

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -745,7 +745,9 @@ export async function sendMediaGroupTelegram(
 
     // Media groups only support photos and videos
     if (kind !== "image" && kind !== "video" && !isGif) {
-      throw new Error(`Media group only supports photos and videos. Got: ${kind} for ${trimmedUrl}`);
+      throw new Error(
+        `Media group only supports photos and videos. Got: ${kind} for ${trimmedUrl}`,
+      );
     }
 
     const fileName = media.fileName ?? inferFilename(kind) ?? "file";
@@ -765,9 +767,7 @@ export async function sendMediaGroupTelegram(
   const mediaGroup = mediaItems.map((item, index) => ({
     type: item.type,
     media: item.media,
-    ...(index === 0 && htmlCaption
-      ? { caption: htmlCaption, parse_mode: "HTML" as const }
-      : {}),
+    ...(index === 0 && htmlCaption ? { caption: htmlCaption, parse_mode: "HTML" as const } : {}),
   }));
 
   const groupParams = {


### PR DESCRIPTION
## Summary

Adds support for sending multiple photos/videos as a Telegram album (media group).

## Changes

- New `sendMediaGroupTelegram` function in `telegram/send.ts`
- Telegram outbound adapter now automatically uses media groups for 2-10 images
- Message tool accepts `mediaUrls` array parameter
- Albums display as a single grouped message in Telegram

## Usage

```typescript
message(action='send', target='123', mediaUrls=['url1.jpg', 'url2.jpg'], caption='My album')
```

Or via the outbound payload with multiple `mediaUrls`.

## Limitations

- Telegram albums don't support inline buttons (sent as follow-up if present)
- Only photos and videos supported (no documents in albums)
- 2-10 items required for album mode; single items or >10 fall back to sequential sends

## Testing

Manual testing needed with Telegram bot.