### PR TITLE
docs: improve CLAUDE.md with overview and single test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,20 @@
-# Repository Guidelines
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Moltbot is a multi-channel AI assistant gateway that connects messaging platforms (WhatsApp, Telegram, Discord, Slack, Signal, iMessage, LINE, and more) to AI models. It runs as a local gateway (CLI or macOS menubar app) and routes messages between users and AI agents.
+
+**Core architecture:**
+- **Gateway** (`src/gateway/`): WebSocket server handling client connections, chat sessions, and channel routing
+- **Channels** (`src/telegram/`, `src/discord/`, `src/slack/`, `src/signal/`, `src/imessage/`, `src/web/`, `src/line/`): Platform-specific message adapters
+- **Agents** (`src/agents/`): AI agent runtime with Pi integration (`@mariozechner/pi-*` packages)
+- **CLI** (`src/cli/`, `src/commands/`): Command-line interface built with Commander
+- **Extensions** (`extensions/`): Plugin system for additional channels (MS Teams, Matrix, Zalo, Twitch, etc.)
+- **Native apps** (`apps/`): macOS, iOS, and Android apps wrapping the gateway
+
+## Repository Guidelines
 - Repo: https://github.com/moltbot/moltbot
 - GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
 
@@ -47,6 +63,9 @@
 - Type-check/build: `pnpm build` (tsc)
 - Lint/format: `pnpm lint` (oxlint), `pnpm format` (oxfmt)
 - Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+- Run a single test file: `pnpm test src/path/to/file.test.ts`
+- Run tests matching a pattern: `pnpm test -t "pattern"`
+- Watch mode: `pnpm test:watch`
 
 ## Coding Style & Naming Conventions
 - Language: TypeScript (ESM). Prefer strict typing; avoid `any`.

