### PR TITLE
fix: prevent gateway crash on fetch failure with unknown cause (#3974).

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -84,7 +84,10 @@ export function isTransientNetworkError(err: unknown): boolean {
   // "fetch failed" TypeError from undici (Node's native fetch)
   if (err instanceof TypeError && err.message === "fetch failed") {
     const cause = getErrorCause(err);
-    if (cause) return isTransientNetworkError(cause);
+    // Check cause for recognized network codes if available
+    if (cause && isTransientNetworkError(cause)) return true;
+    // Fallback: "fetch failed" is inherently a network error,
+    // even if cause lacks standard error codes (#3974)
     return true;
   }
 


### PR DESCRIPTION
## Summary                                                                        
                                                                                    
  - Fix gateway crash when `TypeError: fetch failed` has a cause without standard   
  error codes                                                                       
  - The error itself indicates a network failure; cause validation was incorrectly  
  returning false for unknown cause structures                                      
  - Resolves #3974                                                                  
                                                                                    
  ## Test plan                                                                      
                                                                                    
  - [x] Existing `unhandled-rejections.test.ts` tests pass                          
  - [x] Verified fix handles:                                                       
    - `fetch failed` with cause lacking error code → `true`                         
    - `fetch failed` with recognized cause code → `true`                            
    - `fetch failed` without cause → `true`                                         
  - [ ] Manual test: simulate network drop during gateway operation 