### PR TITLE
fix(runner): use configured primary model as fallback default

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -92,8 +92,22 @@ export async function runEmbeddedPiAgent(
       const resolvedWorkspace = resolveUserPath(params.workspaceDir);
       const prevCwd = process.cwd();
 
-      const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+      // Check config for defaults first
+      let targetProvider = params.provider;
+      let targetModel = params.model;
+
+      if (!targetProvider && !targetModel && params.config?.agents?.defaults?.model?.primary) {
+         // Resolve primary model from config (e.g. "google-gemini-cli/gemini-3-pro-preview")
+         const primary = params.config.agents.defaults.model.primary;
+         const parts = primary.split('/');
+         if (parts.length === 2) {
+             targetProvider = parts[0];
+             targetModel = parts[1];
+         }
+      }
+
+      const provider = (targetProvider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+      const modelId = (targetModel ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveMoltbotAgentDir();
       const fallbackConfigured =
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -97,13 +97,13 @@ export async function runEmbeddedPiAgent(
       let targetModel = params.model;
 
       if (!targetProvider && !targetModel && params.config?.agents?.defaults?.model?.primary) {
-         // Resolve primary model from config (e.g. "google-gemini-cli/gemini-3-pro-preview")
-         const primary = params.config.agents.defaults.model.primary;
-         const parts = primary.split('/');
-         if (parts.length === 2) {
-             targetProvider = parts[0];
-             targetModel = parts[1];
-         }
+        // Resolve primary model from config (e.g. "google-gemini-cli/gemini-3-pro-preview")
+        const primary = params.config.agents.defaults.model.primary;
+        const parts = primary.split("/");
+        if (parts.length === 2) {
+          targetProvider = parts[0];
+          targetModel = parts[1];
+        }
       }
 
       const provider = (targetProvider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;


### PR DESCRIPTION
I am using google-gemini model as my primary model, but whenever I click new session, it throws `Error: No API key found for provider "anthropic"`

## Problem
Internal tools (like llm-slug-generator) calls `runEmbeddedPiAgent` without specifying a model. The runner was hardcoded to fall back to anthropic/claude-opus-4-5. If the I have no Anthropic key, it crashes.

## Solution
Modified `src/agents/pi-embedded-runner/run.ts` to check `params.config.agents.defaults.model.primary` before reverting to hardcoded defaults.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the embedded Pi runner’s model selection so that when `runEmbeddedPiAgent` is called without an explicit provider/model, it can derive defaults from `params.config.agents.defaults.model.primary` before falling back to the hardcoded defaults. This avoids crashes for users who don’t have an Anthropic API key configured but have set another provider as their primary model.

Change is localized to `src/agents/pi-embedded-runner/run.ts` where `provider`/`modelId` are now computed from either `params.provider`/`params.model`, the configured primary model, or the existing `DEFAULT_PROVIDER`/`DEFAULT_MODEL` constants. The rest of the runner (model resolution, auth profile selection, failover) remains unchanged.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the config parsing can miss valid `primary` formats and still fall back to Anthropic in some cases.
- The change is small and localized, but it introduces a new parsing branch that depends on the exact formatting of `agents.defaults.model.primary`. Because it only handles exactly `provider/model`, some real-world config values may not be recognized, undermining the fix and causing the same runtime error for users without Anthropic keys.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->