### PR TITLE
feat(agents): include full date with day of week in system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Status: beta.
 - macOS: finish Moltbot app rename for macOS sources, bundle identifiers, and shared kit paths. (#2844) Thanks @fal3.
 - Branding: update launchd labels, mobile bundle IDs, and logging subsystems to bot.molt (legacy com.clawdbot migrations). Thanks @thewilloftheshadow.
 - Tools: add per-sender group tool policies and fix precedence. (#1757) Thanks @adam91holt.
+- Agents: include full date with day of week in system prompt. (#2108)
 - Agents: summarize dropped messages during compaction safeguard pruning. (#2509) Thanks @jogi47.
 - Skills: add multi-image input support to Nano Banana Pro skill. (#1958) Thanks @tyler6204.
 - Agents: honor tools.exec.safeBins in exec allowlist checks. (#2281)

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -145,6 +145,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Current: Monday, January 5th, 2026 — 3:26 PM");
     expect(prompt).toContain("Time zone: America/Chicago");
   });
 
@@ -157,6 +158,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Current Date & Time");
+    expect(prompt).toContain("Current: Monday, January 5th, 2026 — 15:26");
     expect(prompt).toContain("Time zone: America/Chicago");
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -49,9 +49,15 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(`Current: ${params.userTime}`);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`);
+  lines.push("");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -294,6 +300,7 @@ export function buildAgentSystemPrompt(params: {
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
+  const userTime = params.userTime?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const heartbeatPromptLine = heartbeatPrompt
@@ -445,6 +452,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Moltbot and included below in Project Context.",


### PR DESCRIPTION
## Summary
Fixes #2108

The system prompt now displays the full current date and time when `userTime` is available, including day of week.

## Problem
Previously, the system prompt only showed the timezone:
```
## Current Date & Time
Time zone: Europe/London
```

The agent had to infer the current date from message timestamps (which only show `YYYY-MM-DD` without day of week), leading to confident but incorrect day-of-week statements (e.g., saying "Sunday" when it's actually Monday).

## Solution
When `userTime` is provided, the system prompt now displays:
```
## Current Date & Time
Current: Monday, 26 January 2026, 06:53 GMT
Time zone: Europe/London
```

This eliminates day-of-week guessing errors entirely.

## Changes
- Modified `buildTimeSection` in [system-prompt.ts:52-60](https://github.com/moltbot/moltbot/blob/main/src/agents/system-prompt.ts#L52-L60) to accept and display `userTime` parameter
- Updated function call to pass `userTime` to `buildTimeSection`
- Updated tests to verify `userTime` appears correctly in system prompt
- Format: `Current: <full date>` followed by `Time zone: <timezone>`

## Testing
- Updated existing tests to verify the new format
- Tests confirm both 12-hour and 24-hour time formats display correctly
- Backward compatible: when `userTime` is not provided, falls back to timezone-only display

## Rebase Note
✅ Rebased onto latest main after Moltbot rename (2026.1.27-beta.1)
✅ Resolved CHANGELOG conflicts
✅ Lint passed

Supersedes #2154 (closed due to merge conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)