### PR TITLE
docs(discord): note search does not support OR

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -345,7 +345,7 @@ Reaction notifications use `guilds.<id>.reactionNotifications`:
 | messages | enabled | Read/send/edit/delete |
 | threads | enabled | Create/list/reply |
 | pins | enabled | Pin/unpin/list |
-| search | enabled | Message search (preview feature) |
+| search | enabled | Message search (preview feature). Note: queries are simple keyword matching; don’t use boolean operators like `OR` — run multiple searches instead. |
 | memberInfo | enabled | Member info |
 | roleInfo | enabled | Role list |
 | channelInfo | enabled | Channel info + list |


### PR DESCRIPTION
Adds a small note to Discord channel docs that message search queries are simple keyword matching and do not support boolean operators like OR.