### PR TITLE
Fix/sandbox containerworkdir rw access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Status: beta.
 
 ### Fixes
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
+- Sandbox: include containerWorkdir in sandboxInfo for rw access so agents see correct Docker mount paths. Fixes #4171.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -21,7 +21,10 @@ wizard, and let the agent bootstrap itself.
 7) **Onboarding chat** (dedicated session)
 8) Ready
 
-## 1) Local vs Remote
+## 1) Welcome + security notice
+Read the security notice displayed and decide accordingly.
+
+## 2) Local vs Remote
 
 Where does the **Gateway** run?
 
@@ -36,7 +39,7 @@ Gateway auth tip:
 - If you disable auth, any local process can connect; use that only on fully trusted machines.
 - Use a **token** for multi‑machine access or non‑loopback binds.
 
-## 2) Local-only auth (Anthropic OAuth)
+## 3) Local-only auth (Anthropic OAuth)
 
 The macOS app supports Anthropic OAuth (Claude Pro/Max). The flow:
 
@@ -47,12 +50,12 @@ The macOS app supports Anthropic OAuth (Claude Pro/Max). The flow:
 Other providers (OpenAI, custom APIs) are configured via environment variables
 or config files for now.
 
-## 3) Setup Wizard (Gateway‑driven)
+## 4) Setup Wizard (Gateway‑driven)
 
 The app can run the same setup wizard as the CLI. This keeps onboarding in sync
 with Gateway‑side behavior and avoids duplicating logic in SwiftUI.
 
-## 4) Permissions
+## 5) Permissions
 
 Onboarding requests TCC permissions needed for:
 
@@ -62,12 +65,12 @@ Onboarding requests TCC permissions needed for:
 - Microphone / Speech Recognition
 - Automation (AppleScript)
 
-## 5) CLI (optional)
+## 6) CLI (optional)
 
 The app can install the global `moltbot` CLI via npm/pnpm so terminal
 workflows and launchd tasks work out of the box.
 
-## 6) Onboarding chat (dedicated session)
+## 7) Onboarding chat (dedicated session)
 
 After setup, the app opens a dedicated onboarding chat session so the agent can
 introduce itself and guide next steps. This keeps first‑run guidance separate

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -143,6 +143,76 @@ describe("buildEmbeddedSandboxInfo", () => {
       hostBrowserAllowed: true,
     });
   });
