### PR TITLE
fix: add legacy clawdbot client IDs for backward compatibility

### DIFF
--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -11,6 +11,17 @@ export const GATEWAY_CLIENT_IDS = {
   TEST: "test",
   FINGERPRINT: "fingerprint",
   PROBE: "openclaw-probe",
+  // Legacy client IDs (clawdbot/moltbot -> openclaw rename compat)
+  LEGACY_CLAWDBOT_CONTROL_UI: "clawdbot-control-ui",
+  LEGACY_CLAWDBOT_MACOS_APP: "clawdbot-macos",
+  LEGACY_CLAWDBOT_IOS_APP: "clawdbot-ios",
+  LEGACY_CLAWDBOT_ANDROID_APP: "clawdbot-android",
+  LEGACY_CLAWDBOT_PROBE: "clawdbot-probe",
+  LEGACY_MOLTBOT_CONTROL_UI: "moltbot-control-ui",
+  LEGACY_MOLTBOT_MACOS_APP: "moltbot-macos",
+  LEGACY_MOLTBOT_IOS_APP: "moltbot-ios",
+  LEGACY_MOLTBOT_ANDROID_APP: "moltbot-android",
+  LEGACY_MOLTBOT_PROBE: "moltbot-probe",
 } as const;
 
 export type GatewayClientId = (typeof GATEWAY_CLIENT_IDS)[keyof typeof GATEWAY_CLIENT_IDS];


### PR DESCRIPTION
## Summary

- Adds legacy `clawdbot-*` client IDs to `GATEWAY_CLIENT_IDS` for backward compatibility after the clawdbot → moltbot rename

## Problem

After the rename from `clawdbot` to `moltbot` (commit 6d16a658e), the gateway schema validation rejects connections from older macOS/iOS/Android apps that still send the legacy client IDs (`clawdbot-macos`, `clawdbot-ios`, `clawdbot-android`).

**Error seen in the macOS app:**
```
invalid connect params: at /client/id: must be equal to constant; at /client/id: must match a schema in anyOf
```

This breaks connectivity for users running a pre-rename app against a post-rename gateway.

## Solution

Add the legacy client IDs to the allowed list so older apps can still connect:
- `clawdbot-control-ui`
- `clawdbot-macos`
- `clawdbot-ios`
- `clawdbot-android`
- `clawdbot-probe`

## Test plan

- [x] Verified macOS app version 2026.1.22 (7530) with `clawdbot-macos` client ID can connect to updated gateway
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)