### PR TITLE
feat(web-fetch): add Jina Reader as extraction fallback

### DIFF
--- a/docs/tools/jina.md
+++ b/docs/tools/jina.md
@@ -1,0 +1,108 @@
+---
+summary: "Jina Reader fallback for web_fetch (PDF support + browser rendering)"
+read_when:
+  - You want Jina-backed web extraction
+  - You need a Jina API key
+  - You want PDF extraction for web_fetch
+  - You want browser-rendered extraction for JS-heavy sites
+---
+
+# Jina Reader
+
+Moltbot can use **Jina Reader** as a fallback extractor for `web_fetch`. It is a
+content extraction service optimised for LLM consumption, with excellent PDF support
+and optional browser rendering for JavaScript-heavy sites.
+
+## Get an API key
+
+1) Sign up at https://jina.ai/?sui=apikey (10M free tokens included)
+2) Store it in config or set `JINA_API_KEY` in the gateway environment.
+
+## Configure Jina
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        jina: {
+          apiKey: "JINA_API_KEY_HERE",
+          baseUrl: "https://r.jina.ai",
+          engine: "browser",
+          timeoutSeconds: 30
+        }
+      }
+    }
+  }
+}
+```
+
+Notes:
+- `jina.enabled` defaults to true when an API key is present.
+- `engine` can be "browser" (quality), "direct" (speed), or "cf-browser-rendering" (JS-heavy).
+
+## Engine Options
+
+| Engine | Best For | Speed |
+|--------|----------|-------|
+| `direct` | Simple HTML pages | Fastest |
+| `browser` | Most pages (default) | Medium |
+| `cf-browser-rendering` | JS-heavy SPAs | Slowest |
+
+## Additional Options
+
+| Option | Description |
+|--------|-------------|
+| `noCache` | Bypass Jina's cache for fresh content |
+| `withLinksSummary` | Include a summary of all links at end of content |
+| `withImagesSummary` | Include a summary of all images at end of content |
+| `returnFormat` | Output format: "markdown", "text", or "html" |
+
+## How `web_fetch` uses Jina
+
+`web_fetch` extraction order:
+1) Readability (local)
+2) **Jina** (if configured)
+3) Firecrawl (if configured)
+4) Basic HTML cleanup (last fallback)
+
+Jina is tried before Firecrawl because:
+- Token-based pricing is more affordable for high-volume use
+- Better PDF extraction support
+- No anti-bot circumvention overhead
+
+See [Web tools](/tools/web) for the full web tool setup.
+
+## Comparison with Firecrawl
+
+| Feature | Jina | Firecrawl |
+|---------|------|-----------|
+| **Pricing** | Token-based (10M free) | Credit-based |
+| **PDF Support** | Excellent | Basic |
+| **Image Captioning** | Yes (via VLM) | No |
+| **Anti-bot Bypass** | No | Yes (stealth proxy) |
+| **JS Rendering** | Yes (browser engine) | Yes |
+
+**Recommendation:** Use Jina for most use cases; add Firecrawl if you frequently
+hit bot detection on specific sites.
+
+## Environment Variables
+
+- `JINA_API_KEY` - API key for Jina Reader (fallback when not set in config)
+
+## Rate Limits
+
+| Tier | RPM |
+|------|-----|
+| No API Key | 20 |
+| Free API Key | 500 |
+| Premium | 5,000 |
+
+## Pricing
+
+Jina uses token-based pricing:
+- **Free tier**: 10 million tokens included
+- **Paid**: ~$0.02 per 1M tokens (varies by plan)
+
+This is typically more cost-effective than Firecrawl's credit-based model for
+high-volume extraction.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -209,6 +209,7 @@ Fetch a URL and extract readable content.
 ### Requirements
 
 - `tools.web.fetch.enabled` must not be `false` (default: enabled)
+- Optional Jina fallback: set `tools.web.fetch.jina.apiKey` or `JINA_API_KEY`.
 - Optional Firecrawl fallback: set `tools.web.fetch.firecrawl.apiKey` or `FIRECRAWL_API_KEY`.
 
 ### Config
@@ -225,6 +226,13 @@ Fetch a URL and extract readable content.
         maxRedirects: 3,
         userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
         readability: true,
+        jina: {
+          enabled: true,
+          apiKey: "JINA_API_KEY_HERE", // optional if JINA_API_KEY is set
+          baseUrl: "https://r.jina.ai",
+          engine: "browser", // "browser", "direct", or "cf-browser-rendering"
+          timeoutSeconds: 30
+        },
         firecrawl: {
           enabled: true,
           apiKey: "FIRECRAWL_API_KEY_HERE", // optional if FIRECRAWL_API_KEY is set
@@ -246,12 +254,14 @@ Fetch a URL and extract readable content.
 - `maxChars` (truncate long pages)
 
 Notes:
-- `web_fetch` uses Readability (main-content extraction) first, then Firecrawl (if configured). If both fail, the tool returns an error.
+- `web_fetch` uses Readability (main-content extraction) first, then Jina (if configured), then Firecrawl (if configured). If all fail, the tool returns an error.
+- Jina is tried before Firecrawl because it has better PDF support and more affordable token-based pricing.
 - Firecrawl requests use bot-circumvention mode and cache results by default.
 - `web_fetch` sends a Chrome-like User-Agent and `Accept-Language` by default; override `userAgent` if needed.
 - `web_fetch` blocks private/internal hostnames and re-checks redirects (limit with `maxRedirects`).
 - `web_fetch` is best-effort extraction; some sites will need the browser tool.
-- See [Firecrawl](/tools/firecrawl) for key setup and service details.
+- See [Jina](/tools/jina) for Jina Reader setup and service details.
+- See [Firecrawl](/tools/firecrawl) for Firecrawl key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
 - If the Brave key is missing, `web_search` returns a short setup hint with a docs link.

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -161,7 +161,7 @@ describe("web_fetch extraction fallbacks", () => {
 
     await expect(
       tool?.execute?.("call", { url: "https://example.com/readability-empty" }),
-    ).rejects.toThrow("Readability and Firecrawl returned no content");
+    ).rejects.toThrow("Readability, Jina, and Firecrawl returned no content");
   });
 
   it("uses firecrawl when direct fetch fails", async () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -199,6 +199,15 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.jina.enabled": "Enable Jina Reader",
+  "tools.web.fetch.jina.apiKey": "Jina API Key",
+  "tools.web.fetch.jina.baseUrl": "Jina Base URL",
+  "tools.web.fetch.jina.engine": "Jina Engine",
+  "tools.web.fetch.jina.returnFormat": "Jina Return Format",
+  "tools.web.fetch.jina.timeoutSeconds": "Jina Timeout (sec)",
+  "tools.web.fetch.jina.noCache": "Jina Disable Cache",
+  "tools.web.fetch.jina.withLinksSummary": "Jina Include Links Summary",
+  "tools.web.fetch.jina.withImagesSummary": "Jina Include Images Summary",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
@@ -463,6 +472,17 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.firecrawl.maxAgeMs":
     "Firecrawl maxAge (ms) for cached results when supported by the API.",
   "tools.web.fetch.firecrawl.timeoutSeconds": "Timeout in seconds for Firecrawl requests.",
+  "tools.web.fetch.jina.enabled": "Enable Jina Reader fallback for web_fetch (if configured).",
+  "tools.web.fetch.jina.apiKey": "Jina API key (fallback: JINA_API_KEY env var).",
+  "tools.web.fetch.jina.baseUrl": "Jina base URL (default: https://r.jina.ai).",
+  "tools.web.fetch.jina.engine":
+    'Jina engine ("browser" for quality, "direct" for speed, "cf-browser-rendering" for JS-heavy sites).',
+  "tools.web.fetch.jina.returnFormat": 'Jina return format ("markdown", "text", or "html").',
+  "tools.web.fetch.jina.timeoutSeconds": "Timeout in seconds for Jina requests.",
+  "tools.web.fetch.jina.noCache": "Bypass Jina cache for fresh content (default: false).",
+  "tools.web.fetch.jina.withLinksSummary": "Include a summary of all links at the end of content.",
+  "tools.web.fetch.jina.withImagesSummary":
+    "Include a summary of all images at the end of content.",
   "channels.slack.allowBots":
     "Allow bot-authored messages to trigger Slack replies (default: false).",
   "channels.slack.thread.historyScope":

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -182,6 +182,33 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().int().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+export const ToolsWebFetchJinaSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    engine: z.enum(["browser", "direct", "cf-browser-rendering"]).optional(),
+    returnFormat: z.enum(["markdown", "text", "html"]).optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    noCache: z.boolean().optional(),
+    withLinksSummary: z.boolean().optional(),
+    withImagesSummary: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -190,6 +217,9 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
+    jina: ToolsWebFetchJinaSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Adds [Jina Reader](https://jina.ai/reader/) as an optional fallback extractor for `web_fetch`, positioned between Readability and Firecrawl in the fallback chain.

## Why Jina?

### Pricing Comparison

| Feature | [Jina Reader](https://jina.ai/reader/) | [Firecrawl](https://firecrawl.dev/pricing) |
|---------|-----------|-----------|
| **Free tier** | 10 million tokens | 500 credits (one-time) |
| **Pricing model** | Token-based (output size) | Credit-based (per page) |
| **Starter paid** | Pay-as-you-go after free tier | $16/mo for 3,000 pages |
| **Rate limits (free)** | 500 RPM with API key | 2 concurrent requests |
| **Rate limits (paid)** | 5,000 RPM (premium) | 50-100 concurrent |

### Key Advantages

- **10M free tokens** - Jina's generous free tier means most personal/hobby use cases cost nothing, vs Firecrawl's 500 one-time credits
- **Token-based pricing** - Pay for actual content extracted (output tokens), not per-page. Short pages cost less than long ones
- **Excellent PDF support** - Native PDF extraction with image handling, often better than Firecrawl for academic papers and documents
- **No anti-bot overhead** - Jina doesn't use stealth proxies, resulting in faster responses and simpler pricing (no credit multipliers)
- **Open source** - The [Reader API is open source](https://github.com/jina-ai/reader) on GitHub

### When to Use Each

| Use Case | Recommended |
|----------|-------------|
| Most extraction needs | **Jina** (cost-effective, fast) |
| PDF-heavy workflows | **Jina** (superior PDF support) |
| Sites with bot detection | **Firecrawl** (stealth proxy) |
| High-volume crawling | Either (compare your workload) |

## Changes

- **Schema**: Added `ToolsWebFetchJinaSchema` for type-safe config validation
- **web-fetch.ts**: Added `fetchJinaContent()`, config resolvers, and integrated into fallback chain
- **schema.ts**: Added UI labels/help for Jina config options
- **docs/tools/jina.md**: New documentation for Jina setup
- **docs/tools/web.md**: Updated to reference Jina in fallback chain

## Fallback Order

```
Readability (local) → Jina (if configured) → Firecrawl (if configured) → error
```

Jina is tried before Firecrawl because:
1. Token-based pricing is more affordable for most use cases
2. Better PDF extraction support
3. No anti-bot circumvention overhead = faster responses

## Config Example

```json5
{
  tools: {
    web: {
      fetch: {
        jina: {
          enabled: true,
          apiKey: "jina_...",  // Get free key at https://jina.ai/?sui=apikey
          engine: "browser",   // "browser", "direct", or "cf-browser-rendering"
          timeoutSeconds: 30
        }
      }
    }
  }
}
```

## Test Plan

- [x] Integration tested against Jina API with real API key
- [x] Verified HTML page extraction (example.com)
- [x] Verified documentation page with browser engine (nodejs.org)
- [x] Verified PDF extraction (W3C PDF)
- [x] Verified error handling (non-existent domain throws correctly)

---

🤖 Generated with [Claude Code](https://claude.ai/code)