### PR TITLE
fix(message): disable cross-context marker by default (#1782) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Status: beta.
 - iMessage: normalize messaging targets. (#1708)
 - Signal: fix reactions and add configurable startup timeout. (#1651, #1677)
 - Matrix: decrypt E2EE media with size guard. (#1744)
+- Message tool: disable cross-context origin marker by default; set `tools.message.crossContext.marker.enabled: true` to restore. (#1782)
 
 
 ## 2026.1.24

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -428,7 +428,7 @@ const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.allowAcrossProviders":
     "Allow sends across different providers (default: false).",
   "tools.message.crossContext.marker.enabled":
-    "Add a visible origin marker when sending cross-context (default: true).",
+    "Add a visible origin marker when sending cross-context (default: false).",
   "tools.message.crossContext.marker.prefix":
     'Text prefix for cross-context markers (supports "{channel}").',
   "tools.message.crossContext.marker.suffix":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -403,7 +403,7 @@ export type ToolsConfig = {
       allowAcrossProviders?: boolean;
       /** Cross-context marker configuration. */
       marker?: {
-        /** Enable origin markers for cross-context sends (default: true). */
+        /** Enable origin markers for cross-context sends (default: false). */
         enabled?: boolean;
         /** Text prefix template, supports {channel}. */
         prefix?: string;

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -72,8 +72,12 @@ describe("outbound policy", () => {
   });
 
   it("uses embeds when available and preferred", async () => {
+    const cfg = {
+      ...discordConfig,
+      tools: { message: { crossContext: { marker: { enabled: true } } } },
+    } as MoltbotConfig;
     const decoration = await buildCrossContextDecoration({
-      cfg: discordConfig,
+      cfg,
       channel: "discord",
       target: "123",
       toolContext: { currentChannelId: "C12345678", currentChannelProvider: "discord" },

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -124,7 +124,7 @@ export async function buildCrossContextDecoration(params: {
   if (!isCrossContextTarget(params)) return null;
 
   const markerConfig = params.cfg.tools?.message?.crossContext?.marker;
-  if (markerConfig?.enabled === false) return null;
+  if (markerConfig?.enabled !== true) return null;
 
   const currentName =
     (await lookupDirectoryDisplay({


### PR DESCRIPTION
## Summary
- Disable `[from #...]` prefix on cross-context messages by default
- Users who want the origin marker can set `tools.message.crossContext.marker.enabled: true`
- Updated docs and config schema to reflect new default

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm test` passes (4590/4590)
- [x] Updated test to explicitly enable marker when testing embed behavior

Rebased on latest main and resolved CHANGELOG.md conflict. Ready for review.

Closes #1782

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes cross-context message decoration so the visible origin marker (e.g., `[from …]`) is **disabled by default**, and must be explicitly enabled via `tools.message.crossContext.marker.enabled: true`. It updates the outbound decoration logic (`src/infra/outbound/outbound-policy.ts`) accordingly, adjusts the relevant test to opt in to the marker (`src/infra/outbound/outbound-policy.test.ts`), and updates config UI/schema help text plus the changelog to document the new default.

The change is localized to the outbound message pipeline: `message-action-runner.ts` calls `buildCrossContextDecoration`, which now returns `null` unless the marker is explicitly enabled, preventing the prefix/suffix or embeds from being applied on cross-context sends unless opted in.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the cross-context decoration gate, flips the default as intended, and updates the associated test and config help text. No other call sites rely on the old default, and decoration is already optional (null-safe) in the outbound pipeline.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->