### PR TITLE
fix(voice-call): wait for TTS completion before notify hangup

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -40,6 +40,8 @@ export class CallManager {
   >();
   /** Max duration timers to auto-hangup calls after configured timeout */
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
+  /** Calls pending speak completion for notify auto-hangup */
+  private pendingNotifyHangup = new Set<CallId>();
 
   constructor(config: VoiceCallConfig, storePath?: string) {
     this.config = config;
@@ -269,21 +271,26 @@ export class CallManager {
       return;
     }
 
-    // In notify mode, auto-hangup after delay
+    // In notify mode, register for speak completion hangup
     if (mode === "notify") {
-      const delaySec = this.config.outbound.notifyHangupDelaySec;
+      this.pendingNotifyHangup.add(call.callId);
       console.log(
-        `[voice-call] Notify mode: auto-hangup in ${delaySec}s for call ${call.callId}`,
+        `[voice-call] Notify mode: will hangup after speak completes for call ${call.callId}`,
       );
+      // Fallback timeout in case speak.ended event never arrives
+      const fallbackSec = this.config.outbound.notifyHangupDelaySec;
       setTimeout(async () => {
-        const currentCall = this.getCall(call.callId);
-        if (currentCall && !TerminalStates.has(currentCall.state)) {
-          console.log(
-            `[voice-call] Notify mode: hanging up call ${call.callId}`,
-          );
-          await this.endCall(call.callId);
+        if (this.pendingNotifyHangup.has(call.callId)) {
+          this.pendingNotifyHangup.delete(call.callId);
+          const currentCall = this.getCall(call.callId);
+          if (currentCall && !TerminalStates.has(currentCall.state)) {
+            console.log(
+              `[voice-call] Notify mode: fallback hangup (no speak.ended) for call ${call.callId}`,
+            );
+            await this.endCall(call.callId);
+          }
         }
-      }, delaySec * 1000);
+      }, fallbackSec * 1000);
     }
   }
 
@@ -623,6 +630,18 @@ export class CallManager {
 
       case "call.speaking":
         this.transitionState(call, "speaking");
+        break;
+
+      case "call.speak.ended":
+        this.transitionState(call, "active");
+        // If this call was pending notify hangup, end it now
+        if (this.pendingNotifyHangup.has(call.callId)) {
+          this.pendingNotifyHangup.delete(call.callId);
+          console.log(
+            `[voice-call] Notify mode: speak completed, hanging up call ${call.callId}`,
+          );
+          void this.endCall(call.callId);
+        }
         break;
 
       case "call.speech":

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -200,6 +200,13 @@ export class TelnyxProvider implements VoiceCallProvider {
           text: data.payload?.text || "",
         };
 
+      case "call.speak.ended":
+        return {
+          ...baseEvent,
+          type: "call.speak.ended",
+          text: data.payload?.text || "",
+        };
+
       case "call.transcription":
         return {
           ...baseEvent,

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -102,6 +102,10 @@ export const NormalizedEventSchema = z.discriminatedUnion("type", [
     text: z.string(),
   }),
   BaseEventSchema.extend({
+    type: z.literal("call.speak.ended"),
+    text: z.string().optional(),
+  }),
+  BaseEventSchema.extend({
     type: z.literal("call.speech"),
     transcript: z.string(),
     isFinal: z.boolean(),
@@ -180,7 +184,6 @@ export type WebhookContext = {
   url: string;
   method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
   query?: Record<string, string | string[] | undefined>;
-  remoteAddress?: string;
 };
 
 export type ProviderWebhookParseResult = {


### PR DESCRIPTION
## Summary
Fix voice call notify mode hanging up before TTS completes

## Problems Fixed
1. Notify mode used fixed timer (3s default) that cut off longer messages
2. No handling for Telnyx `call.speak.ended` webhook event

## Solution
- Add `call.speak.ended` event type and handler
- Track calls pending speak completion in `pendingNotifyHangup` Set
- Hangup triggers on speak completion event (with fallback timer)
- Fix sandbox vs embedded mode detection for RPC

## Testing
- Tested on Telnyx provider with various message lengths
- Short messages complete correctly
- Long messages now wait for TTS to finish

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the voice-call extension to prevent notify-mode calls from hanging up before Telnyx TTS finishes by adding support for the `call.speak.ended` webhook and deferring hangup until that event (with a fallback timer). It also adjusts the tool/gateway integration to route calls differently depending on whether it’s running embedded vs sandboxed, and tweaks some config UI keys.

The changes mostly live in the voice-call runtime (CallManager event handling + Telnyx event normalization) and the extension entrypoint (gateway methods + tool execution path).

<h3>Confidence Score: 2/5</h3>

- This PR addresses the core notify hangup issue, but has a couple of high-impact integration regressions that make it risky to merge as-is.
- Main concern is that `resolveVoiceCallConfig` is no longer used, so env-var-backed provider credentials/tunnel settings won’t be applied before validation/runtime creation. Additionally, importing `callGateway` from `dist/` is likely to break in dev/test/non-built contexts. The rest of the changes are reasonable but include some brittle mode-detection and timer-lifecycle concerns.
- extensions/voice-call/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->