### PR TITLE
fix(ui): improve chat session dropdown and refresh behavior

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -21,6 +21,7 @@ type ChatHost = {
   basePath: string;
   hello: GatewayHelloOk | null;
   chatAvatarUrl: string | null;
+  refreshSessionsAfterChat: boolean;
 };
 
 export function isChatBusy(host: ChatHost) {
@@ -39,6 +40,14 @@ export function isChatStopCommand(text: string) {
     normalized === "wait" ||
     normalized === "exit"
   );
+}
+
+function isChatResetCommand(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "/new" || normalized === "/reset") return true;
+  return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
 }
 
 export async function handleAbortChat(host: ChatHost) {
@@ -71,6 +80,7 @@ async function sendChatMessageNow(
     attachments?: ChatAttachment[];
     previousAttachments?: ChatAttachment[];
     restoreAttachments?: boolean;
+    refreshSessions?: boolean;
   },
 ) {
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
@@ -93,6 +103,9 @@ async function sendChatMessageNow(
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
   if (ok && !host.chatRunId) {
     void flushChatQueue(host);
+  }
+  if (ok && opts?.refreshSessions) {
+    host.refreshSessionsAfterChat = true;
   }
   return ok;
 }
@@ -132,6 +145,7 @@ export async function handleSendChat(
     return;
   }
 
+  const refreshSessions = isChatResetCommand(message);
   if (messageOverride == null) {
     host.chatMessage = "";
     // Clear attachments when sending
@@ -149,13 +163,14 @@ export async function handleSendChat(
     attachments: hasAttachments ? attachmentsToSend : undefined,
     previousAttachments: messageOverride == null ? attachments : undefined,
     restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
+    refreshSessions,
   });
 }
 
 export async function refreshChat(host: ChatHost) {
   await Promise.all([
     loadChatHistory(host as unknown as MoltbotApp),
-    loadSessions(host as unknown as MoltbotApp, { activeMinutes: 10 }),
+    loadSessions(host as unknown as MoltbotApp, { activeMinutes: 0 }),
     refreshChatAvatar(host),
   ]);
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -155,7 +155,7 @@ export async function handleSendChat(
 export async function refreshChat(host: ChatHost) {
   await Promise.all([
     loadChatHistory(host as unknown as MoltbotApp),
-    loadSessions(host as unknown as MoltbotApp),
+    loadSessions(host as unknown as MoltbotApp, { activeMinutes: 10 }),
     refreshChatAvatar(host),
   ]);
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -26,6 +26,7 @@ import {
 import type { MoltbotApp } from "./app";
 import type { ExecApprovalRequest } from "./controllers/exec-approval";
 import { loadAssistantIdentity } from "./controllers/assistant-identity";
+import { loadSessions } from "./controllers/sessions";
 
 type GatewayHost = {
   settings: UiSettings;
@@ -50,6 +51,7 @@ type GatewayHost = {
   assistantAgentId: string | null;
   sessionKey: string;
   chatRunId: string | null;
+  refreshSessionsAfterChat: boolean;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
 };
@@ -194,6 +196,12 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       void flushChatQueueForEvent(
         host as unknown as Parameters<typeof flushChatQueueForEvent>[0],
       );
+      if (host.refreshSessionsAfterChat) {
+        host.refreshSessionsAfterChat = false;
+        if (state === "final") {
+          void loadSessions(host as unknown as MoltbotApp, { activeMinutes: 0 });
+        }
+      }
     }
     if (state === "final") void loadChatHistory(host as unknown as MoltbotApp);
     return;

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -35,6 +35,9 @@ type LifecycleHost = {
 
 export function handleConnected(host: LifecycleHost) {
   host.basePath = inferBasePath();
+  applySettingsFromUrl(
+    host as unknown as Parameters<typeof applySettingsFromUrl>[0],
+  );
   syncTabWithLocation(
     host as unknown as Parameters<typeof syncTabWithLocation>[0],
     true,
@@ -46,9 +49,6 @@ export function handleConnected(host: LifecycleHost) {
     host as unknown as Parameters<typeof attachThemeListener>[0],
   );
   window.addEventListener("popstate", host.popStateHandler);
-  applySettingsFromUrl(
-    host as unknown as Parameters<typeof applySettingsFromUrl>[0],
-  );
   connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
   if (host.tab === "logs") {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -258,6 +258,7 @@ export class MoltbotApp extends LitElement {
   private logsScrollFrame: number | null = null;
   private toolStreamById = new Map<string, ToolStreamEntry>();
   private toolStreamOrder: string[] = [];
+  refreshSessionsAfterChat = false;
   basePath = "";
   private popStateHandler = () =>
     onPopStateInternal(

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -14,18 +14,29 @@ export type SessionsState = {
   sessionsIncludeUnknown: boolean;
 };
 
-export async function loadSessions(state: SessionsState) {
+export async function loadSessions(
+  state: SessionsState,
+  overrides?: {
+    activeMinutes?: number;
+    limit?: number;
+    includeGlobal?: boolean;
+    includeUnknown?: boolean;
+  },
+) {
   if (!state.client || !state.connected) return;
   if (state.sessionsLoading) return;
   state.sessionsLoading = true;
   state.sessionsError = null;
   try {
+    const includeGlobal = overrides?.includeGlobal ?? state.sessionsIncludeGlobal;
+    const includeUnknown = overrides?.includeUnknown ?? state.sessionsIncludeUnknown;
+    const activeMinutes =
+      overrides?.activeMinutes ?? toNumber(state.sessionsFilterActive, 0);
+    const limit = overrides?.limit ?? toNumber(state.sessionsFilterLimit, 0);
     const params: Record<string, unknown> = {
-      includeGlobal: state.sessionsIncludeGlobal,
-      includeUnknown: state.sessionsIncludeUnknown,
+      includeGlobal,
+      includeUnknown,
     };
-    const activeMinutes = toNumber(state.sessionsFilterActive, 0);
-    const limit = toNumber(state.sessionsFilterLimit, 0);
     if (activeMinutes > 0) params.activeMinutes = activeMinutes;
     if (limit > 0) params.limit = limit;
     const res = (await state.client.request("sessions.list", params)) as


### PR DESCRIPTION
## Summary
- Session dropdown now prioritizes the main session (based on `sessionDefaults.mainSessionKey` or `sessionDefaults.mainKey`) at the top of the list
- Sessions automatically refresh after `/new` or `/reset` commands to immediately show the newly created session
- Refresh button now reloads sessions with `activeMinutes: 0` to display all recent sessions
- Enhanced `loadSessions` function to accept parameter overrides for more flexible session loading

## Changes
- **Session dropdown ordering**: Main session appears first, followed by current session (if different), then all other sessions
- **Command detection**: Added detection for `/new` and `/reset` commands (case-insensitive, with or without arguments)
- **Auto-refresh on reset**: When a reset command is sent, sessions are automatically refreshed after chat completion
- **Refresh button**: Now uses `refreshChat` which reloads both chat history and sessions (with `activeMinutes: 0`)
- **loadSessions API**: Accepts optional `overrides` parameter for `activeMinutes`, `limit`, `includeGlobal`, and `includeUnknown`
- **Lifecycle fix**: Moved `applySettingsFromUrl` earlier to ensure settings are applied before other initialization

## Test plan
- [x] Verify session dropdown shows main session first
- [x] Send `/new` command and confirm sessions list refreshes automatically
- [x] Send `/reset` command and confirm sessions list refreshes automatically
- [x] Click refresh button and verify all recent sessions appear
- [x] Switch between sessions and verify dropdown ordering remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)