### PR TITLE
improve bash-tools.exec.ts code quality

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -76,11 +76,14 @@ const DEFAULT_APPROVAL_TIMEOUT_MS = 120_000;
 const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = 130_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
+const TIMEOUT_FINALIZE_MS = 1000;
+const PTY_DEFAULT_COLS = 120;
+const PTY_DEFAULT_ROWS = 30;
 
 type PtyExitEvent = { exitCode: number; signal?: number };
 type PtyListener<T> = (event: T) => void;
 type PtyHandle = {
-  pid: number;
+  readonly pid: number;
   write: (data: string | Buffer) => void;
   onData: (listener: PtyListener<string>) => void;
   onExit: (listener: PtyListener<PtyExitEvent>) => void;
@@ -405,14 +408,14 @@ async function runExecProcess(opts: {
       };
       const spawnPty = ptyModule.spawn ?? ptyModule.default?.spawn;
       if (!spawnPty) {
-        throw new Error("PTY support is unavailable (node-pty spawn not found).");
+        throw new Error("PTY support is unavailable. Please install @lydell/node-pty or run without pty=true.");
       }
       pty = spawnPty(shell, [...shellArgs, opts.command], {
         cwd: opts.workdir,
         env: opts.env,
         name: process.env.TERM ?? "xterm-256color",
-        cols: 120,
-        rows: 30,
+        cols: PTY_DEFAULT_COLS,
+        rows: PTY_DEFAULT_ROWS,
       });
       stdin = {
         destroyed: false,
@@ -524,7 +527,7 @@ async function runExecProcess(opts: {
   let timeoutTimer: NodeJS.Timeout | null = null;
   let timeoutFinalizeTimer: NodeJS.Timeout | null = null;
   let timedOut = false;
-  const timeoutFinalizeMs = 1000;
+  const timeoutFinalizeMs = TIMEOUT_FINALIZE_MS;
   let resolveFn: ((outcome: ExecProcessOutcome) => void) | null = null;
 
   const settle = (outcome: ExecProcessOutcome) => {
@@ -751,8 +754,8 @@ export function createExecTool(
         node?: string;
       };
 
-      if (!params.command) {
-        throw new Error("Provide a command to start.");
+      if (!params.command?.trim()) {
+        throw new Error("Command is required. Please provide a valid shell command to execute.");
       }
 
       const maxOutput = DEFAULT_MAX_OUTPUT;


### PR DESCRIPTION
- Better error messages and type safety
- Extract magic numbers to constants
- Stricter input validation

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refines the `exec` tool implementation in `src/agents/bash-tools.exec.ts` by extracting a few “magic numbers” into named constants (PTY default cols/rows and the timeout finalize window), tightening the `command` input validation to reject blank/whitespace-only commands, and slightly improving PTY-related error messaging. These changes are localized to the exec tool/process execution path and don’t affect other agents/tools.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is small and localized, and the changes are straightforward refactors (constants) plus stricter validation (`command?.trim()`) and an error-message tweak; no behavior changes beyond rejecting whitespace-only commands and using named constants for existing values.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->