### PR TITLE
fix: avoid cron self-deadlock when embedded agent calls cron tools

### DIFF
--- a/src/agents/moltbot-tools.ts
+++ b/src/agents/moltbot-tools.ts
@@ -53,6 +53,8 @@ export function createMoltbotTools(options?: {
   modelHasVision?: boolean;
   /** Explicit agent ID override for cron/hook sessions. */
   requesterAgentIdOverride?: string;
+  /** Direct cron service for in-process calls (avoids WebSocket self-deadlock). */
+  cronService?: Parameters<typeof createCronTool>[0] extends { cronService?: infer T } ? T : never;
 }): AnyAgentTool[] {
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
@@ -82,6 +84,7 @@ export function createMoltbotTools(options?: {
     }),
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
+      cronService: options?.cronService,
     }),
     createMessageTool({
       agentAccountId: options?.agentAccountId,

--- a/src/cron/service-registry.ts
+++ b/src/cron/service-registry.ts
@@ -1,0 +1,21 @@
+/**
+ * Module-level registry for the CronService singleton.
+ *
+ * The gateway creates a single CronService instance. The cron tool needs
+ * direct access to it to avoid WebSocket self-deadlock when the embedded
+ * agent calls cron operations from within the same process.
+ *
+ * This registry avoids threading the instance through 7+ layers of params.
+ */
+
+import type { CronService } from "./service.js";
+
+let instance: CronService | undefined;
+
+export function setCronServiceInstance(svc: CronService): void {
+  instance = svc;
+}
+
+export function getCronServiceInstance(): CronService | undefined {
+  return instance;
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -50,6 +50,7 @@ import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
 import { buildGatewayCronService } from "./server-cron.js";
+import { setCronServiceInstance } from "../cron/service-registry.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import { coreGatewayHandlers } from "./server-methods.js";
@@ -334,6 +335,7 @@ export async function startGatewayServer(
     broadcast,
   });
   let { cron, storePath: cronStorePath } = cronState;
+  setCronServiceInstance(cron);
 
   const channelManager = createChannelManager({
     loadConfig,
@@ -519,6 +521,7 @@ export async function startGatewayServer(
       heartbeatRunner = nextState.heartbeatRunner;
       cronState = nextState.cronState;
       cron = cronState.cron;
+      setCronServiceInstance(cron);
       cronStorePath = cronState.storePath;
       browserControl = nextState.browserControl;
     },


### PR DESCRIPTION
## Summary

- When a cron job triggers an agent that calls back into cron (e.g. `cron.list`), the non-reentrant async mutex in `locked()` causes a circular wait: `onTimer` holds the lock → agent runs → agent calls `cron.list` → `cron.list` waits for the lock → deadlock.
- Splits `onTimer` to collect due jobs under the lock, then execute them after releasing it. The `runningAtMs` sentinel prevents double-runs.
- Adds a module-level `CronService` registry so the cron tool can call the service directly in-process, bypassing the gateway WebSocket round-trip.

## Files changed

- `src/cron/service-registry.ts` (new) — singleton get/set for CronService
- `src/cron/service/timer.ts` — collect due jobs under lock, execute outside it
- `src/agents/tools/cron-tool.ts` — prefer direct service call over gateway WebSocket
- `src/agents/moltbot-tools.ts` — thread `cronService` option
- `src/gateway/server.impl.ts` — register singleton at boot and on reload

## Test plan

- [x] Cron job that triggers an agent calling `cron.list` no longer deadlocks
- [ ] Manual `cron.run` still works
- [ ] Timer-fired jobs still execute on schedule
- [ ] No double-runs (verified via `runningAtMs` guard)

🤖 AI-assisted (Claude). I understand what the code does.
Testing: locally tested with cron jobs that call cron.list mid-execution.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a real deadlock scenario where `onTimer()` holds the non-reentrant cron mutex while running jobs, and an embedded agent job calls back into cron tools (e.g. `cron.list`), creating a circular wait. It does this by (1) splitting `onTimer()` to collect due jobs under `locked()` and execute them after releasing the lock, and (2) adding a module-level CronService registry so the cron agent tool can call the in-process CronService instead of doing a gateway WebSocket round-trip.

Main risk introduced is concurrency correctness around claiming due jobs now that execution is outside the lock (and type/behavior drift in the new `cronService` fast-path typing).

<h3>Confidence Score: 3/5</h3>

- This PR is directionally safe but has a plausible concurrency regression risk around job double-execution.
- The deadlock fix is well-motivated, but moving job execution outside `locked()` means the existing `runningAtMs` guard no longer prevents concurrent selection unless the guard is set under the lock. If any other code path selects due jobs while a timer tick is between selection and `executeJob()` start, the same job can run twice. The new CronService registry/tool fast-path is small and isolated, but the `cronService` type doesn’t fully match `CronService` and `wake` still uses the gateway path, which may surprise callers.
- src/cron/service/timer.ts; src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->