### PR TITLE
Connect message_sending and message_sent hooks to outbound pipeline

### DIFF
--- a/src/infra/outbound/deliver.hooks.test.ts
+++ b/src/infra/outbound/deliver.hooks.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { deliverOutboundPayloads } from "./deliver.js";
+import type { MoltbotConfig } from "../../config/config.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { createPluginRegistry } from "../../plugins/registry.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { PluginRecord } from "../../plugins/types.js";
+
+// Mock the channel adapter loader
+vi.mock("../../channels/plugins/outbound/load.js", () => ({
+  loadChannelOutboundAdapter: vi.fn().mockImplementation(async (channel) => {
+    return {
+      sendText: vi.fn().mockResolvedValue({ channel, messageId: "msg-123" }),
+      sendMedia: vi.fn().mockResolvedValue({ channel, messageId: "msg-123" }),
+    };
+  }),
+}));
+
+describe("deliverOutboundPayloads hooks", () => {
+  const cfg = {
+    channels: {
+      telegram: { enabled: true },
+    },
+  } as MoltbotConfig;
+
+  // Mock plugin record for registration
+  const mockPluginRecord = {
+    id: "test-plugin",
+    name: "Test Plugin",
+    source: "test",
+    origin: "workspace",
+    enabled: true,
+    status: "loaded",
+    hookCount: 0,
+  } as PluginRecord;
+
+  const createTestRegistry = () => {
+    return createPluginRegistry({
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      runtime: {} as any,
+    });
+  };
+
+  beforeEach(() => {
+    resetGlobalHookRunner();
+  });
+
+  afterEach(() => {
+    resetGlobalHookRunner();
+    vi.restoreAllMocks();
+  });
+
+  it("should ignore hooks when no runner is initialized", async () => {
+    // NOT initializing global hook runner
+
+    const payloads: ReplyPayload[] = [{ text: "hello" }];
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel: "telegram",
+      to: "123",
+      payloads,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].messageId).toBe("msg-123");
+  });
+
+  it("should call message_sending hook", async () => {
+    const registryHelper = createTestRegistry();
+    const hookFn = vi.fn();
+
+    registryHelper.registerTypedHook(mockPluginRecord, "message_sending", hookFn);
+
+    initializeGlobalHookRunner(registryHelper.registry);
+
+    const payloads: ReplyPayload[] = [{ text: "hello" }];
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "telegram",
+      to: "chat-123",
+      accountId: "acc-1",
+      payloads,
+    });
+
+    expect(hookFn).toHaveBeenCalledTimes(1);
+    expect(hookFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "hello",
+        to: "chat-123",
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "acc-1",
+      }),
+    );
+  });
+
+  it("should allow message_sending hook to modify content", async () => {
+    const registryHelper = createTestRegistry();
+
+    registryHelper.registerTypedHook(mockPluginRecord, "message_sending", async (event) => ({
+      content: event.content + " world",
+    }));
+
+    initializeGlobalHookRunner(registryHelper.registry);
+
+    // We need to spy on the actual send function to verify the content
+    const { loadChannelOutboundAdapter } = await import("../../channels/plugins/outbound/load.js");
+    const sendTextMock = vi.fn().mockResolvedValue({ channel: "telegram", messageId: "msg-1" });
+
+    vi.mocked(loadChannelOutboundAdapter).mockResolvedValue({
+      sendText: sendTextMock,
+      sendMedia: vi.fn(),
+    } as any);
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "telegram",
+      to: "123",
+      payloads: [{ text: "hello" }],
+    });
+
+    expect(sendTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "hello world",
+      }),
+    );
+  });
+
+  it("should allow message_sending hook to cancel delivery", async () => {
+    const registryHelper = createTestRegistry();
+
+    registryHelper.registerTypedHook(mockPluginRecord, "message_sending", async () => ({
+      cancel: true,
+    }));
+
+    initializeGlobalHookRunner(registryHelper.registry);
+
+    const { loadChannelOutboundAdapter } = await import("../../channels/plugins/outbound/load.js");
+    const sendTextMock = vi.fn().mockResolvedValue({ channel: "telegram", messageId: "msg-1" });
+
+    vi.mocked(loadChannelOutboundAdapter).mockResolvedValue({
+      sendText: sendTextMock,
+      sendMedia: vi.fn(),
+    } as any);
+
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel: "telegram",
+      to: "123",
+      payloads: [{ text: "hello" }],
+    });
+
+    expect(results).toHaveLength(0);
+    expect(sendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("should call message_sent hook after success", async () => {
+    const registryHelper = createTestRegistry();
+    const sentHook = vi.fn();
+
+    registryHelper.registerTypedHook(mockPluginRecord, "message_sent", sentHook);
+
+    initializeGlobalHookRunner(registryHelper.registry);
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "telegram",
+      to: "chat-123",
+      payloads: [{ text: "hello" }],
+    });
+
+    expect(sentHook).toHaveBeenCalledTimes(1);
+    expect(sentHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat-123",
+        content: "hello",
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes **#3945**

## Summary
Connects the `message_sending` and `message_sent` hooks to the outbound message delivery pipeline in `src/infra/outbound/deliver.ts`.

## Changes
- **src/infra/outbound/deliver.ts**:
  - Added `message_sending` hook call before delivery loop.
  - Implemented logic to allow hook to modify content or cancel delivery.
  - Added `message_sent` hook call in `finally` block to track delivery status.
- **src/infra/outbound/deliver.hooks.test.ts**:
  - Added comprehensive test suite verifying hook behavior.

## Verification
- Added new unit tests pass: `src/infra/outbound/deliver.hooks.test.ts`
- Verified no regressions in existing delivery tests: `src/infra/outbound/deliver.test.ts`

Used AI Assistance (Gemini Flash)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires plugin hooks into the outbound delivery pipeline (`src/infra/outbound/deliver.ts`): it runs `message_sending` before sending (allowing mutation/cancellation) and triggers `message_sent` afterward to report success/failure. It also adds a dedicated Vitest suite (`src/infra/outbound/deliver.hooks.test.ts`) covering the basic hook behaviors (no runner, call ordering, mutation, cancellation, and success reporting).

The change fits into the existing outbound flow by wrapping per-payload delivery logic with hook invocations while keeping delivery itself delegated to channel outbound adapters and existing chunking logic.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of behavioral edge cases and a potential test flake to address.
- Hook integration is localized and guarded behind `hasHooks()`, and the tests cover key behaviors; however, cancellations currently bypass `message_sent`, and `message_sent` is fire-and-forget which can make tests nondeterministic. The success calculation is also somewhat brittle because it depends on indirect side effects to `results`.
- src/infra/outbound/deliver.ts, src/infra/outbound/deliver.hooks.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->