### PR TITLE
 Prevent crash on unhandled fetch rejections (Closes #3974)

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -87,6 +87,18 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for fetch failed with unknown cause (Regression Test for #3974)", () => {
+    // Simulate Cause with NO code
+    const causeNoCode = new Error("Some obscure network error");
+    const errorNoCode = Object.assign(new TypeError("fetch failed"), { cause: causeNoCode });
+    expect(isTransientNetworkError(errorNoCode)).toBe(true);
+
+    // Simulate Cause with UNKNOWN code
+    const causeUnknown = Object.assign(new Error("Unknown"), { code: "UNKNOWN_123" });
+    const errorUnknown = Object.assign(new TypeError("fetch failed"), { cause: causeUnknown });
+    expect(isTransientNetworkError(errorUnknown)).toBe(true);
+  });
+
   it("returns true for nested cause chain with network error", () => {
     const innerCause = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
     const outerCause = Object.assign(new Error("wrapper"), { cause: innerCause });


### PR DESCRIPTION
## Summary
Updates the global unhandled rejection handler to correctly identify `TypeError: fetch failed` as a transient network error, even when the underlying cause is missing a specific Error Code.
## Changes
- **src/infra/unhandled-rejections.ts**: Relaxed `isTransientNetworkError` check for fetch errors.
- **src/infra/unhandled-rejections.test.ts**: Added regression tests for fetch errors with missing/unknown causes.
## Verification
- Added new unit tests covering the crash scenario.
- Verified `process.exit(1)` is no longer called for these errors.

With Gemini Flash

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the unhandled rejection classification logic for Node/undici `TypeError("fetch failed")` errors and adds a regression test to cover cases where the underlying `cause` is missing or has an unknown `code`.

The logic lives in `src/infra/unhandled-rejections.ts` as part of `isTransientNetworkError`, which is used by the global `unhandledRejection` handler to decide whether to warn-and-continue (transient network / abort) or `process.exit(1)` (fatal/config/unknown). The test changes in `src/infra/unhandled-rejections.test.ts` aim to ensure the gateway doesn’t crash on these fetch failures.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves resilience against a known crash scenario.
- Changes are localized to error classification and add tests, but the new conditional logic in the `fetch failed` branch appears redundant given the unconditional `return true`, so the tests may not actually be validating the intended behavioral distinction.
- src/infra/unhandled-rejections.ts and src/infra/unhandled-rejections.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->