### PR TITLE
security: harden App Transport Security (ATS)

### DIFF
--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -24,7 +24,7 @@
 	<string>20260126</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>NSBonjourServices</key>

--- a/apps/macos/Sources/Moltbot/Resources/Info.plist
+++ b/apps/macos/Sources/Moltbot/Resources/Info.plist
@@ -62,7 +62,7 @@
 
     <key>NSAppTransportSecurity</key>
     <dict>
-        <key>NSAllowsArbitraryLoadsInWebContent</key>
+        <key>NSAllowsLocalNetworking</key>
         <true/>
         <key>NSExceptionDomains</key>
         <dict>


### PR DESCRIPTION
Hardens the network security policy for both iOS and macOS applications by removing the ability to load arbitrary insecure HTTP content. Only local networking (for gateway communication) and explicitly whitelisted domains are now allowed via HTTP.

### Changes
- Replaces `NSAllowsArbitraryLoadsInWebContent` with `NSAllowsLocalNetworking` in iOS Info.plist
- Replaces `NSAllowsArbitraryLoadsInWebContent` with `NSAllowsLocalNetworking` in macOS Info.plist

This aligns with best practices for limiting attack surface while maintaining necessary local gateway functionality.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens App Transport Security settings in the iOS and macOS app Info.plists by replacing `NSAllowsArbitraryLoadsInWebContent` with `NSAllowsLocalNetworking`, aiming to remove broad HTTP allowances while keeping local gateway communication working.

The change is localized to `NSAppTransportSecurity` dictionaries in the two platform plists; no runtime code is modified.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there’s a real chance of unintended HTTP breakage depending on expected allowlisted remote domains and OS support.
- The change is small and security-positive, but iOS currently has no `NSExceptionDomains`, so remote HTTP loads (even if intended to be allowlisted) may stop working. macOS likely OK given minimum system version, but relies on ATS key support.
- apps/ios/Sources/Info.plist; apps/macos/Sources/Moltbot/Resources/Info.plist

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->