### PR TITLE
feat(signal): add poll support

### DIFF
--- a/src/channels/plugins/actions/signal.test.ts
+++ b/src/channels/plugins/actions/signal.test.ts
@@ -21,7 +21,7 @@ describe("signalMessageActions", () => {
     const cfg = {
       channels: { signal: { account: "+15550001111", actions: { reactions: false } } },
     } as MoltbotConfig;
-    expect(signalMessageActions.listActions({ cfg })).toEqual(["send"]);
+    expect(signalMessageActions.listActions({ cfg })).toEqual(["send", "poll"]);
   });
 
   it("enables react when at least one account allows reactions", () => {
@@ -35,7 +35,7 @@ describe("signalMessageActions", () => {
         },
       },
     } as MoltbotConfig;
-    expect(signalMessageActions.listActions({ cfg })).toEqual(["send", "react"]);
+    expect(signalMessageActions.listActions({ cfg })).toEqual(["send", "poll", "react"]);
   });
 
   it("skips send for plugin dispatch", () => {

--- a/src/channels/plugins/actions/signal.ts
+++ b/src/channels/plugins/actions/signal.ts
@@ -37,7 +37,8 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
     const configuredAccounts = accounts.filter((account) => account.configured);
     if (configuredAccounts.length === 0) return [];
 
-    const actions = new Set<ChannelMessageActionName>(["send"]);
+    // Signal supports send and poll via outbound adapter
+    const actions = new Set<ChannelMessageActionName>(["send", "poll"]);
 
     const reactionsEnabled = configuredAccounts.some((account) =>
       createActionGate(account.config.actions)("reactions"),
@@ -48,7 +49,8 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
 
     return Array.from(actions);
   },
-  supportsAction: ({ action }) => action !== "send",
+  // send and poll are handled by outbound adapter, not action handler
+  supportsAction: ({ action }) => action !== "send" && action !== "poll",
 
   handleAction: async ({ action, params, cfg, accountId }) => {
     if (action === "send") {

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -7,23 +7,27 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   }
   if (!normalized) return undefined;
   const lower = normalized.toLowerCase();
+  // Signal group IDs are base64 encoded and CASE-SENSITIVE - don't lowercase them
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
+  // Usernames are case-insensitive, lowercase them
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();
-    return id ? `username:${id}`.toLowerCase() : undefined;
+    return id ? `username:${id.toLowerCase()}` : undefined;
   }
   if (lower.startsWith("u:")) {
     const id = normalized.slice("u:".length).trim();
-    return id ? `username:${id}`.toLowerCase() : undefined;
+    return id ? `username:${id.toLowerCase()}` : undefined;
   }
+  // UUIDs are case-insensitive, lowercase them
   if (lower.startsWith("uuid:")) {
     const id = normalized.slice("uuid:".length).trim();
     return id ? id.toLowerCase() : undefined;
   }
-  return normalized.toLowerCase();
+  // Phone numbers - keep as-is (they're already normalized)
+  return normalized;
 }
 
 // UUID pattern for signal-cli recipient IDs

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -1,5 +1,5 @@
 import { chunkText } from "../../../auto-reply/chunk.js";
-import { sendMessageSignal } from "../../../signal/send.js";
+import { sendMessageSignal, sendPollSignal } from "../../../signal/send.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
 import type { ChannelOutboundAdapter } from "../types.js";
 
@@ -8,6 +8,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
   chunker: chunkText,
   chunkerMode: "text",
   textChunkLimit: 4000,
+  pollMaxOptions: 12,
   sendText: async ({ cfg, to, text, accountId, deps }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveChannelMediaMaxBytes({
@@ -36,5 +37,12 @@ export const signalOutbound: ChannelOutboundAdapter = {
       accountId: accountId ?? undefined,
     });
     return { channel: "signal", ...result };
+  },
+  sendPoll: async ({ to, poll, accountId }) => {
+    const result = await sendPollSignal(to, poll.question, poll.options, {
+      multiSelect: (poll.maxSelections ?? 1) > 1,
+      accountId: accountId ?? undefined,
+    });
+    return { messageId: result.messageId };
   },
 };

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -102,7 +102,7 @@ describe("sendPoll channel normalization", () => {
           source: "test",
           plugin: createMSTeamsPlugin({
             aliases: ["teams"],
-            outbound: createMSTeamsOutbound({ includePoll: true }),
+            outbound: createMSTeamsOutbound({ includePoll: true, deliveryMode: "gateway" }),
           }),
         },
       ]),
