### PR TITLE
fix(daemon): support MOLTBOT_STATE_DIR environment variable

### DIFF
--- a/src/daemon/paths.test.ts
+++ b/src/daemon/paths.test.ts
@@ -34,4 +34,23 @@ describe("resolveGatewayStateDir", () => {
     const env = { CLAWDBOT_STATE_DIR: "C:\\State\\moltbot" };
     expect(resolveGatewayStateDir(env)).toBe("C:\\State\\moltbot");
   });
+
+  it("uses MOLTBOT_STATE_DIR when provided", () => {
+    const env = { HOME: "/Users/test", MOLTBOT_STATE_DIR: "/var/lib/moltbot" };
+    expect(resolveGatewayStateDir(env)).toBe(path.resolve("/var/lib/moltbot"));
+  });
+
+  it("prefers MOLTBOT_STATE_DIR over CLAWDBOT_STATE_DIR", () => {
+    const env = {
+      HOME: "/Users/test",
+      MOLTBOT_STATE_DIR: "/var/lib/moltbot-new",
+      CLAWDBOT_STATE_DIR: "/var/lib/moltbot-old",
+    };
+    expect(resolveGatewayStateDir(env)).toBe(path.resolve("/var/lib/moltbot-new"));
+  });
+
+  it("expands ~ in MOLTBOT_STATE_DIR", () => {
+    const env = { HOME: "/Users/test", MOLTBOT_STATE_DIR: "~/.moltbot" };
+    expect(resolveGatewayStateDir(env)).toBe(path.resolve("/Users/test/.moltbot"));
+  });
 });

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -26,7 +26,7 @@ export function resolveUserPathWithHome(input: string, home?: string): string {
 }
 
 export function resolveGatewayStateDir(env: Record<string, string | undefined>): string {
-  const override = env.CLAWDBOT_STATE_DIR?.trim();
+  const override = env.MOLTBOT_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
   if (override) {
     const home = override.startsWith("~") ? resolveHomeDir(env) : undefined;
     return resolveUserPathWithHome(override, home);

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -140,6 +140,7 @@ export function buildServiceEnvironment(params: {
     HOME: env.HOME,
     PATH: buildMinimalServicePath({ env }),
     CLAWDBOT_PROFILE: profile,
+    MOLTBOT_STATE_DIR: env.MOLTBOT_STATE_DIR,
     CLAWDBOT_STATE_DIR: env.CLAWDBOT_STATE_DIR,
     CLAWDBOT_CONFIG_PATH: env.CLAWDBOT_CONFIG_PATH,
     CLAWDBOT_GATEWAY_PORT: String(port),
@@ -159,6 +160,7 @@ export function buildNodeServiceEnvironment(params: {
   return {
     HOME: env.HOME,
     PATH: buildMinimalServicePath({ env }),
+    MOLTBOT_STATE_DIR: env.MOLTBOT_STATE_DIR,
     CLAWDBOT_STATE_DIR: env.CLAWDBOT_STATE_DIR,
     CLAWDBOT_CONFIG_PATH: env.CLAWDBOT_CONFIG_PATH,
     CLAWDBOT_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),


### PR DESCRIPTION
## Summary
The daemon service installation (launchd/systemd/schtasks) now supports the `MOLTBOT_STATE_DIR` environment variable, matching the behavior of the main config system which already supports both `MOLTBOT_STATE_DIR` (preferred) and `CLAWDBOT_STATE_DIR` (legacy).

## Problem
Currently, `src/config/paths.ts` checks for both `MOLTBOT_STATE_DIR` and `CLAWDBOT_STATE_DIR` (with the former taking precedence), but `src/daemon/paths.ts` only checked `CLAWDBOT_STATE_DIR`. This meant that setting `MOLTBOT_STATE_DIR` would work for CLI commands but not for daemon service installation, requiring users to still use the legacy `CLAWDBOT_STATE_DIR` variable name.

## Changes
- **src/daemon/paths.ts**: Updated `resolveGatewayStateDir()` to check `MOLTBOT_STATE_DIR` first, then fallback to `CLAWDBOT_STATE_DIR` (matching the pattern in `src/config/paths.ts`)
- **src/daemon/service-env.ts**: Updated both `buildServiceEnvironment()` and `buildNodeServiceEnvironment()` to pass `MOLTBOT_STATE_DIR` to the service environment (in addition to the legacy `CLAWDBOT_STATE_DIR`)
- **src/daemon/paths.test.ts**: Added test coverage for the new `MOLTBOT_STATE_DIR` behavior

## Testing
- Added unit tests for `MOLTBOT_STATE_DIR` support
- Added test for precedence (MOLTBOT_STATE_DIR takes priority over CLAWDBOT_STATE_DIR)
- Added test for tilde expansion in `MOLTBOT_STATE_DIR`
- All existing tests should still pass (legacy `CLAWDBOT_STATE_DIR` still works)

## Backwards Compatibility
Fully backwards compatible - `CLAWDBOT_STATE_DIR` continues to work as before, but `MOLTBOT_STATE_DIR` is now the preferred variable name across all parts of the system.