### PR TITLE
feat(ui): Escape key to stop generation + Delete session from Chat tab

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1484,3 +1484,52 @@
   flex-wrap: wrap;
   gap: 8px;
 }
+
+/* Chat delete confirmation modal */
+.chat-delete-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 100;
+  border-radius: var(--radius-lg);
+}
+
+.chat-delete-card {
+  width: min(400px, 100%);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  text-align: center;
+  animation: scale-in 0.15s var(--ease-out);
+}
+
+.chat-delete-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.chat-delete-sub {
+  color: var(--muted);
+  font-size: 13px;
+  margin-bottom: 16px;
+  word-break: break-word;
+}
+
+.chat-delete-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.chat-delete-hint {
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--muted);
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -496,6 +496,15 @@ export function renderApp(state: AppViewState) {
               onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
               assistantName: state.assistantName,
               assistantAvatar: state.assistantAvatar,
+              // Delete session
+              showDeleteConfirm: state.chatDeleteConfirm,
+              onDeleteClick: () => (state.chatDeleteConfirm = true),
+              onDeleteConfirm: async () => {
+                state.chatDeleteConfirm = false;
+                const { deleteSession } = await import("./controllers/sessions");
+                await deleteSession(state as Parameters<typeof deleteSession>[0], state.sessionKey);
+              },
+              onDeleteCancel: () => (state.chatDeleteConfirm = false),
             })
           : nothing}
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -128,6 +128,7 @@ export class MoltbotApp extends LitElement {
   @state() compactionStatus: import("./app-tool-stream").CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
+  @state() chatDeleteConfirm = false;
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
   // Sidebar state for tool output viewing


### PR DESCRIPTION
## Summary

Fixes #3376

Two quality-of-life improvements for the Chat tab:

### 1. Escape to Stop

Press `Escape` during generation to stop (same as clicking Stop button).

- Adds keydown listener on the chat section
- Shows `Esc` hint on the Stop button when generation is active
- Escape also closes the delete confirmation modal if open

### 2. Delete Session from Chat Tab

Delete button directly in the Chat tab with a confirmation modal.

- **Delete button** next to 'New session' button
- **Confirmation modal**: 'Delete this session?' with Cancel/Delete buttons
- **Keyboard shortcuts**: `Enter` = Delete, `Escape` = Cancel
- Button disabled during generation to prevent accidental deletion

## Changes

- `ui/src/ui/views/chat.ts`: Add keydown handler, delete modal, delete button
- `ui/src/ui/app.ts`: Add `chatDeleteConfirm` state
- `ui/src/ui/app-render.ts`: Wire up delete props
- `ui/src/styles/components.css`: Styles for delete confirmation modal

## Screenshots

(Manual testing recommended - keyboard shortcuts are hard to screenshot)

## Testing

1. Start a generation (send a message)
2. Press Escape → generation should stop
3. Click Delete button → modal appears
4. Press Enter → session deleted
5. Click Delete → press Escape → modal closes