### PR TITLE
fix: add DeepSeek to non-standard providers (fixes developer role issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,9 @@
     "tar": "7.5.4"
   },
   "pnpm": {
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.49.3": "patches/@mariozechner__pi-ai@0.49.3.patch"
+    },
     "minimumReleaseAge": 2880,
     "overrides": {
       "@sinclair/typebox": "0.34.47",

--- a/patches/@mariozechner__pi-ai@0.49.3.patch
+++ b/patches/@mariozechner__pi-ai@0.49.3.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -624,6 +624,8 @@ function detectCompat(model) {
+         baseUrl.includes("chutes.ai") ||
+         isZai ||
+         provider === "opencode" ||
++        provider === "deepseek" ||
++        baseUrl.includes("api.deepseek.com") ||
+         baseUrl.includes("opencode.ai");
+     const useMaxTokens = provider === "mistral" || baseUrl.includes("mistral.ai") || baseUrl.includes("chutes.ai");
+     const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");


### PR DESCRIPTION
## Summary

This PR fixes the `Message ordering conflict` error when using DeepSeek models.

## Problem

DeepSeek API does not support the `developer` role, only `system`, `user`, `assistant`, and `tool`. When using DeepSeek models (deepseek-chat, deepseek-reasoner), the API returns:

```
400 Failed to deserialize the JSON body into the target type: messages[0].role: unknown variant `developer`, expected one of `system`, `user`, `assistant`, `tool`
```

## Solution

This PR adds a pnpm patch for `@mariozechner/pi-ai` that adds DeepSeek to the list of "non-standard" providers in the `detectCompat()` function. This makes `supportsDeveloperRole` return `false` for DeepSeek, causing the code to use `system` role instead of `developer`.

## Changes

- Added `patches/@mariozechner__pi-ai@0.49.3.patch` with the fix
- Updated `package.json` to reference the patch via pnpm patchedDependencies

## Testing

Tested locally by applying the patch directly to the installed package. DeepSeek Chat works correctly after the fix.

Fixes #3566

🤖 Generated with [Claude Code](https://claude.com/claude-code)