### PR TITLE
fix(docker): support bash v3 in macos

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen_keys=""
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen_keys+="|$k|"
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen_keys" != *"|$k|"* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
# PR Summary

## Title
docker-setup.sh: Replace associative arrays with POSIX-compatible string tracking

## Description
Fixed `docker-setup.sh` to work on macOS by replacing Bash 4+ associative arrays with a portable POSIX-compatible approach.

### Problem
The script used `declare -A seen=()` in the `upsert_env()` function, which fails on macOS (Bash 3.2) with error:

```
/docker-setup.sh: line 127: declare: -A: invalid option
```

### Solution
Replaced associative array tracking with string-based tracking:
- Changed `seen["$k"]=1` to `seen_keys+="|$k|"`
- Changed `[[ -z "${seen[$k]:-}" ]]` to `[[ "$seen_keys" != *"|$k|"* ]]`

### Testing
- ✅ Works on macOS (Bash 3.2+)
- ✅ Works on Ubuntu (Bash 4+)
- ✅ Works on Windows WSL2
- ✅ Maintains existing functionality—.env file updates work correctly

### Platforms Affected
macOS, Ubuntu, WSL2

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to be compatible with macOS’ default Bash 3.2 by removing the Bash 4+ associative array used in `upsert_env()` and replacing it with a string-based “seen keys” tracker. Functionally, this keeps the script’s behavior of rewriting/adding specific `.env` keys while preserving other existing lines, and enables running the Docker onboarding flow on older Bash versions (macOS, WSL2, Linux).

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; it’s a small compatibility fix with one edge-case correctness concern.
- The change is localized to `upsert_env()` and clearly targets Bash 3.2 compatibility. The main risk is the new substring/pattern match approach, which can mis-detect membership if a key contains glob metacharacters (or the delimiter), though typical env var names avoid these characters.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->