### PR TITLE
feat(discord): peer typing-aware debounce for multi-bot coordination

### DIFF
--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -29,20 +29,66 @@ export function resolveInboundDebounceMs(params: {
   return override ?? byChannel ?? base ?? 0;
 }
 
+export function resolvePeerBots(params: { cfg: MoltbotConfig }): string[] {
+  const peerBots = params.cfg.messages?.inbound?.peerBots;
+  if (!Array.isArray(peerBots)) return [];
+  return peerBots.filter((id): id is string => typeof id === "string" && id.trim().length > 0);
+}
+
+export function resolvePeerTypingDelayMs(params: { cfg: MoltbotConfig }): number {
+  return resolveMs(params.cfg.messages?.inbound?.peerTypingDelayMs) ?? 3000;
+}
+
+export function resolvePeerTypingMaxRetries(params: { cfg: MoltbotConfig }): number {
+  return resolveMs(params.cfg.messages?.inbound?.peerTypingMaxRetries) ?? 3;
+}
+
 type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
+};
+
+export type DebounceFlushContext<T> = {
+  /** Re-enqueue an item with a custom delay (e.g., for peer typing backoff) */
+  requeue: (item: T, delayMs: number) => void;
 };
 
 export function createInboundDebouncer<T>(params: {
   debounceMs: number;
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
-  onFlush: (items: T[]) => Promise<void>;
+  onFlush: (items: T[], ctx: DebounceFlushContext<T>) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
 }) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const debounceMs = Math.max(0, Math.trunc(params.debounceMs));
+
+  const scheduleFlushWithDelay = (key: string, buffer: DebounceBuffer<T>, delayMs: number) => {
+    if (buffer.timeout) clearTimeout(buffer.timeout);
+    buffer.timeout = setTimeout(() => {
+      void flushBuffer(key, buffer);
+    }, delayMs);
+    buffer.timeout.unref?.();
+  };
+
+  const requeueItem = (item: T, delayMs: number) => {
+    const key = params.buildKey(item);
+    if (!key) return;
+
+    const existing = buffers.get(key);
+    if (existing) {
+      existing.items.push(item);
+      scheduleFlushWithDelay(key, existing, delayMs);
+    } else {
+      const buffer: DebounceBuffer<T> = { items: [item], timeout: null };
+      buffers.set(key, buffer);
+      scheduleFlushWithDelay(key, buffer, delayMs);
+    }
+  };
+
+  const flushContext: DebounceFlushContext<T> = {
+    requeue: requeueItem,
+  };
 
   const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
     buffers.delete(key);
