### PR TITLE
fix(gateway): use launchctl stop instead of bootout for gateway stop

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -372,9 +372,11 @@ export async function stopLaunchAgent({
 }): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  // Use "stop" instead of "bootout" to keep the service registered.
+  // This allows "gateway start" to work without reinstalling.
+  const res = await execLaunchctl(["stop", `${domain}/${label}`]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl stop failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
 }


### PR DESCRIPTION
## Summary

- Changed `gateway stop` to use `launchctl stop` instead of `launchctl bootout`
- This keeps the service registered, allowing `gateway start` to work without reinstalling

## Problem

`gateway stop` was using `launchctl bootout` which completely unloads the LaunchAgent from launchd. After running `gateway stop`, `gateway start` would fail with:

```
Gateway service not loaded.
Start with: moltbot gateway install
```

## Solution

Use `launchctl stop gui/$UID/<label>` instead of `launchctl bootout`. This stops the service but keeps it registered, so `gateway start` works as expected.

The `bootout` behavior is still used in `uninstallLaunchAgent` where full removal is intended.

## Test plan

- [x] Existing launchd tests pass (14 tests)
- [x] Lint/type check pass
- Manual verification: `gateway stop` → `gateway start` should work without reinstalling

Fixes #3780

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the macOS launchd stop behavior for the gateway daemon: `gateway stop` now issues `launchctl stop gui/$UID/<label>` instead of `launchctl bootout`, so the LaunchAgent remains registered with launchd and `gateway start` can successfully restart it without requiring a reinstall.

The change is localized to `src/daemon/launchd.ts` in `stopLaunchAgent`, and preserves the use of `bootout` in uninstall/cleanup paths where fully removing the agent is intended.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted substitution of a launchctl subcommand in the macOS stop path, aligns with launchd semantics (stop vs unload), and avoids the previously reported restart failure after stop; no other code paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->