### PR TITLE
fix(gateway): prevent unnecessary restart on meta.lastTouchedAt changes

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -108,6 +108,12 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("gateway.remote.url");
   });
 
+  it("treats meta.* as no-op", () => {
+    const plan = buildGatewayReloadPlan(["meta.lastTouchedAt"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("meta.lastTouchedAt");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -82,6 +82,7 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "gateway", kind: "restart" },
   { prefix: "discovery", kind: "restart" },
   { prefix: "canvasHost", kind: "restart" },
+  { prefix: "meta", kind: "none" },
 ];
 
 let cachedReloadRules: ReloadRule[] | null = null;


### PR DESCRIPTION
## Summary

- Added `{ prefix: "meta", kind: "none" }` to `BASE_RELOAD_RULES_TAIL`
- Prevents gateway restart when `meta.lastTouchedAt` changes

## Problem

When tools modify the config (e.g., `moltbot agents add`), the `meta.lastTouchedAt` field gets updated. Without a reload rule for "meta", this fell through to `restartGateway = true`, causing:

1. Gateway sends SIGUSR1, restarts
2. In-flight HTTP requests to LLM providers are aborted
3. User never receives the agent's response

```
04:58:51.420Z - Tool result received (clawdbot agents add completed)
04:58:51.936Z - [reload] config change detected; evaluating reload (meta.lastTouchedAt, ...)
04:58:51.939Z - [reload] config change requires gateway restart (meta.lastTouchedAt)
04:58:51.961Z - [clawdbot] Unhandled promise rejection: AbortError: This operation was aborted
```

## Solution

Add `meta` prefix to the reload rules with `kind: "none"` so changes to `meta.*` fields are ignored.

## Test plan

- [x] Existing config-reload tests pass (8 tests)
- [x] Lint/type check pass

Fixes #3811

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates gateway config reload rules to treat `meta.*` config changes as a no-op (by adding a `{ prefix: "meta", kind: "none" }` rule). This prevents automatic metadata updates like `meta.lastTouchedAt` from falling through to the default “restart required” behavior, avoiding unnecessary gateway restarts and aborted in-flight provider requests during tool-driven config writes.

The change fits into the existing `config-reload.ts` rule-based reload planner (`matchRule` + `buildGatewayReloadPlan`) that classifies changed config paths into restart/hot/no-op categories, with plugin-provided channel reload rules merged in at runtime.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a small, targeted behavior change in reload classification.
- Only a single reload rule is added and it follows the existing rule-matching semantics; the main residual risk is lack of explicit regression test coverage for `meta.*` changes.
- src/gateway/config-reload.ts (rule ordering/coverage); src/gateway/config-reload.test.ts (add regression test).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->