### PR TITLE
fix(macOS): keep Not configured from snapping back to remote (AI-assisted)

### DIFF
--- a/apps/macos/Sources/Moltbot/AppState.swift
+++ b/apps/macos/Sources/Moltbot/AppState.swift
@@ -533,6 +533,15 @@ final class AppState {
                     gateway["remote"] = remote
                     changed = true
                 }
+            } else if connectionMode == .unconfigured {
+                // Prevent implicit remote-mode re-selection when the user explicitly
+                // chooses "Not configured" in the UI. Leaving gateway.remote.url
+                // behind causes applyConfigOverrides to force .remote.
+                if var remote = gateway["remote"] as? [String: Any], remote["url"] != nil {
+                    remote.removeValue(forKey: "url")
+                    gateway["remote"] = remote
+                    changed = true
+                }
             }
 
             guard changed else { return }


### PR DESCRIPTION
AI-assisted: yes
Testing: fully tested locally

## What & Why
Bug: From Remote mode, switching **Moltbot runs → Not configured** immediately snapped back to Remote.
Cause: `gateway.mode` was removed, but a stale `gateway.remote.url` remained. On reload, the app treated "mode unset + remote url present" as Remote.

## Fix
When `connectionMode == .unconfigured`, clear `gateway.remote.url` during config sync so the app does not implicitly re-select Remote mode.

## Test plan
- ./scripts/restart-mac.sh --no-sign
- cd apps/macos && swift build
- Verified the picker stays on **Not configured** after switching from Remote.

## Notes
- I understand this change clears `gateway.remote.url` when selecting "Not configured".

---
*Rebased from #2628 to resolve merge conflicts*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts macOS config sync to avoid the UI snapping back to Remote after selecting **Not configured**. In `AppState.syncGatewayConfigIfNeeded`, when `connectionMode == .unconfigured` it now clears the persisted `gateway.remote.url` key so that `applyConfigOverrides` won’t infer `.remote` on reload when `gateway.mode` is absent but a stale remote URL remains.

Change is localized to macOS app state/config persistence logic (`apps/macos/Sources/Moltbot/AppState.swift`) and aligns with existing behavior where `gateway.mode` is removed when unconfigured.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; it’s a small, targeted config-write change.
- The change is localized to the unconfigured branch of config syncing and only removes a single persisted key (`gateway.remote.url`) to prevent unintended mode inference. No API surface changes and minimal control-flow impact; main risk is whether other components relied on the URL being preserved while unconfigured.
- apps/macos/Sources/Moltbot/AppState.swift

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->