### PR TITLE
feat: add Eden AI provider support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -118,6 +118,14 @@
       "destination": "/providers/opencode"
     },
     {
+      "source": "/edenai",
+      "destination": "/providers/edenai"
+    },
+    {
+      "source": "/edenai/",
+      "destination": "/providers/edenai"
+    },
+    {
       "source": "/mattermost",
       "destination": "/channels/mattermost"
     },
@@ -1029,6 +1037,7 @@
           "providers/minimax",
           "providers/vercel-ai-gateway",
           "providers/openrouter",
+          "providers/edenai",
           "providers/synthetic",
           "providers/opencode",
           "providers/glm",

--- a/docs/providers/edenai.md
+++ b/docs/providers/edenai.md
@@ -46,6 +46,20 @@ Eden AI supports: Anthropic, OpenAI, Mistral, Google, and more.
 - `edenai/mistral/mistral-large-latest` - Mistral Large
 - `edenai/mistral/mistral-small-latest` - Mistral Small
 
+## Expert models
+
+Beyond LLMs, Eden AI provides access to specialized **expert models** optimized for specific tasks:
+
+- **Video analysis** - person tracking, object tracking, text detection, explicit content detection
+- **OCR** - document parsing, invoice extraction, ID recognition
+- **Image generation** - text-to-image across multiple providers
+- **Video generation** - text-to-video and image-to-video
+- **Speech-to-text** - transcription and dictation
+- **Text-to-speech** - voice synthesis
+- **Content moderation** - explicit content detection, AI-generated content detection
+
+Integration of these expert models into Clawdbot skills is coming soon.
+
 ## Notes
 
 - Model refs are `edenai/<provider>/<model>` (e.g., `edenai/openai/gpt-4o`).

