### PR TITLE
fix(tts): read OPENAI_TTS_BASE_URL at runtime instead of module load

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -757,11 +757,19 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  * Custom OpenAI-compatible TTS endpoint.
  * When set, model/voice validation is relaxed to allow non-OpenAI models.
  * Example: OPENAI_TTS_BASE_URL=http://localhost:8880/v1
+ *
+ * Note: Read at runtime (not module load) to support config.env loading.
  */
-const OPENAI_TTS_BASE_URL = (
-  process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1"
-).replace(/\/+$/, "");
-const isCustomOpenAIEndpoint = OPENAI_TTS_BASE_URL !== "https://api.openai.com/v1";
+function getOpenAITtsBaseUrl(): string {
+  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+function isCustomOpenAIEndpoint(): boolean {
+  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
+}
 export const OPENAI_TTS_VOICES = [
   "alloy",
   "ash",
@@ -778,13 +786,13 @@ type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
 function isValidOpenAIModel(model: string): boolean {
   // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
-  if (isCustomOpenAIEndpoint) return true;
+  if (isCustomOpenAIEndpoint()) return true;
   return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
 }
 
 function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
   // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
-  if (isCustomOpenAIEndpoint) return true;
+  if (isCustomOpenAIEndpoint()) return true;
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
 }
 
@@ -1011,7 +1019,7 @@ async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${OPENAI_TTS_BASE_URL}/audio/speech`, {
+    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
## Summary

Fixes #2816

- Changed `OPENAI_TTS_BASE_URL` from module-level constant to `getOpenAITtsBaseUrl()` function
- Changed `isCustomOpenAIEndpoint` from constant to `isCustomOpenAIEndpoint()` function
- Allows config.env settings to take effect after gateway startup

## Root Cause

The TTS module reads `OPENAI_TTS_BASE_URL` at module import time as a constant, but `config.env` is loaded after modules are imported. This means custom OpenAI-compatible TTS endpoints (like Kokoro) were never used.

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line 763-771 | `const OPENAI_TTS_BASE_URL = ...` | `function getOpenAITtsBaseUrl(): string` |
| Line 769-771 | `const isCustomOpenAIEndpoint = ...` | `function isCustomOpenAIEndpoint(): boolean` |
| Line 792 | `if (isCustomOpenAIEndpoint)` | `if (isCustomOpenAIEndpoint())` |
| Line 798 | `if (isCustomOpenAIEndpoint)` | `if (isCustomOpenAIEndpoint())` |
| Line 1025 | `${OPENAI_TTS_BASE_URL}/audio/speech` | `${getOpenAITtsBaseUrl()}/audio/speech` |

## Test plan

- [x] TypeScript compiles without errors
- [x] CI tests pass
- [x] Behavior: Without env → default api.openai.com
- [x] Behavior: With env → uses custom URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)