### PR TITLE
fix(agents): avoid global lane lock during auto-compaction + prevent double-compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -101,6 +101,7 @@ export type CompactEmbeddedPiSessionParams = {
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
+  skipSkillEnvOverrides?: boolean;
 };
 
 /**
@@ -111,7 +112,6 @@ export async function compactEmbeddedPiSessionDirect(
   params: CompactEmbeddedPiSessionParams,
 ): Promise<EmbeddedPiCompactResult> {
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
-  const prevCwd = process.cwd();
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
   const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
@@ -180,22 +180,24 @@ export async function compactEmbeddedPiSessionDirect(
     cwd: effectiveWorkspace,
   });
 
+  const shouldApplySkillEnvOverrides = !params.skipSkillEnvOverrides;
   let restoreSkillEnv: (() => void) | undefined;
-  process.chdir(effectiveWorkspace);
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
+    if (shouldApplySkillEnvOverrides) {
+      restoreSkillEnv = params.skillsSnapshot
+        ? applySkillEnvOverridesFromSnapshot({
+            snapshot: params.skillsSnapshot,
+            config: params.config,
+          })
+        : applySkillEnvOverrides({
+            skills: skillEntries ?? [],
+            config: params.config,
+          });
+    }
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
@@ -321,7 +323,7 @@ export async function compactEmbeddedPiSessionDirect(
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],
-      cwd: process.cwd(),
+      cwd: effectiveWorkspace,
       moduleUrl: import.meta.url,
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
@@ -476,7 +478,6 @@ export async function compactEmbeddedPiSessionDirect(
     };
   } finally {
     restoreSkillEnv?.();
-    process.chdir(prevCwd);
   }
 }
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -170,6 +170,7 @@ function makeAttemptResult(
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
     messagingToolSentTargets: [],
+    autoCompactionAttempts: 0,
     cloudCodeAssistFormatError: false,
     ...overrides,
   };
@@ -220,6 +221,20 @@ describe("overflow compaction in run loop", () => {
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("auto-compaction succeeded"));
     // Should not be an error result
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("skips manual compaction when auto-compaction already ran", async () => {
+    const overflowError = new Error("request_too_large: Request size exceeds model context window");
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError, autoCompactionAttempts: 1 }),
+    );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error?.kind).toBe("context_overflow");
   });
 
   it("returns error if compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -88,232 +88,226 @@ export async function runEmbeddedPiAgent(
       : "markdown");
   const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
 
-  return enqueueSession(() =>
-    enqueueGlobal(async () => {
-      const started = Date.now();
-      const resolvedWorkspace = resolveUserPath(params.workspaceDir);
-      const prevCwd = process.cwd();
+  const started = Date.now();
+  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const prevCwd = process.cwd();
 
-      const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const fallbackConfigured =
-        (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
-      await ensureOpenClawModelsJson(params.config, agentDir);
+  const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+  const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+  const fallbackConfigured = (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+  await ensureOpenClawModelsJson(params.config, agentDir);
 
-      const { model, error, authStorage, modelRegistry } = resolveModel(
+  const { model, error, authStorage, modelRegistry } = resolveModel(
+    provider,
+    modelId,
+    agentDir,
+    params.config,
+  );
+  if (!model) {
+    throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+  }
+
+  const ctxInfo = resolveContextWindowInfo({
+    cfg: params.config,
+    provider,
+    modelId,
+    modelContextWindow: model.contextWindow,
+    defaultTokens: DEFAULT_CONTEXT_TOKENS,
+  });
+  const ctxGuard = evaluateContextWindowGuard({
+    info: ctxInfo,
+    warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
+    hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+  });
+  if (ctxGuard.shouldWarn) {
+    log.warn(
+      `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+    );
+  }
+  if (ctxGuard.shouldBlock) {
+    log.error(
+      `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
+    );
+    throw new FailoverError(
+      `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
+      { reason: "unknown", provider, model: modelId },
+    );
+  }
+
+  const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const preferredProfileId = params.authProfileId?.trim();
+  let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+  if (lockedProfileId) {
+    const lockedProfile = authStore.profiles[lockedProfileId];
+    if (
+      !lockedProfile ||
+      normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
+    ) {
+      lockedProfileId = undefined;
+    }
+  }
+  const profileOrder = resolveAuthProfileOrder({
+    cfg: params.config,
+    store: authStore,
+    provider,
+    preferredProfile: preferredProfileId,
+  });
+  if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
+    throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+  }
+  const profileCandidates = lockedProfileId
+    ? [lockedProfileId]
+    : profileOrder.length > 0
+      ? profileOrder
+      : [undefined];
+  let profileIndex = 0;
+
+  const initialThinkLevel = params.thinkLevel ?? "off";
+  let thinkLevel = initialThinkLevel;
+  const attemptedThinking = new Set<ThinkLevel>();
+  let apiKeyInfo: ApiKeyInfo | null = null;
+  let lastProfileId: string | undefined;
+
+  const resolveAuthProfileFailoverReason = (params: {
+    allInCooldown: boolean;
+    message: string;
+  }): FailoverReason => {
+    if (params.allInCooldown) return "rate_limit";
+    const classified = classifyFailoverReason(params.message);
+    return classified ?? "auth";
+  };
+
+  const throwAuthProfileFailover = (params: {
+    allInCooldown: boolean;
+    message?: string;
+    error?: unknown;
+  }): never => {
+    const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
+    const message =
+      params.message?.trim() ||
+      (params.error ? describeUnknownError(params.error).trim() : "") ||
+      fallbackMessage;
+    const reason = resolveAuthProfileFailoverReason({
+      allInCooldown: params.allInCooldown,
+      message,
+    });
+    if (fallbackConfigured) {
+      throw new FailoverError(message, {
+        reason,
         provider,
-        modelId,
-        agentDir,
-        params.config,
-      );
-      if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
-      }
+        model: modelId,
+        status: resolveFailoverStatus(reason),
+        cause: params.error,
+      });
+    }
+    if (params.error instanceof Error) throw params.error;
+    throw new Error(message);
+  };
 
-      const ctxInfo = resolveContextWindowInfo({
-        cfg: params.config,
-        provider,
-        modelId,
-        modelContextWindow: model.contextWindow,
-        defaultTokens: DEFAULT_CONTEXT_TOKENS,
-      });
-      const ctxGuard = evaluateContextWindowGuard({
-        info: ctxInfo,
-        warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
-        hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
-      });
-      if (ctxGuard.shouldWarn) {
-        log.warn(
-          `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+  const resolveApiKeyForCandidate = async (candidate?: string) => {
+    return getApiKeyForModel({
+      model,
+      cfg: params.config,
+      profileId: candidate,
+      store: authStore,
+      agentDir,
+    });
+  };
+
+  const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
+    apiKeyInfo = await resolveApiKeyForCandidate(candidate);
+    const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
+    if (!apiKeyInfo.apiKey) {
+      if (apiKeyInfo.mode !== "aws-sdk") {
+        throw new Error(
+          `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );
       }
-      if (ctxGuard.shouldBlock) {
-        log.error(
-          `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
-        );
-        throw new FailoverError(
-          `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
-          { reason: "unknown", provider, model: modelId },
-        );
-      }
-
-      const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-      const preferredProfileId = params.authProfileId?.trim();
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      if (lockedProfileId) {
-        const lockedProfile = authStore.profiles[lockedProfileId];
-        if (
-          !lockedProfile ||
-          normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
-        ) {
-          lockedProfileId = undefined;
-        }
-      }
-      const profileOrder = resolveAuthProfileOrder({
-        cfg: params.config,
-        store: authStore,
-        provider,
-        preferredProfile: preferredProfileId,
+      lastProfileId = resolvedProfileId;
+      return;
+    }
+    if (model.provider === "github-copilot") {
+      const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+      const copilotToken = await resolveCopilotApiToken({
+        githubToken: apiKeyInfo.apiKey,
       });
-      if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
-        throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+      authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+    } else {
+      authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
+    }
+    lastProfileId = apiKeyInfo.profileId;
+  };
+
+  const advanceAuthProfile = async (): Promise<boolean> => {
+    if (lockedProfileId) {
+      return false;
+    }
+    let nextIndex = profileIndex + 1;
+    while (nextIndex < profileCandidates.length) {
+      const candidate = profileCandidates[nextIndex];
+      if (candidate && isProfileInCooldown(authStore, candidate)) {
+        nextIndex += 1;
+        continue;
       }
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : profileOrder.length > 0
-          ? profileOrder
-          : [undefined];
-      let profileIndex = 0;
-
-      const initialThinkLevel = params.thinkLevel ?? "off";
-      let thinkLevel = initialThinkLevel;
-      const attemptedThinking = new Set<ThinkLevel>();
-      let apiKeyInfo: ApiKeyInfo | null = null;
-      let lastProfileId: string | undefined;
-
-      const resolveAuthProfileFailoverReason = (params: {
-        allInCooldown: boolean;
-        message: string;
-      }): FailoverReason => {
-        if (params.allInCooldown) {
-          return "rate_limit";
-        }
-        const classified = classifyFailoverReason(params.message);
-        return classified ?? "auth";
-      };
-
-      const throwAuthProfileFailover = (params: {
-        allInCooldown: boolean;
-        message?: string;
-        error?: unknown;
-      }): never => {
-        const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
-        const message =
-          params.message?.trim() ||
-          (params.error ? describeUnknownError(params.error).trim() : "") ||
-          fallbackMessage;
-        const reason = resolveAuthProfileFailoverReason({
-          allInCooldown: params.allInCooldown,
-          message,
-        });
-        if (fallbackConfigured) {
-          throw new FailoverError(message, {
-            reason,
-            provider,
-            model: modelId,
-            status: resolveFailoverStatus(reason),
-            cause: params.error,
-          });
-        }
-        if (params.error instanceof Error) {
-          throw params.error;
-        }
-        throw new Error(message);
-      };
-
-      const resolveApiKeyForCandidate = async (candidate?: string) => {
-        return getApiKeyForModel({
-          model,
-          cfg: params.config,
-          profileId: candidate,
-          store: authStore,
-          agentDir,
-        });
-      };
-
-      const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
-        apiKeyInfo = await resolveApiKeyForCandidate(candidate);
-        const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
-        if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
-            throw new Error(
-              `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
-            );
-          }
-          lastProfileId = resolvedProfileId;
-          return;
-        }
-        if (model.provider === "github-copilot") {
-          const { resolveCopilotApiToken } =
-            await import("../../providers/github-copilot-token.js");
-          const copilotToken = await resolveCopilotApiToken({
-            githubToken: apiKeyInfo.apiKey,
-          });
-          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
-        } else {
-          authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
-        }
-        lastProfileId = apiKeyInfo.profileId;
-      };
-
-      const advanceAuthProfile = async (): Promise<boolean> => {
-        if (lockedProfileId) {
-          return false;
-        }
-        let nextIndex = profileIndex + 1;
-        while (nextIndex < profileCandidates.length) {
-          const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
-            nextIndex += 1;
-            continue;
-          }
-          try {
-            await applyApiKeyInfo(candidate);
-            profileIndex = nextIndex;
-            thinkLevel = initialThinkLevel;
-            attemptedThinking.clear();
-            return true;
-          } catch (err) {
-            if (candidate && candidate === lockedProfileId) {
-              throw err;
-            }
-            nextIndex += 1;
-          }
-        }
-        return false;
-      };
-
       try {
-        while (profileIndex < profileCandidates.length) {
-          const candidate = profileCandidates[profileIndex];
-          if (
-            candidate &&
-            candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
-          ) {
-            profileIndex += 1;
-            continue;
-          }
-          await applyApiKeyInfo(profileCandidates[profileIndex]);
-          break;
-        }
-        if (profileIndex >= profileCandidates.length) {
-          throwAuthProfileFailover({ allInCooldown: true });
-        }
+        await applyApiKeyInfo(candidate);
+        profileIndex = nextIndex;
+        thinkLevel = initialThinkLevel;
+        attemptedThinking.clear();
+        return true;
       } catch (err) {
-        if (err instanceof FailoverError) {
+        if (candidate && candidate === lockedProfileId) {
           throw err;
         }
-        if (profileCandidates[profileIndex] === lockedProfileId) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-        const advanced = await advanceAuthProfile();
-        if (!advanced) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
+        nextIndex += 1;
       }
+    }
+    return false;
+  };
 
-      let overflowCompactionAttempted = false;
-      try {
-        while (true) {
-          attemptedThinking.add(thinkLevel);
-          await fs.mkdir(resolvedWorkspace, { recursive: true });
+  try {
+    while (profileIndex < profileCandidates.length) {
+      const candidate = profileCandidates[profileIndex];
+      if (
+        candidate &&
+        candidate !== lockedProfileId &&
+        isProfileInCooldown(authStore, candidate)
+      ) {
+        profileIndex += 1;
+        continue;
+      }
+      await applyApiKeyInfo(profileCandidates[profileIndex]);
+      break;
+    }
+    if (profileIndex >= profileCandidates.length) {
+      throwAuthProfileFailover({ allInCooldown: true });
+    }
+  } catch (err) {
+    if (err instanceof FailoverError) {
+      throw err;
+    }
+    if (profileCandidates[profileIndex] === lockedProfileId) {
+      throwAuthProfileFailover({ allInCooldown: false, error: err });
+    }
+    const advanced = await advanceAuthProfile();
+    if (!advanced) {
+      throwAuthProfileFailover({ allInCooldown: false, error: err });
+    }
+  }
 
-          const prompt =
-            provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+  let overflowCompactionAttempted = false;
+  try {
+    while (true) {
+      attemptedThinking.add(thinkLevel);
+      await fs.mkdir(resolvedWorkspace, { recursive: true });
 
-          const attempt = await runEmbeddedAttempt({
+      const prompt =
+        provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+
+      const attempt = await enqueueSession(() =>
+        enqueueGlobal(async () =>
+          runEmbeddedAttempt({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             messageChannel: params.messageChannel,
@@ -366,328 +360,340 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
-          });
+          }),
+        ),
+      );
 
-          const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
+      const {
+        aborted,
+        promptError,
+        timedOut,
+        sessionIdUsed,
+        lastAssistant,
+        autoCompactionAttempts,
+      } = attempt;
 
-          if (promptError && !aborted) {
-            const errorText = describeUnknownError(promptError);
-            if (isContextOverflowError(errorText)) {
-              const isCompactionFailure = isCompactionFailureError(errorText);
-              // Attempt auto-compaction on context overflow (not compaction_failure)
-              if (!isCompactionFailure && !overflowCompactionAttempted) {
-                log.warn(
-                  `context overflow detected; attempting auto-compaction for ${provider}/${modelId}`,
-                );
-                overflowCompactionAttempted = true;
-                const compactResult = await compactEmbeddedPiSessionDirect({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  messageChannel: params.messageChannel,
-                  messageProvider: params.messageProvider,
-                  agentAccountId: params.agentAccountId,
-                  authProfileId: lastProfileId,
-                  sessionFile: params.sessionFile,
-                  workspaceDir: params.workspaceDir,
-                  agentDir,
-                  config: params.config,
-                  skillsSnapshot: params.skillsSnapshot,
-                  provider,
-                  model: modelId,
-                  thinkLevel,
-                  reasoningLevel: params.reasoningLevel,
-                  bashElevated: params.bashElevated,
-                  extraSystemPrompt: params.extraSystemPrompt,
-                  ownerNumbers: params.ownerNumbers,
-                });
-                if (compactResult.compacted) {
-                  log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
-                  continue;
-                }
-                log.warn(
-                  `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
-                );
-              }
-              const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Context overflow: prompt too large for the model. " +
-                      "Try again with less input or a larger-context model.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind, message: errorText },
-                },
-              };
-            }
-            // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Message ordering conflict - please try again. " +
-                      "If this persists, use /new to start a fresh session.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "role_ordering", message: errorText },
-                },
-              };
-            }
-            // Handle image size errors with a user-friendly message (no retry needed)
-            const imageSizeError = parseImageSizeError(errorText);
-            if (imageSizeError) {
-              const maxMb = imageSizeError.maxMb;
-              const maxMbLabel =
-                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
-              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
-              return {
-                payloads: [
-                  {
-                    text:
-                      `Image too large for the model${maxBytesHint}. ` +
-                      "Please compress or resize the image and try again.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "image_size", message: errorText },
-                },
-              };
-            }
-            const promptFailoverReason = classifyFailoverReason(errorText);
-            if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
-              await markAuthProfileFailure({
-                store: authStore,
-                profileId: lastProfileId,
-                reason: promptFailoverReason,
-                cfg: params.config,
-                agentDir: params.agentDir,
-              });
-            }
-            if (
-              isFailoverErrorMessage(errorText) &&
-              promptFailoverReason !== "timeout" &&
-              (await advanceAuthProfile())
-            ) {
-              continue;
-            }
-            const fallbackThinking = pickFallbackThinkingLevel({
-              message: errorText,
-              attempted: attemptedThinking,
-            });
-            if (fallbackThinking) {
-              log.warn(
-                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-              );
-              thinkLevel = fallbackThinking;
-              continue;
-            }
-            // FIX: Throw FailoverError for prompt errors when fallbacks configured
-            // This enables model fallback for quota/rate limit errors during prompt submission
-            if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
-              throw new FailoverError(errorText, {
-                reason: promptFailoverReason ?? "unknown",
+      if (promptError && !aborted) {
+        const errorText = describeUnknownError(promptError);
+        if (isContextOverflowError(errorText)) {
+          const isCompactionFailure = isCompactionFailureError(errorText);
+          // Attempt auto-compaction on context overflow (not compaction_failure)
+          if (
+            !isCompactionFailure &&
+            !overflowCompactionAttempted &&
+            autoCompactionAttempts === 0
+          ) {
+            log.warn(
+              `context overflow detected; attempting auto-compaction for ${provider}/${modelId}`,
+            );
+            overflowCompactionAttempted = true;
+            const compactResult = await enqueueSession(() =>
+              compactEmbeddedPiSessionDirect({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                authProfileId: lastProfileId,
+                sessionFile: params.sessionFile,
+                workspaceDir: params.workspaceDir,
+                agentDir,
+                config: params.config,
+                skillsSnapshot: params.skillsSnapshot,
                 provider,
                 model: modelId,
-                profileId: lastProfileId,
-                status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-              });
-            }
-            throw promptError;
-          }
-
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: lastAssistant?.errorMessage,
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                thinkLevel,
+                reasoningLevel: params.reasoningLevel,
+                bashElevated: params.bashElevated,
+                extraSystemPrompt: params.extraSystemPrompt,
+                ownerNumbers: params.ownerNumbers,
+                skipSkillEnvOverrides: true,
+              }),
             );
-            thinkLevel = fallbackThinking;
-            continue;
-          }
-
-          const authFailure = isAuthAssistantError(lastAssistant);
-          const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
-          const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
-          const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
-
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
-            );
-          }
-
-          // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
-          const shouldRotate = (!aborted && failoverFailure) || timedOut;
-
-          if (shouldRotate) {
-            if (lastProfileId) {
-              const reason =
-                timedOut || assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : (assistantFailoverReason ?? "unknown");
-              await markAuthProfileFailure({
-                store: authStore,
-                profileId: lastProfileId,
-                reason,
-                cfg: params.config,
-                agentDir: params.agentDir,
-              });
-              if (timedOut && !isProbeSession) {
-                log.warn(
-                  `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
-                );
-              }
-              if (cloudCodeAssistFormatError) {
-                log.warn(
-                  `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
-                );
-              }
-            }
-
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
+            if (compactResult.compacted) {
+              log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
               continue;
             }
-
-            if (fallbackConfigured) {
-              // Prefer formatted error message (user-friendly) over raw errorMessage
-              const message =
-                (lastAssistant
-                  ? formatAssistantErrorText(lastAssistant, {
-                      cfg: params.config,
-                      sessionKey: params.sessionKey ?? params.sessionId,
-                    })
-                  : undefined) ||
-                lastAssistant?.errorMessage?.trim() ||
-                (timedOut
-                  ? "LLM request timed out."
-                  : rateLimitFailure
-                    ? "LLM request rate limited."
-                    : authFailure
-                      ? "LLM request unauthorized."
-                      : "LLM request failed.");
-              const status =
-                resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
-                (isTimeoutErrorMessage(message) ? 408 : undefined);
-              throw new FailoverError(message, {
-                reason: assistantFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
-                profileId: lastProfileId,
-                status,
-              });
-            }
+            log.warn(
+              `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+            );
           }
-
-          const usage = normalizeUsage(lastAssistant?.usage as UsageLike);
-          const agentMeta: EmbeddedPiAgentMeta = {
-            sessionId: sessionIdUsed,
-            provider: lastAssistant?.provider ?? provider,
-            model: lastAssistant?.model ?? model.id,
-            usage,
-          };
-
-          const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
-            toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
-            lastToolError: attempt.lastToolError,
-            config: params.config,
-            sessionKey: params.sessionKey ?? params.sessionId,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            inlineToolResultsAllowed: false,
-          });
-
-          log.debug(
-            `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
-          );
-          if (lastProfileId) {
-            await markAuthProfileGood({
-              store: authStore,
-              provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
+          const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
           return {
-            payloads: payloads.length ? payloads : undefined,
+            payloads: [
+              {
+                text:
+                  "Context overflow: prompt too large for the model. " +
+                  "Try again with less input or a larger-context model.",
+                isError: true,
+              },
+            ],
             meta: {
               durationMs: Date.now() - started,
-              agentMeta,
-              aborted,
+              agentMeta: {
+                sessionId: sessionIdUsed,
+                provider,
+                model: model.id,
+              },
               systemPromptReport: attempt.systemPromptReport,
-              // Handle client tool calls (OpenResponses hosted tools)
-              stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
-              pendingToolCalls: attempt.clientToolCall
-                ? [
-                    {
-                      id: `call_${Date.now()}`,
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
-                    },
-                  ]
-                : undefined,
+              error: { kind, message: errorText },
             },
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            messagingToolSentTexts: attempt.messagingToolSentTexts,
-            messagingToolSentTargets: attempt.messagingToolSentTargets,
           };
         }
-      } finally {
-        process.chdir(prevCwd);
+        // Handle role ordering errors with a user-friendly message
+        if (/incorrect role information|roles must alternate/i.test(errorText)) {
+          return {
+            payloads: [
+              {
+                text:
+                  "Message ordering conflict - please try again. " +
+                  "If this persists, use /new to start a fresh session.",
+                isError: true,
+              },
+            ],
+            meta: {
+              durationMs: Date.now() - started,
+              agentMeta: {
+                sessionId: sessionIdUsed,
+                provider,
+                model: model.id,
+              },
+              systemPromptReport: attempt.systemPromptReport,
+              error: { kind: "role_ordering", message: errorText },
+            },
+          };
+        }
+        // Handle image size errors with a user-friendly message (no retry needed)
+        const imageSizeError = parseImageSizeError(errorText);
+        if (imageSizeError) {
+          const maxMb = imageSizeError.maxMb;
+          const maxMbLabel =
+            typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+          const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
+          return {
+            payloads: [
+              {
+                text:
+                  `Image too large for the model${maxBytesHint}. ` +
+                  "Please compress or resize the image and try again.",
+                isError: true,
+              },
+            ],
+            meta: {
+              durationMs: Date.now() - started,
+              agentMeta: {
+                sessionId: sessionIdUsed,
+                provider,
+                model: model.id,
+              },
+              systemPromptReport: attempt.systemPromptReport,
+              error: { kind: "image_size", message: errorText },
+            },
+          };
+        }
+        const promptFailoverReason = classifyFailoverReason(errorText);
+        if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
+          await markAuthProfileFailure({
+            store: authStore,
+            profileId: lastProfileId,
+            reason: promptFailoverReason,
+            cfg: params.config,
+            agentDir: params.agentDir,
+          });
+        }
+        if (
+          isFailoverErrorMessage(errorText) &&
+          promptFailoverReason !== "timeout" &&
+          (await advanceAuthProfile())
+        ) {
+          continue;
+        }
+        const fallbackThinking = pickFallbackThinkingLevel({
+          message: errorText,
+          attempted: attemptedThinking,
+        });
+        if (fallbackThinking) {
+          log.warn(
+            `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+          );
+          thinkLevel = fallbackThinking;
+          continue;
+        }
+        // FIX: Throw FailoverError for prompt errors when fallbacks configured
+        // This enables model fallback for quota/rate limit errors during prompt submission
+        if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
+          throw new FailoverError(errorText, {
+            reason: promptFailoverReason ?? "unknown",
+            provider,
+            model: modelId,
+            profileId: lastProfileId,
+            status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+          });
+        }
+        throw promptError;
       }
-    }),
-  );
+
+      const fallbackThinking = pickFallbackThinkingLevel({
+        message: lastAssistant?.errorMessage,
+        attempted: attemptedThinking,
+      });
+      if (fallbackThinking && !aborted) {
+        log.warn(
+          `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+        );
+        thinkLevel = fallbackThinking;
+        continue;
+      }
+
+      const authFailure = isAuthAssistantError(lastAssistant);
+      const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+      const failoverFailure = isFailoverAssistantError(lastAssistant);
+      const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
+      const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
+      const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
+
+      if (imageDimensionError && lastProfileId) {
+        const details = [
+          imageDimensionError.messageIndex !== undefined
+            ? `message=${imageDimensionError.messageIndex}`
+            : null,
+          imageDimensionError.contentIndex !== undefined
+            ? `content=${imageDimensionError.contentIndex}`
+            : null,
+          imageDimensionError.maxDimensionPx !== undefined
+            ? `limit=${imageDimensionError.maxDimensionPx}px`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" ");
+        log.warn(
+          `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+        );
+      }
+
+      // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
+      const shouldRotate = (!aborted && failoverFailure) || timedOut;
+
+      if (shouldRotate) {
+        if (lastProfileId) {
+          const reason =
+            timedOut || assistantFailoverReason === "timeout"
+              ? "timeout"
+              : (assistantFailoverReason ?? "unknown");
+          await markAuthProfileFailure({
+            store: authStore,
+            profileId: lastProfileId,
+            reason,
+            cfg: params.config,
+            agentDir: params.agentDir,
+          });
+          if (timedOut && !isProbeSession) {
+            log.warn(
+              `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
+            );
+          }
+          if (cloudCodeAssistFormatError) {
+            log.warn(
+              `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
+            );
+          }
+        }
+
+        const rotated = await advanceAuthProfile();
+        if (rotated) continue;
+
+        if (fallbackConfigured) {
+          // Prefer formatted error message (user-friendly) over raw errorMessage
+          const message =
+            (lastAssistant
+              ? formatAssistantErrorText(lastAssistant, {
+                  cfg: params.config,
+                  sessionKey: params.sessionKey ?? params.sessionId,
+                })
+              : undefined) ||
+            lastAssistant?.errorMessage?.trim() ||
+            (timedOut
+              ? "LLM request timed out."
+              : rateLimitFailure
+                ? "LLM request rate limited."
+                : authFailure
+                  ? "LLM request unauthorized."
+                  : "LLM request failed.");
+          const status =
+            resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
+            (isTimeoutErrorMessage(message) ? 408 : undefined);
+          throw new FailoverError(message, {
+            reason: assistantFailoverReason ?? "unknown",
+            provider,
+            model: modelId,
+            profileId: lastProfileId,
+            status,
+          });
+        }
+      }
+
+      const usage = normalizeUsage(lastAssistant?.usage as UsageLike);
+      const agentMeta: EmbeddedPiAgentMeta = {
+        sessionId: sessionIdUsed,
+        provider: lastAssistant?.provider ?? provider,
+        model: lastAssistant?.model ?? model.id,
+        usage,
+      };
+
+      const payloads = buildEmbeddedRunPayloads({
+        assistantTexts: attempt.assistantTexts,
+        toolMetas: attempt.toolMetas,
+        lastAssistant: attempt.lastAssistant,
+        lastToolError: attempt.lastToolError,
+        config: params.config,
+        sessionKey: params.sessionKey ?? params.sessionId,
+        verboseLevel: params.verboseLevel,
+        reasoningLevel: params.reasoningLevel,
+        toolResultFormat: resolvedToolResultFormat,
+        inlineToolResultsAllowed: false,
+      });
+
+      log.debug(
+        `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
+      );
+      if (lastProfileId) {
+        await markAuthProfileGood({
+          store: authStore,
+          provider,
+          profileId: lastProfileId,
+          agentDir: params.agentDir,
+        });
+        await markAuthProfileUsed({
+          store: authStore,
+          profileId: lastProfileId,
+          agentDir: params.agentDir,
+        });
+      }
+      return {
+        payloads: payloads.length ? payloads : undefined,
+        meta: {
+          durationMs: Date.now() - started,
+          agentMeta,
+          aborted,
+          systemPromptReport: attempt.systemPromptReport,
+          // Handle client tool calls (OpenResponses hosted tools)
+          stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
+          pendingToolCalls: attempt.clientToolCall
+            ? [
+                {
+                  id: `call_${Date.now()}`,
+                  name: attempt.clientToolCall.name,
+                  arguments: JSON.stringify(attempt.clientToolCall.params),
+                },
+              ]
+            : undefined,
+        },
+        didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+        messagingToolSentTexts: attempt.messagingToolSentTexts,
+        messagingToolSentTargets: attempt.messagingToolSentTargets,
+      };
+    }
+  } finally {
+    process.chdir(prevCwd);
+  }
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -640,6 +640,7 @@ export async function runEmbeddedAttempt(
         toolMetas,
         unsubscribe,
         waitForCompactionRetry,
+        getCompactionAttempts,
         getMessagingToolSentTexts,
         getMessagingToolSentTargets,
         didSendViaMessagingTool,
@@ -892,6 +893,7 @@ export async function runEmbeddedAttempt(
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        autoCompactionAttempts: getCompactionAttempts(),
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -99,6 +99,7 @@ export type EmbeddedRunAttemptResult = {
   didSendViaMessagingTool: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  autoCompactionAttempts: number;
   cloudCodeAssistFormatError: boolean;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -22,6 +22,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 
 export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
+  ctx.state.compactionAttempts += 1;
   ctx.ensureCompactionPromise();
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
   emitAgentEvent({

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -49,6 +49,7 @@ export type EmbeddedPiSubscribeState = {
   lastReasoningSent?: string;
 
   compactionInFlight: boolean;
+  compactionAttempts: number;
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;
   compactionRetryPromise: Promise<void> | null;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -57,6 +57,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     suppressBlockChunks: false, // Avoid late chunk inserts after final text merge.
     lastReasoningSent: undefined,
     compactionInFlight: false,
+    compactionAttempts: 0,
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,
     compactionRetryPromise: null,
@@ -526,6 +527,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetas,
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
+    getCompactionAttempts: () => state.compactionAttempts,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     // Returns true if any messaging tool successfully sent a message.


### PR DESCRIPTION
## Problem

Auto-compaction freezes the gateway for 5-10 minutes because the LLM summarization API calls run **inside both the session and global lane locks** (`enqueueSession(() => enqueueGlobal(...))`). This blocks all other session work while summarization happens. Additionally, a double-compaction bug fires a second compaction immediately after the first on ~39 tokens.

Manual `/compact` works fine because it runs between turns in a clean lane slot with no contention.

### Evidence
- Gateway logs showed 412,506ms (6.9 min) lane wait on `session:agent:main:main`
- 4 items queued ahead in lane during compaction
- 5 sub-agent announces failed with 60s gateway timeouts
- Second compaction triggered immediately after first on ~39 tokens

## Fix

### 1. Move setup code outside lane locks
Model resolution, context window checks, auth profile handling, and other setup code now runs **before** acquiring lane locks. Only the actual `runEmbeddedAttempt` call runs inside the locks.

### 2. Remove global lock from overflow compaction
When auto-compaction triggers on context overflow, it now only acquires the session lock (not the global lock). This allows other sessions to proceed while compaction runs.

### 3. Prevent double-compaction
Added `compactionAttempts` counter to subscription state. When a context overflow is detected but Pi's internal auto-compaction already ran (`autoCompactionAttempts > 0`), the manual overflow compaction is skipped.

### 4. Minor compact.ts improvements
- Removed `process.chdir()` calls (uses `effectiveWorkspace` directly)
- Added `skipSkillEnvOverrides` parameter for cleaner compaction runs

## Files Changed
- `src/agents/pi-embedded-runner/run.ts` — main restructuring
- `src/agents/pi-embedded-runner/compact.ts` — chdir removal, skip flag
- `src/agents/pi-embedded-runner/run/attempt.ts` — pass compaction attempts
- `src/agents/pi-embedded-runner/run/types.ts` — new `autoCompactionAttempts` field
- `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts` — increment counter
- `src/agents/pi-embedded-subscribe.handlers.types.ts` — new state field
- `src/agents/pi-embedded-subscribe.ts` — init + expose counter
- `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts` — new test for skip behavior

## Testing
- `npx tsc --noEmit` passes
- `npx vitest run src/agents/pi-embedded-runner/` passes
- Deployed and running in production on our gateway with no issues

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR restructures the embedded Pi run loop to reduce lane contention during auto-compaction, adds a compaction-attempts counter surfaced from the subscribe layer to prevent “double compaction”, and adjusts compaction to avoid `process.chdir()` and optionally skip skill env overrides. It also adds a vitest that asserts overflow compaction is skipped when the underlying Pi auto-compaction already ran.

Overall, the changes aim to ensure long summarization calls don’t block unrelated work, while keeping the actual `runEmbeddedAttempt` execution serialized appropriately for a session.

<h3>Confidence Score: 2/5</h3>

- This PR has meaningful concurrency changes, but appears to still hold the global lane lock for the full attempt, which can preserve the original freeze behavior.
- The refactor is conceptually sound and includes targeted test coverage for double-compaction, but the `enqueueSession(() => enqueueGlobal(() => runEmbeddedAttempt(...)))` structure in `run.ts` still serializes the whole run behind the global lane. That’s a high-impact behavioral issue if the goal is to avoid global lock during long LLM operations.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->

Fixes #7688
