### PR TITLE
fix(agents): detect Anthropic 'exceed context limit' error for auto-compaction

### DIFF
--- a/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
@@ -40,6 +40,20 @@ describe("isContextOverflowError", () => {
     }
   });
 
+  it("matches Anthropic 'input length and max_tokens exceed context limit' error", () => {
+    // Anthropic returns this error when input_tokens + max_tokens > context_window.
+    // This typically happens when extended thinking is enabled with a large context.
+    // Without this fix, auto-compaction is NOT triggered.
+    const samples = [
+      "input length and max_tokens exceed context limit: 156321 + 48384 > 200000, decrease input length or max_tokens and try again",
+      '{"type":"invalid_request_error","message":"input length and max_tokens exceed context limit: 158984 + 48384 > 200000"}',
+      "LLM request rejected: input length and max_tokens exceed context limit",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
+
   it("ignores unrelated errors", () => {
     expect(isContextOverflowError("rate limit exceeded")).toBe(false);
     expect(isContextOverflowError("request size exceeds upload limit")).toBe(false);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -21,6 +21,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow") ||
+    lower.includes("exceed context limit") || // Anthropic: "input length and max_tokens exceed context limit"
     (lower.includes("413") && lower.includes("too large"))
   );
 }


### PR DESCRIPTION
## Summary
Detect Anthropic's 'input length and max_tokens exceed context limit' error to trigger auto-compaction.

## Problem
When using extended thinking with large contexts, Anthropic returns this specific error:
```
input length and max_tokens exceed context limit: 156321 + 48384 > 200000
```

Without detection, auto-compaction is not triggered and the request fails.

## Solution
Add pattern matching for this error format in `isContextOverflowError()`.

## Testing
Added test cases for the new error format.