### PR TITLE
fix: respect toolsEnabled config for CLI backends [AI-assisted]

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -65,7 +65,8 @@ export async function runCliAgent(params: {
 
   const extraSystemPrompt = [
     params.extraSystemPrompt?.trim(),
-    "Tools are disabled in this session. Do not call tools.",
+    // Only add "tools disabled" message if tools aren't enabled for this backend
+    backend.toolsEnabled ? undefined : "Tools are disabled in this session. Do not call tools.",
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -89,6 +89,8 @@ export type CliBackendConfig = {
   imageMode?: "repeat" | "list";
   /** Serialize runs for this CLI. */
   serialize?: boolean;
+  /** Whether tools are enabled for this CLI backend (default: false). */
+  toolsEnabled?: boolean;
 };
 
 export type AgentDefaultsConfig = {


### PR DESCRIPTION
## Problem
When using CLI backends like Claude CLI with `--allowedTools`, the system prompt incorrectly states "Tools are disabled in this session. Do not call tools." even though tools ARE enabled.

This causes the model to refuse to use tools that are actually available.

## Solution
Add a `toolsEnabled` boolean option to `CliBackendConfig`. When `true`, the "Tools are disabled" system prompt injection is skipped.

Default behavior is unchanged (tools assumed disabled unless explicitly enabled).

## Usage
```json
{
  "agents": {
    "defaults": {
      "cliBackends": {
        "claude-cli": {
          "args": ["-p", "--output-format", "json", "--allowedTools", "Bash Edit Write"],
          "toolsEnabled": true
        }
      }
    }
  }
}
```

## Testing
- Tested locally on a moltbot instance with Claude CLI and `--allowedTools`
- Linted with `npm run lint`

🤖 AI-assisted (Claude Code) - fully tested on live instance