### PR TITLE
fix(sessions): always compute session paths from current environment

### DIFF
--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -54,8 +54,10 @@ export function resolveSessionFilePath(
   entry?: SessionEntry,
   opts?: { agentId?: string },
 ): string {
-  const candidate = entry?.sessionFile?.trim();
-  return candidate ? candidate : resolveSessionTranscriptPath(sessionId, opts?.agentId);
+  // Always compute path from current environment rather than trusting stored paths.
+  // Stored absolute paths in sessions.json break when migrating to a different user
+  // or home directory, causing EACCES errors when accessing the old user's paths.
+  return resolveSessionTranscriptPath(sessionId, opts?.agentId);
 }
 
 export function resolveStorePath(store?: string, opts?: { agentId?: string }) {


### PR DESCRIPTION
## Summary

- Remove trust in stored absolute paths in `sessions.json`
- Always compute session file paths fresh from current `HOME` environment
- Fixes EACCES permission errors when migrating Moltbot to a different user

## Problem

When migrating Moltbot from one user to another (e.g., from `stellarprune` to `helmi`), sessions created under the old user contain hardcoded absolute paths in `sessions.json`:

```json
{
  "agent:main:main": {
    "sessionId": "fc35ff1f-0863-4ae0-aac4-75d7497976ec",
    "sessionFile": "/home/olduser/.clawdbot/agents/main/sessions/fc35ff1f-0863-4ae0-aac4-75d7497976ec.jsonl"
  }
}
```

The `resolveSessionFilePath()` function trusted these stored paths over computing fresh ones, causing:

```
EACCES: permission denied, mkdir '/home/olduser/.clawdbot/agents/main/sessions'
```

This occurs even when:
- The systemd service `User=` is set to the new user
- `HOME` environment variable is correctly set
- All config files exist in the new user's home directory

## Solution

Always compute paths from the current environment rather than trusting stored paths:

```typescript
export function resolveSessionFilePath(
  sessionId: string,
  entry?: SessionEntry,
  opts?: { agentId?: string },
): string {
  // Always compute path from current environment rather than trusting stored paths.
  // Stored absolute paths in sessions.json break when migrating to a different user
  // or home directory, causing EACCES errors when accessing the old user's paths.
  return resolveSessionTranscriptPath(sessionId, opts?.agentId);
}
```

## Test plan

- [x] Verified fix resolves EACCES errors on real migration (stellarprune -> helmi)
- [x] Sessions continue to work normally after fix
- [x] Existing session data preserved (only path resolution changes)

## Affected components

This bug affects **all channels** that use session storage:
- Telegram
- Email bridges  
- CLI sessions
- Discord
- Any other channel using the session system

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveSessionFilePath()` to always compute the session transcript path from the current environment (state dir / `HOME`) instead of trusting the `sessionFile` field persisted in `sessions.json`. This is intended to prevent user/home migrations from breaking session access due to stale absolute paths.

The change sits in the session path resolution helpers (`src/config/sessions/paths.ts`) which are used across channels/features that read/write session transcripts.

<h3>Confidence Score: 3/5</h3>

- Likely safe to merge, but it may not fully fix the stated migration issue because other code paths still trust persisted absolute transcript paths.
- The change is small and localized, but it introduces an inconsistency: only callers using `resolveSessionFilePath()` benefit from the new behavior, while other write paths (notably transcript mirroring) still prioritize `entry.sessionFile`. That means the reported EACCES scenario can still occur depending on which code path is exercised.
- src/config/sessions/transcript.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->