### PR TITLE
fix: trim leading newlines from streaming/block-flush text output

### DIFF
--- a/NEWLINE-FIX-TASK.md
+++ b/NEWLINE-FIX-TASK.md
@@ -1,0 +1,45 @@
+# Task: Fix Leading Newline Bug
+
+## Problem
+iMessage responses have 1-2 blank lines prepended. Root cause: Anthropic models in thinking mode emit a `\n\n` text block before the thinking block, and the streaming/flush path doesn't trim leading whitespace.
+
+## Fixes Required (apply ALL THREE for defense in depth)
+
+### Fix 1: `emitBlockChunk` in `src/agents/pi-embedded-subscribe.ts`
+Find the line that does `.trimEnd()` on the chunk text and change it to `.trim()`:
+```
+// Find something like:
+const chunk = stripBlockTags(text, state.blockState).trimEnd();
+// Change to:
+const chunk = stripBlockTags(text, state.blockState).trim();
+```
+
+### Fix 2: `collapseConsecutiveDuplicateBlocks` in `src/agents/pi-embedded-helpers/errors.ts`
+Fix the early return to use trimmed text instead of original:
+```
+// Find:
+if (blocks.length < 2) return text;
+// Change to:
+if (blocks.length < 2) return trimmed;
+```
+
+### Fix 3: Safety net in `sanitizeUserFacingText` in same file (`errors.ts`)
+Make sure the final return trims:
+```
+// Find the final return of collapseConsecutiveDuplicateBlocks(stripped)
+// Change to:
+return collapseConsecutiveDuplicateBlocks(stripped).trim();
+```
+
+## Rules
+- Edit the TypeScript SOURCE files in `src/`, NOT the compiled `dist/` files
+- Build after changes: `npm run build` or `npx tsc`
+- Commit with message: `fix: trim leading newlines from streaming/block-flush text output`
+- Co-author: `Co-authored-by: Zach Canepa <zcanepa19@gmail.com>`
+- Push to branch: `fix/leading-newline-trim`
+- Do NOT create a PR, just push
+
+## Verification
+After building, check that the compiled JS in `dist/` reflects your changes:
+- `dist/agents/pi-embedded-subscribe.js` should have `.trim()` not `.trimEnd()`
+- `dist/agents/pi-embedded-helpers/errors.js` should return `trimmed` not `text` in early return

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -98,7 +98,7 @@ function collapseConsecutiveDuplicateBlocks(text: string): string {
   }
   const blocks = trimmed.split(/\n{2,}/);
   if (blocks.length < 2) {
-    return text;
+    return trimmed;
   }
 
   const normalizeBlock = (value: string) => value.trim().replace(/\s+/g, " ");
@@ -410,7 +410,7 @@ export function sanitizeUserFacingText(text: string): string {
     return formatRawAssistantErrorForUi(trimmed);
   }
 
-  return collapseConsecutiveDuplicateBlocks(stripped);
+  return collapseConsecutiveDuplicateBlocks(stripped).trim();
 }
 
 export function isRateLimitAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -393,7 +393,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
-    const chunk = stripBlockTags(text, state.blockState).trimEnd();
+    const chunk = stripBlockTags(text, state.blockState).trim();
     if (!chunk) {
       return;
     }


### PR DESCRIPTION
## Problem

iMessage (and likely other channel) responses have 1-2 blank lines prepended before the actual text content when using extended thinking mode.

## Root Cause

Anthropic models in extended thinking mode emit a `\n\n` text content block **before** the thinking block. The streaming/block-flush path preserves these leading newlines because:

1. `emitBlockChunk()` in `pi-embedded-subscribe.ts` uses `.trimEnd()` instead of `.trim()` — preserves leading newlines
2. `collapseConsecutiveDuplicateBlocks()` in `pi-embedded-helpers/errors.ts` returns the original untrimmed text when there's only one paragraph block (early return `if (blocks.length < 2) return text;`)
3. `sanitizeUserFacingText()` doesn't trim the final output

The final payloads path (`extractAssistantText()`) is NOT affected because it trims individual content blocks and filters empties.

## Fixes (defense in depth)

1. **`emitBlockChunk`**: `.trimEnd()` → `.trim()` — stops leading newlines at the source
2. **`collapseConsecutiveDuplicateBlocks`**: early return now returns `trimmed` instead of `text` — fixes the sanitizer
3. **`sanitizeUserFacingText`**: added `.trim()` to final return — safety net for all paths

## Testing

- Verified compiled JS reflects all three changes
- No behavior change for well-formed text (already trimmed)
- Only affects text with leading whitespace, which should never be user-facing

Co-authored-by: Zach Canepa <zcanepa19@gmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a user-facing formatting bug where some streaming/block-flush reply paths could prepend blank lines (e.g., Anthropic extended thinking emitting an initial `\n\n` text block). The change trims leading whitespace earlier in the streaming path (`emitBlockChunk` now uses `.trim()`), and adds defense-in-depth trimming in the sanitizer (`sanitizeUserFacingText` now trims final output) plus a fix to avoid returning untrimmed content in a short-circuit path of `collapseConsecutiveDuplicateBlocks`.

Overall, the approach fits the codebase’s existing “sanitize at boundaries” patterns in the embedded Pi streaming pipeline: raw provider output is cleaned before being stored/emitted, and final UI-facing strings are sanitized again.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one small logic edge case to address to fully achieve the intended trimming behavior.
- Changes are localized string-sanitization adjustments in the embedded streaming pipeline. The main potential issue is that `collapseConsecutiveDuplicateBlocks` can still return the original untrimmed `text` when it decides nothing changed, which can reintroduce leading newlines and partially negate the fix in certain paths.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->

Fixes #7689
