### PR TITLE
feat(auth): track cooldown per (auth profile + model)

### DIFF
--- a/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
+++ b/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { calculateAuthProfileCooldownMs } from "./auth-profiles.js";
+import {
+  calculateAuthProfileCooldownMs,
+  cooldownKey,
+  isProfileInCooldown,
+} from "./auth-profiles.js";
+import type { AuthProfileStore } from "./auth-profiles.js";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 
 describe("auth profile cooldowns", () => {
   it("applies exponential backoff with a 1h cap", () => {
@@ -8,5 +14,94 @@ describe("auth profile cooldowns", () => {
     expect(calculateAuthProfileCooldownMs(3)).toBe(25 * 60_000);
     expect(calculateAuthProfileCooldownMs(4)).toBe(60 * 60_000);
     expect(calculateAuthProfileCooldownMs(5)).toBe(60 * 60_000);
+  });
+});
+
+describe("cooldownKey", () => {
+  it("returns profileId when model is not provided", () => {
+    expect(cooldownKey("openai:default")).toBe("openai:default");
+    expect(cooldownKey("openai:default", undefined)).toBe("openai:default");
+  });
+
+  it("returns composite key when model is provided", () => {
+    expect(cooldownKey("openai:default", "gpt-4")).toBe("openai:default:gpt-4");
+    expect(cooldownKey("github-copilot:default", "gpt-5.2")).toBe("github-copilot:default:gpt-5.2");
+  });
+});
+
+describe("isProfileInCooldown with per-model support", () => {
+  it("returns false when no cooldown exists", () => {
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "test" },
+      },
+    };
+    expect(isProfileInCooldown(store, "openai:default")).toBe(false);
+    expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(false);
+  });
+
+  it("checks profile-level cooldown when model not provided", () => {
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "test" },
+      },
+      usageStats: {
+        "openai:default": { cooldownUntil: Date.now() + 60_000 },
+      },
+    };
+    expect(isProfileInCooldown(store, "openai:default")).toBe(true);
+  });
+
+  it("checks per-model cooldown when model is provided", () => {
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "test" },
+      },
+      usageStats: {
+        "openai:default:gpt-4": { cooldownUntil: Date.now() + 60_000 },
+      },
+    };
+    // model-specific cooldown exists
+    expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(true);
+    // different model is not in cooldown
+    expect(isProfileInCooldown(store, "openai:default", "gpt-3.5")).toBe(false);
+    // profile-level is not in cooldown
+    expect(isProfileInCooldown(store, "openai:default")).toBe(false);
+  });
+
+  it("allows independent cooldowns per model", () => {
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "github-copilot:default": {
+          type: "api_key",
+          provider: "github-copilot",
+          key: "test",
+        },
+      },
+      usageStats: {
+        // gpt-5.2 is in cooldown (rate limited)
+        "github-copilot:default:gpt-5.2": { cooldownUntil: Date.now() + 60_000 },
+        // gpt-5-mini has no cooldown (unlimited quota)
+      },
+    };
+    expect(isProfileInCooldown(store, "github-copilot:default", "gpt-5.2")).toBe(true);
+    expect(isProfileInCooldown(store, "github-copilot:default", "gpt-5-mini")).toBe(false);
+  });
+
+  it("returns false when cooldown has expired", () => {
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "test" },
+      },
+      usageStats: {
+        "openai:default:gpt-4": { cooldownUntil: Date.now() - 1000 }, // expired
+      },
+    };
+    expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(false);
   });
 });

