### PR TITLE
feat(agents): support OpenRouter image generation models

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -618,7 +618,7 @@ export async function runEmbeddedPiAgent(
             usage,
           };
 
-          const payloads = buildEmbeddedRunPayloads({
+          const payloads = await buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -206,6 +206,32 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
   return blocks.join("\n").trim();
 }
 
+/**
+ * Extract image blocks from assistant message content.
+ * Used for OpenRouter image generation models that return images as ImageContent.
+ */
+export function extractAssistantImages(
+  msg: AssistantMessage,
+): Array<{ mimeType: string; data: string }> {
+  if (!Array.isArray(msg.content)) return [];
+  const images: Array<{ mimeType: string; data: string }> = [];
+  for (const block of msg.content) {
+    if (!block || typeof block !== "object") continue;
+    const record = block as unknown as Record<string, unknown>;
+    if (
+      record.type === "image" &&
+      typeof record.data === "string" &&
+      typeof record.mimeType === "string"
+    ) {
+      images.push({
+        mimeType: record.mimeType,
+        data: record.data,
+      });
+    }
+  }
+  return images;
+}
+
 export function formatReasoningMessage(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) return "";

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -325,3 +325,32 @@ export function extractAssistantText(message: unknown): string | undefined {
   const joined = chunks.join("").trim();
   return joined ? sanitizeUserFacingText(joined) : undefined;
 }
+
+/**
+ * Extract image blocks from an assistant message.
+ * Used for OpenRouter image generation models that return images.
+ */
+export function extractAssistantImages(
+  message: unknown,
+): Array<{ mimeType: string; data: string }> {
+  if (!message || typeof message !== "object") return [];
+  if ((message as { role?: unknown }).role !== "assistant") return [];
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return [];
+  const images: Array<{ mimeType: string; data: string }> = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const record = block as Record<string, unknown>;
+    if (
+      record.type === "image" &&
+      typeof record.data === "string" &&
+      typeof record.mimeType === "string"
+    ) {
+      images.push({
+        mimeType: record.mimeType,
+        data: record.data,
+      });
+    }
+  }
+  return images;
+}


### PR DESCRIPTION
## Summary

Add support for extracting and saving generated images from OpenRouter models that return images (like `gpt-5-image-mini`).

## Changes

- Add `extractAssistantImages()` utility to extract base64 images from assistant responses
- Save generated images using standard media store (in "generated" subdirectory)
- Send generated images to users via message channels automatically
- Support both direct agent responses and subagent image generation

## How it works

When using an OpenRouter model that returns images (like `openai/gpt-5-image-mini`), the agent now:
1. Extracts base64 image data from the response
2. Saves images to `~/.moltbot/media/generated/`
3. Sends the images to the user along with any text response

Works with both:
- Direct agent conversations (image appears in chat)
- Subagent tasks via `sessions_spawn({ model: "ImageGen", ... })`

## Testing

- [x] Lint passes
- [x] Build passes
- [x] Tested locally with gpt-5-image-mini

## Notes

- AI-assisted (Claude) - code reviewed and tested by human
- Uses existing `saveMediaBuffer` from media store for proper path handling
- No hardcoded paths - works on any moltbot installation