### PR TITLE
feat(tts): add Telnyx as TTS provider

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -120,7 +120,7 @@ working option**:
    - `whisper` (Python CLI; downloads models automatically)
 2) **Gemini CLI** (`gemini`) using `read_many_files`
 3) **Provider keys**
-   - Audio: OpenAI → Groq → Deepgram → Google
+   - Audio: OpenAI → Groq → Deepgram → Google → Telnyx
    - Image: OpenAI → Anthropic → Google → MiniMax
    - Video: Google
 
@@ -145,6 +145,7 @@ lists, Moltbot can infer defaults:
 - `google` (Gemini API): **image + audio + video**
 - `groq`: **audio**
 - `deepgram`: **audio**
+- `telnyx`: **audio**
 
 For CLI entries, **set `capabilities` explicitly** to avoid surprising matches.
 If you omit `capabilities`, the entry is eligible for the list it appears in.
@@ -153,7 +154,7 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 | Capability | Provider integration | Notes |
 |------------|----------------------|-------|
 | Image | OpenAI / Anthropic / Google / others via `pi-ai` | Any image-capable model in the registry works. |
-| Audio | OpenAI, Groq, Deepgram, Google | Provider transcription (Whisper/Deepgram/Gemini). |
+| Audio | OpenAI, Groq, Deepgram, Google, Telnyx | Provider transcription (Whisper/Deepgram/Gemini/Telnyx). |
 | Video | Google (Gemini API) | Provider video understanding. |
 
 ## Recommended providers
@@ -162,9 +163,10 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 - Good defaults: `openai/gpt-5.2`, `anthropic/claude-opus-4-5`, `google/gemini-3-pro-preview`.
 
 **Audio**
-- `openai/gpt-4o-mini-transcribe`, `groq/whisper-large-v3-turbo`, or `deepgram/nova-3`.
+- `openai/gpt-4o-mini-transcribe`, `groq/whisper-large-v3-turbo`, `deepgram/nova-3`, or `telnyx/openai/whisper-large-v3-turbo`.
 - CLI fallback: `whisper-cli` (whisper-cpp) or `whisper`.
 - Deepgram setup: [Deepgram (audio transcription)](/providers/deepgram).
+- Telnyx setup: [Telnyx (audio transcription)](/providers/telnyx).
 
 **Video**
 - `google/gemini-3-flash-preview` (fast), `google/gemini-3-pro-preview` (richer).

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -50,6 +50,7 @@ See [Venice AI](/providers/venice).
 ## Transcription providers
 
 - [Deepgram (audio transcription)](/providers/deepgram)
+- [Telnyx (audio transcription)](/providers/telnyx)
 
 ## Community tools
 

--- a/docs/providers/telnyx.md
+++ b/docs/providers/telnyx.md
@@ -1,0 +1,73 @@
+---
+summary: "Telnyx speech-to-text for inbound voice notes"
+read_when:
+  - You want Telnyx speech-to-text for audio attachments
+  - You need a quick Telnyx STT config example
+---
+# Telnyx (Audio Transcription)
+
+Telnyx provides speech-to-text via their AI API powered by Whisper. In OpenClaw it is used
+for **inbound audio/voice note transcription** via `tools.media.audio`.
+
+When enabled, OpenClaw uploads the audio file to Telnyx and injects the transcript
+into the reply pipeline (`{{Transcript}}` + `[Audio]` block). This is **not streaming**;
+it uses the pre-recorded transcription endpoint.
+
+Website: https://telnyx.com
+Docs: https://developers.telnyx.com/docs/voice/programmable-voice/stt-standalone
+
+## Quick start
+
+1) Set your API key:
+```
+TELNYX_API_KEY=KEY...
+```
+
+2) Enable the provider:
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [{ provider: "telnyx", model: "openai/whisper-large-v3-turbo" }]
+      }
+    }
+  }
+}
+```
+
+## Options
+
+- `model`: Telnyx model id (default: `openai/whisper-large-v3-turbo`)
+- `language`: language hint (optional)
+
+Example with language:
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [
+          { provider: "telnyx", model: "openai/whisper-large-v3-turbo", language: "en" }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Available models
+
+Telnyx offers Whisper-based transcription models:
+
+- `openai/whisper-large-v3-turbo` (default) - Fast, high-quality transcription
+- `openai/whisper-large-v3` - Higher accuracy, slightly slower
+
+## Notes
+
+- Authentication follows the standard provider auth order; `TELNYX_API_KEY` is the simplest path.
+- The API follows OpenAI's transcription format, making it compatible with existing tooling.
+- Override endpoints or headers with `tools.media.audio.baseUrl` and `tools.media.audio.headers` when using a proxy.
+- Output follows the same audio rules as other providers (size caps, timeouts, transcript injection).

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -8,13 +8,14 @@ read_when:
 
 # Text-to-speech (TTS)
 
-Moltbot can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
+Moltbot can convert outbound replies into audio using ElevenLabs, OpenAI, Telnyx, or Edge TTS.
 It works anywhere Moltbot can send audio; Telegram gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
+- **Telnyx** (primary or fallback provider; great quality, cheaper than ElevenLabs)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
 ### Edge TTS notes
@@ -31,9 +32,10 @@ does not publish limits, so assume similar or lower limits. citeturn0searc
 
 ## Optional keys
 
-If you want OpenAI or ElevenLabs:
+If you want OpenAI, ElevenLabs, or Telnyx:
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
+- `TELNYX_API_KEY`
 
 Edge TTS does **not** require an API key. If no API keys are found, Moltbot defaults
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
@@ -202,9 +204,9 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"openai"`, `"telnyx"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, Moltbot prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
+  then `telnyx` (if key), otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
@@ -250,7 +252,7 @@ Here you go.
 ```
 
 Available directive keys (when enabled):
