### PR TITLE
fix(docker): expose moltbot CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ ENV NODE_ENV=production
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
+# Expose moltbot CLI globally (use root entrypoint, pnpm-safe)
+
+RUN printf '#!/bin/sh\nexec node /app/moltbot.mjs "$@"\n' \
+    > /usr/local/bin/moltbot \
+ && chmod +x /usr/local/bin/moltbot
+
+
 USER node
 
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
### What
Fixes the `moltbot` CLI not being available inside Docker containers.

### Why
The Docker image builds successfully, but the `moltbot` command is not exposed
in PATH. pnpm workspace `.bin` shims are not reliable as a Docker entrypoint,
especially when running as a non-root user.

### How
Expose the actual CLI entrypoint (`/app/moltbot.mjs`) via a lightweight wrapper
script at `/usr/local/bin/moltbot`.

### Testing
- docker build
- docker run moltbot moltbot --version
- docker run moltbot moltbot doctor
- docker run moltbot moltbot --help

Fixes #3994

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker image so the `moltbot` CLI is reliably available in `PATH` at runtime. Instead of relying on pnpm workspace `.bin` shims (which can be brittle as an entrypoint and under non-root users), it exposes the real CLI entrypoint (`/app/moltbot.mjs`) via a small wrapper installed at `/usr/local/bin/moltbot`. This fits the repo’s container packaging by making the CLI callable uniformly in `docker run … moltbot …` without depending on pnpm’s runtime layout.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the change is small and localized to Docker runtime behavior.
- Only the Dockerfile is modified to add a wrapper script exposing an existing CLI entrypoint. Risk is limited to container execution paths and user/permission behavior; no application logic changes are introduced.
- Dockerfile (verify wrapper has correct shebang/permissions and works under non-root)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->