### PR TITLE
feat(telegram): support nativeSkills whitelist for command registration

### DIFF
--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -1,6 +1,6 @@
 import type { ChannelId } from "../channels/plugins/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
-import type { NativeCommandsSetting } from "./types.js";
+import type { NativeCommandsSetting, NativeSkillsSetting } from "./types.js";
 
 function resolveAutoDefault(providerId?: ChannelId): boolean {
   const id = normalizeChannelId(providerId);
@@ -17,6 +17,22 @@ export function resolveNativeSkillsEnabled(params: {
 }): boolean {
   const { providerId, providerSetting, globalSetting } = params;
   const setting = providerSetting === undefined ? globalSetting : providerSetting;
+  if (setting === true) return true;
+  if (setting === false) return false;
+  return resolveAutoDefault(providerId);
+}
+
+// Returns boolean (enable all/none) or string[] (whitelist of skill names)
+export function resolveNativeSkillsSetting(params: {
+  providerId: ChannelId;
+  providerSetting?: NativeSkillsSetting;
+  globalSetting?: NativeSkillsSetting;
+}): boolean | string[] {
+  const { providerId, providerSetting, globalSetting } = params;
+  const setting = providerSetting === undefined ? globalSetting : providerSetting;
+  // If it is an array, return the whitelist
+  if (Array.isArray(setting)) return setting;
+  // Otherwise resolve as boolean
   if (setting === true) return true;
   if (setting === false) return false;
   return resolveAutoDefault(providerId);

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -87,12 +87,13 @@ export type MessagesConfig = {
 };
 
 export type NativeCommandsSetting = boolean | "auto";
+export type NativeSkillsSetting = boolean | "auto" | string[];
 
 export type CommandsConfig = {
   /** Enable native command registration when supported (default: "auto"). */
   native?: NativeCommandsSetting;
   /** Enable native skill command registration when supported (default: "auto"). */
-  nativeSkills?: NativeCommandsSetting;
+  nativeSkills?: NativeSkillsSetting;
   /** Enable text command parsing (default: true). */
   text?: boolean;
   /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
@@ -113,5 +114,5 @@ export type ProviderCommandsConfig = {
   /** Override native command registration for this provider (bool or "auto"). */
   native?: NativeCommandsSetting;
   /** Override native skill command registration for this provider (bool or "auto"). */
-  nativeSkills?: NativeCommandsSetting;
+  nativeSkills?: NativeSkillsSetting;
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -493,10 +493,17 @@ export const ToolsLinksSchema = z
 
 export const NativeCommandsSettingSchema = z.union([z.boolean(), z.literal("auto")]);
 
+// nativeSkills can be boolean/auto OR an array of skill names to whitelist
+export const NativeSkillsSettingSchema = z.union([
+  z.boolean(),
+  z.literal("auto"),
+  z.array(z.string()).describe("Whitelist of skill names to register as native commands"),
+]);
+
 export const ProviderCommandsSchema = z
   .object({
     native: NativeCommandsSettingSchema.optional(),
-    nativeSkills: NativeCommandsSettingSchema.optional(),
+    nativeSkills: NativeSkillsSettingSchema.optional(),
   })
   .strict()
   .optional();

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -78,7 +78,7 @@ type RegisterTelegramNativeCommandsParams = {
   textLimit: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
-  nativeSkillsEnabled: boolean;
+  nativeSkillsEnabled: boolean | string[];
   nativeDisabledExplicit: boolean;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
@@ -258,7 +258,13 @@ export const registerTelegramNativeCommands = ({
   opts,
 }: RegisterTelegramNativeCommandsParams) => {
   const skillCommands =
-    nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];
+    nativeEnabled && nativeSkillsEnabled
+      ? Array.isArray(nativeSkillsEnabled)
+        ? listSkillCommandsForAgents({ cfg }).filter((s) =>
+            nativeSkillsEnabled.includes(s.skillName),
+          )
+        : listSkillCommandsForAgents({ cfg })
+      : [];
   const nativeCommands = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "telegram" })
     : [];

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -11,6 +11,7 @@ import {
   isNativeCommandsExplicitlyDisabled,
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
+  resolveNativeSkillsSetting,
 } from "../config/commands.js";
 import type { MoltbotConfig, ReplyToMode } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -241,7 +242,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     providerSetting: telegramCfg.commands?.native,
     globalSetting: cfg.commands?.native,
   });
-  const nativeSkillsEnabled = resolveNativeSkillsEnabled({
+  const nativeSkillsEnabled = resolveNativeSkillsSetting({
     providerId: "telegram",
     providerSetting: telegramCfg.commands?.nativeSkills,
     globalSetting: cfg.commands?.nativeSkills,


### PR DESCRIPTION
## Summary
Allow `nativeSkills` config to accept an array of skill names instead of just boolean/auto.

## Problem
Telegram has a 100 command limit. With many skills, users hit this limit and get `BOT_COMMANDS_TOO_MUCH` errors.

## Solution
Add support for whitelisting specific skills:

```json
{
  "commands": {
    "nativeSkills": ["perplexity-search", "google-workspace", "meeting-notes"]
  }
}
```

This registers only the specified skills as native Telegram commands while keeping all skills functional via chat.

## Changes
- Updated `NativeSkillsSettingSchema` to accept `string[]` in addition to boolean/auto
- Added `NativeSkillsSetting` type
- Added `resolveNativeSkillsSetting()` function that returns `boolean | string[]`
- Updated Telegram bot to filter skills when whitelist is provided

## Testing
- [ ] TypeScript compiles
- [ ] Existing tests pass
- [ ] Manual test with whitelist config
