### PR TITLE
fix(docker): use .moltbot state dir instead of legacy .clawdbot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,13 @@ services:
     environment:
       HOME: /home/node
       TERM: xterm-256color
+      MOLTBOT_STATE_DIR: /home/node/.moltbot
       CLAWDBOT_GATEWAY_TOKEN: ${CLAWDBOT_GATEWAY_TOKEN}
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${CLAWDBOT_CONFIG_DIR}:/home/node/.clawdbot
+      - ${CLAWDBOT_CONFIG_DIR}:/home/node/.moltbot
       - ${CLAWDBOT_WORKSPACE_DIR}:/home/node/clawd
     ports:
       - "${CLAWDBOT_GATEWAY_PORT:-18789}:18789"
@@ -33,11 +34,12 @@ services:
       HOME: /home/node
       TERM: xterm-256color
       BROWSER: echo
+      MOLTBOT_STATE_DIR: /home/node/.moltbot
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${CLAWDBOT_CONFIG_DIR}:/home/node/.clawdbot
+      - ${CLAWDBOT_CONFIG_DIR}:/home/node/.moltbot
       - ${CLAWDBOT_WORKSPACE_DIR}:/home/node/clawd
     stdin_open: true
     tty: true

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -21,10 +21,10 @@ if ! docker compose version >/dev/null 2>&1; then
   exit 1
 fi
 
-mkdir -p "${CLAWDBOT_CONFIG_DIR:-$HOME/.clawdbot}"
+mkdir -p "${CLAWDBOT_CONFIG_DIR:-$HOME/.moltbot}"
 mkdir -p "${CLAWDBOT_WORKSPACE_DIR:-$HOME/clawd}"
 
-export CLAWDBOT_CONFIG_DIR="${CLAWDBOT_CONFIG_DIR:-$HOME/.clawdbot}"
+export CLAWDBOT_CONFIG_DIR="${CLAWDBOT_CONFIG_DIR:-$HOME/.moltbot}"
 export CLAWDBOT_WORKSPACE_DIR="${CLAWDBOT_WORKSPACE_DIR:-$HOME/clawd}"
 export CLAWDBOT_GATEWAY_PORT="${CLAWDBOT_GATEWAY_PORT:-18789}"
 export CLAWDBOT_BRIDGE_PORT="${CLAWDBOT_BRIDGE_PORT:-18790}"
@@ -62,7 +62,7 @@ YAML
 
   if [[ -n "$home_volume" ]]; then
     printf '      - %s:/home/node\n' "$home_volume" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s:/home/node/.clawdbot\n' "$CLAWDBOT_CONFIG_DIR" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s:/home/node/.moltbot\n' "$CLAWDBOT_CONFIG_DIR" >>"$EXTRA_COMPOSE_FILE"
     printf '      - %s:/home/node/clawd\n' "$CLAWDBOT_WORKSPACE_DIR" >>"$EXTRA_COMPOSE_FILE"
   fi
 
@@ -77,7 +77,7 @@ YAML
 
   if [[ -n "$home_volume" ]]; then
     printf '      - %s:/home/node\n' "$home_volume" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s:/home/node/.clawdbot\n' "$CLAWDBOT_CONFIG_DIR" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s:/home/node/.moltbot\n' "$CLAWDBOT_CONFIG_DIR" >>"$EXTRA_COMPOSE_FILE"
     printf '      - %s:/home/node/clawd\n' "$CLAWDBOT_WORKSPACE_DIR" >>"$EXTRA_COMPOSE_FILE"
   fi
 


### PR DESCRIPTION
fixes: #3773 
 ## Summary                                                                                                                                                            
  - Mount config volume at `/home/node/.moltbot` instead of `/home/node/.clawdbot` in both gateway and CLI services                                                     
  - Set `MOLTBOT_STATE_DIR` env var so the app resolves to the mounted path                                                                                             
  - Update `docker-setup.sh` defaults and extra-compose paths to match                                                                                                  
                                                                                                                                                                        
  Fixes device pairing not persisting across container restarts — the app was ignoring the `.moltbot` mount and creating a new `.clawdbot` directory.                   
                                                                                                                                                                        
  **Note:** Container-internal path change only. Host-side volume (`$CLAWDBOT_CONFIG_DIR`) is unchanged — no migration needed for existing deployments.      