### PR TITLE
feat(memory-lancedb): support custom embedding endpoints

### DIFF
--- a/extensions/memory-lancedb/clawdbot.plugin.json
+++ b/extensions/memory-lancedb/clawdbot.plugin.json
@@ -6,12 +6,24 @@
       "label": "OpenAI API Key",
       "sensitive": true,
       "placeholder": "sk-proj-...",
-      "help": "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})"
+      "help": "API key for embeddings (use 'not-needed' for local servers)"
     },
     "embedding.model": {
       "label": "Embedding Model",
       "placeholder": "text-embedding-3-small",
-      "help": "OpenAI embedding model to use"
+      "help": "Embedding model name"
+    },
+    "embedding.baseUrl": {
+      "label": "Custom Endpoint URL",
+      "placeholder": "http://localhost:8080/v1",
+      "help": "Custom OpenAI-compatible embedding endpoint (for local/self-hosted servers)",
+      "advanced": true
+    },
+    "embedding.dimensions": {
+      "label": "Vector Dimensions",
+      "placeholder": "1536",
+      "help": "Override vector dimensions (required for custom models not in built-in list)",
+      "advanced": true
     },
     "dbPath": {
       "label": "Database Path",
@@ -39,11 +51,15 @@
             "type": "string"
           },
           "model": {
+            "type": "string"
+          },
+          "baseUrl": {
             "type": "string",
-            "enum": [
-              "text-embedding-3-small",
-              "text-embedding-3-large"
-            ]
+            "description": "Custom OpenAI-compatible endpoint URL"
+          },
+          "dimensions": {
+            "type": "number",
+            "description": "Override vector dimensions for custom models"
           }
         },
         "required": [

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -156,8 +156,9 @@ class Embeddings {
   constructor(
     apiKey: string,
     private model: string,
+    baseUrl?: string,
   ) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ apiKey, baseURL: baseUrl });
   }
 
   async embed(text: string): Promise<number[]> {
@@ -223,9 +224,16 @@ const memoryPlugin = {
   register(api: MoltbotPluginApi) {
     const cfg = memoryConfigSchema.parse(api.pluginConfig);
     const resolvedDbPath = api.resolvePath(cfg.dbPath!);
-    const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small");
+    const vectorDim = vectorDimsForModel(
+      cfg.embedding.model ?? "text-embedding-3-small",
+      cfg.embedding.dimensions,
+    );
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!);
+    const embeddings = new Embeddings(
+      cfg.embedding.apiKey,
+      cfg.embedding.model!,
+      cfg.embedding.baseUrl,
+    );
 
     api.logger.info(
       `memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`,


### PR DESCRIPTION
## Summary

Add support for self-hosted OpenAI-compatible embedding servers in memory-lancedb.

## Changes

- Add `embedding.baseUrl` config option for custom endpoint URL
- Add `embedding.dimensions` config option to override vector dimensions  
- Remove model enum restriction to allow any model name
- Update Embeddings class to pass baseURL to OpenAI client

## Motivation

Many users want to run local embedding models instead of using OpenAI API:
- Privacy: keep data local
- Cost: avoid API charges for high-volume use
- Latency: local inference can be faster
- Flexibility: use specialized models

This enables servers like:
- llama.cpp with `--embedding` flag
- Hugging Face text-embeddings-inference
- Any OpenAI-compatible embedding endpoint

## Example Config

```json
{
  "embedding": {
    "apiKey": "not-needed",
    "baseUrl": "http://localhost:8080/v1",
    "model": "Qwen3-Embedding-8B",
    "dimensions": 4096
  }
}
```

## Testing

Tested with:
- llama.cpp running Qwen3-Embedding-8B (4096 dims)
- Successfully indexes and recalls memories
- Works with autoCapture and autoRecall enabled