### PR TITLE
fix: bypass empty-heartbeat-file check for cron jobs

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -459,13 +459,14 @@ export async function runHeartbeatOnce(opts: {
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
-  // EXCEPTION: Don't skip for exec events - they have pending system events to process.
+  // EXCEPTION: Don't skip for exec events or cron jobs - they have pending system events to process.
   const isExecEventReason = opts.reason === "exec-event";
+  const isCronReason = opts.reason?.startsWith("cron:");
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason) {
+    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason && !isCronReason) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -466,7 +466,11 @@ export async function runHeartbeatOnce(opts: {
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason && !isCronReason) {
+    if (
+      isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
+      !isExecEventReason &&
+      !isCronReason
+    ) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",


### PR DESCRIPTION
## Summary

Cron jobs with `wakeMode: 'now'` were being skipped when `HEARTBEAT.md` was empty or contained only comments, even though they had pending system events to process.

## Problem

When a cron job fires with `wakeMode: 'now'`, it:
1. Enqueues the system event via `enqueueSystemEvent(text)`
2. Calls `runHeartbeatOnce({ reason: 'cron:${job.id}' })`

But `runHeartbeatOnce()` checks if `HEARTBEAT.md` is effectively empty and skips if so — returning `{ status: 'skipped', reason: 'empty-heartbeat-file' }`.

The bypass only existed for `reason === 'exec-event'`, not for cron jobs.

## Fix

Add cron jobs to the bypass list:
```typescript
const isCronReason = opts.reason?.startsWith('cron:');
```

This ensures cron-triggered wakes are treated the same as exec-event wakes — both have pending system events that need processing regardless of `HEARTBEAT.md` state.

## Testing

Tested locally with:
- Cron job with `wakeMode: 'now'` and empty `HEARTBEAT.md`
- Before: `lastStatus: 'skipped'`, `lastError: 'empty-heartbeat-file'`
- After: Job executes and delivers as expected

Fixes #4224