### PR TITLE
feat: inject native command outputs into agent context

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -277,6 +277,7 @@ const FIELD_LABELS: Record<string, string> = {
   "commands.debug": "Allow /debug",
   "commands.restart": "Allow Restart",
   "commands.useAccessGroups": "Use Access Groups",
+  "commands.injectToContext": "Inject Commands to Context",
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
@@ -593,6 +594,8 @@ const FIELD_HELP: Record<string, string> = {
   "commands.debug": "Allow /debug chat command for runtime-only overrides (default: false).",
   "commands.restart": "Allow /restart and gateway restart tool actions (default: false).",
   "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
+  "commands.injectToContext":
+    "Inject native command outputs (like /models, /model) into agent context so the agent sees what commands the user ran (default: true).",
   "session.dmScope":
     'DM session scoping: "main" keeps continuity; "per-peer", "per-channel-peer", or "per-account-channel-peer" isolates DM history (recommended for shared inboxes/multi-account).',
   "session.identityLinks":

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -23,6 +23,18 @@ export type SessionOrigin = {
   threadId?: string | number;
 };
 
+/**
+ * Entry for recent native command outputs (for agent context injection).
+ */
+export type RecentCommandEntry = {
+  /** The command that was executed (e.g., "/models") */
+  cmd: string;
+  /** Summarized output of the command */
+  summary: string;
+  /** Timestamp (ms) when the command was executed */
+  ts: number;
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -94,6 +106,11 @@ export type SessionEntry = {
   lastThreadId?: string | number;
   skillsSnapshot?: SessionSkillSnapshot;
   systemPromptReport?: SessionSystemPromptReport;
+  /**
+   * Recent native command outputs for agent context injection.
+   * Cleared after being injected into the agent's context.
+   */
+  recentCommands?: RecentCommandEntry[];
 };
 
 export function mergeSessionEntry(

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -107,6 +107,8 @@ export type CommandsConfig = {
   restart?: boolean;
   /** Enforce access-group allowlists/policies for commands (default: true). */
   useAccessGroups?: boolean;
+  /** Inject native command outputs into agent context (default: true). */
+  injectToContext?: boolean;
 };
 
 export type ProviderCommandsConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -112,7 +112,9 @@ export const CommandsSchema = z
     debug: z.boolean().optional(),
     restart: z.boolean().optional(),
     useAccessGroups: z.boolean().optional(),
+    /** Inject native command outputs into agent context. Default: true */
+    injectToContext: z.boolean().optional().default(true),
   })
   .strict()
   .optional()
-  .default({ native: "auto", nativeSkills: "auto" });
+  .default({ native: "auto", nativeSkills: "auto", injectToContext: true });


### PR DESCRIPTION
## Summary
Capture outputs from native slash commands (`/models`, `/status`, `/model`, etc.) and inject them into the agent's context so it can understand what the user saw when following up with questions.

## Problem
When users run native commands like `/models` or `/status`, the response goes directly to them but the agent never sees it. This leads to confusion when users ask follow-up questions like "which providers do I have?" after running `/models`.

## Solution
- Store recent command outputs in the session entry
- Inject them into the agent's system prompt as "Recent Commands"
- Clear after injection to prevent repetition
- New `commands.injectToContext` config option (default: true) to opt-out

## Changes
- `sessions/types.ts`: Add `RecentCommandEntry` type
- `commands-core.ts`: Capture in handleCommands loop  
- `get-reply-directives.ts`: Capture for directive responses
- `get-reply-run.ts`: Format and inject into extraSystemPrompt
- Config files: Add `injectToContext` option

## Example
After user runs `/models`, agent sees:
```
## Recent Commands (user ran these before this message)
- `/models` (13s ago): Providers: | - anthropic (1) | - openai-codex (3)
```

## Testing
Tested manually with `/models`, `/status` commands via Telegram native commands.