### PR TITLE
fix(ui): improve mobile viewport and sticky nav

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
     <title>Moltbot Control</title>
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -194,6 +194,16 @@
 html,
 body {
   height: 100%;
+  overflow: hidden;
+}
+
+/* iOS safe area support */
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
 }
 
 body {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -197,15 +197,6 @@ body {
   overflow: hidden;
 }
 
-/* iOS safe area support */
-@supports (padding: env(safe-area-inset-top)) {
-  body {
-    padding-top: env(safe-area-inset-top);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
-  }
-}
-
 body {
   margin: 0;
   font: 400 14px/1.55 var(--font-body);

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -2,8 +2,15 @@
    Mobile Layout
    =========================================== */
 
-/* Tablet: Horizontal nav */
+/* Tablet: Horizontal nav - sticky header */
 @media (max-width: 1100px) {
+  /* Keep topbar sticky on mobile */
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+  }
+
   .nav {
     display: flex;
     flex-direction: row;
@@ -13,6 +20,10 @@
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
+    /* Sticky nav below topbar */
+    position: sticky;
+    top: var(--shell-topbar-height, 56px);
+    z-index: 30;
   }
 
   .nav::-webkit-scrollbar {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -4,6 +4,17 @@
 
 /* Tablet: Horizontal nav - sticky header */
 @media (max-width: 1100px) {
+  /* iOS safe area support - apply to shell container */
+  @supports (padding: env(safe-area-inset-top)) {
+    .shell {
+      padding-top: env(safe-area-inset-top);
+      padding-left: env(safe-area-inset-left);
+      padding-right: env(safe-area-inset-right);
+      padding-bottom: env(safe-area-inset-bottom);
+      height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    }
+  }
+
   /* Keep topbar sticky on mobile */
   .topbar {
     position: sticky;


### PR DESCRIPTION
## Summary

Fixes mobile viewport issues on iOS Safari and makes navigation sticky on mobile/tablet.

## Changes

### Viewport fixes
- Add `viewport-fit=cover` and `maximum-scale=1.0` to prevent iOS sizing issues
- Add `overflow: hidden` on html/body to prevent content overflow
- Add iOS safe-area-inset padding for notch support

### Sticky navigation  
- Make topbar sticky at `top: 0` on mobile/tablet (≤1100px)
- Make nav sticky at `top: var(--shell-topbar-height)` below topbar

## Problem

On iPhone (tested on iPhone 17 Pro Max), the Control UI was:
1. ~15% too wide and tall, requiring scroll to see the full interface
2. Navigation tabs scrolled away when scrolling chat content

## Testing

Tested on iPhone 17 Pro Max via Tailscale Serve.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

These changes adjust the UI’s mobile rendering by (1) updating the HTML viewport meta to include `viewport-fit=cover` and `maximum-scale=1.0`, (2) disabling document-level overflow on `html, body`, and (3) adding mobile/tablet CSS to support iOS safe-area insets and make the topbar/nav sticky.

The overall approach aligns with the app’s existing layout model where `.shell` is a fixed-height grid container and `.content` is the primary scroll container (`ui/src/styles/layout.css`). The main risks are scope/side-effects: global `overflow: hidden` on the entire document and applying a `.shell` height override to all <=1100px devices that support `env()` (even when safe-area insets are 0).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the CSS changes have a non-trivial chance of causing scroll/viewport regressions on other pages/devices.
- Viewport and sticky-nav changes are small and localized, but `overflow: hidden` on `html, body` and the broad `.shell` height override under `@supports (env())` can have unintended side effects outside the original iOS Safari scenario. No automated test validation was shown for layout regressions.
- ui/src/styles/base.css; ui/src/styles/layout.mobile.css

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->