### PR TITLE
fix(ollama): add missing api field to auto-discovered models

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -120,6 +120,7 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
         cost: OLLAMA_DEFAULT_COST,
         contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
         maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+        api: "openai-completions",
       };
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes auto-discovered Ollama models missing the `api` field
- Adds `api: "openai-completions"` to models returned by `discoverOllamaModels()`

## Problem
When using Ollama as a provider with auto-discovered models, the gateway may crash with:
```
Error: Unhandled API in mapOptionsForApi: undefined
```

The root cause is that `discoverOllamaModels()` returns model objects without the `api` field, while the runtime code in `pi-embedded-runner/run/attempt.ts` expects `params.model.api` to be defined when calling `streamSimple()`.

## Solution
Add `api: "openai-completions"` to the model objects returned by `discoverOllamaModels()`, matching the provider-level configuration in `buildOllamaProvider()`.

## Test plan
- [x] Lint passes (`pnpm lint`)
- [x] Build passes (`pnpm build`)
- [x] Tests pass (790/793 files, pre-existing failures unrelated to this change)

**Note:** I encountered a separate issue where Ollama models also need to be added to `agents.defaults.models` if that allowlist exists. This code fix addresses the auto-discovery path; users may also need to configure the allowlist.

Fixes #3153

🤖 Generated with [Claude Code](https://claude.ai/code)