### PR TITLE
docs: remove numeric model selection references and document /models

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -92,15 +92,19 @@ You can switch models for the current session without restarting:
 
 ```
 /model
-/model list
-/model 3
-/model openai/gpt-5.2
 /model status
+/model openai/gpt-5.2
+/model opus
+/models
+/models openai
 ```
 
 Notes:
-- `/model` (and `/model list`) is a compact, numbered picker (model family + available providers).
-- `/model <#>` selects from that picker.
+- `/model` shows a summary of the current model and brief usage instructions.
+- `/model <provider/model>` switches to that exact model.
+- `/model <alias>` switches using a configured alias (for example, `/model opus`).
+- `/models` lists available providers, and `/models <provider>` lists that provider's models.
+- Numeric selection like `/model 3` is not supported.
 - `/model status` is the detailed view (auth candidates and, when configured, provider endpoint `baseUrl` + `api` mode).
 - Model refs are parsed by splitting on the **first** `/`. Use `provider/model` when typing `/model <ref>`.
 - If the model ID itself contains `/` (OpenRouter-style), you must include the provider prefix (example: `/model openrouter/moonshotai/kimi-k2`).

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1925,13 +1925,9 @@ Use the `/model` command as a standalone message:
 /model gemini-flash
 ```
 
-You can list available models with `/model`, `/model list`, or `/model status`.
+You can view providers with `/models`, list a provider's models with `/models <provider>`, and switch models with `/model <provider/model>` or `/model <alias>`.
 
-`/model` (and `/model list`) shows a compact, numbered picker. Select by number:
-
-```
-/model 3
-```
+Use `/model status` for a detailed view of your current model and auth configuration.
 
 You can also force a specific auth profile for the provider (per session):
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1970,7 +1970,7 @@ Model "provider/model" is not allowed. Use /model to list available models.
 ```
 
 That error is returned **instead of** a normal reply. Fix: add the model to
-`agents.defaults.models`, remove the allowlist, or pick a model from `/model list`.
+`agents.defaults.models`, remove the allowlist, or pick a model from `/models`.
 
 ### Why do I see Unknown model minimaxMiniMaxM21
 
@@ -1988,7 +1988,7 @@ Fix checklist:
    ```bash
    moltbot models list
    ```
-   and pick from the list (or `/model list` in chat).
+   and pick from the list (or `/models` in chat).
 
 See [MiniMax](/providers/minimax) and [Models](/concepts/models).
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -131,16 +131,19 @@ Examples:
 
 ```
 /model
-/model list
-/model 3
-/model openai/gpt-5.2
-/model opus@anthropic:default
 /model status
+/model openai/gpt-5.2
+/model opus
+/models
+/models openai
 ```
 
 Notes:
-- `/model` and `/model list` show a compact, numbered picker (model family + available providers).
-- `/model <#>` selects from that picker (and prefers the current provider when possible).
+- `/model` shows a summary of the current model plus usage instructions.
+- `/model <provider/model>` switches to that exact model.
+- `/model <alias>` switches using a configured alias (for example, `/model opus`).
+- `/models` lists available providers, and `/models <provider>` lists that provider's models.
+- Numeric selection like `/model 3` is not supported.
 - `/model status` shows the detailed view, including configured provider endpoint (`baseUrl`) and API mode (`api`) when available.
 
 ## Debug overrides

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -85,7 +85,8 @@ Text + native (when enabled):
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
 - `/elevated on|off|ask|full` (alias: `/elev`; `full` skips exec approvals)
 - `/exec host=<sandbox|gateway|node> security=<deny|allowlist|full> ask=<off|on-miss|always> node=<id>` (send `/exec` to show current)
-- `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/model <name>` (or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/models [provider]` (list available providers, or models for a provider)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 - `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
 


### PR DESCRIPTION
## Summary
- Update `/model` docs to reflect summary view and alias/provider syntax
- Remove numbered picker and `/model <#>` references
- Add `/models` and `/models <provider>` guidance

## Why
PR #1398 (Jan 21, 2026) removed numeric model selection from chat, but the docs were never updated. Users see `/model 3` in docs but get "Numeric model selection is not supported in chat" when they try it.

## Files Changed
- `docs/concepts/models.md`
- `docs/tools/slash-commands.md`
- `docs/help/faq.md`

## Testing
- [x] Docs-only change, no code testing needed
- [x] Verified examples match current `/model` behavior

## AI Disclosure 🤖
This PR was drafted with Claude (Opus 4.5) assistance. The changes are straightforward docs updates that I understand and have verified against the actual code behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Docs update aligns model-selection guidance with current chat behavior: removes numeric `/model <#>` examples, documents `/model` summary + `provider/model` and alias usage, and introduces `/models` / `/models <provider>` discovery guidance.

Main inconsistency spotted: the slash-command list still claims `/models` is an alias of `/model`, which conflicts with the new `/models` semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk, but has a couple doc inconsistencies that should be corrected.
- Docs-only changes and the intent is clear, but there are conflicting statements about `/models` (alias vs distinct command) and some leftover `/model list` references that could mislead users.
- docs/tools/slash-commands.md (command list entry) and docs/help/faq.md (remaining `/model list` references).

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->