### PR TITLE
feat(compaction): add post-compaction recovery turn

### DIFF
--- a/src/auto-reply/reply/post-compaction.test.ts
+++ b/src/auto-reply/reply/post-compaction.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_POST_COMPACTION_PROMPT,
+  DEFAULT_POST_COMPACTION_SYSTEM_PROMPT,
+  resolvePostCompactionSettings,
+  shouldRunPostCompaction,
+} from "./post-compaction.js";
+
+describe("post-compaction settings", () => {
+  it("defaults to enabled with fallback prompt and system prompt", () => {
+    const settings = resolvePostCompactionSettings();
+    expect(settings).not.toBeNull();
+    expect(settings?.enabled).toBe(true);
+    expect(settings?.prompt.length).toBeGreaterThan(0);
+    expect(settings?.systemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it("respects disable flag", () => {
+    expect(
+      resolvePostCompactionSettings({
+        agents: {
+          defaults: { compaction: { postCompaction: { enabled: false } } },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("uses default prompts when not configured", () => {
+    const settings = resolvePostCompactionSettings();
+    expect(settings?.prompt).toContain("Compaction completed");
+    expect(settings?.systemPrompt).toContain("Post-compaction recovery turn");
+  });
+
+  it("appends NO_REPLY hint when missing", () => {
+    const settings = resolvePostCompactionSettings({
+      agents: {
+        defaults: {
+          compaction: {
+            postCompaction: {
+              prompt: "Recovery turn now.",
+              systemPrompt: "Check memory.",
+            },
+          },
+        },
+      },
+    });
+    expect(settings?.prompt).toContain("NO_REPLY");
+    expect(settings?.systemPrompt).toContain("NO_REPLY");
+  });
+
+  it("preserves NO_REPLY hint when already present", () => {
+    const settings = resolvePostCompactionSettings({
+      agents: {
+        defaults: {
+          compaction: {
+            postCompaction: {
+              prompt: "Recovery turn. Reply NO_REPLY if nothing needed.",
+              systemPrompt: "Check memory. Use NO_REPLY when appropriate.",
+            },
+          },
+        },
+      },
+    });
+    // Should not double-append the hint
+    const promptHintCount = (settings?.prompt.match(/NO_REPLY/g) || []).length;
+    const systemHintCount = (settings?.systemPrompt.match(/NO_REPLY/g) || []).length;
+    expect(promptHintCount).toBe(1);
+    expect(systemHintCount).toBe(1);
+  });
+});
+
+describe("shouldRunPostCompaction", () => {
+  it("requires memoryCompactionCompleted to be true", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: { compactionCount: 1 },
+        memoryCompactionCompleted: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("runs when compaction just completed", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: { compactionCount: 1 },
+        memoryCompactionCompleted: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips when entry is missing but compaction completed", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: undefined,
+        memoryCompactionCompleted: true,
+      }),
+    ).toBe(true); // Should still run even without entry
+  });
+
+  it("skips when already ran for current compaction count", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: {
+          compactionCount: 2,
+          postCompactionCompactionCount: 2,
+        },
+        memoryCompactionCompleted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("runs when compaction count increased since last post-compaction", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: {
+          compactionCount: 3,
+          postCompactionCompactionCount: 2,
+        },
+        memoryCompactionCompleted: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("runs on first compaction when postCompactionCompactionCount is undefined", () => {
+    expect(
+      shouldRunPostCompaction({
+        entry: {
+          compactionCount: 1,
+        },
+        memoryCompactionCompleted: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("default prompts", () => {
+  it("DEFAULT_POST_COMPACTION_PROMPT includes memory file reference", () => {
+    expect(DEFAULT_POST_COMPACTION_PROMPT).toContain("memory/YYYY-MM-DD.md");
+  });
+
+  it("DEFAULT_POST_COMPACTION_SYSTEM_PROMPT mentions memory files", () => {
+    expect(DEFAULT_POST_COMPACTION_SYSTEM_PROMPT).toContain("memory files");
+  });
+});

--- a/src/auto-reply/reply/post-compaction.ts
+++ b/src/auto-reply/reply/post-compaction.ts
@@ -1,0 +1,57 @@
+import type { MoltbotConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
+
+export const DEFAULT_POST_COMPACTION_PROMPT = [
+  "Compaction completed.",
+  "Read memory/YYYY-MM-DD.md to recover context and continue any pending work.",
+  `Reply with ${SILENT_REPLY_TOKEN} if nothing requires attention.`,
+].join(" ");
+
+export const DEFAULT_POST_COMPACTION_SYSTEM_PROMPT = [
+  "Post-compaction recovery turn.",
+  "Check memory files for recent work context and verify if you were mid-task.",
+].join(" ");
+
+export type PostCompactionSettings = {
+  enabled: boolean;
+  prompt: string;
+  systemPrompt: string;
+};
+
+export function resolvePostCompactionSettings(cfg?: MoltbotConfig): PostCompactionSettings | null {
+  const defaults = cfg?.agents?.defaults?.compaction?.postCompaction;
+  const enabled = defaults?.enabled ?? true;
+  if (!enabled) return null;
+
+  const prompt = defaults?.prompt?.trim() || DEFAULT_POST_COMPACTION_PROMPT;
+  const systemPrompt = defaults?.systemPrompt?.trim() || DEFAULT_POST_COMPACTION_SYSTEM_PROMPT;
+
+  return {
+    enabled,
+    prompt: ensureNoReplyHint(prompt),
+    systemPrompt: ensureNoReplyHint(systemPrompt),
+  };
+}
+
+function ensureNoReplyHint(text: string): string {
+  if (text.includes(SILENT_REPLY_TOKEN)) return text;
+  return `${text}\n\nIf no user-visible reply is needed, start with ${SILENT_REPLY_TOKEN}.`;
+}
+
+export function shouldRunPostCompaction(params: {
+  entry?: Pick<SessionEntry, "compactionCount" | "postCompactionCompactionCount">;
+  memoryCompactionCompleted: boolean;
+}): boolean {
+  if (!params.memoryCompactionCompleted) return false;
+
+  const compactionCount = params.entry?.compactionCount ?? 0;
+  const lastPostCompactionAt = params.entry?.postCompactionCompactionCount;
+
+  // Don't run if we've already run post-compaction for this compaction cycle
+  if (typeof lastPostCompactionAt === "number" && lastPostCompactionAt === compactionCount) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -546,6 +546,30 @@ const FIELD_HELP: Record<string, string> = {
     "Minimum appended bytes before session transcripts trigger reindex (default: 100000).",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages":
     "Minimum appended JSONL lines before session transcripts trigger reindex (default: 50).",
+  "agents.defaults.compaction": "Compaction tuning and pre/post-compaction agentic turns.",
+  "agents.defaults.compaction.mode": 'Compaction summarization mode ("default" or "safeguard").',
+  "agents.defaults.compaction.reserveTokensFloor":
+    "Minimum reserve tokens enforced for Pi compaction (0 disables the floor).",
+  "agents.defaults.compaction.maxHistoryShare":
+    "Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5).",
+  "agents.defaults.compaction.memoryFlush":
+    "Pre-compaction memory flush (agentic turn). Default: enabled.",
+  "agents.defaults.compaction.memoryFlush.enabled":
+    "Enable the pre-compaction memory flush (default: true).",
+  "agents.defaults.compaction.memoryFlush.softThresholdTokens":
+    "Run the memory flush when context is within this many tokens of the compaction threshold.",
+  "agents.defaults.compaction.memoryFlush.prompt":
+    "User prompt used for the memory flush turn (NO_REPLY is enforced if missing).",
+  "agents.defaults.compaction.memoryFlush.systemPrompt":
+    "System prompt appended for the memory flush turn.",
+  "agents.defaults.compaction.postCompaction":
+    "Post-compaction recovery turn (agentic turn). Default: enabled.",
+  "agents.defaults.compaction.postCompaction.enabled":
+    "Enable the post-compaction recovery turn (default: true).",
+  "agents.defaults.compaction.postCompaction.prompt":
+    "User prompt used for the post-compaction recovery turn (NO_REPLY is enforced if missing).",
+  "agents.defaults.compaction.postCompaction.systemPrompt":
+    "System prompt appended for the post-compaction recovery turn.",
   "plugins.enabled": "Enable plugin/extension loading (default: true).",
   "plugins.allow": "Optional allowlist of plugin ids; when set, only listed plugins load.",
   "plugins.deny": "Optional denylist of plugin ids; deny wins over allowlist.",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -77,6 +77,8 @@ export type SessionEntry = {
   compactionCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
+  postCompactionAt?: number;
+  postCompactionCompactionCount?: number;
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;
   label?: string;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -248,6 +248,8 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Post-compaction recovery turn (agentic turn). Default: enabled. */
+  postCompaction?: AgentCompactionPostCompactionConfig;
 };
 
 export type AgentCompactionMemoryFlushConfig = {
@@ -258,5 +260,14 @@ export type AgentCompactionMemoryFlushConfig = {
   /** User prompt used for the memory flush turn (NO_REPLY is enforced if missing). */
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
+  systemPrompt?: string;
+};
+
+export type AgentCompactionPostCompactionConfig = {
+  /** Enable the post-compaction recovery turn (default: true). */
+  enabled?: boolean;
+  /** User prompt used for the post-compaction recovery turn (NO_REPLY is enforced if missing). */
+  prompt?: string;
+  /** System prompt appended for the post-compaction recovery turn. */
   systemPrompt?: string;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -100,6 +100,14 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        postCompaction: z
+          .object({
+            enabled: z.boolean().optional(),
+            prompt: z.string().optional(),
+            systemPrompt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

After auto-compaction completes, run an agentic turn to help the agent recover context from memory files and continue any pending work.

Closes #3452

## Configuration

```yaml
agents:
  defaults:
    compaction:
      postCompaction:
        enabled: true  # default
        prompt: "..."      # optional custom prompt
        systemPrompt: "..." # optional custom system prompt
```

## Default Behavior

- **Prompt:** Instructs agent to read `memory/YYYY-MM-DD.md` and reply with `NO_REPLY` if nothing requires attention
- **System Prompt:** "Post-compaction recovery turn. Check memory files for recent work context and verify if you were mid-task."

## Implementation

- `post-compaction.ts`: Settings resolver and helper functions
- Integration in `agent-runner-memory.ts` after compaction completes
- Tracks `postCompactionCompactionCount` to avoid duplicate runs
- Follows same pattern as `memoryFlush` feature

## Tests

- 13 unit tests covering settings resolution, default values, and edge cases
- Build passes
- Lint passes (0 errors, 0 warnings)