-- `provider` (`openai` | `elevenlabs` | `edge`)
+- `provider` (`openai` | `elevenlabs` | `telnyx` | `edge`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -50,7 +50,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• telnyx — Great quality, cheaper than ElevenLabs (requires API key)\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -151,6 +152,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     if (!args.trim()) {
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
+      const hasTelnyx = Boolean(resolveTtsApiKey(config, "telnyx"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
@@ -160,18 +162,24 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `Primary: ${currentProvider}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
+            `Telnyx key: ${hasTelnyx ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | telnyx | edge`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "telnyx" &&
+      requested !== "edge"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 
-    setTtsProvider(prefsPath, requested);
+    setTtsProvider(prefsPath, requested as "openai" | "elevenlabs" | "telnyx" | "edge");
     return {
       shouldContinue: false,
       reply: { text: `✅ TTS provider set to ${requested}.` },

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "telnyx";
 
 export type TtsMode = "final" | "all";
 
@@ -72,6 +72,14 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** Telnyx TTS configuration. */
+  telnyx?: {
+    apiKey?: string;
+    /** Voice ID (e.g. "Telnyx.NaturalHD.astra", "Telnyx.Kokoro.af_heart"). */
+    voice?: string;
+    /** WebSocket inactivity timeout in seconds (default: 20). */
+    inactivityTimeout?: number;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -156,7 +156,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "telnyx"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -221,6 +221,14 @@ export const TtsConfigSchema = z
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    telnyx: z
+      .object({
+        apiKey: z.string().optional(),
+        voice: z.string().optional(),
+        inactivityTimeout: z.number().int().min(1).max(300).optional(),
       })
       .strict()
       .optional(),

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -31,6 +31,7 @@ export const DEFAULT_AUDIO_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   openai: "gpt-4o-mini-transcribe",
   deepgram: "nova-3",
+  telnyx: "openai/whisper-large-v3-turbo",
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;

--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -6,6 +6,7 @@ import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
 import { minimaxProvider } from "./minimax/index.js";
 import { openaiProvider } from "./openai/index.js";
+import { telnyxProvider } from "./telnyx/index.js";
 
 const PROVIDERS: MediaUnderstandingProvider[] = [
   groqProvider,
@@ -14,6 +15,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   anthropicProvider,
   minimaxProvider,
   deepgramProvider,
+  telnyxProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {

--- a/src/media-understanding/providers/telnyx/index.test.ts
+++ b/src/media-understanding/providers/telnyx/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { telnyxProvider } from "./index.js";
+
+const resolveRequestUrl = (input: RequestInfo | URL) => {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+};
+
+describe("telnyxProvider", () => {
+  it("has correct id and capabilities", () => {
+    expect(telnyxProvider.id).toBe("telnyx");
+    expect(telnyxProvider.capabilities).toEqual(["audio"]);
+    expect(telnyxProvider.transcribeAudio).toBeDefined();
+  });
+
+  it("uses the correct Telnyx API base URL", async () => {
+    let seenUrl: string | null = null;
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      seenUrl = resolveRequestUrl(input);
+      return new Response(JSON.stringify({ text: "transcribed text" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const result = await telnyxProvider.transcribeAudio!({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.ogg",
+      apiKey: "test-telnyx-key",
+      timeoutMs: 5000,
+      fetchFn,
+    });
+
+    expect(seenUrl).toBe("https://api.telnyx.com/v2/ai/audio/transcriptions");
+    expect(result.text).toBe("transcribed text");
+  });
+
+  it("allows overriding the base URL", async () => {
+    let seenUrl: string | null = null;
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      seenUrl = resolveRequestUrl(input);
+      return new Response(JSON.stringify({ text: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await telnyxProvider.transcribeAudio!({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      baseUrl: "https://custom.telnyx.example/v1",
+      fetchFn,
+    });
+
+    expect(seenUrl).toBe("https://custom.telnyx.example/v1/audio/transcriptions");
+  });
+
+  it("sends the correct authorization header", async () => {
+    let seenAuth: string | null = null;
+    const fetchFn = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seenAuth = headers.get("authorization");
+      return new Response(JSON.stringify({ text: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await telnyxProvider.transcribeAudio!({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "KEY_TELNYX_12345",
+      timeoutMs: 1000,
+      fetchFn,
+    });
+
+    expect(seenAuth).toBe("Bearer KEY_TELNYX_12345");
+  });
+});

--- a/src/media-understanding/providers/telnyx/index.ts
+++ b/src/media-understanding/providers/telnyx/index.ts
@@ -1,0 +1,14 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeOpenAiCompatibleAudio } from "../openai/audio.js";
+
+const DEFAULT_TELNYX_AUDIO_BASE_URL = "https://api.telnyx.com/v2/ai";
+
+export const telnyxProvider: MediaUnderstandingProvider = {
+  id: "telnyx",
+  capabilities: ["audio"],
+  transcribeAudio: (req) =>
+    transcribeOpenAiCompatibleAudio({
+      ...req,
+      baseUrl: req.baseUrl ?? DEFAULT_TELNYX_AUDIO_BASE_URL,
+    }),
+};

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -49,7 +49,7 @@ import {
 import { describeImageWithModel } from "./providers/image.js";
 import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
-const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google"] as const;
+const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google", "telnyx"] as const;
 const AUTO_IMAGE_KEY_PROVIDERS = ["openai", "anthropic", "google", "minimax"] as const;
 const AUTO_VIDEO_KEY_PROVIDERS = ["google"] as const;
 const DEFAULT_IMAGE_MODELS: Record<string, string> = {

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -202,6 +202,14 @@ describe("tts", () => {
       expect(result.overrides.provider).toBe("edge");
     });
 
+    it("accepts telnyx as provider override", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts:provider=telnyx]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("telnyx");
+    });
+
     it("keeps text intact when overrides are disabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: false });
       const input = "Hello [[tts:voice=alloy]] world";
@@ -426,11 +434,28 @@ describe("tts", () => {
           OPENAI_API_KEY: undefined,
           ELEVENLABS_API_KEY: undefined,
           XI_API_KEY: undefined,
+          TELNYX_API_KEY: undefined,
         },
         () => {
           const config = resolveTtsConfig(baseCfg);
           const provider = getTtsProvider(config, "/tmp/tts-prefs-edge.json");
           expect(provider).toBe("edge");
+        },
+      );
+    });
+
+    it("prefers Telnyx when OpenAI and ElevenLabs are missing and Telnyx key exists", () => {
+      withEnv(
+        {
+          OPENAI_API_KEY: undefined,
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
+          TELNYX_API_KEY: "test-telnyx-key",
+        },
+        () => {
+          const config = resolveTtsConfig(baseCfg);
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-telnyx.json");
+          expect(provider).toBe("telnyx");
         },
       );
     });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -69,7 +69,6 @@ const TELEGRAM_OUTPUT = {
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
   elevenlabs: "opus_48000_64",
-  // Telnyx outputs MP3 only (16kHz); not ideal for Telegram voice bubbles but works.
   telnyx: "mp3_16000" as const,
   extension: ".opus",
   voiceCompatible: true,
@@ -1380,7 +1379,7 @@ export async function textToSpeechTelephony(params: {
         continue;
       }
       if (provider === "telnyx") {
-        lastError = "telnyx: unsupported for telephony (MP3 output only)";
+        lastError = "telnyx: WebSocket API outputs MP3, telephony requires PCM";
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Add Telnyx as a new TTS provider with WebSocket streaming support
- Support for multiple Telnyx voices
- Real-time audio streaming via WebSocket API

## Changes
- New `src/tts/providers/telnyx.ts` - Telnyx TTS implementation with WebSocket streaming
- Add Telnyx to `/tts provider` command for easy switching
- Documentation for the new provider

## Test plan
- [x] Manual testing with Telnyx API key
- [x] Verified audio output quality with multiple voices
- [x] Tested WebSocket streaming functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Franco Viotti <francov@telnyx.com>