### PR TITLE
feat(onboard): add Ollama provider support

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -21,7 +21,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "ollama";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -120,6 +121,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "API key",
     choices: ["opencode-zen"],
   },
+  {
+    value: "ollama",
+    label: "Ollama",
+    hint: "Local + cloud models",
+    choices: ["ollama"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -193,6 +200,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "ollama",
+    label: "Ollama",
+    hint: "Sign-in is handled by Ollama when required",
   });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice.apply.ollama.ts
+++ b/src/commands/auth-choice.apply.ollama.ts
@@ -1,0 +1,73 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import {
+  applyAuthProfileConfig,
+  applyOllamaProviderConfig,
+  OLLAMA_BASE_URL,
+  OLLAMA_DEFAULT_API_KEY,
+  setOllamaApiKey,
+} from "./onboard-auth.js";
+
+export async function applyAuthChoiceOllama(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "ollama") {
+    return null;
+  }
+
+  let nextConfig = params.config;
+
+  await params.prompter.note(
+    [
+      "Ollama runs models locally or in the cloud.",
+      "Make sure Ollama is installed and running: https://ollama.com",
+      "Default server: http://127.0.0.1:11434",
+    ].join("\n"),
+    "Ollama",
+  );
+
+  const useDefault = await params.prompter.confirm({
+    message: `Use default Ollama server (${OLLAMA_BASE_URL.replace("/v1", "")})?`,
+    initialValue: true,
+  });
+
+  let baseUrl = OLLAMA_BASE_URL;
+  if (!useDefault) {
+    const customUrl = await params.prompter.text({
+      message: "Enter Ollama server URL (e.g., http://192.168.1.100:11434)",
+      validate: (value) => {
+        if (!value?.trim()) return "URL is required";
+        try {
+          new URL(value.trim());
+          return undefined;
+        } catch {
+          return "Invalid URL format";
+        }
+      },
+    });
+    // Append /v1 if not present for OpenAI-compatible endpoint
+    const trimmedUrl = String(customUrl).trim().replace(/\/+$/, "");
+    baseUrl = trimmedUrl.endsWith("/v1") ? trimmedUrl : `${trimmedUrl}/v1`;
+  }
+
+  // Store the placeholder API key to enable provider discovery
+  await setOllamaApiKey(OLLAMA_DEFAULT_API_KEY, params.agentDir);
+
+  nextConfig = applyAuthProfileConfig(nextConfig, {
+    profileId: "ollama:default",
+    provider: "ollama",
+    mode: "api_key",
+  });
+
+  nextConfig = applyOllamaProviderConfig(nextConfig, { baseUrl });
+
+  await params.prompter.note(
+    [
+      "Ollama configured successfully.",
+      "Models will be discovered automatically from your Ollama server.",
+      "Use `ollama pull <model>` to download models, then `moltbot models list` to see them.",
+    ].join("\n"),
+    "Setup complete",
+  );
+
+  return { config: nextConfig };
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -9,6 +9,7 @@ import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-ant
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
+import { applyAuthChoiceOllama } from "./auth-choice.apply.ollama.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
 import { applyAuthChoiceQwenPortal } from "./auth-choice.apply.qwen-portal.js";
 import type { AuthChoice } from "./onboard-types.js";
@@ -46,6 +47,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
     applyAuthChoiceQwenPortal,
+    applyAuthChoiceOllama,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -29,6 +29,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   minimax: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
+  ollama: "ollama",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -178,3 +178,15 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export async function setOllamaApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "ollama:default",
+    credential: {
+      type: "api_key",
+      provider: "ollama",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -15,6 +15,9 @@ export const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 export const KIMI_CODING_MODEL_ID = "k2p5";
 export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
 
+export const OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
+export const OLLAMA_DEFAULT_API_KEY = "ollama";
+
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 export const MINIMAX_API_COST = {
   input: 15,

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -9,6 +9,8 @@ export {
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
   applyMoonshotProviderConfig,
+  applyOllamaConfig,
+  applyOllamaProviderConfig,
   applyOpenrouterConfig,
   applyOpenrouterProviderConfig,
   applySyntheticConfig,
@@ -41,6 +43,7 @@ export {
   setKimiCodingApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
+  setOllamaApiKey,
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
   setSyntheticApiKey,
@@ -66,4 +69,6 @@ export {
   MOONSHOT_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
+  OLLAMA_BASE_URL,
+  OLLAMA_DEFAULT_API_KEY,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -32,6 +32,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "ollama"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -73,6 +74,7 @@ export type OnboardOptions = {
   syntheticApiKey?: string;
   veniceApiKey?: string;
   opencodeZenApiKey?: string;
+  ollamaBaseUrl?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
# Description:
## Summary
  - Adds Ollama as a provider option in the onboarding wizard
  - Supports both default local server (127.0.0.1:11434) and custom URLs
  - Models are discovered dynamically from the Ollama server at runtime

## Test plan
  - [x] Ran onboarding wizard and selected Ollama provider
  - [x] Tested with default localhost URL
  - [x] Tested with custom Ollama server URL

Generated partially with `Claude Code`/`Kimi-K2.5`/`Ollama`

Resolves #3494
