### PR TITLE
fix: canvas root should respect agents.defaults.workspace

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -38,7 +38,7 @@ export type DiscoveryConfig = {
 
 export type CanvasHostConfig = {
   enabled?: boolean;
-  /** Directory to serve (default: ~/.openclaw/workspace/canvas). */
+  /** Directory to serve (default: <workspace>/canvas, e.g. ~/clawd/canvas). */
   root?: string;
   /** HTTP port to listen on (default: 18793). */
   port?: number;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -1,4 +1,5 @@
 import type { Server as HttpServer } from "node:http";
+import path from "node:path";
 import { WebSocketServer } from "ws";
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
@@ -37,6 +38,7 @@ export async function createGatewayRuntimeState(params: {
   deps: CliDeps;
   canvasRuntime: RuntimeEnv;
   canvasHostEnabled: boolean;
+  defaultWorkspaceDir: string;
   allowCanvasHostInTests?: boolean;
   logCanvas: { info: (msg: string) => void; warn: (msg: string) => void };
   log: { info: (msg: string) => void; warn: (msg: string) => void };
@@ -75,7 +77,7 @@ export async function createGatewayRuntimeState(params: {
     try {
       const handler = await createCanvasHostHandler({
         runtime: params.canvasRuntime,
-        rootDir: params.cfg.canvasHost?.root,
+        rootDir: params.cfg.canvasHost?.root ?? path.join(params.defaultWorkspaceDir, "canvas"),
         basePath: CANVAS_HOST_PATH,
         allowInTests: params.allowCanvasHostInTests,
         liveReload: params.cfg.canvasHost?.liveReload,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -301,6 +301,7 @@ export async function startGatewayServer(
     deps,
     canvasRuntime,
     canvasHostEnabled,
+    defaultWorkspaceDir,
     allowCanvasHostInTests: opts.allowCanvasHostInTests,
     logCanvas,
     log,


### PR DESCRIPTION
## Summary

When `canvasHost.root` is not explicitly configured, the canvas directory defaults to `~/clawd/canvas` regardless of the user's `agents.defaults.workspace` setting. This PR derives the default from the workspace directory instead, so users with a custom workspace (e.g. `~/Bot`) get `~/Bot/canvas` automatically.

Closes #2282

- Pass `defaultWorkspaceDir` into `createGatewayRuntimeState`
- Use `path.join(defaultWorkspaceDir, "canvas")` as fallback when `canvasHost.root` is unset
- Update doc comment in `CanvasHostConfig` to reflect the new default

Backward compatible: if workspace is not customized, the default remains `~/clawd/canvas`.

## Test plan

- Set `agents.defaults.workspace` to a custom dir (e.g. `~/Bot`), leave `canvasHost.root` unset → canvas mounts at `~/Bot/canvas`
- Explicitly set `canvasHost.root` → that value is used (unchanged behavior)
- No workspace or canvas config → defaults to `~/clawd/canvas` (unchanged behavior)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads the resolved default agent workspace directory (`defaultWorkspaceDir`) into gateway runtime initialization and uses it to derive the canvas host root when `cfg.canvasHost.root` is unset. Specifically, `createGatewayRuntimeState` now falls back to `path.join(defaultWorkspaceDir, "canvas")` rather than an implicit hardcoded workspace path, so users customizing `agents.defaults.workspace` get a matching default canvas directory.

The behavior for an explicitly configured `canvasHost.root` remains unchanged; only the implicit default changes.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and changes a single default path derivation without altering explicit configuration behavior.
- Changes are localized to gateway startup/runtime wiring and a nullish-coalescing fallback for `canvasHost.root`; the main risk is around documentation clarity and how “workspace” is defined (default agent vs per-agent) rather than runtime correctness.
- src/config/types.gateway.ts (comment accuracy)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->