### PR TITLE
feat(gateway): add wireguard bind mode for WireGuard mesh VPNs

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -42,7 +42,7 @@ Notes:
 ### Options
 
 - `--port <port>`: WebSocket port (default comes from config/env; usually `18789`).
-- `--bind <loopback|lan|tailnet|auto|custom>`: listener bind mode.
+- `--bind <loopback|lan|tailnet|wireguard|auto|custom>`: listener bind mode.
 - `--auth <token|password>`: auth mode override.
 - `--token <token>`: token override (also sets `OPENCLAW_GATEWAY_TOKEN` for the process).
 - `--password <password>`: password override (also sets `OPENCLAW_GATEWAY_PASSWORD` for the process).

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3275,6 +3275,7 @@ Bind modes:
 
 - `lan`: `0.0.0.0` (reachable on any interface, including LAN/Wi‑Fi and Tailscale)
 - `tailnet`: bind only to the machine’s Tailscale IP (recommended for Vienna ⇄ London)
+- `wireguard`: bind only to the machine's WireGuard mesh IP (wg0/wt0 interface - Netbird, Headscale, etc.)
 - `loopback`: `127.0.0.1` (local only)
 - `auto`: prefer tailnet IP if present, else `lan`
 

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -54,7 +54,7 @@ function resolveAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return undefined;
   }
-  return accounts[accountId] as GoogleChatAccountConfig | undefined;
+  return accounts[accountId];
 }
 
 function mergeGoogleChatAccountConfig(

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -181,11 +181,14 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     bindRaw === "lan" ||
     bindRaw === "auto" ||
     bindRaw === "custom" ||
-    bindRaw === "tailnet"
+    bindRaw === "tailnet" ||
+    bindRaw === "wireguard"
       ? bindRaw
       : null;
   if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.error(
+      'Invalid --bind (use "loopback", "lan", "tailnet", "wireguard", "auto", or "custom")',
+    );
     defaultRuntime.exit(1);
     return;
   }
