### PR TITLE
fix(discord): respect replyToMode in threads

### DIFF
--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -11,7 +11,7 @@ export type ReplyReferencePlanner = {
 
 export function createReplyReferencePlanner(options: {
   replyToMode: ReplyToMode;
-  /** Existing thread/reference id (used when present, unless replyToMode is "off"). */
+  /** Existing thread/reference id (always used when present). */
   existingId?: string;
   /** Id to start a new thread/reference when allowed (e.g., parent message id). */
   startId?: string;
@@ -27,12 +27,12 @@ export function createReplyReferencePlanner(options: {
 
   const use = (): string | undefined => {
     if (!allowReference) return undefined;
-    if (options.replyToMode === "off") return undefined;
     if (existingId) {
       hasReplied = true;
       return existingId;
     }
     if (!startId) return undefined;
+    if (options.replyToMode === "off") return undefined;
     if (options.replyToMode === "all") {
       hasReplied = true;
       return startId;

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -11,7 +11,7 @@ export type ReplyReferencePlanner = {
 
 export function createReplyReferencePlanner(options: {
   replyToMode: ReplyToMode;
-  /** Existing thread/reference id (always used when present). */
+  /** Existing thread/reference id (used when present, unless replyToMode is "off"). */
   existingId?: string;
   /** Id to start a new thread/reference when allowed (e.g., parent message id). */
   startId?: string;
@@ -27,12 +27,12 @@ export function createReplyReferencePlanner(options: {
 
   const use = (): string | undefined => {
     if (!allowReference) return undefined;
+    if (options.replyToMode === "off") return undefined;
     if (existingId) {
       hasReplied = true;
       return existingId;
     }
     if (!startId) return undefined;
-    if (options.replyToMode === "off") return undefined;
     if (options.replyToMode === "all") {
       hasReplied = true;
       return startId;

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -74,10 +74,21 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
     expect(plan.replyReference.use()).toBeUndefined();
   });
 
-  it("always uses existingId when inside a thread", () => {
+  it("respects replyToMode off when inside a thread", () => {
     const plan = resolveDiscordReplyDeliveryPlan({
       replyTarget: "channel:thread",
       replyToMode: "off",
+      messageId: "m1",
+      threadChannel: { id: "thread" },
+      createdThreadId: null,
+    });
+    expect(plan.replyReference.use()).toBeUndefined();
+  });
+
+  it("uses message reference when inside a thread with replyToMode first", () => {
+    const plan = resolveDiscordReplyDeliveryPlan({
+      replyTarget: "channel:thread",
+      replyToMode: "first",
       messageId: "m1",
       threadChannel: { id: "thread" },
       createdThreadId: null,

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -304,9 +304,14 @@ export function resolveDiscordReplyDeliveryPlan(params: {
     replyTarget = deliverTarget;
   }
   const allowReference = deliverTarget === originalReplyTarget;
+  const effectiveReplyToMode = allowReference ? params.replyToMode : "off";
+  // Don't pass existingId when replyToMode is "off" - this prevents
+  // unwanted reply references in threads when the user has disabled them
+  const existingId =
+    params.threadChannel && effectiveReplyToMode !== "off" ? params.messageId : undefined;
   const replyReference = createReplyReferencePlanner({
-    replyToMode: allowReference ? params.replyToMode : "off",
-    existingId: params.threadChannel ? params.messageId : undefined,
+    replyToMode: effectiveReplyToMode,
+    existingId,
     startId: params.messageId,
     allowReference,
   });


### PR DESCRIPTION
## Problem

When `replyToMode` is set to `"off"` in the Discord channel config, messages in threads still include a reply reference. This is because the `existingId` check in `createReplyReferencePlanner` happens before the `replyToMode` check.

## Root Cause

In `src/auto-reply/reply/reply-reference.ts`:

```typescript
const use = (): string | undefined => {
  if (!allowReference) return undefined;
  if (existingId) {           // <-- checked first
    hasReplied = true;
    return existingId;        // returns early, ignoring replyToMode
  }
  // ...
  if (options.replyToMode === "off") return undefined;  // <-- too late
};
```

When replying in a thread, `existingId` is set to the parent message ID, so the function returns early before ever checking `replyToMode`.

## Fix

Move the `replyToMode === "off"` check to the top (right after `allowReference`), so it's respected in all contexts including threads.

## Testing

- Set `channels.discord.replyToMode: "off"` in config
- Send messages in a Discord thread
- Verify no reply references are added to outgoing messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Discord thread reply planning so `replyToMode: "off"` is honored even when replying inside an existing thread. Concretely, `resolveDiscordReplyDeliveryPlan` now computes an `effectiveReplyToMode` (forced to `"off"` when replying is not allowed due to target changes) and conditionally omits `existingId` when `replyToMode` is off, preventing `createReplyReferencePlanner` from returning early on an existing reference.

Coverage is updated via `src/discord/monitor/threading.test.ts` to assert both the fixed behavior for `off` and the preserved behavior for `first` inside threads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to Discord reply reference planning, adds a focused regression test for the thread + replyToMode="off" case, and preserves expected behavior for replyToMode="first". The logic aligns with how the shared reply reference planner currently prioritizes existingId.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->