### PR TITLE
fix: Auto-expire auth profile cooldowns when timestamp expires

### DIFF
--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -98,14 +98,23 @@ export function resolveAuthProfileOrder(params: {
     const inCooldown: Array<{ profileId: string; cooldownUntil: number }> = [];
 
     for (const profileId of deduped) {
-      const cooldownUntil = resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? 0;
+      const stats = store.usageStats?.[profileId];
+      const cooldownUntil = resolveProfileUnusableUntil(stats ?? {}) ?? 0;
+      
+      // Auto-expire cooldowns that have passed
+      if (stats && cooldownUntil > 0 && now >= cooldownUntil) {
+        stats.cooldownUntil = undefined;
+        stats.disabledUntil = undefined;
+      }
+      
+      const updatedCooldownUntil = resolveProfileUnusableUntil(stats ?? {}) ?? 0;
       if (
-        typeof cooldownUntil === "number" &&
-        Number.isFinite(cooldownUntil) &&
-        cooldownUntil > 0 &&
-        now < cooldownUntil
+        typeof updatedCooldownUntil === "number" &&
+        Number.isFinite(updatedCooldownUntil) &&
+        updatedCooldownUntil > 0 &&
+        now < updatedCooldownUntil
       ) {
-        inCooldown.push({ profileId, cooldownUntil });
+        inCooldown.push({ profileId, cooldownUntil: updatedCooldownUntil });
       } else {
         available.push(profileId);
       }
@@ -144,6 +153,16 @@ function orderProfilesByMode(order: string[], store: AuthProfileStore): string[]
   const inCooldown: string[] = [];
 
   for (const profileId of order) {
+    const stats = store.usageStats?.[profileId];
+    if (stats) {
+      const unusableUntil = resolveProfileUnusableUntil(stats);
+      // Auto-expire cooldowns that have passed
+      if (unusableUntil && unusableUntil > 0 && now >= unusableUntil) {
+        stats.cooldownUntil = undefined;
+        stats.disabledUntil = undefined;
+      }
+    }
+    
     if (isProfileInCooldown(store, profileId)) {
       inCooldown.push(profileId);
     } else {


### PR DESCRIPTION
Fixes #3604

## Problem
Auth profiles were getting stuck in cooldown even after the `cooldownUntil` timestamp had expired, blocking the agent from making API calls indefinitely.

## Root Cause
The cooldown check only happened during profile selection (`isProfileInCooldown`), but expired cooldowns were never cleared from the store. Profiles remained marked as unavailable even when `Date.now() >= cooldownUntil`.

## Solution
Added auto-expiry logic in `resolveAuthProfileOrder` (both explicit and round-robin paths):
- When `now >= unusableUntil`, clear both `cooldownUntil` and `disabledUntil`
- Ensures profiles become available immediately after cooldown expires
- Minimal change, no new dependencies

## Testing
Manually tested by:
1. Setting expired cooldown timestamp in auth-profiles.json
2. Making API call
3. Verifying profile becomes available without manual intervention

## Evidence
Before fix:
- Cooldown set to: 1769633531559 (Jan 28 20:52:11 UTC)
- Current time: 1769634806000 (Jan 28 21:13:26 UTC)
- Diff: -1274 seconds (20+ minutes expired)
- Profile still marked unavailable

After fix:
- Profile auto-expires and becomes available

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates auth profile ordering (`src/agents/auth-profiles/order.ts`) to auto-expire cooldown/disable timestamps when they’re already in the past, preventing profiles from remaining stuck as “in cooldown” indefinitely. The logic is applied in both the explicit-order path and the round-robin ordering path so that `resolveAuthProfileOrder` returns available profiles immediately after expiry.


<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, with one behavior edge case to double-check around disabled-vs-cooldown expiry.
- The change is localized and addresses a real stuck-state bug, but it mutates stored usage stats during ordering and clears both `cooldownUntil` and `disabledUntil` together, which could unintentionally re-enable a profile if those fields are meant to expire independently.
- src/agents/auth-profiles/order.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->