### PR TITLE
fix(exec): clean up PTY resources to prevent FD leaks

### DIFF
--- a/src/types/lydell-node-pty.d.ts
+++ b/src/types/lydell-node-pty.d.ts
@@ -1,11 +1,13 @@
 declare module "@lydell/node-pty" {
   export type PtyExitEvent = { exitCode: number; signal?: number };
   export type PtyListener<T> = (event: T) => void;
+  export type PtyDisposable = { dispose: () => void };
   export type PtyHandle = {
     pid: number;
     write: (data: string | Buffer) => void;
-    onData: (listener: PtyListener<string>) => void;
-    onExit: (listener: PtyListener<PtyExitEvent>) => void;
+    onData: (listener: PtyListener<string>) => PtyDisposable;
+    onExit: (listener: PtyListener<PtyExitEvent>) => PtyDisposable;
+    kill: (signal?: string) => void;
   };
 
   export type PtySpawn = (


### PR DESCRIPTION
## Summary
- Add proper cleanup of node-pty resources when PTY process exits
- Dispose `onData` and `onExit` listeners to release references
- Call `pty.kill()` to release native file descriptors

## Problem
PTY-mode exec commands leak ~3 FDs per invocation. After extended uptime, this leads to `spawn EBADF` errors.

## Solution
```typescript
ptyExitDisposable = pty.onExit((event) => {
  handleExit(event.exitCode ?? null, normalizedSignal);
  // Clean up PTY resources to prevent FD leaks
  try {
    ptyDataDisposable?.dispose();
    ptyExitDisposable?.dispose();
    pty.kill();
  } catch {
    // Ignore cleanup errors
  }
});
```

## Test plan
- [x] Type-check passes
- [x] Lint passes  
- [x] All 12 exec tests pass including PTY tests
- [ ] Manual: Long-running gateway with PTY commands should not leak FDs

Closes #4102

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the PTY execution path in `src/agents/bash-tools.exec.ts` to retain and dispose `@lydell/node-pty` `onData`/`onExit` listener disposables, and adds a `kill()` method to the local PTY handle typings (mirrored in `src/types/lydell-node-pty.d.ts`). The intent is to ensure PTY-related native resources (notably file descriptors) are released after PTY process exit, addressing long-running FD leaks that can lead to `spawn EBADF` failures.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and align with node-pty’s disposable listener API.
- Review focused on the PTY lifecycle changes and type updates. Listener disposal is straightforward and should help with leaks. Main remaining concern is the unconditional `pty.kill()` inside the `onExit` callback potentially being redundant/racy across platforms, but it’s wrapped in a try/catch and unlikely to break core behavior.
- src/agents/bash-tools.exec.ts (PTY exit/cleanup ordering and whether kill-on-exit is necessary)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->