### PR TITLE
feat(tui): enable @path fuzzy file picker with fd detection

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -6,6 +6,33 @@ import {
   Text,
   TUI,
 } from "@mariozechner/pi-tui";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Detect the fd binary for @path fuzzy file picker.
+ * fd is a fast alternative to `find` that respects .gitignore.
+ * On some systems (e.g., Ubuntu) it's called 'fdfind'.
+ *
+ * @returns Path to fd binary, or undefined if not found
+ */
+function detectFd(): string | undefined {
+  for (const name of ["fd", "fdfind"]) {
+    try {
+      const result = spawnSync("which", [name], {
+        encoding: "utf-8",
+        timeout: 1000,
+      });
+      if (result.status === 0 && result.stdout?.trim()) {
+        return result.stdout.trim();
+      }
+    } catch {
+      // Continue to next candidate
+    }
+  }
+  return undefined;
+}
+
+const fdPath = detectFd();
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -251,6 +278,7 @@ export async function runTui(opts: TuiOptions) {
           model: sessionInfo.model,
         }),
         process.cwd(),
+        fdPath,
       ),
     );
   };


### PR DESCRIPTION
## Summary

The TUI's `CombinedAutocompleteProvider` from pi-tui already supports `@path` fuzzy file search via the `fd` binary, but this feature was never enabled because `fdPath` wasn't being passed to the provider.

## Changes

- Add `detectFd()` function to locate the `fd` or `fdfind` binary
- Pass `fdPath` as the third parameter to `CombinedAutocompleteProvider`

## Result

Users with `fd` installed now get fuzzy file autocomplete when typing `@` in the TUI input:

```bash
# Install fd
brew install fd        # macOS
apt install fd-find    # Ubuntu/Debian

# Then in TUI, type @ to trigger file picker
```

## Attribution

Inspired by [opencode](https://github.com/opencode-ai/opencode)'s file picker UX (MIT License).

## Testing

Tested locally on macOS with fd 10.3.0 — typing `@` in TUI now shows fuzzy file search results from the workspace directory.