### PR TITLE
fix(slack): support multiple file attachments in messages

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -43,7 +43,7 @@ import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-li
 import { resolveSlackEffectiveAllowFrom } from "../auth.js";
 import { resolveSlackChannelConfig } from "../channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
-import { resolveSlackMedia, resolveSlackThreadStarter } from "../media.js";
+import { resolveSlackMediaAll, resolveSlackThreadStarter, type SlackMediaRef } from "../media.js";
 
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
@@ -330,15 +330,14 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const media = await resolveSlackMedia({
+  const allMedia = await resolveSlackMediaAll({
     files: message.files,
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
-  if (!rawBody) {
-    return null;
-  }
+  const mediaPlaceholder = allMedia.length > 0 ? allMedia.map((m) => m.placeholder).join(" ") : "";
+  const rawBody = (message.text ?? "").trim() || mediaPlaceholder || "";
+  if (!rawBody) return null;
 
   const ackReaction = resolveAckReaction(cfg, route.agentId);
   const ackReactionValue = ackReaction ?? "";
@@ -454,7 +453,7 @@ export async function prepareSlackMessage(params: {
 
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
-  let threadStarterMedia: Awaited<ReturnType<typeof resolveSlackMedia>> = null;
+  let threadStarterMedia: SlackMediaRef[] = [];
   if (isThreadReply && threadTs) {
     const starter = await resolveSlackThreadStarter({
       channelId: message.channel,
@@ -475,15 +474,15 @@ export async function prepareSlackMessage(params: {
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
       threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
       // If current message has no files but thread starter does, fetch starter's files
-      if (!media && starter.files && starter.files.length > 0) {
-        threadStarterMedia = await resolveSlackMedia({
+      if (allMedia.length === 0 && starter.files && starter.files.length > 0) {
+        threadStarterMedia = await resolveSlackMediaAll({
           files: starter.files,
           token: ctx.botToken,
           maxBytes: ctx.mediaMaxBytes,
         });
-        if (threadStarterMedia) {
+        if (threadStarterMedia.length > 0) {
           logVerbose(
-            `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,
+            `slack: hydrated ${threadStarterMedia.length} thread starter file(s) from root message`,
           );
         }
       }
@@ -493,7 +492,7 @@ export async function prepareSlackMessage(params: {
   }
 
   // Use thread starter media if current message has none
-  const effectiveMedia = media ?? threadStarterMedia;
+  const effectiveMedia = allMedia.length > 0 ? allMedia : threadStarterMedia;
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -520,9 +519,15 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: effectiveMedia?.path,
-    MediaType: effectiveMedia?.contentType,
-    MediaUrl: effectiveMedia?.path,
+    MediaPath: effectiveMedia[0]?.path,
+    MediaType: effectiveMedia[0]?.contentType,
+    MediaUrl: effectiveMedia[0]?.path,
+    MediaPaths: effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
+    MediaUrls: effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
+    MediaTypes:
+      effectiveMedia.length > 0
+        ? (effectiveMedia.map((m) => m.contentType).filter(Boolean) as string[])
+        : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -337,7 +337,9 @@ export async function prepareSlackMessage(params: {
   });
   const mediaPlaceholder = allMedia.length > 0 ? allMedia.map((m) => m.placeholder).join(" ") : "";
   const rawBody = (message.text ?? "").trim() || mediaPlaceholder || "";
-  if (!rawBody) return null;
+  if (!rawBody) {
+    return null;
+  }
 
   const ackReaction = resolveAckReaction(cfg, route.agentId);
   const ackReactionValue = ackReaction ?? "";

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -527,9 +527,7 @@ export async function prepareSlackMessage(params: {
     MediaPaths: effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaUrls: effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaTypes:
-      effectiveMedia.length > 0
-        ? (effectiveMedia.map((m) => m.contentType).filter(Boolean) as string[])
-        : undefined,
+      effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.contentType ?? "") : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,


### PR DESCRIPTION
## Summary
- Add `resolveSlackMediaAll()` function that returns all successfully downloaded files
- Update `prepareSlackMessage` to use `MediaPaths`, `MediaUrls`, `MediaTypes` for multiple files
- Maintain backward compatibility by keeping `MediaPath`/`MediaType`/`MediaUrl` for first file

Fixes #2348

Also related to metelix/rin-agent#148 (thread image attachments not working)

## Changes
- `src/slack/monitor/media.ts`: New `resolveSlackMediaAll()` function, deprecate single-file `resolveSlackMedia()`
- `src/slack/monitor/message-handler/prepare.ts`: Use new multi-file API
- `src/slack/monitor/media.test.ts`: Add tests for multi-file handling

## Test plan
- [x] New unit tests for `resolveSlackMediaAll()`
- [x] All existing Slack tests pass (129 tests)
- [x] `pnpm lint && pnpm build` passes

---
Supersedes #3868 (rebased to remove unrelated changes from #3864)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds first-class multi-attachment support for Slack inbound messages by introducing `resolveSlackMediaAll()` (returning an array of downloaded media refs), updating `prepareSlackMessage()` to populate `MediaPaths`/`MediaUrls`/`MediaTypes`, and keeping the legacy single-file fields (`MediaPath`/`MediaType`/`MediaUrl`) for the first attachment.

The overall approach fits the existing Slack monitor flow: media hydration happens during message preparation and is threaded through the finalized inbound context for downstream agents/templating.


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the new multi-file context fields may be inconsistent for downstream consumers.
- Core changes are localized and covered by new tests, but there are potential semantic mismatches in the context payload (`MediaUrl`/`MediaUrls` currently hold local paths) and possible misalignment between `MediaTypes` and the other media arrays.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->