### PR TITLE
fix: nc-talk only the message is signed

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -90,7 +90,7 @@ export async function sendMessageNextcloudTalk(
   const bodyStr = JSON.stringify(body);
 
   const { random, signature } = generateNextcloudTalkSignature({
-    body: bodyStr,
+    body: message,
     secret,
   });
 


### PR DESCRIPTION
```js  
const body: Record<string, unknown> = {
    message,
  };
  if (opts.replyTo) {
    body.replyTo = opts.replyTo;
  }
  const bodyStr = JSON.stringify(body);

  const { random, signature } = generateNextcloudTalkSignature({
    body: bodyStr,
    secret,
  });
```
This is the source code for sending messages using the Nextcloud Talk plugin. However, according to the official documentation, the encrypted body should not be in the format `{ "message": message }`, but rather a plain text variable `message`.

[nextclout_bot send message sample shell](https://nextcloud-talk.readthedocs.io/en/latest/bots/#sample-bash-script)

I tested it on the latest Nextcloud Talk. Without the modification, it resulted in an authentication error. After making the modification, everything worked.


