### PR TITLE
feat: add message:received and message:sent internal hook events

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -196,7 +196,7 @@ Each event includes:
 
 ```typescript
 {
-  type: 'command' | 'session' | 'agent' | 'gateway',
+  type: 'command' | 'session' | 'agent' | 'gateway' | 'message',
   action: string,              // e.g., 'new', 'reset', 'stop'
   sessionKey: string,          // Session identifier
   timestamp: Date,             // When the event occurred
@@ -241,6 +241,35 @@ These hooks are not event-stream listeners; they let plugins synchronously adjus
 
 - **`tool_result_persist`**: transform tool results before they are written to the session transcript. Must be synchronous; return the updated tool result payload or `undefined` to keep it as-is. See [Agent Loop](/concepts/agent-loop).
 
+### Message Events
+
+Triggered during the message lifecycle:
+
+- **`message:received`**: When an inbound message is received (fired alongside the plugin `message_received` hook)
+- **`message:sent`**: When an outbound reply is successfully delivered (fired alongside the plugin `message_sent` hook)
+
+#### `message:received` Context
+
+| Field            | Type                | Description                        |
+|------------------|---------------------|------------------------------------|
+| `from`           | `string`            | Sender identifier                  |
+| `content`        | `string`            | Message body text                  |
+| `channel`        | `string`            | Channel / surface (lowercase)      |
+| `conversationId` | `string \| undefined` | Conversation or chat identifier  |
+| `timestamp`      | `number`            | Message timestamp (epoch ms)       |
+| `messageId`      | `string \| undefined` | Platform message ID              |
+| `senderId`       | `string \| undefined` | Sender user ID                   |
+| `senderName`     | `string \| undefined` | Sender display name              |
+
+#### `message:sent` Context
+
+| Field     | Type     | Description                               |
+|-----------|----------|-------------------------------------------|
+| `content` | `string` | Reply body text                           |
+| `channel` | `string` | Channel / surface (lowercase)             |
+| `to`      | `string` | Recipient identifier                      |
+| `kind`    | `string` | Dispatch kind (`"tool"`, `"block"`, or `"final"`) |
+
 ### Future Events
 
 Planned event types:
@@ -248,8 +277,6 @@ Planned event types:
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
-- **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
 
 ## Creating Custom Hooks
 

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,6 +1,8 @@
 import type { MoltbotConfig } from "../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { GetReplyOptions } from "./types.js";
+import type { GetReplyOptions, ReplyPayload } from "./types.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
@@ -10,9 +12,50 @@ import {
   type ReplyDispatcher,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
+  type ReplyDispatchKind,
 } from "./reply/reply-dispatcher.js";
 
 export type DispatchInboundResult = DispatchFromConfigResult;
+
+/**
+ * Create an `onDelivered` callback that fires message:sent hooks
+ * (both internal and plugin) after each reply is successfully delivered.
+ */
+function createMessageSentHook(
+  ctx: FinalizedMsgContext,
+  origOnDelivered?: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => void,
+): (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => void {
+  const sessionKey = ctx.SessionKey ?? "";
+  const channel = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+  const to = ctx.To ?? ctx.From ?? "";
+  const accountId = ctx.AccountId;
+  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From;
+
+  return (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
+    origOnDelivered?.(payload, info);
+
+    // Internal hook: message:sent
+    void triggerInternalHook(
+      createInternalHookEvent("message", "sent", sessionKey, {
+        content: payload.text ?? "",
+        channel,
+        to,
+        kind: info.kind,
+      }),
+    );
+
+    // Plugin hook: message_sent
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("message_sent")) {
+      void hookRunner
+        .runMessageSent(
+          { to, content: payload.text ?? "", success: true },
+          { channelId: channel, accountId, conversationId },
+        )
+        .catch(() => {});
+    }
+  };
+}
 
 export async function dispatchInboundMessage(params: {
   ctx: MsgContext | FinalizedMsgContext;
@@ -38,12 +81,16 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
-    params.dispatcherOptions,
-  );
+  const finalized = finalizeInboundContext(params.ctx);
+  const onDelivered = createMessageSentHook(finalized, params.dispatcherOptions.onDelivered);
+
+  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+    ...params.dispatcherOptions,
+    onDelivered,
+  });
 
   const result = await dispatchInboundMessage({
-    ctx: params.ctx,
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,
@@ -64,9 +111,15 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const dispatcher = createReplyDispatcher(params.dispatcherOptions);
+  const finalized = finalizeInboundContext(params.ctx);
+  const onDelivered = createMessageSentHook(finalized, params.dispatcherOptions.onDelivered);
+
+  const dispatcher = createReplyDispatcher({
+    ...params.dispatcherOptions,
+    onDelivered,
+  });
   const result = await dispatchInboundMessage({
-    ctx: params.ctx,
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -49,6 +49,8 @@ export type ReplyDispatcherOptions = {
   onError?: ReplyDispatchErrorHandler;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
+  /** Called after a reply is successfully delivered. */
+  onDelivered?: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => void;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
 };
@@ -131,6 +133,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           if (delayMs > 0) await sleep(delayMs);
         }
         await options.deliver(normalized, { kind });
+        options.onDelivered?.(normalized, { kind });
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { MoltbotConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;


### PR DESCRIPTION
Reviving #2307 by @AhmedTheGeek - rebased on current main.

Original PR: #2307
Original author: @AhmedTheGeek

## Changes (from original PR)

- Added `"message"` to `InternalHookEventType`
- Fire `message:received` internal hook in dispatch-from-config alongside existing plugin hook
- Added `onDelivered` callback to `ReplyDispatcherOptions` for post-delivery hooks
- Fire `message:sent` internal hook after successful reply delivery
- Wired the existing (but previously unused) plugin `message_sent` hook
- Updated docs and tests

## Motivation

These events were listed as "Future Events" in the hooks documentation. They enable audit trail tools and other integrations that need to observe the full message lifecycle.

## Details

### `message:received` (dispatch-from-config.ts)
Hoisted the hook context variables (content, channelId, conversationId, timestamp, messageId) out of the plugin-only `if` block so both the plugin `message_received` hook and the new internal `message:received` hook share them. The internal hook fires unconditionally (fire-and-forget via `void`).

### `message:sent` (dispatch.ts + reply-dispatcher.ts)
Added an `onDelivered` callback to `ReplyDispatcherOptions` that fires after each successful `deliver()` call. In `dispatch.ts`, both `dispatchInboundMessageWithBufferedDispatcher` and `dispatchInboundMessageWithDispatcher` wrap this callback to fire both the internal `message:sent` hook and the plugin `message_sent` hook. Extracted a shared `createMessageSentHook()` helper to avoid duplication.

### Tests
Added 4 new test cases covering:
- `message:received` handler triggering
- `message:sent` handler triggering
- General `message` handler catching both events
- Event isolation (sent handler doesn't fire for received events)

## Rebase Notes

Resolved merge conflicts:
- `dispatch.ts`: Kept `MoltbotConfig` import (project rename) + added hook imports
- `reply-dispatcher.ts`: Merged both `onSkip` (from main) and `onDelivered` (from this PR) into `ReplyDispatcherOptions`