### PR TITLE
feat (macOS): add remote gateway token field (AI-assisted)

### DIFF
--- a/apps/macos/Sources/Moltbot/GeneralSettings.swift
+++ b/apps/macos/Sources/Moltbot/GeneralSettings.swift
@@ -145,6 +145,8 @@ struct GeneralSettings: View {
                 self.remoteDirectRow
             }
 
+            self.remoteTokenRow
+
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
                 currentTarget: self.state.remoteTarget,
@@ -299,6 +301,23 @@ struct GeneralSettings: View {
                     .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
             Text("Direct mode requires a ws:// or wss:// URL (Tailscale Serve uses wss://<magicdns>).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteTokenRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("Shared gateway auth token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            Text("Must match gateway.auth.token (or gateway.remote.token) on the gateway host.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)


### PR DESCRIPTION
AI-assisted: yes
Testing: lightly tested

## Summary
- Add a visible "Gateway token" field to the macOS Remote settings card
- Bind it to `gateway.remote.token` so the client can authenticate to remote gateways
- Keep the value in sync when config changes on disk

## Why
Remote connection attempts can fail with "gateway token missing," but the macOS UI previously had no place to enter the token. This makes remote setup look broken even when the gateway is correctly configured.

## Notes
The token is entered via a `SecureField` (masked), but it is still stored in `~/.clawdbot/clawdbot.json` like the CLI.

## Test plan
- `./scripts/restart-mac.sh --no-sign`
- Verified the new token field appears under Settings → General → Remote (another host)
- Verified edits persist to gateway.remote.token
- Attempted gateway connection flow (expected improvement: token can now be provided)

---
*Rebased from #2695 to resolve merge conflicts*