### PR TITLE
feat(ui): add drag-and-drop and file picker for image attachments

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -263,6 +263,43 @@
   cursor: not-allowed;
 }
 
+/* Drag-over visual feedback */
+.chat-compose--drag-over {
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+  background: rgba(var(--accent-rgb), 0.05);
+  border-radius: 12px;
+}
+
+/* File attach button */
+.chat-compose__attach {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  transition: all 150ms ease-out;
+}
+
+.chat-compose__attach:hover {
+  background: var(--panel);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.chat-compose__attach svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+}
+
 .chat-compose__actions {
   flex-shrink: 0;
   display: flex;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -93,4 +93,24 @@ describe("chat view", () => {
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
   });
+
+  it("renders file input for image attachments", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          onAttachmentsChange: vi.fn(),
+        }),
+      ),
+      container,
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(fileInput).not.toBeNull();
+    expect(fileInput?.accept).toBe("image/*");
+    expect(fileInput?.multiple).toBe(true);
+
+    const attachLabel = container.querySelector('label[for="chat-file-input"]');
+    expect(attachLabel).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Add two intuitive ways to attach images to chat messages:
1. **Drag-and-drop** - Drag images onto the compose area (shows dashed outline feedback)
2. **File picker button** - Click the paperclip icon to open native file picker

Existing clipboard paste functionality remains unchanged.

## Changes

- Add `handleDragOver`, `handleDragLeave`, `handleDrop` event handlers
- Add shared `processFiles()` helper for consistent file handling
- Add hidden `<input type="file">` with paperclip label button
- Add `.chat-compose--drag-over` visual feedback style
- Add `.chat-compose__attach` button styling
- Add test case for file input rendering

## Files Changed

- `ui/src/ui/views/chat.ts` - New handlers + file input element
- `ui/src/styles/chat/layout.css` - Drag-over and button styles
- `ui/src/ui/views/chat.test.ts` - Test for file input

## Testing

- [x] Drag image onto compose area → visual feedback appears
- [x] Drop image → appears in attachment preview
- [x] Click paperclip → file picker opens
- [x] Select images → appear in preview
- [x] Multiple images work
- [x] Existing paste still works
- [x] CI passes (lint, format, build)

🤖 AI-assisted (Claude Code)