### PR TITLE
CLI: add OpenAI-compatible endpoint auth choice

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -48,7 +48,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
     value: "openai",
     label: "OpenAI",
     hint: "Codex OAuth + API key",
-    choices: ["openai-codex", "openai-api-key"],
+    choices: ["openai-codex", "openai-api-key", "openai-custom-endpoint"],
   },
   {
     value: "anthropic",
@@ -155,6 +155,11 @@ export function buildAuthChoiceOptions(params: {
   });
   options.push({ value: "chutes", label: "Chutes (OAuth)" });
   options.push({ value: "openai-api-key", label: "OpenAI API key" });
+  options.push({
+    value: "openai-custom-endpoint",
+    label: "OpenAI-compatible endpoint",
+    hint: "Use a private base URL + bearer token",
+  });
   options.push({ value: "openrouter-api-key", label: "OpenRouter API key" });
   options.push({ value: "xai-api-key", label: "xAI (Grok) API key" });
   options.push({

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -10,6 +10,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "codex-cli": "openai-codex",
   chutes: "chutes",
   "openai-api-key": "openai",
+  "openai-custom-endpoint": "openai",
   "openrouter-api-key": "openrouter",
   "ai-gateway-api-key": "vercel-ai-gateway",
   "cloudflare-ai-gateway-api-key": "cloudflare-ai-gateway",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -11,6 +11,7 @@ export type AuthChoice =
   | "chutes"
   | "openai-codex"
   | "openai-api-key"
+  | "openai-custom-endpoint"
   | "openrouter-api-key"
   | "ai-gateway-api-key"
   | "cloudflare-ai-gateway-api-key"


### PR DESCRIPTION
## Summary
- add OpenAI-compatible endpoint auth flow for base URL + bearer token
- expose the new auth choice and preferred provider mapping
- make the canvas host test create a temporary A2UI bundle if missing

## Testing
- not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new onboarding/auth selection for an OpenAI-compatible endpoint (base URL + bearer token), wires it into the OpenAI auth apply flow, and maps the choice to the `openai` provider. It also updates the canvas host test to ensure an A2UI bundle exists so the scaffold can be served during tests.

Overall, the changes fit into the existing onboarding CLI by extending `AuthChoice` and the auth-choice option/group builders, and by adding a new branch in `applyAuthChoiceOpenAI` for collecting/storing endpoint env vars.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is at least one test-related reliability issue that could break CI in some environments.
- The main functional change is straightforward and localized to onboarding/auth selection. The primary concern is the canvas-host test writing into the repository tree, which can fail in read-only or parallelized test setups and can dirty the working tree during runs.
- src/canvas-host/server.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->