@@ -126,8 +126,11 @@ describe("sendPoll channel normalization", () => {
 
 const emptyRegistry = createTestRegistry([]);
 
-const createMSTeamsOutbound = (opts?: { includePoll?: boolean }): ChannelOutboundAdapter => ({
-  deliveryMode: "direct",
+const createMSTeamsOutbound = (opts?: {
+  includePoll?: boolean;
+  deliveryMode?: "direct" | "gateway";
+}): ChannelOutboundAdapter => ({
+  deliveryMode: opts?.deliveryMode ?? "direct",
   sendText: async ({ deps, to, text }) => {
     const send = deps?.sendMSTeams;
     if (!send) {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -70,6 +70,7 @@ type MessagePollParams = {
   maxSelections?: number;
   durationHours?: number;
   channel?: string;
+  accountId?: string;
   dryRun?: boolean;
   cfg?: MoltbotConfig;
   gateway?: MessageGatewayOptions;
@@ -83,7 +84,7 @@ export type MessagePollResult = {
   options: string[];
   maxSelections: number;
   durationHours: number | null;
-  via: "gateway";
+  via: "direct" | "gateway";
   result?: {
     messageId: string;
     toJid?: string;
@@ -243,6 +244,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
   const normalized = outbound.pollMaxOptions
     ? normalizePollInput(pollInput, { maxOptions: outbound.pollMaxOptions })
     : normalizePollInput(pollInput);
+  const deliveryMode = outbound.deliveryMode ?? "direct";
 
   if (params.dryRun) {
     return {
@@ -252,8 +254,44 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
       options: normalized.options,
       maxSelections: normalized.maxSelections,
       durationHours: normalized.durationHours ?? null,
-      via: "gateway",
+      via: deliveryMode === "gateway" ? "gateway" : "direct",
       dryRun: true,
+    };
+  }
+
+  // Direct delivery for channels with direct mode (e.g., Signal)
+  if (deliveryMode !== "gateway") {
+    const resolvedTarget = resolveOutboundTarget({
+      channel: channel as Exclude<OutboundChannel, "none">,
+      to: params.to,
+      cfg,
+      accountId: params.accountId,
+      mode: "explicit",
+    });
+    if (!resolvedTarget.ok) throw resolvedTarget.error;
+
+    const result = await outbound.sendPoll({
+      cfg,
+      to: resolvedTarget.to,
+      poll: normalized,
+      accountId: params.accountId,
+    });
+
+    return {
+      channel,
+      to: params.to,
+      question: normalized.question,
+      options: normalized.options,
+      maxSelections: normalized.maxSelections,
+      durationHours: normalized.durationHours ?? null,
+      via: "direct",
+      result: {
+        messageId: result.messageId,
+        toJid: result.toJid,
+        channelId: result.channelId,
+        conversationId: result.conversationId,
+        pollId: result.pollId,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary

Wire up signal-cli's `sendPollCreate` to the message tool, enabling poll creation in Signal chats and groups.

### Changes
- Add `sendPollSignal()` function in `src/signal/send.ts`
- Add `sendPoll` method to signal outbound adapter
- **Add "poll" to Signal actions list** so agents can discover and use it
- **Fix direct delivery support** - polls now route directly via signal-cli instead of gateway
- **Fix case sensitivity bug** - Signal group IDs (base64-encoded) are now preserved with correct case
- Support 2-12 options, single or multi-select

## Usage

```typescript
message({
  action: "poll",
  to: "group:GROUP_ID",
  pollQuestion: "What should we have for dinner?",
  pollOption: ["Pizza", "Tacos", "Sushi"],
  pollMulti: true
})
```

## Testing

- [x] Lint passes
- [x] Build passes
- [x] Tested locally with signal-cli daemon
- [x] Verified group ID case sensitivity preserved
- [x] Verified direct delivery works (bypasses gateway)

## Notes

- AI-assisted (Claude) - code reviewed and tested by human
- signal-cli has supported polls since 0.11.0, this just wires it up to Moltbot's message tool
- Group IDs are base64-encoded and CASE-SENSITIVE - previous code incorrectly lowercased them