### PR TITLE
feat(infra): introduce global proxy configuration via undici

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -7,6 +7,7 @@ import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { configureGlobalProxy } from "../infra/proxy.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
@@ -27,6 +28,7 @@ export async function runCli(argv: string[] = process.argv) {
   const normalizedArgv = stripWindowsNodeExec(argv);
   loadDotEnv({ quiet: true });
   normalizeEnv();
+  configureGlobalProxy();
   ensureOpenClawCliOnPath();
 
   // Enforce the minimum supported runtime before doing any work.

--- a/src/infra/proxy.ts
+++ b/src/infra/proxy.ts
@@ -1,0 +1,41 @@
+import { setGlobalDispatcher, EnvHttpProxyAgent } from "undici";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("infra/proxy");
+
+/**
+ * Configures the global undici dispatcher to respect standard proxy environment variables:
+ * - HTTP_PROXY / http_proxy
+ * - HTTPS_PROXY / https_proxy
+ * - NO_PROXY / no_proxy
+ *
+ * This affects all global fetch() calls and undici-based requests.
+ */
+export function configureGlobalProxy(): void {
+  const hasProxyEnv =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  if (!hasProxyEnv) {
+    return;
+  }
+
+  try {
+    // EnvHttpProxyAgent is the industry-standard way in undici to handle env-based proxies.
+    // It automatically manages the logic for NO_PROXY and selecting the right proxy per protocol.
+    const agent = new EnvHttpProxyAgent();
+    setGlobalDispatcher(agent);
+
+    // We don't log the full proxy URL by default to avoid leaking potential credentials
+    // but we log that the proxy system is active.
+    log.debug("global proxy dispatcher initialized via environment variables");
+  } catch (err) {
+    // If proxy configuration fails, we log it but don't crash the app.
+    // Standard behavior is to fallback to direct connection if possible.
+    log.error(
+      `failed to initialize global proxy dispatcher: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a centralized global proxy configuration for the CLI. It leverages `undici`'s `EnvHttpProxyAgent` to automatically respect standard environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) across all outgoing requests.

## Context
Previously, network requests—especially those made by extensions or third-party integrations—could fail in environments requiring a proxy (e.g., corporate networks, VPNs, or local debugging setups). Some extensions handled this ad-hoc, while others ignored it entirely, leading to inconsistent connectivity.

This change ensures that **all** `fetch` requests and `undici` clients used throughout the application inherit the correct proxy settings from the environment immediately upon CLI startup.

## Technical Details
- **Infrastructure**: Added `src/infra/proxy.ts`, which initializes the `EnvHttpProxyAgent` and sets it as the global dispatcher.
- **Entry Point**: Updated `src/cli/run-main.ts` to invoke `configureGlobalProxy()` during the bootstrap phase, ensuring the environment is ready before any network calls occur.
- **Security**: The system logs when a proxy is detected/active but intentionally avoids logging the full proxy URL to prevent leaking credentials (e.g., `http://user:pass@host`).

## Verification
- **Manual Testing**:
  1. Set `HTTPS_PROXY=http://127.0.0.1:8888`.
  2. Executed CLI commands requiring network access (e.g., auth, plugin sync).
  3. Verified that traffic was correctly routed through the local proxy.
- **Regression**: Confirmed that the CLI functions normally (direct connection) when no proxy environment variables are set.