### PR TITLE
fix: respect groupPolicy when explicit group configs exist

### DIFF
--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -110,7 +110,13 @@ export function resolveChannelGroupPolicy(params: {
 }): ChannelGroupPolicy {
   const { cfg, channel } = params;
   const groups = resolveChannelGroups(cfg, channel, params.accountId);
-  const allowlistEnabled = Boolean(groups && Object.keys(groups).length > 0);
+  // Only enable allowlist when groupPolicy is explicitly "allowlist".
+  // This allows explicit group configs (e.g., requireMention) to coexist
+  // with groupPolicy: "open" without creating an implicit allowlist.
+  const channelConfig = cfg.channels?.[channel];
+  const groupPolicy = channelConfig?.groupPolicy ?? "open";
+  const allowlistEnabled =
+    groupPolicy === "allowlist" && Boolean(groups && Object.keys(groups).length > 0);
   const normalizedId = params.groupId?.trim();
   const groupConfig = normalizedId && groups ? groups[normalizedId] : undefined;
   const defaultConfig = groups?.["*"];


### PR DESCRIPTION
## Summary

Fixes #3323

Previously, having ANY explicit group config in `channels.<channel>.groups` would enable allowlist mode, blocking all groups not explicitly listed — even when `groupPolicy` was set to `'open'`.

## Changes

Modified `resolveChannelGroupPolicy()` in `src/config/group-policy.ts` to only enable allowlist when `groupPolicy === 'allowlist'`.

This allows explicit group configs (e.g., `requireMention` settings) to coexist with `groupPolicy: 'open'` without creating an implicit allowlist.

## Testing

1. Configure with `groupPolicy: 'open'` and one explicit group entry
2. Get mentioned in a different group (not in explicit config)
3. Bot now responds correctly

Verified working on Clawdbot 2026.1.24-3 with local patch.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes channel group allowlist behavior by gating allowlist enforcement on an explicit `groupPolicy: "allowlist"` setting, so that per-group configs (e.g. `requireMention`) can exist without implicitly blocking unlisted groups when `groupPolicy` is open.

This change is localized to `resolveChannelGroupPolicy()` in `src/config/group-policy.ts`, which is used by the downstream helpers (`resolveChannelGroupRequireMention`, `resolveChannelGroupToolsPolicy`) to decide whether a group is allowed and which group/default configs apply.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and targeted: it only alters how `allowlistEnabled` is computed, aligning behavior with the documented intent (only enforce allowlist when explicitly configured). It doesn’t change group config resolution or tool/mention logic beyond the allowlist gate.
- src/config/group-policy.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->