### PR TITLE
fix(tui): handle /model status and /model list subcommands

### DIFF
--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -293,6 +293,19 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "model":
         if (!args) {
           await openModelSelector();
+        } else if (args === "status") {
+          // Show current model information
+          const provider = state.sessionInfo.modelProvider ?? "unknown";
+          const model = state.sessionInfo.model ?? "unknown";
+          const current = `${provider}/${model}`;
+          chatLog.addSystem(
+            [`Current: ${current}`, "", "Switch: /model <provider/model>", "Browse: /models"].join(
+              "\n",
+            ),
+          );
+        } else if (args === "list") {
+          // /model list is an alias for /models
+          await openModelSelector();
         } else {
           try {
             const result = await client.patchSession({


### PR DESCRIPTION
## Summary
Fixes #3469

The TUI's `/model` command was treating `status` and `list` as model names instead of subcommands, resulting in errors like `model not allowed: anthropic/status`.

## Changes
- Added handling for `/model status` - shows current model information
- Added handling for `/model list` - opens the model selector (same as `/models`)

## Test Plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm test` passes (793 test files, 4826 tests)
- [ ] Manual test: run `moltbot tui`, type `/model status` - should show current model info
- [ ] Manual test: run `moltbot tui`, type `/model list` - should open model selector

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (issue-hunter-pro)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the TUI `/model` command so that `status` and `list` are treated as subcommands rather than model IDs. `/model status` now prints the current provider/model from `state.sessionInfo`, and `/model list` opens the same model selector UI as `/models`.

It also introduces `normalizeOutboundTextNewlines` and applies it to WhatsApp outbound messages so literal `\\n`/`\\r` escape sequences from LLM output render as actual newlines. Corresponding unit tests were added for the new normalizer, and the changelog was updated to reflect both fixes.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and covered by tests, with only minor behavioral/maintainability concerns.
- The `/model` subcommand handling is a small, well-scoped change in the TUI command switch, and the outbound newline normalization is exercised by new unit tests and applied only in the WhatsApp adapter. The main remaining concern is the unconditional decoding of literal `\\n` sequences (which may or may not match intended semantics for inbound text) and the slightly confusing module naming/location for the outbound normalizer.
- src/auto-reply/reply/inbound-text.ts (semantics), src/channels/plugins/outbound/whatsapp.ts (helper placement/naming)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->