### PR TITLE
feat(hooks): add TTL-based cleanup for hook sessions

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -36,6 +36,8 @@ export type HookMappingConfig = {
   thinking?: string;
   timeoutSeconds?: number;
   transform?: HookMappingTransform;
+  /** Session cleanup after hook completes: "delete" archives the session, "keep" preserves it (default: "keep"). */
+  cleanup?: "delete" | "keep";
 };
 
 export type HooksGmailTailscaleMode = "off" | "serve" | "funnel";
@@ -67,6 +69,8 @@ export type HooksGmailConfig = {
   model?: string;
   /** Optional thinking level override for Gmail hook processing. */
   thinking?: "off" | "minimal" | "low" | "medium" | "high";
+  /** Session cleanup after Gmail hook completes: "delete" archives the session, "keep" preserves it (default: "delete" for Gmail). */
+  cleanup?: "delete" | "keep";
 };
 
 export type InternalHookHandlerConfig = {
@@ -121,4 +125,6 @@ export type HooksConfig = {
   gmail?: HooksGmailConfig;
   /** Internal agent event hooks */
   internal?: InternalHooksConfig;
+  /** TTL in milliseconds for hook sessions before auto-cleanup (default: 86400000 = 24h). Set to 0 to disable. */
+  sessionTtlMs?: number;
 };

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -40,6 +40,7 @@ export const HookMappingSchema = z
       })
       .strict()
       .optional(),
+    cleanup: z.union([z.literal("delete"), z.literal("keep")]).optional(),
   })
   .strict()
   .optional();
@@ -125,6 +126,7 @@ export const HooksGmailSchema = z
         z.literal("high"),
       ])
       .optional(),
+    cleanup: z.union([z.literal("delete"), z.literal("keep")]).optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -242,6 +242,7 @@ export const MoltbotSchema = z
         mappings: z.array(HookMappingSchema).optional(),
         gmail: HooksGmailSchema,
         internal: InternalHooksSchema,
+        sessionTtlMs: z.number().int().min(0).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/hooks-session-cleanup.ts
+++ b/src/gateway/hooks-session-cleanup.ts
@@ -1,0 +1,83 @@
+/**
+ * TTL-based cleanup for hook sessions.
+ * Runs periodically to delete stale hook sessions older than the configured TTL.
+ */
+
+import type { MoltbotConfig } from "../config/config.js";
+import { loadCombinedSessionStoreForGateway, listSessionsFromStore } from "./session-utils.js";
+import { callGateway } from "./call.js";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+const DEFAULT_HOOK_SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const HOOK_SESSION_PREFIX = "hook:";
+
+export type HookSessionCleanupResult = {
+  checked: number;
+  deleted: number;
+  errors: number;
+};
+
+/**
+ * Clean up stale hook sessions older than TTL.
+ * Returns counts of checked/deleted/errored sessions.
+ */
+export async function cleanupStaleHookSessions(params: {
+  cfg: MoltbotConfig;
+  log?: SubsystemLogger;
+}): Promise<HookSessionCleanupResult> {
+  const { cfg, log } = params;
+
+  // Get TTL from config (0 = disabled)
+  const ttlMs = cfg.hooks?.sessionTtlMs ?? DEFAULT_HOOK_SESSION_TTL_MS;
+  if (ttlMs <= 0) {
+    return { checked: 0, deleted: 0, errors: 0 };
+  }
+
+  const cutoffMs = Date.now() - ttlMs;
+
+  // List all sessions
+  const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+  const allSessions = listSessionsFromStore({
+    cfg,
+    storePath,
+    store,
+    opts: { limit: 10000 }, // High limit to get all sessions
+  });
+
+  // Filter to hook sessions that are stale
+  const staleSessions = allSessions.sessions.filter((session) => {
+    // Check if it's a hook session (key starts with "hook:")
+    if (!session.key.startsWith(HOOK_SESSION_PREFIX)) return false;
+    // Check if it's older than TTL
+    const lastActivity = session.updatedAt ?? 0;
+    return lastActivity < cutoffMs;
+  });
+
+  let deleted = 0;
+  let errors = 0;
+
+  for (const session of staleSessions) {
+    try {
+      await callGateway({
+        method: "sessions.delete",
+        params: { key: session.key, deleteTranscript: true },
+        timeoutMs: 10_000,
+      });
+      deleted++;
+      log?.debug?.(`cleaned up stale hook session: ${session.key}`);
+    } catch (err) {
+      errors++;
+      log?.warn?.(`failed to cleanup hook session ${session.key}: ${String(err)}`);
+    }
+  }
+
+  if (deleted > 0 || errors > 0) {
+    log?.info?.(
+      `hook session cleanup: checked=${staleSessions.length} deleted=${deleted} errors=${errors}`,
+    );
+  }
+
+  return { checked: staleSessions.length, deleted, errors };
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -47,6 +47,7 @@ type HookDispatchers = {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    cleanup?: "delete" | "keep";
   }) => string;
 };
 
@@ -182,6 +183,7 @@ export function createHooksRequestHandler(
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            cleanup: mapped.action.cleanup,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;


### PR DESCRIPTION
## Summary

Hook sessions (e.g., from Gmail hooks) now auto-cleanup after a configurable TTL. This prevents hook sessions from accumulating indefinitely while still allowing time for debugging.

## Changes

- Add `hooks.sessionTtlMs` config option (default: 24 hours = 86400000ms)
- Add `cleanupStaleHookSessions()` function that deletes stale hook sessions  
- Run cleanup hourly via existing maintenance interval
- Only affects sessions with keys starting with `hook:`
- Sessions + transcripts are deleted after TTL expires
- Set `sessionTtlMs: 0` to disable cleanup entirely

## Config Example

```yaml
hooks:
  sessionTtlMs: 86400000  # 24 hours (default)
  # Set to 0 to disable cleanup
```

## Files Changed

- `src/config/types.hooks.ts` - Added `sessionTtlMs` to HooksConfig type
- `src/config/zod-schema.hooks.ts` - Added cleanup validation
- `src/config/zod-schema.ts` - Added `sessionTtlMs` validation
- `src/gateway/hooks-session-cleanup.ts` - **New file** with cleanup logic
- `src/gateway/server-maintenance.ts` - Wired in hourly cleanup
- `src/gateway/hooks-mapping.ts` - Plumbed cleanup option through types
- `src/gateway/server-http.ts` - Plumbed cleanup option through dispatcher
- `src/gateway/server/hooks.ts` - Added comment about TTL cleanup

## Testing

Tested locally with Gmail hooks - sessions are created and persist for debugging, then cleaned up after TTL expires.