### PR TITLE
fix: quote Windows paths with spaces in UI runner command

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -101,6 +101,11 @@ if (!runner) {
   process.stderr.write("Missing UI runner: install pnpm, then retry.\n");
   process.exit(1);
 }
+// On Windows, paths with spaces (e.g. C:\Program Files\...) must be quoted
+// so the shell does not split them.
+if (process.platform === "win32" && runner.cmd.includes(" ")) {
+  runner.cmd = `"${runner.cmd}"`;
+}
 
 const script =
   action === "install"


### PR DESCRIPTION
**What:** Quote the pnpm path on Windows when it contains spaces (e.g. `C:\Program Files\...`), so `pnpm ui:build` no longer fails with `'C:\Program' is not recognized`.

**Why:** `scripts/ui.js` uses `which("pnpm")` and passes the path to `spawn` with `shell: true`; the shell was splitting the path on the space.

**How:** Wrap `runner.cmd` in double quotes when `process.platform === "win32"` and the path includes a space.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `scripts/ui.js` to handle Windows installations where the resolved `pnpm` executable path includes spaces (e.g. under `C:\\Program Files`). It does this by wrapping `runner.cmd` in quotes before invoking `spawn`/`spawnSync` with `shell` enabled on Windows, preventing `cmd.exe` from splitting the path and causing `'C:\\Program' is not recognized` failures.

The change fits into the existing UI helper script’s flow: it resolves a runner (`pnpm`) via a custom `which()` function, then uses that runner to install UI deps and run UI scripts; quoting is applied immediately after runner resolution so all subsequent invocations benefit.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the Windows quoting approach can introduce shell-parsing edge cases and security concerns when PATH is attacker-controlled.
- The change is small and addresses a real Windows failure mode, but it operates in a sensitive area (manual quoting with `shell: true`). If `runner.cmd` contains quotes or cmd metacharacters, behavior can break or become unsafe; a `shell: false` approach would be more robust.
- scripts/ui.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->