### PR TITLE
fix: repair unpaired tool calls when loading sessions

### DIFF
--- a/apps/macos/Sources/Moltbot/AppState.swift
+++ b/apps/macos/Sources/Moltbot/AppState.swift
@@ -418,11 +418,10 @@ final class AppState {
         let trimmedUser = parsed.user?.trimmingCharacters(in: .whitespacesAndNewlines)
         let user = (trimmedUser?.isEmpty ?? true) ? nil : trimmedUser
         let port = parsed.port
-        let assembled: String
-        if let user {
-            assembled = port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
+        let assembled: String = if let user {
+            port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
         } else {
-            assembled = port == 22 ? host : "\(host):\(port)"
+            port == 22 ? host : "\(host):\(port)"
         }
         if assembled != self.remoteTarget {
             self.remoteTarget = assembled
@@ -694,7 +693,9 @@ extension AppState {
 @MainActor
 enum AppStateStore {
     static let shared = AppState()
-    static var isPausedFlag: Bool { UserDefaults.standard.bool(forKey: pauseDefaultsKey) }
+    static var isPausedFlag: Bool {
+        UserDefaults.standard.bool(forKey: pauseDefaultsKey)
+    }
 
     static func updateLaunchAtLogin(enabled: Bool) {
         Task.detached(priority: .utility) {

--- a/apps/macos/Sources/Moltbot/SkillsSettings.swift
+++ b/apps/macos/Sources/Moltbot/SkillsSettings.swift
@@ -142,7 +142,9 @@ private enum SkillsFilter: String, CaseIterable, Identifiable {
     case needsSetup
     case disabled
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {

--- a/apps/macos/Sources/MoltbotDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/MoltbotDiscovery/GatewayDiscoveryModel.swift
@@ -1,5 +1,5 @@
-import MoltbotKit
 import Foundation
+import MoltbotKit
 import Network
 import Observation
 import OSLog
@@ -18,7 +18,9 @@ public final class GatewayDiscoveryModel {
     }
 
     public struct DiscoveredGateway: Identifiable, Equatable, Sendable {
-        public var id: String { self.stableID }
+        public var id: String {
+            self.stableID
+        }
         public var displayName: String
         public var lanHost: String?
         public var tailnetDns: String?

--- a/apps/macos/Sources/MoltbotDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/MoltbotDiscovery/WideAreaGatewayDiscovery.swift
@@ -1,5 +1,5 @@
-import MoltbotKit
 import Foundation
+import MoltbotKit
 
 struct WideAreaGatewayBeacon: Sendable, Equatable {
     var instanceName: String
@@ -117,13 +117,12 @@ enum WideAreaGatewayDiscovery {
         }
 
         var seen = Set<String>()
-        let ordered = ips.filter { value in
+        return ips.filter { value in
             guard self.isTailnetIPv4(value) else { return false }
             if seen.contains(value) { return false }
             seen.insert(value)
             return true
         }
-        return ordered
     }
 
     private static func readTailscaleStatus() -> String? {
@@ -370,5 +369,7 @@ private struct TailscaleStatus: Decodable {
 }
 
 extension Collection {
-    fileprivate var nonEmpty: Self? { isEmpty ? nil : self }
+    fileprivate var nonEmpty: Self? {
+        isEmpty ? nil : self
+    }
 }

--- a/apps/macos/Sources/MoltbotIPC/IPC.swift
+++ b/apps/macos/Sources/MoltbotIPC/IPC.swift
@@ -407,7 +407,7 @@ extension Request: Codable {
     }
 }
 
-// Shared transport settings
+/// Shared transport settings
 public let controlSocketPath = FileManager()
     .homeDirectoryForCurrentUser
     .appendingPathComponent("Library/Application Support/moltbot/control.sock")

--- a/apps/macos/Sources/MoltbotMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/MoltbotMacCLI/ConnectCommand.swift
@@ -1,6 +1,6 @@
+import Foundation
 import MoltbotKit
 import MoltbotProtocol
-import Foundation
 #if canImport(Darwin)
 import Darwin
 #endif
@@ -101,15 +101,15 @@ func runConnect(_ args: [String]) async {
     let opts = ConnectOptions.parse(args)
     if opts.help {
         print("""
-        moltbot-mac connect
+            moltbot-mac connect
 
-        Usage:
-          moltbot-mac connect [--url <ws://host:port>] [--token <token>] [--password <password>]
-                               [--mode <local|remote>] [--timeout <ms>] [--probe] [--json]
-                               [--client-id <id>] [--client-mode <mode>] [--display-name <name>]
-                               [--role <role>] [--scopes <a,b,c>]
+            Usage:
+              moltbot-mac connect [--url <ws://host:port>] [--token <token>] [--password <password>]
+                                   [--mode <local|remote>] [--timeout <ms>] [--probe] [--json]
+                                   [--client-id <id>] [--client-mode <mode>] [--display-name <name>]
+                                   [--role <role>] [--scopes <a,b,c>]
 
-        Options:
+            Options:
           --url <url>        Gateway WebSocket URL (overrides config)
           --token <token>    Gateway token (if required)
           --password <pw>    Gateway password (if required)

--- a/apps/macos/Sources/MoltbotMacCLI/DiscoverCommand.swift
+++ b/apps/macos/Sources/MoltbotMacCLI/DiscoverCommand.swift
@@ -1,5 +1,5 @@
-import MoltbotDiscovery
 import Foundation
+import MoltbotDiscovery
 
 struct DiscoveryOptions {
     var timeoutMs: Int = 2000
@@ -58,12 +58,12 @@ func runDiscover(_ args: [String]) async {
     let opts = DiscoveryOptions.parse(args)
     if opts.help {
         print("""
-        moltbot-mac discover
+            moltbot-mac discover
 
-        Usage:
-          moltbot-mac discover [--timeout <ms>] [--json] [--include-local]
+            Usage:
+              moltbot-mac discover [--timeout <ms>] [--json] [--include-local]
 
-        Options:
+            Options:
           --timeout <ms>     Discovery window in milliseconds (default: 2000)
           --json             Emit JSON
           --include-local    Include gateways considered local

--- a/apps/macos/Sources/MoltbotMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/MoltbotMacCLI/WizardCommand.swift
@@ -1,7 +1,7 @@
-import MoltbotKit
-import MoltbotProtocol
 import Darwin
 import Foundation
+import MoltbotKit
+import MoltbotProtocol
 
 struct WizardCliOptions {
     var url: String?
@@ -71,13 +71,13 @@ func runWizardCommand(_ args: [String]) async {
     let opts = WizardCliOptions.parse(args)
     if opts.help {
         print("""
-        moltbot-mac wizard
+            moltbot-mac wizard
 
-        Usage:
-          moltbot-mac wizard [--url <ws://host:port>] [--token <token>] [--password <password>]
-                              [--mode <local|remote>] [--workspace <path>] [--json]
+            Usage:
+              moltbot-mac wizard [--url <ws://host:port>] [--token <token>] [--password <password>]
+                                  [--mode <local|remote>] [--workspace <path>] [--json]
 
-        Options:
+            Options:
           --url <url>        Gateway WebSocket URL (overrides config)
           --token <token>    Gateway token (if required)
           --password <pw>    Gateway password (if required)

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock logger before importing the module
+vi.mock("../../logger.js", () => ({
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { prepareSessionManagerForRun } from "./session-manager-init.js";
+import { logWarn } from "../../logger.js";
+
+describe("prepareSessionManagerForRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("tool use/result repair on load", () => {
+    it("should inject synthetic tool results for unpaired tool calls", async () => {
+      const sessionManager = {
+        sessionId: "test-session",
+        flushed: true,
+        fileEntries: [
+          { type: "session", id: "test-session", cwd: "/test" },
+          {
+            type: "message",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "Hello" }],
+            },
+          },
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Let me check that" },
+                {
+                  type: "toolCall",
+                  id: "tool-123",
+                  name: "exec",
+                  arguments: { command: "find /Users -name '*.txt'" },
+                },
+              ],
+            },
+          },
+          // Missing toolResult for tool-123!
+        ],
+        byId: new Map(),
+        labelsById: new Map(),
+        leafId: null,
+      };
+
+      await prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile: "/tmp/test-session.jsonl",
+        hadSessionFile: true,
+        sessionId: "test-session",
+        cwd: "/test",
+      });
+
+      // Should have added a synthetic tool result
+      const messages = sessionManager.fileEntries
+        .filter((e: any) => e.type === "message")
+        .map((e: any) => e.message);
+
+      const toolResults = messages.filter((m: any) => m.role === "toolResult");
+      expect(toolResults.length).toBe(1);
+      expect(toolResults[0].toolCallId).toBe("tool-123");
+      expect(toolResults[0].isError).toBe(true);
+      expect(toolResults[0].content[0].text).toContain("missing tool result");
+
+      // Should have logged a warning
+      expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("Repaired session transcript"));
+
+      // Should mark session as unflushed so repairs are persisted
+      expect(sessionManager.flushed).toBe(false);
+    });
+
+    it("should not modify session if all tool calls have results", async () => {
+      const sessionManager = {
+        sessionId: "test-session",
+        flushed: true,
+        fileEntries: [
+          { type: "session", id: "test-session", cwd: "/test" },
+          {
+            type: "message",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "Hello" }],
+            },
+          },
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolCall",
+                  id: "tool-123",
+                  name: "exec",
+                  arguments: { command: "ls" },
+                },
+              ],
+            },
+          },
+          {
+            type: "message",
+            message: {
+              role: "toolResult",
+              toolCallId: "tool-123",
+              toolName: "exec",
+              content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
+              isError: false,
+            },
+          },
+        ],
+        byId: new Map(),
+        labelsById: new Map(),
+        leafId: null,
+      };
+
+      await prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile: "/tmp/test-session.jsonl",
+        hadSessionFile: true,
+        sessionId: "test-session",
+        cwd: "/test",
+      });
+
+      // Should not have logged a warning
+      expect(logWarn).not.toHaveBeenCalled();
+
+      // Session should remain flushed
+      expect(sessionManager.flushed).toBe(true);
+    });
+
+    it("should handle multiple unpaired tool calls", async () => {
+      const sessionManager = {
+        sessionId: "test-session",
+        flushed: true,
+        fileEntries: [
+          { type: "session", id: "test-session", cwd: "/test" },
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "toolCall", id: "tool-1", name: "exec" },
+                { type: "toolCall", id: "tool-2", name: "read" },
+              ],
+            },
+          },
+          // Missing both tool results!
+        ],
+        byId: new Map(),
+        labelsById: new Map(),
+        leafId: null,
+      };
+
+      await prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile: "/tmp/test-session.jsonl",
+        hadSessionFile: true,
+        sessionId: "test-session",
+        cwd: "/test",
+      });
+
+      const messages = sessionManager.fileEntries
+        .filter((e: any) => e.type === "message")
+        .map((e: any) => e.message);
+
+      const toolResults = messages.filter((m: any) => m.role === "toolResult");
+      expect(toolResults.length).toBe(2);
+
+      const ids = toolResults.map((r: any) => r.toolCallId);
+      expect(ids).toContain("tool-1");
+      expect(ids).toContain("tool-2");
+    });
+
+    it("should not repair new sessions without existing files", async () => {
+      const sessionManager = {
+        sessionId: "test-session",
+        flushed: false,
+        fileEntries: [{ type: "session", id: undefined, cwd: undefined }],
+        byId: new Map(),
+        labelsById: new Map(),
+        leafId: null,
+      };
+
+      await prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile: "/tmp/new-session.jsonl",
+        hadSessionFile: false,
+        sessionId: "new-session",
+        cwd: "/test",
+      });
+
+      // Should not have logged anything
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
When a session is loaded with assistant tool calls that never received results (e.g., due to exec timeout, crash, or interruption), the session would become stuck and unresponsive.

This fix adds repair logic during session initialization that:
- Detects unpaired tool calls in the loaded session history
- Injects synthetic error tool results for missing results
- Marks the session as unflushed so repairs are persisted

This ensures sessions can always recover from incomplete tool executions instead of remaining permanently stuck.

Fixes group chat sessions getting stuck when exec commands time out.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes session loading more resilient by repairing incomplete tool execution transcripts during `SessionManager` initialization. It detects assistant tool calls that never received matching tool results and injects synthetic error `toolResult` messages so strict providers don’t reject the transcript; it also marks the session as unflushed so the repaired transcript is persisted. Additionally, it includes SwiftFormat-driven formatting updates across several macOS CLI/app files.

<h3>Confidence Score: 4/5</h3>

- This PR appears safe to merge; changes are localized and include tests for the new transcript repair behavior.
- The core repair logic delegates to existing `repairToolUseResultPairing` and is exercised by a new Vitest suite. The main remaining concern is type-safety around the `any` cast when passing session messages into the repair function, which could hide unexpected message shapes at runtime, but it’s unlikely to break existing behavior.
- src/agents/pi-embedded-runner/session-manager-init.ts (type-safety around message casting); macOS CLI help text alignment if output formatting matters.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->