### PR TITLE
Add onCompactionStart callback to handle context compaction notifications (#2730)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -367,6 +367,7 @@ export async function runEmbeddedPiAgent(
                 log.warn(
                   `context overflow detected; attempting auto-compaction for ${provider}/${modelId}`,
                 );
+                await params.onCompactionStart?.();
                 overflowCompactionAttempted = true;
                 const compactResult = await compactEmbeddedPiSessionDirect({
                   sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -86,6 +86,7 @@ export type RunEmbeddedPiAgentParams = {
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
+  onCompactionStart?: () => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -276,6 +276,13 @@ export async function runAgentTurnWithFallback(params: {
             abortSignal: params.opts?.abortSignal,
             blockReplyBreak: params.resolvedBlockStreamingBreak,
             blockReplyChunking: params.blockReplyChunking,
+            onCompactionStart: async () => {
+              if (params.opts?.onPartialReply) {
+                await params.opts.onPartialReply({
+                  text: "🧹 Compacting context, please wait...",
+                });
+              }
+            },
             onPartialReply: allowPartialStream
               ? async (payload) => {
                   const textForTyping = await handlePartialForTyping(payload);


### PR DESCRIPTION
This pull request introduces a new callback to notify when context compaction starts during an embedded Pi agent run, and integrates this notification into the agent execution flow. The changes improve the user experience by providing real-time feedback when the system is compacting context to handle overflows.

**Callback and notification enhancements:**

* Added an optional `onCompactionStart` callback to the `RunEmbeddedPiAgentParams` type, allowing consumers to react when compaction begins.
* Invoked the `onCompactionStart` callback in `runEmbeddedPiAgent` when a context overflow triggers auto-compaction.
* Implemented a handler for `onCompactionStart` in `runAgentTurnWithFallback` to send a partial reply ("🧹 Compacting context, please wait...") to the user, improving transparency during compaction events.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a new `onCompactionStart` callback through the embedded Pi agent runner so callers can react when an automatic context compaction begins (triggered on context overflow). It wires the callback into `runEmbeddedPiAgent` right before `compactEmbeddedPiSessionDirect`, and integrates it in `runAgentTurnWithFallback` by emitting a user-visible partial message indicating compaction is happening.

Overall the change is small and fits the existing streaming/notification hooks pattern in the agent execution flow, but the new partial reply should be gated to avoid sending intermediate messages to external messaging channels that only support final replies.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new compaction notification may violate channel delivery constraints if it reaches external messaging surfaces.
- Changes are localized and type-safe (optional callback plumbing), but `onCompactionStart` currently uses `opts.onPartialReply` without checking the message surface/channel, which can introduce user-visible behavior changes on providers where partial streaming is disallowed.
- src/auto-reply/reply/agent-runner-execution.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->