### PR TITLE
fix: ignore mDNS socket errors to prevent gateway crashes

### DIFF
--- a/src/infra/bonjour-ciao.ts
+++ b/src/infra/bonjour-ciao.ts
@@ -4,9 +4,15 @@ import { formatBonjourError } from "./bonjour-errors.js";
 
 export function ignoreCiaoCancellationRejection(reason: unknown): boolean {
   const message = formatBonjourError(reason).toUpperCase();
-  if (!message.includes("CIAO ANNOUNCEMENT CANCELLED")) {
-    return false;
+  // Ignore ciao cancellation rejections (normal cleanup)
+  if (message.includes("CIAO ANNOUNCEMENT CANCELLED")) {
+    logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatBonjourError(reason)}`);
+    return true;
   }
-  logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatBonjourError(reason)}`);
-  return true;
+  // Ignore socket errors from mDNS announcements (non-fatal, can happen due to network issues)
+  if (message.includes("ANNOUNCEMENT FAILED") && message.includes("SOCKET ERRORS")) {
+    logDebug(`bonjour: ignoring mDNS socket error: ${formatBonjourError(reason)}`);
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Problem
Gateway crashes every ~2 minutes due to unhandled promise rejection from mDNS announcement failures (EAFNOSUPPORT socket errors).

## Solution
Extended `ignoreCiaoCancellationRejection` to also handle mDNS socket errors, which are non-fatal and typically caused by network interface configuration issues.

## Testing
- Tested locally: gateway remained stable for 150+ seconds after fix, compared to crashing every ~120 seconds before
- Environment: macOS 15.2, with HTTP_PROXY configuration

## Notes
- These socket errors don't affect gateway functionality since mDNS is only for local network discovery
- Gateway continues to work normally even when mDNS is unavailable

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the unhandled-rejection filter used by the Bonjour/mDNS advertiser so that certain `@homebridge/ciao` promise rejections are treated as non-fatal. Specifically, `ignoreCiaoCancellationRejection()` now explicitly ignores the normal “announcement cancelled” rejection and additionally tries to ignore mDNS announcement socket errors, preventing the gateway from crashing due to unhandled rejections during mDNS advertising.

This fits into the existing startup flow in `src/infra/bonjour.ts`, where an unhandled rejection handler is registered when services are created and advertising is intentionally done “fire-and-forget” so the gateway can still start even if Bonjour fails.

<h3>Confidence Score: 4/5</h3>

- Likely safe to merge; change is localized and defensive, but string-matching may not cover the reported errors reliably.
- The PR only adjusts a boolean filter for unhandled rejections and adds debug logging; there are no API or control-flow changes outside this handler. Main concern is correctness of the new error matching: if the ciao error message differs (common across OS/network configurations), the gateway could still see unhandled rejections.
- src/infra/bonjour-ciao.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->