### PR TITLE
Update ad-hoc signing instructions in dev setup

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -30,7 +30,11 @@ To build the macOS app and package it into `dist/OpenClaw.app`, run:
 ./scripts/package-mac-app.sh
 ```
 
-If you don't have an Apple Developer ID certificate, the script will automatically use **ad-hoc signing** (`-`). 
+If you don't have an Apple Developer ID certificate, run the following command, which will use **ad-hoc signing** (`-`). 
+
+```bash
+ALLOW_ADHOC_SIGNING=1 ./scripts/package-mac-app.sh
+```
 
 For dev run modes, signing flags, and Team ID troubleshooting, see the macOS app README:
 https://github.com/openclaw/openclaw/blob/main/apps/macos/README.md


### PR DESCRIPTION
Clarify instructions for using ad-hoc signing in the packaging script. 

Without this flag, macos will report building failure.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the macOS developer setup guide to clarify how to build/package the app without an Apple Developer ID certificate by explicitly opting into ad-hoc signing via `ALLOW_ADHOC_SIGNING=1` when running `scripts/package-mac-app.sh`.

This aligns the dev-setup docs with the packaging/signing scripts’ behavior (ad-hoc signing is an explicit opt-in) and points developers to the macOS app README for deeper signing/run-mode troubleshooting.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, localized documentation clarification.
- Only one markdown file is updated, and the new instruction (`ALLOW_ADHOC_SIGNING=1 ./scripts/package-mac-app.sh`) matches existing documented/scripted behavior elsewhere in the repo (e.g., mac signing docs and macOS app README). No code or config changes are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->