### PR TITLE
fix: trigger agent response for webchat sessions after restart

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -14,7 +14,24 @@ import { defaultRuntime } from "../runtime.js";
 import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
 import { loadSessionEntry } from "./session-utils.js";
 
-export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
+export type AddChatRunFn = (
+  runId: string,
+  entry: { sessionKey: string; clientRunId: string },
+) => void;
+
+export type BroadcastFn = (
+  event: string,
+  payload: unknown,
+  opts?: { dropIfSlow?: boolean },
+) => void;
+
+export interface RestartSentinelParams {
+  deps: CliDeps;
+  addChatRun?: AddChatRunFn;
+  broadcast?: BroadcastFn;
+}
+
+export async function scheduleRestartSentinelWake(params: RestartSentinelParams) {
   const sentinel = await consumeRestartSentinel();
   if (!sentinel) return;
   const payload = sentinel.payload;
@@ -61,7 +78,27 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
   const to = origin?.to;
   if (!channel || !to) {
+    // No outbound channel (e.g., webchat sessions use WebSocket, not channel delivery).
+    // For webchat: register the run with addChatRun so responses stream to the client.
     enqueueSystemEvent(message, { sessionKey });
+    if (params.addChatRun && params.broadcast) {
+      const runId = `restart-${Date.now()}`;
+      params.addChatRun(runId, { sessionKey, clientRunId: runId });
+      try {
+        await agentCommand(
+          {
+            message: `System: ${summary}`,
+            sessionKey,
+            runId,
+            deliver: false,
+          },
+          defaultRuntime,
+          params.deps,
+        );
+      } catch {
+        // Agent turn failed; system event already queued as fallback context
+      }
+    }
     return;
   }
 

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -19,6 +19,8 @@ import type { loadMoltbotPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import {
+  type AddChatRunFn,
+  type BroadcastFn,
   scheduleRestartSentinelWake,
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
@@ -37,6 +39,8 @@ export async function startGatewaySidecars(params: {
   };
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logBrowser: { error: (msg: string) => void };
+  addChatRun?: AddChatRunFn;
+  broadcast?: BroadcastFn;
 }) {
   // Start clawd browser control server (unless disabled via config).
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
@@ -152,7 +156,11 @@ export async function startGatewaySidecars(params: {
 
   if (shouldWakeFromRestartSentinel()) {
     setTimeout(() => {
-      void scheduleRestartSentinelWake({ deps: params.deps });
+      void scheduleRestartSentinelWake({
+        deps: params.deps,
+        addChatRun: params.addChatRun,
+        broadcast: params.broadcast,
+      });
     }, 750);
   }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -503,6 +503,8 @@ export async function startGatewayServer(
     logHooks,
     logChannels,
     logBrowser,
+    addChatRun,
+    broadcast,
   }));
 
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({


### PR DESCRIPTION
Webchat sessions don't have channel/to in their delivery context, so
   the restart sentinel was falling back to enqueueSystemEvent() which
   queues the message but doesn't trigger an agent turn.

   This fix passes addChatRun and broadcast through to the sentinel,
   allowing it to register the run and call agentCommand() so responses
   stream to webchat clients.

   🤖 AI-assisted (Claude)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads gateway webchat runtime hooks (`addChatRun`, `broadcast`) into the restart sentinel wake path so that after a gateway restart, a pending “restart sentinel” message can trigger an agent turn even when the session lacks a channel/to delivery context (notably webchat/WebSocket sessions). The main behavior change is in `scheduleRestartSentinelWake`, which now enqueues the restart message for context and additionally attempts to start an agent run (with `deliver: false`) when outbound delivery isn’t possible.

These changes fit into the gateway lifecycle by passing runtime functions from `startGatewayServer` → `startGatewaySidecars` → `scheduleRestartSentinelWake`, aligning the sentinel wake with the same run-tracking/streaming machinery used by live webchat requests.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but the webchat streaming path may still not be reliably triggered.
- The change is small and localized, but the new `broadcast` plumbing is unused in the sentinel itself, and the sentinel-run initiation relies on assumptions about how `addChatRun` + `agentCommand(deliver:false)` produces a streamed response. Lack of error visibility (swallowed catch) also makes regressions harder to diagnose.
- src/gateway/server-restart-sentinel.ts (webchat/no-channel branch)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->