### PR TITLE
docs: recommend @beta instead of @latest for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Model note: while any model is supported, I strongly recommend **Anthropic Pro/M
 Runtime: **Node ≥22**.
 
 ```bash
-npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
+npm install -g openclaw@beta
+# or: pnpm add -g openclaw@beta
 
 openclaw onboard --install-daemon
 ```
+
+> **Note:** Use `@beta` instead of `@latest` until npm `@latest` is updated. The `@latest` tag currently points to an old version (v0.1.0) that lacks the CLI binary. See [#3787](https://github.com/moltbot/moltbot/issues/3787).
 
 The wizard installs the Gateway daemon (launchd/systemd user service) so it stays running.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -813,7 +813,7 @@ openclaw gateway restart
 From git → npm:
 
 ```bash
-npm install -g openclaw@latest
+npm install -g openclaw@beta  # Use @beta until npm @latest is updated
 openclaw doctor
 openclaw gateway restart
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,8 +111,9 @@ Runtime requirement: **Node ≥ 22**.
 
 ```bash
 # Recommended: global install (npm/pnpm)
-npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
+npm install -g openclaw@beta
+# or: pnpm add -g openclaw@beta
+# Note: Use @beta until npm @latest is updated (see issue #3787)
 
 # Onboard + install the service (launchd/systemd user service)
 openclaw onboard --install-daemon

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -62,13 +62,15 @@ curl -fsSL https://openclaw.bot/install.sh | bash -s -- --no-onboard
 If you already have Node:
 
 ```bash
-npm install -g openclaw@latest
+npm install -g openclaw@beta
 ```
+
+> **Note:** Use `@beta` instead of `@latest` until npm `@latest` is updated. The `@latest` tag currently points to an old version (v0.1.0) that lacks the CLI binary.
 
 If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails to install, force prebuilt binaries:
 
 ```bash
-SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
+SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@beta
 ```
 
 If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
@@ -76,7 +78,7 @@ If you see `sharp: Please add node-gyp to your dependencies`, either install bui
 Or:
 
 ```bash
-pnpm add -g openclaw@latest
+pnpm add -g openclaw@beta
 ```
 
 Then:

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -30,14 +30,16 @@ If the installer completes but `openclaw` is not found in a new terminal, it’s
 
 ## install.sh (recommended)
 
+> **Note:** The installer currently uses `@latest`, but `@latest` points to an old version (v0.1.0) without CLI support. Until the installer is updated, use manual install with `npm install -g moltbot@beta` instead. See [#3787](https://github.com/moltbot/moltbot/issues/3787).
+
 What it does (high level):
 
 - Detect OS (macOS / Linux / WSL).
 - Ensure Node.js **22+** (macOS via Homebrew; Linux via NodeSource).
 - Choose install method:
-  - `npm` (default): `npm install -g openclaw@latest`
+  - `npm` (default): `npm install -g openclaw@beta` (recommended; `@latest` is outdated)
   - `git`: clone/build a source checkout and install a wrapper script
-- On Linux: avoid global npm permission errors by switching npm’s prefix to `~/.npm-global` when needed.
+- On Linux: avoid global npm permission errors by switching npm's prefix to `~/.npm-global` when needed.
 - If upgrading an existing install: runs `openclaw doctor --non-interactive` (best effort).
 - For git installs: runs `openclaw doctor --non-interactive` after install/update (best effort).
 - Mitigates `sharp` native install gotchas by defaulting `SHARP_IGNORE_GLOBAL_LIBVIPS=1` (avoids building against system libvips).
@@ -83,11 +85,13 @@ curl -fsSL https://openclaw.bot/install-cli.sh | bash -s -- --help
 
 ## install.ps1 (Windows PowerShell)
 
+> **Note:** The installer currently uses `@latest`, but `@latest` points to an old version (v0.1.0) without CLI support. Until the installer is updated, use manual install with `npm install -g moltbot@beta` instead. See [#3787](https://github.com/moltbot/moltbot/issues/3787).
+
 What it does (high level):
 
 - Ensure Node.js **22+** (winget/Chocolatey/Scoop or manual).
 - Choose install method:
-  - `npm` (default): `npm install -g openclaw@latest`
+  - `npm` (default): `npm install -g openclaw@beta` (recommended; `@latest` is outdated)
   - `git`: clone/build a source checkout and install a wrapper script
 - Runs `openclaw doctor --non-interactive` on upgrades and git installs (best effort).
 

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -68,12 +68,14 @@ iwr -useb https://openclaw.ai/install.ps1 | iex
 Alternative (global install):
 
 ```bash
-npm install -g openclaw@latest
+npm install -g openclaw@beta
 ```
 
 ```bash
-pnpm add -g openclaw@latest
+pnpm add -g openclaw@beta
 ```
+
+> **Note:** Use `@beta` instead of `@latest` until npm `@latest` is updated. The `@latest` tag currently points to an old version (v0.1.0) that lacks the CLI binary.
 
 ## 2) Run the onboarding wizard (and install the service)
 


### PR DESCRIPTION
## Summary
- Updates documentation to recommend `npm install -g moltbot@beta` instead of `moltbot@latest`
- Adds warning notes explaining that `@latest` currently points to v0.1.0 which lacks the CLI binary
- Updates 6 documentation files with the fix

## Problem
The npm `@latest` tag for `moltbot` points to v0.1.0, which:
1. Has no `bin` field in package.json
2. Doesn't expose the `moltbot` CLI command after global install
3. Causes the Windows installer to fail with ENOENT

This affects all platforms, not just Windows, but Windows users are particularly impacted since they can't easily work around it.

## Solution
Update documentation to recommend `@beta` until `@latest` is updated:
```bash
npm install -g moltbot@beta
# instead of
npm install -g moltbot@latest
```

## Files changed
- `README.md` - Main readme install instructions
- `docs/index.md` - Docs homepage quick start
- `docs/install/index.md` - Main install documentation
- `docs/install/installer.md` - Installer script documentation (added warnings)
- `docs/start/getting-started.md` - Getting started guide
- `docs/help/faq.md` - FAQ section

## Test plan
- [x] Documentation changes only - no code changes
- [ ] Verify that `npm install -g moltbot@beta` works correctly

## Note
This is a documentation workaround. The proper fix is to publish the current version to npm with the `@latest` tag. The installer scripts (`install.sh`, `install.ps1`) hosted on molt.bot also need to be updated separately.

Fixes #3787

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)