### PR TITLE
feat(tts): add new OpenAI gpt-4o-mini-tts voices

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -773,13 +773,17 @@ function isCustomOpenAIEndpoint(): boolean {
 export const OPENAI_TTS_VOICES = [
   "alloy",
   "ash",
+  "ballad",
+  "cedar",
   "coral",
   "echo",
   "fable",
-  "onyx",
+  "marin",
   "nova",
+  "onyx",
   "sage",
   "shimmer",
+  "verse",
 ] as const;
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];


### PR DESCRIPTION
## Summary
Add the new voices introduced with `gpt-4o-mini-tts` to `OPENAI_TTS_VOICES`:
- ballad
- cedar  
- marin
- verse

## Problem
These voices were missing from the validation list, causing `isValidOpenAIVoice()` to reject them and fall back to Edge TTS.

## Solution
Added the 4 new voices to the hardcoded list in `src/tts/tts.ts`.

## Testing
Tested with `cedar` voice - now works correctly with `gpt-4o-mini-tts`.