### PR TITLE
Handle "fetch failed" unhandled rejections as transient

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -81,6 +81,11 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it('returns true for Error with "TypeError: fetch failed" message', () => {
+    const error = new Error("TypeError: fetch failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns true for fetch failed with network cause", () => {
     const cause = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
     const error = Object.assign(new TypeError("fetch failed"), { cause });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { extractErrorCode, formatUncaughtError } from "./errors.js";
+import { extractErrorCode, formatErrorMessage, formatUncaughtError } from "./errors.js";
 
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 
@@ -83,6 +83,14 @@ export function isTransientNetworkError(err: unknown): boolean {
 
   // "fetch failed" TypeError from undici (Node's native fetch)
   if (err instanceof TypeError && err.message === "fetch failed") {
+    const cause = getErrorCause(err);
+    if (cause) return isTransientNetworkError(cause);
+    return true;
+  }
+
+  // Some environments wrap fetch failures as generic Errors (e.g., "TypeError: fetch failed")
+  const message = formatErrorMessage(err).toLowerCase();
+  if (message.includes("fetch failed")) {
     const cause = getErrorCause(err);
     if (cause) return isTransientNetworkError(cause);
     return true;


### PR DESCRIPTION
## Summary\n- Treats wrapped "TypeError: fetch failed" messages as transient network errors.\n- Prevents gateway crash on unhandled fetch failures when they are wrapped or stringified.\n- Adds unit test for the wrapped message case.\n\n## Context\nRelated to: #4212, #4248\n\n## Testing\n- Not run (pnpm not installed in environment).\n

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the unhandled rejection/transient-network classification to also treat stringified/wrapped `fetch failed` errors (e.g., `"TypeError: fetch failed"`) as transient, preventing the gateway from exiting on those unhandled rejections. It also adds a Vitest unit test covering the wrapped message case. The change fits into the existing `src/infra/unhandled-rejections.ts` policy layer that decides which unhandled rejections should be suppressed vs treated as fatal/config errors.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a small risk of over-classifying unrelated errors as transient based on message matching.
- Changes are localized to transient-network detection and are covered by an added unit test; the main concern is the broadened substring match (`includes("fetch failed")`) which could suppress some non-network failures if their messages contain that phrase.
- src/infra/unhandled-rejections.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->