+  it("includes containerWorkdir as agentWorkspaceMount for rw access", () => {
+    const sandbox = {
+      enabled: true,
+      sessionKey: "session:test",
+      workspaceDir: "/tmp/moltbot-sandbox",
+      agentWorkspaceDir: "/tmp/moltbot-workspace",
+      workspaceAccess: "rw",
+      containerName: "moltbot-sbx-test",
+      containerWorkdir: "/workspace",
+      docker: {
+        image: "moltbot-sandbox:bookworm-slim",
+        containerPrefix: "moltbot-sbx-",
+        workdir: "/workspace",
+        readOnlyRoot: true,
+        tmpfs: ["/tmp"],
+        network: "none",
+        user: "1000:1000",
+        capDrop: ["ALL"],
+        env: { LANG: "C.UTF-8" },
+      },
+      tools: {
+        allow: ["exec"],
+        deny: ["browser"],
+      },
+      browserAllowHostControl: false,
+    } satisfies SandboxContext;
+
+    expect(buildEmbeddedSandboxInfo(sandbox)).toEqual({
+      enabled: true,
+      workspaceDir: "/tmp/moltbot-sandbox",
+      workspaceAccess: "rw",
+      agentWorkspaceMount: "/workspace",
+      hostBrowserAllowed: false,
+    });
+  });
+  it("includes /agent as agentWorkspaceMount for ro access", () => {
+    const sandbox = {
+      enabled: true,
+      sessionKey: "session:test",
+      workspaceDir: "/tmp/moltbot-sandbox",
+      agentWorkspaceDir: "/tmp/moltbot-workspace",
+      workspaceAccess: "ro",
+      containerName: "moltbot-sbx-test",
+      containerWorkdir: "/workspace",
+      docker: {
+        image: "moltbot-sandbox:bookworm-slim",
+        containerPrefix: "moltbot-sbx-",
+        workdir: "/workspace",
+        readOnlyRoot: true,
+        tmpfs: ["/tmp"],
+        network: "none",
+        user: "1000:1000",
+        capDrop: ["ALL"],
+        env: { LANG: "C.UTF-8" },
+      },
+      tools: {
+        allow: ["exec"],
+        deny: ["browser"],
+      },
+      browserAllowHostControl: false,
+    } satisfies SandboxContext;
+
+    expect(buildEmbeddedSandboxInfo(sandbox)).toEqual({
+      enabled: true,
+      workspaceDir: "/tmp/moltbot-sandbox",
+      workspaceAccess: "ro",
+      agentWorkspaceMount: "/agent",
+      hostBrowserAllowed: false,
+    });
+  });
   it("includes elevated info when allowed", () => {
     const sandbox = {
       enabled: true,

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -8,11 +8,20 @@ export function buildEmbeddedSandboxInfo(
 ): EmbeddedSandboxInfo | undefined {
   if (!sandbox?.enabled) return undefined;
   const elevatedAllowed = Boolean(execElevated?.enabled && execElevated.allowed);
+  // For rw access, the agent workspace is mounted at containerWorkdir (typically /workspace).
+  // For ro access, the agent workspace is mounted read-only at /agent.
+  // For none access, there is no agent workspace mount.
+  const agentWorkspaceMount =
+    sandbox.workspaceAccess === "rw"
+      ? sandbox.containerWorkdir
+      : sandbox.workspaceAccess === "ro"
+        ? "/agent"
+        : undefined;
   return {
     enabled: true,
     workspaceDir: sandbox.workspaceDir,
     workspaceAccess: sandbox.workspaceAccess,
-    agentWorkspaceMount: sandbox.workspaceAccess === "ro" ? "/agent" : undefined,
+    agentWorkspaceMount,
     browserBridgeUrl: sandbox.browser?.bridgeUrl,
     browserNoVncUrl: sandbox.browser?.noVncUrl,
     hostBrowserAllowed: sandbox.browserAllowHostControl,


### PR DESCRIPTION
## Summary

Fixes #4171 - Cron isolated agent does not pass sandboxInfo to system prompt

## Problem

When running a cron job with `sessionTarget: "isolated"` and sandbox enabled with `workspaceAccess: "rw"`, the agent receives the host workspace path (e.g., `/home/node/loom-novia`) in the system prompt instead of the Docker container mount path (`/workspace`).

## Root Cause

The [buildEmbeddedSandboxInfo()](cci:1://file:///Users/ozgur/Documents/Repos/Apps/moltbot/moltbot/src/agents/pi-embedded-runner/sandbox-info.ts:4:0-36:1) function was only setting `agentWorkspaceMount` for read-only ([ro](cci:2://file:///Users/ozgur/Documents/Repos/Apps/moltbot/moltbot/src/agents/system-prompt.ts:12:0-12:53)) access, but not for read-write (`rw`) access.

## Changes

- **[src/agents/pi-embedded-runner/sandbox-info.ts](cci:7://file:///Users/ozgur/Documents/Repos/Apps/moltbot/moltbot/src/agents/pi-embedded-runner/sandbox-info.ts:0:0-0:0)**: Added logic to set `agentWorkspaceMount` to `containerWorkdir` (typically `/workspace`) for `rw` access
- **[src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts](cci:7://file:///Users/ozgur/Documents/Repos/Apps/moltbot/moltbot/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts:0:0-0:0)**: Added 2 new test cases for `rw` and [ro](cci:2://file:///Users/ozgur/Documents/Repos/Apps/moltbot/moltbot/src/agents/system-prompt.ts:12:0-12:53) workspace access modes

## Testing

- [x] All existing tests pass
- [x] New test cases added for rw/ro access modes  
- [x] Lint passes
- [x] Build passes

## AI-Assisted

- [x] This PR was AI-assisted
- [x] Lightly tested (unit tests only)
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `buildEmbeddedSandboxInfo` to populate `agentWorkspaceMount` for `workspaceAccess: "rw"` using the sandbox’s `containerWorkdir`, so system prompts reference the container-mounted workspace path (e.g. `/workspace`) instead of host paths. It also adds unit coverage for `rw`/`ro` access modes, and includes small doc/changelog updates.

In the codebase, `EmbeddedSandboxInfo` is used to shape what the agent sees in the system prompt about its execution sandbox; this change ensures the prompt reflects the actual filesystem mount point when the agent has read/write workspace access inside the container.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported sandbox path issue with minimal surface area.
- The change is localized to sandbox prompt info construction and is backed by new unit tests. Remaining risk is mostly around assumptions that `containerWorkdir` is always set for `rw`, and that tests don’t fully assert the originally reported host-vs-container path mismatch scenario.
- src/agents/pi-embedded-runner/sandbox-info.ts; src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->