### PR TITLE
Update Dockerfile to support Homebrew and Go for skill execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,31 @@ FROM node:22-bookworm
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
+# Install dependencies Start
+RUN apt-get update && apt-get install -y bash build-essential curl file git sudo
+
+## Create user for brew
+
+# 1. Create user (via /bin/sh)
+RUN /bin/sh -c "useradd -m -s /bin/bash linuxbrew && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
+
+USER linuxbrew
+
+# 2. Install Homebrew (via /bin/sh, calling bash for the script)
+RUN /bin/sh -c "curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash"
+
+# Setup paths
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
+RUN brew update
+# Now you can install go
+RUN brew install go
+
+# Install dependencies End
+
+# Switch back to superuser for system settings
+USER root
+
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
Description:

This PR introduces changes to the Dockerfile to include the installation of Homebrew and the Go programming language. These additions are required to ensure compatibility with specific skills that depend on the Go runtime or binaries managed via Homebrew.

Motivation:

Currently, the environment lacks the necessary tooling to run . 
To support the installation and execution of these skills, we need to:

Integrate Homebrew as a package manager.
Install the Go compiler and toolchain.
Technical Details:

Since Homebrew strictly refuses to run as the root user for security reasons, the installation process required the following structural changes:

User Creation: A dedicated user (linuxbrew) is created with a home directory and bash shell.
Sudo Privileges: The user is granted NOPASSWD sudo access. This is necessary because Homebrew scripts often require elevated permissions to create directories and symlinks in system locations during the installation process, even if the core installation happens in the user's home folder.
Installation: Homebrew is bootstrapped via the official install script, running under the linuxbrew user context.
Environment Setup: The PATH environment variable is updated to include /home/linuxbrew/.linuxbrew/bin and /home/linuxbrew/.linuxbrew/sbin, making brew and installed binaries (like go) globally accessible.
Go Installation: The go formula is installed via Homebrew.
Root Restoration: The Dockerfile switches back to the root user at the end. This ensures that any subsequent system-level configurations or the main container process can run with the expected default permissions.
Changes:

Added linuxbrew user setup.
Integrated Homebrew installation logic.
Installed Go (brew install go).
Configured environment variables for the new paths.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker build environment to support skills that rely on Homebrew-managed binaries and the Go toolchain. It installs additional Debian packages, creates a dedicated `linuxbrew` user to satisfy Homebrew’s non-root requirement, bootstraps Homebrew, adds brew paths to `PATH`, installs Go via brew, and then switches back to `root` before continuing the existing Node/Bun/corepack build steps.

The changes are confined to the `Dockerfile` and primarily affect image security posture (sudoers), reproducibility (unpinned `brew update`/installer), and image size/build determinism (apt layer cleanup).

<h3>Confidence Score: 3/5</h3>

- Moderate risk to merge due to security/reproducibility concerns in the Docker build steps.
- The functional intent is clear and limited to the Dockerfile, but the new passwordless sudo entry and unpinned Homebrew installer/update reduce security hardening and make builds non-deterministic; these are fixable with small Dockerfile adjustments.
- Dockerfile

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->