### PR TITLE
fix(nextcloud-talk): calculate signature over message text, not JSON body

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -90,7 +90,7 @@ export async function sendMessageNextcloudTalk(
   const bodyStr = JSON.stringify(body);
 
   const { random, signature } = generateNextcloudTalkSignature({
-    body: bodyStr,
+    body: message,
     secret,
   });
 


### PR DESCRIPTION
## Summary

- Fix HMAC signature calculation to use message text instead of JSON body
- Resolves authentication failures when bots send responses to NextCloud Talk

## Problem

NextCloud Talk's Bot API expects the signature to be calculated as:
```
HMAC-SHA256(random + message, secret)
```

But Moltbot was calculating:
```
HMAC-SHA256(random + {"message":"..."}, secret)
```

This caused all bot response attempts to fail with:
```
Nextcloud Talk: authentication failed - check bot secret
```

## Solution

Changed line 93 in `extensions/nextcloud-talk/src/send.ts`:
```diff
  const { random, signature } = generateNextcloudTalkSignature({
-   body: bodyStr,
+   body: message,
    secret,
  });
```

The HTTP request body (line 107) still correctly uses `bodyStr` (JSON format).

## Testing

Verified manually:
1. Signature over `message` text → ✅ 201 Created
2. Signature over `bodyStr` JSON → ❌ 401 Unauthorized

## Related

Closes #4073

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Nextcloud Talk bot message sending to compute the HMAC signature over the raw message text (`message`) rather than the JSON request body string (`bodyStr`). The HTTP request payload remains unchanged (still POSTing `{ message, replyTo? }` as JSON), but the signature header now matches Nextcloud Talk’s documented expectation of signing `random + message`.

Change is localized to `extensions/nextcloud-talk/src/send.ts` within `sendMessageNextcloudTalk`, and aligns message sends with how the API authenticates bot requests, resolving 401 “authentication failed” errors when responding.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it is a narrow, correctness-focused change to match the Nextcloud Talk Bot API signature requirements.
- The change is a one-line adjustment in signature input for message sending, consistent with the documented signing scheme and validated manually by the author. It does not alter request payload structure or broader runtime behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->