### PR TITLE
docs(discord): clarify search doesn't support OR/AND operators

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -263,6 +263,8 @@ Use `discord.actions.*` to disable action groups:
 }
 ```
 
+**Note:** Discord search does **not** support boolean operators like `OR` or `AND`. Queries are matched literally as phrases. To search for multiple terms, make separate search calls for each term.
+
 ### Member + role info
 
 ```json


### PR DESCRIPTION
## Summary
Agents often mistakenly try to use boolean operators (OR/AND) in Discord search queries, expecting SQL-like or web-search behavior. Discord's search API matches queries literally as phrases.

## Changes
Added a note to the Discord skill's search section clarifying this limitation and suggesting separate calls for multiple terms.

## AI-assisted
- **Tool:** Claude
- **Testing level:** Lightly tested (documentation-only change)
- **Understanding:** Yes, this is a simple doc clarification based on observed agent behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Discord skill documentation (`skills/discord/SKILL.md`) by adding a note in the message search section clarifying that Discord search does not support boolean operators like `OR`/`AND` and that queries are matched literally; it recommends issuing separate searches for multiple terms. This fits into the repo’s skill docs as guidance to reduce common agent/user misuse of `searchMessages` queries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Documentation-only change localized to the Discord skill docs; no code paths or tooling behavior are modified, and the added note is consistent with the described Discord search limitation.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->