### PR TITLE
fix: classify AWS SSO token errors as auth for model fallback (AI-assisted)

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -388,6 +388,10 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
+    // AWS SSO / aws-sdk auth resolution errors (e.g. Bedrock)
+    "sso session token",
+    "error loading sso token",
+    "was not found or is invalid",
   ],
   format: [
     "string should match pattern",


### PR DESCRIPTION
## Summary

AWS SSO auth failures (common with Amazon Bedrock when SSO expires) were not recognized as auth/failover errors, which prevented model fallbacks from triggering.

This change adds a few AWS SSO-specific substrings to the auth failover patterns so these errors are classified as `auth` and will trigger model fallback instead of surfacing as "Agent failed before reply".

## Changes
- Add SSO-related patterns to `ERROR_PATTERNS.auth` in `src/agents/pi-embedded-helpers/errors.ts`:
  - `"sso session token"`
  - `"error loading sso token"`
  - `"was not found or is invalid"`

## Testing
- ✅ `pnpm install --frozen-lockfile`
- ✅ `pnpm run lint`
- ✅ `pnpm run test`

## AI Disclosure

This PR was AI-assisted. The change is minimal, reviewed, and tested locally.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the auth/failover error classification by adding AWS SSO-related substrings to `ERROR_PATTERNS.auth` in `src/agents/pi-embedded-helpers/errors.ts`, so common Bedrock/AWS SDK SSO credential resolution failures are treated as `auth` and trigger model fallback rather than surfacing as a generic agent failure.

The change fits into the existing error-handling pipeline by influencing `isAuthErrorMessage()` and therefore `classifyFailoverReason()`, which drives whether the system attempts model failover on certain categories of errors.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it is a small, low-risk change to string matching that affects failover classification.
- Only adds three string patterns to an existing auth error matcher; main risk is accidental overmatching causing unnecessary failover, not crashes or security regressions.
- src/agents/pi-embedded-helpers/errors.ts (pattern specificity/false positives)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->