### PR TITLE
fix(slack): pass toolContext to read action for thread reply support

### DIFF
--- a/extensions/slack/src/channel.read-threadid.test.ts
+++ b/extensions/slack/src/channel.read-threadid.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { slackPlugin } from "./channel.js";
+import { setSlackRuntime } from "./runtime.js";
+
+import type { MoltbotConfig } from "../../../src/config/config.js";
+import { createPluginRuntime } from "../../../src/plugins/runtime/index.js";
+
+describe("slack plugin read action", () => {
+  it("forwards threadId to readMessages", async () => {
+    const runtime = createPluginRuntime();
+
+    const handleSlackAction = vi.fn(async () => ({ ok: true }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (runtime.channel.slack as any).handleSlackAction = handleSlackAction;
+
+    setSlackRuntime(runtime);
+
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          appToken: "xapp-test",
+        },
+      },
+    } as MoltbotConfig;
+
+    await slackPlugin.actions.handleAction({
+      action: "read",
+      params: {
+        channelId: "C123",
+        threadId: "1712345678.000100",
+        limit: 3,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: undefined,
+    });
+
+    expect(handleSlackAction).toHaveBeenCalledTimes(1);
+    expect(handleSlackAction.mock.calls[0]?.[0]).toMatchObject({
+      action: "readMessages",
+      channelId: "C123",
+      limit: 3,
+      threadId: "1712345678.000100",
+    });
+  });
+});

--- a/extensions/slack/src/channel.read-threadid.test.ts
+++ b/extensions/slack/src/channel.read-threadid.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-
-import { slackPlugin } from "./channel.js";
-import { setSlackRuntime } from "./runtime.js";
-
 import type { MoltbotConfig } from "../../../src/config/config.js";
 import { createPluginRuntime } from "../../../src/plugins/runtime/index.js";
