### PR TITLE
fix: enforce allowlist for explicit sends across all channels

### DIFF
--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -398,7 +398,17 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
             ),
           };
         }
-        return { ok: true, to: normalized };
+        const hasWildcard = allowListRaw.includes("*");
+        if (hasWildcard || allowList.length === 0 || allowList.includes(normalized)) {
+          return { ok: true, to: normalized };
+        }
+        if (mode === "implicit" || mode === "heartbeat") {
+          return { ok: true, to: allowList[0] };
+        }
+        return {
+          ok: false,
+          error: new Error(`Google Chat target ${trimmed} is not in the allowFrom list.`),
+        };
       }
 
       if (allowList.length > 0) {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -51,25 +51,19 @@ export const twitchOutbound: ChannelOutboundAdapter = {
       .map((entry: string) => normalizeTwitchChannel(entry))
       .filter((entry): entry is string => entry.length > 0);
 
-    // If target is provided, normalize and validate it
     if (trimmed) {
       const normalizedTo = normalizeTwitchChannel(trimmed);
-
-      // For implicit/heartbeat modes with allowList, check against allowlist
+      if (hasWildcard || allowList.length === 0 || allowList.includes(normalizedTo)) {
+        return { ok: true, to: normalizedTo };
+      }
       if (mode === "implicit" || mode === "heartbeat") {
-        if (hasWildcard || allowList.length === 0) {
-          return { ok: true, to: normalizedTo };
-        }
-        if (allowList.includes(normalizedTo)) {
-          return { ok: true, to: normalizedTo };
-        }
-        // Fallback to first allowFrom entry
         // biome-ignore lint/style/noNonNullAssertion: length > 0 check ensures element exists
         return { ok: true, to: allowList[0]! };
       }
-
-      // For explicit mode, accept any valid channel name
-      return { ok: true, to: normalizedTo };
+      return {
+        ok: false,
+        error: new Error(`Twitch target ${trimmed} is not in the allowFrom list.`),
+      };
     }
 
     // No target provided, use allowFrom fallback

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -303,18 +303,24 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           };
         }
         if (isWhatsAppGroupJid(normalizedTo)) {
+          if (hasWildcard || allowList.length === 0 || allowList.includes(normalizedTo)) {
+            return { ok: true, to: normalizedTo };
+          }
+          return {
+            ok: false,
+            error: new Error(`WhatsApp group ${trimmed} is not in the allowFrom list.`),
+          };
+        }
+        if (hasWildcard || allowList.length === 0 || allowList.includes(normalizedTo)) {
           return { ok: true, to: normalizedTo };
         }
         if (mode === "implicit" || mode === "heartbeat") {
-          if (hasWildcard || allowList.length === 0) {
-            return { ok: true, to: normalizedTo };
-          }
-          if (allowList.includes(normalizedTo)) {
-            return { ok: true, to: normalizedTo };
-          }
           return { ok: true, to: allowList[0] };
         }
-        return { ok: true, to: normalizedTo };
+        return {
+          ok: false,
+          error: new Error(`WhatsApp target ${trimmed} is not in the allowFrom list.`),
+        };
       }
 
       if (allowList.length > 0) {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -162,6 +162,16 @@ export function resolveOutboundTarget(params: {
 
   const trimmed = params.to?.trim();
   if (trimmed) {
+    const mode = params.mode ?? "explicit";
+    if (allowFrom && allowFrom.length > 0 && !allowFrom.includes("*")) {
+      const list = allowFrom.map((e) => String(e).trim()).filter(Boolean);
+      if (list.includes(trimmed)) return { ok: true, to: trimmed };
+      if (mode === "implicit" || mode === "heartbeat") {
+        const fallback = list[0];
+        if (fallback) return { ok: true, to: fallback };
+      }
+      return { ok: false, error: new Error(`Target ${trimmed} is not in the allowFrom list.`) };
+    }
     return { ok: true, to: trimmed };
   }
   const hint = plugin.messaging?.targetResolver?.hint;


### PR DESCRIPTION
## Summary

Explicit-mode sends (agent tool calls, gateway `send` command) bypassed the `allowFrom` allowlist on every channel adapter. An agent hallucination or prompt injection could send messages to arbitrary recipients despite `dmPolicy: "allowlist"` being configured.

- Adds allowlist enforcement to the default fallback in `targets.ts`, covering all channels without a custom `resolveTarget` (Discord, Slack, Matrix, MS Teams, etc.)
- Fixes WhatsApp (core + extension), Twitch, and Google Chat adapters to reject explicit sends to non-allowlisted targets
- Enforces allowlist on WhatsApp group JIDs (previously unguarded)

Implicit and heartbeat modes still fall back to `allowList[0]` as before.

## Files changed

- `src/infra/outbound/targets.ts` — default fallback now checks allowlist
- `src/channels/plugins/outbound/whatsapp.ts` — enforce for DMs + groups
- `extensions/whatsapp/src/channel.ts` — same fix for extension copy
- `extensions/twitch/src/outbound.ts` — enforce for explicit sends
- `extensions/googlechat/src/channel.ts` — enforce for explicit sends

## Test plan

- [ ] Explicit send to non-allowlisted target is rejected
- [ ] Implicit/heartbeat sends still fall back to `allowList[0]`
- [ ] Wildcard (`*`) in allowFrom still permits all targets
- [ ] Empty allowFrom still permits all targets (no allowlist configured)
- [ ] Group JIDs in WhatsApp require allowlist entry

🤖 AI-assisted (Claude). I understand what the code does.
Testing: locally tested with WhatsApp allowlist configuration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens outbound target resolution so that **explicit sends** (agent tool calls / gateway `send`) no longer bypass per-channel `allowFrom` allowlists when `dmPolicy: "allowlist"` is configured.

The change is implemented in two layers:
- A safer default in `src/infra/outbound/targets.ts` that enforces `allowFrom` for any channel that doesn’t supply a custom `outbound.resolveTarget`.
- Adapter-specific fixes for channels that *do* override target resolution (WhatsApp core + extension, Twitch, Google Chat), ensuring explicit mode rejects non-allowlisted targets while implicit/heartbeat continue to fall back to the first allowlist entry.

Overall, this aligns explicit-mode behavior with the allowlist policy across more channels and closes a prompt-injection/hallucination path for sending to unintended recipients.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and improves security posture, with a small risk of edge-case target normalization regressions.
- Changes are localized to target resolution logic and follow existing allowlist patterns, but a couple of adapters may now accept/deny edge-case targets differently (e.g. Twitch empty channel normalization; wildcard normalization consistency).
- extensions/twitch/src/outbound.ts; extensions/googlechat/src/channel.ts; src/infra/outbound/targets.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->