### PR TITLE
fix(whatsapp): resolve Brazilian mobile JID variants (8/9 digit)

### DIFF
--- a/src/web/inbound/brazil-jid.ts
+++ b/src/web/inbound/brazil-jid.ts
@@ -1,0 +1,186 @@
+/**
+ * Brazil WhatsApp JID Resolver
+ *
+ * Handles the legacy 8-digit vs 9-digit mobile number issue in Brazil.
+ * Uses Baileys' onWhatsApp() to discover the correct registered JID.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+const CONFIG_DIR = process.env.CLAWDBOT_CONFIG_DIR || join(homedir(), ".config", "clawdbot");
+const CACHE_FILE = join(CONFIG_DIR, "brazil-jid-cache.json");
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface CacheEntry {
+  jid: string;
+  originalInput: string;
+  variant: string;
+  timestamp: number;
+}
+
+interface JidCache {
+  entries: Record<string, CacheEntry>;
+  updatedAt: string;
+}
+
+// In-memory cache (persisted to disk)
+let jidCache: Record<string, CacheEntry> | null = null;
+
+function loadCache(): Record<string, CacheEntry> {
+  if (jidCache !== null) return jidCache;
+
+  try {
+    if (existsSync(CACHE_FILE)) {
+      const data = JSON.parse(readFileSync(CACHE_FILE, "utf-8")) as JidCache;
+      jidCache = data.entries || {};
+    } else {
+      jidCache = {};
+    }
+  } catch {
+    jidCache = {};
+  }
+  return jidCache;
+}
+
+function saveCache(): void {
+  try {
+    mkdirSync(dirname(CACHE_FILE), { recursive: true });
+    writeFileSync(
+      CACHE_FILE,
+      JSON.stringify(
+        {
+          entries: jidCache,
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (err) {
+    console.error("[brazil-jid] Failed to save cache:", (err as Error).message);
+  }
+}
+
+/**
+ * Check if a number is a Brazilian mobile number that needs resolution
+ */
+export function isBrazilianMobile(digits: string): boolean {
+  if (!digits.startsWith("55")) return false;
+
+  const afterCountryCode = digits.slice(2);
+  if (afterCountryCode.length < 10 || afterCountryCode.length > 11) return false;
+
+  const areaCode = afterCountryCode.slice(0, 2);
+  const areaNum = parseInt(areaCode, 10);
+  if (areaNum < 11 || areaNum > 99) return false;
+
+  const localNumber = afterCountryCode.slice(2);
+
+  // Mobile numbers: 8-digit legacy or 9-digit modern (starts with 9)
+  if (localNumber.length >= 8 && localNumber.length <= 9) {
+    if (localNumber.length === 9 && localNumber[0] === "9") return true;
+    if (localNumber.length === 8 && ["6", "7", "8", "9"].includes(localNumber[0])) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Generate both 8-digit and 9-digit variants for a Brazilian number
+ */
+export function generateBrazilianVariants(digits: string): string[] {
+  if (!digits.startsWith("55")) return [digits];
+
+  const areaCode = digits.slice(2, 4);
+  const localNumber = digits.slice(4);
+
+  const variants: string[] = [];
+
+  if (localNumber.length === 9 && localNumber.startsWith("9")) {
+    // Has 9-digit format: try as-is and without leading 9
+    variants.push(digits); // 9-digit
+    variants.push(`55${areaCode}${localNumber.slice(1)}`); // 8-digit
+  } else if (localNumber.length === 8) {
+    // Has 8-digit format: try as-is and with leading 9
+    variants.push(digits); // 8-digit
+    variants.push(`55${areaCode}9${localNumber}`); // 9-digit
+  } else {
+    variants.push(digits);
+  }
+
+  return variants;
+}
+
+interface OnWhatsAppResult {
+  exists: boolean;
+  jid?: string;
+}
+
+interface SockWithOnWhatsApp {
+  onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[]>;
+}
+
+/**
+ * Resolve a Brazilian WhatsApp JID to its correct registered format
+ */
+export async function resolveBrazilianJid(
+  sock: SockWithOnWhatsApp,
+  inputJid: string,
+): Promise<string> {
+  // Extract digits from JID
+  const match = inputJid.match(/^(\d+)@/);
+  if (!match) return inputJid;
+
+  const digits = match[1];
+
+  // Only process Brazilian mobile numbers
+  if (!isBrazilianMobile(digits)) {
+    return inputJid;
+  }
+
+  // Check cache first
+  const cache = loadCache();
+  const cached = cache[digits];
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    console.log(`[brazil-jid] Cache hit: ${digits} → ${cached.jid}`);
+    return cached.jid;
+  }
+
+  // Need onWhatsApp to resolve
+  if (!sock.onWhatsApp) {
+    return inputJid;
+  }
+
+  // Generate variants and query WhatsApp
+  const variants = generateBrazilianVariants(digits);
+  console.log(`[brazil-jid] Checking variants for ${digits}:`, variants);
+
+  for (const variant of variants) {
+    try {
+      const results = await sock.onWhatsApp(variant);
+      if (results?.[0]?.exists && results[0].jid) {
+        const resolvedJid = results[0].jid;
+        console.log(`[brazil-jid] Found: ${digits} → ${resolvedJid}`);
+
+        // Cache the result
+        cache[digits] = {
+          jid: resolvedJid,
+          originalInput: digits,
+          variant,
+          timestamp: Date.now(),
+        };
+        jidCache = cache;
+        saveCache();
+
+        return resolvedJid;
+      }
+    } catch {
+      // Continue to next variant
+    }
+  }
+
+  // Fallback to original
+  return inputJid;
+}

--- a/src/web/inbound/brazil-jid.ts
+++ b/src/web/inbound/brazil-jid.ts
@@ -119,7 +119,7 @@ interface OnWhatsAppResult {
 }
 
 interface SockWithOnWhatsApp {
-  onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[]>;
+  onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[] | undefined>;
 }
 
 /**

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -336,6 +336,7 @@ export async function monitorWebInbox(options: {
     sock: {
       sendMessage: (jid: string, content: AnyMessageContent) => sock.sendMessage(jid, content),
       sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
+      onWhatsApp: (jid: string) => sock.onWhatsApp(jid),
     },
     defaultAccountId: options.accountId,
   });

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -13,7 +13,7 @@ export function createWebSendApi(params: {
   sock: {
     sendMessage: (jid: string, content: AnyMessageContent) => Promise<unknown>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
-    onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[]>;
+    onWhatsApp?: (jid: string) => Promise<OnWhatsAppResult[] | undefined>;
   };
   defaultAccountId: string;
 }) {
@@ -23,7 +23,10 @@ export function createWebSendApi(params: {
       try {
         return await resolveBrazilianJid(params.sock, jid);
       } catch (err) {
-        console.warn('[send-api] Brazil JID resolution failed, using original:', (err as Error).message);
+        console.warn(
+          "[send-api] Brazil JID resolution failed, using original:",
+          (err as Error).message,
+        );
         return jid;
       }
     }


### PR DESCRIPTION
## Summary

Brazilian mobile numbers transitioned from 8 to 9 digits (adding a leading `9`) around 2012-2016. WhatsApp accounts created before the migration may still be registered internally with the **old 8-digit format**, causing silent message delivery failures.

## Changes

### `brazil-jid.ts` (new file)
Resolver module that:
- Detects Brazilian mobile numbers (`55` + 2-digit area code + 8/9 digit local)
- Generates both 8-digit and 9-digit variants
- Uses `sock.onWhatsApp()` to find which format is actually registered
- Caches verified JIDs for 7 days to avoid repeated lookups

### `send-api.ts`
- Optionally accepts `onWhatsApp` in the sock params
- Calls the resolver before sending messages, polls, reactions, and presence updates
- Falls back gracefully if `onWhatsApp` is not available

### `monitor.ts`
- Passes `onWhatsApp` to `createWebSendApi` so the resolver can query WhatsApp

## Example

| Input Number | Variants Checked | Resolution |
|-------------|-----------------|------------|
| +5511**9**99998888 | `5511999998888`, `551199998888` | ✅ Queries find correct one |

## Testing

- Tested locally with Brazilian numbers in both formats
- Confirmed message delivery to legacy 8-digit account
- Cache stored at `~/.config/clawdbot/brazil-jid-cache.json`

## Logs

```
[brazil-jid] Checking variants for 5511999998888: [ '5511999998888', '551199998888' ]
[brazil-jid] Found: 5511999998888 → 551199998888@s.whatsapp.net
```

Fixes #4168

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Brazilian WhatsApp JID resolver to handle legacy 8-digit vs modern 9-digit mobile numbers by generating both variants, probing `sock.onWhatsApp()`, and caching the resolved JID to disk. It wires the resolver into the outbound web send API so messages/polls/reactions/presence updates resolve the correct JID before sending, and passes `onWhatsApp` through from the monitor socket wrapper.

Overall the approach fits the existing `createWebSendApi` abstraction by keeping the resolution local to outbound sends and falling back when `onWhatsApp` is unavailable. The main concerns are around correctness of the `onWhatsApp()` response handling and operational considerations of a per-user JSON cache written directly to a fixed config path.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple correctness/operational edge cases worth addressing.
- The change is localized to outbound WhatsApp send paths and is guarded when `onWhatsApp` isn’t available. However, the resolver’s assumption about `onWhatsApp()` result ordering can cause missed resolutions, and the new on-disk JSON cache introduces cross-platform path/atomic-write concerns that could lead to surprising behavior or cache corruption in multi-process use.
- src/web/inbound/brazil-jid.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->