### PR TITLE
fix: prevent hallucination after failed compaction summary

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -1,0 +1,47 @@
+# Proposed Clawdbot Improvements
+
+## Issue: Hallucination after failed compaction summary
+
+When compaction summarization fails (no API key, error, etc.), the agent receives:
+"Summary unavailable due to context limits. Older messages were truncated."
+
+This provides ZERO context, leading to hallucination about non-existent conversations.
+
+## Proposed Fix 1: Better fallback message
+
+In `src/agents/pi-extensions/compaction-safeguard.ts`:
+
+```typescript
+const FALLBACK_SUMMARY = [
+  "Summary unavailable due to context limits. Older messages were truncated.",
+  "",
+  "⚠️ IMPORTANT: You have NO context from previous messages.",
+  "Before continuing:",
+  "1. Read CURRENT_WORK.md if it exists",
+  "2. Read memory/YYYY-MM-DD.md for today's context", 
+  "3. ASK the user what they were working on if unclear",
+  "4. DO NOT assume or hallucinate previous conversation content",
+].join("\n");
+```
+
+## Proposed Fix 2: Better default memory flush prompt
+
+In `src/auto-reply/reply/memory-flush.ts`:
+
+```typescript
+export const DEFAULT_MEMORY_FLUSH_PROMPT = [
+  "Pre-compaction memory flush.",
+  "MANDATORY: Update CURRENT_WORK.md with the current task and context.",
+  "Also store durable memories to memory/YYYY-MM-DD.md.",
+  `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
+].join(" ");
+```
+
+## Why this matters
+
+Without proper context recovery instructions, Claude will:
+- Hallucinate about previous conversations
+- Continue non-existent tasks
+- Confuse users with irrelevant responses
+
+The fix ensures the agent knows to CHECK files and ASK rather than assume.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -12,8 +12,19 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
-const FALLBACK_SUMMARY =
-  "Summary unavailable due to context limits. Older messages were truncated.";
+const FALLBACK_SUMMARY = [
+  "Summary unavailable due to context limits. Older messages were truncated.",
+  "",
+  "⚠️ CRITICAL: You have NO context from previous messages.",
+  "Before responding, you MUST:",
+  "1. Read CURRENT_WORK.md if it exists - this contains your active task",
+  "2. Read memory/YYYY-MM-DD.md for today's context",
+  "3. ASK the user what they need if context is still unclear",
+  "4. DO NOT assume or hallucinate previous conversation content",
+  "",
+  "If you proceed without checking these files, you risk responding to",
+  "conversations that never happened.",
+].join("\n");
 const TURN_PREFIX_INSTRUCTIONS =
   "This summary covers the prefix of a split turn. Focus on the original request," +
   " early progress, and any details needed to understand the retained suffix.";

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -9,14 +9,21 @@ export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
 
 export const DEFAULT_MEMORY_FLUSH_PROMPT = [
   "Pre-compaction memory flush.",
-  "Store durable memories now (use memory/YYYY-MM-DD.md; create memory/ if needed).",
+  "MANDATORY: Update CURRENT_WORK.md with your current task, context, and any important state.",
+  "Also store durable memories to memory/YYYY-MM-DD.md (create memory/ if needed).",
+  "This is critical to avoid context loss and hallucination after compaction.",
   `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
 ].join(" ");
 
 export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
-  "Pre-compaction memory flush turn.",
-  "The session is near auto-compaction; capture durable memories to disk.",
-  `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
+  "⚠️ PRE-COMPACTION MEMORY FLUSH - ACTION REQUIRED.",
+  "The session is near auto-compaction. You MUST update CURRENT_WORK.md with:",
+  "- Current task description",
+  "- Important context and decisions",
+  "- Any state needed to resume after compaction",
+  "Also write to memory/YYYY-MM-DD.md for daily logs.",
+  "Failure to do this will result in context loss and potential hallucination.",
+  `After writing, reply with ${SILENT_REPLY_TOKEN}.`,
 ].join(" ");
 
 export type MemoryFlushSettings = {


### PR DESCRIPTION
## Problem

When compaction summarization fails (no API key, network error, etc.), the agent receives only:

```
Summary unavailable due to context limits. Older messages were truncated.
```

This provides **zero context**, causing the agent to:
- Hallucinate about conversations that never happened
- Continue non-existent tasks
- Confuse users with irrelevant responses

## Solution

### 1. Improved FALLBACK_SUMMARY (compaction-safeguard.ts)

Now includes explicit instructions:
- Check CURRENT_WORK.md for active task
- Read memory/YYYY-MM-DD.md for daily context
- ASK the user if unclear
- DO NOT hallucinate

### 2. Stronger memory flush prompts (memory-flush.ts)

- Made CURRENT_WORK.md update **mandatory** (not optional)
- Added warning about context loss consequences
- Emphasized this is critical, not just a suggestion

## Testing

This was discovered in production when an agent started discussing "Age Selection" and "Traveler Age" with a user who had never mentioned these topics - the agent was continuing a conversation from before compaction that the user never started.

## Related

This improves the pre-compaction memory flush feature and compaction safeguard extension.