### PR TITLE
fix(googlechat): space type detection for modern API

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isSenderAllowed } from "./monitor.js";
+import { isSenderAllowed, resolveSpaceType } from "./monitor.js";
 
 describe("isSenderAllowed", () => {
   it("matches allowlist entries with users/<email>", () => {
@@ -23,5 +23,87 @@ describe("isSenderAllowed", () => {
     expect(isSenderAllowed("users/123", "jane@example.com", ["users/other@example.com"])).toBe(
       false,
     );
+  });
+});
+
+describe("resolveSpaceType", () => {
+  describe("modern spaceType field", () => {
+    it("detects DIRECT_MESSAGE as DM", () => {
+      const result = resolveSpaceType({ spaceType: "DIRECT_MESSAGE" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+
+    it("detects SPACE as group", () => {
+      const result = resolveSpaceType({ spaceType: "SPACE" });
+      expect(result.spaceType).toBe("SPACE");
+      expect(result.isGroup).toBe(true);
+    });
+
+    it("detects GROUP_CHAT as group", () => {
+      const result = resolveSpaceType({ spaceType: "GROUP_CHAT" });
+      expect(result.spaceType).toBe("GROUP_CHAT");
+      expect(result.isGroup).toBe(true);
+    });
+
+    it("handles lowercase spaceType", () => {
+      const result = resolveSpaceType({ spaceType: "direct_message" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+  });
+
+  describe("deprecated type field fallback", () => {
+    it("maps legacy DM to DIRECT_MESSAGE", () => {
+      const result = resolveSpaceType({ type: "DM" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+
+    it("maps legacy ROOM to SPACE", () => {
+      const result = resolveSpaceType({ type: "ROOM" });
+      expect(result.spaceType).toBe("SPACE");
+      expect(result.isGroup).toBe(true);
+    });
+
+    it("handles lowercase legacy type", () => {
+      const result = resolveSpaceType({ type: "dm" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+  });
+
+  describe("field priority", () => {
+    it("prefers modern spaceType over deprecated type", () => {
+      const result = resolveSpaceType({ spaceType: "SPACE", type: "DM" });
+      expect(result.spaceType).toBe("SPACE");
+      expect(result.isGroup).toBe(true);
+    });
+
+    it("falls back to type only when spaceType is missing", () => {
+      const result = resolveSpaceType({ type: "DM" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+
+    it("falls back to type when spaceType is empty string", () => {
+      const result = resolveSpaceType({ spaceType: "", type: "DM" });
+      expect(result.spaceType).toBe("DIRECT_MESSAGE");
+      expect(result.isGroup).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats empty space as group", () => {
+      const result = resolveSpaceType({});
+      expect(result.spaceType).toBe("");
+      expect(result.isGroup).toBe(true);
+    });
+
+    it("treats unknown spaceType as group", () => {
+      const result = resolveSpaceType({ spaceType: "UNKNOWN_TYPE" });
+      expect(result.spaceType).toBe("UNKNOWN_TYPE");
+      expect(result.isGroup).toBe(true);
+    });
   });
 });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -297,6 +297,27 @@ function normalizeUserId(raw?: string | null): string {
   return trimmed.replace(/^users\//i, "").toLowerCase();
 }
 
+/**
+ * Resolves the space type from Google Chat space object.
+ * Normalizes to modern 'spaceType' format with fallback for deprecated 'type' field.
+ */
+export function resolveSpaceType(space: { type?: string; spaceType?: string }): {
+  spaceType: string;
+  isGroup: boolean;
+} {
+  // Normalize to modern 'spaceType' format
+  let spaceType = (space.spaceType ?? "").toUpperCase();
+
+  // @deprecated fallback: map legacy 'type' to modern values
+  if (!spaceType && space.type) {
+    const legacyType = space.type.toUpperCase();
+    spaceType = legacyType === "DM" ? "DIRECT_MESSAGE" : "SPACE";
+  }
+
+  const isGroup = spaceType !== "DIRECT_MESSAGE";
+  return { spaceType, isGroup };
+}
+
 export function isSenderAllowed(
   senderId: string,
   senderEmail: string | undefined,
@@ -388,16 +409,7 @@ async function processMessageWithPipeline(params: {
   const spaceId = space.name ?? "";
   if (!spaceId) return;
 
-  // Normalize to modern 'spaceType' format
-  let spaceType = (space.spaceType ?? "").toUpperCase();
-
-  // @deprecated fallback: map legacy 'type' to modern values
-  if (!spaceType && space.type) {
-    const legacyType = space.type.toUpperCase();
-    spaceType = legacyType === "DM" ? "DIRECT_MESSAGE" : "SPACE";
-  }
-
-  const isGroup = spaceType !== "DIRECT_MESSAGE";
+  const { isGroup } = resolveSpaceType(space);
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -387,8 +387,17 @@ async function processMessageWithPipeline(params: {
 
   const spaceId = space.name ?? "";
   if (!spaceId) return;
-  const spaceType = (space.type ?? "").toUpperCase();
-  const isGroup = spaceType !== "DM";
+
+  // Normalize to modern 'spaceType' format
+  let spaceType = (space.spaceType ?? "").toUpperCase();
+
+  // @deprecated fallback: map legacy 'type' to modern values
+  if (!spaceType && space.type) {
+    const legacyType = space.type.toUpperCase();
+    spaceType = legacyType === "DM" ? "DIRECT_MESSAGE" : "SPACE";
+  }
+
+  const isGroup = spaceType !== "DIRECT_MESSAGE";
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";

--- a/extensions/googlechat/src/types.ts
+++ b/extensions/googlechat/src/types.ts
@@ -1,7 +1,9 @@
 export type GoogleChatSpace = {
   name?: string;
   displayName?: string;
+  /** @deprecated Use spaceType instead */
   type?: string;
+  spaceType?: string;
 };
 
 export type GoogleChatUser = {


### PR DESCRIPTION
## Summary
- Fix space type detection to use modern `spaceType` field instead of deprecated `type`
- Add backwards-compatible fallback for legacy API responses

## Problem
Google Chat deprecated `space.type` (values: `DM`, `ROOM`) in favor of `space.spaceType` (values: `DIRECT_MESSAGE`, `GROUP_CHAT`, `SPACE`). Modern API responses may only include `spaceType`, causing the integration to misidentify space types and return bad request errors for group chats/spaces.

## References
- [Google Chat spaces REST API](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces) - documents `spaceType` enum values
- [Google Chat Event reference](https://developers.google.com/workspace/chat/api/reference/rest/v1/Event) - webhook payload structure

## AI-Assisted 🤖
- [x] AI-assisted (Claude)
- [x] Lightly tested (unit tests pass, no live Google Chat testing)
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Google Chat space type detection to support the modern `space.spaceType` field (e.g., `DIRECT_MESSAGE`, `GROUP_CHAT`, `SPACE`) and adds unit tests for the new resolution logic. It introduces `resolveSpaceType()` in `extensions/googlechat/src/monitor.ts` and uses it when deciding whether an inbound message is a group chat vs DM, with a fallback to the deprecated legacy `space.type` field.


<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge; it’s a small behavioral change with test coverage, with one edge-case mapping that could misclassify legacy space types.
- Changes are localized (space type normalization + tests) and should fix modern API payloads. The main concern is the legacy `type` fallback mapping any non-`DM` value to `SPACE`, which could over-classify unknown/empty legacy values as group chats and affect policy enforcement paths.
- extensions/googlechat/src/monitor.ts (legacy type fallback mapping logic)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->