### PR TITLE
fix(cron): delete deleteAfterRun jobs regardless of execution status

### DIFF
--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -410,6 +410,112 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
+  it("deletes deleteAfterRun job even when skipped", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+    // Invalid main job (agentTurn payload) that will be skipped at runtime.
+    // Write directly to disk to bypass add() validation.
+    const jobId = "skip-delete-test";
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          {
+            id: jobId,
+            name: "skipped delete test",
+            enabled: true,
+            deleteAfterRun: true,
+            createdAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+            updatedAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+            schedule: { kind: "at", atMs },
+            sessionTarget: "main",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "bad" },
+            state: { nextRunAtMs: atMs },
+          },
+        ],
+      }),
+    );
+
+    // Reload to pick up the manually written job.
+    cron.stop();
+    const cron2 = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+    await cron2.start();
+
+    vi.setSystemTime(new Date("2025-12-13T00:00:02.000Z"));
+    await vi.runOnlyPendingTimersAsync();
+
+    // Job should be deleted even though it was skipped.
+    const jobs = await cron2.list({ includeDisabled: true });
+    expect(jobs.find((j) => j.id === jobId)).toBeUndefined();
+
+    cron2.stop();
+    await store.cleanup();
+  });
+
+  it("deletes deleteAfterRun job even when failed", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "boom",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+    const job = await cron.add({
+      name: "error delete test",
+      enabled: true,
+      deleteAfterRun: true,
+      schedule: { kind: "at", atMs },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "fail me", deliver: false },
+    });
+
+    vi.setSystemTime(new Date("2025-12-13T00:00:02.000Z"));
+    await vi.runOnlyPendingTimersAsync();
+
+    // Job should be deleted even though it errored.
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs.find((j) => j.id === job.id)).toBeUndefined();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("skips invalid main jobs with agentTurn payloads from disk", async () => {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -93,8 +93,9 @@ export async function executeJob(
     job.state.lastDurationMs = Math.max(0, endedAt - startedAt);
     job.state.lastError = err;
 
-    const shouldDelete =
-      job.schedule.kind === "at" && status === "ok" && job.deleteAfterRun === true;
+    // deleteAfterRun: true means "delete after execution regardless of outcome"
+    // This prevents infinite loops when skipped/failed jobs keep their past nextRunAtMs.
+    const shouldDelete = job.schedule.kind === "at" && job.deleteAfterRun === true;
 
     if (!shouldDelete) {
       if (job.schedule.kind === "at" && status === "ok") {


### PR DESCRIPTION
## Summary

- Fixed infinite loop bug where `deleteAfterRun: true` one-shot jobs would loop every 40ms when skipped or failed
- Changed deletion condition to trigger regardless of execution status (ok, skipped, or error)
- Added tests for skipped and failed scenarios

## Problem

One-shot jobs with `deleteAfterRun: true` were only deleted when `status === "ok"`. When the job was skipped or failed:
- The job was not deleted (`shouldDelete = false`)
- The job was not disabled (line 86-89 only handles `status === "ok"`)
- `nextRunAtMs` remained in the past
- Timer immediately re-fired → 40ms infinite loop

## Solution

Changed `src/cron/service/timer.ts:82-83` from:
```typescript
const shouldDelete =
  job.schedule.kind === "at" && status === "ok" && job.deleteAfterRun === true;
```

To:
```typescript
const shouldDelete =
  job.schedule.kind === "at" && job.deleteAfterRun === true;
```

This matches the intended semantics of `deleteAfterRun: true` — "delete after execution regardless of outcome".

## Test plan

- [x] Existing cron tests pass (54 tests)
- [x] Added test: `deleteAfterRun: true` + `status: "skipped"` → job deleted
- [x] Added test: `deleteAfterRun: true` + `status: "error"` → job deleted

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an infinite re-run loop for one-shot (`schedule.kind === "at"`) jobs configured with `deleteAfterRun: true` by deleting them after execution regardless of whether they finished `ok`, `skipped`, or `error` (`src/cron/service/timer.ts`). It also extends the CronService test suite with new cases that verify delete-after-run behavior for skipped main-lane jobs loaded from disk and for isolated jobs that return an error status.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and addresses a real runaway-timer scenario.
- The production change is narrowly scoped (only affects deletion criteria for one-shot deleteAfterRun jobs) and is backed by new tests covering skipped and errored outcomes. The only concern is minor test robustness around stopping/cleanup ordering if CronService.stop ever becomes async.
- src/cron/service.runs-one-shot-main-job-disables-it.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->