### PR TITLE
fix(slack): pass threadId param in message read action

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -337,6 +337,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
The Slack channel plugin's read action handler was not forwarding the threadId parameter to handleSlackAction, causing message action=read channel=slack threadId=X to always return channel history instead of thread replies.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack channel `read` message actions by forwarding the `threadId` parameter from action params into `handleSlackAction`, enabling `action=read channel=slack threadId=...` to return thread replies instead of falling back to channel history.

The change is localized to `extensions/slack/src/channel.ts` inside the Slack `ChannelPlugin` action handler, aligning the `read` action’s parameter mapping with the existing `send` behavior that already threads via `threadId`/`replyTo`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line parameter plumbing fix confined to the Slack channel action handler, and it matches existing threading behavior elsewhere in the same file. No control flow changes, no new external interactions, and low regression surface area.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->