### PR TITLE
fix(auth): refresh all OAuth profiles per provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Docker: use container port for gateway command instead of host port. (#5110) Thanks @mise42.
 - Docker: start gateway CMD by default for container deployments. (#6635) Thanks @kaizen403.
 - fix(lobster): block arbitrary exec via lobsterPath/cwd injection (GHSA-4mhr-g7xj-cg8j). (#5335) Thanks @vignesh07.
+- OAuth: fix refresh only refreshing one profile per provider, leaving other accounts expired. (#3803) Thanks @Daviey.
 - Security: sanitize WhatsApp accountId to prevent path traversal. (#4610)
 - Security: restrict MEDIA path extraction to prevent LFI. (#4930)
 - Security: validate message-tool filePath/path against sandbox root. (#6398)

--- a/src/agents/auth-profiles/oauth-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock pi-ai's getOAuthApiKey
+const mockGetOAuthApiKey = vi.fn();
+vi.mock("@mariozechner/pi-ai", () => ({
+  getOAuthApiKey: mockGetOAuthApiKey,
+}));
+
+describe("OAuth refresh for Google providers", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "moltbot-oauth-test-"));
+    vi.resetModules();
+    mockGetOAuthApiKey.mockReset();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("refreshes google-gemini-cli tokens via pi-ai when expired", async () => {
+    // Setup: expired google-gemini-cli credentials
+    const now = Date.now();
+    const expiredCreds = {
+      type: "oauth" as const,
+      provider: "google-gemini-cli",
+      access: "old-access-token",
+      refresh: "valid-refresh-token",
+      expires: now - 1000, // expired
+      email: "user@gmail.com",
+      projectId: "test-project-123",
+    };
+
+    // Mock successful refresh
+    mockGetOAuthApiKey.mockResolvedValue({
+      apiKey: JSON.stringify({
+        token: "new-access-token",
+        projectId: "test-project-123",
+      }),
+      newCredentials: {
+        access: "new-access-token",
+        refresh: "new-refresh-token",
+        expires: now + 3600_000,
+        projectId: "test-project-123",
+      },
+    });
+
+    const { ensureAuthProfileStore, saveAuthProfileStore } = await import("./store.js");
+    const { resolveApiKeyForProfile } = await import("./oauth.js");
+
+    // Create auth store with expired credentials
+    const store = ensureAuthProfileStore(tempDir);
+    store.profiles["google-gemini-cli:user@gmail.com"] = expiredCreds;
+    saveAuthProfileStore(store, tempDir);
+
+    // Attempt to resolve API key (should trigger refresh)
+    const result = await resolveApiKeyForProfile({
+      store,
+      profileId: "google-gemini-cli:user@gmail.com",
+      agentDir: tempDir,
+    });
+
+    expect(result).toBeTruthy();
+    expect(mockGetOAuthApiKey).toHaveBeenCalledWith("google-gemini-cli", {
+      "google-gemini-cli": expect.objectContaining({
+        refresh: "valid-refresh-token",
+        projectId: "test-project-123",
+      }),
+    });
+
+    // Verify credentials were updated in store
+    const updatedStore = ensureAuthProfileStore(tempDir);
+    const updatedCred = updatedStore.profiles["google-gemini-cli:user@gmail.com"];
+    expect(updatedCred).toMatchObject({
+      type: "oauth",
+      access: "new-access-token",
+      refresh: "new-refresh-token",
+    });
+    expect(updatedCred.expires).toBeGreaterThan(now);
+  });
+
+  it("refreshes google-antigravity tokens via pi-ai when expired", async () => {
+    const now = Date.now();
+    const expiredCreds = {
+      type: "oauth" as const,
+      provider: "google-antigravity",
+      access: "old-access-token",
+      refresh: "valid-refresh-token",
+      expires: now - 1000,
+      email: "user@gmail.com",
+      projectId: "antigravity-project",
+    };
+
+    mockGetOAuthApiKey.mockResolvedValue({
+      apiKey: JSON.stringify({
+        token: "new-access-token",
+        projectId: "antigravity-project",
+      }),
+      newCredentials: {
+        access: "new-access-token",
+        refresh: "new-refresh-token",
+        expires: now + 3600_000,
+        projectId: "antigravity-project",
+      },
+    });
+
+    const { ensureAuthProfileStore, saveAuthProfileStore } = await import("./store.js");
+    const { resolveApiKeyForProfile } = await import("./oauth.js");
+
+    const store = ensureAuthProfileStore(tempDir);
+    store.profiles["google-antigravity:user@gmail.com"] = expiredCreds;
+    saveAuthProfileStore(store, tempDir);
+
+    const result = await resolveApiKeyForProfile({
+      store,
+      profileId: "google-antigravity:user@gmail.com",
+      agentDir: tempDir,
+    });
+
+    expect(result).toBeTruthy();
+    expect(mockGetOAuthApiKey).toHaveBeenCalledWith("google-antigravity", {
+      "google-antigravity": expect.objectContaining({
+        refresh: "valid-refresh-token",
+        projectId: "antigravity-project",
+      }),
+    });
+  });
+
+  it("handles refresh failure and throws meaningful error", async () => {
+    const now = Date.now();
+    const expiredCreds = {
+      type: "oauth" as const,
+      provider: "google-gemini-cli",
+      access: "old-access-token",
+      refresh: "invalid-refresh-token",
+      expires: now - 1000,
+      email: "user@gmail.com",
+      projectId: "test-project",
+    };
+
+    // Mock refresh failure
+    mockGetOAuthApiKey.mockRejectedValue(new Error("Invalid refresh token"));
+
+    const { ensureAuthProfileStore, saveAuthProfileStore } = await import("./store.js");
+    const { resolveApiKeyForProfile } = await import("./oauth.js");
+
+    const store = ensureAuthProfileStore(tempDir);
+    store.profiles["google-gemini-cli:user@gmail.com"] = expiredCreds;
+    saveAuthProfileStore(store, tempDir);
+
+    await expect(
+      resolveApiKeyForProfile({
+        store,
+        profileId: "google-gemini-cli:user@gmail.com",
+        agentDir: tempDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for google-gemini-cli/);
+  });
+
+  it("works with multiple accounts independently", async () => {
+    const now = Date.now();
+
+    // Setup: Two expired accounts
+    const account1 = {
+      type: "oauth" as const,
+      provider: "google-gemini-cli",
+      access: "old-access-1",
+      refresh: "refresh-1",
+      expires: now - 1000,
+      email: "user1@gmail.com",
+      projectId: "project-1",
+    };
+
+    const account2 = {
+      type: "oauth" as const,
+      provider: "google-gemini-cli",
+      access: "old-access-2",
+      refresh: "refresh-2",
+      expires: now - 1000,
+      email: "user2@gmail.com",
+      projectId: "project-2",
+    };
+
+    // Mock refresh for each account
+    mockGetOAuthApiKey
+      .mockResolvedValueOnce({
+        apiKey: JSON.stringify({ token: "new-access-1", projectId: "project-1" }),
+        newCredentials: {
+          access: "new-access-1",
+          refresh: "new-refresh-1",
+          expires: now + 3600_000,
+          projectId: "project-1",
+        },
+      })
+      .mockResolvedValueOnce({
+        apiKey: JSON.stringify({ token: "new-access-2", projectId: "project-2" }),
+        newCredentials: {
+          access: "new-access-2",
+          refresh: "new-refresh-2",
+          expires: now + 3600_000,
+          projectId: "project-2",
+        },
+      });
+
+    const { ensureAuthProfileStore, saveAuthProfileStore } = await import("./store.js");
+    const { resolveApiKeyForProfile } = await import("./oauth.js");
+
+    const store = ensureAuthProfileStore(tempDir);
+    store.profiles["google-gemini-cli:user1@gmail.com"] = account1;
+    store.profiles["google-gemini-cli:user2@gmail.com"] = account2;
+    saveAuthProfileStore(store, tempDir);
+
+    // Refresh account 1
+    const result1 = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(tempDir),
+      profileId: "google-gemini-cli:user1@gmail.com",
+      agentDir: tempDir,
+    });
+
+    expect(result1).toBeTruthy();
+    expect(mockGetOAuthApiKey).toHaveBeenNthCalledWith(1, "google-gemini-cli", {
+      "google-gemini-cli": expect.objectContaining({
+        refresh: "refresh-1",
+        projectId: "project-1",
+      }),
+    });
+
+    // Refresh account 2
+    const result2 = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(tempDir),
+      profileId: "google-gemini-cli:user2@gmail.com",
+      agentDir: tempDir,
+    });
+
+    expect(result2).toBeTruthy();
+    expect(mockGetOAuthApiKey).toHaveBeenNthCalledWith(2, "google-gemini-cli", {
+      "google-gemini-cli": expect.objectContaining({
+        refresh: "refresh-2",
+        projectId: "project-2",
+      }),
+    });
+
+    // Verify both accounts were updated independently
+    const updatedStore = ensureAuthProfileStore(tempDir);
+    expect(updatedStore.profiles["google-gemini-cli:user1@gmail.com"]).toMatchObject({
+      access: "new-access-1",
+      refresh: "new-refresh-1",
+    });
+    expect(updatedStore.profiles["google-gemini-cli:user2@gmail.com"]).toMatchObject({
+      access: "new-access-2",
+      refresh: "new-refresh-2",
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock pi-ai's getOAuthApiKey
 const mockGetOAuthApiKey = vi.fn();


### PR DESCRIPTION
## Summary

Fixes #3803 - OAuth tokens for google-gemini-cli and google-antigravity providers now refresh all accounts, not just the first one per provider.

### Root Cause

Previously, `resolveOAuthToken()` in `src/infra/provider-usage.auth.ts` would return immediately after finding the first valid profile for a provider. This left other profiles with expired tokens until they were specifically accessed.

Additionally, the status display showed stale expiry times because it read credentials before the usage fetch triggered token refreshes.

### Changes

1. **Refresh all profiles per provider** (`src/infra/provider-usage.auth.ts`):
   - Renamed `resolveOAuthToken()` to `resolveOAuthTokens()` 
   - Changed from returning early to collecting all valid profiles in an array
   - Updated `resolveProviderAuths()` to spread all resolved tokens

2. **Display refreshed state** (`src/commands/models/list.status-command.ts`):
   - Added store re-read after usage fetch completes
   - Rebuilt auth health summary with fresh credential data
   - Status display now shows post-refresh state immediately

### Test Plan

- [x] Verified all 6 Google OAuth accounts refresh on single `moltbot models status` run
- [x] Confirmed status display shows refreshed expiry times (no stale "expired" entries)
- [x] Existing OAuth refresh tests pass
- [x] Multi-account test scenario validates all profiles get new tokens

### Before

```
$ moltbot models status
# Only 2 out of 6 expired accounts refreshed
# Status showed "expired expires in 0m" for 4 accounts
```

### After

```
$ moltbot models status
# All 6 accounts refresh
# All show "expiring expires in Xm" with valid times
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-account OAuth refresh by changing provider usage auth resolution to collect tokens for *all* OAuth/token profiles per provider (instead of returning after the first match), and updates the `models status` command to rebuild the displayed OAuth health after the usage snapshot fetch triggers refresh.

Key flow changes:
- `src/infra/provider-usage.auth.ts` now returns a `ProviderAuth[]` from `resolveOAuthTokens()` and spreads all resolved tokens into `resolveProviderAuths()`, which is used by provider usage snapshots.
- `src/commands/models/list.status-command.ts` re-reads the auth store and rebuilds the auth health summary after `loadProviderUsageSummary()` completes so the status output reflects refreshed expiry times.
- Adds a Vitest suite covering OAuth refresh behavior for the Google OAuth providers via the pi-ai API wrapper.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is a likely agent-scope bug in the refreshed status display path.
- The auth refresh logic change is localized and aligned with the PR goal (returning all OAuth tokens per provider). However, the new post-usage refresh re-read in `models status` appears to ignore `agentDir`, which can show incorrect refreshed state for `--agent` usage, and the new test suite has a potentially flaky module-reset/mocking pattern.
- src/commands/models/list.status-command.ts; src/agents/auth-profiles/oauth-refresh.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->