### PR TITLE
feat(ui): expand chat textarea max-height for longer messages

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -247,7 +247,7 @@
   width: 100%;
   height: 40px;
   min-height: 40px;
-  max-height: 150px;
+  max-height: min(400px, 50vh);
   padding: 9px 12px;
   border-radius: 8px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

Increase chat textarea `max-height` from 150px to `min(400px, 50vh)` so users can see more of their message while typing instead of scrolling in a tiny box.

The textarea currently limits to ~3 lines before requiring internal scrolling, making it hard to compose longer messages.

## Changes

- CSS only: `max-height: min(400px, 50vh)` in `ui/src/styles/chat/layout.css`

This allows the textarea to grow up to 400px or 50% of viewport height (whichever is smaller), preserving usability on both large and small screens.

## Testing

- [x] Tested locally with long messages (20+ lines)
- [x] Verified textarea expands without internal scroll until limit
- [x] Chat thread remains scrollable above
- [x] CI passes (lint, format, build)

## Screenshots

Before: Textarea limited to ~3 lines, requires internal scrolling
After: Textarea expands to show more content

🤖 AI-assisted (Claude Code)