### PR TITLE
feat(webhooks): custom webhook verification

### DIFF
--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -101,6 +101,116 @@ Mapping options (summary):
 - `openclaw webhooks gmail setup` writes `hooks.gmail` config for `openclaw webhooks gmail run`.
 See [Gmail Pub/Sub](/automation/gmail-pubsub) for the full Gmail watch flow.
 
+## Transform Functions
+
+When templates aren't flexible enough, use a transform function to process webhook
+payloads with code.
+
+### Basic Example
+
+```yaml
+hooks:
+  enabled: true
+  token: "secret"
+  transformsDir: ./hooks  # relative to config file
+  mappings:
+    - id: github
+      match:
+        path: github
+      action: agent
+      transform:
+        module: github.js      # resolves to ./hooks/github.js
+        export: handleWebhook  # optional, defaults to "default" or "transform"
+```
+
+The transform function receives a context object:
+
+```typescript
+type HookMappingContext = {
+  payload: Record<string, unknown>;  // Parsed JSON body
+  headers: Record<string, string>;   // Lowercase header names
+  url: URL;                          // Parsed request URL
+  path: string;                      // Subpath after /hooks/ (e.g., "github")
+};
+```
+
+```javascript
+// hooks/github.js
+export function handleWebhook(ctx) {
+  const event = ctx.headers["x-github-event"];
+  
+  // Return null to skip this webhook entirely (no agent run)
+  if (event === "ping") return null;
+  
+  // Return fields to override the mapping defaults
+  return {
+    message: `GitHub ${event}: ${ctx.payload.action} on ${ctx.payload.repository?.full_name}`,
+    name: "GitHub",
+    sessionKey: `github:${ctx.payload.repository?.id}`,
+  };
+}
+```
+
+### Return Values
+
+Return an object with fields to override, or `null` to skip:
+
+```typescript
+// For action: "agent" (default)
+return {
+  message: string;           // Required if not set in mapping
+  name?: string;             // Display name for the hook
+  sessionKey?: string;       // Session identifier
+  wakeMode?: "now" | "next-heartbeat";
+  deliver?: boolean;         // Send response to chat
+  channel?: string;          // Target channel
+  to?: string;               // Recipient
+  model?: string;            // Model override
+  thinking?: string;         // Thinking level
+  timeoutSeconds?: number;
+};
+
+// For action: "wake"
+return {
+  text: string;              // Required
+  mode?: "now" | "next-heartbeat";
+};
+
+// Skip this webhook (no action taken, returns 204)
+return null;
+```
+
+### Async Transforms
+
+Transforms can be async:
+
+```javascript
+export default async function(ctx) {
+  const extra = await fetchAdditionalContext(ctx.payload.id);
+  return {
+    message: `Event: ${ctx.payload.type}\nContext: ${extra}`,
+  };
+}
+```
+
+### TypeScript
+
+JavaScript (`.js` / `.mjs`) transforms work out of the box with no extra setup.
+
+TypeScript transforms require a loader at runtime:
+
+```bash
+# Run gateway with tsx
+npx tsx node_modules/.bin/moltbot gateway start
+
+# Or use bun
+bun run moltbot gateway start
+
+# Or precompile to .js
+tsc hooks/*.ts --outDir hooks-dist
+# then reference hooks-dist/github.js in config
+```
+
 ## Responses
 
 - `200` for `/hooks/wake`

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -4,7 +4,13 @@ import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
-import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
+import {
+  type HookMappingResolved,
+  type HookMappingTransformResolved,
+  type HookVerifyFn,
+  loadVerify,
+  resolveHookMappings,
+} from "./hooks-mapping.js";
 
 const DEFAULT_HOOKS_PATH = "/hooks";
 const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
@@ -63,10 +69,10 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
   return { token: undefined, fromQuery: false };
 }
 
