### PR TITLE
fix(compaction): inject workspace context into summarization

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,5 +1,6 @@
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
+  workspaceContext?: string;
 };
 
 // Session-scoped runtime registry keyed by object identity.


### PR DESCRIPTION
## Problem

After compaction, the agent loses workspace context (project names, user identity, ongoing tasks) because the summarization system uses a hardcoded generic prompt that has no knowledge of the workspace files.

## Root Cause

1. `compact.ts` resolves `contextFiles` but the `session_before_compact` event has no access to them
2. Summarization calls `summarizeInStages()` with only generic `customInstructions`
3. The summarizing LLM never sees AGENTS.md, TOOLS.md, MEMORY.md, USER.md, etc.

## Solution

This PR injects actual workspace file contents into the summarization prompt:

1. **`compaction-safeguard-runtime.ts`**: Add `workspaceContext?: string` to runtime type
2. **`compact.ts`**: Serialize contextFiles and store in runtime via `setCompactionSafeguardRuntime()`
3. **`compaction-safeguard.ts`**: Retrieve workspace context and inject into all summarization calls

## Changes

| File | Change |
|------|--------|
| `compaction-safeguard-runtime.ts` | +5 lines - Add `workspaceContext` to runtime type |
| `compact.ts` | +16 lines - Serialize and store contextFiles |
| `compaction-safeguard.ts` | +31/-3 lines - Inject context into summarization |

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| USER.md | Not visible to summarizer | Full content injected |
| AGENTS.md | Not visible | Full content injected |
| TOOLS.md | Not visible | Full content injected |
| MEMORY.md | Not visible | Full content injected |

The summarizing LLM now receives the actual workspace files, enabling it to generate summaries that preserve project context, user identity, and ongoing work items.

## Testing

- ✅ `compaction-safeguard.test.ts`: 17 tests passed
- ✅ `compaction.test.ts`: 7 tests passed
- ✅ Local testing with real workspace context
