### PR TITLE
fix(telegram): scope skill commands to bound agent per bot

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -257,8 +257,12 @@ export const registerTelegramNativeCommands = ({
   shouldSkipUpdate,
   opts,
 }: RegisterTelegramNativeCommandsParams) => {
+  const boundRoute = resolveAgentRoute({ cfg, channel: "telegram", accountId });
+  const boundAgentIds = boundRoute?.agentId ? [boundRoute.agentId] : undefined;
   const skillCommands =
-    nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];
+    nativeEnabled && nativeSkillsEnabled
+      ? listSkillCommandsForAgents({ cfg, agentIds: boundAgentIds })
+      : [];
   const nativeCommands = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "telegram" })
     : [];


### PR DESCRIPTION
## Summary

- `registerTelegramNativeCommands()` calls `listSkillCommandsForAgents({ cfg })` without passing `agentIds`, so **every** Telegram bot registers **all** agents' skill commands
- When multiple agents share skill names (e.g. two agents both have "butler", "housekeeper"), the shared `used` Set causes de-duplication suffixes (`/butler_2`, `/housekeeper_2`)
- With enough agents/skills, total commands exceed Telegram's 100-command limit → `BOT_COMMANDS_TOO_MUCH` errors

This fix passes the bound agent's ID to `listSkillCommandsForAgents()` so each Telegram bot only registers its own agent's skill commands. The function already accepts `agentIds` — it just wasn't wired from the Telegram path.

## What changed

One file: `src/telegram/bot-native-commands.ts`

```typescript
// Before (line 260):
const skillCommands =
  nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];

// After:
const boundRoute = resolveAgentRoute({ cfg, channel: "telegram", accountId });
const boundAgentIds = boundRoute?.agentId ? [boundRoute.agentId] : undefined;
const skillCommands =
  nativeEnabled && nativeSkillsEnabled
    ? listSkillCommandsForAgents({ cfg, agentIds: boundAgentIds })
    : [];
```

`resolveAgentRoute` is already imported (line 25) and `accountId` is already a parameter of `registerTelegramNativeCommands`.

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| 2 agents with same skill names | `/butler`, `/butler_2` on both bots | `/butler` on each bot (scoped) |
| 3+ agents with many skills | `BOT_COMMANDS_TOO_MUCH` | Each bot stays under 100 commands |
| Single agent setup | No change | No change (fallback to undefined = all agents) |

## Testing

- [x] Tested locally with 2 Telegram agents (`park-rob`, `park-kyla`) sharing 6 workspace skills
- [x] Verified zero dedup entries in gateway logs after fix
- [x] Verified zero `BOT_COMMANDS_TOO_MUCH` errors
- [x] Verified `/housekeeper` and `/butler` invoke correctly on the bound agent's bot
- [x] Single-agent setups unaffected (when `boundRoute.agentId` is undefined, `agentIds` defaults to all)

## AI Disclosure

🤖 AI-assisted (Claude Opus 4.5). The root cause was identified by tracing the code path from `registerTelegramNativeCommands` → `listSkillCommandsForAgents` → shared `used` Set. The fix was tested on a production multi-agent Clawdbot instance before submitting.