-export async function readJsonBody(
+export async function readRawBody(
   req: IncomingMessage,
   maxBytes: number,
-): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+): Promise<{ ok: true; value: Buffer } | { ok: false; error: string }> {
   return await new Promise((resolve) => {
     let done = false;
     let total = 0;
@@ -85,17 +91,7 @@ export async function readJsonBody(
     req.on("end", () => {
       if (done) return;
       done = true;
-      const raw = Buffer.concat(chunks).toString("utf-8").trim();
-      if (!raw) {
-        resolve({ ok: true, value: {} });
-        return;
-      }
-      try {
-        const parsed = JSON.parse(raw) as unknown;
-        resolve({ ok: true, value: parsed });
-      } catch (err) {
-        resolve({ ok: false, error: String(err) });
-      }
+      resolve({ ok: true, value: Buffer.concat(chunks) });
     });
     req.on("error", (err) => {
       if (done) return;
@@ -103,6 +99,97 @@ export async function readJsonBody(
       resolve({ ok: false, error: String(err) });
     });
   });
+}
+
+export function parseJsonBody(
+  raw: Buffer,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  const str = raw.toString("utf-8").trim();
+  if (!str) {
+    return { ok: true, value: {} };
+  }
+  try {
+    const parsed = JSON.parse(str) as unknown;
+    return { ok: true, value: parsed };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function readJsonBody(
+  req: IncomingMessage,
+  maxBytes: number,
+): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+  const raw = await readRawBody(req, maxBytes);
+  if (!raw.ok) return raw;
+  return parseJsonBody(raw.value);
+}
+
+export type AuthenticateHookContext = {
+  req: IncomingMessage;
+  url: URL;
+  subPath: string;
+  headers: Record<string, string>;
+  rawBody: Buffer;
+  transform: HookMappingTransformResolved | undefined;
+  expectedToken: string;
+};
+
+export type AuthenticateHookResult =
+  | { ok: true; tokenFromQuery: boolean }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Authenticate a webhook request.
+ *
+ * If the mapping has a verify export, use custom auth.
+ * Otherwise, fall back to standard token auth.
+ */
+export async function authenticateHook(
+  ctx: AuthenticateHookContext,
+): Promise<AuthenticateHookResult> {
+  if (ctx.transform) {
+    const result = await verifyFromMapping(ctx.transform, ctx);
+    if (result) return result;
+  }
+  return verifyFromToken(ctx.req, ctx.url, ctx.expectedToken);
+}
+
+async function verifyFromMapping(
+  transform: HookMappingTransformResolved,
+  ctx: Pick<AuthenticateHookContext, "headers" | "url" | "subPath" | "rawBody">,
+): Promise<AuthenticateHookResult | undefined> {
+  let verify: HookVerifyFn | undefined;
+  try {
+    verify = await loadVerify(transform);
+  } catch (err) {
+    return { ok: false, status: 500, error: `Failed to load verify: ${String(err)}` };
+  }
+  if (!verify) return undefined;
+  try {
+    const ok = await verify({
+      headers: ctx.headers,
+      url: ctx.url,
+      path: ctx.subPath,
+      rawBody: ctx.rawBody,
+    });
+    if (!ok) return { ok: false, status: 401, error: "Unauthorized" };
+    return { ok: true, tokenFromQuery: false };
+  } catch (err) {
+    return { ok: false, status: 401, error: `verify error: ${String(err)}` };
+  }
+}
+
+function verifyFromToken(
+  req: IncomingMessage,
+  url: URL,
+  expectedToken: string,
+): AuthenticateHookResult {
+  const { token, fromQuery } = extractHookToken(req, url);
+  if (!token || token !== expectedToken) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+  return { ok: true, tokenFromQuery: fromQuery };
 }
 
 export function normalizeHookHeaders(req: IncomingMessage) {


### PR DESCRIPTION
# Note
This has grown, see https://github.com/openclaw/openclaw/issues/4977 for more details
 
## Summary

Two changes:

1. **Document existing transform functions** — the `hooks.mappings` transform feature was only mentioned in bullet points with no examples, context type, or return value documentation.
2. **Add custom `verifyAuth` support** — transform modules can now export a `verifyAuth` function for custom webhook authentication (e.g., GitHub HMAC signatures), bypassing standard token auth.

## Motivation

External webhooks (GitHub, Stripe, Linear, etc.) use their own authentication schemes like HMAC signatures. 
Currently, hooks only support bearer token auth, making it difficult to receive webhooks from these services securely.

## Changes

### Commit 1: docs(hooks): document transform functions
- Add "Transform Functions" section to `docs/automation/webhook.md`
- Document `HookMappingContext` type, return values, `null` to skip, async support
- Clarify JS works out of the box, TS needs a loader

### Commit 2: feat(hooks): support custom verifyAuth in transform modules

**hooks.ts:**
- Split `readJsonBody` into `readRawBody` + `parseJsonBody` (raw body needed for signature verification)
- Add `authenticateHook()` as a dispatcher: tries `verifyFromMapping()` first, falls back to `verifyFromToken()`
- Remove `verifyAndParseWebhook()` — auth is now a separate concern from body parsing

**hooks-mapping.ts:**
- Add `HookVerifyAuthContext`, `HookVerifyAuthFn` types
- Add `resolveVerifyFn()` parallel to `resolveTransformFn()` — validates the export
- Add `loadVerifyAuth()` export, cached via `CachedTransform`
- Add `findMapping()` export — replaces `applyHookMappings()` loop
- Make `mappingMatches()` private — only `findMapping` is exported

**server-http.ts — linear flow:**
1. `readRawBody` + `parseJsonBody`
2. `findMapping()` — find matching mapping
3. `authenticateHook()` — custom or token auth
4. Route: wake / agent / `applyMapping()`

**Tests:** `authenticateHook` (token auth, invalid token, query token), `loadVerifyAuth` (with/without export)

## Usage

```javascript
// hooks/github.js
import { createHmac, timingSafeEqual } from "crypto";

export function verifyAuth(ctx) {
  const signature = ctx.headers["x-hub-signature-256"];
  if (!signature) return false;
  const secret = process.env.GITHUB_WEBHOOK_SECRET;
  const expected = "sha256=" + createHmac("sha256", secret)
    .update(ctx.rawBody).digest("hex");
  try {
    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
  } catch { return false; }
}

export default function transform(ctx) {
  const event = ctx.headers["x-github-event"];
  if (event === "ping") return null;
  return { message: `GitHub ${event}: ${ctx.payload.action}` };
}
```

```yaml
hooks:
  mappings:
    - id: github
      match: 
        path: github
      action: agent
      name: GitHub
      transform: 
        module: github.js
```

When a mapping's transform exports `verifyAuth`, it replaces standard token auth for that mapping. 
Return `true` to allow, `false` to reject with 401. Mappings without `verifyAuth` use standard token auth as before.

## Checklist
- [x] Documentation updated
- [x] Tests added (21 passing)
- [x] No breaking changes — existing hooks behaviour unchanged

## Note

I'm also playing around with an alternative API tweak here https://github.com/openclaw/openclaw/compare/main...bradleypriest:clawdbot:feat/webhook-auth-modes

---

*Implemented by Shellby (assistant) working with Bradley*
