### PR TITLE
fix: add security hardening for media text attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Status: beta.
 - Telegram: centralize API error logging for delivery and bot calls. (#2492) Thanks @altryne.
 - Voice Call: enforce Twilio webhook signature verification for ngrok URLs; disable ngrok free tier bypass by default.
 - Security: harden Tailscale Serve auth by validating identity via local tailscaled before trusting headers.
+- Media: fix text attachment MIME misclassification with CSV/TSV inference and UTF-16 detection; add XML attribute escaping for file output. (#3628) Thanks @frankekn.
 - Build: align memory-core peer dependency with lockfile.
 - Security: add mDNS discovery mode with minimal default to reduce information disclosure. (#1882) Thanks @orlyjamie.
 - Security: harden URL fetches with DNS pinning to reduce rebinding risk. Thanks Chris Zheng.


### PR DESCRIPTION
Follow-up to #3628 - adds security hardening:

- Add `xmlEscapeAttr` function to escape XML special characters in filenames and MIME types
- Add MIME override logging for auditability when non-text types are converted to text
- Add comprehensive security-focused test cases:
  - XML special character escaping in filenames
  - MIME type normalization prevents injection
  - Path traversal handling
  - Non-ASCII Unicode filename support

This ensures the media text attachment feature is safe against injection attacks.