### PR TITLE
feat(cli): add --json flag to channels login for programmatic QR access

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -40,6 +40,27 @@ moltbot channels login --channel whatsapp
 moltbot channels logout --channel whatsapp
 ```
 
+### JSON mode (programmatic)
+
+For programmatic use (e.g., web dashboards, hosting platforms), use `--json` to get QR data as JSON instead of terminal output:
+
+```bash
+moltbot channels login --channel whatsapp --json --timeout 60000
+```
+
+This outputs two JSON objects:
+1. Initial response with QR data:
+```json
+{"status":"pending","qrDataUrl":"data:image/png;base64,...","message":"Scan this QR...","accountId":"default","channel":"whatsapp"}
+```
+
+2. Final response after scan (or timeout):
+```json
+{"status":"connected","connected":true,"message":"✅ Linked!","accountId":"default","channel":"whatsapp"}
+```
+
+The `qrDataUrl` is a base64-encoded PNG that can be displayed directly in an `<img>` tag.
+
 ## Troubleshooting
 
 - Run `moltbot status --deep` for a broad probe.

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -215,6 +215,8 @@ export function registerChannelsCli(program: Command) {
     .option("--channel <channel>", "Channel alias (default: whatsapp)")
     .option("--account <id>", "Account id (accountId)")
     .option("--verbose", "Verbose connection logs", false)
+    .option("--json", "Output QR data as JSON (for programmatic use)", false)
+    .option("--timeout <ms>", "Timeout for QR generation in ms", "60000")
     .action(async (opts) => {
       await runChannelsCommandWithDanger(async () => {
         await runChannelLogin(
@@ -222,6 +224,8 @@ export function registerChannelsCli(program: Command) {
             channel: opts.channel as string | undefined,
             account: opts.account as string | undefined,
             verbose: Boolean(opts.verbose),
+            json: Boolean(opts.json),
+            timeoutMs: parseInt(String(opts.timeout), 10) || 60000,
           },
           defaultRuntime,
         );

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -208,7 +208,7 @@ describe("cli program (smoke)", () => {
       from: "user",
     });
     expect(runChannelLogin).toHaveBeenCalledWith(
-      { channel: undefined, account: "work", verbose: false },
+      { channel: undefined, account: "work", verbose: false, json: false, timeoutMs: 60000 },
       runtime,
     );
   });


### PR DESCRIPTION
## Summary

  Adds a `--json` flag to `moltbot channels login` that outputs QR code data as JSON instead of
  rendering to the terminal. This enables programmatic WhatsApp linking for web dashboards, hosting
  platforms, and automation tools.

  ## Motivation

  When building hosting platforms or web UIs for moltbot, there's no way to programmatically obtain
  the WhatsApp QR code - the current `channels login` command only renders to the terminal. This
  forces hosting providers to either:
  - Require users to SSH into their server
  - Build custom solutions outside of moltbot

  The gateway already has `loginWithQrStart` and `loginWithQrWait` methods that return structured
  data - this PR exposes them via CLI.

  ## Changes

  - **`src/cli/channels-cli.ts`**: Added `--json` and `--timeout` flags to the login command
  - **`src/cli/channel-auth.ts`**: JSON mode uses `plugin.gateway.loginWithQrStart/Wait` instead of
  `plugin.auth.login`
  - **`docs/cli/channels.md`**: Documented the new JSON mode with examples

  ## Usage

  ```bash
  # Existing interactive mode (unchanged)
  moltbot channels login --channel whatsapp

  # New JSON mode
  moltbot channels login --channel whatsapp --json --timeout 60000

  Output format

  Two JSON objects are printed to stdout:

  1. Initial response (QR data):
  {
    "status": "pending",
    "qrDataUrl": "data:image/png;base64,iVBORw0KGgo...",
    "message": "Scan this QR in WhatsApp → Linked Devices.",
    "accountId": "default",
    "channel": "whatsapp"
  }

  2. Final response (after scan or timeout):
  {
    "status": "connected",
    "connected": true,
    "message": "✅ Linked! WhatsApp is ready.",
    "accountId": "default",
    "channel": "whatsapp"
  }

  The qrDataUrl is a base64-encoded PNG that can be displayed directly in an <img src="..."> tag.