### PR TITLE
fix(whatsapp): resolve Brazilian mobile JID variants (8/9 digit)

### DIFF
--- a/src/web/inbound/brazil-jid.ts
+++ b/src/web/inbound/brazil-jid.ts
@@ -1,0 +1,144 @@
+/**
+ * Brazil WhatsApp JID Resolution
+ *
+ * Brazilian mobile numbers transitioned from 8 to 9 digits (adding leading '9')
+ * around 2012-2016. WhatsApp accounts created before migration may still be
+ * registered with the old 8-digit format internally.
+ *
+ * This resolver queries WhatsApp to find the correct registered JID format.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+interface JidCache {
+  [inputJid: string]: { resolvedJid: string; ts: number };
+}
+
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CACHE_PATH = join(homedir(), ".config", "moltbot", "brazil-jid-cache.json");
+
+function loadCache(): JidCache {
+  try {
+    if (existsSync(CACHE_PATH)) {
+      return JSON.parse(readFileSync(CACHE_PATH, "utf-8"));
+    }
+  } catch {
+    // Ignore cache read errors
+  }
+  return {};
+}
+
+function saveCache(cache: JidCache): void {
+  try {
+    const dir = dirname(CACHE_PATH);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(CACHE_PATH, JSON.stringify(cache, null, 2));
+  } catch {
+    // Ignore cache write errors
+  }
+}
+
+/**
+ * Check if a JID is a Brazilian mobile number that might need resolution
+ */
+function isBrazilianMobile(jid: string): boolean {
+  const match = jid.match(/^(\d+)@s\.whatsapp\.net$/i);
+  if (!match) return false;
+
+  const digits = match[1];
+  if (!digits.startsWith("55")) return false;
+
+  // Brazil format: 55 + 2-digit area code + 8 or 9 digit local
+  // Area codes are 11-99
+  const areaCode = digits.slice(2, 4);
+  const areaNum = parseInt(areaCode, 10);
+  if (areaNum < 11 || areaNum > 99) return false;
+
+  const localNumber = digits.slice(4);
+  // Mobile numbers are 8 digits (legacy) or 9 digits (modern, starts with 9)
+  return localNumber.length === 8 || (localNumber.length === 9 && localNumber.startsWith("9"));
+}
+
+/**
+ * Generate both 8-digit and 9-digit variants of a Brazilian mobile JID
+ */
+function generateVariants(jid: string): string[] {
+  const match = jid.match(/^(\d+)@s\.whatsapp\.net$/i);
+  if (!match) return [jid];
+
+  const digits = match[1];
+  const areaCode = digits.slice(2, 4);
+  const localNumber = digits.slice(4);
+
+  const variants: string[] = [];
+
+  if (localNumber.length === 9 && localNumber.startsWith("9")) {
+    // Input is 9-digit format, generate 8-digit variant
+    variants.push(`55${areaCode}${localNumber}@s.whatsapp.net`); // 9-digit
+    variants.push(`55${areaCode}${localNumber.slice(1)}@s.whatsapp.net`); // 8-digit
+  } else if (localNumber.length === 8) {
+    // Input is 8-digit format, generate 9-digit variant
+    variants.push(`55${areaCode}${localNumber}@s.whatsapp.net`); // 8-digit
+    variants.push(`55${areaCode}9${localNumber}@s.whatsapp.net`); // 9-digit
+  } else {
+    variants.push(jid);
+  }
+
+  return variants;
+}
+
+export interface OnWhatsAppResult {
+  exists: boolean;
+  jid?: string;
+}
+
+export type OnWhatsAppFn = (jid: string) => Promise<OnWhatsAppResult[]>;
+
+/**
+ * Resolve a Brazilian WhatsApp JID to its correct registered format
+ *
+ * @param jid - The input JID (e.g., "5511999998888@s.whatsapp.net")
+ * @param onWhatsApp - Baileys onWhatsApp function to query registration
+ * @returns The resolved JID (may be different from input for Brazilian numbers)
+ */
+export async function resolveBrazilianJid(
+  jid: string,
+  onWhatsApp: OnWhatsAppFn,
+): Promise<string> {
+  // Only process Brazilian mobile numbers
+  if (!isBrazilianMobile(jid)) {
+    return jid;
+  }
+
+  // Check cache first
+  const cache = loadCache();
+  const cached = cache[jid];
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.resolvedJid;
+  }
+
+  // Generate variants and query WhatsApp
+  const variants = generateVariants(jid);
+
+  for (const variant of variants) {
+    try {
+      const results = await onWhatsApp(variant);
+      if (results?.[0]?.exists) {
+        const resolvedJid = results[0].jid || variant;
+
+        // Cache the result
+        cache[jid] = { resolvedJid, ts: Date.now() };
+        saveCache(cache);
+
+        return resolvedJid;
+      }
+    } catch {
+      // Continue to next variant on error
+    }
+  }
+
+  // Fallback to original JID if no variant found
+  return jid;
+}

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -2,14 +2,27 @@ import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
 import { toWhatsappJid } from "../../utils.js";
 import type { ActiveWebSendOptions } from "../active-listener.js";
