### PR TITLE
fix: sanitize tool call IDs for Azure OpenAI

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -73,6 +73,9 @@ export function resolveTranscriptPolicy(params: {
   const isGoogle = isGoogleModelApi(params.modelApi);
   const isAnthropic = isAnthropicApi(params.modelApi, provider);
   const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
+  // Azure OpenAI uses OpenAI-compatible APIs but has stricter limits (40 char tool call IDs).
+  // Detect via provider name containing "azure".
+  const isAzureOpenAi = isOpenAiApi(params.modelApi) && provider.includes("azure");
   const isMistral = isMistralModel({ provider, modelId });
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode") &&
@@ -83,9 +86,9 @@ export function resolveTranscriptPolicy(params: {
     modelId,
   });
 
-  const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
+  const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini || isAzureOpenAi;
 
-  const sanitizeToolCallIds = isGoogle || isMistral;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAzureOpenAi;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds


### PR DESCRIPTION
Azure OpenAI enforces a 40-character limit on tool_calls[].id fields,
    which causes HTTP 400 errors when tool call IDs exceed this limit.

    Add Azure OpenAI detection (via provider name containing "azure") and
    enable tool call ID sanitization for Azure providers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveTranscriptPolicy` (`src/agents/transcript-policy.ts`) to detect “Azure OpenAI” providers and enable transcript/tool-call sanitization to avoid Azure’s 40-character `tool_calls[].id` limit.

The policy object returned here is consumed by the session history/message sanitizers (e.g. `sanitizeSessionMessagesImages`), so toggles like `sanitizeToolCallIds` and `toolCallIdMode` directly affect whether outbound requests have tool-call IDs rewritten into a stricter format.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the main intended behavior change appears not to take effect for Azure OpenAI.
- The PR adds an `isAzureOpenAi` flag and includes it in `sanitizeToolCallIds`/`needsNonImageSanitize`, but the returned policy still gates `sanitizeToolCallIds` behind `!isOpenAi`, so Azure (which uses OpenAI APIs) likely won’t have tool-call IDs sanitized and will continue to hit 400s. Azure detection logic is also heuristic and may miss real Azure configs depending on provider naming/normalization.
- src/agents/transcript-policy.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->