### PR TITLE
fix: trim whitespace from config input fields on change

### DIFF
--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -260,6 +260,11 @@ function renderTextInput(params: {
             }
             onPatch(path, raw);
           }}
+          @change=${(e: Event) => {
+            if (inputType === "number") return;
+            const raw = (e.target as HTMLInputElement).value;
+            onPatch(path, raw.trim());
+          }}
         />
         ${schema.default !== undefined ? html`
           <button


### PR DESCRIPTION
This PR automatically trims whitespace from configuration input fields when the value changes. This addresses an issue where pasting tokens (like from Claude setup) could include invisible newline characters that cause authentication failures.