### PR TITLE
feat(ui): clarify debug toggle with bug icon and extended filtering

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -107,9 +107,9 @@ export function renderChatControls(state: AppViewState) {
         aria-pressed=${showThinking}
         title=${disableThinkingToggle
           ? "Disabled during onboarding"
-          : "Toggle assistant thinking/working output"}
+          : "Show/hide debug info (tool calls, heartbeats)"}
       >
-        ${icons.brain}
+        ${icons.bug}
       </button>
       <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -93,4 +93,44 @@ describe("chat view", () => {
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
   });
+
+  it("filters debug messages when showThinking is false", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: false,
+          messages: [
+            { role: "user", content: "hello", timestamp: 1 },
+            { role: "toolresult", content: "debug info", timestamp: 2 },
+            { role: "assistant", content: "world", timestamp: 3 },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("hello");
+    expect(container.textContent).toContain("world");
+    expect(container.textContent).not.toContain("debug info");
+  });
+
+  it("shows debug messages when showThinking is true", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          messages: [
+            { role: "user", content: "hello", timestamp: 1 },
+            { role: "toolresult", content: "debug info", timestamp: 2 },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("hello");
+    expect(container.textContent).toContain("debug info");
+  });
 });


### PR DESCRIPTION
## Summary

The "Show Thinking" toggle in the web chat was confusing - users didn't know what it did and thought it controlled LLM reasoning mode, not debug visibility.

This change makes the toggle purpose clear and extends filtering to catch more debug messages.

## Changes

**Icon and tooltip** (`app-render.helpers.ts`):
- Change icon from 🧠 brain to 🐛 bug (clearer for debug output)
- Update tooltip: "Show/hide debug info (tool calls, heartbeats)"

**Extended filtering** (`chat.ts`):
- Add `isDebugMessage()` helper that filters:
  - `toolresult`, `tool_result`, `tool` role messages
  - System messages containing "heartbeat", "scheduled", "context compacted/trimmed"
- Replace simple role check with `isDebugMessage()` call

**Tests** (`chat.test.ts`):
- Add test: debug messages hidden when `showThinking` is false
- Add test: debug messages shown when `showThinking` is true

## Files Changed

- `ui/src/ui/app-render.helpers.ts` - Icon and tooltip
- `ui/src/ui/views/chat.ts` - Extended filtering logic
- `ui/src/ui/views/chat.test.ts` - New test cases

## Testing

- [x] With toggle OFF: heartbeat/tool messages hidden
- [x] With toggle ON: debug messages appear
- [x] Normal user/assistant messages always visible
- [x] Bug icon is clearer than brain for debug purpose
- [x] CI passes (lint, format, build)

🤖 AI-assisted (Claude Code)