### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -14,7 +14,7 @@ jobs:
   auto-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: "2729701"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,7 @@ jobs:
           accept-android-sdk-licenses: false
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           gradle-version: 8.11.1
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: "2729701"


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/create-github-app-token` | [`v1`](https://github.com/actions/create-github-app-token/releases/tag/v1) | [`v2`](https://github.com/actions/create-github-app-token/releases/tag/v2) | [Release](https://github.com/actions/create-github-app-token/releases/tag/v2) | auto-response.yml, labeler.yml |
| `gradle/actions/setup-gradle` | [`v4`](https://github.com/gradle/actions/setup-gradle/releases/tag/v4) | [`v5`](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | [Release](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | ci.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates GitHub Actions versions in the repository’s workflows: `actions/create-github-app-token` is bumped from `v1` to `v2` in the `auto-response` and `labeler` workflows, and `gradle/actions/setup-gradle` is bumped from `v4` to `v5` in the Android portion of the main CI workflow. These changes are confined to `.github/workflows/*` and primarily affect how the workflows authenticate and set up Gradle during CI runs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are limited to GitHub Actions version bumps, with one security hardening mismatch to double-check.
- The diffs are small and localized to workflow `uses:` lines. The main risk is behavioral changes in major-version upgrades (notably `create-github-app-token@v2`) and the PR’s stated intent to pin actions to SHAs not being reflected in the actual workflow changes, which could affect supply-chain hardening expectations.
- .github/workflows/auto-response.yml, .github/workflows/labeler.yml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->