### PR TITLE
fix(tui): ensure UI updates when status changes

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -348,10 +348,12 @@ export async function runTui(opts: TuiOptions) {
           phrases: waitingPhrase ? [waitingPhrase] : undefined,
         }),
       );
+      tui.requestRender();
       return;
     }
 
     statusLoader.setMessage(`${activityStatus} • ${elapsed} | ${connectionStatus}`);
+    tui.requestRender();
   };
 
   const startStatusTimer = () => {
@@ -423,11 +425,13 @@ export async function runTui(opts: TuiOptions) {
   const setConnectionStatus = (text: string, ttlMs?: number) => {
     connectionStatus = text;
     renderStatus();
+    tui.requestRender();
     if (statusTimeout) clearTimeout(statusTimeout);
     if (ttlMs && ttlMs > 0) {
       statusTimeout = setTimeout(() => {
         connectionStatus = isConnected ? "connected" : "disconnected";
         renderStatus();
+        tui.requestRender();
       }, ttlMs);
     }
   };
@@ -435,6 +439,7 @@ export async function runTui(opts: TuiOptions) {
   const setActivityStatus = (text: string) => {
     activityStatus = text;
     renderStatus();
+    tui.requestRender();
   };
 
   const updateFooter = () => {


### PR DESCRIPTION
Add missing tui.requestRender() calls after status updates to prevent UI from becoming stale. This ensures the terminal interface reflects current connection and activity status immediately.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `tui.requestRender()` calls after status/loader message updates so the terminal UI reflects connection/activity status changes immediately instead of getting stale.

Changes are isolated to `src/tui/tui.ts`, primarily around the status rendering pipeline (`updateBusyStatusMessage`, `setConnectionStatus`, `setActivityStatus`, and the status TTL timeout).

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but may regress TUI performance due to extra renders on timer-driven paths.
- The change is small and localized, but it adds `requestRender()` calls inside hot timer paths (waiting updates at 120ms) and duplicates render triggers across layers; without certainty about `@mariozechner/pi-tui` render semantics, there’s some risk of CPU/flicker regressions.
- src/tui/tui.ts (status timers and render scheduling)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->