### PR TITLE
feat(identity): include emoji in message prefix

### DIFF
--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -18,9 +18,12 @@ export function resolveAckReaction(cfg: MoltbotConfig, agentId: string): string 
 }
 
 export function resolveIdentityNamePrefix(cfg: MoltbotConfig, agentId: string): string | undefined {
-  const name = resolveAgentIdentity(cfg, agentId)?.name?.trim();
-  if (!name) return undefined;
-  return `[${name}]`;
+  const identity = resolveAgentIdentity(cfg, agentId);
+  const name = identity?.name?.trim();
+  const emoji = identity?.emoji?.trim();
+  if (!name && !emoji) return undefined;
+  const parts = [emoji, name].filter(Boolean);
+  return `[${parts.join(" ")}]`;
 }
 
 /** Returns just the identity name (without brackets) for template context. */


### PR DESCRIPTION
## Summary

When `identity.emoji` is configured, include it in the resolved message prefix alongside the name.

## Configuration

```json
{
  "agents": {
    "list": [{
      "id": "main",
      "identity": {
        "name": "Richbot",
        "emoji": "🦁"
      }
    }]
  }
}
```

## Current behavior
<img width="978" height="130" alt="CleanShot 2026-01-28 at 16 47 00@2x" src="https://github.com/user-attachments/assets/c0db6dda-3fb2-4465-8be9-e971dd03cfe0" />

The resolved prefix is `[Richbot]`: the emoji is ignored.

## Proposed behavior

| Config | Result |
|--------|--------|
| name + emoji | `[🦁 Richbot]` |
| name only | `[Richbot]` |
| emoji only | `[🦁]` |

## Code change

```diff
 export function resolveIdentityNamePrefix(cfg: MoltbotConfig, agentId: string): string | undefined {
-  const name = resolveAgentIdentity(cfg, agentId)?.name?.trim();
-  if (!name) return undefined;
-  return `[${name}]`;
+  const identity = resolveAgentIdentity(cfg, agentId);
+  const name = identity?.name?.trim();
+  const emoji = identity?.emoji?.trim();
+  if (!name && !emoji) return undefined;
+  const parts = [emoji, name].filter(Boolean);
+  return `[${parts.join(" ")}]`;
 }
```

Builds on the identity.name prefix feature from 8112b27.