### PR TITLE
fix: drop assistant messages with stopReason 'error' to avoid orphaning tool results (#3860)

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,6 +116,15 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // If the assistant message has an error stop reason, it might be filtered out
+    // by the provider on subsequent requests (e.g. Anthropic content filtering).
+    // We drop it to avoid orphaning any tool results that would be added below.
+    if ((assistant as any).stopReason === "error") {
+      changed = true;
+      continue;
+    }
+
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);


### PR DESCRIPTION
This PR fixes issue #3860 where assistant messages with stopReason 'error' (e.g., from content filtering) would have synthetic tool results added by the transcript repair logic. These tool results would then become orphaned if the provider filtered out the errored assistant message on subsequent requests, leading to 400 errors.

The fix ensures that assistant messages with an error stop reason are dropped during transcript repair, preventing the addition of synthetic tool results for them.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `repairToolUseResultPairing` to drop assistant messages whose `stopReason` is `"error"`, preventing transcript-repair from inserting synthetic tool results that could later become orphaned if a provider filters the errored assistant turn (the #3860 scenario). The change fits into the existing transcript sanitizer’s responsibilities: keeping tool calls/results strictly adjacent and removing free-floating toolResult entries so strict providers don’t reject requests.

Main follow-ups: avoid the new `as any` access for `stopReason` and add a regression test covering an errored assistant toolCall turn to ensure the fix stays in place.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real provider-compatibility failure mode.
- The change is small and localized to transcript repair logic. Main concerns are maintainability (new `as any`) and missing regression coverage for the new behavior, rather than functional correctness of the fix itself.
- src/agents/session-transcript-repair.ts (type-safety + add targeted test coverage)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->