### PR TITLE
[AI-assisted] test(cli): add missing test cases for parseDurationMs

### DIFF
--- a/src/cli/parse-duration.test.ts
+++ b/src/cli/parse-duration.test.ts
@@ -26,4 +26,28 @@ describe("parseDurationMs", () => {
   it("supports decimals", () => {
     expect(parseDurationMs("0.5s")).toBe(500);
   });
+
+  it("throws on empty string", () => {
+    expect(() => parseDurationMs("")).toThrow("invalid duration (empty)");
+    expect(() => parseDurationMs("  ")).toThrow("invalid duration (empty)");
+  });
+
+  it("throws on invalid format", () => {
+    expect(() => parseDurationMs("abc")).toThrow("invalid duration: abc");
+    expect(() => parseDurationMs("10x")).toThrow("invalid duration: 10x");
+    expect(() => parseDurationMs("not-a-number")).toThrow("invalid duration: not-a-number");
+  });
+
+  it("throws on negative values", () => {
+    expect(() => parseDurationMs("-5")).toThrow("invalid duration: -5");
+    expect(() => parseDurationMs("-10s")).toThrow("invalid duration: -10s");
+  });
+
+  it("respects custom defaultUnit option", () => {
+    expect(parseDurationMs("10", { defaultUnit: "s" })).toBe(10_000);
+    expect(parseDurationMs("5", { defaultUnit: "m" })).toBe(300_000);
+    expect(parseDurationMs("2", { defaultUnit: "h" })).toBe(7_200_000);
+    expect(parseDurationMs("1", { defaultUnit: "d" })).toBe(86_400_000);
+    expect(parseDurationMs("100", { defaultUnit: "ms" })).toBe(100);
+  });
 });


### PR DESCRIPTION
# PR Description

## Summary
Add missing test cases for the `parseDurationMs` function to improve test coverage and document expected error handling behavior.

## Changes
Added 4 new test cases to `src/cli/parse-duration.test.ts`:
1. **Empty string validation** - Verifies that empty or whitespace-only strings throw "invalid duration (empty)"
2. **Invalid format handling** - Tests that malformed inputs (like "abc", "10x", "not-a-number") throw appropriate errors
3. **Negative value rejection** - Ensures negative durations are rejected with proper error messages
4. **Custom defaultUnit option** - Validates that the `defaultUnit` parameter works correctly for all supported units (ms, s, m, h, d)

## Testing Status
✅ **Fully tested**
- All 10 tests in `src/cli/parse-duration.test.ts` pass (6 existing + 4 new)
- Lint checks pass (`pnpm lint`)
- Build completes successfully (`pnpm build`)
- No production code changes, test-only improvement

## AI Involvement
🤖 **AI-assisted contribution** - This PR was created with Claude Code assistance.

I understand what the code does:
- The `parseDurationMs` function parses human-readable duration strings (like "5s", "2h", "100ms") into milliseconds
- It validates input format, handles various time units, and includes safeguards against invalid/negative values
- The new tests ensure these validation paths are properly covered and documented

## Why This Matters
- Improves test coverage for edge cases and error paths
- Documents expected behavior for future contributors
- Makes the validation rules more discoverable
- No risk to production code (test-only changes)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Test improvement
- [ ] Documentation
- [ ] Refactoring

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds additional Vitest coverage for `parseDurationMs` by asserting behavior for empty/whitespace input, malformed duration strings, negative values, and the `defaultUnit` option.

These tests live alongside the existing duration parsing cases in `src/cli/parse-duration.test.ts`, and effectively document the expected error messages and option handling without changing production logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only adds test cases and doesn’t modify production code.
- The diff is confined to a single test file and adds straightforward assertions that match the documented intent (error cases and defaultUnit behavior). No behavioral changes outside tests, and no signs of brittle environmental dependencies were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->