### PR TITLE
fix: release session locks on SIGUSR1 restart + instance nonce for stale detection

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -164,6 +164,123 @@ describe("acquireSessionWriteLock", () => {
     process.off("SIGINT", keepAlive);
   });
 
+  it("reclaims lock with same PID but different nonce (stale from prior boot)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-lock-nonce-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockPath = `${sessionFile}.lock`;
+
+      // Simulate a lock left by a previous boot iteration: same PID, different nonce
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          nonce: "stale-nonce-from-previous-boot",
+          createdAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+
+      // Should reclaim the lock despite same PID and fresh createdAt
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 2000 });
+      const raw = await fs.readFile(lockPath, "utf8");
+      const payload = JSON.parse(raw) as { pid: number; nonce: string };
+
+      expect(payload.pid).toBe(process.pid);
+      expect(payload.nonce).toBe(__testing.instanceNonce);
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reclaim lock with matching nonce (held by current boot)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-lock-nonce-current-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+
+      // Acquire normally — writes current nonce
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+      // A second acquire on a different normalized path pointing to the same
+      // file should reuse the in-memory held lock (already tested elsewhere),
+      // but if we manually simulate a contention scenario by NOT going through
+      // the in-memory path, the nonce check should NOT treat our own lock as
+      // stale. We verify indirectly: the lock file should contain our nonce.
+      const lockPath = `${sessionFile}.lock`;
+      const raw = await fs.readFile(lockPath, "utf8");
+      const payload = JSON.parse(raw) as { pid: number; nonce: string };
+
+      expect(payload.nonce).toBe(__testing.instanceNonce);
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to pid+staleMs for locks without a nonce (backward compat)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-lock-no-nonce-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockPath = `${sessionFile}.lock`;
+
+      // Old-format lock: no nonce, same PID, recent timestamp
+      // This should NOT be reclaimed (backward compat: no nonce → skip nonce check)
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+
+      // With a short timeout this should fail — lock appears valid (same PID, alive, not stale)
+      await expect(
+        acquireSessionWriteLock({ sessionFile, timeoutMs: 200, staleMs: 60_000 }),
+      ).rejects.toThrow(/locked/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rotates instance nonce on releaseAllSessionWriteLocks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-lock-nonce-rotate-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+
+      // Acquire a lock — captures current nonce
+      const nonceBefore = __testing.instanceNonce;
+      await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+      // Release all — should rotate the nonce
+      await releaseAllSessionWriteLocks();
+      const nonceAfter = __testing.instanceNonce;
+
+      expect(nonceAfter).not.toBe(nonceBefore);
+
+      // A stale lock file with the OLD nonce should now be reclaimable
+      const lockPath = `${sessionFile}.lock`;
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          nonce: nonceBefore,
+          createdAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 2000 });
+      const raw = await fs.readFile(lockPath, "utf8");
+      const payload = JSON.parse(raw) as { pid: number; nonce: string };
+      expect(payload.nonce).toBe(nonceAfter);
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("releaseAllSessionWriteLocks removes all held locks", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "moltbot-lock-release-all-"));
     try {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -51,7 +51,7 @@ function isAlive(pid: number): boolean {
  * Used during process exit when async operations aren't reliable.
  */
 function releaseAllLocksSync(): void {
-  for (const [sessionFile, held] of HELD_LOCKS) {
+  for (const [sessionFile, held] of [...HELD_LOCKS]) {
     try {
       if (typeof held.handle.close === "function") {
         void held.handle.close().catch(() => {});
@@ -228,7 +228,7 @@ export async function acquireSessionWriteLock(params: {
  * appear valid for up to `staleMs` (30 min).
  */
 export async function releaseAllSessionWriteLocks(): Promise<void> {
-  for (const [sessionFile, held] of HELD_LOCKS) {
+  for (const [sessionFile, held] of [...HELD_LOCKS]) {
     try {
       await held.handle.close();
     } catch {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -103,7 +103,13 @@ export function createGatewayCloseHandler(params: {
     // owned by PID 1, which appear valid to the new server iteration because
     // isAlive(1) returns true (same process). This blocks session access for
     // up to staleMs (30 min) until the lock expires.
-    await releaseAllSessionWriteLocks();
+    try {
+      await releaseAllSessionWriteLocks();
+    } catch {
+      // Best effort — don't let lock cleanup failure prevent shutdown.
+      // The instance nonce mechanism will detect surviving stale locks
+      // on the next server iteration.
+    }
 
     for (const c of params.clients) {
       try {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,5 +1,6 @@
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
+import { releaseAllSessionWriteLocks } from "../agents/session-write-lock.js";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
@@ -96,6 +97,14 @@ export function createGatewayCloseHandler(params: {
       }
     }
     params.chatRunState.clear();
+
+    // Release all held session write locks before restarting.
+    // Without this, in-process restarts (SIGUSR1) leave on-disk .lock files
+    // owned by PID 1, which appear valid to the new server iteration because
+    // isAlive(1) returns true (same process). This blocks session access for
+    // up to staleMs (30 min) until the lock expires.
+    await releaseAllSessionWriteLocks();
+
     for (const c of params.clients) {
       try {
         c.socket.close(1012, "service restart");


### PR DESCRIPTION
## Summary

Fixes #4043 — stale session write locks persist after SIGUSR1 in-process restart in containers (PID 1), blocking session access for up to 30 minutes.

## Changes

Two-layer fix across 3 files:

### Layer 1: Explicit cleanup on shutdown (`server-close.ts`)
- Call `releaseAllSessionWriteLocks()` after `chatRunState.clear()` during server shutdown
- Wrapped in try-catch so cleanup failure cannot prevent shutdown
- This is the primary fix — locks are actively released before the new server iteration starts

### Layer 2: Instance nonce for stale detection (`session-write-lock.ts`)
- Add a per-instance nonce (`instanceNonce`) to lock file payloads: `{ pid, nonce, createdAt }`
- Nonce is rotated via `resetInstanceNonce()` at the end of `releaseAllSessionWriteLocks()`
- On lock acquisition, if the on-disk nonce differs from the current instance nonce and the PID matches → lock is treated as stale and immediately reclaimed
- Defense-in-depth: catches any locks that survive the explicit cleanup (e.g. due to fs errors or race conditions during shutdown)

### Key design decisions
- **Mutable nonce, not const**: ESM modules are cached for the process lifetime and are NOT re-evaluated on SIGUSR1 in-process restart. The nonce must be explicitly rotated.
- **Nonce rotated AFTER lock cleanup**: Prevents a race where a concurrent acquirer could see the old nonce as stale and reclaim a lock before cleanup finishes.
- **Backward compatible**: Lock files without a nonce (from older versions) fall through to the existing `pid + staleMs` checks unchanged.

## Testing

13 tests covering:
- Lock release on all termination signals (SIGINT, SIGTERM, SIGQUIT, SIGABRT)
- `releaseAllSessionWriteLocks()` removes all held locks
- Nonce mismatch reclaims stale locks from previous iterations
- Matching nonce preserves locks from current instance
- No-nonce fallback for backward compatibility
- Nonce rotation on `releaseAllSessionWriteLocks()`

All existing tests continue to pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses stale session write locks that can persist across in-process restarts (SIGUSR1), especially in container setups where the PID may remain 1. It does this by (1) explicitly releasing all held session write locks during gateway shutdown (`src/gateway/server-close.ts`) and (2) adding a per-process “instance nonce” to lock file payloads to detect and reclaim locks left behind by a prior server iteration even when the PID is unchanged (`src/agents/session-write-lock.ts`). Tests in `src/agents/session-write-lock.test.ts` cover nonce mismatch behavior, backward compatibility for nonce-less lock files, and the new “release all locks” behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one correctness issue in the new lock-release helper that may leave some locks behind in multi-lock scenarios.
- The changes are small and well-tested, but `releaseAllSessionWriteLocks()` (and the existing sync variant) mutate `HELD_LOCKS` while iterating it, which can skip entries and undermine the primary shutdown cleanup path.
- src/agents/session-write-lock.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->