### PR TITLE
feat(sessions): add toolPolicy param to sessions_spawn for sub-agent tool restrictions

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -313,6 +313,7 @@ export async function runEmbeddedPiAgent(
             groupChannel: params.groupChannel,
             groupSpace: params.groupSpace,
             spawnedBy: params.spawnedBy,
+            spawnToolPolicy: params.spawnToolPolicy,
             currentChannelId: params.currentChannelId,
             currentThreadTs: params.currentThreadTs,
             replyToMode: params.replyToMode,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -215,6 +215,7 @@ export async function runEmbeddedAttempt(
           groupChannel: params.groupChannel,
           groupSpace: params.groupSpace,
           spawnedBy: params.spawnedBy,
+          spawnToolPolicy: params.spawnToolPolicy,
           senderId: params.senderId,
           senderName: params.senderName,
           senderUsername: params.senderUsername,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -35,6 +35,8 @@ export type RunEmbeddedPiAgentParams = {
   groupSpace?: string | null;
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
+  /** Per-spawn tool policy override from sessions_spawn toolPolicy param. */
+  spawnToolPolicy?: { allow?: string[]; deny?: string[] };
   senderId?: string | null;
   senderName?: string | null;
   senderUsername?: string | null;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -31,6 +31,8 @@ export type EmbeddedRunAttemptParams = {
   groupSpace?: string | null;
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
+  /** Per-spawn tool policy override from sessions_spawn toolPolicy param. */
+  spawnToolPolicy?: { allow?: string[]; deny?: string[] };
   senderId?: string | null;
   senderName?: string | null;
   senderUsername?: string | null;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -418,6 +418,7 @@ export async function agentCommand(
             groupChannel: runContext.groupChannel,
             groupSpace: runContext.groupSpace,
             spawnedBy,
+            spawnToolPolicy: sessionEntry?.spawnToolPolicy,
             currentChannelId: runContext.currentChannelId,
             currentThreadTs: runContext.currentThreadTs,
             replyToMode: runContext.replyToMode,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -36,6 +36,8 @@ export type SessionEntry = {
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;
+  /** Per-spawn tool policy override. Set by sessions_spawn to restrict child session tools. */
+  spawnToolPolicy?: { allow?: string[]; deny?: string[] };
   systemSent?: boolean;
   abortedLastRun?: boolean;
   chatType?: SessionChatType;

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -72,6 +72,15 @@ export const SessionsPatchParamsSchema = Type.Object(
     execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    spawnToolPolicy: Type.Optional(
+      Type.Union([
+        Type.Object({
+          allow: Type.Optional(Type.Array(Type.String())),
+          deny: Type.Optional(Type.Array(Type.String())),
+        }),
+        Type.Null(),
+      ]),
+    ),
     sendPolicy: Type.Optional(
       Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()]),
     ),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -247,6 +247,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         providerOverride: entry?.providerOverride,
         label: labelValue,
         spawnedBy: spawnedByValue,
+        spawnToolPolicy: entry?.spawnToolPolicy,
         channel: entry?.channel ?? request.channel?.trim(),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -90,6 +90,30 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
+  if ("spawnToolPolicy" in patch) {
+    const raw = patch.spawnToolPolicy;
+    if (raw === null) {
+      delete next.spawnToolPolicy;
+    } else if (raw !== undefined) {
+      if (!isSubagentSessionKey(storeKey)) {
+        return invalid("spawnToolPolicy is only supported for subagent:* sessions");
+      }
+      if (existing?.spawnToolPolicy) {
+        return invalid("spawnToolPolicy cannot be changed once set");
+      }
+      const policy: { allow?: string[]; deny?: string[] } = {};
+      if (Array.isArray(raw.allow) && raw.allow.length > 0) {
+        policy.allow = raw.allow.filter((v: unknown) => typeof v === "string" && v.trim()).map((v: string) => v.trim());
+      }
+      if (Array.isArray(raw.deny) && raw.deny.length > 0) {
+        policy.deny = raw.deny.filter((v: unknown) => typeof v === "string" && v.trim()).map((v: string) => v.trim());
+      }
+      if (policy.allow || policy.deny) {
+        next.spawnToolPolicy = policy;
+      }
+    }
+  }
+
   if ("label" in patch) {
     const raw = patch.label;
     if (raw === null) {


### PR DESCRIPTION
## Summary

Add a \	oolPolicy\ parameter to \sessions_spawn\ that allows the parent agent to restrict the tool set available to spawned sub-agents. This enables sandboxed sub-agents with fine-grained tool access control.

## Usage

\\\js
sessions_spawn({
  task: 'Fetch and summarize this page',
  toolPolicy: {
    allow: ['web_fetch', 'read', 'group:web'],  // whitelist
    deny: ['exec', 'group:runtime'],             // additional denials
  }
})
\\\

- **allow**: When set, narrows the sub-agent to only the listed tools (on top of the default subagent deny list)
- **deny**: Additional tools/groups to block (appended to default deny list)
- Supports existing tool group syntax (\group:web\, \group:fs\, \group:runtime\, etc.)

## Motivation

Currently, spawned sub-agents get the full default tool set minus the hardcoded subagent deny list. There's no way for the parent agent to further restrict tools on a per-spawn basis. This is needed for use cases like:

- Running untrusted tasks with minimal tool exposure
- Creating sub-agents that can only access specific capabilities (e.g. web-only, read-only)
- Sandboxing agents that interact with external content

## Implementation

- \SessionEntry\ gains a \spawnToolPolicy\ field (persisted per-session, immutable once set)
- \sessions.patch\ accepts \spawnToolPolicy\ for subagent sessions
- The spawn tool patches the child session before launching the agent run
- Policy merges with existing default subagent deny list:
  - \llow\ from spawn replaces default allow (narrows)
  - \deny\ from spawn appends to default deny (additive)
- Applied in both embedded agent path (\pi-tools.ts\) and HTTP tool invoke path (\	ools-invoke-http.ts\)

## Files Changed (12)

- \src/config/sessions/types.ts\ — SessionEntry type
- \src/gateway/protocol/schema/sessions.ts\ — Patch schema
- \src/gateway/sessions-patch.ts\ — Patch handler
- \src/gateway/server-methods/agent.ts\ — Preserve field in session entry
- \src/agents/tools/sessions-spawn-tool.ts\ — Tool schema + execution logic
- \src/commands/agent.ts\ — Thread to runner
- \src/agents/pi-embedded-runner/run/params.ts\ — Param type
- \src/agents/pi-embedded-runner/run/types.ts\ — Attempt param type
- \src/agents/pi-embedded-runner/run.ts\ — Forward param
- \src/agents/pi-embedded-runner/run/attempt.ts\ — Forward to createMoltbotCodingTools
- \src/agents/pi-tools.ts\ — Merge + apply policy
- \src/gateway/tools-invoke-http.ts\ — HTTP tool invoke path support