### PR TITLE
Fix: Plugin hooks registered but never fire #3249

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -29,9 +29,9 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
-  const hookCount = registry.hooks.length;
-  if (hookCount > 0) {
-    log.info(`hook runner initialized with ${hookCount} registered hooks`);
+  const typedHookCount = registry.typedHooks.length;
+  if (typedHookCount > 0) {
+    log.info(`hook runner initialized with ${typedHookCount} registered hooks`);
   }
 }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -81,6 +81,7 @@ export type MoltbotPluginHookOptions = {
   name?: string;
   description?: string;
   register?: boolean;
+  priority?: number;
 };
 
 export type ProviderAuthKind = "oauth" | "api_key" | "token" | "device_code" | "custom";
@@ -301,6 +302,23 @@ export type PluginHookName =
   | "session_end"
   | "gateway_start"
   | "gateway_stop";
+
+export const TYPED_HOOK_NAMES: Set<PluginHookName> = new Set<PluginHookName>([
+  "before_agent_start",
+  "agent_end",
+  "before_compaction",
+  "after_compaction",
+  "message_received",
+  "message_sending",
+  "message_sent",
+  "before_tool_call",
+  "after_tool_call",
+  "tool_result_persist",
+  "session_start",
+  "session_end",
+  "gateway_start",
+  "gateway_stop",
+]);
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {


### PR DESCRIPTION
Root Cause
The codebase had two separate hook systems that weren't properly connected:

Legacy hooks: api.registerHook() → registry.hooks
Typed hooks: api.on() → registry.typedHooks
The hook runner's hasHooks() and execution logic only checked registry.typedHooks, but the log message counted registry.hooks — creating a misleading situation where hooks appeared registered but never fired.

- types.ts: Added TYPED_HOOK_NAMES export to src\plugins\types.ts
- imported TYPED_HOOK_NAMES into src\plugins\registry.ts and modified `registerHook()` to bridge to `typedHooks `when the event name matches a typed hook like `message_received`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a mismatch between plugin hook registration and execution by bridging legacy `api.registerHook()` registrations into the typed hook registry when the event name matches a typed hook (e.g. `message_received`). It also corrects the global hook runner init log to report the number of typed hooks (the only ones the runner checks).

Overall, this aligns registration and execution so hooks that appear registered will actually fire through the typed hook runner path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should resolve the reported hook firing issue.
- Changes are localized and conceptually align hook registration with the hook runner’s lookup path; the main remaining concern is internal accounting (`hookCount`) consistency due to the new bridge incrementing counts.
- src/plugins/registry.ts (hookCount accounting and ensuring the bridge doesn’t skew plugin metadata)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->