### PR TITLE
fix(slack): ack reactions not executing due to early return on empty text

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -337,8 +337,9 @@ export async function prepareSlackMessage(params: {
     maxBytes: ctx.mediaMaxBytes,
   });
   const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
-  if (!rawBody) return null;
 
+  // Handle ack reactions BEFORE checking for message content
+  // This ensures reactions work even for messages with no text body
   const ackReaction = resolveAckReaction(cfg, route.agentId);
   const ackReactionValue = ackReaction ?? "";
 
@@ -371,6 +372,8 @@ export async function prepareSlackMessage(params: {
           },
         )
       : null;
+
+  if (!rawBody) return null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);


### PR DESCRIPTION
## Summary

This PR fixes a bug where ack reactions were not appearing in Slack messages, even when properly configured.

## Root Cause

The ack reaction logic was placed after a check that returns `null` if the message has no text content:

```typescript
const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
if (!rawBody) return null;  // ← This prevented ack reactions!

// Ack reaction logic was here (never reached for empty messages)
```

When users mention the bot without additional text (like just `@clawdbot`), there's no `rawBody`, so the function returns early and never reaches the ack reaction code.

## The Fix

Moved the ack reaction logic **before** the text content check:

```typescript
// Handle ack reactions BEFORE checking for message content  
// This ensures reactions work even for messages with no text body
const ackReaction = resolveAckReaction(cfg, route.agentId);
// ... ack reaction logic ...

if (!rawBody) return null;  // Now comes after ack reactions
```

## Testing

- ✅ Tested with mentions that have text content
- ✅ Tested with bare mentions (just `@bot`)
- ✅ Tested in both DMs and channels
- ✅ Verified reactions appear immediately
- ✅ Verified `removeAckAfterReply` setting works correctly

## Impact

This fix ensures ack reactions work for all message types:
- Messages with text (`hello @clawdbot`)  
- Just mentions (`@clawdbot`)
- Both DMs and channels

---

**Co-authored-by:** Claude Sonnet 4.5 <claude@anthropic.com>  
**Primary analysis and implementation:** AI assistance with systematic debugging

🤖 *Most of the debugging, root cause analysis, and code implementation was performed by Claude Sonnet 4.5 using systematic debugging methodologies.*