### PR TITLE
fix(config): write built-in channel enabled state to channels, not plugins.entries

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -11,21 +11,27 @@ describe("applyPluginAutoEnable", () => {
       env: {},
     });
 
-    expect(result.config.plugins?.entries?.slack?.enabled).toBe(true);
-    expect(result.config.plugins?.allow).toEqual(["telegram", "slack"]);
+    // Built-in channels (slack) are enabled via channels.<id>.enabled, not plugins.entries.
+    expect((result.config.channels as Record<string, unknown>)?.slack).toMatchObject({
+      enabled: true,
+    });
+    // Built-in channels don't need plugins.allow entry.
+    expect(result.config.plugins?.allow).toEqual(["telegram"]);
     expect(result.changes.join("\n")).toContain("Slack configured, not enabled yet.");
   });
 
   it("respects explicit disable", () => {
     const result = applyPluginAutoEnable({
       config: {
-        channels: { slack: { botToken: "x" } },
-        plugins: { entries: { slack: { enabled: false } } },
+        channels: { slack: { botToken: "x", enabled: false } },
       },
       env: {},
     });
 
-    expect(result.config.plugins?.entries?.slack?.enabled).toBe(false);
+    // Built-in channels check enabled in channels.<id>.enabled.
+    expect((result.config.channels as Record<string, unknown>)?.slack).toMatchObject({
+      enabled: false,
+    });
     expect(result.changes).toEqual([]);
   });
 
@@ -72,8 +78,12 @@ describe("applyPluginAutoEnable", () => {
         env: {},
       });
 
+      // bluebubbles is a plugin channel, so it goes to plugins.entries.
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBe(true);
-      expect(result.config.plugins?.entries?.imessage?.enabled).toBeUndefined();
+      // imessage is a built-in channel, but it's skipped due to preferOver.
+      expect((result.config.channels as Record<string, unknown>)?.imessage).not.toMatchObject({
+        enabled: true,
+      });
       expect(result.changes.join("\n")).toContain("bluebubbles configured, not enabled yet.");
       expect(result.changes.join("\n")).not.toContain("iMessage configured, not enabled yet.");
     });
@@ -83,15 +93,17 @@ describe("applyPluginAutoEnable", () => {
         config: {
           channels: {
             bluebubbles: { serverUrl: "http://localhost:1234", password: "x" },
-            imessage: { cliPath: "/usr/local/bin/imsg" },
+            imessage: { cliPath: "/usr/local/bin/imsg", enabled: true },
           },
-          plugins: { entries: { imessage: { enabled: true } } },
         },
         env: {},
       });
 
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBe(true);
-      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
+      // imessage was already enabled in channels, stays enabled.
+      expect((result.config.channels as Record<string, unknown>)?.imessage).toMatchObject({
+        enabled: true,
+      });
     });
 
     it("allows imessage auto-enable when bluebubbles is explicitly disabled", () => {
@@ -107,7 +119,10 @@ describe("applyPluginAutoEnable", () => {
       });
 
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBe(false);
-      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
+      // imessage is a built-in channel, so it goes to channels.imessage.enabled.
+      expect((result.config.channels as Record<string, unknown>)?.imessage).toMatchObject({
+        enabled: true,
+      });
       expect(result.changes.join("\n")).toContain("iMessage configured, not enabled yet.");
     });
 
@@ -124,7 +139,10 @@ describe("applyPluginAutoEnable", () => {
       });
 
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBeUndefined();
-      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
+      // imessage is a built-in channel, so it goes to channels.imessage.enabled.
+      expect((result.config.channels as Record<string, unknown>)?.imessage).toMatchObject({
+        enabled: true,
+      });
     });
 
     it("enables imessage normally when only imessage is configured", () => {
@@ -135,7 +153,10 @@ describe("applyPluginAutoEnable", () => {
         env: {},
       });
 
-      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
+      // imessage is a built-in channel, so it goes to channels.imessage.enabled.
+      expect((result.config.channels as Record<string, unknown>)?.imessage).toMatchObject({
+        enabled: true,
+      });
       expect(result.changes.join("\n")).toContain("iMessage configured, not enabled yet.");
     });
   });

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -305,6 +305,8 @@ function resolveConfiguredPlugins(
       if (key === "defaults") {
         continue;
       }
+      // Keep raw keys here - isChannelConfigured can detect config under alias keys.
+      // Normalization happens later in enablePluginEntry and check functions.
       channelIds.add(key);
     }
   }
