### PR TITLE
fix(agents): provide model fallback for compaction safeguard extension

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -79,6 +79,9 @@ export function buildEmbeddedExtensionPaths(params: {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
+      // Provide model as fallback for when ctx.model is undefined
+      // (ExtensionRunner not initialized during direct compaction calls)
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,5 +1,13 @@
+import type { Model } from "@mariozechner/pi-ai";
+
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
+  /**
+   * Fallback model for compaction summarization.
+   * Used when ctx.model is undefined (ExtensionRunner not initialized).
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Model API type varies by provider
+  model?: Model<any>;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -146,8 +146,15 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    // Use ctx.model if available, otherwise fall back to runtime.model
+    // (needed when ExtensionRunner is not initialized during direct compaction)
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
+      console.warn(
+        "Compaction safeguard: no model available (ctx.model and runtime.model both undefined). " +
+          "Returning fallback summary.",
+      );
       return {
         compaction: {
           summary: fallbackSummary,


### PR DESCRIPTION
## Summary
Provide a model fallback for the compaction safeguard extension so it can perform summarization even when `ctx.model` is undefined.

Fixes #4121

## Changes
- `src/agents/pi-extensions/compaction-safeguard.ts`: Add `modelFallback` option
- `src/agents/pi-extensions/compaction-safeguard-runtime.ts`: Use fallback when `ctx.model` is undefined
- `src/agents/pi-embedded-runner/extensions.ts`: Pass resolved model as fallback

## Test plan
- [x] `pnpm lint && pnpm build` passes
- [ ] Manual test: verify compaction safeguard produces summaries

---
Supersedes #4157 (rebased to remove 55 unrelated files)