### PR TITLE
fix: add missing arguments/input field to tool calls [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
@@ -86,7 +86,7 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(toolResult.role).toBe("toolResult");
     expect(toolResult.toolCallId).toBe("call123fc456");
   });
-  it("does not synthesize tool call input when missing", async () => {
+  it("synthesizes tool call arguments when missing (API requires it)", async () => {
     const input = [
       {
         role: "assistant",
@@ -98,7 +98,8 @@ describe("sanitizeSessionMessagesImages", () => {
     const assistant = out[0] as { content?: Array<Record<string, unknown>> };
     const toolCall = assistant.content?.find((b) => b.type === "toolCall");
     expect(toolCall).toBeTruthy();
-    expect("input" in (toolCall ?? {})).toBe(false);
-    expect("arguments" in (toolCall ?? {})).toBe(false);
+    // API requires arguments field to be present (even if empty)
+    expect("arguments" in (toolCall ?? {})).toBe(true);
+    expect(toolCall?.arguments).toEqual({});
   });
 });

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.keeps-tool-call-tool-result-ids-unchanged.test.ts
@@ -92,7 +92,7 @@ describe("sanitizeSessionMessagesImages", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_1", name: "read" }],
       },
-    ] satisfies AgentMessage[];
+    ] as AgentMessage[];
 
     const out = await sanitizeSessionMessagesImages(input, "test");
     const assistant = out[0] as { content?: Array<Record<string, unknown>> };

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -117,4 +117,48 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(out[0]?.role).toBe("user");
     expect(out[1]?.role).toBe("toolResult");
   });
+
+  it("adds missing arguments field to tool calls", async () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "session_status" }, // Missing arguments!
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    const content = (out[0] as { content?: unknown }).content as Array<{
+      type?: string;
+      arguments?: unknown;
+    }>;
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe("toolCall");
+    expect(content[0]?.arguments).toEqual({});
+  });
+
+  it("adds missing input field to toolUse blocks", async () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "call_1", name: "session_status" }, // Missing input!
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    const content = (out[0] as { content?: unknown }).content as Array<{
+      type?: string;
+      input?: unknown;
+    }>;
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe("toolUse");
+    expect(content[0]?.input).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2889

When models call tools without parameters (e.g., `session_status`), they sometimes omit the `arguments` field entirely. The Anthropic/Cloud Code Assist API requires this field to be present (even if empty `{}`), causing the error:
```
messages.X.content.Y.tool_use.input: Field required
```

This corrupts the session history and prevents any further messages until the session is reset.

## Changes

- Added `sanitizeToolCallArguments()` function in `images.ts` that adds `arguments: {}` or `input: {}` to tool call blocks missing the required field
- Added 2 test cases to verify the fix

## Testing

- [x] Unit tests pass (8/8 tests)
- [x] Linter passes (0 warnings, 0 errors)  
- [x] Tested locally with Moltbot instance

## AI Disclosure 🤖

- [x] AI-assisted (built with Anthropic Claude via Antigravity)
- [x] **Testing level**: Fully tested (unit tests + local testing)
- [x] I understand what this code does