+import { slackPlugin } from "./channel.js";
+import { setSlackRuntime } from "./runtime.js";
 
 describe("slack plugin read action", () => {
   it("forwards threadId to readMessages", async () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -366,6 +366,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             accountId: accountId ?? undefined,
           },
           cfg,
+          toolContext,
         );
       }
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,6 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -133,6 +133,12 @@ function buildFetchSchema() {
     around: Type.Optional(Type.String()),
     fromMe: Type.Optional(Type.Boolean()),
     includeArchived: Type.Optional(Type.Boolean()),
+    threadId: Type.Optional(
+      Type.String({
+        description:
+          "Thread ID (ts) to read replies from. Required for reading Slack thread messages.",
+      }),
+    ),
   };
 }
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -240,6 +240,15 @@ export async function runPreparedReply(
     prefixedBodyBase,
   });
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
+  const threadStarterBody = ctx.ThreadStarterBody?.trim();
+  const threadStarterNote =
+    isNewSession && threadStarterBody
+      ? `[Thread starter - for context]\n${threadStarterBody}`
+      : undefined;
+  const threadRepliesBody = ctx.ThreadRepliesBody?.trim();
+  const threadRepliesNote = threadRepliesBody
+    ? `[Thread replies - for context]\n${threadRepliesBody}`
+    : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,
@@ -254,7 +263,9 @@ export async function runPreparedReply(
   sessionEntry = skillResult.sessionEntry ?? sessionEntry;
   currentSystemSent = skillResult.systemSent;
   const skillsSnapshot = skillResult.skillsSnapshot;
-  const prefixedBody = prefixedBodyBase;
+  const prefixedBody = [threadStarterNote, threadRepliesNote, prefixedBodyBase]
+    .filter(Boolean)
+    .join("\n\n");
   const mediaNote = buildInboundMediaNote(ctx);
   const mediaReplyHint = mediaNote
     ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -30,6 +30,7 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   normalized.CommandBody = normalizeTextField(normalized.CommandBody);
   normalized.Transcript = normalizeTextField(normalized.Transcript);
   normalized.ThreadStarterBody = normalizeTextField(normalized.ThreadStarterBody);
+  normalized.ThreadRepliesBody = normalizeTextField(normalized.ThreadRepliesBody);
   if (Array.isArray(normalized.UntrustedContext)) {
     const normalizedUntrusted = normalized.UntrustedContext.map((entry) =>
       normalizeInboundTextNewlines(entry),

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -69,6 +69,8 @@ export type MsgContext = {
   ForwardedFromMessageId?: number;
   ForwardedDate?: number;
   ThreadStarterBody?: string;
+  /** Thread replies context (recent messages in the thread, excluding starter and current). */
+  ThreadRepliesBody?: string;
   ThreadLabel?: string;
   MediaPath?: string;
   MediaUrl?: string;

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -149,6 +149,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
             accountId: accountId ?? undefined,
           },
           cfg,
+          toolContext,
         );
       }
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -239,11 +239,17 @@ export async function resolveSlackThreadReplies(params: {
     // Filter out the thread starter (first message) and the excluded message.
     const replies = messages
       .filter((msg) => {
-        if (!msg.ts) return false;
+        if (!msg.ts) {
+          return false;
+        }
         // Exclude thread starter (ts === threadTs).
-        if (msg.ts === params.threadTs) return false;
+        if (msg.ts === params.threadTs) {
+          return false;
+        }
         // Exclude the specified message (usually the current inbound).
-        if (params.excludeTs && msg.ts === params.excludeTs) return false;
+        if (params.excludeTs && msg.ts === params.excludeTs) {
+          return false;
+        }
         return true;
       })
       .map((msg) => ({

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -226,12 +226,14 @@ export async function resolveSlackThreadReplies(params: {
   /** Maximum number of replies to fetch (default: 10). */
   limit?: number;
 }): Promise<SlackThreadReply[]> {
-  const limit = params.limit ?? 10;
+  // Clamp limit to valid range (Slack API max: 1000, default: 10).
+  const rawLimit = params.limit ?? 10;
+  const limit = Math.max(1, Math.min(rawLimit, 998));
   try {
     const response = (await params.client.conversations.replies({
       channel: params.channelId,
       ts: params.threadTs,
-      // Fetch more than limit to account for exclusions.
+      // Fetch more than limit to account for exclusions (starter + current message).
       limit: limit + 2,
       inclusive: true,
     })) as { messages?: Array<{ text?: string; user?: string; ts?: string }> };

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -493,31 +493,34 @@ export async function prepareSlackMessage(params: {
     }
 
     // Fetch recent thread replies (excluding starter and current message).
-    const threadReplies = await resolveSlackThreadReplies({
-      channelId: message.channel,
-      threadTs,
-      client: ctx.app.client,
-      excludeTs: message.ts,
-      limit: ctx.historyLimit > 0 ? ctx.historyLimit : 10,
-    });
-    if (threadReplies.length > 0) {
-      const formattedReplies = await Promise.all(
-        threadReplies.map(async (reply) => {
-          const replyUser = reply.userId ? await ctx.resolveUserName(reply.userId) : null;
-          const replyName = replyUser?.name ?? reply.userId ?? "Unknown";
-          const replyWithId = `${reply.text}\n[slack message id: ${reply.ts ?? "unknown"} channel: ${message.channel}]`;
-          return formatInboundEnvelope({
-            channel: "Slack",
-            from: roomLabel,
-            timestamp: reply.ts ? Math.round(Number(reply.ts) * 1000) : undefined,
-            body: replyWithId,
-            chatType: "channel",
-            senderLabel: replyName,
-            envelope: envelopeOptions,
-          });
-        }),
-      );
-      threadRepliesBody = formattedReplies.join("\n\n");
+    // Respect historyLimit=0 to disable context injection.
+    if (ctx.historyLimit > 0) {
+      const threadReplies = await resolveSlackThreadReplies({
+        channelId: message.channel,
+        threadTs,
+        client: ctx.app.client,
+        excludeTs: message.ts,
+        limit: ctx.historyLimit,
+      });
+      if (threadReplies.length > 0) {
+        const formattedReplies = await Promise.all(
+          threadReplies.map(async (reply) => {
+            const replyUser = reply.userId ? await ctx.resolveUserName(reply.userId) : null;
+            const replyName = replyUser?.name ?? reply.userId ?? "Unknown";
+            const replyWithId = `${reply.text}\n[slack message id: ${reply.ts ?? "unknown"} channel: ${message.channel}]`;
+            return formatInboundEnvelope({
+              channel: "Slack",
+              from: roomLabel,
+              timestamp: reply.ts ? Math.round(Number(reply.ts) * 1000) : undefined,
+              body: replyWithId,
+              chatType: "channel",
+              senderLabel: replyName,
+              envelope: envelopeOptions,
+            });
+          }),
+        );
+        threadRepliesBody = formattedReplies.join("\n\n");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Forward `threadId` for Slack message read actions
- Pass `toolContext` to `handleSlackAction` in read action (extensions/slack)
- Auto-inject `threadId` when reading from current thread context
- Add `ThreadRepliesBody` for automatic thread context in agent prompts
- Add `resolveSlackThreadReplies` helper for fetching thread replies
- Add `threadId` parameter to message tool fetch schema
- Respect `historyLimit=0` to skip thread replies fetch

## Problem
When an agent was in a Slack thread and used `message.read` to read messages, it could only read the channel's top-level messages, not the thread replies. This made it impossible for the agent to understand the thread context.

## Solution
Pass `toolContext` (containing `currentChannelId` and `currentThreadTs`) through the read action path so that `threadId` is auto-injected when reading from the current thread.

## Testing
- Added regression test for read threadId forwarding
- Manually verified thread replies are now correctly fetched
- Verified `historyLimit=0` properly skips thread context injection

---

## 🤖 AI-Assisted PR

- **AI Tools Used:** Claude (via Claude Code CLI)
- **Testing Level:** Lightly tested - manual verification + regression test added
- **Human Review:** Code changes reviewed and understood by contributor

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Slack thread awareness across both the Slack plugin action path and the agent message tool by:

- forwarding `threadId` through Slack `read`/`readMessages` actions and passing `toolContext` into `handleSlackAction` so reads can auto-inject the current thread when appropriate.
- extending the message tool fetch schema with an optional `threadId` parameter.
- injecting recent Slack thread replies into inbound context via a new `ThreadRepliesBody` field, populated in the Slack monitor message preparation flow using `resolveSlackThreadReplies`, while respecting `historyLimit=0`.

Overall this fits into the existing threading/tool-context approach (similar to send auto-threading) and should make `message.read` within threads return relevant context instead of only top-level channel history.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low-to-moderate behavioral risk focused on Slack thread context handling.
- Changes are narrowly scoped to Slack read/thread context plumbing and prompt-context enrichment, with a regression test added for threadId forwarding. Main residual risk is subtle behavior around thread reply ordering and limits/edge cases in the new thread replies fetch (errors are swallowed, and large/invalid limits could degrade behavior silently).
- src/slack/monitor/media.ts and src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->