--- a/docs/architecture/channel-message-flows.md
+++ b/docs/architecture/channel-message-flows.md
@@ -1,0 +1,769 @@
+# Channel Message Flow Architecture
+
+This document describes how messages flow through Moltbot's channel system, comparing WhatsApp, Discord, and Gmail to highlight the unified architecture and channel-specific differences.
+
+## Architecture Overview
+
+All channels in Moltbot follow a common pattern:
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  External   │    │  Channel    │    │   Shared    │    │  Pi Agent   │
+│  Platform   │───▶│  Adapter    │───▶│  Router     │───▶│  Framework  │
+└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
+       ▲                                                        │
+       │                                                        │
+       └────────────────────────────────────────────────────────┘
+                         Response Delivery
+```
+
+### Shared Components (All Channels)
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Agent Router | `src/routing/resolve-route.ts` | Routes messages to agents |
+| Reply Dispatcher | `src/auto-reply/reply/reply-dispatcher.ts` | Queues & delivers responses |
+| Agent Runner | `src/auto-reply/reply/get-reply.ts` | Sets up agent execution |
+| Pi Framework | `src/agents/pi-embedded-runner/` | Executes AI agents |
+| Outbound Service | `src/infra/outbound/` | Cross-channel delivery |
+
+### Channel-Specific Components
+
+| Channel | Adapter Location | Protocol |
+|---------|------------------|----------|
+| WhatsApp | `src/web/` | Baileys (WhatsApp Web) |
+| Discord | `src/discord/` | Carbon (@buape/carbon) |
+| Gmail | `src/hooks/` | Webhooks + gog CLI |
+| Telegram | `src/telegram/` | grammY |
+| Slack | `src/slack/` | Bolt |
+| Signal | `src/signal/` | signal-cli |
+| iMessage | `src/imessage/` | AppleScript/sqlite |
+
+---
+
+## Channel Comparison Matrix
+
+### Connection Method
+
+| Aspect | WhatsApp | Discord | Gmail |
+|--------|----------|---------|-------|
+| **Protocol** | WebSocket (Baileys) | WebSocket (Gateway) | HTTP Webhooks |
+| **Auth** | QR Code scan | Bot Token | OAuth2 (gog CLI) |
+| **Connection Type** | Persistent | Persistent | Push notifications |
+| **Library** | `@whiskeysockets/baileys` | `@buape/carbon` | `gog` CLI |
+| **Reconnect** | Auto with backoff | Auto with backoff | N/A (stateless) |
+
+### Message Reception
+
+| Aspect | WhatsApp | Discord | Gmail |
+|--------|----------|---------|-------|
+| **Event Source** | `messages.upsert` | `MESSAGE_CREATE` | Pub/Sub push |
+| **Debouncing** | Yes (configurable) | Yes (300ms default) | No |
+| **Deduplication** | By message ID | By message ID | By message ID |
+| **Media Download** | On reception | On demand | Via gog CLI |
+
+### Routing & Gating
+
+| Aspect | WhatsApp | Discord | Gmail |
+|--------|----------|---------|-------|
+| **Peer Types** | DM, Group | DM, Channel, Thread | Single inbox |
+| **Mention Required** | Configurable (groups) | Configurable | N/A |
+| **Allowlist** | Phone numbers | Users, Channels, Guilds | N/A |
+| **Session Key Format** | `agent:wa:phone:+1234` | `agent:discord:channel:123` | `hook:gmail:msgId` |
+
+### Response Delivery
+
+| Aspect | WhatsApp | Discord | Gmail |
+|--------|----------|---------|-------|
+| **Max Message Length** | ~65KB | 2000 chars | Unlimited |
+| **Chunking** | Markdown-aware | Markdown-aware | N/A |
+| **Media Support** | Image, Audio, Video, Doc | Image, Video, File | N/A (use gog) |
+| **Typing Indicator** | Yes | Yes | N/A |
+| **Reactions** | Limited | Full support | N/A |
+| **Threading** | Reply-to | Native threads | N/A |
+
+---
+
+## Detailed Flow Diagrams
+
+### Unified Message Flow
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           MOLTBOT UNIFIED MESSAGE FLOW                      │
+└────────────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │ WhatsApp │   │ Discord  │   │  Gmail   │
+  └────┬─────┘   └────┬─────┘   └────┬─────┘
+       │              │              │
+       ▼              ▼              ▼
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │ Baileys  │   │  Carbon  │   │   gog    │
+  │ Socket   │   │  Client  │   │  watch   │
+  └────┬─────┘   └────┬─────┘   └────┬─────┘
+       │              │              │
+       │   WebSocket  │   WebSocket  │   HTTP POST
+       ▼              ▼              ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                         CHANNEL ADAPTER LAYER                               │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ monitorWebInbox │  │ DiscordMessage  │  │ createHooksReq  │             │
+│  │      ()         │  │   Listener      │  │   Handler()     │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+│           │                    │                    │                       │
+│           ▼                    ▼                    ▼                       │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ Extract:        │  │ Extract:        │  │ Extract:        │             │
+│  │ - body          │  │ - content       │  │ - from          │             │
+│  │ - sender        │  │ - author        │  │ - subject       │             │
+│  │ - media         │  │ - attachments   │  │ - body          │             │
+│  │ - group info    │  │ - guild/channel │  │ - snippet       │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+└───────────┼────────────────────┼────────────────────┼───────────────────────┘
+            │                    │                    │
+            ▼                    ▼                    ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           VALIDATION LAYER                                  │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ checkInbound    │  │ preflightDiscord│  │ validateToken   │             │
+│  │ AccessControl() │  │    Message()    │  │      ()         │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+│           │                    │                    │                       │
+│           ▼                    ▼                    ▼                       │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ - Allowlist     │  │ - DM Policy     │  │ - Hook token    │             │
+│  │ - Group gating  │  │ - Guild access  │  │ - Path matching │             │
+│  │ - Mention check │  │ - Mention check │  │                 │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+└───────────┼────────────────────┼────────────────────┼───────────────────────┘
+            │                    │                    │
+            └────────────────────┼────────────────────┘
+                                 │
+                                 ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           ROUTING LAYER (SHARED)                            │
+│                                                                             │
+│                      ┌─────────────────────┐                                │
+│                      │  resolveAgentRoute  │                                │
+│                      │        ()           │                                │
+│                      └──────────┬──────────┘                                │
+│                                 │                                           │
+│                                 ▼                                           │
+│                      ┌─────────────────────┐                                │
+│                      │ Returns:            │                                │
+│                      │ - agentId           │                                │
+│                      │ - sessionKey        │                                │
+│                      │ - channel           │                                │
+│                      └──────────┬──────────┘                                │
+└─────────────────────────────────┼───────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           AGENT LAYER (SHARED)                              │
+│                                                                             │
+│                      ┌─────────────────────┐                                │
+│                      │  getReplyFromConfig │                                │
+│                      │        ()           │                                │
+│                      └──────────┬──────────┘                                │
+│                                 │                                           │
+│                                 ▼                                           │
+│                      ┌─────────────────────┐                                │
+│                      │ runEmbeddedPiAgent  │                                │
+│                      │        ()           │                                │
+│                      └──────────┬──────────┘                                │
+│                                 │                                           │
+│                                 ▼                                           │
+│                      ┌─────────────────────┐                                │
+│                      │    LLM Provider     │                                │
+│                      │ (Claude/GPT/Gemini) │                                │
+│                      └──────────┬──────────┘                                │
+└─────────────────────────────────┼───────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           DISPATCH LAYER (SHARED)                           │
+│                                                                             │
+│                      ┌─────────────────────┐                                │
+│                      │ createReplyDispatcher│                               │
+│                      │        ()           │                                │
+│                      └──────────┬──────────┘                                │
+│                                 │                                           │
+│                                 ▼                                           │
+│                      ┌─────────────────────┐                                │
+│                      │ Queue responses:    │                                │
+│                      │ - Block replies     │                                │
+│                      │ - Tool results      │                                │
+│                      │ - Final reply       │                                │
+│                      └──────────┬──────────┘                                │
+└─────────────────────────────────┼───────────────────────────────────────────┘
+                                  │
+            ┌─────────────────────┼─────────────────────┐
+            │                     │                     │
+            ▼                     ▼                     ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           DELIVERY LAYER                                    │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ deliverWebReply │  │ deliverDiscord  │  │ deliverOutbound │             │
+│  │       ()        │  │    Reply()      │  │   Payloads()    │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+│           │                    │                    │                       │
+│           ▼                    ▼                    ▼                       │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ - Chunk text    │  │ - Chunk text    │  │ - Route to last │             │
+│  │ - Send via      │  │ - Send via REST │  │   known channel │             │
+│  │   Baileys       │  │ - Add reactions │  │ - Or default    │             │
+│  │ - Retry logic   │  │ - Threading     │  │   (WhatsApp)    │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+└───────────┼────────────────────┼────────────────────┼───────────────────────┘
+            │                    │                    │
+            ▼                    ▼                    ▼
+       ┌─────────┐         ┌─────────┐         ┌─────────┐
+       │WhatsApp │         │ Discord │         │ Any Chan│
+       │ Server  │         │ Server  │         │  nel    │
+       └─────────┘         └─────────┘         └─────────┘
+```
+
+---
+
+## WhatsApp Flow
+
+### Sequence Diagram
+
+```
+┌──────────┐ ┌─────────┐ ┌──────────┐ ┌────────┐ ┌────────┐ ┌─────────┐
+│ WhatsApp │ │ Baileys │ │ Monitor  │ │ Router │ │ Agent  │ │Dispatcher│
+└────┬─────┘ └────┬────┘ └────┬─────┘ └───┬────┘ └───┬────┘ └────┬────┘
+     │            │           │           │          │           │
+     │  message   │           │           │          │           │
+     │───────────▶│           │           │          │           │
+     │            │  upsert   │           │          │           │
+     │            │──────────▶│           │          │           │
+     │            │           │           │          │           │
+     │            │           │ debounce  │          │           │
+     │            │           │───┐       │          │           │
+     │            │           │◀──┘       │          │           │
+     │            │           │           │          │           │
+     │            │           │  route    │          │           │
+     │            │           │──────────▶│          │           │
+     │            │           │           │          │           │
+     │            │           │  agentId  │          │           │
+     │            │           │◀──────────│          │           │
+     │            │           │           │          │           │
+     │            │           │ (group?) check mention           │
+     │            │           │───┐       │          │           │
+     │            │           │◀──┘       │          │           │
+     │            │           │           │          │           │
+     │            │           │  dispatch │          │           │
+     │            │           │─────────────────────▶│           │
+     │            │           │           │          │           │
+     │            │           │           │          │  run Pi   │
+     │            │           │           │          │───┐       │
+     │            │           │           │          │◀──┘       │
+     │            │           │           │          │           │
+     │            │           │           │          │  reply    │
+     │            │           │           │          │──────────▶│
+     │            │           │           │          │           │
+     │            │           │  deliver  │          │           │
+     │            │◀──────────────────────────────────────────────
+     │            │           │           │          │           │
+     │   send     │           │           │          │           │
+     │◀───────────│           │           │          │           │
+     │            │           │           │          │           │
+```
+
+### Key Files
+
+| Step | File | Function |
+|------|------|----------|
+| Connect | `src/web/session.ts` | `createWaSocket()` |
+| Receive | `src/web/inbound/monitor.ts` | `monitorWebInbox()` |
+| Validate | `src/web/auto-reply/monitor/on-message.ts` | `createWebOnMessageHandler()` |
+| Route | `src/routing/resolve-route.ts` | `resolveAgentRoute()` |
+| Process | `src/web/auto-reply/monitor/process-message.ts` | `processMessage()` |
+| Execute | `src/agents/pi-embedded-runner/run.ts` | `runEmbeddedPiAgent()` |
+| Deliver | `src/web/auto-reply/deliver-reply.ts` | `deliverWebReply()` |
+
+### WhatsApp-Specific Features
+
+- **QR Code Auth**: First-time login requires scanning QR code
+- **Group Metadata**: Fetches participant list, subject, description
+- **Read Receipts**: Sends read receipts on message reception
+- **Location Messages**: Extracts latitude/longitude/address
+- **Reply Context**: Includes quoted message in context
+- **Presence Updates**: Shows "online" status
+
+---
+
+## Discord Flow
+
+### Sequence Diagram
+
+```
+┌──────────┐ ┌─────────┐ ┌──────────┐ ┌────────┐ ┌────────┐ ┌─────────┐
+│ Discord  │ │ Carbon  │ │ Listener │ │Preflight│ │ Agent  │ │ Send    │
+│ Gateway  │ │ Client  │ │          │ │        │ │        │ │         │
+└────┬─────┘ └────┬────┘ └────┬─────┘ └───┬────┘ └───┬────┘ └────┬────┘
+     │            │           │           │          │           │
+     │  READY     │           │           │          │           │
+     │───────────▶│           │           │          │           │
+     │            │           │           │          │           │
+     │ MESSAGE_   │           │           │          │           │
+     │ CREATE     │           │           │          │           │
+     │───────────▶│           │           │          │           │
+     │            │  handle   │           │          │           │
+     │            │──────────▶│           │          │           │
+     │            │           │           │          │           │
+     │            │           │ debounce  │          │           │
+     │            │           │───┐       │          │           │
+     │            │           │◀──┘       │          │           │
+     │            │           │           │          │           │
+     │            │           │ preflight │          │           │
+     │            │           │──────────▶│          │           │
+     │            │           │           │          │           │
+     │            │           │           │ validate │           │
+     │            │           │           │ - DM policy          │
+     │            │           │           │ - Guild access       │
+     │            │           │           │ - Mention req        │
+     │            │           │           │───┐      │           │
+     │            │           │           │◀──┘      │           │
+     │            │           │           │          │           │
+     │            │           │   ok      │          │           │
+     │            │           │◀──────────│          │           │
+     │            │           │           │          │           │
+     │            │           │  dispatch │          │           │
+     │            │           │─────────────────────▶│           │
+     │            │           │           │          │           │
+     │            │           │           │          │  run Pi   │
+     │            │           │           │          │───┐       │
+     │            │           │           │          │◀──┘       │
+     │            │           │           │          │           │
+     │            │           │           │          │  reply    │
+     │            │           │           │          │──────────▶│
+     │            │           │           │          │           │
+     │            │           │           │          │           │ chunk
+     │            │           │           │          │           │──┐
+     │            │           │           │          │           │◀─┘
+     │            │           │           │          │           │
+     │   REST     │           │           │          │           │
+     │◀──────────────────────────────────────────────────────────│
+     │            │           │           │          │           │
+```
+
+### Key Files
+
+| Step | File | Function |
+|------|------|----------|
+| Connect | `src/discord/monitor/provider.ts` | `monitorDiscordProvider()` |
+| Listen | `src/discord/monitor/listeners.ts` | `DiscordMessageListener` |
+| Debounce | `src/discord/monitor/message-handler.ts` | `createDiscordDebouncer()` |
+| Validate | `src/discord/monitor/message-handler.preflight.ts` | `preflightDiscordMessage()` |
+| Process | `src/discord/monitor/message-handler.process.ts` | `processDiscordMessage()` |
+| Execute | `src/agents/pi-embedded-runner/run.ts` | `runEmbeddedPiAgent()` |
+| Deliver | `src/discord/monitor/reply-delivery.ts` | `deliverDiscordReply()` |
+| Send | `src/discord/send.outbound.ts` | `sendMessageDiscord()` |
+
+### Discord-Specific Features
+
+- **Guilds & Channels**: Multi-server support with per-channel config
+- **Threads**: Native thread support (public, private, forum)
+- **Reactions**: Add/remove reactions, ack reactions on processing
+- **Slash Commands**: Native Discord commands via `deployDiscordCommands()`
+- **Presence**: Optional presence/status monitoring
+- **Moderation**: Ban, kick, timeout, role management tools
+- **Embeds**: Rich embed support for responses
+- **2000 Char Limit**: Auto-chunking for long responses
+
+---
+
+## Gmail Flow
+
+### Sequence Diagram
+
+```
+┌──────────┐ ┌─────────┐ ┌──────────┐ ┌────────┐ ┌────────┐ ┌─────────┐
+│  Gmail   │ │  gog    │ │ Webhook  │ │ Hook   │ │ Cron   │ │Outbound │
+│  Server  │ │  watch  │ │ Handler  │ │Mapping │ │ Agent  │ │ Deliver │
+└────┬─────┘ └────┬────┘ └────┬─────┘ └───┬────┘ └───┬────┘ └────┬────┘
+     │            │           │           │          │           │
+     │  New email │           │           │          │           │
+     │───────────▶│           │           │          │           │
+     │            │           │           │          │           │
+     │            │ Pub/Sub   │           │          │           │
+     │            │ push      │           │          │           │
+     │            │──────────▶│           │          │           │
+     │            │           │           │          │           │
+     │            │           │ POST      │          │           │
+     │            │           │ /hooks/   │          │           │
+     │            │           │ gmail     │          │           │
+     │            │           │───┐       │          │           │
+     │            │           │◀──┘       │          │           │
+     │            │           │           │          │           │
+     │            │           │ validate  │          │           │
+     │            │           │ token     │          │           │
+     │            │           │───┐       │          │           │
+     │            │           │◀──┘       │          │           │
+     │            │           │           │          │           │
+     │            │           │  match    │          │           │
+     │            │           │──────────▶│          │           │
+     │            │           │           │          │           │
+     │            │           │           │ template │           │
+     │            │           │           │ render   │           │
+     │            │           │           │───┐      │           │
+     │            │           │           │◀──┘      │           │
+     │            │           │           │          │           │
+     │            │           │           │ dispatch │           │
+     │            │           │           │─────────▶│           │
+     │            │           │           │          │           │
+     │            │           │           │          │  run Pi   │
+     │            │           │           │          │  (isolated)
+     │            │           │           │          │───┐       │
+     │            │           │           │          │◀──┘       │
+     │            │           │           │          │           │
+     │            │           │           │          │  deliver  │
+     │            │           │           │          │──────────▶│
+     │            │           │           │          │           │
+     │            │           │           │          │           │ route to
+     │            │           │           │          │           │ last chan
+     │            │           │           │          │           │──┐
+     │            │           │           │          │           │◀─┘
+     │            │           │           │          │           │
+     └─────────────────────────────────────────────────◀─────────│
+                  (Response via WhatsApp/Discord/Telegram/etc)
+```
+
+### Key Files
+
+| Step | File | Function |
+|------|------|----------|
+| Watch | `src/hooks/gmail-watcher.ts` | `startGmailWatcher()` |
+| Receive | `src/gateway/server-http.ts` | `createHooksRequestHandler()` |
+| Match | `src/gateway/hooks-mapping.ts` | `applyHookMappings()` |
+| Template | `src/gateway/hooks-mapping.ts` | `renderTemplate()` |
+| Dispatch | `src/gateway/server/hooks.ts` | `dispatchAgentHook()` |
+| Execute | `src/cron/isolated-agent/run.ts` | `runCronIsolatedAgentTurn()` |
+| Deliver | `src/infra/outbound/deliver.ts` | `deliverOutboundPayloads()` |
+
+### Gmail-Specific Features
+
+- **Pub/Sub Push**: Uses Google Cloud Pub/Sub for real-time notifications
+- **gog CLI**: External CLI handles Gmail API, OAuth, watch registration
+- **Template Rendering**: `{{messages[0].from}}`, `{{messages[0].subject}}`
+- **Isolated Sessions**: Each email creates isolated agent session
+- **Cross-Channel Delivery**: Responses go to last-used channel (WhatsApp default)
+- **No Direct Reply**: Cannot reply to emails (use gog CLI tool if needed)
+- **Webhook Auth**: Token-based authentication for security
+
+---
+
+## Similarities Across Channels
+
+### 1. Message Reception Pattern
+
+All channels follow the same pattern:
+```typescript
+// Pseudocode - common pattern
+async function onMessage(rawMessage) {
+  // 1. Extract normalized message
+  const msg = extractMessage(rawMessage)
+
+  // 2. Debounce (optional)
+  await debouncer.enqueue(msg)
+
+  // 3. Validate access
+  if (!validateAccess(msg)) return
+
+  // 4. Route to agent
+  const route = await resolveAgentRoute(msg)
+
+  // 5. Dispatch
+  await dispatchToAgent(msg, route)
+}
+```
+
+### 2. Shared Routing Logic
+
+All channels use `resolveAgentRoute()` with the same interface:
+
+```typescript
+// src/routing/resolve-route.ts
+interface RouteInput {
+  channel: string           // 'whatsapp' | 'discord' | 'gmail' | ...
+  accountId: string         // Account identifier
+  peer: {
+    kind: 'dm' | 'group' | 'channel' | 'hook'
+    id: string              // Phone, user ID, channel ID, etc.
+  }
+}
+
+interface ResolvedRoute {
+  agentId: string
+  sessionKey: string
+  mainSessionKey: string
+  matchedBy: string
+}
+```
+
+### 3. Shared Agent Execution
+
+All channels ultimately call the same agent runner:
+
+```typescript
+// src/agents/pi-embedded-runner/run.ts
+const result = await runEmbeddedPiAgent({
+  sessionKey,
+  message: userMessage,
+  model,
+  tools,
+  onBlockReply,
+  onToolResult,
+})
+```
+
+### 4. Shared Reply Dispatcher
+
+All channels use the same dispatcher pattern:
+
+```typescript
+// src/auto-reply/reply/reply-dispatcher.ts
+const dispatcher = createReplyDispatcher({
+  deliver: (payload) => channelSpecificDeliver(payload),
+  onIdle: () => cleanup(),
+})
+
+dispatcher.sendBlockReply(chunk)
+dispatcher.sendFinalReply(response)
+await dispatcher.waitForIdle()
+```
+
+### 5. Common Configuration Structure
+
+```json5
+{
+  channels: {
+    whatsapp: { /* channel-specific */ },
+    discord: { /* channel-specific */ },
+  },
+  hooks: {
+    gmail: { /* webhook-specific */ },
+  },
+  routing: {
+    bindings: [
+      // Shared routing rules
+    ],
+    default: { agentId: 'main' }
+  },
+  agents: {
+    // Shared agent config
+  }
+}
+```
+
+---
+
+## Key Differences
+
+### 1. Connection Model
+
+| Channel | Model | Implication |
+|---------|-------|-------------|
+| WhatsApp | Persistent WebSocket | Always connected, real-time |
+| Discord | Persistent WebSocket | Always connected, real-time |
+| Gmail | HTTP Webhooks | Stateless, push-based |
+
+### 2. Authentication
+
+| Channel | Auth Type | User Action Required |
+|---------|-----------|---------------------|
+| WhatsApp | QR Code | Scan with phone |
+| Discord | Bot Token | Create bot, copy token |
+| Gmail | OAuth2 | Create GCP project, authorize |
+
+### 3. Message Threading
+
+| Channel | Threading Model |
+|---------|-----------------|
+| WhatsApp | Reply-to (quote) |
+| Discord | Native threads, forums |
+| Gmail | Email threads (not used) |
+
+### 4. Response Delivery
+
+| Channel | Direct Reply | Cross-Channel |
+|---------|--------------|---------------|
+| WhatsApp | Yes | No |
+| Discord | Yes | No |
+| Gmail | No | Yes (always) |
+
+### 5. Access Control
+
+| Channel | Allowlist Granularity |
+|---------|-----------------------|
+| WhatsApp | Phone numbers, groups |
+| Discord | Users, channels, guilds, roles |
+| Gmail | N/A (single inbox) |
+
+### 6. Rich Features
+
+| Feature | WhatsApp | Discord | Gmail |
+|---------|----------|---------|-------|
+| Reactions | Limited | Full | No |
+| Threads | No | Yes | No |
+| Embeds | No | Yes | No |
+| Slash Commands | No | Yes | No |
+| Typing Indicator | Yes | Yes | No |
+| Read Receipts | Yes | No | No |
+| Media Upload | Yes | Yes | No |
+
+---
+
+## Data Structure Comparison
+
+### Inbound Message
+
+```typescript
+// WhatsApp
+interface WebInboundMsg {
+  from: string              // JID
+  body: string
+  chatType: 'dm' | 'group'
+  senderE164: string
+  groupSubject?: string
+  mediaPath?: string
+  replyToId?: string
+  mentionedJids?: string[]
+}
+
+// Discord
+interface DiscordInboundMsg {
+  author: { id: string, username: string }
+  content: string
+  channelId: string
+  guildId?: string
+  attachments: Attachment[]
+  referencedMessage?: Message
+  mentions: User[]
+}
+
+// Gmail (webhook payload)
+interface GmailHookPayload {
+  messages: [{
+    id: string
+    from: string
+    subject: string
+    snippet: string
+    body?: string
+  }]
+}
+```
+
+### Session Key Format
+
+| Channel | Format | Example |
+|---------|--------|---------|
+| WhatsApp | `agent:<agentId>:whatsapp:<accountId>:dm:<phone>` | `agent:main:whatsapp:default:dm:+1234567890` |
+| WhatsApp Group | `agent:<agentId>:whatsapp:<accountId>:group:<jid>` | `agent:main:whatsapp:default:group:123@g.us` |
+| Discord DM | `agent:<agentId>:discord:<accountId>:user:<userId>` | `agent:main:discord:default:user:123456789` |
+| Discord Channel | `agent:<agentId>:discord:<accountId>:channel:<channelId>` | `agent:main:discord:default:channel:987654321` |
+| Gmail | `hook:gmail:<messageId>` | `hook:gmail:18a1b2c3d4e5f6` |
+
+---
+
+## Adding a New Channel
+
+To add a new channel, implement these components:
+
+### 1. Channel Adapter (Required)
+
+```typescript
+// src/<channel>/monitor.ts
+export async function monitor<Channel>Channel(options: Options) {
+  // Connect to platform
+  const client = await connect()
+
+  // Register message handler
+  client.on('message', async (raw) => {
+    // Extract normalized message
+    const msg = extractMessage(raw)
+
+    // Validate
+    if (!validate(msg)) return
+
+    // Route
+    const route = await resolveAgentRoute({
+      channel: '<channel>',
+      accountId: options.accountId,
+      peer: { kind: msg.chatType, id: msg.peerId }
+    })
+
+    // Dispatch
+    await dispatchInboundMessage({
+      ctx: buildContext(msg, route),
+      deliver: (reply) => deliver<Channel>Reply(msg, reply),
+    })
+  })
+}
+```
+
+### 2. Delivery Function (Required)
+
+```typescript
+// src/<channel>/deliver.ts
+export async function deliver<Channel>Reply(
+  msg: InboundMsg,
+  reply: ReplyPayload
+) {
+  // Chunk if needed
+  const chunks = chunkText(reply.text, MAX_LENGTH)
+
+  // Send each chunk
+  for (const chunk of chunks) {
+    await client.send(msg.replyTo, chunk)
+  }
+}
+```
+
+### 3. Channel Plugin (Optional)
+
+```typescript
+// extensions/<channel>/src/channel.ts
+export const <channel>Plugin: ChannelPlugin = {
+  id: '<channel>',
+  name: '<Channel>',
+
+  async start(runtime) {
+    await monitor<Channel>Channel(runtime.options)
+  },
+
+  async stop() {
+    await disconnect()
+  },
+
+  async send(to, payload) {
+    await sendMessage(to, payload)
+  }
+}
+```
+
+### 4. Configuration Schema
+
+```typescript
+// Add to config schema
+channels: {
+  <channel>: {
+    enabled: Type.Boolean(),
+    token: Type.String(),
+    // Channel-specific options
+  }
+}
+```
+
+---
+
+## Related Documentation
+
+- [WhatsApp Message Flow](./whatsapp-message-flow.md)
+- [Gateway Architecture](./gateway.md)
+- [Agent Configuration](/configuration)
+- [Hooks System](/configuration#hooks)
+- [Channel Plugins](/extensions)

--- a/docs/architecture/whatsapp-message-flow.md
+++ b/docs/architecture/whatsapp-message-flow.md
@@ -1,0 +1,794 @@
+# WhatsApp Message Flow Architecture
+
+This document describes the complete lifecycle of a WhatsApp message in Moltbot, from reception through AI processing to response delivery.
+
+## Overview
+
+Moltbot uses the [Baileys](https://github.com/WhiskeySockets/Baileys) library to connect to WhatsApp Web. When a message arrives, it flows through several layers before reaching the Pi agent framework for AI processing, then returns through a dispatcher for delivery.
+
+```
+┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐
+│WhatsApp │───▶│ Baileys │───▶│ Monitor │───▶│ Router  │───▶│Pi Agent │
+│ Server  │    │ Socket  │    │ Layer   │    │         │    │ Runtime │
+└─────────┘    └─────────┘    └─────────┘    └─────────┘    └─────────┘
+     ▲                                                            │
+     │                                                            │
+     └────────────────────────────────────────────────────────────┘
+                         Response Delivery
+```
+
+## Layer Architecture
+
+| Layer | Purpose | Key Files |
+|-------|---------|-----------|
+| Baileys | WhatsApp Web protocol | `src/web/session.ts` |
+| Monitor | Message extraction & deduplication | `src/web/inbound/monitor.ts` |
+| Channel | Connection orchestration | `src/web/auto-reply/monitor.ts` |
+| Router | Agent & session resolution | `src/routing/resolve-route.ts` |
+| Processor | Context building & dispatch | `src/web/auto-reply/monitor/process-message.ts` |
+| Agent | AI execution via Pi framework | `src/agents/pi-embedded-runner/run.ts` |
+| Dispatcher | Response queuing & delivery | `src/auto-reply/reply/reply-dispatcher.ts` |
+
+## Detailed Flow
+
+### Step 1: Baileys Connection
+
+**File:** `src/web/session.ts`
+**Function:** `createWaSocket()`
+
+The Baileys socket manages the WhatsApp Web connection:
+
+```typescript
+// Creates socket with multi-file auth state
+const { state, saveCreds } = await useMultiFileAuthState(authDir)
+const { version } = await fetchLatestBaileysVersion()
+
+const sock = makeWASocket({
+  version,
+  auth: state,
+  printQRInTerminal: printQr,
+  // ... other options
+})
+```
+
+**Responsibilities:**
+- QR code authentication for first-time login
+- Credential persistence in `~/.clawdbot/sessions/`
+- Connection state management (connecting, open, close)
+- Event emission for `messages.upsert`, `connection.update`, `creds.update`
+
+---
+
+### Step 2: Message Reception
+
+**File:** `src/web/inbound/monitor.ts`
+**Function:** `monitorWebInbox()`
+
+When Baileys emits a `messages.upsert` event, `handleMessagesUpsert()` processes it:
+
+```typescript
+sock.ev.on('messages.upsert', async ({ messages, type }) => {
+  for (const msg of messages) {
+    // Filter status/broadcast messages
+    if (isStatusMessage(msg)) continue
+
+    // Deduplicate
+    if (isRecentInboundMessage(msg.key.id)) continue
+
+    // Extract content
+    const body = extractText(msg)
+    const mediaPath = await downloadInboundMedia(msg)
+    const location = extractLocationData(msg)
+
+    // Build WebInboundMsg and call handler
+    onMessage(webInboundMsg)
+  }
+})
+```
+
+**Extracts:**
+- Message text (`body`)
+- Sender info (`senderJid`, `senderE164`, `senderName`)
+- Group metadata (`groupSubject`, `groupParticipants`)
+- Media content (`mediaPath`, `mediaType`, `mediaUrl`)
+- Reply context (`replyToId`, `replyToBody`, `replyToSender`)
+- Location data (`latitude`, `longitude`)
+- Mentions (`mentionedJids`, `wasMentioned`)
+
+---
+
+### Step 3: Channel Monitoring
+
+**File:** `src/web/auto-reply/monitor.ts`
+**Function:** `monitorWebChannel()`
+
+Orchestrates the WhatsApp channel lifecycle:
+
+```typescript
+export async function monitorWebChannel(
+  verbose: boolean,
+  listenerFactory: ListenerFactory,
+  keepAlive: KeepAliveController,
+  replyResolver: ReplyResolver,
+  runtime: ChannelRuntime,
+  abortSignal?: AbortSignal,
+  tuning?: MonitorTuning
+) {
+  // Load config
+  const config = await loadConfig()
+
+  // Create message handler
+  const onMessage = createWebOnMessageHandler({ ... })
+
+  // Start monitoring with reconnect logic
+  while (!abortSignal?.aborted) {
+    const listener = await monitorWebInbox({ onMessage, ... })
+    // Handle disconnects with exponential backoff
+  }
+}
+```
+
+**Responsibilities:**
+- Connection retry with exponential backoff
+- Heartbeat logging
+- Watchdog timer for 30+ minute inactivity
+- Status tracking (connected, reconnectAttempts, lastMessageAt)
+
+---
+
+### Step 4: Message Handling & Routing
+
+**File:** `src/web/auto-reply/monitor/on-message.ts`
+**Function:** `createWebOnMessageHandler()`
+
+**File:** `src/routing/resolve-route.ts`
+**Function:** `resolveAgentRoute()`
+
+Routes the message to the correct agent:
+
+```typescript
+// Resolve conversation and peer IDs
+const conversationId = resolveConversationId(msg)
+const peerId = resolvePeerId(msg)
+
+// Route to agent
+const route = await resolveAgentRoute({
+  channel: 'whatsapp',
+  accountId: msg.accountId,
+  peer: { kind: msg.chatType, id: peerId }
+})
+
+// For groups, apply gating
+if (msg.chatType === 'group') {
+  const gateResult = applyGroupGating(msg, route, config)
+  if (gateResult.blocked) return
+}
+
+// Process message with resolved route
+await processMessage({ msg, route, ... })
+```
+
+**Routing Logic:**
+- Matches against configured bindings (peer, guild, team, account, channel)
+- Falls back to default agent if no match
+- Returns `agentId` and `sessionKey` for persistence
+
+**Group Gating:**
+- Checks if bot was mentioned
+- Validates against allowlist
+- Applies activation rules
+
+---
+
+### Step 5: Message Processing
+
+**File:** `src/web/auto-reply/monitor/process-message.ts`
+**Function:** `processMessage()`
+
+Builds context and dispatches to the agent:
+
+```typescript
+export async function processMessage(params: ProcessMessageParams) {
+  const { msg, route, ... } = params
+
+  // Build history context from recent messages
+  const historyContext = await buildHistoryContextFromEntries(...)
+
+  // Check command authorization
+  const authorized = await resolveWhatsAppCommandAuthorized(msg, config)
+
+  // Build MsgContext
+  const ctx: MsgContext = {
+    body: msg.body,
+    from: msg.from,
+    agentId: route.agentId,
+    sessionKey: route.sessionKey,
+    mediaPath: msg.mediaPath,
+    // ... other fields
+  }
+
+  // Send ACK reaction (optional)
+  await maybeSendAckReaction(msg, config)
+
+  // Dispatch to agent
+  await dispatchReplyWithBufferedBlockDispatcher({
+    ctx,
+    onBlockReply: (reply) => deliverWebReply(msg, reply),
+    // ...
+  })
+}
+```
+
+---
+
+### Step 6: Agent Execution
+
+**File:** `src/auto-reply/reply/get-reply.ts`
+**Function:** `getReplyFromConfig()`
+
+**File:** `src/auto-reply/reply/get-reply-run.ts`
+**Function:** `runPreparedReply()`
+
+Sets up and runs the AI agent:
+
+```typescript
+export async function getReplyFromConfig(ctx: MsgContext, opts: ReplyOpts) {
+  // Resolve model (Claude, GPT, Gemini, etc.)
+  const model = await resolveDefaultModel(ctx.agentId)
+
+  // Ensure agent workspace exists
+  await ensureAgentWorkspace(ctx.agentId)
+
+  // Create typing controller
+  const typing = createTypingController(ctx.sendComposing)
+
+  // Apply media understanding (images, audio, video, PDFs)
+  const mediaContext = await applyMediaUnderstanding(ctx.mediaPath, model)
+
+  // Apply link understanding (URL previews)
+  const linkContext = await applyLinkUnderstanding(ctx.body)
+
+  // Run the agent
+  return runPreparedReply({ ctx, model, typing, ... })
+}
+```
+
+---
+
+### Step 7: Pi Framework Execution
+
+**File:** `src/agents/pi-embedded-runner/run.ts`
+**Function:** `runEmbeddedPiAgent()`
+
+Executes the AI agent using the Pi framework:
+
+```typescript
+export async function runEmbeddedPiAgent(
+  params: RunEmbeddedPiAgentParams
+): Promise<EmbeddedPiRunResult> {
+  // Resolve auth profile and API key
+  const apiKey = await getApiKeyForModel(params.model)
+
+  // Load or create session
+  const session = await loadSession(params.sessionKey)
+
+  // Build system prompt with skills
+  const systemPrompt = await createSystemPromptOverride(params)
+
+  // Run agent attempt with streaming
+  const result = await runEmbeddedAttempt({
+    session,
+    systemPrompt,
+    message: params.message,
+    tools: params.tools,
+    onChunk: (chunk) => params.onBlockReply?.(chunk),
+    onToolCall: (call) => params.onToolResult?.(call),
+  })
+
+  // Save session transcript
+  await saveSession(params.sessionKey, result.session)
+
+  return result
+}
+```
+
+**Pi Framework Components:**
+- `@mariozechner/pi-agent-core` - Agent loop, tool execution
+- `@mariozechner/pi-ai` - Multi-provider LLM API
+- `@mariozechner/pi-coding-agent` - Session management, tools
+- `@mariozechner/pi-tui` - Terminal UI (optional)
+
+**Default Tools:**
+- `read` - Read files
+- `write` - Write files
+- `edit` - Edit files
+- `bash` - Execute shell commands
+- Custom skills from `skills/` directory
+
+---
+
+### Step 8: Response Dispatch
+
+**File:** `src/auto-reply/reply/reply-dispatcher.ts`
+**Function:** `createReplyDispatcher()`
+
+Queues and delivers responses:
+
+```typescript
+export function createReplyDispatcher(options: DispatcherOptions) {
+  const queue: ReplyPayload[] = []
+  let sendChain = Promise.resolve()
+
+  return {
+    sendBlockReply(reply: ReplyPayload) {
+      queue.push(reply)
+      sendChain = sendChain.then(() => deliver(reply))
+    },
+
+    sendToolResult(result: ToolResult) {
+      // Optional: send tool updates to user
+    },
+
+    sendFinalReply(reply: ReplyPayload) {
+      queue.push(reply)
+      sendChain = sendChain.then(() => deliver(reply))
+    },
+
+    async waitForIdle() {
+      await sendChain
+    }
+  }
+}
+```
+
+**Features:**
+- Serializes deliveries to maintain order
+- Adds human-like delays between messages
+- Tracks pending deliveries for idle signal
+- Supports streaming block replies
+
+---
+
+### Step 9: WhatsApp Delivery
+
+**File:** `src/web/auto-reply/deliver-reply.ts`
+**Function:** `deliverWebReply()`
+
+**File:** `src/web/inbound/send-api.ts`
+**Function:** `createWebSendApi()`
+
+Sends the response back to WhatsApp:
+
+```typescript
+export async function deliverWebReply(params: DeliverParams) {
+  const { msg, reply } = params
+
+  // Convert markdown tables for WhatsApp
+  const text = convertMarkdownTables(reply.text)
+
+  // Chunk long messages
+  const chunks = chunkMarkdownTextWithMode(text, 4096)
+
+  for (const chunk of chunks) {
+    // Retry with backoff
+    await retry(async () => {
+      await msg.reply(chunk)
+    }, { retries: 3, backoff: 'exponential' })
+  }
+}
+
+// In send-api.ts
+export function createWebSendApi(params: SendApiParams) {
+  return {
+    async sendMessage(to, text, media) {
+      const jid = toWhatsappJid(to)
+      const payload = buildPayload(text, media)
+
+      const result = await sock.sendMessage(jid, payload)
+      return result.key.id
+    }
+  }
+}
+```
+
+---
+
+## Sequence Diagrams
+
+### Complete Message Lifecycle
+
+```
+┌──────────┐ ┌─────────┐ ┌─────────┐ ┌────────┐ ┌────────┐ ┌─────────┐
+│ WhatsApp │ │ Baileys │ │ Monitor │ │ Router │ │ Agent  │ │   LLM   │
+└────┬─────┘ └────┬────┘ └────┬────┘ └───┬────┘ └───┬────┘ └────┬────┘
+     │            │           │          │          │           │
+     │  message   │           │          │          │           │
+     │───────────▶│           │          │          │           │
+     │            │           │          │          │           │
+     │            │  upsert   │          │          │           │
+     │            │──────────▶│          │          │           │
+     │            │           │          │          │           │
+     │            │           │  route   │          │           │
+     │            │           │─────────▶│          │           │
+     │            │           │          │          │           │
+     │            │           │  agentId │          │           │
+     │            │           │◀─────────│          │           │
+     │            │           │          │          │           │
+     │            │           │  dispatch│          │           │
+     │            │           │─────────────────────▶           │
+     │            │           │          │          │           │
+     │            │           │          │          │  request  │
+     │            │           │          │          │──────────▶│
+     │            │           │          │          │           │
+     │            │           │          │          │  stream   │
+     │            │           │          │          │◀──────────│
+     │            │           │          │          │           │
+     │            │           │  reply   │          │           │
+     │            │           │◀─────────────────────           │
+     │            │           │          │          │           │
+     │            │  send     │          │          │           │
+     │            │◀──────────│          │          │           │
+     │            │           │          │          │           │
+     │  deliver   │           │          │          │           │
+     │◀───────────│           │          │          │           │
+     │            │           │          │          │           │
+```
+
+### Group Message with Mention Check
+
+```
+┌──────────┐ ┌─────────┐ ┌─────────┐ ┌────────┐
+│ WhatsApp │ │ Monitor │ │ Gating  │ │ Agent  │
+└────┬─────┘ └────┬────┘ └────┬────┘ └───┬────┘
+     │            │           │          │
+     │ @bot hello │           │          │
+     │───────────▶│           │          │
+     │            │           │          │
+     │            │ is group? │          │
+     │            │───────────▶          │
+     │            │           │          │
+     │            │ mentioned?│          │
+     │            │───────────▶          │
+     │            │           │          │
+     │            │   yes ✓   │          │
+     │            │◀───────────          │
+     │            │           │          │
+     │            │ dispatch  │          │
+     │            │──────────────────────▶
+     │            │           │          │
+     │            │   reply   │          │
+     │◀───────────────────────────────────
+     │            │           │          │
+```
+
+### Tool Execution Flow
+
+```
+┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐
+│  Agent  │ │   LLM   │ │  Tool   │ │Dispatcher│
+└────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘
+     │           │           │           │
+     │  request  │           │           │
+     │──────────▶│           │           │
+     │           │           │           │
+     │ tool_call │           │           │
+     │◀──────────│           │           │
+     │           │           │           │
+     │  execute  │           │           │
+     │──────────────────────▶│           │
+     │           │           │           │
+     │  result   │           │           │
+     │◀──────────────────────│           │
+     │           │           │           │
+     │ tool_result           │           │
+     │──────────▶│           │           │
+     │           │           │           │
+     │  continue │           │           │
+     │◀──────────│           │           │
+     │           │           │           │
+     │ final text│           │           │
+     │◀──────────│           │           │
+     │           │           │           │
+     │  deliver  │           │           │
+     │──────────────────────────────────▶│
+     │           │           │           │
+```
+
+---
+
+## Key Data Structures
+
+### WebInboundMsg
+
+Represents an incoming WhatsApp message:
+
+```typescript
+interface WebInboundMsg {
+  id?: string
+  from: string              // Sender JID
+  to: string                // Recipient JID
+  body: string              // Message text
+  chatType: 'dm' | 'group'
+
+  // Sender info
+  senderE164?: string       // Phone number (+1234567890)
+  senderJid?: string        // WhatsApp JID
+  senderName?: string       // Display name
+  selfE164?: string         // Bot's phone number
+
+  // Group info
+  groupSubject?: string     // Group name
+  groupParticipants?: string[]
+  groupMembers?: GroupMember[]
+
+  // Media
+  mediaPath?: string        // Local file path
+  mediaType?: string        // MIME type
+  mediaUrl?: string         // Remote URL
+
+  // Reply context
+  replyToId?: string        // Quoted message ID
+  replyToBody?: string      // Quoted message text
+  replyToSender?: string    // Quoted message sender
+
+  // Location
+  location?: {
+    latitude: number
+    longitude: number
+    name?: string
+    address?: string
+  }
+
+  // Mentions
+  mentionedJids?: string[]
+  wasMentioned?: boolean
+
+  // Account
+  accountId: string
+
+  // Methods
+  reply(text: string, media?: Buffer): Promise<void>
+  sendComposing(): void     // Show typing indicator
+}
+```
+
+### ResolvedAgentRoute
+
+Routing decision for a message:
+
+```typescript
+interface ResolvedAgentRoute {
+  agentId: string           // Target agent ID
+  channel: string           // 'whatsapp'
+  accountId: string         // WhatsApp account ID
+  sessionKey: string        // Unique per conversation
+  mainSessionKey: string    // For collapsing multiple DMs
+  matchedBy:
+    | 'binding.peer'
+    | 'binding.guild'
+    | 'binding.team'
+    | 'binding.account'
+    | 'binding.channel'
+    | 'default'
+}
+```
+
+### MsgContext
+
+Context passed to the agent:
+
+```typescript
+interface MsgContext {
+  body: string              // User message
+  from: string              // Sender identifier
+  agentId: string           // Target agent
+  sessionKey: string        // Session for persistence
+
+  // Media
+  mediaPath?: string
+  mediaType?: string
+  mediaContext?: string     // AI-generated description
+
+  // Conversation
+  historyContext?: string   // Recent message history
+  replyToBody?: string      // Quoted message
+
+  // Authorization
+  authorized: boolean
+  elevated: boolean
+
+  // Callbacks
+  sendComposing?: () => void
+  onBlockReply?: (reply: ReplyPayload) => void
+  onToolResult?: (result: ToolResult) => void
+}
+```
+
+### ReplyPayload
+
+Response to deliver:
+
+```typescript
+interface ReplyPayload {
+  text?: string             // Response text
+  mediaUrl?: string         // Single media URL
+  mediaUrls?: string[]      // Multiple media URLs
+  mediaBuffer?: Buffer      // Raw media data
+  mediaType?: string        // MIME type
+
+  // Formatting
+  markdown?: boolean        // Enable markdown
+  monospace?: boolean       // Code block style
+}
+```
+
+---
+
+## Configuration
+
+### Agent Routing
+
+Configure in `~/.clawdbot/config.json5`:
+
+```json5
+{
+  routing: {
+    bindings: [
+      {
+        // Route specific contact to agent
+        peer: { kind: 'dm', id: '+1234567890' },
+        agentId: 'work-agent'
+      },
+      {
+        // Route group to agent
+        peer: { kind: 'group', id: 'group-jid@g.us' },
+        agentId: 'group-agent'
+      }
+    ],
+    default: {
+      agentId: 'main'  // Fallback agent
+    }
+  }
+}
+```
+
+### Group Gating
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      groups: {
+        // Require mention to respond
+        requireMention: true,
+
+        // Allowlist specific groups
+        allowlist: ['group-jid@g.us'],
+
+        // Or blocklist
+        blocklist: ['spam-group@g.us']
+      }
+    }
+  }
+}
+```
+
+### Media Understanding
+
+```json5
+{
+  agents: {
+    defaults: {
+      mediaUnderstanding: {
+        // Enable vision for images
+        images: true,
+
+        // Transcribe audio
+        audio: true,
+
+        // Extract video frames
+        video: true,
+
+        // Parse PDFs
+        documents: true
+      }
+    }
+  }
+}
+```
+
+---
+
+## Error Handling
+
+### Connection Failures
+
+```typescript
+// Exponential backoff for reconnection
+const backoff = [1000, 2000, 5000, 10000, 30000, 60000]
+let attempt = 0
+
+while (!aborted) {
+  try {
+    await connect()
+    attempt = 0  // Reset on success
+  } catch (err) {
+    const delay = backoff[Math.min(attempt, backoff.length - 1)]
+    await sleep(delay)
+    attempt++
+  }
+}
+```
+
+### Message Delivery Failures
+
+```typescript
+// Retry with backoff
+await retry(
+  () => msg.reply(text),
+  {
+    retries: 3,
+    backoff: 'exponential',
+    onRetry: (err, attempt) => {
+      log.warn(`Delivery failed (attempt ${attempt}): ${err.message}`)
+    }
+  }
+)
+```
+
+### Agent Failures
+
+```typescript
+// Failover to backup model
+try {
+  return await runWithModel('claude-3-opus')
+} catch (err) {
+  if (isRateLimitError(err)) {
+    return await runWithModel('gpt-4')  // Failover
+  }
+  throw err
+}
+```
+
+---
+
+## Observability
+
+### Logging
+
+Key log points:
+- Connection state changes
+- Message reception (with IDs)
+- Routing decisions
+- Agent execution start/end
+- Tool calls
+- Delivery confirmation
+
+### Metrics
+
+Tracked metrics:
+- `whatsapp.messages.received` - Inbound message count
+- `whatsapp.messages.sent` - Outbound message count
+- `whatsapp.connection.uptime` - Connection duration
+- `agent.execution.duration` - Agent response time
+- `agent.tokens.used` - Token consumption
+
+### Health Checks
+
+```bash
+# Check channel status
+moltbot channels status --probe
+
+# Check gateway health
+curl http://localhost:18789/health
+```
+
+---
+
+## Related Documentation
+
+- [Gateway Architecture](/docs/architecture/gateway.md)
+- [Agent Configuration](/docs/configuration.md)
+- [Skills System](/docs/skills.md)
+- [Pi Framework](https://github.com/badlogic/pi-mono)
+- [Baileys Library](https://github.com/WhiskeySockets/Baileys)


### PR DESCRIPTION
## Summary
- Add required Claude Code header ("This file provides guidance to Claude Code...")
- Add high-level architecture overview explaining what Moltbot is and its core components
- Document how to run single test files, pattern matching, and watch mode
- Add comprehensive WhatsApp message flow architecture documentation
- Add unified channel comparison documentation (WhatsApp vs Discord vs Gmail)

## New Documentation

### `docs/architecture/whatsapp-message-flow.md`
Complete lifecycle documentation for WhatsApp messages:
- Layer-by-layer breakdown (Baileys → Monitor → Router → Agent → Dispatcher)
- Sequence diagrams for message flow, group gating, tool execution
- Key data structures (WebInboundMsg, ResolvedAgentRoute, MsgContext)
- Configuration examples and error handling patterns

### `docs/architecture/channel-message-flows.md`
Unified comparison of all channel message flows:
- Shared components vs channel-specific adapters
- Comparison matrix (connection, reception, routing, delivery)
- Detailed sequence diagrams for WhatsApp, Discord, Gmail
- Key similarities (shared routing, agent execution, dispatcher)
- Key differences (WebSocket vs webhooks, auth methods, threading)
- Guide for adding new channels

## Test plan
- [x] Verified CLAUDE.md symlink points to AGENTS.md
- [x] Confirmed markdown renders correctly
- [x] Verified all file paths referenced in docs exist
- [x] Sequence diagrams render in markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)