### PR TITLE
Fix Kimi/Moonshot integration (#3475)

### DIFF
--- a/patches/@mariozechner__pi-ai@0.49.3.patch
+++ b/patches/@mariozechner__pi-ai@0.49.3.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index c4b291d86ce40b2df319c439263d16d67592d22e..769528bc7847b454ccb41ce2c184bb48ca13caee 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -624,7 +624,9 @@ function detectCompat(model) {
+         baseUrl.includes("chutes.ai") ||
+         isZai ||
+         provider === "opencode" ||
+-        baseUrl.includes("opencode.ai");
++        baseUrl.includes("opencode.ai") ||
++        provider === "moonshot" ||
++        baseUrl.includes("moonshot.ai");
+     const useMaxTokens = provider === "mistral" || baseUrl.includes("mistral.ai") || baseUrl.includes("chutes.ai");
+     const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
+     const isMistral = provider === "mistral" || baseUrl.includes("mistral.ai");


### PR DESCRIPTION
## Summary
Fixes #3475 - Kimi/Moonshot models now work correctly with Clawdbot.

## Problem
Kimi models (both `moonshot` and `kimi-code` providers) failed silently due to the `openai-completions` adapter not recognizing Moonshot as a non-standard provider. This caused it to use `role: "developer"` for system prompts, which Moonshot doesn't support.

## Solution
Added Moonshot provider detection to the `isNonStandard` check in `@mariozechner/pi-ai`'s openai-completions adapter via pnpm patch:

```javascript
provider === "moonshot" || baseUrl.includes("moonshot.ai")
```

This forces `supportsDeveloperRole: false`, ensuring Moonshot receives standard `role: "system"` prompts.

## Testing
Verified working with:
- ✅ `moonshot/kimi-k2.5`
- ✅ `moonshot/kimi-k2-thinking`  
- ✅ `sessions_spawn` integration
- ✅ Tool/function calling
- ✅ Reasoning mode  
- ✅ Cross-session messaging

## Implementation
Uses pnpm patch to apply the fix to `@mariozechner/pi-ai@0.49.3` until upstream fix is available.

Direct API calls already worked (as reported in #3475); this fixes the Clawdbot integration layer.