### PR TITLE
chore: add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+.idea/


### PR DESCRIPTION
Add JetBrains IDE project directory to .gitignore to prevent IDE configuration files from being tracked.