### PR TITLE
fix(cli): avoid crash when os.networkInterfaces fails

### DIFF
--- a/src/infra/system-presence.networkinterfaces-error.test.ts
+++ b/src/infra/system-presence.networkinterfaces-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+const realOs = await vi.importActual<typeof import("node:os")>("node:os");
+
+vi.mock("node:os", () => {
+  const hostname = () => "moltbot-test-host";
+  const platform = () => "linux";
+  const networkInterfaces = () => {
+    throw new Error("uv_interface_addresses returned Unknown system error 1");
+  };
+  return {
+    ...realOs,
+    default: {
+      ...realOs,
+      hostname,
+      platform,
+      networkInterfaces,
+    },
+    hostname,
+    platform,
+    networkInterfaces,
+  };
+});
+
+describe("system-presence", () => {
+  it("does not crash when os.networkInterfaces throws", async () => {
+    vi.resetModules();
+    const { listSystemPresence } = await import("./system-presence.js");
+    const entries = listSystemPresence();
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.some((entry) => entry.host === "moltbot-test-host")).toBe(true);
+  });
+});

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -39,21 +39,27 @@ function normalizePresenceKey(key: string | undefined): string | undefined {
 }
 
 function resolvePrimaryIPv4(): string | undefined {
-  const nets = os.networkInterfaces();
-  const prefer = ["en0", "eth0"];
-  const pick = (names: string[]) => {
-    for (const name of names) {
-      const list = nets[name];
-      const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
-      if (entry?.address) return entry.address;
-    }
-    for (const list of Object.values(nets)) {
-      const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
-      if (entry?.address) return entry.address;
-    }
-    return undefined;
-  };
-  return pick(prefer) ?? os.hostname();
+  try {
+    const nets = os.networkInterfaces();
+    const prefer = ["en0", "eth0"];
+    const pick = (names: string[]) => {
+      for (const name of names) {
+        const list = nets[name];
+        const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
+        if (entry?.address) return entry.address;
+      }
+      for (const list of Object.values(nets)) {
+        const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
+        if (entry?.address) return entry.address;
+      }
+      return undefined;
+    };
+    return pick(prefer) ?? os.hostname();
+  } catch {
+    // Some environments (e.g. certain VPS setups) can throw from os.networkInterfaces().
+    // Fall back to hostname so the CLI can still boot.
+    return os.hostname();
+  }
 }
 
 function initSelfPresence() {


### PR DESCRIPTION
Fixes #3199.

Summary:
- Wrap `os.networkInterfaces()` in a try/catch during system presence initialization.
- Fall back to `os.hostname()` so the CLI can boot even when libuv reports `uv_interface_addresses` errors.
- Add a regression test that mocks `os.networkInterfaces` throwing.

Testing:
- pnpm lint
- pnpm format
- pnpm vitest run --config vitest.unit.config.ts src/infra/system-presence.networkinterfaces-error.test.ts src/infra/system-presence.test.ts

AI-assisted: yes (Codex CLI).
