### PR TITLE
fix(plugins): default configSchema when missing from manifest

### DIFF
--- a/src/plugins/manifest.test.ts
+++ b/src/plugins/manifest.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginManifest } from "./manifest.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = path.join(os.tmpdir(), `openclaw-manifest-test-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+});
+
+describe("loadPluginManifest", () => {
+  it("returns error when manifest file is missing", () => {
+    const dir = makeTempDir();
+    const result = loadPluginManifest(dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not found");
+    }
+  });
+
+  it("returns error when manifest is missing id", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({ name: "test" }),
+      "utf-8",
+    );
+    const result = loadPluginManifest(dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("requires id");
+    }
+  });
+
+  it("defaults configSchema to empty object schema when missing", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "test-plugin" }),
+      "utf-8",
+    );
+    const result = loadPluginManifest(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("test-plugin");
+      expect(result.manifest.configSchema).toEqual({
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      });
+    }
+  });
+
+  it("uses provided configSchema when present", () => {
+    const dir = makeTempDir();
+    const customSchema = {
+      type: "object",
+      properties: { apiKey: { type: "string" } },
+    };
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "test-plugin", configSchema: customSchema }),
+      "utf-8",
+    );
+    const result = loadPluginManifest(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.configSchema).toEqual(customSchema);
+    }
+  });
+
+  it("parses optional fields correctly", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "full-plugin",
+        name: "Full Plugin",
+        description: "A test plugin",
+        version: "1.0.0",
+        kind: "memory",
+        channels: ["telegram"],
+        providers: ["openai"],
+      }),
+      "utf-8",
+    );
+    const result = loadPluginManifest(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.name).toBe("Full Plugin");
+      expect(result.manifest.description).toBe("A test plugin");
+      expect(result.manifest.version).toBe("1.0.0");
+      expect(result.manifest.kind).toBe("memory");
+      expect(result.manifest.channels).toEqual(["telegram"]);
+      expect(result.manifest.providers).toEqual(["openai"]);
+    }
+  });
+});

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -66,10 +66,9 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
   if (!id) {
     return { ok: false, error: "plugin manifest requires id", manifestPath };
   }
-  const configSchema = isRecord(raw.configSchema) ? raw.configSchema : null;
-  if (!configSchema) {
-    return { ok: false, error: "plugin manifest requires configSchema", manifestPath };
-  }
+  const configSchema = isRecord(raw.configSchema)
+    ? raw.configSchema
+    : { type: "object", additionalProperties: false, properties: {} };
 
   const kind = typeof raw.kind === "string" ? (raw.kind as PluginKind) : undefined;
   const name = typeof raw.name === "string" ? raw.name.trim() : undefined;


### PR DESCRIPTION
## Summary

When loading a plugin from `~/.clawdbot/extensions/`, if the manifest is missing the `configSchema` field, the gateway crashes. This PR defaults to an empty object schema instead, matching the workaround users already apply manually.

## Changes

- Default `configSchema` to `{ type: "object", additionalProperties: false, properties: {} }` when missing
- Add `manifest.test.ts` with test coverage for the new behavior

## Testing

- `npm run lint` — passed
- `npx tsc` — passed
- `npx vitest run src/plugins/manifest.test.ts` — 5/5 passed
- `npx vitest run src/plugins/loader.test.ts` — 14/14 passed

Fixes #4069

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes plugin manifest loading so that `configSchema` is no longer mandatory: when absent, `loadPluginManifest` now defaults it to an empty object schema, preventing gateway crashes when loading local extensions under `~/.clawdbot/extensions/`. It also adds a new Vitest suite that covers missing-file, missing-id, default-schema, and optional-field parsing behavior.

The change is localized to `src/plugins/manifest.ts` (manifest parsing) and is exercised via `src/plugins/manifest.test.ts`, aligning behavior with how users were previously working around missing `configSchema` manually.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the behavioral change is small and covered by new tests.
- Changes are limited to manifest parsing with a straightforward default value and accompanying unit tests. Main risk is whether downstream schema validation expects a specific JSON Schema draft/shape beyond a basic object schema.
- src/plugins/manifest.ts (ensure default schema matches downstream validator expectations)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->