@@ -52,7 +98,7 @@ export function createInboundDebouncer<T>(params: {
     }
     if (buffer.items.length === 0) return;
     try {
-      await params.onFlush(buffer.items);
+      await params.onFlush(buffer.items, flushContext);
     } catch (err) {
       params.onError?.(err, buffer.items);
     }
@@ -80,7 +126,7 @@ export function createInboundDebouncer<T>(params: {
       if (key && buffers.has(key)) {
         await flushKey(key);
       }
-      await params.onFlush([item]);
+      await params.onFlush([item], flushContext);
       return;
     }
 

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -25,6 +25,12 @@ export type InboundDebounceByProvider = Record<string, number>;
 export type InboundDebounceConfig = {
   debounceMs?: number;
   byChannel?: InboundDebounceByProvider;
+  /** Bot user IDs to watch for typing indicators (multi-bot coordination). */
+  peerBots?: string[];
+  /** Delay (ms) when a peer bot is typing. Default: 3000. */
+  peerTypingDelayMs?: number;
+  /** Max retries when peer keeps typing. Default: 3. */
+  peerTypingMaxRetries?: number;
 };
 
 export type BroadcastStrategy = "parallel" | "sequential";

--- a/src/discord/monitor/peer-typing.ts
+++ b/src/discord/monitor/peer-typing.ts
@@ -1,0 +1,65 @@
+import { TypingStartListener, type Client } from "@buape/carbon";
+
+const TYPING_TTL_MS = 10_000;
+
+// channelId → Map<userId, expiresAtMs>
+const peerTypingState = new Map<string, Map<string, number>>();
+
+/**
+ * Listener that tracks typing indicators from configured peer bots.
+ * Used to implement typing-aware debounce for multi-bot coordination.
+ */
+export class PeerTypingListener extends TypingStartListener {
+  constructor(private peerBotIds: Set<string>) {
+    super();
+  }
+
+  async handle(data: { channel_id: string; user_id: string }, _client: Client): Promise<void> {
+    // Only track typing from configured peer bots
+    if (!this.peerBotIds.has(data.user_id)) return;
+
+    let channelMap = peerTypingState.get(data.channel_id);
+    if (!channelMap) {
+      channelMap = new Map();
+      peerTypingState.set(data.channel_id, channelMap);
+    }
+    channelMap.set(data.user_id, Date.now() + TYPING_TTL_MS);
+  }
+}
+
+/**
+ * Check if any of the specified peer bots are currently typing in the channel.
+ * Returns true if at least one peer has a non-expired typing indicator.
+ */
+export function isPeerTyping(channelId: string, peerBotIds: string[]): boolean {
+  const channelMap = peerTypingState.get(channelId);
+  if (!channelMap) return false;
+
+  const now = Date.now();
+  for (const id of peerBotIds) {
+    const expiresAt = channelMap.get(id);
+    if (expiresAt && expiresAt > now) return true;
+  }
+  return false;
+}
+
+/**
+ * Clean up expired typing indicators from the state map.
+ * Called periodically or on-demand to prevent memory leaks.
+ */
+export function clearExpiredTyping(): void {
+  const now = Date.now();
+  for (const [channelId, channelMap] of peerTypingState) {
+    for (const [userId, expiresAt] of channelMap) {
+      if (expiresAt <= now) channelMap.delete(userId);
+    }
+    if (channelMap.size === 0) peerTypingState.delete(channelId);
+  }
+}
+
+/**
+ * Get the current typing state for debugging/diagnostics.
+ */
+export function getPeerTypingState(): Map<string, Map<string, number>> {
+  return peerTypingState;
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -34,6 +34,8 @@ import {
   registerDiscordListener,
 } from "./listeners.js";
 import { createDiscordMessageHandler } from "./message-handler.js";
+import { PeerTypingListener } from "./peer-typing.js";
+import { resolvePeerBots } from "../../auto-reply/inbound-debounce.js";
 import {
   createDiscordCommandArgFallbackButton,
   createDiscordNativeCommand,
@@ -547,6 +549,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       new DiscordPresenceListener({ logger, accountId: account.accountId }),
     );
     runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
+  }
+
+  // Register peer typing listener for multi-bot coordination
+  const peerBotIds = resolvePeerBots({ cfg });
+  if (peerBotIds.length > 0) {
+    registerDiscordListener(client.listeners, new PeerTypingListener(new Set(peerBotIds)));
+    runtime.log?.(`discord: peer typing listener registered for ${peerBotIds.length} bot(s)`);
   }
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);


### PR DESCRIPTION
## Problem

Multiple Moltbot instances responding to the same channel can generate simultaneous responses because they don't know when peers are mid-generation. This creates "response storms" in shared channels.

## Solution

Track peer bot typing indicators and extend debounce when detected.

### New Config Options (`messages.inbound`)

```json5
{
  "messages": {
    "inbound": {
      "peerBots": ["123456789", "987654321"],  // Bot user IDs to watch
      "peerTypingDelayMs": 3000,                  // Backoff delay (default: 3000)
      "peerTypingMaxRetries": 3                   // Max retries (default: 3)
    }
  }
}
```

### Implementation

1. **PeerTypingListener** - Subscribes to Discord TYPING_START events and tracks peer bot typing state in a TTL-based map (10s expiry matching Discord's typing indicator)

2. **Debouncer enhancement** - `onFlush` callback now receives a `requeue(item, delayMs)` function for custom-delay re-enqueueing

3. **Message handler integration** - Before processing, checks if any configured peer is typing. If so, re-queues with backoff delay (up to max retries)

### Files Changed

- `src/discord/monitor/peer-typing.ts` (new) - Typing listener and state management
- `src/auto-reply/inbound-debounce.ts` - Added requeue support and config resolvers
- `src/discord/monitor/message-handler.ts` - Peer typing check in onFlush
- `src/discord/monitor/provider.ts` - Listener registration
- `src/config/types.messages.ts` - New config types

### Testing

1. Configure two Moltbot instances with each other's bot ID in `peerBots`
2. Send a message that triggers both
3. First bot to start typing should cause second to delay
4. Only one response should appear (or responses should be staggered)

---

*Built in collaboration with Vesper during the Waking Town experiment* 🏛️