@@ -314,7 +317,7 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option("--port <port>", "Port for the gateway WebSocket")
     .option(
       "--bind <mode>",
-      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
+      'Bind mode ("loopback"|"lan"|"tailnet"|"wireguard"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
     )
     .option(
       "--token <token>",

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -42,6 +42,11 @@ export async function promptGatewayConfig(
           hint: "Bind to your Tailscale IP only (100.x.x.x)",
         },
         {
+          value: "wireguard",
+          label: "WireGuard (WireGuard IP)",
+          hint: "Bind to your WireGuard mesh IP (wg0/wt0 interface)",
+        },
+        {
           value: "auto",
           label: "Auto (Loopback → LAN)",
           hint: "Prefer loopback; fall back to all interfaces if unavailable",

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -20,7 +20,14 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
 
   const gatewayBind = (cfg.gateway?.bind ?? "loopback") as string;
   const customBindHost = cfg.gateway?.customBindHost?.trim();
-  const bindModes: GatewayBindMode[] = ["auto", "lan", "loopback", "custom", "tailnet"];
+  const bindModes: GatewayBindMode[] = [
+    "auto",
+    "lan",
+    "loopback",
+    "custom",
+    "tailnet",
+    "wireguard",
+  ];
   const bindMode = bindModes.includes(gatewayBind as GatewayBindMode)
     ? (gatewayBind as GatewayBindMode)
     : undefined;

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -12,6 +12,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
+import { pickPrimaryWireguardIPv4 } from "../infra/wireguard.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -436,7 +437,7 @@ export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;
 
 export function resolveControlUiLinks(params: {
   port: number;
-  bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";
+  bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet" | "wireguard";
   customBindHost?: string;
   basePath?: string;
 }): { httpUrl: string; wsUrl: string } {
@@ -444,12 +445,16 @@ export function resolveControlUiLinks(params: {
   const bind = params.bind ?? "loopback";
   const customBindHost = params.customBindHost?.trim();
   const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const wireguardIPv4 = pickPrimaryWireguardIPv4();
   const host = (() => {
     if (bind === "custom" && customBindHost && isValidIPv4(customBindHost)) {
       return customBindHost;
     }
     if (bind === "tailnet" && tailnetIPv4) {
       return tailnetIPv4 ?? "127.0.0.1";
+    }
+    if (bind === "wireguard" && wireguardIPv4) {
+      return wireguardIPv4 ?? "127.0.0.1";
     }
     return "127.0.0.1";
   })();

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -96,7 +96,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
   const daemonRuntimeRaw = opts.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
   if (!opts.skipHealth) {
     const links = resolveControlUiLinks({
-      bind: gatewayResult.bind as "auto" | "lan" | "loopback" | "custom" | "tailnet",
+      bind: gatewayResult.bind as "auto" | "lan" | "loopback" | "custom" | "tailnet" | "wireguard",
       port: gatewayResult.port,
       customBindHost: nextConfig.gateway?.customBindHost,
       basePath: undefined,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -36,7 +36,7 @@ export type AuthChoice =
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
-export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet";
+export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet" | "wireguard";
 export type TailscaleMode = "off" | "serve" | "funnel";
 export type NodeManagerChoice = "npm" | "pnpm" | "bun";
 export type ChannelChoice = ChannelId;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,4 +1,4 @@
-export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
+export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet" | "wireguard";
 
 export type GatewayTlsConfig = {
   /** Enable TLS for the gateway server. */
@@ -221,6 +221,7 @@ export type GatewayConfig = {
    * - lan: 0.0.0.0 (all interfaces, no fallback)
    * - loopback: 127.0.0.1 (local-only)
    * - tailnet: Tailnet IPv4 if available (100.64.0.0/10), else loopback
+   * - wireguard: WireGuard IPv4 if available (wg0/wt0 interface), else loopback
    * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable (requires customBindHost)
    * Default: loopback (127.0.0.1).
    */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -312,6 +312,7 @@ export const OpenClawSchema = z
             z.literal("loopback"),
             z.literal("custom"),
             z.literal("tailnet"),
+            z.literal("wireguard"),
           ])
           .optional(),
         controlUi: z

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -212,7 +212,7 @@ export const testState = {
   allowFrom: undefined as string[] | undefined,
   cronStorePath: undefined as string | undefined,
   cronEnabled: false as boolean | undefined,
-  gatewayBind: undefined as "auto" | "lan" | "tailnet" | "loopback" | undefined,
+  gatewayBind: undefined as "auto" | "lan" | "tailnet" | "wireguard" | "loopback" | undefined,
   gatewayAuth: undefined as Record<string, unknown> | undefined,
   gatewayControlUi: undefined as Record<string, unknown> | undefined,
   hooksConfig: undefined as HooksConfig | undefined,

--- a/src/infra/wireguard.ts
+++ b/src/infra/wireguard.ts
@@ -1,0 +1,52 @@
+import os from "node:os";
+
+export type WireguardAddresses = {
+  ipv4: string[];
+  ipv6: string[];
+};
+
+/**
+ * Detect WireGuard mesh VPN interfaces (Netbird wt*, standard wg*, etc.).
+ * These typically use the 100.64.0.0/10 CGNAT range or private RFC1918 ranges.
+ */
+function isWireguardInterface(name: string): boolean {
+  // wt0, wt1 (Netbird); wg0, wg1
+  return /^(wt|wg)\d+$/.test(name);
+}
+
+export function listWireguardAddresses(): WireguardAddresses {
+  const ipv4: string[] = [];
+  const ipv6: string[] = [];
+
+  const ifaces = os.networkInterfaces();
+  for (const [ifaceName, entries] of Object.entries(ifaces)) {
+    if (!entries) {
+      continue;
+    }
+    if (!isWireguardInterface(ifaceName)) {
+      continue;
+    }
+
+    for (const e of entries) {
+      if (!e || e.internal) {
+        continue;
+      }
+      const address = e.address?.trim();
+      if (!address) {
+        continue;
+      }
+      if (e.family === "IPv4" || (e.family as unknown) === 4) {
+        ipv4.push(address);
+      }
+      if (e.family === "IPv6" || (e.family as unknown) === 6) {
+        ipv6.push(address);
+      }
+    }
+  }
+
+  return { ipv4: [...new Set(ipv4)], ipv6: [...new Set(ipv6)] };
+}
+
+export function pickPrimaryWireguardIPv4(): string | undefined {
+  return listWireguardAddresses().ipv4[0];
+}

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -96,11 +96,14 @@ async function main() {
     bindRaw === "lan" ||
     bindRaw === "auto" ||
     bindRaw === "custom" ||
-    bindRaw === "tailnet"
+    bindRaw === "tailnet" ||
+    bindRaw === "wireguard"
       ? bindRaw
       : null;
   if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.error(
+      'Invalid --bind (use "loopback", "lan", "tailnet", "wireguard", "auto", or "custom")',
+    );
     process.exit(1);
   }
 

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -54,6 +54,7 @@ export async function configureGatewayForOnboarding(
             { value: "loopback", label: "Loopback (127.0.0.1)" },
             { value: "lan", label: "LAN (0.0.0.0)" },
             { value: "tailnet", label: "Tailnet (Tailscale IP)" },
+            { value: "wireguard", label: "WireGuard (WireGuard IP)" },
             { value: "auto", label: "Auto (Loopback → LAN)" },
             { value: "custom", label: "Custom IP" },
           ],

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -239,7 +239,9 @@ export async function runOnboardingWizard(
   })();
 
   if (flow === "quickstart") {
-    const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet") => {
+    const formatBind = (
+      value: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "wireguard",
+    ) => {
       if (value === "loopback") {
         return "Loopback (127.0.0.1)";
       }
@@ -251,6 +253,9 @@ export async function runOnboardingWizard(
       }
       if (value === "tailnet") {
         return "Tailnet (Tailscale IP)";
+      }
+      if (value === "wireguard") {
+        return "WireGuard (WireGuard IP)";
       }
       return "Auto";
     };

--- a/src/wizard/onboarding.types.ts
+++ b/src/wizard/onboarding.types.ts
@@ -5,7 +5,7 @@ export type WizardFlow = "quickstart" | "advanced";
 export type QuickstartGatewayDefaults = {
   hasExisting: boolean;
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "wireguard";
   authMode: GatewayAuthChoice;
   tailscaleMode: "off" | "serve" | "funnel";
   token?: string;
@@ -16,7 +16,7 @@ export type QuickstartGatewayDefaults = {
 
 export type GatewayWizardSettings = {
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "wireguard";
   customBindHost?: string;
   authMode: GatewayAuthChoice;
   gatewayToken?: string;


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                                         
                                                                                                                                                                                                                                     
When first trying Moltbot on a remote VM connected via WireGuard, I had trouble understanding how to bind the gateway. Using `--bind lan` exposes it on all interfaces, but I wanted to restrict access to just the WireGuard network for better security.                                                                                                                                                                                                              
                                                                                                                                                                                                                                     
This adds a wireguard bind mode `--bind wireguard` (similar to the existing tailnet mode for Tailscale) that automatically detects and binds to WireGuard mesh interfaces, like `wt0`.                                                                            
                                                                                                                                                                                                                                     
## Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                     

-   Adds wireguard bind mode for WireGuard-based mesh VPNs (Netbird, Headscale, Firezone, plain WireGuard)                                                                                                                           
-   Detects wg* and wt* interfaces automatically                                                                                                                                                                                     
-   Falls back to loopback if no WireGuard interface is found                                                                                                                                                                        

                                                                                                                                                                                                                                     
## Test plan                                                                                                                                                                                                                          
                                                                                                                                                                                                                                     

-   Tested with Netbird (wt0 interface) on Linux ARM64                                                                                                                                                                               
-   Gateway binds to WireGuard IP and is accessible from mesh peers                                                                                                                                                                  
-   Fallback to loopback works when no WireGuard interface present 