### PR TITLE
fix(telegram): preserve messageThreadId for DM reply threads

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -656,7 +656,8 @@ export const buildTelegramMessageContext = async ({
     msg,
     chatId,
     isGroup,
-    resolvedThreadId,
+    // For DM reply threads use messageThreadId; for forum groups use resolvedThreadId
+    resolvedThreadId: isGroup ? resolvedThreadId : messageThreadId,
     isForum,
     historyKey,
     historyLimit,


### PR DESCRIPTION
## Problem

Telegram DM reply threads were not working correctly. When a user replied within a thread in a DM conversation with the bot, responses were sent to the main chat instead of staying in the thread.

## Root Cause

`buildTelegramMessageContext` was returning `resolvedThreadId` for all chat types. However, `resolveTelegramForumThreadId()` returns `undefined` for non-forum chats (including DMs), because it's designed specifically for forum topic resolution.

This meant DM reply threads lost their `messageThreadId` context during delivery.

## Fix

For DM chats, use the raw `messageThreadId` directly instead of `resolvedThreadId`. Forum groups continue to use `resolvedThreadId` where topic resolution is needed.

```typescript
// Before
resolvedThreadId,

// After  
resolvedThreadId: isGroup ? resolvedThreadId : messageThreadId,
```

## Testing

- ✅ DM reply threads now receive responses in the correct thread
- ✅ Streaming replies work
- ✅ Followup queue (subagents) delivers to correct thread
- ✅ Forum groups unaffected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Telegram DM reply-thread routing by preserving `message_thread_id` for direct messages instead of relying on `resolveTelegramForumThreadId()` (which intentionally returns `undefined` for non-forum chats). Forum/supergroup topic handling continues to use the resolved forum thread id.

The change is localized to `src/telegram/bot-message-context.ts`, adjusting the context returned by `buildTelegramMessageContext` so downstream delivery can include the correct thread id for DMs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes a real DM threading issue with low surface area.
- The change is small and localized, and the underlying reasoning (forum resolver returning undefined for DMs) matches Telegram semantics. Main remaining risk is semantic overload of `resolvedThreadId` potentially confusing downstream usage/logging, but it’s unlikely to break functionality immediately.
- src/telegram/bot-message-context.ts (thread id naming/semantics)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->