### PR TITLE
fix(media): skip audio in extractFileBlocks + hasBinaryAudioMagic defense-in-depth

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -216,7 +216,7 @@ async function extractFileBlocks(params: {
     }
     const forcedTextMime = resolveTextMimeFromName(attachment.path ?? attachment.url ?? "");
     const kind = forcedTextMime ? "document" : resolveAttachmentKind(attachment);
-    if (!forcedTextMime && (kind === "image" || kind === "video")) {
+    if (!forcedTextMime && (kind === "image" || kind === "audio" || kind === "video")) {
       continue;
     }
     if (!limits.allowUrl && attachment.url && !attachment.path) {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -162,6 +162,48 @@ function looksLikeUtf8Text(buffer?: Buffer): boolean {
   return printable / total > 0.85;
 }
 
+/**
+ * Detects binary audio/video formats by magic bytes (file signatures).
+ *
+ * OGG files (used by Telegram voice messages as OGG Opus) have ASCII-heavy
+ * headers that can pass looksLikeUtf8Text() due to Vorbis/Opus comment metadata
+ * containing printable strings. This causes them to be misidentified as text.
+ *
+ * Magic bytes provide authoritative format detection independent of MIME type
+ * or file extension, following established file format specifications.
+ *
+ * References:
+ * - OGG container: RFC 3533 (https://datatracker.ietf.org/doc/html/rfc3533)
+ *   Section 6: "OggS" capture pattern at byte offset 0
+ * - MP3 ID3v2: id3.org spec (https://id3.org/id3v2.4.0-structure)
+ *   Section 3.1: "ID3" identifier at file start
+ *
+ * @see https://github.com/moltbot/moltbot/issues/1989
+ */
+function hasBinaryAudioMagic(buffer?: Buffer): boolean {
+  if (!buffer || buffer.length < 4) return false;
+  // OGG container format: "OggS" signature (RFC 3533 Section 6)
+  // Covers OGG Vorbis, OGG Opus (Telegram voice), OGG Theora, etc.
+  if (
+    buffer[0] === 0x4f && // 'O'
+    buffer[1] === 0x67 && // 'g'
+    buffer[2] === 0x67 && // 'g'
+    buffer[3] === 0x53 // 'S'
+  ) {
+    return true;
+  }
+  // MP3 with ID3v2 tag: "ID3" signature (id3.org spec Section 3.1)
+  // ID3v2 tags can contain large amounts of ASCII text (lyrics, comments)
+  if (
+    buffer[0] === 0x49 && // 'I'
+    buffer[1] === 0x44 && // 'D'
+    buffer[2] === 0x33 // '3'
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function decodeTextSample(buffer?: Buffer): string {
   if (!buffer || buffer.length === 0) return "";
   const sample = buffer.subarray(0, Math.min(buffer.length, 8192));
@@ -242,7 +284,11 @@ async function extractFileBlocks(params: {
     const forcedTextMimeResolved = forcedTextMime ?? resolveTextMimeFromName(nameHint ?? "");
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
-    const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
+    // Check if content looks like text, but exclude files with known binary audio magic bytes
+    // OGG files can pass looksLikeUtf8Text() due to ASCII-heavy headers (>85% printable)
+    const textLike =
+      (Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer)) &&
+      !hasBinaryAudioMagic(bufferResult?.buffer);
     if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
       continue;
     }


### PR DESCRIPTION
## Summary

Fixes #1989 — complementary to #3904.

OGG audio files (Telegram voice messages) were misidentified as `text/tab-separated-values` because `looksLikeUtf8Text()` passes on OGG headers (>85% printable ASCII) and `guessDelimitedMime()` finds tabs in the metadata.

This PR combines two defenses:

### 1. Early skip for `kind === "audio"` in `extractFileBlocks()`

Adds `"audio"` to the existing `image`/`video` skip list, so audio attachments bypass text extraction entirely — no buffer read needed.

```typescript
if (!forcedTextMime && (kind === "image" || kind === "audio" || kind === "video")) {
  continue;
}
```

### 2. `hasBinaryAudioMagic()` buffer check (same approach as #3904)

Detects OGG (`OggS`) and MP3-with-ID3 (`ID3`) by magic bytes, so even if an audio file slips past the kind check, `textLike` will be `false`:

```typescript
const textLike =
  (Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer)) &&
  !hasBinaryAudioMagic(bufferResult?.buffer);
```

### Why both?

- The kind skip handles the common path efficiently (no I/O)
- The magic bytes check catches edge cases where `resolveAttachmentKind()` fails or returns something unexpected
- Defense-in-depth: two independent checks for the same class of bug

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens file-text extraction heuristics in `src/media-understanding/apply.ts` to prevent binary audio (notably Telegram OGG voice messages) from being misclassified as text (e.g., TSV) and passed through `extractFileContentFromSource`.

Key changes:
- Adds `audio` to the early skip list in `extractFileBlocks()` when no text MIME is forced by filename.
- Introduces `hasBinaryAudioMagic()` and incorporates it into the `textLike` heuristic so OGG (`OggS`) and MP3-with-ID3 (`ID3`) won’t be treated as text-like even if they have ASCII-heavy headers.

This fits into the media-understanding pipeline by ensuring only genuinely text-like file attachments proceed to the text/PDF extraction step, while audio is handled via the separate audio capability path.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; changes are localized and defensive.
- Edits are confined to `src/media-understanding/apply.ts` and primarily add early skipping and a magic-byte guard to prevent audio being treated as text. This should reduce misclassification without affecting normal text extraction. The main nit is the helper’s docstring scope (mentions video) vs actual checks (audio-only), which is maintenance-related rather than a runtime risk.
- src/media-understanding/apply.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->