### PR TITLE
fix(ui): Prefer session label over displayName in dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -140,14 +140,14 @@ function resolveSessionOptions(sessionKey: string, sessions: SessionsListResult 
 
   // Add current session key first
   seen.add(sessionKey);
-  options.push({ key: sessionKey, displayName: resolvedCurrent?.displayName });
+  options.push({ key: sessionKey, displayName: resolvedCurrent?.label ?? resolvedCurrent?.displayName });
 
   // Add sessions from the result
   if (sessions?.sessions) {
     for (const s of sessions.sessions) {
       if (!seen.has(s.key)) {
         seen.add(s.key);
-        options.push({ key: s.key, displayName: s.displayName });
+        options.push({ key: s.key, displayName: s.label ?? s.displayName });
       }
     }
   }


### PR DESCRIPTION
When sessions have a label (like valet-pm, fsi-pm), show that instead of the cryptic session key or displayName.

Falls back to displayName if no label is set, then to key.

This makes the session dropdown much more user-friendly when working with labeled sub-agents.