+import { resolveBrazilianJid, type OnWhatsAppResult } from "./brazil-jid.js";
 
 export function createWebSendApi(params: {
   sock: {
     sendMessage: (jid: string, content: AnyMessageContent) => Promise<unknown>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
+    onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[]>;
   };
   defaultAccountId: string;
 }) {
+  /**
+   * Resolve JID, handling Brazilian number variants if onWhatsApp is available
+   */
+  const resolveJid = async (to: string): Promise<string> => {
+    const jid = toWhatsappJid(to);
+    if (params.sock.onWhatsApp) {
+      return resolveBrazilianJid(jid, params.sock.onWhatsApp);
+    }
+    return jid;
+  };
+
   return {
     sendMessage: async (
       to: string,
@@ -18,7 +31,7 @@ export function createWebSendApi(params: {
       mediaType?: string,
       sendOptions?: ActiveWebSendOptions,
     ): Promise<{ messageId: string }> => {
-      const jid = toWhatsappJid(to);
+      const jid = await resolveJid(to);
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {
@@ -65,7 +78,7 @@ export function createWebSendApi(params: {
       to: string,
       poll: { question: string; options: string[]; maxSelections?: number },
     ): Promise<{ messageId: string }> => {
-      const jid = toWhatsappJid(to);
+      const jid = await resolveJid(to);
       const result = await params.sock.sendMessage(jid, {
         poll: {
           name: poll.question,
@@ -91,7 +104,7 @@ export function createWebSendApi(params: {
       fromMe: boolean,
       participant?: string,
     ): Promise<void> => {
-      const jid = toWhatsappJid(chatJid);
+      const jid = await resolveJid(chatJid);
       await params.sock.sendMessage(jid, {
         react: {
           text: emoji,
@@ -105,7 +118,7 @@ export function createWebSendApi(params: {
       } as AnyMessageContent);
     },
     sendComposingTo: async (to: string): Promise<void> => {
-      const jid = toWhatsappJid(to);
+      const jid = await resolveJid(to);
       await params.sock.sendPresenceUpdate("composing", jid);
     },
   } as const;


### PR DESCRIPTION
## Summary

Brazilian mobile numbers transitioned from 8 to 9 digits (adding a leading `9`) around 2012-2016. WhatsApp accounts created before the migration may still be registered internally with the **old 8-digit format**, causing silent message delivery failures.

## Changes

- Added `brazil-jid.ts` - resolver module that:
  - Detects Brazilian mobile numbers (`55` + 2-digit area code + 8/9 digit local)
  - Generates both 8-digit and 9-digit variants
  - Uses `sock.onWhatsApp()` to find which format is actually registered
  - Caches verified JIDs for 7 days to avoid repeated lookups

- Modified `send-api.ts` to:
  - Optionally accept `onWhatsApp` in the sock params
  - Call the resolver before sending messages, polls, reactions, and presence updates
  - Fall back gracefully if `onWhatsApp` is not available

## Example

| Dialable Number | Possible Internal JIDs | Resolution |
|-----------------|----------------------|------------|
| +5511**9**99998888 | `5511**9**99998888@s.whatsapp.net` (modern) | ✅ Query finds correct one |
| +5511**9**99998888 | `5511**99998888**@s.whatsapp.net` (legacy) | ✅ Query finds correct one |

## Testing

- Tested locally with Brazilian numbers in both formats
- Cache stored at `~/.config/moltbot/brazil-jid-cache.json`

Fixes #4168