### PR TITLE
fix(security): bind temporary media server to loopback by default

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ClawdbotConfig } from "../config/config.js";
+import type { MoltbotConfig } from "../config/config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { fetchRemoteMedia } from "../media/fetch.js";
@@ -41,7 +41,7 @@ describe("applyMediaUnderstanding", () => {
     mockedResolveApiKey.mockClear();
     mockedFetchRemoteMedia.mockReset();
     mockedFetchRemoteMedia.mockResolvedValue({
-      buffer: Buffer.from("audio-bytes"),
+      buffer: Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
       contentType: "audio/ogg",
       fileName: "note.ogg",
     });
@@ -49,16 +49,16 @@ describe("applyMediaUnderstanding", () => {
 
   it("sets Transcript and replaces Body when audio transcription succeeds", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, "hello");
+    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
       MediaPath: audioPath,
       MediaType: "audio/ogg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -92,16 +92,16 @@ describe("applyMediaUnderstanding", () => {
 
   it("keeps caption for command parsing when audio has user text", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, "hello");
+    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
 
     const ctx: MsgContext = {
       Body: "<media:audio> /capture status",
       MediaPath: audioPath,
       MediaType: "audio/ogg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -140,7 +140,7 @@ describe("applyMediaUnderstanding", () => {
       MediaType: "audio/ogg",
       ChatType: "dm",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -174,9 +174,9 @@ describe("applyMediaUnderstanding", () => {
 
   it("skips audio transcription when attachment exceeds maxBytes", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPath = path.join(dir, "large.wav");
-    await fs.writeFile(audioPath, "0123456789");
+    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -184,7 +184,7 @@ describe("applyMediaUnderstanding", () => {
       MediaType: "audio/wav",
     };
     const transcribeAudio = vi.fn(async () => ({ text: "should-not-run" }));
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -209,16 +209,16 @@ describe("applyMediaUnderstanding", () => {
 
   it("falls back to CLI model when provider fails", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, "hello");
+    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
       MediaPath: audioPath,
       MediaType: "audio/ogg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -262,7 +262,7 @@ describe("applyMediaUnderstanding", () => {
 
   it("uses CLI image understanding and preserves caption for commands", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const imagePath = path.join(dir, "photo.jpg");
     await fs.writeFile(imagePath, "image-bytes");
 
@@ -271,7 +271,7 @@ describe("applyMediaUnderstanding", () => {
       MediaPath: imagePath,
       MediaType: "image/jpeg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           image: {
@@ -309,7 +309,7 @@ describe("applyMediaUnderstanding", () => {
 
   it("uses shared media models list when capability config is missing", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const imagePath = path.join(dir, "shared.jpg");
     await fs.writeFile(imagePath, "image-bytes");
 
@@ -318,7 +318,7 @@ describe("applyMediaUnderstanding", () => {
       MediaPath: imagePath,
       MediaType: "image/jpeg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           models: [
@@ -350,16 +350,16 @@ describe("applyMediaUnderstanding", () => {
 
   it("uses active model when enabled and models are missing", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPath = path.join(dir, "fallback.ogg");
-    await fs.writeFile(audioPath, "hello");
+    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6]));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
       MediaPath: audioPath,
       MediaType: "audio/ogg",
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -387,18 +387,18 @@ describe("applyMediaUnderstanding", () => {
 
   it("handles multiple audio attachments when attachment mode is all", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const audioPathA = path.join(dir, "note-a.ogg");
     const audioPathB = path.join(dir, "note-b.ogg");
-    await fs.writeFile(audioPathA, "hello");
-    await fs.writeFile(audioPathB, "world");
+    await fs.writeFile(audioPathA, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
+    await fs.writeFile(audioPathB, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
       MediaPaths: [audioPathA, audioPathB],
       MediaTypes: ["audio/ogg", "audio/ogg"],
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           audio: {
@@ -430,12 +430,12 @@ describe("applyMediaUnderstanding", () => {
 
   it("orders mixed media outputs as image, audio, video", async () => {
     const { applyMediaUnderstanding } = await loadApply();
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-media-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     const imagePath = path.join(dir, "photo.jpg");
     const audioPath = path.join(dir, "note.ogg");
     const videoPath = path.join(dir, "clip.mp4");
     await fs.writeFile(imagePath, "image-bytes");
-    await fs.writeFile(audioPath, "audio-bytes");
+    await fs.writeFile(audioPath, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
     await fs.writeFile(videoPath, "video-bytes");
 
     const ctx: MsgContext = {
@@ -443,7 +443,7 @@ describe("applyMediaUnderstanding", () => {
       MediaPaths: [imagePath, audioPath, videoPath],
       MediaTypes: ["image/jpeg", "audio/ogg", "video/mp4"],
     };
-    const cfg: ClawdbotConfig = {
+    const cfg: MoltbotConfig = {
       tools: {
         media: {
           image: { enabled: true, models: [{ provider: "openai", model: "gpt-5.2" }] },
@@ -486,5 +486,188 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Transcript).toBe("audio ok");
     expect(ctx.CommandBody).toBe("audio ok");
     expect(ctx.BodyForCommands).toBe("audio ok");
+  });
+
+  it("treats text-like audio attachments as CSV (comma wins over tabs)", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    const csvPath = path.join(dir, "data.mp3");
+    const csvText = '"a","b"\t"c"\n"1","2"\t"3"';
+    const csvBuffer = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(csvText, "utf16le")]);
+    await fs.writeFile(csvPath, csvBuffer);
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaPath: csvPath,
+      MediaType: "audio/mpeg",
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain('<file name="data.mp3" mime="text/csv">');
+    expect(ctx.Body).toContain('"a","b"\t"c"');
+  });
+
+  it("infers TSV when tabs are present without commas", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    const tsvPath = path.join(dir, "report.mp3");
+    const tsvText = "a\tb\tc\n1\t2\t3";
+    await fs.writeFile(tsvPath, tsvText);
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaPath: tsvPath,
+      MediaType: "audio/mpeg",
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain('<file name="report.mp3" mime="text/tab-separated-values">');
+    expect(ctx.Body).toContain("a\tb\tc");
+  });
+
+  it("escapes XML special characters in filenames to prevent injection", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    // Use & in filename — valid on all platforms (including Windows, which
+    // forbids < and > in NTFS filenames) and still requires XML escaping.
+    // Note: The sanitizeFilename in store.ts would strip most dangerous chars,
+    // but we test that even if some slip through, they get escaped in output
+    const filePath = path.join(dir, "file&test.txt");
+    await fs.writeFile(filePath, "safe content");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "text/plain",
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    // Verify XML special chars are escaped in the output
+    expect(ctx.Body).toContain("&amp;");
+    // The name attribute should contain the escaped form, not a raw unescaped &
+    expect(ctx.Body).toMatch(/name="file&amp;test\.txt"/);
+  });
+
+  it("normalizes MIME types to prevent attribute injection", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    const filePath = path.join(dir, "data.txt");
+    await fs.writeFile(filePath, "test content");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      // Attempt to inject via MIME type with quotes - normalization should strip this
+      MediaType: 'text/plain" onclick="alert(1)',
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    // MIME normalization strips everything after first ; or " - verify injection is blocked
+    expect(ctx.Body).not.toContain("onclick=");
+    expect(ctx.Body).not.toContain("alert(1)");
+    // Verify the MIME type is normalized to just "text/plain"
+    expect(ctx.Body).toContain('mime="text/plain"');
+  });
+
+  it("handles path traversal attempts in filenames safely", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    // Even if a file somehow got a path-like name, it should be handled safely
+    const filePath = path.join(dir, "normal.txt");
+    await fs.writeFile(filePath, "legitimate content");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "text/plain",
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    // Verify the file was processed and output contains expected structure
+    expect(ctx.Body).toContain('<file name="');
+    expect(ctx.Body).toContain('mime="text/plain"');
+    expect(ctx.Body).toContain("legitimate content");
+  });
+
+  it("handles files with non-ASCII Unicode filenames", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
+    const filePath = path.join(dir, "文档.txt");
+    await fs.writeFile(filePath, "中文内容");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "text/plain",
+    };
+    const cfg: MoltbotConfig = {
+      tools: {
+        media: {
+          audio: { enabled: false },
+          image: { enabled: false },
+          video: { enabled: false },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("中文内容");
   });
 });

--- a/src/media/host.ts
+++ b/src/media/host.ts
@@ -42,7 +42,7 @@ export async function ensureMediaHosted(
   }
   if (needsServerStart && opts.startServer) {
     if (!mediaServer) {
-      mediaServer = await startMediaServer(port, TTL_MS, undefined, runtime);
+      mediaServer = await startMediaServer(port, TTL_MS, runtime);
       logInfo(
         `🦞 Started temporary media host on http://127.0.0.1:${port}/media/:id (TTL ${TTL_MS / 1000}s)`,
         runtime,

--- a/src/media/host.ts
+++ b/src/media/host.ts
@@ -42,9 +42,9 @@ export async function ensureMediaHosted(
   }
   if (needsServerStart && opts.startServer) {
     if (!mediaServer) {
-      mediaServer = await startMediaServer(port, TTL_MS, runtime);
+      mediaServer = await startMediaServer(port, TTL_MS, undefined, runtime);
       logInfo(
-        `🦞 Started temporary media host on http://localhost:${port}/media/:id (TTL ${TTL_MS / 1000}s)`,
+        `🦞 Started temporary media host on http://127.0.0.1:${port}/media/:id (TTL ${TTL_MS / 1000}s)`,
         runtime,
       );
       mediaServer.unref?.();

--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -54,6 +54,13 @@ describe("media server", () => {
     await new Promise((r) => server.close(r));
   });
 
+  it("binds to loopback by default", async () => {
+    const server = await startMediaServer(0, 5_000);
+    const addr = server.address() as AddressInfo;
+    expect(["127.0.0.1", "::1"]).toContain(addr.address);
+    await new Promise((r) => server.close(r));
+  });
+
   it("expires old media", async () => {
     const file = path.join(MEDIA_DIR, "old");
     await fs.writeFile(file, "stale");

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -83,8 +83,8 @@ export function attachMediaRoutes(
 export async function startMediaServer(
   port: number,
   ttlMs = DEFAULT_TTL_MS,
-  host = "127.0.0.1",
   runtime: RuntimeEnv = defaultRuntime,
+  host = "127.0.0.1",
 ): Promise<Server> {
   const app = express();
   attachMediaRoutes(app, ttlMs, runtime);

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -83,12 +83,13 @@ export function attachMediaRoutes(
 export async function startMediaServer(
   port: number,
   ttlMs = DEFAULT_TTL_MS,
+  host = "127.0.0.1",
   runtime: RuntimeEnv = defaultRuntime,
 ): Promise<Server> {
   const app = express();
   attachMediaRoutes(app, ttlMs, runtime);
   return await new Promise((resolve, reject) => {
-    const server = app.listen(port);
+    const server = app.listen(port, host);
     server.once("listening", () => resolve(server));
     server.once("error", (err) => {
       runtime.error(danger(`Media server failed: ${String(err)}`));


### PR DESCRIPTION
## Summary
The temporary media host (`startMediaServer`) was starting via `app.listen(port)` which binds to all interfaces by default. This is easy to misread as “localhost-only” (especially since the log message suggested `http://localhost:...`).

This PR binds the temporary media server to loopback (`127.0.0.1`) by default and aligns the log output accordingly.

## Security impact
Reduces unintended LAN exposure of temporary hosted media files.

## Changes
- Bind temporary media server to `127.0.0.1` by default (`src/media/server.ts`).
- Update startup log to reflect the actual bind host (`src/media/host.ts`).
- Add a unit test to ensure the default bind address is loopback (`src/media/server.test.ts`).

## Testing
- Added unit test coverage, but I couldn't run `pnpm test` locally because `pnpm install` is currently blocked by a workspace package naming mismatch (see outpost note: ISSUE-0003). CI should validate.

Related outpost analysis: ISSUE-0002-media-server-binds-all-interfaces.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the temporary media server by binding it to loopback by default (`startMediaServer(..., host = "127.0.0.1")` and `app.listen(port, host)`), and aligns the startup log to reflect the actual bind host.

While touching the server, it also strengthens `/media/:id` handling by delegating path/symlink safety to `openFileWithinRoot`, adding explicit media-id validation, and returning clearer status codes for invalid IDs, missing files, expired content, and oversized files. Tests were updated to preserve the real `MEDIA_MAX_BYTES` export while mocking `getMediaDir`/`cleanOldMedia`, and new cases were added for loopback binding, invalid IDs, and oversize rejection.


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and improves security defaults.
- The primary behavior change (binding to 127.0.0.1) is targeted and covered by tests, and the route hardening via `openFileWithinRoot` is a net security win. Remaining concerns are limited to test assertion precision and a potential file-descriptor leak on exceptional paths in `attachMediaRoutes`.
- src/media/server.ts (ensure file handle is always closed), src/media/server.test.ts (tighten default bind assertion)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->