### PR TITLE
fix(errors): recognize auth profile cooldown as rate_limit

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -504,6 +504,8 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isCloudCodeAssistFormatError(raw)) return "format";
   if (isBillingErrorMessage(raw)) return "billing";
   if (isTimeoutErrorMessage(raw)) return "timeout";
+  // Check for specific auth profile unavailability/cooldown patterns to allow fallback
+  if (/no available auth profile.*all in cooldown/i.test(raw)) return "rate_limit";
   if (isAuthErrorMessage(raw)) return "auth";
   return null;
 }


### PR DESCRIPTION
## Summary

Improves error classification to allow fallback when all auth profiles for a provider are in cooldown.

## Problem

When the primary model/agent run fails because its auth provider is completely blocked or rate-limited, the system can throw an error like: .

Previously, this error could be misclassified, preventing fallback to backup models.

## Solution

Updated  in  to explicitly recognize the pattern  as a  issue.

This ensures that the intended failover behavior is triggered, allowing the system to switch to backup models (e.g., from ) when a specific provider's profiles are temporarily unavailable.

## Changes

*   : Added specific check for auth profile cooldown to classify as .

---

Fixes #4260