### PR TITLE
feat: add proxy support for web_search tool

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { ProxyAgent } from "undici";
 
 import type { MoltbotConfig } from "../../config/config.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -31,6 +32,18 @@ const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
 const BRAVE_FRESHNESS_RANGE = /^(\d{4}-\d{2}-\d{2})to(\d{4}-\d{2}-\d{2})$/;
+
+/**
+ * Get proxy dispatcher from environment variables for HTTP requests.
+ * Respects HTTP_PROXY, HTTPS_PROXY environment variables.
+ */
+function getProxyDispatcher(): ProxyAgent | undefined {
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  if (proxyUrl) {
+    return new ProxyAgent(proxyUrl);
+  }
+  return undefined;
+}
 
 const WebSearchSchema = Type.Object({
   query: Type.String({ description: "Search query string." }),
@@ -273,6 +286,7 @@ async function runPerplexitySearch(params: {
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: string[] }> {
   const endpoint = `${params.baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const proxyDispatcher = getProxyDispatcher();
 
   const res = await fetch(endpoint, {
     method: "POST",
@@ -292,6 +306,7 @@ async function runPerplexitySearch(params: {
       ],
     }),
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+    ...(proxyDispatcher && { dispatcher: proxyDispatcher }),
   });
 
   if (!res.ok) {
@@ -371,6 +386,7 @@ async function runWebSearch(params: {
     url.searchParams.set("freshness", params.freshness);
   }
 
+  const proxyDispatcher = getProxyDispatcher();
   const res = await fetch(url.toString(), {
     method: "GET",
     headers: {
@@ -378,6 +394,7 @@ async function runWebSearch(params: {
       "X-Subscription-Token": params.apiKey,
     },
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+    ...(proxyDispatcher && { dispatcher: proxyDispatcher }),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Add HTTP/HTTPS proxy support for the `web_search` tool using `undici`'s `ProxyAgent`.

This change resolves issues where the `web_search` tool fails to access external APIs (Brave Search, Perplexity) when Moltbot runs behind corporate proxies or VPNs.

## Changes

- Import `ProxyAgent` from `undici`
- Add `getProxyDispatcher()` helper function to read proxy configuration from environment variables
- Apply proxy dispatcher to both `runPerplexitySearch()` and `runWebSearch()` fetch calls
- Respect `HTTP_PROXY` and `HTTPS_PROXY` environment variables

## Testing

- ✅ All unit tests pass (73 test files)
- ✅ Local validation: Successfully called Brave Search API through proxy
- ✅ Build verification: TypeScript compilation with no errors

## Motivation

Node.js `fetch` API does not automatically use system proxy settings. When users run Moltbot behind a proxy or VPN, web search requests fail with "fetch failed" errors. This PR adds explicit proxy support following `undici` best practices.

## Related Issues

Fixes web_search failures for users running behind proxies/VPNs who were experiencing "fetch failed" errors.