### PR TITLE
fix(agents): suppress exec/bash exit code errors from user display

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -171,10 +171,41 @@ describe("buildEmbeddedRunPayloads", () => {
       toolResultFormat: "plain",
     });
 
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.isError).toBe(true);
-    expect(payloads[0]?.text).toContain("Exec");
-    expect(payloads[0]?.text).toContain("code 1");
+    // Exec exit code errors are now suppressed as internal/recoverable errors
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("suppresses exec exit code errors (grep no matches, etc.)", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      sessionKey: "session:telegram",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+
+    // Exec/bash exit code errors should not be sent to the user
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("suppresses bash exit code errors", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      lastToolError: { toolName: "bash", error: "Command exited with code 127" },
+      sessionKey: "session:telegram",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+
+    expect(payloads).toHaveLength(0);
   });
 
   it("suppresses recoverable tool errors containing 'required'", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -204,7 +204,13 @@ export function buildEmbeddedRunPayloads(params: {
     // Check if this is a recoverable/internal tool error that shouldn't be shown to users
     // when there's already a user-facing reply (the model should have retried).
     const errorLower = (params.lastToolError.error ?? "").toLowerCase();
+    const toolNameLower = (params.lastToolError.toolName ?? "").toLowerCase();
+    const isExecTool = toolNameLower === "exec" || toolNameLower === "bash";
+    // Exec/bash non-zero exit codes are internal errors (e.g., grep no matches) that
+    // the model should handle, not surface to users.
+    const isExecExitCodeError = isExecTool && errorLower.includes("exited with code");
     const isRecoverableError =
+      isExecExitCodeError ||
       errorLower.includes("required") ||
       errorLower.includes("missing") ||
       errorLower.includes("invalid") ||


### PR DESCRIPTION
## Summary

- Exec/bash exit code errors are now suppressed from user display
- These errors are treated as internal/recoverable errors that the model should handle

## Problem

When using Telegram, exec tool errors like this were being sent to users:

```
⚠️ 🛠️ Exec: clawdbot status | grep -A5 "Runtime\|verbose\|elevated\|Think" failed: Command exited with code 1
```

Non-zero exit codes from commands like `grep` (no matches = exit 1) are normal workflow results, not failures that users need to see.

## Solution

Added `exec`/`bash` exit code errors to the `isRecoverableError` check in `buildEmbeddedRunPayloads()`. Now these errors:
- Stay in the model's context for internal handling
- Are not surfaced to users
- Allow the model to retry or continue appropriately

## Test plan

- [x] Updated existing test expectations
- [x] Added new tests for exec and bash exit code suppression
- [x] All 14 payloads tests pass
- [x] Lint/type check pass

Fixes #3765

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `buildEmbeddedRunPayloads()` to classify `exec`/`bash` “exited with code …” tool errors as recoverable, preventing those tool failures from being included in user-visible payloads. Tests were updated and expanded to cover suppression for `exec` and `bash` exit code error cases, aligning behavior with Telegram’s UX needs where non-zero exit codes (e.g., `grep` no matches) are normal.

The change fits into the existing payload-building logic that already suppresses certain internal/retryable tool errors (validation/missing params) so the model can handle retries without surfacing noisy tool failures to end users.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but current suppression may hide genuinely actionable exec/bash failures.
- The code change is small and covered by tests, but it broadens suppression to any exec/bash error containing “exited with code”, which can include real failures (e.g., bash 127) and may lead to users receiving no message when there’s no assistant output.
- src/agents/pi-embedded-runner/run/payloads.ts (recoverable error classification logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->