@@ -331,31 +333,72 @@ function resolveConfiguredPlugins(
 }
 
 function isPluginExplicitlyDisabled(cfg: OpenClawConfig, pluginId: string): boolean {
-  // Built-in channels use channels.<id>.enabled, not plugins.entries.
-  const builtinChannelId = normalizeChatChannelId(pluginId);
-  if (builtinChannelId) {
-    const channels = cfg.channels as Record<string, unknown> | undefined;
-    const entry = channels?.[builtinChannelId];
-    return isRecord(entry) && entry.enabled === false;
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+
+  // Check the raw pluginId first (might be an alias like "imsg")
+  const rawEntry = channels?.[pluginId];
+  if (isRecord(rawEntry) && rawEntry.enabled === false) {
+    return true;
   }
-  const entry = cfg.plugins?.entries?.[pluginId];
-  return entry?.enabled === false;
+
+  // For built-in channels, also check the canonical ID if different
+  const builtinChannelId = normalizeChatChannelId(pluginId);
+  if (builtinChannelId && builtinChannelId !== pluginId) {
+    const canonicalEntry = channels?.[builtinChannelId];
+    if (isRecord(canonicalEntry) && canonicalEntry.enabled === false) {
+      return true;
+    }
+  }
+
+  // For non-builtin channels (plugins), check plugins.entries
+  if (!builtinChannelId) {
+    const entry = cfg.plugins?.entries?.[pluginId];
+    return entry?.enabled === false;
+  }
+
+  return false;
 }
 
 function isPluginAlreadyEnabled(cfg: OpenClawConfig, pluginId: string): boolean {
-  // Built-in channels use channels.<id>.enabled, not plugins.entries.
-  const builtinChannelId = normalizeChatChannelId(pluginId);
-  if (builtinChannelId) {
-    const channels = cfg.channels as Record<string, unknown> | undefined;
-    const entry = channels?.[builtinChannelId];
-    return isRecord(entry) && entry.enabled === true;
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+
+  // Check the raw pluginId first (might be an alias like "imsg")
+  const rawEntry = channels?.[pluginId];
+  if (isRecord(rawEntry) && rawEntry.enabled === true) {
+    return true;
   }
-  return cfg.plugins?.entries?.[pluginId]?.enabled === true;
+
+  // For built-in channels, also check the canonical ID if different
+  const builtinChannelId = normalizeChatChannelId(pluginId);
+  if (builtinChannelId && builtinChannelId !== pluginId) {
+    const canonicalEntry = channels?.[builtinChannelId];
+    if (isRecord(canonicalEntry) && canonicalEntry.enabled === true) {
+      return true;
+    }
+  }
+
+  // For non-builtin channels (plugins), check plugins.entries
+  if (!builtinChannelId) {
+    return cfg.plugins?.entries?.[pluginId]?.enabled === true;
+  }
+
+  return false;
 }
 
 function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
   const deny = cfg.plugins?.deny;
-  return Array.isArray(deny) && deny.includes(pluginId);
+  if (!Array.isArray(deny)) {
+    return false;
+  }
+  // Check both raw pluginId and canonical ID in deny list
+  if (deny.includes(pluginId)) {
+    return true;
+  }
+  const builtinChannelId = normalizeChatChannelId(pluginId);
+  if (builtinChannelId && builtinChannelId !== pluginId) {
+    return deny.includes(builtinChannelId);
+  }
+  return false;
 }
 
 function resolvePreferredOverIds(pluginId: string): string[] {
@@ -372,6 +415,9 @@ function shouldSkipPreferredPluginAutoEnable(
   entry: PluginEnableChange,
   configured: PluginEnableChange[],
 ): boolean {
+  // Use canonical ID for preferOver comparison since preferOver uses canonical IDs
+  const entryCanonicalId = normalizeChatChannelId(entry.pluginId) ?? entry.pluginId;
+
   for (const other of configured) {
     if (other.pluginId === entry.pluginId) {
       continue;
@@ -383,7 +429,7 @@ function shouldSkipPreferredPluginAutoEnable(
       continue;
     }
     const preferOver = resolvePreferredOverIds(other.pluginId);
-    if (preferOver.includes(entry.pluginId)) {
+    if (preferOver.includes(entryCanonicalId)) {
       return true;
     }
   }
@@ -449,7 +495,8 @@ function formatAutoEnableChange(entry: PluginEnableChange): string {
   const channelId = normalizeChatChannelId(entry.pluginId);
   if (channelId) {
     const label = getChatChannelMeta(channelId).label;
-    reason = reason.replace(new RegExp(`^${channelId}\\b`, "i"), label);
+    // Replace the original pluginId (might be an alias like "imsg") with the label
+    reason = reason.replace(new RegExp(`^${entry.pluginId}\\b`, "i"), label);
   }
   return `${reason}, not enabled yet.`;
 }


### PR DESCRIPTION
## Summary

- Built-in channels (telegram, slack, discord, etc.) are now auto-enabled via `channels.<channel>.enabled`
- Plugin channels continue to use `plugins.entries.<plugin>.enabled`
- Built-in channels no longer added to `plugins.allow`

## Problem

The gateway's auto-enable logic was writing built-in channel state to `plugins.entries.telegram`, which fails config validation because `telegram` is a built-in channel, not a plugin.

```
gateway: failed to persist plugin auto-enable changes: Error: Config validation failed: plugins.entries.telegram: plugin not found: telegram
```

This caused Telegram (and other built-in channels) to fail to start.

## Solution

Modified `enablePluginEntry()` to check if the channel is a built-in channel using `normalizeChatChannelId()`. If it is:
- Write enabled state to `channels.<id>.enabled`
- Skip adding to `plugins.allow`

If it's a plugin channel:
- Continue using `plugins.entries.<id>.enabled`
- Add to `plugins.allow` as before

## Test plan

- [x] Updated existing tests to reflect new behavior
- [x] All 9 plugin-auto-enable tests pass
- [x] Lint/type check pass

Fixes #3741

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes auto-enable persistence for built-in channels by writing their enabled state to `channels.<id>.enabled` instead of `plugins.entries.<id>.enabled`, while keeping plugin channels on `plugins.entries` and only allowlisting true plugins.

The change fits the config validation model: `plugins.entries.*` is validated against installed plugins, whereas built-in channel ids live under `channels.*` and should not appear as plugin entries or be added to `plugins.allow`.

Main concern: the new built-in-vs-plugin detection relies on `normalizeChatChannelId(pluginId)`, but `resolveConfiguredPlugins` currently injects raw keys from `cfg.channels` into the candidate set. If users configure built-in channels using alias keys like `imsg`/`gchat`/`google-chat`, later steps normalize to the canonical id and can (a) write `enabled: true` under a *different* key than the one configured and (b) fail to respect `enabled: false` set under the alias key, and (c) break `preferOver` comparisons due to raw-vs-canonical mismatch.

There’s also a minor test expectation that still checks the legacy `plugins.entries.slack.enabled` path in the "plugins globally disabled" test, which no longer directly reflects built-in channel enable state.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there is a real edge-case regression for built-in channel aliases that can produce incorrect config writes.
- Core fix (built-in enable state moved from plugins.entries to channels.* and skipping plugins.allow) matches validation behavior and is likely correct for canonical ids. However, auto-enable currently treats raw `channels` keys as ids, while enable/disable and preferOver logic uses normalized built-in ids; if aliases like `imsg`/`gchat` are used as config keys, this can create new canonical entries and bypass alias-level disables or preference checks. One test also still asserts the old plugins.entries location for a built-in channel in the global-disable scenario.
- src/config/plugin-auto-enable.ts; src/config/plugin-auto-enable.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->