### PR TITLE
fix: include error details in subagent findings [AI-assisted]

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -384,12 +384,24 @@ export async function runSubagentAnnounceFlow(params: {
             : "finished with unknown status";
 
     // Build instructional message for main agent
+    // Include error context in findings when no reply available
+    let findings = reply;
+    if (!findings) {
+      if (outcome?.status === "error" && outcome?.error) {
+        findings = `Error encountered:\n${outcome.error}`;
+      } else if (outcome?.status === "timeout") {
+        findings = `Task timed out before producing output.`;
+      } else if (outcome?.status === "unknown") {
+        findings = `Task ended with unknown status.`;
+      }
+    }
+
     const taskLabel = params.label || params.task || "background task";
     const triggerMessage = [
       `A background task "${taskLabel}" just ${statusLabel}.`,
       "",
       "Findings:",
-      reply || "(no output)",
+      findings || "(no output)",
       "",
       statsLine,
       "",


### PR DESCRIPTION
## Problem
When a sub-agent spawned via `sessions_spawn` fails (network error, timeout, model error), the result returns `Findings: (no output)` with no indication of what went wrong.

## Solution
Populate `findings` with contextual error information when no assistant reply is available:
- For errors: `Error encountered:\n<error message>`
- For timeouts: `Task timed out before producing output.`
- For unknown status: `Task ended with unknown status.`

## Testing
- Tested locally on a live moltbot instance
- Linted with `npm run lint`

## Before
```
Findings: (no output)
```

## After
```
Findings: Error encountered:
fetch failed sending request
```

🤖 AI-assisted (Claude Code) - fully tested on live instance