### PR TITLE
fix(hooks): remove debug console.log statements from session-memory hook

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -14,6 +14,9 @@ import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+
+const log = createSubsystemLogger("hooks:session-memory");
 
 /**
  * Read recent messages from session file for slug generation
@@ -68,8 +71,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
   }
 
   try {
-    console.log("[session-memory] Hook triggered for /new command");
-
     const context = event.context || {};
     const cfg = context.cfg as MoltbotConfig | undefined;
     const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
@@ -88,12 +89,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       string,
       unknown
     >;
-    const currentSessionId = sessionEntry.sessionId as string;
     const currentSessionFile = sessionEntry.sessionFile as string;
-
-    console.log("[session-memory] Current sessionId:", currentSessionId);
-    console.log("[session-memory] Current sessionFile:", currentSessionFile);
-    console.log("[session-memory] cfg present:", !!cfg);
 
     const sessionFile = currentSessionFile || undefined;
 
@@ -110,10 +106,8 @@ const saveSessionToMemory: HookHandler = async (event) => {
     if (sessionFile) {
       // Get recent conversation content
       sessionContent = await getRecentSessionContent(sessionFile, messageCount);
-      console.log("[session-memory] sessionContent length:", sessionContent?.length || 0);
 
       if (sessionContent && cfg) {
-        console.log("[session-memory] Calling generateSlugViaLLM...");
         // Dynamically import the LLM slug generator (avoids module caching issues)
         // When compiled, handler is at dist/hooks/bundled/session-memory/handler.js
         // Going up ../.. puts us at dist/hooks/, so just add llm-slug-generator.js
@@ -123,7 +117,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
         // Use LLM to generate a descriptive slug
         slug = await generateSlugViaLLM({ sessionContent, cfg });
-        console.log("[session-memory] Generated slug:", slug);
       }
     }
 
@@ -131,14 +124,11 @@ const saveSessionToMemory: HookHandler = async (event) => {
     if (!slug) {
       const timeSlug = now.toISOString().split("T")[1]!.split(".")[0]!.replace(/:/g, "");
       slug = timeSlug.slice(0, 4); // HHMM
-      console.log("[session-memory] Using fallback timestamp slug:", slug);
     }
 
     // Create filename with date and slug
     const filename = `${dateStr}-${slug}.md`;
     const memoryFilePath = path.join(memoryDir, filename);
-    console.log("[session-memory] Generated filename:", filename);
-    console.log("[session-memory] Full path:", memoryFilePath);
 
     // Format time as HH:MM:SS UTC
     const timeStr = now.toISOString().split("T")[1]!.split(".")[0];
@@ -166,11 +156,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Write to new memory file
     await fs.writeFile(memoryFilePath, entry, "utf-8");
-    console.log("[session-memory] Memory file written successfully");
 
-    // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
+    // Log completion using subsystem logger (visible when log level is trace/debug)
     const relPath = memoryFilePath.replace(os.homedir(), "~");
-    console.log(`[session-memory] Session context saved to ${relPath}`);
+    log.trace(`Session context saved to ${relPath}`);
   } catch (err) {
     console.error(
       "[session-memory] Failed to save session memory:",


### PR DESCRIPTION
## Summary

Remove development debug `console.log` statements from the session-memory hook handler. These debug statements were polluting the console output during normal operation.

## Changes

- Remove 13 debug `console.log` statements that were logging internal state (sessionId, sessionFile, slug generation steps, etc.)
- Add proper `SubsystemLogger` for trace-level logging of completion message
- Keep `console.error` for actual failure cases (consistent with other bundled hooks like `command-logger`)
- Remove unused `currentSessionId` variable that was only used for logging

## Why

The session-memory hook contained numerous debug statements that were likely left over from development/debugging:

```typescript
console.log("[session-memory] Hook triggered for /new command");
console.log("[session-memory] Current sessionId:", currentSessionId);
console.log("[session-memory] Generated slug:", slug);
// ... 10 more similar statements
```

These statements pollute the console during normal operation and don't follow the project's standard logging infrastructure.

## After

The hook now uses `createSubsystemLogger("hooks:session-memory")` for any operational logging, which:
- Can be enabled via log level configuration when debugging is needed
- Follows the same pattern used by other parts of the codebase (e.g., `gmail-watcher`)
- Keeps the console clean during normal operation

## Testing

- [x] TypeScript compilation passes
- [x] Lint check passes (0 warnings, 0 errors)
- [x] All 9 session-memory hook tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR cleans up `src/hooks/bundled/session-memory/handler.ts` by removing leftover debug `console.log` statements and switching the “success/completion” message to the project’s `SubsystemLogger` (`createSubsystemLogger("hooks:session-memory")`) at `trace` level. The hook’s error reporting remains `console.error` in the catch block, keeping user-facing console output clean while still enabling opt-in operational logging via configured log levels/subsystem filtering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to removing noisy debug output and routing a completion message through the existing logging subsystem; no control flow or data handling is altered. The added logger usage follows established patterns in the repo and should not affect runtime unless trace logs are enabled.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->