### PR TITLE
fix: merge provider config api into registry model

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -239,4 +239,38 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("gpt-5.3-codex");
     expect(result.model?.provider).toBe("openai-codex");
   });
+  it("inherits provider api when registry model has no api (issue #1695)", () => {
+    const mockModel = {
+      id: "test-model",
+      name: "test-model",
+      provider: "lmstudio",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 4096,
+      maxTokens: 4096,
+      // No api field set
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn(() => mockModel),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const cfg = {
+      models: {
+        providers: {
+          lmstudio: {
+            api: "openai-responses",
+            baseUrl: "http://localhost:1234",
+          },
+        },
+      },
+    } as MoltbotConfig;
+
+    const result = resolveModel("lmstudio", "test-model", "/tmp/agent", cfg);
+
+    expect(result.model?.api).toBe("openai-responses");
+    expect(result.model?.id).toBe("test-model");
+    expect(result.model?.provider).toBe("lmstudio");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -221,5 +221,7 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  const providerCfg = cfg?.models?.providers?.[provider];
+  const merged = { ...model, api: model.api ?? providerCfg?.api };
+  return { model: normalizeModelCompat(merged), authStorage, modelRegistry };
 }


### PR DESCRIPTION
Fixes #1695

## Problem
When `modelRegistry.find()` returns a model, provider config `models.providers.*.api` was ignored — registry model was used as-is.

## Solution
Shallow clone + merge provider config api when `model.api` is missing.

## Changes
- `src/agents/pi-embedded-runner/model.ts` — 3 lines
- `src/agents/pi-embedded-runner/model.test.ts` — regression test

## Testing
All related tests pass ✓

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes #1695 by ensuring models returned from the Pi model registry inherit the provider-level `api` from `cfg.models.providers[provider]` when the registry model lacks an `api`. It does this by shallow-cloning the registry model, filling `api` via nullish-coalescing, and then passing the merged result through `normalizeModelCompat`.

A regression test was added in `src/agents/pi-embedded-runner/model.test.ts` to cover the scenario where `discoverModels().find()` returns a model without `api` and config specifies `models.providers.lmstudio.api`.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge, but there is a small chance provider config lookup misses normalized provider IDs.
- Change is narrowly scoped (one merge point + one regression test) and preserves precedence of registry model fields. Main concern is config lookup uses the raw provider key, which may not match the normalization used elsewhere (already used for inline models), potentially leaving some cases of #1695 unresolved.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->