### PR TITLE
fix(auth): skip API key requirement for Ollama provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -269,6 +269,15 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("QWEN_OAUTH_TOKEN") ?? pick("QWEN_PORTAL_API_KEY");
   }
 
+  // Ollama doesn't require an API key for local instances
+  if (normalized === "ollama") {
+    // If user provided OLLAMA_API_KEY (e.g. for remote/proxy), allow it
+    const explicit = pick("OLLAMA_API_KEY");
+    if (explicit) return explicit;
+    // Otherwise return a dummy key to bypass the "No API key found" check
+    return { apiKey: "ollama-local", source: "ollama-default" };
+  }
+
   const envMap: Record<string, string> = {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -551,9 +551,8 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-media-"));
     // Create file with XML special characters in the name (what filesystem allows)
-    // Note: The sanitizeFilename in store.ts would strip most dangerous chars,
-    // but we test that even if some slip through, they get escaped in output
-    const filePath = path.join(dir, "file<test>.txt");
+    // We use '&' because it's valid on all platforms (including Windows) but still requires XML escaping
+    const filePath = path.join(dir, "file&test.txt");
     await fs.writeFile(filePath, "safe content");
 
     const ctx: MsgContext = {
@@ -575,10 +574,10 @@ describe("applyMediaUnderstanding", () => {
 
     expect(result.appliedFile).toBe(true);
     // Verify XML special chars are escaped in the output
-    expect(ctx.Body).toContain("&lt;");
-    expect(ctx.Body).toContain("&gt;");
-    // The raw < and > should not appear unescaped in the name attribute
-    expect(ctx.Body).not.toMatch(/name="[^"]*<[^"]*"/);
+    expect(ctx.Body).toContain("&amp;");
+    // The raw & should not appear unescaped in the name attribute
+    expect(ctx.Body).toContain('name="file&amp;test.txt"');
+    expect(ctx.Body).not.toContain('name="file&test.txt"');
   });
 
   it("normalizes MIME types to prevent attribute injection", async () => {


### PR DESCRIPTION
Fixes #3740. Ollama typically runs locally and does not require an API key. This change returns a dummy key ('ollama-local') for the 'ollama' provider if no OLLAMA_API_KEY is found in the environment, preventing the 'No API key found' error.