--- a/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
+++ b/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
@@ -1,3 +1,16 @@
+/*
+ * Per-Model Cooldown Tests
+ * ────────────────────────
+ * These tests verify the per-model cooldown feature (discussion #3417).
+ *
+ * Key design asymmetry:
+ * - Failures CREATE per-model keys (e.g., "openai:default:gpt-4")
+ * - Successes UPDATE profile-level keys AND clear per-model keys (if they exist)
+ * - Per-model keys are ephemeral "penalty boxes" that only exist during cooldowns
+ *
+ * This allows independent rate limits per model while keeping the store clean.
+ * See: src/agents/auth-profiles/usage.ts for implementation details.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
+++ b/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
@@ -20,13 +20,30 @@ import {
   clearAuthProfileCooldown,
   cooldownKey,
   isProfileInCooldown,
-  markAuthProfileCooldown,
   markAuthProfileFailure,
   markAuthProfileUsed,
   saveAuthProfileStore,
 } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+
+// Test helpers
+const makeStore = (usageStats?: AuthProfileStore["usageStats"]): AuthProfileStore => ({
+  version: AUTH_STORE_VERSION,
+  profiles: {
+    "openai:default": { type: "api_key", provider: "openai", key: "test" },
+  },
+  ...(usageStats && { usageStats }),
+});
+
+async function withTempDir<T>(fn: (tempDir: string) => Promise<T>): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
+  try {
+    return await fn(tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
 
 describe("auth profile cooldowns", () => {
   it("applies exponential backoff with a 1h cap", () => {
@@ -39,9 +56,11 @@ describe("auth profile cooldowns", () => {
 });
 
 describe("cooldownKey", () => {
-  it("returns profileId when model is not provided", () => {
+  it("returns profileId when model is not provided or empty", () => {
     expect(cooldownKey("openai:default")).toBe("openai:default");
     expect(cooldownKey("openai:default", undefined)).toBe("openai:default");
+    expect(cooldownKey("openai:default", "")).toBe("openai:default");
+    expect(cooldownKey("openai:default", "   ")).toBe("openai:default");
   });
 
   it("returns composite key when model is provided", () => {
@@ -52,44 +71,20 @@ describe("cooldownKey", () => {
 
 describe("isProfileInCooldown with per-model support", () => {
   it("returns false when no cooldown exists", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-    };
+    const store = makeStore();
     expect(isProfileInCooldown(store, "openai:default")).toBe(false);
     expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(false);
   });
 
   it("checks profile-level cooldown when model not provided", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
-        "openai:default": { cooldownUntil: Date.now() + 60_000 },
-      },
-    };
+    const store = makeStore({ "openai:default": { cooldownUntil: Date.now() + 60_000 } });
     expect(isProfileInCooldown(store, "openai:default")).toBe(true);
   });
 
   it("checks per-model cooldown when model is provided", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
-        "openai:default:gpt-4": { cooldownUntil: Date.now() + 60_000 },
-      },
-    };
-    // model-specific cooldown exists
+    const store = makeStore({ "openai:default:gpt-4": { cooldownUntil: Date.now() + 60_000 } });
     expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(true);
-    // different model is not in cooldown
     expect(isProfileInCooldown(store, "openai:default", "gpt-3.5")).toBe(false);
-    // profile-level is not in cooldown
     expect(isProfileInCooldown(store, "openai:default")).toBe(false);
   });
 
@@ -97,55 +92,31 @@ describe("isProfileInCooldown with per-model support", () => {
     const store: AuthProfileStore = {
       version: AUTH_STORE_VERSION,
       profiles: {
-        "github-copilot:default": {
-          type: "api_key",
-          provider: "github-copilot",
-          key: "test",
-        },
+        "github-copilot:default": { type: "api_key", provider: "github-copilot", key: "test" },
       },
-      usageStats: {
-        // gpt-5.2 is in cooldown (rate limited)
-        "github-copilot:default:gpt-5.2": { cooldownUntil: Date.now() + 60_000 },
-        // gpt-5-mini has no cooldown (unlimited quota)
-      },
+      usageStats: { "github-copilot:default:gpt-5.2": { cooldownUntil: Date.now() + 60_000 } },
     };
     expect(isProfileInCooldown(store, "github-copilot:default", "gpt-5.2")).toBe(true);
     expect(isProfileInCooldown(store, "github-copilot:default", "gpt-5-mini")).toBe(false);
   });
 
   it("returns false when cooldown has expired", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
-        "openai:default:gpt-4": { cooldownUntil: Date.now() - 1000 }, // expired
-      },
-    };
+    const store = makeStore({ "openai:default:gpt-4": { cooldownUntil: Date.now() - 1000 } });
     expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(false);
   });
 });
 
 describe("markAuthProfileUsed with per-model support", () => {
   it("clears per-model cooldown when model is provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const cooldownTime = Date.now() + 60_000;
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
+    await withTempDir(async (tempDir) => {
+      const cooldownTime = Date.now() + 60_000;
+      const store = makeStore({
         "openai:default": { cooldownUntil: cooldownTime },
         "openai:default:gpt-4": { cooldownUntil: cooldownTime, errorCount: 3 },
         "openai:default:gpt-3.5": { cooldownUntil: cooldownTime },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+      });
+      saveAuthProfileStore(store, tempDir);
 
-    try {
-      // Mark gpt-4 as used (successful)
       await markAuthProfileUsed({
         store,
         profileId: "openai:default",
@@ -153,84 +124,41 @@ describe("markAuthProfileUsed with per-model support", () => {
         agentDir: tempDir,
       });
 
-      // Profile-level cooldown should be cleared
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
-      // Per-model cooldown for gpt-4 should be cleared
       expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBeUndefined();
       expect(store.usageStats?.["openai:default:gpt-4"]?.errorCount).toBe(0);
-      // Per-model cooldown for gpt-3.5 should remain (different model)
       expect(store.usageStats?.["openai:default:gpt-3.5"]?.cooldownUntil).toBe(cooldownTime);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("only clears profile-level cooldown when model is not provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const cooldownTime = Date.now() + 60_000;
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
+    await withTempDir(async (tempDir) => {
+      const cooldownTime = Date.now() + 60_000;
+      const store = makeStore({
         "openai:default": { cooldownUntil: cooldownTime },
         "openai:default:gpt-4": { cooldownUntil: cooldownTime },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+      });
+      saveAuthProfileStore(store, tempDir);
 
-    try {
-      // Mark profile as used without specifying model
       await markAuthProfileUsed({ store, profileId: "openai:default", agentDir: tempDir });
 
-      // Profile-level cooldown should be cleared
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
-      // Per-model cooldown should remain (no model specified)
       expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBe(cooldownTime);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
-});
-
-describe("cooldownKey edge cases", () => {
-  it("treats empty string model the same as undefined", () => {
-    // Empty string should be treated as "no model" to avoid trailing colon
-    expect(cooldownKey("openai:default", "")).toBe("openai:default");
-    expect(cooldownKey("openai:default", "   ")).toBe("openai:default");
+    });
   });
 });
 
 describe("isProfileInCooldown backward compatibility", () => {
   it("returns true for any model when profile-level cooldown exists", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
-        "openai:default": { cooldownUntil: Date.now() + 60_000 }, // profile-level only
-      },
-    };
-    // Any model should be blocked when profile-level cooldown exists
+    const store = makeStore({ "openai:default": { cooldownUntil: Date.now() + 60_000 } });
     expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(true);
     expect(isProfileInCooldown(store, "openai:default", "gpt-3.5")).toBe(true);
     expect(isProfileInCooldown(store, "openai:default", "o1-preview")).toBe(true);
-    // Profile-level check also works
     expect(isProfileInCooldown(store, "openai:default")).toBe(true);
   });
 
   it("checks disabledUntil for per-model cooldowns (billing failures)", () => {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
-        "openai:default:gpt-4": { disabledUntil: Date.now() + 60_000 }, // billing failure
-      },
-    };
+    const store = makeStore({ "openai:default:gpt-4": { disabledUntil: Date.now() + 60_000 } });
     expect(isProfileInCooldown(store, "openai:default", "gpt-4")).toBe(true);
     expect(isProfileInCooldown(store, "openai:default", "gpt-3.5")).toBe(false);
   });
@@ -238,16 +166,10 @@ describe("isProfileInCooldown backward compatibility", () => {
 
 describe("markAuthProfileFailure with per-model support", () => {
   it("tracks failure per model when model is provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+    await withTempDir(async (tempDir) => {
+      const store = makeStore();
+      saveAuthProfileStore(store, tempDir);
 
-    try {
       await markAuthProfileFailure({
         store,
         profileId: "openai:default",
@@ -256,29 +178,18 @@ describe("markAuthProfileFailure with per-model support", () => {
         agentDir: tempDir,
       });
 
-      // Per-model key should have cooldown
       expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBeGreaterThan(Date.now());
       expect(store.usageStats?.["openai:default:gpt-4"]?.errorCount).toBe(1);
-      // Profile-level should NOT have cooldown (only model-specific)
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
-      // Other models should not be affected
       expect(store.usageStats?.["openai:default:gpt-3.5"]).toBeUndefined();
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("tracks failure at profile level when model is not provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+    await withTempDir(async (tempDir) => {
+      const store = makeStore();
+      saveAuthProfileStore(store, tempDir);
 
-    try {
       await markAuthProfileFailure({
         store,
         profileId: "openai:default",
@@ -286,25 +197,16 @@ describe("markAuthProfileFailure with per-model support", () => {
         agentDir: tempDir,
       });
 
-      // Profile-level key should have cooldown
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeGreaterThan(Date.now());
       expect(store.usageStats?.["openai:default"]?.errorCount).toBe(1);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("tracks billing failures with disabledUntil per model", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+    await withTempDir(async (tempDir) => {
+      const store = makeStore();
+      saveAuthProfileStore(store, tempDir);
 
-    try {
       await markAuthProfileFailure({
         store,
         profileId: "openai:default",
@@ -313,62 +215,23 @@ describe("markAuthProfileFailure with per-model support", () => {
         agentDir: tempDir,
       });
 
-      // Billing failures use disabledUntil instead of cooldownUntil
       expect(store.usageStats?.["openai:default:gpt-4"]?.disabledUntil).toBeGreaterThan(Date.now());
       expect(store.usageStats?.["openai:default:gpt-4"]?.disabledReason).toBe("billing");
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
-});
-
-describe("markAuthProfileCooldown with per-model support", () => {
-  it("marks cooldown per model when model is provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
-
-    try {
-      await markAuthProfileCooldown({
-        store,
-        profileId: "openai:default",
-        model: "gpt-4",
-        agentDir: tempDir,
-      });
-
-      // Per-model key should have cooldown
-      expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBeGreaterThan(Date.now());
-      // Profile-level should NOT have cooldown
-      expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 });
 
 describe("clearAuthProfileCooldown with per-model support", () => {
   it("clears per-model cooldown when model is provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const cooldownTime = Date.now() + 60_000;
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
+    await withTempDir(async (tempDir) => {
+      const cooldownTime = Date.now() + 60_000;
+      const store = makeStore({
         "openai:default": { cooldownUntil: cooldownTime },
         "openai:default:gpt-4": { cooldownUntil: cooldownTime, errorCount: 3 },
         "openai:default:gpt-3.5": { cooldownUntil: cooldownTime },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
+      });
+      saveAuthProfileStore(store, tempDir);
 
-    try {
       await clearAuthProfileCooldown({
         store,
         profileId: "openai:default",
@@ -376,47 +239,27 @@ describe("clearAuthProfileCooldown with per-model support", () => {
         agentDir: tempDir,
       });
 
-      // Per-model cooldown for gpt-4 should be cleared
       expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBeUndefined();
       expect(store.usageStats?.["openai:default:gpt-4"]?.errorCount).toBe(0);
-      // Profile-level cooldown should remain (different key)
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(cooldownTime);
-      // Other model cooldown should remain
       expect(store.usageStats?.["openai:default:gpt-3.5"]?.cooldownUntil).toBe(cooldownTime);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("clears profile-level cooldown when model is not provided", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
-    const cooldownTime = Date.now() + 60_000;
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {
-        "openai:default": { type: "api_key", provider: "openai", key: "test" },
-      },
-      usageStats: {
+    await withTempDir(async (tempDir) => {
+      const cooldownTime = Date.now() + 60_000;
+      const store = makeStore({
         "openai:default": { cooldownUntil: cooldownTime, errorCount: 2 },
         "openai:default:gpt-4": { cooldownUntil: cooldownTime },
-      },
-    };
-    saveAuthProfileStore(store, tempDir);
-
-    try {
-      await clearAuthProfileCooldown({
-        store,
-        profileId: "openai:default",
-        agentDir: tempDir,
       });
+      saveAuthProfileStore(store, tempDir);
 
-      // Profile-level cooldown should be cleared
+      await clearAuthProfileCooldown({ store, profileId: "openai:default", agentDir: tempDir });
+
       expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
       expect(store.usageStats?.["openai:default"]?.errorCount).toBe(0);
-      // Per-model cooldown should remain (different key)
       expect(store.usageStats?.["openai:default:gpt-4"]?.cooldownUntil).toBe(cooldownTime);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -32,6 +32,7 @@ export type {
 export {
   calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
+  cooldownKey,
   isProfileInCooldown,
   markAuthProfileCooldown,
   markAuthProfileFailure,

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -50,6 +50,14 @@ function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
   return Math.max(...values);
 }
 
+/** Checks if a key is currently in cooldown. */
+function isKeyInCooldown(store: AuthProfileStore, key: string, now: number): boolean {
+  const stats = store.usageStats?.[key];
+  if (!stats) return false;
+  const unusableUntil = resolveProfileUnusableUntil(stats);
+  return unusableUntil !== null && now < unusableUntil;
+}
+
 /**
  * Check if a profile is currently in cooldown (due to rate limiting or errors).
  *
@@ -73,22 +81,43 @@ export function isProfileInCooldown(
   const now = Date.now();
 
   // Check per-model cooldown first (if model provided)
-  if (model) {
-    const modelKey = cooldownKey(profileId, model);
-    const modelStats = store.usageStats?.[modelKey];
-    if (modelStats) {
-      const modelUnusableUntil = resolveProfileUnusableUntil(modelStats);
-      if (modelUnusableUntil && now < modelUnusableUntil) {
-        return true;
-      }
-    }
+  if (model && isKeyInCooldown(store, cooldownKey(profileId, model), now)) {
+    return true;
   }
 
   // Also check profile-level cooldown (applies to all models)
-  const profileStats = store.usageStats?.[profileId];
-  if (!profileStats) return false;
-  const profileUnusableUntil = resolveProfileUnusableUntil(profileStats);
-  return profileUnusableUntil ? now < profileUnusableUntil : false;
+  return isKeyInCooldown(store, profileId, now);
+}
+
+/** Clears cooldown fields from usage stats, preserving other fields. */
+function clearCooldownFields(
+  stats: ProfileUsageStats | undefined,
+  options?: { setLastUsed?: boolean },
+): ProfileUsageStats {
+  return {
+    ...stats,
+    ...(options?.setLastUsed ? { lastUsed: Date.now() } : {}),
+    errorCount: 0,
+    cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
+  };
+}
+
+/** Applies success updates to usage stats in-place. */
+function applySuccessUpdates(
+  usageStats: Record<string, ProfileUsageStats>,
+  profileId: string,
+  model?: string,
+): void {
+  usageStats[profileId] = clearCooldownFields(usageStats[profileId], { setLastUsed: true });
+  if (model) {
+    const modelKey = cooldownKey(profileId, model);
+    if (usageStats[modelKey]) {
+      usageStats[modelKey] = clearCooldownFields(usageStats[modelKey]);
+    }
+  }
 }
 
 /**
@@ -116,30 +145,7 @@ export async function markAuthProfileUsed(params: {
         return false;
       }
       freshStore.usageStats = freshStore.usageStats ?? {};
-      // Clear profile-level cooldown
-      freshStore.usageStats[profileId] = {
-        ...freshStore.usageStats[profileId],
-        lastUsed: Date.now(),
-        errorCount: 0,
-        cooldownUntil: undefined,
-        disabledUntil: undefined,
-        disabledReason: undefined,
-        failureCounts: undefined,
-      };
-      // Also clear per-model cooldown if model provided
-      if (model) {
-        const modelKey = cooldownKey(profileId, model);
-        if (freshStore.usageStats[modelKey]) {
-          freshStore.usageStats[modelKey] = {
-            ...freshStore.usageStats[modelKey],
-            errorCount: 0,
-            cooldownUntil: undefined,
-            disabledUntil: undefined,
-            disabledReason: undefined,
-            failureCounts: undefined,
-          };
-        }
-      }
+      applySuccessUpdates(freshStore.usageStats, profileId, model);
       return true;
     },
   });
@@ -152,30 +158,7 @@ export async function markAuthProfileUsed(params: {
   }
 
   store.usageStats = store.usageStats ?? {};
-  // Clear profile-level cooldown
-  store.usageStats[profileId] = {
-    ...store.usageStats[profileId],
-    lastUsed: Date.now(),
-    errorCount: 0,
-    cooldownUntil: undefined,
-    disabledUntil: undefined,
-    disabledReason: undefined,
-    failureCounts: undefined,
-  };
-  // Also clear per-model cooldown if model provided
-  if (model) {
-    const modelKey = cooldownKey(profileId, model);
-    if (store.usageStats[modelKey]) {
-      store.usageStats[modelKey] = {
-        ...store.usageStats[modelKey],
-        errorCount: 0,
-        cooldownUntil: undefined,
-        disabledUntil: undefined,
-        disabledReason: undefined,
-        failureCounts: undefined,
-      };
-    }
-  }
+  applySuccessUpdates(store.usageStats, profileId, model);
   saveAuthProfileStore(store, agentDir);
 }
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -7,9 +7,14 @@ import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } fr
  * Generate a cooldown key that optionally includes the model.
  * When model is provided, cooldowns are tracked per (profile + model) combination.
  * This allows different models from the same provider to have independent cooldowns.
+ *
+ * @example cooldownKey("openai:default", "gpt-4") => "openai:default:gpt-4"
+ * @example cooldownKey("openai:default") => "openai:default"
  */
 export function cooldownKey(profileId: string, model?: string): string {
-  return model ? `${profileId}:${model}` : profileId;
+  // Treat empty/whitespace-only string as "no model" to avoid trailing colon in key
+  const normalizedModel = model?.trim() || undefined;
+  return normalizedModel ? `${profileId}:${normalizedModel}` : profileId;
 }
 
 function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
