### PR TITLE
fix: correct 'Venius' typo to 'Venice' in provider docs

### DIFF
--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -4,9 +4,9 @@ read_when:
   - You want privacy-focused inference in Moltbot
   - You want Venice AI setup guidance
 ---
-# Venice AI (Venius highlight)
+# Venice AI (Venice highlight)
 
-**Venius** is our highlight Venice setup for privacy-first inference with optional anonymized access to proprietary models.
+**Venice** is our highlight Venice setup for privacy-first inference with optional anonymized access to proprietary models.
 
 Venice AI provides privacy-focused AI inference with support for uncensored models and access to major proprietary models through their anonymized proxy. All inference is private by default—no training on your data, no logging.
 


### PR DESCRIPTION
The Venice provider doc (`docs/providers/venice.md`) has 'Venius' in the heading and intro paragraph — should be 'Venice'. This PR fixes both occurrences.