### PR TITLE
fix: skip heartbeat wake for subagent exec completions

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -318,7 +318,10 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  // Skip heartbeat for subagent exec completions - prevents main session spam
+  if (!sessionKey.includes(":subagent:")) {
+    requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  }
 }
 
 function createApprovalSlug(id: string) {
@@ -337,7 +340,10 @@ function emitExecSystemEvent(text: string, opts: { sessionKey?: string; contextK
   const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) return;
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  // Skip heartbeat for subagent exec events
+  if (!sessionKey.includes(":subagent:")) {
+    requestHeartbeatNow({ reason: "exec-event" });
+  }
 }
 
 async function runExecProcess(opts: {


### PR DESCRIPTION
## Problem

When sub-agents run many exec commands (e.g., during builds), each completion triggers `requestHeartbeatNow()` which wakes the main session. With only 250ms coalesce time, this causes heartbeat spam flooding the main session.

**Observed behavior:** Main session receives dozens of heartbeat polls per minute when sub-agents are running builds or other multi-exec workflows.

## Solution

Skip the `requestHeartbeatNow()` call when the exec belongs to a subagent session (sessionKey contains `:subagent:`). 

The system event is still enqueued for the subagent session to process, but the main session heartbeat is not triggered.

## Changes

- `src/agents/bash-tools.exec.ts`: Add subagent check before both `requestHeartbeatNow()` calls
  - `maybeNotifyOnExit()` - exec completion notifications
  - `emitExecSystemEvent()` - exec event notifications

## Testing

Tested locally by running sub-agent builds. Main session no longer receives heartbeat spam when sub-agents execute many commands.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces “heartbeat spam” by skipping `requestHeartbeatNow()` when an exec completion/event belongs to a subagent session, while still enqueuing the system event for that session.

The change is localized to `src/agents/bash-tools.exec.ts`, gating heartbeat wakes in `maybeNotifyOnExit()` and `emitExecSystemEvent()` based on a `:subagent:` marker in the `sessionKey`.

Main review note: the new gating logic uses a raw substring check instead of the repo’s existing `isSubagentSessionKey()` helper, which can lead to mismatches for legacy/session-key variants and can drift if the session-key format evolves.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should reduce unnecessary heartbeat wakes, with low functional impact.
- Changes are small and localized (only gating `requestHeartbeatNow()` calls). Main risk is correctness/consistency of the subagent detection via a raw substring check, which could miss certain session-key variants or be brittle if formats evolve.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->