### PR TITLE
fix(test): use '&' for XML escaping test to support Windows CI

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -576,7 +576,12 @@ describe("applyMediaUnderstanding", () => {
     // Verify XML special chars are escaped in the output
     expect(ctx.Body).toContain("&amp;");
     // The raw & should not appear unescaped in the name attribute
-    expect(ctx.Body).not.toMatch(/name="[^"]*&[^"]*"/);
+    // Note: The regex /name="[^"]*&[^"]*"/ matches both unescaped '&' AND escaped '&amp;' because '&amp;' contains '&'.
+    // We need a regex that matches '&' NOT followed by 'amp;' (and other entities if we cared, but &amp; is the main one here).
+    // Or simpler: check that it DOES match &amp; and DOES NOT match a raw & that isn't the start of an entity.
+    // But since we know the input is specifically "file&test.txt", we expect "file&amp;test.txt".
+    expect(ctx.Body).toContain('name="file&amp;test.txt"');
+    expect(ctx.Body).not.toContain('name="file&test.txt"');
   });
 
   it("normalizes MIME types to prevent attribute injection", async () => {

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -551,9 +551,8 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     // Create file with XML special characters in the name (what filesystem allows)
-    // Note: The sanitizeFilename in store.ts would strip most dangerous chars,
-    // but we test that even if some slip through, they get escaped in output
-    const filePath = path.join(dir, "file<test>.txt");
+    // We use '&' because it's valid on all platforms (including Windows) but still requires XML escaping
+    const filePath = path.join(dir, "file&test.txt");
     await fs.writeFile(filePath, "safe content");
 
     const ctx: MsgContext = {
@@ -575,10 +574,9 @@ describe("applyMediaUnderstanding", () => {
 
     expect(result.appliedFile).toBe(true);
     // Verify XML special chars are escaped in the output
-    expect(ctx.Body).toContain("&lt;");
-    expect(ctx.Body).toContain("&gt;");
-    // The raw < and > should not appear unescaped in the name attribute
-    expect(ctx.Body).not.toMatch(/name="[^"]*<[^"]*"/);
+    expect(ctx.Body).toContain("&amp;");
+    // The raw & should not appear unescaped in the name attribute
+    expect(ctx.Body).not.toMatch(/name="[^"]*&[^"]*"/);
   });
 
   it("normalizes MIME types to prevent attribute injection", async () => {


### PR DESCRIPTION
Fixes #3748 by replacing '<>' with '&' in the XML escaping test filename. Windows (NTFS) does not allow '<' or '>' in filenames, causing the test to fail on Windows CI. '&' is a valid filename character that still requires XML escaping, preserving the intent of the test.