### PR TITLE
TUI: fix /reasoning by supporting stream + normalization-Mark as AI-assisted-lightly tested

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -19,4 +19,13 @@ describe("tui slash commands", () => {
     expect(commands.some((command) => command.name === "context")).toBe(true);
     expect(commands.some((command) => command.name === "commands")).toBe(true);
   });
+
+  it("offers reasoning stream mode", () => {
+    const commands = getSlashCommands({});
+    const reasoning = commands.find((command) => command.name === "reasoning");
+    expect(reasoning).toBeTruthy();
+    expect(reasoning?.getArgumentCompletions?.("")).toEqual(
+      expect.arrayContaining([{ value: "stream", label: "stream" }]),
+    );
+  });
 });

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -146,7 +146,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/verbose <on|off>",
-    "/reasoning <on|off>",
+    "/reasoning <on|off|stream>",
     "/usage <off|tokens|full>",
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -4,7 +4,7 @@ import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thi
 import type { MoltbotConfig } from "../config/types.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
-const REASONING_LEVELS = ["on", "off"];
+const REASONING_LEVELS = ["on", "off", "stream"];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
 const USAGE_FOOTER_LEVELS = ["off", "tokens", "full"];
@@ -68,7 +68,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "reasoning",
-      description: "Set reasoning on/off",
+      description: "Set reasoning visibility",
       getArgumentCompletions: (prefix) =>
         REASONING_LEVELS.filter((v) => v.startsWith(prefix.toLowerCase())).map((value) => ({
           value,

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -44,4 +44,43 @@ describe("tui command handlers", () => {
     );
     expect(requestRender).toHaveBeenCalled();
   });
+
+  it("normalizes /reasoning streaming to stream", async () => {
+    const patchSession = vi.fn().mockResolvedValue(undefined);
+    const addUser = vi.fn();
+    const addSystem = vi.fn();
+    const requestRender = vi.fn();
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+
+    const { handleCommand } = createCommandHandlers({
+      client: { patchSession } as never,
+      chatLog: { addUser, addSystem } as never,
+      tui: { requestRender } as never,
+      opts: {},
+      state: {
+        currentSessionKey: "agent:main:main",
+        activeChatRunId: null,
+        sessionInfo: {},
+      } as never,
+      deliverDefault: false,
+      openOverlay: vi.fn(),
+      closeOverlay: vi.fn(),
+      refreshSessionInfo,
+      loadHistory: vi.fn(),
+      setSession: vi.fn(),
+      refreshAgents: vi.fn(),
+      abortActive: vi.fn(),
+      setActivityStatus: vi.fn(),
+      formatSessionKey: vi.fn(),
+    });
+
+    await handleCommand("/reasoning streaming");
+
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      reasoningLevel: "stream",
+    });
+    expect(addSystem).toHaveBeenCalledWith("reasoning set to stream");
+    expect(refreshSessionInfo).toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -1,6 +1,7 @@
 import type { Component, TUI } from "@mariozechner/pi-tui";
 import {
   formatThinkingLevels,
+  normalizeReasoningLevel,
   normalizeUsageDisplay,
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
@@ -333,15 +334,20 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "reasoning":
         if (!args) {
-          chatLog.addSystem("usage: /reasoning <on|off>");
+          chatLog.addSystem("usage: /reasoning <on|off|stream>");
           break;
         }
         try {
+          const normalized = normalizeReasoningLevel(args);
+          if (!normalized) {
+            chatLog.addSystem("usage: /reasoning <on|off|stream>");
+            break;
+          }
           await client.patchSession({
             key: state.currentSessionKey,
-            reasoningLevel: args,
+            reasoningLevel: normalized,
           });
-          chatLog.addSystem(`reasoning set to ${args}`);
+          chatLog.addSystem(`reasoning set to ${normalized}`);
           await refreshSessionInfo();
         } catch (err) {
           chatLog.addSystem(`reasoning failed: ${String(err)}`);


### PR DESCRIPTION
This change fixes a mismatch between the TUI /reasoning command and the project’s canonical reasoning enum.

What was wrong before

The core enum is ReasoningLevel = "off" | "on" | "stream" ([thinking.ts](https://file+.vscode-resource.vscode-cdn.net/Users/aaron/.vscode/extensions/openai.chatgpt-0.4.67-darwin-arm64/webview/#)), and the Gateway session patch logic validates the same set (on|off|stream).
The TUI, however:
Only advertised /reasoning <on|off> (help text).
Only offered on/off in autocomplete.
Passed the raw argument through to patchSession without normalization/validation.
What this fixes

Adds stream to TUI autocomplete for /reasoning.
Updates /reasoning help text to include stream.
Normalizes user input via normalizeReasoningLevel() so common inputs like streaming become stream before calling patchSession.
If you didn’t make this change, when would it fail and how

If a user tries to enable streaming reasoning in TUI (e.g. /reasoning stream or /reasoning streaming):
The TUI would either not guide them to the correct value (no autocomplete, wrong usage).
For /reasoning streaming specifically, the TUI would send reasoningLevel: "streaming" to the Gateway, which rejects it as invalid (Gateway expects exactly on|off|stream).
Result: the command fails (you’d see a “reasoning failed: …” message in the TUI), and the session would not enter reasoning:stream, so the user cannot enable streaming reasoning from TUI reliably.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the TUI `/reasoning` command to match the canonical `ReasoningLevel` enum (`off|on|stream`). It adds `stream` to `/reasoning` autocomplete, updates the command description, and normalizes user input via `normalizeReasoningLevel()` before calling `client.patchSession`, with tests covering autocomplete and normalization behavior.

The main integration point is `src/tui/tui-command-handlers.ts`, where slash command arguments are parsed and translated into gateway `patchSession` calls; the TUI’s slash command registry in `src/tui/commands.ts` drives help/autocomplete UI.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and mostly safe to merge; the main remaining issue is a minor documentation mismatch in `/help` output.
- Changes are localized to TUI command wiring and add straightforward normalization using an existing helper (`normalizeReasoningLevel`). New tests cover autocomplete and normalization. I couldn’t run the test/lint/typecheck commands in this environment (npm unavailable), so confidence is slightly reduced.
- src/tui/commands.ts (helpText line for /reasoning)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->