### PR TITLE
fix(update): remove restore control-ui step

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -112,7 +112,6 @@ describe("runGatewayUpdate", () => {
       "pnpm install": { stdout: "" },
       "pnpm build": { stdout: "" },
       "pnpm ui:build": { stdout: "" },
-      [`git -C ${tempDir} checkout -- dist/control-ui/`]: { stdout: "" },
       "pnpm moltbot doctor --non-interactive": { stdout: "" },
     });
 

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -676,17 +676,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     );
     steps.push(uiBuildStep);
 
-    // Restore dist/control-ui/ to committed state to prevent dirty repo after update
-    // (ui:build regenerates assets with new hashes, which would block future updates)
-    const restoreUiStep = await runStep(
-      step(
-        "restore control-ui",
-        ["git", "-C", gitRoot, "checkout", "--", "dist/control-ui/"],
-        gitRoot,
-      ),
-    );
-    steps.push(restoreUiStep);
-
     const doctorStep = await runStep(
       step(
         "moltbot doctor",


### PR DESCRIPTION
The gateway update runner currently fails when it unconditionally runs:

    git checkout -- dist/control-ui/

…but that path is not tracked in git in some releases/checkouts.

This change removes the restore step entirely, relying on the existing dirty-check + git restore/git clean behavior instead.

Motivation: auto-update should not fail on non-guaranteed build artifact paths.

Changes:
- Remove the "restore control-ui" step from runGatewayUpdate
- Update the unit test to no longer expect that git checkout call
