### PR TITLE
fix: add audio capability to OpenAI provider

### DIFF
--- a/src/media-understanding/providers/openai/index.ts
+++ b/src/media-understanding/providers/openai/index.ts
@@ -4,7 +4,7 @@ import { transcribeOpenAiCompatibleAudio } from "./audio.js";
 
 export const openaiProvider: MediaUnderstandingProvider = {
   id: "openai",
-  capabilities: ["image"],
+  capabilities: ["image", "audio"],
   describeImage: describeImageWithModel,
   transcribeAudio: transcribeOpenAiCompatibleAudio,
 };

--- a/src/media-understanding/providers/providers.test.ts
+++ b/src/media-understanding/providers/providers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMediaUnderstandingRegistry } from "./index.js";
+
+describe("media understanding providers", () => {
+  const registry = buildMediaUnderstandingRegistry();
+
+  it("providers declare capabilities matching their implemented methods", () => {
+    for (const [id, provider] of registry) {
+      const declared = provider.capabilities ?? [];
+
+      if (provider.transcribeAudio) {
+        expect(
+          declared.includes("audio"),
+          `Provider "${id}" has transcribeAudio but doesn't declare "audio" capability`,
+        ).toBe(true);
+      }
+
+      if (provider.describeImage) {
+        expect(
+          declared.includes("image"),
+          `Provider "${id}" has describeImage but doesn't declare "image" capability`,
+        ).toBe(true);
+      }
+
+      if (provider.describeVideo) {
+        expect(
+          declared.includes("video"),
+          `Provider "${id}" has describeVideo but doesn't declare "video" capability`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("openai provider declares both image and audio capabilities", () => {
+    const openai = registry.get("openai");
+    expect(openai).toBeDefined();
+    expect(openai?.capabilities).toContain("image");
+    expect(openai?.capabilities).toContain("audio");
+    expect(openai?.describeImage).toBeDefined();
+    expect(openai?.transcribeAudio).toBeDefined();
+  });
+
+  it("groq provider declares audio capability", () => {
+    const groq = registry.get("groq");
+    expect(groq).toBeDefined();
+    expect(groq?.capabilities).toContain("audio");
+    expect(groq?.transcribeAudio).toBeDefined();
+  });
+
+  it("google provider declares image, audio, and video capabilities", () => {
+    const google = registry.get("google");
+    expect(google).toBeDefined();
+    expect(google?.capabilities).toContain("image");
+    expect(google?.capabilities).toContain("audio");
+    expect(google?.capabilities).toContain("video");
+  });
+
+  it("deepgram provider declares audio capability", () => {
+    const deepgram = registry.get("deepgram");
+    expect(deepgram).toBeDefined();
+    expect(deepgram?.capabilities).toContain("audio");
+    expect(deepgram?.transcribeAudio).toBeDefined();
+  });
+});

--- a/src/media-understanding/providers/providers.test.ts
+++ b/src/media-understanding/providers/providers.test.ts
@@ -31,35 +31,4 @@ describe("media understanding providers", () => {
       }
     }
   });
-
-  it("openai provider declares both image and audio capabilities", () => {
-    const openai = registry.get("openai");
-    expect(openai).toBeDefined();
-    expect(openai?.capabilities).toContain("image");
-    expect(openai?.capabilities).toContain("audio");
-    expect(openai?.describeImage).toBeDefined();
-    expect(openai?.transcribeAudio).toBeDefined();
-  });
-
-  it("groq provider declares audio capability", () => {
-    const groq = registry.get("groq");
-    expect(groq).toBeDefined();
-    expect(groq?.capabilities).toContain("audio");
-    expect(groq?.transcribeAudio).toBeDefined();
-  });
-
-  it("google provider declares image, audio, and video capabilities", () => {
-    const google = registry.get("google");
-    expect(google).toBeDefined();
-    expect(google?.capabilities).toContain("image");
-    expect(google?.capabilities).toContain("audio");
-    expect(google?.capabilities).toContain("video");
-  });
-
-  it("deepgram provider declares audio capability", () => {
-    const deepgram = registry.get("deepgram");
-    expect(deepgram).toBeDefined();
-    expect(deepgram?.capabilities).toContain("audio");
-    expect(deepgram?.transcribeAudio).toBeDefined();
-  });
 });

--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -4,7 +4,7 @@ import type { MoltbotConfig } from "../config/config.js";
 import { resolveEntriesWithActiveFallback, resolveModelEntries } from "./resolve.js";
 
 const providerRegistry = new Map([
-  ["openai", { capabilities: ["image"] }],
+  ["openai", { capabilities: ["image", "audio"] }],
   ["groq", { capabilities: ["audio"] }],
 ]);
 
@@ -30,7 +30,7 @@ describe("resolveModelEntries", () => {
       capability: "audio",
       providerRegistry,
     });
-    expect(audioEntries).toHaveLength(0);
+    expect(audioEntries).toHaveLength(1);
   });
 
   it("keeps per-capability entries even without explicit caps", () => {


### PR DESCRIPTION
## Summary

- OpenAI provider had `transcribeAudio` method but didn't declare `"audio"` in its capabilities array
- This caused audio transcription to fail for Telegram voice messages when using OpenAI

## Changes

- Added `"audio"` to OpenAI provider's capabilities
- Updated test mock to reflect the fix
- Added new test to validate providers declare capabilities matching their implemented methods

Fixes #3539

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes OpenAI audio transcription selection by adding the missing `"audio"` capability to the OpenAI media-understanding provider, updates the `resolveModelEntries` test fixture accordingly, and introduces a registry-level invariant test to ensure providers’ declared capabilities match the methods they implement.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and should fix OpenAI audio transcription selection with low behavioral risk.
- Change is small and localized (capability list + test updates). Main residual risk is test fragility/churn from redundant provider-specific assertions; no runtime logic changes beyond capability exposure.
- src/media-understanding/providers/providers.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->