### PR TITLE
fix(whatsapp): require participant field for group reactions

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -255,17 +255,28 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       const messageId = readStringParam(params, "messageId", {
         required: true,
       });
+      const chatJid =
+        readStringParam(params, "chatJid") ?? readStringParam(params, "to", { required: true });
+      const participant = readStringParam(params, "participant");
+      
+      // Validate participant for group reactions
+      if (!participant && chatJid.endsWith("@g.us")) {
+        throw new Error(
+          "WhatsApp group reactions require the 'participant' field (sender JID). " +
+          "Example: participant: '1234567890@s.whatsapp.net'"
+        );
+      }
+      
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
       const remove = typeof params.remove === "boolean" ? params.remove : undefined;
       return await getWhatsAppRuntime().channel.whatsapp.handleWhatsAppAction(
         {
           action: "react",
-          chatJid:
-            readStringParam(params, "chatJid") ?? readStringParam(params, "to", { required: true }),
+          chatJid,
           messageId,
           emoji,
           remove,
-          participant: readStringParam(params, "participant"),
+          participant: participant ?? undefined,
           accountId: accountId ?? undefined,
           fromMe: typeof params.fromMe === "boolean" ? params.fromMe : undefined,
         },


### PR DESCRIPTION
## Problem

When using the `message` tool with `action=react` to react to WhatsApp group messages, reactions silently fail (return `{ok: true}` but don't actually send) unless the `participant` parameter is explicitly provided.

This is because WhatsApp's Baileys library requires the `participant` field for group reactions, but the tool was accepting reactions without it and failing silently.

## Solution

Added validation to require the `participant` field when reacting to group messages (identified by `@g.us` suffix in `chatJid`). If missing, the tool now fails fast with a clear error:

```
WhatsApp group reactions require the 'participant' field (sender JID).
Example: participant: '1234567890@s.whatsapp.net'
```

## Testing

Tested with:
- Moltbot version: `2026.1.27-beta.1`
- WhatsApp group: `120363405719479303@g.us`
- Confirmed error is thrown when `participant` is missing
- Confirmed reactions work correctly when `participant` is provided

## Before

```typescript
message({
  action: "react",
  channel: "whatsapp",
  target: "120363405719479303@g.us",
  messageId: "3A753B865517A93AB697",
  emoji: "👀"
})
// Returns: {ok: true, added: "👀"}
// But reaction never appears ❌
```

## After

```typescript
message({
  action: "react",
  channel: "whatsapp",
  target: "120363405719479303@g.us",
  messageId: "3A753B865517A93AB697",
  emoji: "👀"
})
// Throws: "WhatsApp group reactions require the 'participant' field..." ✅
```

## Related

- Fixes silent failure in group reactions
- Improves developer experience with clearer error messages
- No breaking changes for DM reactions or existing code that already provides `participant`