### PR TITLE
fix(macos): menu bar activity badge not showing during agent work

### DIFF
--- a/apps/macos/Sources/Moltbot/AgentEventsWindow.swift
+++ b/apps/macos/Sources/Moltbot/AgentEventsWindow.swift
@@ -67,7 +67,7 @@ private struct EventRow: View {
 
     private var tint: Color {
         switch self.event.stream {
-        case "job": .blue
+        case "lifecycle": .blue
         case "tool": .orange
         case "assistant": .green
         default: .gray

--- a/apps/macos/Sources/Moltbot/ControlChannel.swift
+++ b/apps/macos/Sources/Moltbot/ControlChannel.swift
@@ -379,8 +379,11 @@ final class ControlChannel {
         let sessionKey = (event.data["sessionKey"]?.value as? String) ?? "main"
 
         switch event.stream.lowercased() {
-        case "job":
-            if let state = event.data["state"]?.value as? String {
+        case "lifecycle":
+            // Gateway emits phase: "start" | "end" | "error"
+            // WorkActivityStore expects state: "started" | "streaming" | (anything else = done)
+            if let phase = event.data["phase"]?.value as? String {
+                let state = phase.lowercased() == "start" ? "started" : "done"
                 WorkActivityStore.shared.handleJob(sessionKey: sessionKey, state: state)
             }
         case "tool":

--- a/apps/macos/Sources/Moltbot/ControlChannel.swift
+++ b/apps/macos/Sources/Moltbot/ControlChannel.swift
@@ -1,6 +1,6 @@
+import Foundation
 import MoltbotKit
 import MoltbotProtocol
-import Foundation
 import Observation
 import SwiftUI
 
@@ -15,7 +15,9 @@ struct ControlHeartbeatEvent: Codable {
 }
 
 struct ControlAgentEvent: Codable, Sendable, Identifiable {
-    var id: String { "\(self.runId)-\(self.seq)" }
+    var id: String {
+        "\(self.runId)-\(self.seq)"
+    }
     let runId: String
     let seq: Int
     let stream: String


### PR DESCRIPTION
## Summary
Fixes two macOS issues:
1. **Menu bar activity badge** - Wasn't showing during agent work due to missing state update
2. **Chat window crash** - Prevented crash when opening chat window

## Rebased from #1994
Previous PR was closed due to merge conflicts. This is a clean rebase on current main.

## Changes
- Fix activity badge state propagation in menu bar
- Add nil check for chat window initialization

## Testing
- Verified badge appears during agent activity
- Confirmed chat window opens without crash

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates macOS agent activity/UI state wiring so the menu bar activity badge reflects active agent work, and it adds a defensive path in chat markdown rendering to avoid a crash when `Textual`’s SwiftPM resource bundle isn’t found in packaged app layouts.

Key changes are:
- `ControlChannel.routeWorkActivity` now listens to `stream == "lifecycle"` events and converts gateway lifecycle signals into `WorkActivityStore.handleJob` state updates, so the badge can transition into and out of “working”.
- `AgentEventsWindow` display logic aligns the stream label/tint mapping with the new lifecycle stream name.
- `ChatMarkdownRenderer` conditionally uses `StructuredText` only when Textual resources appear available; otherwise it falls back to plain `Text`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the new Textual-bundle gating logic may regress markdown rendering in some packaging/configurations.
- ControlChannel’s stream/state mapping is small and localized, and aligns with WorkActivityStore’s started-vs-done semantics. The higher risk is in ChatMarkdownRenderer: bundle detection is eager (static), path-based, and relies on DEBUG heuristics, which could cause unnecessary plain-text fallback or fail to prevent the original crash in some build modes.
- apps/shared/MoltbotKit/Sources/MoltbotChatUI/ChatMarkdownRenderer.swift

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->