### PR TITLE
Fix macOS compatibility in docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -124,7 +124,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen_keys=""
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -133,7 +133,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen_keys="${seen_keys}${k};"
           replaced=true
           break
         fi
@@ -145,7 +145,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen_keys" != *"${k};"* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
## Summary
- Fixes docker-setup.sh failing on macOS with Bash 3.2
- Replaces Bash 4 associative array with string-based tracking

## Problem
macOS ships with Bash 3.2 which doesn't support `declare -A` (associative arrays introduced in Bash 4). This caused the script to fail immediately on macOS:

```
./docker-setup.sh: line 127: declare: -A: invalid option
```

## Solution
Replaced the `seen` associative array in the `upsert_env` function with a simple delimited string `seen_keys` to track processed environment variables.

**Before:**
```bash
declare -A seen=()
seen["$k"]=1
if [[ -z "${seen[$k]:-}" ]]; then
```

**After:**
```bash
local seen_keys=""
seen_keys="${seen_keys}${k};"
if [[ "$seen_keys" != *"${k};\"* ]]; then
```

## Testing
- ✅ Syntax check passed on macOS Bash 3.2.57
- ✅ Unit tested the `upsert_env` function logic
- ✅ Verified environment file update/insert behavior

The logic remains identical, just using string operations instead of associative array operations for Bash 3.2 compatibility.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to work on macOS’s default Bash 3.2 by replacing the Bash 4 associative array used to track “seen” env keys in `upsert_env` with string-based tracking.

The change fits into the script’s existing flow where it rewrites/creates the repo `.env` file by upserting a fixed list of `CLAWDBOT_*` variables before building and running the Docker Compose stack.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the string-based key tracking can change behavior in edge cases.
- The Bash 3 compatibility change is small and localized, but the new `seen_keys` implementation uses substring matching, which can mis-detect membership when env keys overlap, leading to missing entries in the generated `.env`. If the key set is fixed and non-overlapping this won’t surface, but it’s easy to harden without losing Bash 3 support.
- docker-setup.sh (upsert_env key tracking logic)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->