### PR TITLE
fix: write gateway transcripts for CLI provider runs

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -89,6 +89,10 @@ export type CliBackendConfig = {
   imageMode?: "repeat" | "list";
   /** Serialize runs for this CLI. */
   serialize?: boolean;
+  /** Directory where this CLI stores session transcripts (for reading history). */
+  transcriptDir?: string;
+  /** Pattern for transcript file names (use {sessionId} placeholder, defaults to {sessionId}.jsonl). */
+  transcriptPattern?: string;
 };
 
 export type AgentDefaultsConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -266,6 +266,8 @@ export const CliBackendSchema = z
     imageArg: z.string().optional(),
     imageMode: z.union([z.literal("repeat"), z.literal("list")]).optional(),
     serialize: z.boolean().optional(),
+    transcriptDir: z.string().optional(),
+    transcriptPattern: z.string().optional(),
   })
   .strict();
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -34,6 +34,7 @@ import type {
 } from "./session-utils.types.js";
 
 export {
+  appendAssistantTranscriptEntry,
   archiveFileOnDisk,
   capArrayByJsonBytes,
   readFirstUserMessageFromTranscript,
@@ -42,6 +43,7 @@ export {
   readSessionMessages,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
+export type { CliTranscriptConfig, TranscriptAppendResult } from "./session-utils.fs.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,


### PR DESCRIPTION
## Summary

- Fix chat history not loading for CLI provider sessions (e.g., claude-cli)
- Gateway now writes its own transcript files when CLI provider runs complete
- Add config options for specifying CLI transcript locations

## Problem

When using CLI model providers, the gateway skipped writing transcript files because `onAgentRunStart` was called, setting `agentRunStarted = true` and bypassing the transcript writing code path.

## Solution

- Write transcripts in `emitChatFinal` when CLI provider runs complete
- Add `appendAssistantTranscriptEntry` utility for transcript writing
- Add `transcriptDir`/`transcriptPattern` config options to `CliBackendConfig`
- Update `resolveSessionTranscriptCandidates` to check CLI-configured paths

## Test plan

- [x] Added unit tests for `appendAssistantTranscriptEntry`
- [x] Added unit tests for `resolveSessionTranscriptCandidates` with CLI config
- [x] Manual testing: verified transcripts are created in `~/.clawdbot/agents/main/sessions/`
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test src/gateway/session-utils.fs.test.ts` passes (36 tests)

Fixes #3723

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses missing chat history for CLI-backed provider sessions by having the gateway append an assistant message transcript entry when a run completes, and by extending transcript discovery to include CLI-configured transcript directories/patterns. It also adds `transcriptDir`/`transcriptPattern` to `CliBackendConfig` (+ zod schema) and unit tests for the new transcript append helper and candidate resolution logic.

Main integration points are in `src/gateway/server-chat.ts` (writing the transcript on final events) and `src/gateway/session-utils.fs.ts` (resolving transcript paths and appending transcript entries), which are used by gateway session history/preview helpers.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but the transcript-write path likely needs a tighter scope to avoid duplicate or unintended transcript writes.
- Core changes are small and covered by unit tests for the new FS helpers, but the gateway now appends transcripts on every successful run in `emitChatFinal`, which may affect non-CLI providers and could lead to duplicate transcript entries or unexpected file writes. The path resolution behavior also expands `~` broadly, which can surprise users with nonstandard inputs.
- src/gateway/server-chat.ts, src/gateway/session-utils.fs.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->