### PR TITLE
security: mitigate tab-nabbing in UI

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -119,10 +119,10 @@ export function renderApp(state: AppViewState) {
           <button
             class="nav-collapse-toggle"
             @click=${() =>
-              state.applySettings({
-                ...state.settings,
-                navCollapsed: !state.settings.navCollapsed,
-              })}
+      state.applySettings({
+        ...state.settings,
+        navCollapsed: !state.settings.navCollapsed,
+      })}
             title="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
             aria-label="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
           >
@@ -149,20 +149,20 @@ export function renderApp(state: AppViewState) {
       </header>
       <aside class="nav ${state.settings.navCollapsed ? "nav--collapsed" : ""}">
         ${TAB_GROUPS.map((group) => {
-          const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-          return html`
+        const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
+        const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+        return html`
             <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
               <button
                 class="nav-label"
                 @click=${() => {
-                  const next = { ...state.settings.navGroupsCollapsed };
-                  next[group.label] = !isGroupCollapsed;
-                  state.applySettings({
-                    ...state.settings,
-                    navGroupsCollapsed: next,
-                  });
-                }}
+            const next = { ...state.settings.navGroupsCollapsed };
+            next[group.label] = !isGroupCollapsed;
+            state.applySettings({
+              ...state.settings,
+              navGroupsCollapsed: next,
+            });
+          }}
                 aria-expanded=${!isGroupCollapsed}
               >
                 <span class="nav-label__text">${group.label}</span>
@@ -173,7 +173,7 @@ export function renderApp(state: AppViewState) {
               </div>
             </div>
           `;
-        })}
+      })}
         <div class="nav-group nav-group--links">
           <div class="nav-label nav-label--static">
             <span class="nav-label__text">Resources</span>
@@ -183,7 +183,7 @@ export function renderApp(state: AppViewState) {
               class="nav-item nav-item--external"
               href="https://docs.molt.bot"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               title="Docs (opens in new tab)"
             >
               <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
@@ -200,383 +200,383 @@ export function renderApp(state: AppViewState) {
           </div>
           <div class="page-meta">
             ${state.lastError
-              ? html`<div class="pill danger">${state.lastError}</div>`
-              : nothing}
+      ? html`<div class="pill danger">${state.lastError}</div>`
+      : nothing}
             ${isChat ? renderChatControls(state) : nothing}
           </div>
         </section>
 
         ${state.tab === "overview"
-          ? renderOverview({
-              connected: state.connected,
-              hello: state.hello,
-              settings: state.settings,
-              password: state.password,
-              lastError: state.lastError,
-              presenceCount,
-              sessionsCount,
-              cronEnabled: state.cronStatus?.enabled ?? null,
-              cronNext,
-              lastChannelsRefresh: state.channelsLastSuccess,
-              onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.resetToolStream();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-              },
-              onConnect: () => state.connect(),
-              onRefresh: () => state.loadOverview(),
-            })
-          : nothing}
+      ? renderOverview({
+        connected: state.connected,
+        hello: state.hello,
+        settings: state.settings,
+        password: state.password,
+        lastError: state.lastError,
+        presenceCount,
+        sessionsCount,
+        cronEnabled: state.cronStatus?.enabled ?? null,
+        cronNext,
+        lastChannelsRefresh: state.channelsLastSuccess,
+        onSettingsChange: (next) => state.applySettings(next),
+        onPasswordChange: (next) => (state.password = next),
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.resetToolStream();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+        },
+        onConnect: () => state.connect(),
+        onRefresh: () => state.loadOverview(),
+      })
+      : nothing}
 
         ${state.tab === "channels"
-          ? renderChannels({
-              connected: state.connected,
-              loading: state.channelsLoading,
-              snapshot: state.channelsSnapshot,
-              lastError: state.channelsError,
-              lastSuccessAt: state.channelsLastSuccess,
-              whatsappMessage: state.whatsappLoginMessage,
-              whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-              whatsappConnected: state.whatsappLoginConnected,
-              whatsappBusy: state.whatsappBusy,
-              configSchema: state.configSchema,
-              configSchemaLoading: state.configSchemaLoading,
-              configForm: state.configForm,
-              configUiHints: state.configUiHints,
-              configSaving: state.configSaving,
-              configFormDirty: state.configFormDirty,
-              nostrProfileFormState: state.nostrProfileFormState,
-              nostrProfileAccountId: state.nostrProfileAccountId,
-              onRefresh: (probe) => loadChannels(state, probe),
-              onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-              onWhatsAppWait: () => state.handleWhatsAppWait(),
-              onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-              onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onConfigSave: () => state.handleChannelConfigSave(),
-              onConfigReload: () => state.handleChannelConfigReload(),
-              onNostrProfileEdit: (accountId, profile) =>
-                state.handleNostrProfileEdit(accountId, profile),
-              onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-              onNostrProfileFieldChange: (field, value) =>
-                state.handleNostrProfileFieldChange(field, value),
-              onNostrProfileSave: () => state.handleNostrProfileSave(),
-              onNostrProfileImport: () => state.handleNostrProfileImport(),
-              onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-            })
-          : nothing}
+      ? renderChannels({
+        connected: state.connected,
+        loading: state.channelsLoading,
+        snapshot: state.channelsSnapshot,
+        lastError: state.channelsError,
+        lastSuccessAt: state.channelsLastSuccess,
+        whatsappMessage: state.whatsappLoginMessage,
+        whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+        whatsappConnected: state.whatsappLoginConnected,
+        whatsappBusy: state.whatsappBusy,
+        configSchema: state.configSchema,
+        configSchemaLoading: state.configSchemaLoading,
+        configForm: state.configForm,
+        configUiHints: state.configUiHints,
+        configSaving: state.configSaving,
+        configFormDirty: state.configFormDirty,
+        nostrProfileFormState: state.nostrProfileFormState,
+        nostrProfileAccountId: state.nostrProfileAccountId,
+        onRefresh: (probe) => loadChannels(state, probe),
+        onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+        onWhatsAppWait: () => state.handleWhatsAppWait(),
+        onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+        onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onConfigSave: () => state.handleChannelConfigSave(),
+        onConfigReload: () => state.handleChannelConfigReload(),
+        onNostrProfileEdit: (accountId, profile) =>
+          state.handleNostrProfileEdit(accountId, profile),
+        onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+        onNostrProfileFieldChange: (field, value) =>
+          state.handleNostrProfileFieldChange(field, value),
+        onNostrProfileSave: () => state.handleNostrProfileSave(),
+        onNostrProfileImport: () => state.handleNostrProfileImport(),
+        onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+      })
+      : nothing}
 
         ${state.tab === "instances"
-          ? renderInstances({
-              loading: state.presenceLoading,
-              entries: state.presenceEntries,
-              lastError: state.presenceError,
-              statusMessage: state.presenceStatus,
-              onRefresh: () => loadPresence(state),
-            })
-          : nothing}
+      ? renderInstances({
+        loading: state.presenceLoading,
+        entries: state.presenceEntries,
+        lastError: state.presenceError,
+        statusMessage: state.presenceStatus,
+        onRefresh: () => loadPresence(state),
+      })
+      : nothing}
 
         ${state.tab === "sessions"
-          ? renderSessions({
-              loading: state.sessionsLoading,
-              result: state.sessionsResult,
-              error: state.sessionsError,
-              activeMinutes: state.sessionsFilterActive,
-              limit: state.sessionsFilterLimit,
-              includeGlobal: state.sessionsIncludeGlobal,
-              includeUnknown: state.sessionsIncludeUnknown,
-              basePath: state.basePath,
-              onFiltersChange: (next) => {
-                state.sessionsFilterActive = next.activeMinutes;
-                state.sessionsFilterLimit = next.limit;
-                state.sessionsIncludeGlobal = next.includeGlobal;
-                state.sessionsIncludeUnknown = next.includeUnknown;
-	              },
-	              onRefresh: () => loadSessions(state),
-	              onPatch: (key, patch) => patchSession(state, key, patch),
-	              onDelete: (key) => deleteSession(state, key),
-	            })
-	          : nothing}
+      ? renderSessions({
+        loading: state.sessionsLoading,
+        result: state.sessionsResult,
+        error: state.sessionsError,
+        activeMinutes: state.sessionsFilterActive,
+        limit: state.sessionsFilterLimit,
+        includeGlobal: state.sessionsIncludeGlobal,
+        includeUnknown: state.sessionsIncludeUnknown,
+        basePath: state.basePath,
+        onFiltersChange: (next) => {
+          state.sessionsFilterActive = next.activeMinutes;
+          state.sessionsFilterLimit = next.limit;
+          state.sessionsIncludeGlobal = next.includeGlobal;
+          state.sessionsIncludeUnknown = next.includeUnknown;
+        },
+        onRefresh: () => loadSessions(state),
+        onPatch: (key, patch) => patchSession(state, key, patch),
+        onDelete: (key) => deleteSession(state, key),
+      })
+      : nothing}
 
         ${state.tab === "cron"
-          ? renderCron({
-              loading: state.cronLoading,
-              status: state.cronStatus,
-              jobs: state.cronJobs,
-              error: state.cronError,
-              busy: state.cronBusy,
-              form: state.cronForm,
-              channels: state.channelsSnapshot?.channelMeta?.length
-                ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                : state.channelsSnapshot?.channelOrder ?? [],
-              channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-              channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-              runsJobId: state.cronRunsJobId,
-              runs: state.cronRuns,
-              onFormChange: (patch) => (state.cronForm = { ...state.cronForm, ...patch }),
-              onRefresh: () => state.loadCron(),
-              onAdd: () => addCronJob(state),
-              onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-              onRun: (job) => runCronJob(state, job),
-              onRemove: (job) => removeCronJob(state, job),
-              onLoadRuns: (jobId) => loadCronRuns(state, jobId),
-            })
-          : nothing}
+      ? renderCron({
+        loading: state.cronLoading,
+        status: state.cronStatus,
+        jobs: state.cronJobs,
+        error: state.cronError,
+        busy: state.cronBusy,
+        form: state.cronForm,
+        channels: state.channelsSnapshot?.channelMeta?.length
+          ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+          : state.channelsSnapshot?.channelOrder ?? [],
+        channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+        channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+        runsJobId: state.cronRunsJobId,
+        runs: state.cronRuns,
+        onFormChange: (patch) => (state.cronForm = { ...state.cronForm, ...patch }),
+        onRefresh: () => state.loadCron(),
+        onAdd: () => addCronJob(state),
+        onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+        onRun: (job) => runCronJob(state, job),
+        onRemove: (job) => removeCronJob(state, job),
+        onLoadRuns: (jobId) => loadCronRuns(state, jobId),
+      })
+      : nothing}
 
         ${state.tab === "skills"
-          ? renderSkills({
-              loading: state.skillsLoading,
-              report: state.skillsReport,
-              error: state.skillsError,
-              filter: state.skillsFilter,
-              edits: state.skillEdits,
-              messages: state.skillMessages,
-              busyKey: state.skillsBusyKey,
-              onFilterChange: (next) => (state.skillsFilter = next),
-              onRefresh: () => loadSkills(state, { clearMessages: true }),
-              onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-              onEdit: (key, value) => updateSkillEdit(state, key, value),
-              onSaveKey: (key) => saveSkillApiKey(state, key),
-              onInstall: (skillKey, name, installId) =>
-                installSkill(state, skillKey, name, installId),
-            })
-          : nothing}
+      ? renderSkills({
+        loading: state.skillsLoading,
+        report: state.skillsReport,
+        error: state.skillsError,
+        filter: state.skillsFilter,
+        edits: state.skillEdits,
+        messages: state.skillMessages,
+        busyKey: state.skillsBusyKey,
+        onFilterChange: (next) => (state.skillsFilter = next),
+        onRefresh: () => loadSkills(state, { clearMessages: true }),
+        onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+        onEdit: (key, value) => updateSkillEdit(state, key, value),
+        onSaveKey: (key) => saveSkillApiKey(state, key),
+        onInstall: (skillKey, name, installId) =>
+          installSkill(state, skillKey, name, installId),
+      })
+      : nothing}
 
         ${state.tab === "nodes"
-          ? renderNodes({
-              loading: state.nodesLoading,
-              nodes: state.nodes,
-              devicesLoading: state.devicesLoading,
-              devicesError: state.devicesError,
-              devicesList: state.devicesList,
-              configForm: state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null),
-              configLoading: state.configLoading,
-              configSaving: state.configSaving,
-              configDirty: state.configFormDirty,
-              configFormMode: state.configFormMode,
-              execApprovalsLoading: state.execApprovalsLoading,
-              execApprovalsSaving: state.execApprovalsSaving,
-              execApprovalsDirty: state.execApprovalsDirty,
-              execApprovalsSnapshot: state.execApprovalsSnapshot,
-              execApprovalsForm: state.execApprovalsForm,
-              execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-              execApprovalsTarget: state.execApprovalsTarget,
-              execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-              onRefresh: () => loadNodes(state),
-              onDevicesRefresh: () => loadDevices(state),
-              onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-              onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-              onDeviceRotate: (deviceId, role, scopes) =>
-                rotateDeviceToken(state, { deviceId, role, scopes }),
-              onDeviceRevoke: (deviceId, role) =>
-                revokeDeviceToken(state, { deviceId, role }),
-              onLoadConfig: () => loadConfig(state),
-              onLoadExecApprovals: () => {
-                const target =
-                  state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                    ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                    : { kind: "gateway" as const };
-                return loadExecApprovals(state, target);
-              },
-              onBindDefault: (nodeId) => {
-                if (nodeId) {
-                  updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                } else {
-                  removeConfigFormValue(state, ["tools", "exec", "node"]);
-                }
-              },
-              onBindAgent: (agentIndex, nodeId) => {
-                const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                if (nodeId) {
-                  updateConfigFormValue(state, basePath, nodeId);
-                } else {
-                  removeConfigFormValue(state, basePath);
-                }
-              },
-              onSaveBindings: () => saveConfig(state),
-              onExecApprovalsTargetChange: (kind, nodeId) => {
-                state.execApprovalsTarget = kind;
-                state.execApprovalsTargetNodeId = nodeId;
-                state.execApprovalsSnapshot = null;
-                state.execApprovalsForm = null;
-                state.execApprovalsDirty = false;
-                state.execApprovalsSelectedAgent = null;
-              },
-              onExecApprovalsSelectAgent: (agentId) => {
-                state.execApprovalsSelectedAgent = agentId;
-              },
-              onExecApprovalsPatch: (path, value) =>
-                updateExecApprovalsFormValue(state, path, value),
-              onExecApprovalsRemove: (path) =>
-                removeExecApprovalsFormValue(state, path),
-              onSaveExecApprovals: () => {
-                const target =
-                  state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                    ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                    : { kind: "gateway" as const };
-                return saveExecApprovals(state, target);
-              },
-            })
-          : nothing}
+      ? renderNodes({
+        loading: state.nodesLoading,
+        nodes: state.nodes,
+        devicesLoading: state.devicesLoading,
+        devicesError: state.devicesError,
+        devicesList: state.devicesList,
+        configForm: state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null),
+        configLoading: state.configLoading,
+        configSaving: state.configSaving,
+        configDirty: state.configFormDirty,
+        configFormMode: state.configFormMode,
+        execApprovalsLoading: state.execApprovalsLoading,
+        execApprovalsSaving: state.execApprovalsSaving,
+        execApprovalsDirty: state.execApprovalsDirty,
+        execApprovalsSnapshot: state.execApprovalsSnapshot,
+        execApprovalsForm: state.execApprovalsForm,
+        execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+        execApprovalsTarget: state.execApprovalsTarget,
+        execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+        onRefresh: () => loadNodes(state),
+        onDevicesRefresh: () => loadDevices(state),
+        onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+        onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+        onDeviceRotate: (deviceId, role, scopes) =>
+          rotateDeviceToken(state, { deviceId, role, scopes }),
+        onDeviceRevoke: (deviceId, role) =>
+          revokeDeviceToken(state, { deviceId, role }),
+        onLoadConfig: () => loadConfig(state),
+        onLoadExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return loadExecApprovals(state, target);
+        },
+        onBindDefault: (nodeId) => {
+          if (nodeId) {
+            updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+          } else {
+            removeConfigFormValue(state, ["tools", "exec", "node"]);
+          }
+        },
+        onBindAgent: (agentIndex, nodeId) => {
+          const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+          if (nodeId) {
+            updateConfigFormValue(state, basePath, nodeId);
+          } else {
+            removeConfigFormValue(state, basePath);
+          }
+        },
+        onSaveBindings: () => saveConfig(state),
+        onExecApprovalsTargetChange: (kind, nodeId) => {
+          state.execApprovalsTarget = kind;
+          state.execApprovalsTargetNodeId = nodeId;
+          state.execApprovalsSnapshot = null;
+          state.execApprovalsForm = null;
+          state.execApprovalsDirty = false;
+          state.execApprovalsSelectedAgent = null;
+        },
+        onExecApprovalsSelectAgent: (agentId) => {
+          state.execApprovalsSelectedAgent = agentId;
+        },
+        onExecApprovalsPatch: (path, value) =>
+          updateExecApprovalsFormValue(state, path, value),
+        onExecApprovalsRemove: (path) =>
+          removeExecApprovalsFormValue(state, path),
+        onSaveExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return saveExecApprovals(state, target);
+        },
+      })
+      : nothing}
 
         ${state.tab === "chat"
-          ? renderChat({
-              sessionKey: state.sessionKey,
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.chatAttachments = [];
-                state.chatStream = null;
-                state.chatStreamStartedAt = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.resetChatScroll();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-                void loadChatHistory(state);
-                void refreshChatAvatar(state);
-              },
-              thinkingLevel: state.chatThinkingLevel,
-              showThinking,
-              loading: state.chatLoading,
-              sending: state.chatSending,
-              compactionStatus: state.compactionStatus,
-              assistantAvatarUrl: chatAvatarUrl,
-              messages: state.chatMessages,
-              toolMessages: state.chatToolMessages,
-              stream: state.chatStream,
-              streamStartedAt: state.chatStreamStartedAt,
-              draft: state.chatMessage,
-              queue: state.chatQueue,
-              connected: state.connected,
-              canSend: state.connected,
-              disabledReason: chatDisabledReason,
-              error: state.lastError,
-              sessions: state.sessionsResult,
-              focusMode: chatFocus,
-              onRefresh: () => {
-                state.resetToolStream();
-                return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-              },
-              onToggleFocusMode: () => {
-                if (state.onboarding) return;
-                state.applySettings({
-                  ...state.settings,
-                  chatFocusMode: !state.settings.chatFocusMode,
-                });
-              },
-              onChatScroll: (event) => state.handleChatScroll(event),
-              onDraftChange: (next) => (state.chatMessage = next),
-              attachments: state.chatAttachments,
-              onAttachmentsChange: (next) => (state.chatAttachments = next),
-              onSend: () => state.handleSendChat(),
-              canAbort: Boolean(state.chatRunId),
-              onAbort: () => void state.handleAbortChat(),
-              onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onNewSession: () =>
-                state.handleSendChat("/new", { restoreDraft: true }),
-              // Sidebar props for tool output viewing
-              sidebarOpen: state.sidebarOpen,
-              sidebarContent: state.sidebarContent,
-              sidebarError: state.sidebarError,
-              splitRatio: state.splitRatio,
-              onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-              onCloseSidebar: () => state.handleCloseSidebar(),
-              onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-              assistantName: state.assistantName,
-              assistantAvatar: state.assistantAvatar,
-            })
-          : nothing}
+      ? renderChat({
+        sessionKey: state.sessionKey,
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.chatAttachments = [];
+          state.chatStream = null;
+          state.chatStreamStartedAt = null;
+          state.chatRunId = null;
+          state.chatQueue = [];
+          state.resetToolStream();
+          state.resetChatScroll();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+          void loadChatHistory(state);
+          void refreshChatAvatar(state);
+        },
+        thinkingLevel: state.chatThinkingLevel,
+        showThinking,
+        loading: state.chatLoading,
+        sending: state.chatSending,
+        compactionStatus: state.compactionStatus,
+        assistantAvatarUrl: chatAvatarUrl,
+        messages: state.chatMessages,
+        toolMessages: state.chatToolMessages,
+        stream: state.chatStream,
+        streamStartedAt: state.chatStreamStartedAt,
+        draft: state.chatMessage,
+        queue: state.chatQueue,
+        connected: state.connected,
+        canSend: state.connected,
+        disabledReason: chatDisabledReason,
+        error: state.lastError,
+        sessions: state.sessionsResult,
+        focusMode: chatFocus,
+        onRefresh: () => {
+          state.resetToolStream();
+          return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+        },
+        onToggleFocusMode: () => {
+          if (state.onboarding) return;
+          state.applySettings({
+            ...state.settings,
+            chatFocusMode: !state.settings.chatFocusMode,
+          });
+        },
+        onChatScroll: (event) => state.handleChatScroll(event),
+        onDraftChange: (next) => (state.chatMessage = next),
+        attachments: state.chatAttachments,
+        onAttachmentsChange: (next) => (state.chatAttachments = next),
+        onSend: () => state.handleSendChat(),
+        canAbort: Boolean(state.chatRunId),
+        onAbort: () => void state.handleAbortChat(),
+        onQueueRemove: (id) => state.removeQueuedMessage(id),
+        onNewSession: () =>
+          state.handleSendChat("/new", { restoreDraft: true }),
+        // Sidebar props for tool output viewing
+        sidebarOpen: state.sidebarOpen,
+        sidebarContent: state.sidebarContent,
+        sidebarError: state.sidebarError,
+        splitRatio: state.splitRatio,
+        onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+        onCloseSidebar: () => state.handleCloseSidebar(),
+        onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+        assistantName: state.assistantName,
+        assistantAvatar: state.assistantAvatar,
+      })
+      : nothing}
 
         ${state.tab === "config"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.configFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.configSearchQuery,
-              activeSection: state.configActiveSection,
-              activeSubsection: state.configActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onFormModeChange: (mode) => (state.configFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.configSearchQuery = query),
-              onSectionChange: (section) => {
-                state.configActiveSection = section;
-                state.configActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.configActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-            })
-          : nothing}
+      ? renderConfig({
+        raw: state.configRaw,
+        originalRaw: state.configRawOriginal,
+        valid: state.configValid,
+        issues: state.configIssues,
+        loading: state.configLoading,
+        saving: state.configSaving,
+        applying: state.configApplying,
+        updating: state.updateRunning,
+        connected: state.connected,
+        schema: state.configSchema,
+        schemaLoading: state.configSchemaLoading,
+        uiHints: state.configUiHints,
+        formMode: state.configFormMode,
+        formValue: state.configForm,
+        originalValue: state.configFormOriginal,
+        searchQuery: state.configSearchQuery,
+        activeSection: state.configActiveSection,
+        activeSubsection: state.configActiveSubsection,
+        onRawChange: (next) => {
+          state.configRaw = next;
+        },
+        onFormModeChange: (mode) => (state.configFormMode = mode),
+        onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onSearchChange: (query) => (state.configSearchQuery = query),
+        onSectionChange: (section) => {
+          state.configActiveSection = section;
+          state.configActiveSubsection = null;
+        },
+        onSubsectionChange: (section) => (state.configActiveSubsection = section),
+        onReload: () => loadConfig(state),
+        onSave: () => saveConfig(state),
+        onApply: () => applyConfig(state),
+        onUpdate: () => runUpdate(state),
+      })
+      : nothing}
 
         ${state.tab === "debug"
-          ? renderDebug({
-              loading: state.debugLoading,
-              status: state.debugStatus,
-              health: state.debugHealth,
-              models: state.debugModels,
-              heartbeat: state.debugHeartbeat,
-              eventLog: state.eventLog,
-              callMethod: state.debugCallMethod,
-              callParams: state.debugCallParams,
-              callResult: state.debugCallResult,
-              callError: state.debugCallError,
-              onCallMethodChange: (next) => (state.debugCallMethod = next),
-              onCallParamsChange: (next) => (state.debugCallParams = next),
-              onRefresh: () => loadDebug(state),
-              onCall: () => callDebugMethod(state),
-            })
-          : nothing}
+      ? renderDebug({
+        loading: state.debugLoading,
+        status: state.debugStatus,
+        health: state.debugHealth,
+        models: state.debugModels,
+        heartbeat: state.debugHeartbeat,
+        eventLog: state.eventLog,
+        callMethod: state.debugCallMethod,
+        callParams: state.debugCallParams,
+        callResult: state.debugCallResult,
+        callError: state.debugCallError,
+        onCallMethodChange: (next) => (state.debugCallMethod = next),
+        onCallParamsChange: (next) => (state.debugCallParams = next),
+        onRefresh: () => loadDebug(state),
+        onCall: () => callDebugMethod(state),
+      })
+      : nothing}
 
         ${state.tab === "logs"
-          ? renderLogs({
-              loading: state.logsLoading,
-              error: state.logsError,
-              file: state.logsFile,
-              entries: state.logsEntries,
-              filterText: state.logsFilterText,
-              levelFilters: state.logsLevelFilters,
-              autoFollow: state.logsAutoFollow,
-              truncated: state.logsTruncated,
-              onFilterTextChange: (next) => (state.logsFilterText = next),
-              onLevelToggle: (level, enabled) => {
-                state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
-              },
-              onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-              onRefresh: () => loadLogs(state, { reset: true }),
-              onExport: (lines, label) => state.exportLogs(lines, label),
-              onScroll: (event) => state.handleLogsScroll(event),
-            })
-          : nothing}
+      ? renderLogs({
+        loading: state.logsLoading,
+        error: state.logsError,
+        file: state.logsFile,
+        entries: state.logsEntries,
+        filterText: state.logsFilterText,
+        levelFilters: state.logsLevelFilters,
+        autoFollow: state.logsAutoFollow,
+        truncated: state.logsTruncated,
+        onFilterTextChange: (next) => (state.logsFilterText = next),
+        onLevelToggle: (level, enabled) => {
+          state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+        },
+        onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+        onRefresh: () => loadLogs(state, { reset: true }),
+        onExport: (lines, label) => state.exportLogs(lines, label),
+        onScroll: (event) => state.handleLogsScroll(event),
+      })
+      : nothing}
       </main>
       ${renderExecApprovalPrompt(state)}
       ${renderGatewayUrlConfirmation(state)}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -69,7 +69,7 @@ export function renderOverview(props: OverviewProps) {
             class="session-link"
             href="https://docs.molt.bot/web/dashboard"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             title="Control UI auth docs (opens in new tab)"
             >Docs: Control UI auth</a
           >
@@ -98,7 +98,7 @@ export function renderOverview(props: OverviewProps) {
             class="session-link"
             href="https://docs.molt.bot/gateway/tailscale"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             title="Tailscale Serve docs (opens in new tab)"
             >Docs: Tailscale Serve</a
           >
@@ -107,7 +107,7 @@ export function renderOverview(props: OverviewProps) {
             class="session-link"
             href="https://docs.molt.bot/web/control-ui#insecure-http"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             title="Insecure HTTP docs (opens in new tab)"
             >Docs: Insecure HTTP</a
           >
@@ -127,9 +127,9 @@ export function renderOverview(props: OverviewProps) {
             <input
               .value=${props.settings.gatewayUrl}
               @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSettingsChange({ ...props.settings, gatewayUrl: v });
-              }}
+      const v = (e.target as HTMLInputElement).value;
+      props.onSettingsChange({ ...props.settings, gatewayUrl: v });
+    }}
               placeholder="ws://100.x.y.z:18789"
             />
           </label>
@@ -138,9 +138,9 @@ export function renderOverview(props: OverviewProps) {
             <input
               .value=${props.settings.token}
               @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSettingsChange({ ...props.settings, token: v });
-              }}
+      const v = (e.target as HTMLInputElement).value;
+      props.onSettingsChange({ ...props.settings, token: v });
+    }}
               placeholder="CLAWDBOT_GATEWAY_TOKEN"
             />
           </label>
@@ -150,9 +150,9 @@ export function renderOverview(props: OverviewProps) {
               type="password"
               .value=${props.password}
               @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onPasswordChange(v);
-              }}
+      const v = (e.target as HTMLInputElement).value;
+      props.onPasswordChange(v);
+    }}
               placeholder="system or shared password"
             />
           </label>
@@ -161,9 +161,9 @@ export function renderOverview(props: OverviewProps) {
             <input
               .value=${props.settings.sessionKey}
               @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSessionKeyChange(v);
-              }}
+      const v = (e.target as HTMLInputElement).value;
+      props.onSessionKeyChange(v);
+    }}
             />
           </label>
         </div>
@@ -196,18 +196,18 @@ export function renderOverview(props: OverviewProps) {
             <div class="stat-label">Last Channels Refresh</div>
             <div class="stat-value">
               ${props.lastChannelsRefresh
-                ? formatAgo(props.lastChannelsRefresh)
-                : "n/a"}
+      ? formatAgo(props.lastChannelsRefresh)
+      : "n/a"}
             </div>
           </div>
         </div>
         ${props.lastError
-          ? html`<div class="callout danger" style="margin-top: 14px;">
+      ? html`<div class="callout danger" style="margin-top: 14px;">
               <div>${props.lastError}</div>
               ${authHint ?? ""}
               ${insecureContextHint ?? ""}
             </div>`
-          : html`<div class="callout" style="margin-top: 14px;">
+      : html`<div class="callout" style="margin-top: 14px;">
               Use Channels to link WhatsApp, Telegram, Discord, Signal, or iMessage.
             </div>`}
       </div>
@@ -228,10 +228,10 @@ export function renderOverview(props: OverviewProps) {
         <div class="stat-label">Cron</div>
         <div class="stat-value">
           ${props.cronEnabled == null
-            ? "n/a"
-            : props.cronEnabled
-              ? "Enabled"
-              : "Disabled"}
+      ? "n/a"
+      : props.cronEnabled
+        ? "Enabled"
+        : "Disabled"}
         </div>
         <div class="muted">Next wake ${formatNextRun(props.cronNext)}</div>
       </div>


### PR DESCRIPTION
Audited the web UI for external links and ensured that all links opening in a new tab (`target="_blank"`) explicitly use `rel="noopener noreferrer"`. 

### Changes
- Added `rel="noopener noreferrer"` to external links in `ui/src/ui/views/overview.ts`
- Added `rel="noopener noreferrer"` to external links in `ui/src/ui/app-render.ts`

This mitigates "tab-nabbing" vulnerabilities where a malicious page opened in a new tab could maintain a reference to `window.opener` and potentially redirect the original page.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR audits UI links that open in a new tab and adds `rel="noopener noreferrer"` to mitigate tab-nabbing by preventing access to `window.opener`.

One instance in `ui/src/ui/views/overview.ts` still uses `rel="noreferrer"` on a `target="_blank"` link inside the auth hint block, so the mitigation is not consistently applied across all external links.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but one remaining external link still lacks `rel="noopener"` and leaves the tab-nabbing vector open for that path.
- Changes are localized to HTML template attributes, but a missed instance (`rel="noreferrer"` without `noopener`) means the intended security mitigation is not fully applied. No broader behavior changes observed.
- ui/src/ui/views/overview.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->