@@ -24,15 +29,13 @@ function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
 
 /**
  * Check if a profile is currently in cooldown (due to rate limiting or errors).
- */
-/**
- * Check if a profile is currently in cooldown (due to rate limiting or errors).
- * When model is provided, checks the per-model cooldown key.
- */
-/**
- * Check if a profile is currently in cooldown (due to rate limiting or errors).
- * When model is provided, checks both the per-model cooldown key and the profile-level key.
- * A profile-level cooldown applies to all models (backward compatibility).
+ *
+ * When model is provided, checks both:
+ * 1. The per-model cooldown key (e.g., "openai:default:gpt-4")
+ * 2. The profile-level cooldown key (e.g., "openai:default")
+ *
+ * Profile-level cooldowns apply to all models under that profile, supporting
+ * legacy entries and scenarios where failures affect all models (e.g., auth errors).
  */
 export function isProfileInCooldown(
   store: AuthProfileStore,
@@ -65,10 +68,6 @@ export function isProfileInCooldown(
   return profileUnusableUntil ? now < profileUnusableUntil : false;
 }
 
-/**
- * Mark a profile as successfully used. Resets error count and updates lastUsed.
- * Uses store lock to avoid overwriting concurrent usage updates.
- */
 /**
  * Mark a profile as successfully used. Resets error count and updates lastUsed.
  * Uses store lock to avoid overwriting concurrent usage updates.
@@ -277,10 +276,6 @@ function computeNextProfileUsageStats(params: {
 /**
  * Mark a profile as failed for a specific reason. Billing failures are treated
  * as "disabled" (longer backoff) vs the regular cooldown window.
- */
-/**
- * Mark a profile as failed for a specific reason. Billing failures are treated
- * as "disabled" (longer backoff) vs the regular cooldown window.
  * When model is provided, cooldown is tracked per (profile + model) combination.
  */
 export async function markAuthProfileFailure(params: {
@@ -346,14 +341,9 @@ export async function markAuthProfileFailure(params: {
 }
 
 /**
- * Mark a profile as failed/rate-limited. Applies exponential backoff cooldown.
- * Cooldown times: 1min, 5min, 25min, max 1 hour.
- * Uses store lock to avoid overwriting concurrent usage updates.
- */
-/**
- * Mark a profile as failed/rate-limited. Applies exponential backoff cooldown.
- * Cooldown times: 1min, 5min, 25min, max 1 hour.
- * Uses store lock to avoid overwriting concurrent usage updates.
+ * Mark a profile as failed/rate-limited with "unknown" reason.
+ * Convenience wrapper around markAuthProfileFailure() for generic failures.
+ * Applies exponential backoff cooldown: 1min, 5min, 25min, max 1 hour.
  * When model is provided, cooldown is tracked per (profile + model) combination.
  */
 export async function markAuthProfileCooldown(params: {
@@ -371,10 +361,6 @@ export async function markAuthProfileCooldown(params: {
   });
 }
 
-/**
- * Clear cooldown for a profile (e.g., manual reset).
- * Uses store lock to avoid overwriting concurrent usage updates.
- */
 /**
  * Clear cooldown for a profile (e.g., manual reset).
  * Uses store lock to avoid overwriting concurrent usage updates.

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -69,12 +69,18 @@ export function isProfileInCooldown(
  * Mark a profile as successfully used. Resets error count and updates lastUsed.
  * Uses store lock to avoid overwriting concurrent usage updates.
  */
+/**
+ * Mark a profile as successfully used. Resets error count and updates lastUsed.
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ * When model is provided, also clears the per-model cooldown.
+ */
 export async function markAuthProfileUsed(params: {
   store: AuthProfileStore;
   profileId: string;
+  model?: string;
   agentDir?: string;
 }): Promise<void> {
-  const { store, profileId, agentDir } = params;
+  const { store, profileId, model, agentDir } = params;
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
@@ -82,6 +88,7 @@ export async function markAuthProfileUsed(params: {
         return false;
       }
       freshStore.usageStats = freshStore.usageStats ?? {};
+      // Clear profile-level cooldown
       freshStore.usageStats[profileId] = {
         ...freshStore.usageStats[profileId],
         lastUsed: Date.now(),
@@ -91,6 +98,20 @@ export async function markAuthProfileUsed(params: {
         disabledReason: undefined,
         failureCounts: undefined,
       };
+      // Also clear per-model cooldown if model provided
+      if (model) {
+        const modelKey = cooldownKey(profileId, model);
+        if (freshStore.usageStats[modelKey]) {
+          freshStore.usageStats[modelKey] = {
+            ...freshStore.usageStats[modelKey],
+            errorCount: 0,
+            cooldownUntil: undefined,
+            disabledUntil: undefined,
+            disabledReason: undefined,
+            failureCounts: undefined,
+          };
+        }
+      }
       return true;
     },
   });
@@ -103,6 +124,7 @@ export async function markAuthProfileUsed(params: {
   }
 
   store.usageStats = store.usageStats ?? {};
+  // Clear profile-level cooldown
   store.usageStats[profileId] = {
     ...store.usageStats[profileId],
     lastUsed: Date.now(),
@@ -112,6 +134,20 @@ export async function markAuthProfileUsed(params: {
     disabledReason: undefined,
     failureCounts: undefined,
   };
+  // Also clear per-model cooldown if model provided
+  if (model) {
+    const modelKey = cooldownKey(profileId, model);
+    if (store.usageStats[modelKey]) {
+      store.usageStats[modelKey] = {
+        ...store.usageStats[modelKey],
+        errorCount: 0,
+        cooldownUntil: undefined,
+        disabledUntil: undefined,
+        disabledReason: undefined,
+        failureCounts: undefined,
+      };
+    }
+  }
   saveAuthProfileStore(store, agentDir);
 }
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -94,7 +94,13 @@ export function isProfileInCooldown(
 /**
  * Mark a profile as successfully used. Resets error count and updates lastUsed.
  * Uses store lock to avoid overwriting concurrent usage updates.
- * When model is provided, also clears the per-model cooldown.
+ *
+ * Success metrics (lastUsed, lastGood) are ALWAYS updated at the profile level,
+ * regardless of which model was used. This is intentional: if ANY model works,
+ * the credentials are valid and the profile should be remembered as "good".
+ *
+ * When model is provided, also clears the per-model cooldown (if one exists).
+ * This allows a recovered model to be used immediately without waiting for expiry.
  */
 export async function markAuthProfileUsed(params: {
   store: AuthProfileStore;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -3,6 +3,15 @@ import { normalizeProviderId } from "../model-selection.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
+/**
+ * Generate a cooldown key that optionally includes the model.
+ * When model is provided, cooldowns are tracked per (profile + model) combination.
+ * This allows different models from the same provider to have independent cooldowns.
+ */
+export function cooldownKey(profileId: string, model?: string): string {
+  return model ? `${profileId}:${model}` : profileId;
+}
+
 function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
   const values = [stats.cooldownUntil, stats.disabledUntil]
     .filter((value): value is number => typeof value === "number")
@@ -16,13 +25,44 @@ function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
 /**
  * Check if a profile is currently in cooldown (due to rate limiting or errors).
  */
-export function isProfileInCooldown(store: AuthProfileStore, profileId: string): boolean {
+/**
+ * Check if a profile is currently in cooldown (due to rate limiting or errors).
+ * When model is provided, checks the per-model cooldown key.
+ */
+/**
+ * Check if a profile is currently in cooldown (due to rate limiting or errors).
+ * When model is provided, checks both the per-model cooldown key and the profile-level key.
+ * A profile-level cooldown applies to all models (backward compatibility).
+ */
+export function isProfileInCooldown(
+  store: AuthProfileStore,
+  profileId: string,
+  model?: string,
+): boolean {
   const stats = store.usageStats?.[profileId];
   if (!stats) {
     return false;
   }
-  const unusableUntil = resolveProfileUnusableUntil(stats);
-  return unusableUntil ? Date.now() < unusableUntil : false;
+
+  const now = Date.now();
+
+  // Check per-model cooldown first (if model provided)
+  if (model) {
+    const modelKey = cooldownKey(profileId, model);
+    const modelStats = store.usageStats?.[modelKey];
+    if (modelStats) {
+      const modelUnusableUntil = resolveProfileUnusableUntil(modelStats);
+      if (modelUnusableUntil && now < modelUnusableUntil) {
+        return true;
+      }
+    }
+  }
+
+  // Also check profile-level cooldown (applies to all models)
+  const profileStats = store.usageStats?.[profileId];
+  if (!profileStats) return false;
+  const profileUnusableUntil = resolveProfileUnusableUntil(profileStats);
+  return profileUnusableUntil ? now < profileUnusableUntil : false;
 }
 
 /**
@@ -202,14 +242,21 @@ function computeNextProfileUsageStats(params: {
  * Mark a profile as failed for a specific reason. Billing failures are treated
  * as "disabled" (longer backoff) vs the regular cooldown window.
  */
+/**
+ * Mark a profile as failed for a specific reason. Billing failures are treated
+ * as "disabled" (longer backoff) vs the regular cooldown window.
+ * When model is provided, cooldown is tracked per (profile + model) combination.
+ */
 export async function markAuthProfileFailure(params: {
   store: AuthProfileStore;
   profileId: string;
+  model?: string;
   reason: AuthProfileFailureReason;
   cfg?: OpenClawConfig;
   agentDir?: string;
 }): Promise<void> {
-  const { store, profileId, reason, agentDir, cfg } = params;
+  const { store, profileId, model, reason, agentDir, cfg } = params;
+  const key = cooldownKey(profileId, model);
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
@@ -218,7 +265,7 @@ export async function markAuthProfileFailure(params: {
         return false;
       }
       freshStore.usageStats = freshStore.usageStats ?? {};
-      const existing = freshStore.usageStats[profileId] ?? {};
+      const existing = freshStore.usageStats[key] ?? {};
 
       const now = Date.now();
       const providerKey = normalizeProviderId(profile.provider);
@@ -227,7 +274,7 @@ export async function markAuthProfileFailure(params: {
         providerId: providerKey,
       });
 
-      freshStore.usageStats[profileId] = computeNextProfileUsageStats({
+      freshStore.usageStats[key] = computeNextProfileUsageStats({
         existing,
         now,
         reason,
@@ -245,7 +292,7 @@ export async function markAuthProfileFailure(params: {
   }
 
   store.usageStats = store.usageStats ?? {};
-  const existing = store.usageStats[profileId] ?? {};
+  const existing = store.usageStats[key] ?? {};
   const now = Date.now();
   const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
   const cfgResolved = resolveAuthCooldownConfig({
@@ -253,7 +300,7 @@ export async function markAuthProfileFailure(params: {
     providerId: providerKey,
   });
 
-  store.usageStats[profileId] = computeNextProfileUsageStats({
+  store.usageStats[key] = computeNextProfileUsageStats({
     existing,
     now,
     reason,
@@ -267,14 +314,22 @@ export async function markAuthProfileFailure(params: {
  * Cooldown times: 1min, 5min, 25min, max 1 hour.
  * Uses store lock to avoid overwriting concurrent usage updates.
  */
+/**
+ * Mark a profile as failed/rate-limited. Applies exponential backoff cooldown.
+ * Cooldown times: 1min, 5min, 25min, max 1 hour.
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ * When model is provided, cooldown is tracked per (profile + model) combination.
+ */
 export async function markAuthProfileCooldown(params: {
   store: AuthProfileStore;
   profileId: string;
+  model?: string;
   agentDir?: string;
 }): Promise<void> {
   await markAuthProfileFailure({
     store: params.store,
     profileId: params.profileId,
+    model: params.model,
     reason: "unknown",
     agentDir: params.agentDir,
   });
@@ -284,21 +339,26 @@ export async function markAuthProfileCooldown(params: {
  * Clear cooldown for a profile (e.g., manual reset).
  * Uses store lock to avoid overwriting concurrent usage updates.
  */
+/**
+ * Clear cooldown for a profile (e.g., manual reset).
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ * When model is provided, clears the per-model cooldown key.
+ */
 export async function clearAuthProfileCooldown(params: {
   store: AuthProfileStore;
   profileId: string;
+  model?: string;
   agentDir?: string;
 }): Promise<void> {
-  const { store, profileId, agentDir } = params;
+  const { store, profileId, model, agentDir } = params;
+  const key = cooldownKey(profileId, model);
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
-      if (!freshStore.usageStats?.[profileId]) {
-        return false;
-      }
+      if (!freshStore.usageStats?.[key]) return false;
 
-      freshStore.usageStats[profileId] = {
-        ...freshStore.usageStats[profileId],
+      freshStore.usageStats[key] = {
+        ...freshStore.usageStats[key],
         errorCount: 0,
         cooldownUntil: undefined,
       };
@@ -309,12 +369,10 @@ export async function clearAuthProfileCooldown(params: {
     store.usageStats = updated.usageStats;
     return;
   }
-  if (!store.usageStats?.[profileId]) {
-    return;
-  }
+  if (!store.usageStats?.[key]) return;
 
-  store.usageStats[profileId] = {
-    ...store.usageStats[profileId],
+  store.usageStats[key] = {
+    ...store.usageStats[key],
     errorCount: 0,
     cooldownUntil: undefined,
   };

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -244,6 +244,66 @@ describe("runWithModelFallback", () => {
     }
   });
 
+  it("allows different models from same provider when only one model is in cooldown", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-auth-"));
+    const provider = `per-model-cooldown-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        // Only model-a is in cooldown (per-model key)
+        [`${profileId}:model-a`]: {
+          cooldownUntil: Date.now() + 60_000,
+        },
+        // model-b has no cooldown
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/model-a`,
+            fallbacks: [`${provider}/model-b`],
+          },
+        },
+      },
+    });
+
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (modelId === "model-b") return "ok";
+      throw new Error(`unexpected model: ${providerId}/${modelId}`);
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "model-a",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      // model-a should be skipped (in cooldown), model-b should be tried
+      expect(run.mock.calls).toEqual([[provider, "model-b"]]);
+      expect(result.attempts[0]?.reason).toBe("rate_limit");
+      expect(result.attempts[0]?.model).toBe("model-a");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not append configured primary when fallbacksOverride is set", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -261,14 +261,16 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, candidate.model),
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
+        // All profiles for this provider+model are in cooldown; skip without attempting
         attempts.push({
           provider: candidate.provider,
           model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+          error: `${candidate.provider}/${candidate.model} is in cooldown (all profiles unavailable)`,
           reason: "rate_limit",
         });
         continue;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -660,6 +660,7 @@ export async function runEmbeddedPiAgent(
             await markAuthProfileUsed({
               store: authStore,
               profileId: lastProfileId,
+              model: modelId,
               agentDir: params.agentDir,
             });
           }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -486,6 +486,7 @@ export async function runEmbeddedPiAgent(
               await markAuthProfileFailure({
                 store: authStore,
                 profileId: lastProfileId,
+                model: modelId,
                 reason: promptFailoverReason,
                 cfg: params.config,
                 agentDir: params.agentDir,
@@ -573,6 +574,7 @@ export async function runEmbeddedPiAgent(
               await markAuthProfileFailure({
                 store: authStore,
                 profileId: lastProfileId,
+                model: modelId,
                 reason,
                 cfg: params.config,
                 agentDir: params.agentDir,


### PR DESCRIPTION
## Summary

Changes cooldown tracking from auth-profile-level to per-(auth profile + model), allowing different models from the same provider to have independent cooldowns.

**Problem:** When a model hits rate limit, the current implementation blocks ALL models using that auth profile. For example, if `github-copilot/gpt-5.2` hits rate limit, `github-copilot/gpt-5-mini` (which has unlimited quota) is also blocked.

**Solution:** Key cooldowns by `${profileId}:${model}` instead of just `profileId`. Profile-level cooldowns are still respected for backward compatibility.

Ref: #3417

## Changes

- Add `cooldownKey()` helper for composite key generation
- Update `isProfileInCooldown` to check both per-model and profile-level cooldowns
- Update `markAuthProfileFailure`, `markAuthProfileCooldown`, `clearAuthProfileCooldown` with optional `model` param
- Pass model to cooldown checks in `model-fallback.ts`
- Pass model when marking failures in `pi-embedded-runner/run.ts`

## Test Plan

- [x] Added tests for `cooldownKey()` function
- [x] Added tests for per-model cooldown behavior in `isProfileInCooldown`
- [x] Added test for same-provider different-model fallback scenario
- [x] Full test suite passes
- [x] Build and lint pass

## Prompt

Claude Code (Opus 4.5)

> Create an implementation plan for the discussion #3417. Understand the problem and the solution, check the existing implementation, check the possibility of making the proposal works. The plan should also include update or creating new tests, depending of the existing ones. If and when the plan is approved, create a new branch for it. Use Serena for everything: exploration and implementation

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Fully tested locally
- [x] I understand what the code does