### PR TITLE
docs: fix Venice AI typo (Venius → Venice)

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -11,9 +11,9 @@ default model as `provider/model`.
 
 Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/channels).
 
-## Highlight: Venius (Venice AI)
+## Highlight: Venice (Venice AI)
 
-Venius is our recommended Venice AI setup for privacy-first inference with an option to use Opus for hard tasks.
+Venice is our recommended Venice AI setup for privacy-first inference with an option to use Opus for hard tasks.
 
 - Default: `venice/llama-3.3-70b`
 - Best overall: `venice/claude-opus-45` (Opus remains the strongest)
@@ -44,7 +44,7 @@ See [Venice AI](/providers/venice).
 - [Z.AI](/providers/zai)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
-- [Venius (Venice AI, privacy-focused)](/providers/venice)
+- [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Ollama (local models)](/providers/ollama)
 
 ## Transcription providers

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -9,9 +9,9 @@ read_when:
 Moltbot can use many LLM providers. Pick one, authenticate, then set the default
 model as `provider/model`.
 
-## Highlight: Venius (Venice AI)
+## Highlight: Venice (Venice AI)
 
-Venius is our recommended Venice AI setup for privacy-first inference with an option to use Opus for the hardest tasks.
+Venice is our recommended Venice AI setup for privacy-first inference with an option to use Opus for the hardest tasks.
 
 - Default: `venice/llama-3.3-70b`
 - Best overall: `venice/claude-opus-45` (Opus remains the strongest)
@@ -41,7 +41,7 @@ See [Venice AI](/providers/venice).
 - [Z.AI](/providers/zai)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
-- [Venius (Venice AI)](/providers/venice)
+- [Venice (Venice AI)](/providers/venice)
 - [Amazon Bedrock](/bedrock)
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,


### PR DESCRIPTION
## Summary

Fixes a typo in the docs where "Venice" was misspelled as "Venius" in the provider documentation.

## Changes

- `docs/providers/index.md`: Fixed 3 instances of "Venius" → "Venice"
- `docs/providers/models.md`: Fixed 3 instances of "Venius" → "Venice"

## Affected sections

- "Highlight: Venice (Venice AI)" heading
- Recommendation description text
- Sidebar navigation links