### PR TITLE
FIX:Issue #2590 [Security] :default gateway bind to loopback, require explicit opt-in for public exposure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         "dist/index.js",
         "gateway",
         "--bind",
-        "${CLAWDBOT_GATEWAY_BIND:-lan}",
+        "${CLAWDBOT_GATEWAY_BIND:-loopback}",
         "--port",
         "${CLAWDBOT_GATEWAY_PORT:-18789}"
       ]

--- a/fly.private.toml
+++ b/fly.private.toml
@@ -22,7 +22,8 @@ primary_region = "iad"  # change to your closest region
   NODE_OPTIONS = "--max-old-space-size=1536"
 
 [processes]
-  app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+  # Default bind is loopback (127.0.0.1) - appropriate for private deployment.
+  app = "node dist/index.js gateway --allow-unconfigured --port 3000"
 
 # NOTE: No [http_service] block = no public ingress allocated.
 # The gateway will only be accessible via:

--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,9 @@ primary_region = "iad"  # change to your closest region
   NODE_OPTIONS = "--max-old-space-size=1536"
 
 [processes]
-  app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+  # Default bind is loopback (127.0.0.1). For public access, add: --bind lan --token YOUR_SECRET
+  # WARNING: Using --bind lan exposes your gateway to internet scanners (Shodan).
+  app = "node dist/index.js gateway --allow-unconfigured --port 3000"
 
 [http_service]
   internal_port = 3000

--- a/fly.toml
+++ b/fly.toml
@@ -15,9 +15,9 @@ primary_region = "iad"  # change to your closest region
   NODE_OPTIONS = "--max-old-space-size=1536"
 
 [processes]
-  # Default bind is loopback (127.0.0.1). For public access, add: --bind lan --token YOUR_SECRET
-  # WARNING: Using --bind lan exposes your gateway to internet scanners (Shodan).
-  app = "node dist/index.js gateway --allow-unconfigured --port 3000"
+  # --bind lan required for Fly's proxy to reach the app (listens on private interface, not public internet)
+  # Set MOLTBOT_TOKEN env var or use --token for auth
+  app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
   internal_port = 3000

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -256,6 +256,17 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     return;
   }
 
+  // Warn when binding to non-loopback even with auth
+  if (bind !== "loopback" && hasSharedSecret) {
+    gatewayLog.warn(
+      [
+        `Gateway binding to ${bind} (network-accessible).`,
+        "Ensure this is intentional. The gateway may be discoverable via internet scanners.",
+        "For local-only access, use --bind loopback or omit the --bind flag.",
+      ].join("\n"),
+    );
+  }
+
   try {
     await runGatewayLoop({
       runtime: defaultRuntime,

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -60,6 +60,7 @@ export async function noteSecurityWarnings(cfg: MoltbotConfig) {
       warnings.push(
         `- CRITICAL: Gateway bound to ${bindDescriptor} without authentication.`,
         `  Anyone on your network (or internet if port-forwarded) can fully control your agent.`,
+        `  Your gateway is discoverable via internet scanners (Shodan, Censys).`,
         `  Fix: ${formatCliCommand("moltbot config set gateway.bind loopback")}`,
         ...authFixLines,
       );
@@ -67,6 +68,7 @@ export async function noteSecurityWarnings(cfg: MoltbotConfig) {
       // Auth is configured, but still warn about network exposure
       warnings.push(
         `- WARNING: Gateway bound to ${bindDescriptor} (network-accessible).`,
+        `  The gateway may be discoverable via internet scanners (Shodan, Censys).`,
         `  Ensure your auth credentials are strong and not exposed.`,
       );
     }


### PR DESCRIPTION
## Summary
- Change default gateway bind from `lan` to `loopback` in deployment templates
- Add startup warning when binding to non-loopback (even with auth)
- Enhance security doctor warnings about public exposure

Resolves: Gateway binds to public network interfaces by default

## Changes
- `docker-compose.yml`: Default `CLAWDBOT_GATEWAY_BIND` to `loopback`
- `fly.toml`: Remove explicit `--bind lan`, use default loopback
- `fly.private.toml`: Same as above
- `src/cli/gateway-cli/run.ts`: Add warning for non-loopback binding
- `src/commands/doctor-security.ts`: Enhance exposure warning

## Security Impact
- New deployments default to localhost-only binding
- Existing deployments using explicit `--bind lan` continue working
- Users get clear warning when exposing gateway publicly

## Test Plan
- [ ] `moltbot gateway` starts on 127.0.0.1 by default
- [ ] `moltbot gateway --bind lan --token secret` shows warning but starts
- [ ] `moltbot gateway --bind lan` (no auth) still fails
- [ ] `moltbot doctor security` shows enhanced warning for public exposure
- [ ] Docker Compose starts with loopback by default

Verification Steps
1.Build and test locally:
pnpm build
node dist/index.js gateway  # Should bind to 127.0.0.1
node dist/index.js gateway --bind lan  # Should fail (no auth)
node dist/index.js gateway --bind lan --token test  # Should warn then start

2.Test docker-compose:
docker-compose up moltbot-gateway  # Should bind to loopback
CLAWDBOT_GATEWAY_BIND=lan docker-compose up moltbot-gateway  # Should bind to lan

3.Run security audit:

node dist/index.js doctor security

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens default gateway exposure by switching deployment templates to `loopback` binding by default, adding a runtime warning when users bind the gateway to a non-loopback interface even with auth configured, and expanding `doctor security` messaging about discoverability.

The direction matches the repo’s security posture (don’t expose by default; warn loudly when users do). The main concern is Fly deployments: with `[http_service]` enabled, binding only to loopback will likely break inbound connectivity via Fly’s proxy unless the process listens on a non-loopback interface.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to likely broken Fly ingress when binding to loopback.
- Templates moving Fly’s gateway process to default loopback binding conflicts with Fly’s public proxy expectations (needs non-loopback listening). The other changes are mostly additive warnings, but the deployment breakage is significant.
- fly.toml, fly.private.toml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->