### PR TITLE
fix(sandbox): use absolute /bin/sh path + add allowedReadPaths config

### DIFF
--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -62,6 +62,7 @@ export type ApplyPatchToolDetails = {
 type ApplyPatchOptions = {
   cwd: string;
   sandboxRoot?: string;
+  allowedReadPaths?: string[];
   signal?: AbortSignal;
 };
 
@@ -72,11 +73,12 @@ const applyPatchSchema = Type.Object({
 });
 
 export function createApplyPatchTool(
-  options: { cwd?: string; sandboxRoot?: string } = {},
+  options: { cwd?: string; sandboxRoot?: string; allowedReadPaths?: string[] } = {},
   // oxlint-disable-next-line typescript/no-explicit-any
 ): AgentTool<any, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandboxRoot = options.sandboxRoot;
+  const allowedReadPaths = options.allowedReadPaths;
 
   return {
     name: "apply_patch",
@@ -99,6 +101,7 @@ export function createApplyPatchTool(
       const result = await applyPatch(input, {
         cwd,
         sandboxRoot,
+        allowedReadPaths,
         signal,
       });
 
@@ -221,6 +224,7 @@ async function resolvePatchPath(
       filePath,
       cwd: options.cwd,
       root: options.sandboxRoot,
+      allowedPaths: options.allowedReadPaths,
     });
     return {
       resolved: resolved.resolved,

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -77,7 +77,8 @@ export function buildDockerExecArgs(params: {
   const pathExport = hasCustomPath
     ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
     : "";
-  args.push(params.containerName, "sh", "-lc", `${pathExport}${params.command}`);
+  // Use absolute path /bin/sh to avoid OCI runtime PATH resolution issues in nix containers
+  args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
   return args;
 }
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -407,7 +407,7 @@ describe("buildDockerExecArgs", () => {
       tty: false,
     });
 
-    expect(args).toContain("sh");
+    expect(args).toContain("/bin/sh");
     expect(args).toContain("-lc");
   });
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -37,6 +37,8 @@ export function createOpenClawTools(options?: {
   agentGroupSpace?: string | null;
   agentDir?: string;
   sandboxRoot?: string;
+  /** Allowed read paths for sandbox path validation. */
+  allowedReadPaths?: string[];
   workspaceDir?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
@@ -63,6 +65,7 @@ export function createOpenClawTools(options?: {
         config: options?.config,
         agentDir: options.agentDir,
         sandboxRoot: options?.sandboxRoot,
+        allowedReadPaths: options?.allowedReadPaths,
         modelHasVision: options?.modelHasVision,
       })
     : null;

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { resolveSandboxPath, assertSandboxPath } from "./sandbox-paths.js";
+import path from "node:path";
+
+describe("resolveSandboxPath", () => {
+  const root = "/workspace";
+  const cwd = "/workspace";
+
+  it("allows paths within root", () => {
+    const result = resolveSandboxPath({
+      filePath: "subdir/file.txt",
+      cwd,
+      root,
+    });
+    expect(result.resolved).toBe("/workspace/subdir/file.txt");
+    expect(result.relative).toBe("subdir/file.txt");
+    expect(result.base).toBe("/workspace");
+  });
+
+  it("rejects paths escaping root without allowedPaths", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "/other/path/file.txt",
+        cwd,
+        root,
+      }),
+    ).toThrow(/escapes sandbox root/);
+  });
+
+  it("allows paths in allowedPaths when they escape root", () => {
+    // /external/skills is outside /workspace, but allowed via allowedPaths
+    const result = resolveSandboxPath({
+      filePath: "/external/skills/tameson/SKILL.md",
+      cwd,
+      root,
+      allowedPaths: ["/external/skills"],
+    });
+    expect(result.resolved).toBe("/external/skills/tameson/SKILL.md");
+    expect(result.relative).toBe("tameson/SKILL.md");
+    expect(result.base).toBe("/external/skills");
+  });
+
+  it("still rejects paths not in root or allowedPaths", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "/etc/passwd",
+        cwd,
+        root,
+        allowedPaths: ["/external/skills"],
+      }),
+    ).toThrow(/escapes sandbox root/);
+  });
+
+  it("allows exact match of allowedPath", () => {
+    const result = resolveSandboxPath({
+      filePath: "/external/skills",
+      cwd,
+      root,
+      allowedPaths: ["/external/skills"],
+    });
+    expect(result.resolved).toBe("/external/skills");
+    expect(result.relative).toBe("");
+    expect(result.base).toBe("/external/skills");
+  });
+
+  it("prefers root over allowedPaths for paths inside root", () => {
+    // Path is inside root - should use root as base, not allowedPaths
+    const result = resolveSandboxPath({
+      filePath: "/workspace/file.txt",
+      cwd,
+      root,
+      allowedPaths: ["/workspace"], // redundant, but shouldn't matter
+    });
+    expect(result.base).toBe("/workspace");
+    expect(result.relative).toBe("file.txt");
+  });
+
+  it("handles multiple allowedPaths", () => {
+    const result = resolveSandboxPath({
+      filePath: "/data/files/test.txt",
+      cwd,
+      root,
+      allowedPaths: ["/external/skills", "/data/files"],
+    });
+    expect(result.resolved).toBe("/data/files/test.txt");
+    expect(result.relative).toBe("test.txt");
+    expect(result.base).toBe("/data/files");
+  });
+});

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSandboxPath, assertSandboxPath } from "./sandbox-paths.js";
-import path from "node:path";
+import { resolveSandboxPath } from "./sandbox-paths.js";
 
 describe("resolveSandboxPath", () => {
   const root = "/workspace";

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -30,25 +30,53 @@ function resolveToCwd(filePath: string, cwd: string): string {
   return path.resolve(cwd, expanded);
 }
 
-export function resolveSandboxPath(params: { filePath: string; cwd: string; root: string }): {
+export function resolveSandboxPath(params: {
+  filePath: string;
+  cwd: string;
+  root: string;
+  allowedPaths?: string[];
+}): {
   resolved: string;
   relative: string;
+  base: string;
 } {
   const resolved = resolveToCwd(params.filePath, params.cwd);
   const rootResolved = path.resolve(params.root);
   const relative = path.relative(rootResolved, resolved);
+
+  // Check if path is within the main root
   if (!relative || relative === "") {
-    return { resolved, relative: "" };
+    return { resolved, relative: "", base: rootResolved };
   }
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
+  if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return { resolved, relative, base: rootResolved };
   }
-  return { resolved, relative };
+
+  // Path escapes main root - check allowedPaths
+  if (params.allowedPaths?.length) {
+    for (const allowedPath of params.allowedPaths) {
+      const allowedResolved = path.resolve(allowedPath);
+      const relativeToAllowed = path.relative(allowedResolved, resolved);
+      if (
+        relativeToAllowed === "" ||
+        (!relativeToAllowed.startsWith("..") && !path.isAbsolute(relativeToAllowed))
+      ) {
+        return { resolved, relative: relativeToAllowed, base: allowedResolved };
+      }
+    }
+  }
+
+  throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
 }
 
-export async function assertSandboxPath(params: { filePath: string; cwd: string; root: string }) {
+export async function assertSandboxPath(params: {
+  filePath: string;
+  cwd: string;
+  root: string;
+  allowedPaths?: string[];
+}) {
   const resolved = resolveSandboxPath(params);
-  await assertNoSymlink(resolved.relative, path.resolve(params.root));
+  await assertNoSymlink(resolved.relative, resolved.base);
   return resolved;
 }
 

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -3,6 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// Use POSIX paths for sandbox path resolution since sandboxes are always Linux containers
+const posix = path.posix;
+
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const HTTP_URL_RE = /^https?:\/\//i;
 const DATA_URL_RE = /^data:/i;
@@ -24,10 +27,10 @@ function expandPath(filePath: string): string {
 
 function resolveToCwd(filePath: string, cwd: string): string {
   const expanded = expandPath(filePath);
-  if (path.isAbsolute(expanded)) {
+  if (posix.isAbsolute(expanded)) {
     return expanded;
   }
-  return path.resolve(cwd, expanded);
+  return posix.resolve(cwd, expanded);
 }
 
 export function resolveSandboxPath(params: {
@@ -41,25 +44,25 @@ export function resolveSandboxPath(params: {
   base: string;
 } {
   const resolved = resolveToCwd(params.filePath, params.cwd);
-  const rootResolved = path.resolve(params.root);
-  const relative = path.relative(rootResolved, resolved);
+  const rootResolved = posix.resolve(params.root);
+  const relative = posix.relative(rootResolved, resolved);
 
   // Check if path is within the main root
   if (!relative || relative === "") {
     return { resolved, relative: "", base: rootResolved };
   }
-  if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+  if (!relative.startsWith("..") && !posix.isAbsolute(relative)) {
     return { resolved, relative, base: rootResolved };
   }
 
   // Path escapes main root - check allowedPaths
   if (params.allowedPaths?.length) {
     for (const allowedPath of params.allowedPaths) {
-      const allowedResolved = path.resolve(allowedPath);
-      const relativeToAllowed = path.relative(allowedResolved, resolved);
+      const allowedResolved = posix.resolve(allowedPath);
+      const relativeToAllowed = posix.relative(allowedResolved, resolved);
       if (
         relativeToAllowed === "" ||
-        (!relativeToAllowed.startsWith("..") && !path.isAbsolute(relativeToAllowed))
+        (!relativeToAllowed.startsWith("..") && !posix.isAbsolute(relativeToAllowed))
       ) {
         return { resolved, relative: relativeToAllowed, base: allowedResolved };
       }
@@ -118,9 +121,11 @@ async function assertNoSymlink(relative: string, root: string) {
   if (!relative) {
     return;
   }
-  const parts = relative.split(path.sep).filter(Boolean);
+  // relative is a POSIX path from the sandbox, split by forward slash
+  const parts = relative.split(posix.sep).filter(Boolean);
   let current = root;
   for (const part of parts) {
+    // Use native path.join for host filesystem access
     current = path.join(current, part);
     try {
       const stat = await fs.lstat(current);

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -53,6 +53,10 @@ export function resolveSandboxDockerConfig(params: {
     : globalDocker?.ulimits;
 
   const binds = [...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
+  const allowedReadPaths = [
+    ...(globalDocker?.allowedReadPaths ?? []),
+    ...(agentDocker?.allowedReadPaths ?? []),
+  ];
 
   return {
     image: agentDocker?.image ?? globalDocker?.image ?? DEFAULT_SANDBOX_IMAGE,
@@ -78,6 +82,7 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    allowedReadPaths: allowedReadPaths.length ? allowedReadPaths : undefined,
   };
 }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -240,7 +240,8 @@ async function createSandboxContainer(params: {
   await execDocker(["start", name]);
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "sh", "-lc", cfg.setupCommand]);
+    // Use absolute path /bin/sh to avoid OCI runtime PATH resolution issues in nix containers
+    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
   }
 }
 

--- a/src/agents/sandbox/types.docker.ts
+++ b/src/agents/sandbox/types.docker.ts
@@ -19,4 +19,10 @@ export type SandboxDockerConfig = {
   dns?: string[];
   extraHosts?: string[];
   binds?: string[];
+  /**
+   * Additional paths (inside the container) that are allowed for read operations.
+   * Useful for bind-mounted paths outside the workspace root.
+   * Example: ["/workspace/.skills"] to allow reading from bind-mounted skills.
+   */
+  allowedReadPaths?: string[];
 };

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -181,6 +181,7 @@ function buildImageContext(prompt: string, base64: string, mimeType: string): Co
 async function resolveSandboxedImagePath(params: {
   sandboxRoot: string;
   imagePath: string;
+  allowedReadPaths?: string[];
 }): Promise<{ resolved: string; rewrittenFrom?: string }> {
   const normalize = (p: string) => (p.startsWith("file://") ? p.slice("file://".length) : p);
   const filePath = normalize(params.imagePath);
@@ -189,6 +190,7 @@ async function resolveSandboxedImagePath(params: {
       filePath,
       cwd: params.sandboxRoot,
       root: params.sandboxRoot,
+      allowedPaths: params.allowedReadPaths,
     });
     return { resolved: out.resolved };
   } catch (err) {
@@ -204,6 +206,7 @@ async function resolveSandboxedImagePath(params: {
       filePath: candidateRel,
       cwd: params.sandboxRoot,
       root: params.sandboxRoot,
+      allowedPaths: params.allowedReadPaths,
     });
     return { resolved: out.resolved, rewrittenFrom: filePath };
   }
@@ -300,6 +303,7 @@ export function createImageTool(options?: {
   config?: OpenClawConfig;
   agentDir?: string;
   sandboxRoot?: string;
+  allowedReadPaths?: string[];
   /** If true, the model has native vision capability and images in the prompt are auto-injected */
   modelHasVision?: boolean;
 }): AnyAgentTool | null {
@@ -399,6 +403,7 @@ export function createImageTool(options?: {
           ? await resolveSandboxedImagePath({
               sandboxRoot,
               imagePath: resolvedImage,
+              allowedReadPaths: options?.allowedReadPaths,
             })
           : {
               resolved: resolvedImage.startsWith("file://")


### PR DESCRIPTION
## Context / Why this PR

We hit two sandbox pain points in production usage:

### 1) Intermittent sandbox exec failures ("sh not found")

**Observed error** (Docker/runc):
```
OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH
```

This happened in a long-running nix2container-based sandbox container (no restarts), and then worked fine when retried later — a classic intermittent failure.

**Root cause:** Our sandbox exec code used the bare executable `"sh"` when calling `docker exec`. That requires the OCI runtime to resolve `sh` via PATH. In nix2container images, PATH/executable resolution can be brittle (symlinked shells, minimal roots, etc.) and we saw runc fail resolution intermittently.

**Why this fix:** Use an **absolute** shell path (`/bin/sh`) so the runtime does not need to search PATH at all. `/bin/sh` is present in our sandbox images (symlinked to bash). This is a minimal, robust fix that matches how most container tooling avoids PATH lookup for critical entrypoints.

### 2) Read tool cannot access bind-mounted paths outside workspace root

We bind-mount extra paths into the sandbox (e.g. shared skills directories) but the host-side path validation blocks reads if the requested path is outside the configured workspace root. This forces workarounds like copying bind-mounted content into the workspace, which is slow and error-prone.

**Why this fix:** Introduce an explicit allowlist `allowedReadPaths` so we can safely permit reads from specific additional directories (typically bind mounts) without weakening the sandbox boundary.

---

## What this PR changes

### Fix: use `/bin/sh` for sandbox docker exec
- `src/agents/bash-tools.shared.ts`: `docker exec … sh -lc …` → `docker exec … /bin/sh -lc …`
- `src/agents/sandbox/docker.ts`: same fix for `setupCommand`

### Feature: `allowedReadPaths` for bind mount access
- `src/agents/sandbox/types.docker.ts`: add `allowedReadPaths?: string[]`
- `src/agents/sandbox/config.ts`: merge arrays from global + agent config (same as `binds`)
- `src/agents/sandbox-paths.ts`:
  - `resolveSandboxPath` now accepts `allowedPaths?: string[]`
  - Path is valid if within workspace root **OR** any allowed path
  - Returns `{ base }` so symlink checks apply correctly to the matched subtree
- New tests: `src/agents/sandbox-paths.test.ts`

---

## Example config

```json
{
  "sandbox": {
    "docker": {
      "binds": ["/host/path/skills:/workspace/.skills:ro"],
      "allowedReadPaths": ["/workspace/.skills"]
    }
  }
}
```

---

## Design Note: Why separate `allowedReadPaths` instead of auto-deriving from `binds`?

We intentionally keep these as separate config options:

- **`binds`** = "what is available inside the container" (container-side visibility)
- **`allowedReadPaths`** = "what host-side path validation should permit" (host-side security gate)

Auto-deriving allowed paths from bind mounts would be convenient but risky: someone might mount a path for container-internal use (e.g. a cache directory) without intending to expose it to host-side read validation. Keeping them separate ensures explicit opt-in for each security boundary.

---

## Testing

✅ 27 related tests pass:
- `src/agents/sandbox-paths.test.ts` — new coverage for allowedPaths (7 tests)
- `src/agents/bash-tools.test.ts` — updated expectation for /bin/sh
- `src/agents/sandbox/tool-policy.test.ts`

---

## Safety

- `allowedReadPaths` is explicit opt-in — does not broaden access arbitrarily
- Symlink protection still enforced within allowed paths
- `/bin/sh` is conservative — avoids PATH resolution entirely

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens sandbox command execution by switching `docker exec … sh -lc` to `docker exec … /bin/sh -lc` (avoids OCI PATH resolution issues), and introduces an `allowedReadPaths` concept intended to permit read access to specific bind-mounted directories outside the workspace root. It also updates `resolveSandboxPath`/`assertSandboxPath` to support allowlisted bases and adds unit tests for the new path resolution behavior.

Main concerns are around integration: `allowedReadPaths` is currently only added to config/types and `sandbox-paths.ts`, but the sandboxed tool wrappers that enforce path access (`assertSandboxPath`) don’t pass these allowed paths yet, so the feature may not work as intended. There’s also a scope-merging inconsistency where per-agent `allowedReadPaths` can leak into `shared` scope despite other docker overrides being ignored.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but the new allowlist feature appears partially integrated and may not work as intended (and may subtly affect shared-scope behavior).
- The /bin/sh change is straightforward and well-scoped. However, `allowedReadPaths` is not yet propagated to the main path-guard call sites that enforce sandbox file access, so the advertised functionality likely won’t take effect. Additionally, config merging includes per-agent allowed paths under shared scope, which is inconsistent with other shared-scope rules and could broaden access unexpectedly.
- src/agents/pi-tools.read.ts, src/agents/sandbox/config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->