--- a/docs/providers/edenai.md
+++ b/docs/providers/edenai.md
@@ -1,0 +1,60 @@
+---
+summary: "Use Eden AI's unified API to access many models in Clawdbot"
+read_when:
+  - You want a European multi-provider API gateway
+  - You want a single API key for many LLMs
+---
+# Eden AI
+
+Eden AI provides a **unified API** that routes requests to many models behind a single
+endpoint and API key. It is OpenAI-compatible and based in Europe.
+
+## CLI setup
+
+```bash
+clawdbot onboard --auth-choice edenai-api-key
+```
+
+Or non-interactive:
+
+```bash
+clawdbot onboard --auth-choice apiKey --token-provider edenai --token "$EDENAI_API_KEY"
+```
+
+## Config snippet
+
+```json5
+{
+  env: { EDENAI_API_KEY: "..." },
+  agents: {
+    defaults: {
+      model: { primary: "edenai/anthropic/claude-sonnet-4-5" }
+    }
+  }
+}
+```
+
+## Supported providers
+
+Eden AI supports: Anthropic, OpenAI, Mistral, Google, and more.
+
+## Example models
+
+- `edenai/anthropic/claude-sonnet-4-5` - Claude Sonnet 4.5
+- `edenai/openai/gpt-4o` - GPT-4o
+- `edenai/openai/gpt-4o-mini` - GPT-4o Mini (cheaper)
+- `edenai/mistral/mistral-large-latest` - Mistral Large
+- `edenai/mistral/mistral-small-latest` - Mistral Small
+
+## Notes
+
+- Model refs are `edenai/<provider>/<model>` (e.g., `edenai/openai/gpt-4o`).
+- For more model/provider options, see [/concepts/model-providers](/concepts/model-providers).
+- Eden AI uses Bearer token authentication.
+
+## Links
+
+- [Eden AI website](https://www.edenai.co/)
+- [Eden AI documentation](https://docs.edenai.co/)
+- [Supported models](https://app.edenai.run/models)
+- [Get your API key](https://app.edenai.run/admin/account/settings)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -37,6 +37,7 @@ See [Venice AI](/providers/venice).
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [Qwen (OAuth)](/providers/qwen)
 - [OpenRouter](/providers/openrouter)
+- [Eden AI](/providers/edenai)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -277,6 +277,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     cerebras: "CEREBRAS_API_KEY",
     xai: "XAI_API_KEY",
     openrouter: "OPENROUTER_API_KEY",
+    edenai: "EDENAI_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
     "kimi-code": "KIMICODE_API_KEY",

--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { scanOpenRouterModels } from "./model-scan.js";
+import { scanEdenAiModels, scanOpenRouterModels } from "./model-scan.js";
 
 function createFetchFixture(payload: unknown): typeof fetch {
   return async () =>
@@ -84,5 +84,151 @@ describe("scanOpenRouterModels", () => {
         process.env.OPENROUTER_API_KEY = previousKey;
       }
     }
+  });
+});
+
+describe("scanEdenAiModels", () => {
+  it("lists models from {object, data} response format", async () => {
+    const fetchImpl = createFetchFixture({
+      object: "list",
+      data: [
+        {
+          id: "anthropic/claude-3-haiku",
+          model_name: "Claude 3 Haiku",
+          owned_by: "anthropic",
+          context_length: 200000,
+          created: 1700000000,
+          capabilities: {
+            supports_function_calling: true,
+            supports_vision: false,
+            supports_tool_choice: true,
+            input_modalities: ["text"],
+            output_modalities: ["text"],
+          },
+          pricing: { input_cost_per_token: 0.00025, output_cost_per_token: 0.00125 },
+        },
+      ],
+    });
+
+    const results = await scanEdenAiModels({
+      fetchImpl,
+      apiKey: "test-key",
+      probe: false,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("anthropic/claude-3-haiku");
+    expect(results[0]?.modelRef).toBe("edenai/anthropic/claude-3-haiku");
+    expect(results[0]?.provider).toBe("edenai");
+    expect(results[0]?.name).toBe("Claude 3 Haiku");
+    expect(results[0]?.supportsToolsMeta).toBe(true);
+  });
+
+  it("requires an API key", async () => {
+    const fetchImpl = createFetchFixture({ object: "list", data: [] });
+    const previousKey = process.env.EDENAI_API_KEY;
+    try {
+      delete process.env.EDENAI_API_KEY;
+      await expect(scanEdenAiModels({ fetchImpl, probe: false, apiKey: "" })).rejects.toThrow(
+        /Missing Eden AI API key/,
+      );
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env.EDENAI_API_KEY;
+      } else {
+        process.env.EDENAI_API_KEY = previousKey;
+      }
+    }
+  });
+
+  it("filters by provider", async () => {
+    const fetchImpl = createFetchFixture({
+      object: "list",
+      data: [
+        {
+          id: "anthropic/claude-3",
+          model_name: "Claude",
+          owned_by: "anthropic",
+          context_length: 200000,
+          created: 1700000000,
+          capabilities: {
+            supports_function_calling: true,
+            supports_vision: false,
+            supports_tool_choice: true,
+            input_modalities: ["text"],
+            output_modalities: ["text"],
+          },
+          pricing: { input_cost_per_token: 0.001, output_cost_per_token: 0.002 },
+        },
+        {
+          id: "openai/gpt-4",
+          model_name: "GPT-4",
+          owned_by: "openai",
+          context_length: 128000,
+          created: 1700000000,
+          capabilities: {
+            supports_function_calling: true,
+            supports_vision: true,
+            supports_tool_choice: true,
+            input_modalities: ["text", "image"],
+            output_modalities: ["text"],
+          },
+          pricing: { input_cost_per_token: 0.003, output_cost_per_token: 0.006 },
+        },
+      ],
+    });
+
+    const results = await scanEdenAiModels({
+      fetchImpl,
+      apiKey: "test-key",
+      probe: false,
+      providerFilter: "anthropic",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("anthropic/claude-3");
+  });
+
+  it("detects free models", async () => {
+    const fetchImpl = createFetchFixture({
+      object: "list",
+      data: [
+        {
+          id: "free/model",
+          model_name: "Free Model",
+          owned_by: "free",
+          context_length: 4096,
+          created: 1700000000,
+          capabilities: {
+            supports_function_calling: false,
+            supports_vision: false,
+            supports_tool_choice: false,
+            input_modalities: ["text"],
+            output_modalities: ["text"],
+          },
+          pricing: { input_cost_per_token: 0, output_cost_per_token: 0 },
+        },
+        {
+          id: "paid/model",
+          model_name: "Paid Model",
+          owned_by: "paid",
+          context_length: 8192,
+          created: 1700000000,
+          capabilities: {
+            supports_function_calling: true,
+            supports_vision: false,
+            supports_tool_choice: true,
+            input_modalities: ["text"],
+            output_modalities: ["text"],
+          },
+          pricing: { input_cost_per_token: 0.001, output_cost_per_token: 0.002 },
+        },
+      ],
+    });
+
+    const results = await scanEdenAiModels({ fetchImpl, apiKey: "test-key", probe: false });
+
+    expect(results.find((r) => r.id === "free/model")?.isFree).toBe(true);
+    expect(results.find((r) => r.id === "paid/model")?.isFree).toBe(false);
   });
 });

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -246,7 +246,8 @@ export function registerModelsCli(program: Command) {
 
   models
     .command("scan")
-    .description("Scan OpenRouter free models for tools + images")
+    .description("Scan model registries for tools + images")
+    .option("--source <registry>", "Model registry (openrouter, edenai)", "openrouter")
     .option("--min-params <b>", "Minimum parameter size (billions)")
     .option("--max-age-days <days>", "Skip models older than N days")
     .option("--provider <name>", "Filter by provider prefix")

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -52,7 +52,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|claude-cli|token|chutes|openai-codex|openai-api-key|openrouter-api-key|edenai-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|codex-cli|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
     )
     .option(
       "--token-provider <id>",
@@ -67,6 +67,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--anthropic-api-key <key>", "Anthropic API key")
     .option("--openai-api-key <key>", "OpenAI API key")
     .option("--openrouter-api-key <key>", "OpenRouter API key")
+    .option("--edenai-api-key <key>", "Eden AI API key")
     .option("--ai-gateway-api-key <key>", "Vercel AI Gateway API key")
     .option("--moonshot-api-key <key>", "Moonshot API key")
     .option("--kimi-code-api-key <key>", "Kimi Code API key")
@@ -118,6 +119,7 @@ export function registerOnboardCommand(program: Command) {
             anthropicApiKey: opts.anthropicApiKey as string | undefined,
             openaiApiKey: opts.openaiApiKey as string | undefined,
             openrouterApiKey: opts.openrouterApiKey as string | undefined,
+            edenaiApiKey: opts.edenaiApiKey as string | undefined,
             aiGatewayApiKey: opts.aiGatewayApiKey as string | undefined,
             moonshotApiKey: opts.moonshotApiKey as string | undefined,
             kimiCodeApiKey: opts.kimiCodeApiKey as string | undefined,

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -13,6 +13,7 @@ export type AuthChoiceGroupId =
   | "google"
   | "copilot"
   | "openrouter"
+  | "edenai"
   | "ai-gateway"
   | "moonshot"
   | "zai"
@@ -91,6 +92,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["openrouter-api-key"],
   },
   {
+    value: "edenai",
+    label: "Eden AI",
+    hint: "API Key",
+    choices: ["edenai-api-key"],
+  },
+  {
     value: "ai-gateway",
     label: "Vercel AI Gateway",
     hint: "API key",
@@ -142,6 +149,11 @@ export function buildAuthChoiceOptions(params: {
   options.push({ value: "chutes", label: "Chutes (OAuth)" });
   options.push({ value: "openai-api-key", label: "OpenAI API key" });
   options.push({ value: "openrouter-api-key", label: "OpenRouter API key" });
+  options.push({
+    value: "edenai-api-key",
+    label: "Eden AI API key",
+    hint: "European multi-provider gateway",
+  });
   options.push({
     value: "ai-gateway-api-key",
     label: "Vercel AI Gateway API key",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -11,6 +11,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   chutes: "chutes",
   "openai-api-key": "openai",
   "openrouter-api-key": "openrouter",
+  "edenai-api-key": "edenai",
   "ai-gateway-api-key": "vercel-ai-gateway",
   "moonshot-api-key": "moonshot",
   "kimi-code-api-key": "kimi-code",

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -131,6 +131,7 @@ export async function modelsStatusCommand(
     "cerebras",
     "xai",
     "openrouter",
+    "edenai",
     "zai",
     "mistral",
     "synthetic",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -177,3 +177,17 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export const EDENAI_DEFAULT_MODEL_REF = "edenai/anthropic/claude-sonnet-4-5";
+
+export async function setEdenaiApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "edenai:default",
+    credential: {
+      type: "api_key",
+      provider: "edenai",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyEdenaiConfig,
+  applyEdenaiProviderConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
@@ -20,6 +22,7 @@ export {
   applyXiaomiConfig,
   applyXiaomiProviderConfig,
   applyZaiConfig,
+  EDENAI_BASE_URL,
 } from "./onboard-auth.config-core.js";
 export {
   applyMinimaxApiConfig,
@@ -35,8 +38,10 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  EDENAI_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
+  setEdenaiApiKey,
   setGeminiApiKey,
   setKimiCodeApiKey,
   setMinimaxApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -8,6 +8,7 @@ import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-tok
 import { applyGoogleGeminiModelDefault } from "../../google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyEdenaiConfig,
   applyKimiCodeConfig,
   applyMinimaxApiConfig,
   applyMinimaxConfig,
@@ -20,6 +21,7 @@ import {
   applyXiaomiConfig,
   applyZaiConfig,
   setAnthropicApiKey,
+  setEdenaiApiKey,
   setGeminiApiKey,
   setKimiCodeApiKey,
   setMinimaxApiKey,
@@ -233,6 +235,25 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyOpenrouterConfig(nextConfig);
+  }
+
+  if (authChoice === "edenai-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "edenai",
+      cfg: baseConfig,
+      flagValue: opts.edenaiApiKey,
+      flagName: "--edenai-api-key",
+      envVar: "EDENAI_API_KEY",
+      runtime,
+    });
+    if (!resolved) return null;
+    if (resolved.source !== "profile") await setEdenaiApiKey(resolved.key);
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "edenai:default",
+      provider: "edenai",
+      mode: "api_key",
+    });
+    return applyEdenaiConfig(nextConfig);
   }
 
   if (authChoice === "ai-gateway-api-key") {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,7 @@ export type AuthChoice =
   | "openai-codex"
   | "openai-api-key"
   | "openrouter-api-key"
+  | "edenai-api-key"
   | "ai-gateway-api-key"
   | "moonshot-api-key"
   | "kimi-code-api-key"
@@ -63,6 +64,7 @@ export type OnboardOptions = {
   anthropicApiKey?: string;
   openaiApiKey?: string;
   openrouterApiKey?: string;
+  edenaiApiKey?: string;
   aiGatewayApiKey?: string;
   moonshotApiKey?: string;
   kimiCodeApiKey?: string;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
  Add [Eden AI](https://www.edenai.co/) as a supported provider. Eden AI provides a unified API that routes requests to many models behind a single endpoint and API key. It is OpenAI-compatible and based in Europe.  (Check  [Eden AI Doc](https://docs.edenai.co/))                                      
                                                                                                                                                                                                                                                              
  ## What's included                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                              
  - **Model scanning** — `moltbot models` discovers and lists Eden AI models using refs like `edenai/<provider>/<model>` (e.g. `edenai/openai/gpt-4o`)                                                                                                        
  - **Onboarding auth** — interactive (`--auth-choice edenai-api-key`) and non-interactive (`--token-provider edenai`) flows with Bearer token authentication                                                                                                 
  - **Config wiring** — credentials, config-core, and preferred-provider integration                                                                                                                                                                          
  - **Provider docs** — full setup guide at `docs/providers/edenai.md`                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  ## LLM access                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                              
  Access models from Anthropic, OpenAI, Mistral, Google, and more through a single API key:                                                                                                                                                                   
                                                                                                                                                                                                                                                              
  - `edenai/anthropic/claude-sonnet-4-5`                                                                                                                                                                                                                      
  - `edenai/openai/gpt-4o`                                                                                                                                                                                                                                    
  - `edenai/openai/gpt-4o-mini`                                                                                                                                                                                                                               
  - `edenai/mistral/mistral-large-latest`                                                                                                                                                                                                                     
  - `edenai/mistral/mistral-small-latest`                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                              
  ## Expert models                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                              
  Beyond LLMs, Eden AI provides specialized expert models optimized for specific tasks:                                                                                                                                                                       
                                                                                                                                                                                                                                                              
  - **Video analysis** — person tracking, object tracking, text detection, explicit content detection                                                                                                                                                         
  - **OCR** — document parsing, invoice extraction, ID recognition                                                                                                                                                                                            
  - **Image generation** — text-to-image across multiple providers                                                                                                                                                                                            
  - **Video generation** — text-to-video and image-to-video                                                                                                                                                                                                   
  - **Speech-to-text** — transcription and dictation                                                                                                                                                                                                          
  - **Text-to-speech** — voice synthesis                                                                                                                                                                                                                      
  - **Content moderation** — explicit content detection, AI-generated content detection                                                                                                                                                                       
                                                                                                                                                                                                                                                              
  Integration of these expert models into Moltbot skills is coming soon.                                                                                                                                                                                      
                                                                                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                              
  - [ ] `moltbot onboard --auth-choice edenai-api-key` completes successfully                                                                                                                                                                                 
  - [ ] `moltbot onboard --non-interactive --auth-choice apiKey --token-provider edenai --token "$KEY"` works                                                                                                                                                 
  - [ ] `moltbot models` lists Eden AI models when key is configured                                                                                                                                                                                          
  - [ ] `pnpm test` passes                                                                                                                                                                                                                                    
                                                                                       