### PR TITLE
fix(telegram): properly nest link tags inside bold/italic formatting

### DIFF
--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -93,18 +93,20 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
   for (let i = 0; i < points.length; i += 1) {
     const pos = points[i];
 
-    while (stack.length && stack[stack.length - 1]?.end === pos) {
-      const span = stack.pop();
-      if (!span) break;
-      const marker = styleMarkers[span.style];
-      if (marker) out += marker.close;
-    }
-
+    // Close links before styles to maintain proper nesting order
+    // (links are typically nested inside styles like bold/italic)
     const closingLinks = linkEnds.get(pos);
     if (closingLinks && closingLinks.length > 0) {
       for (const link of closingLinks) {
         out += link.close;
       }
+    }
+
+    while (stack.length && stack[stack.length - 1]?.end === pos) {
+      const span = stack.pop();
+      if (!span) break;
+      const marker = styleMarkers[span.style];
+      if (marker) out += marker.close;
     }
 
     const openingLinks = linkStarts.get(pos);

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -47,4 +47,19 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("```js\nconst x = 1;\n```");
     expect(res).toBe("<pre><code>const x = 1;\n</code></pre>");
   });
+
+  it("properly nests link tags inside bold when URL is at end of bold span", () => {
+    const res = markdownToTelegramHtml("**Check https://example.com**");
+    expect(res).toBe('<b>Check <a href="https://example.com">https://example.com</a></b>');
+  });
+
+  it("properly nests link tags inside italic", () => {
+    const res = markdownToTelegramHtml("_visit https://docs.molt.bot_");
+    expect(res).toBe('<i>visit <a href="https://docs.molt.bot">https://docs.molt.bot</a></i>');
+  });
+
+  it("renders emoji before bold correctly", () => {
+    const res = markdownToTelegramHtml("🧪 **Header text**");
+    expect(res).toBe("🧪 <b>Header text</b>");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where bold/italic formatting breaks when containing auto-linked URLs in Telegram messages.

### Problem

When a URL appears inside bold/italic text (e.g., `**Check https://example.com**`), the HTML tags were being closed in the wrong order:

```html
<!-- Before (broken) -->
<b>Check <a href="https://example.com">https://example.com</b></a>

<!-- After (fixed) -->
<b>Check <a href="https://example.com">https://example.com</a></b>
```

The misnested tags caused Telegram to fail to render the bold formatting when URLs were present inside styled spans.

### Root Cause

In `src/markdown/render.ts`, the `renderMarkdownWithMarkers` function was closing style tags (bold/italic) before link tags at the same position. Since links are nested inside styles, the inner element (link) should close first.

### Solution

Reordered the closing logic to close links before styles, maintaining proper HTML nesting order.

### Changes

- `src/markdown/render.ts`: Swapped order of closing links and styles
- `src/telegram/format.test.ts`: Added 3 test cases for the fix

## Test Plan

- [x] All existing tests pass (292 tests across markdown, telegram, discord, slack, whatsapp)
- [x] New test cases added:
  - `properly nests link tags inside bold when URL is at end of bold span`
  - `properly nests link tags inside italic`
  - `renders emoji before bold correctly`

## Testing

```typescript
// Before fix
markdownToTelegramHtml("**Check https://example.com**")
// => '<b>Check <a href="https://example.com">https://example.com</b></a>' (broken)

// After fix  
markdownToTelegramHtml("**Check https://example.com**")
// => '<b>Check <a href="https://example.com">https://example.com</a></b>' (correct)
```

Fixes #4174

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the shared markdown renderer (`renderMarkdownWithMarkers`) to close link tags before closing style markers at the same boundary, fixing mis-nested HTML when Telegram auto-linking occurs inside bold/italic spans. It also adds Telegram formatting regression tests covering bold/italic spans that include linkified URLs.

Because `renderMarkdownWithMarkers` is used by other formatters (e.g., Slack mrkdwn and markdown table conversion), the behavioral change applies across those outputs too; if the “links are always nested inside styles” invariant isn’t guaranteed by the IR, it may need to be documented or encoded more explicitly.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported Telegram HTML nesting bug.
- The change is small and directly targets tag-nesting order, with targeted Telegram regression tests added. Main residual risk is that `renderMarkdownWithMarkers` is a shared renderer, so the changed close ordering could subtly affect other outputs if they rely on different nesting assumptions at identical boundaries.
- src/markdown/render.ts (shared renderer behavior); src/telegram/format.test.ts (test relevance/naming)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->