### PR TITLE
fix(logging): use local timezone for console timestamps

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -7,6 +7,7 @@ import { readLoggingConfig } from "./config.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger, type LoggerSettings } from "./logger.js";
 import { loggingState } from "./state.js";
+import { formatLocalHHMMSS } from "./time.js";
 
 export type ConsoleStyle = "pretty" | "compact" | "json";
 type ConsoleSettings = {
@@ -136,11 +137,10 @@ function isEpipeError(err: unknown): boolean {
 }
 
 function formatConsoleTimestamp(style: ConsoleStyle): string {
-  const now = new Date().toISOString();
   if (style === "pretty") {
-    return now.slice(11, 19);
+    return formatLocalHHMMSS();
   }
-  return now;
+  return new Date().toISOString();
 }
 
 function hasTimestampPrefix(value: string): boolean {

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -8,6 +8,7 @@ import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger } from "./logger.js";
 import { loggingState } from "./state.js";
+import { formatLocalHHMMSS } from "./time.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
 
@@ -175,7 +176,7 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatLocalHHMMSS());
     }
     if (loggingState.consoleTimestampPrefix) {
       return color.gray(new Date().toISOString());

--- a/src/logging/time.ts
+++ b/src/logging/time.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats the current local time as HH:MM:SS.
+ * Respects the system TZ environment variable.
+ */
+export function formatLocalHHMMSS(): string {
+  const now = new Date();
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Summary
- Console log timestamps now respect the `TZ` environment variable
- Only affects `consoleStyle: "pretty"` output
- Compact, JSON, and file logs remain in UTC for tool compatibility

## Test plan
- [x] `npx vitest run src/logging/` - all 25 tests pass
- [x] Type-check passes
- [x] Lint passes
- [ ] Manual: `TZ=Asia/Tokyo npx moltbot gateway run` shows JST timestamps

Closes #3867

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates console timestamp formatting so that **pretty** console output uses local time (`HH:MM:SS`) rather than slicing `toISOString()` (UTC). It does this by introducing a small helper (`src/logging/time.ts`) and using it from both the console capture layer (`src/logging/console.ts`) and subsystem console formatting (`src/logging/subsystem.ts`). Compact/JSON/file logs continue to use `Date#toISOString()` for UTC/tooling compatibility.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, localized change to console pretty timestamp formatting.
- Changes are confined to console formatting and a new helper; no core logging routing changed. Main risk is subtle formatting inconsistencies around timestamp prefix detection when mixing pretty/local timestamps with the optional prefixing logic.
- src/logging/console.ts (timestamp prefix detection)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->