### PR TITLE
fix(cli): bypass config guard for tui --url

### DIFF
--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -9,6 +9,8 @@ read_when:
 
 Open the terminal UI connected to the Gateway.
 
+Tip: If you pass `--url`, Moltbot treats this as client-only mode and won’t block on local config validation.
+
 Related:
 - TUI guide: [TUI](/tui)
 
@@ -19,4 +21,3 @@ moltbot tui
 moltbot tui --url ws://127.0.0.1:18789 --token <token>
 moltbot tui --session main --deliver
 ```
-

--- a/src/cli/program/preaction.tui-remote-bypass.test.ts
+++ b/src/cli/program/preaction.tui-remote-bypass.test.ts
@@ -1,0 +1,42 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ensureConfigReady = vi.fn(async () => undefined);
+vi.mock("./config-guard.js", () => ({ ensureConfigReady }));
+
+const { registerPreActionHooks } = await import("./preaction.js");
+
+describe("cli preAction config guard", () => {
+  const originalArgv = process.argv.slice();
+
+  afterEach(() => {
+    process.argv = originalArgv.slice();
+    vi.clearAllMocks();
+  });
+
+  it("bypasses config guard for tui --url (client mode)", async () => {
+    process.argv = ["node", "moltbot", "tui", "--url", "ws://example"];
+
+    const program = new Command();
+    registerPreActionHooks(program, "test");
+    const tuiAction = vi.fn(async () => undefined);
+    program.command("tui").option("--url <url>").action(tuiAction);
+
+    await program.parseAsync(["tui", "--url", "ws://example"], { from: "user" });
+
+    expect(ensureConfigReady).not.toHaveBeenCalled();
+    expect(tuiAction).toHaveBeenCalled();
+  });
+
+  it("runs config guard for tui without --url", async () => {
+    process.argv = ["node", "moltbot", "tui"];
+
+    const program = new Command();
+    registerPreActionHooks(program, "test");
+    program.command("tui").action(async () => undefined);
+
+    await program.parseAsync(["tui"], { from: "user" });
+
+    expect(ensureConfigReady).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #3107.

Summary:
- Treat `moltbot tui --url ...` as client-only mode.
- Bypass config validation in the CLI preAction hook so a remote TUI client doesn’t require local plugins/config.

Testing:
- pnpm lint
- pnpm build
- pnpm test

AI-assisted: yes (Codex CLI).
Docker: not available locally for `docker run ...` smoke checks.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI preAction hook so `moltbot tui --url …` is treated as a client-only mode and skips `ensureConfigReady`, allowing remote TUI usage without requiring local config/plugins. It also documents the behavior in `docs/cli/tui.md` and adds a focused Vitest to ensure the config guard is bypassed when `--url` is provided and still enforced otherwise.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and covered by a targeted unit test.
- The change is localized to the CLI preAction hook and gated on `tui` + `--url`, with a new test asserting both bypass and non-bypass paths. Main remaining risk is edge-case argv ordering/flag forms not covered by tests, and the new test’s reliance on global `process.argv` state.
- src/cli/program/preaction.ts; src/cli/program/preaction.tui-remote-bypass.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->