### PR TITLE
fix: ensure model failover works across different providers

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -234,14 +234,17 @@ export async function runWithModelFallback<T>(params: {
       const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
-        attempts.push({
-          provider: candidate.provider,
-          model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-          reason: "rate_limit",
-        });
-        continue;
+        // Only skip if this provider is the same as the original one to ensure fallbacks to other providers are still tried
+        const originalProvider = candidates[0]?.provider;
+        if (candidate.provider === originalProvider) {
+          attempts.push({
+            provider: candidate.provider,
+            model: candidate.model,
+            error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+            reason: "rate_limit",
+          });
+          continue;
+        }
       }
     }
     try {


### PR DESCRIPTION
When the primary provider reaches quota limits, ensure fallback models from different providers are still tried.

Fixes #4260

The issue was that when all profiles for a provider were in cooldown, the code would skip that provider entirely. But this caused problems when the fallback list included models from different providers.

The fix adds a check to only skip the original provider, allowing fallback models from other providers to still be tried.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `runWithModelFallback` to avoid skipping all candidates when the current provider has no available auth profiles (all profiles in cooldown), so that fallbacks from other providers can still be attempted.

The change adds a special-case: only skip the “original” provider when all of its profiles are in cooldown, rather than skipping any provider with all profiles in cooldown. This fits into the existing fallback loop that builds a list of `(provider, model)` candidates from config and tries them sequentially while recording `attempts` for error reporting.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the new provider-skip condition may not match the intended “original provider” in all configurations.
- The change is small and localized, but it relies on `candidates[0]?.provider` as the definition of “original provider”, which is derived from resolved candidates (config/alias) rather than the provider that actually triggered cooldown/quota issues. If the candidate list order changes, the fix could skip the wrong provider and still inadvertently block cross-provider fallback in some cases.
- src/agents/model-fallback.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->