### PR TITLE
fix: Telegram reconnect, rebrand compat, and update restore step

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(node --version:*)",
+      "Bash(npm:*)",
+      "Bash(/usr/local/bin/node:*)",
+      "Bash(/opt/homebrew/bin/node --version)",
+      "Bash(/Users/abhaybhat/.nvm/versions/node/v22.21.1/bin/node --version)",
+      "Bash(brew list:*)",
+      "Bash(echo:*)",
+      "Bash(ls:*)",
+      "Bash(nvm which:*)",
+      "Bash(nvm current:*)",
+      "Bash(nvm ls:*)",
+      "Bash(for i in 1 2 3)",
+      "Bash(do echo \"=== Shell restart $i ===\")",
+      "Bash(zsh -c 'source ~/.zshrc && node --version && nvm current')",
+      "Bash(done)"
+    ]
+  }
+}

--- a/src/cli/cli-name.ts
+++ b/src/cli/cli-name.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 
 export const DEFAULT_CLI_NAME = "moltbot";
-export const LEGACY_CLI_NAME = "moltbot";
+export const LEGACY_CLI_NAME = "clawdbot";
 
 const KNOWN_CLI_NAMES = new Set([DEFAULT_CLI_NAME, LEGACY_CLI_NAME]);
-const CLI_PREFIX_RE = /^(?:((?:pnpm|npm|bunx|npx)\s+))?(moltbot|moltbot)\b/;
+const CLI_PREFIX_RE = /^(?:((?:pnpm|npm|bunx|npx)\s+))?(moltbot|clawdbot)\b/;
 
 export function resolveCliName(
   argv: string[] = process.argv,

--- a/src/cli/command-format.ts
+++ b/src/cli/command-format.ts
@@ -1,7 +1,7 @@
 import { normalizeProfileName } from "./profile-utils.js";
 import { replaceCliName, resolveCliName } from "./cli-name.js";
 
-const CLI_PREFIX_RE = /^(?:pnpm|npm|bunx|npx)\s+(?:moltbot|moltbot)\b|^(?:moltbot|moltbot)\b/;
+const CLI_PREFIX_RE = /^(?:pnpm|npm|bunx|npx)\s+(?:moltbot|clawdbot)\b|^(?:moltbot|clawdbot)\b/;
 const PROFILE_FLAG_RE = /(?:^|\s)--profile(?:\s|=|$)/;
 const DEV_FLAG_RE = /(?:^|\s)--dev(?:\s|$)/;
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -129,10 +129,9 @@ export async function checkGitUpdateStatus(params: {
   ).catch(() => null);
   const upstream = upstreamRes && upstreamRes.code === 0 ? upstreamRes.stdout.trim() : null;
 
-  const dirtyRes = await runCommandWithTimeout(
-    ["git", "-C", root, "status", "--porcelain", "--", ":!dist/control-ui/"],
-    { timeoutMs },
-  ).catch(() => null);
+  const dirtyRes = await runCommandWithTimeout(["git", "-C", root, "status", "--porcelain"], {
+    timeoutMs,
+  }).catch(() => null);
   const dirty = dirtyRes && dirtyRes.code === 0 ? dirtyRes.stdout.trim().length > 0 : null;
 
   const fetchOk = params.fetch

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -676,17 +676,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     );
     steps.push(uiBuildStep);
 
-    // Restore dist/control-ui/ to committed state to prevent dirty repo after update
-    // (ui:build regenerates assets with new hashes, which would block future updates)
-    const restoreUiStep = await runStep(
-      step(
-        "restore control-ui",
-        ["git", "-C", gitRoot, "checkout", "--", "dist/control-ui/"],
-        gitRoot,
-      ),
-    );
-    steps.push(restoreUiStep);
-
     const doctorStep = await runStep(
       step(
         "moltbot doctor",

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -78,6 +78,7 @@ const NETWORK_ERROR_SNIPPETS = [
   "fetch failed",
   "network",
   "timeout",
+  "timed out",
   "socket",
   "econnreset",
   "econnrefused",

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -31,6 +31,11 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(new Error("Undici: socket failure"))).toBe(true);
   });
 
+  it("detects grammY getUpdates timeout format", () => {
+    const err = new Error("Request to 'getUpdates' timed out after 500 seconds");
+    expect(isRecoverableTelegramNetworkError(err)).toBe(true);
+  });
+
   it("skips message matches for send context", () => {
     const err = new TypeError("fetch failed");
     expect(isRecoverableTelegramNetworkError(err, { context: "send" })).toBe(false);

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -36,6 +36,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "client network socket disconnected",
   "socket hang up",
   "getaddrinfo",
+  "timed out",
 ];
 
 function normalizeCode(code?: string): string {


### PR DESCRIPTION
## Summary

- **Telegram auto-reconnect**: grammY throws `"timed out after 500 seconds"` on `getUpdates` timeout — neither `isNetworkRelatedError()` (checks `"timeout"`) nor `isRecoverableTelegramNetworkError()` matched `"timed out"`, so the error was re-thrown and the channel exited permanently. Added `"timed out"` to both snippet arrays.
- **Rebrand legacy compat**: `LEGACY_CLI_NAME` was set to `"moltbot"` (same as `DEFAULT_CLI_NAME`) instead of `"clawdbot"`, and the regex alternations were duplicated `(moltbot|moltbot)` instead of `(moltbot|clawdbot)`. The embedded agent's `exec` tool failed with `command not found` in environments where only `clawdbot` is in PATH.
- **Update restore step**: `dist/control-ui/` was un-tracked from git (commit `615ccf641`) but the update runner still tried `git checkout -- dist/control-ui/`, causing a failed step. The matching dirty-check exemption in `update-check.ts` was also dead code.

## Changes

| File | Change |
|------|--------|
| `src/telegram/monitor.ts` | Add `"timed out"` to `NETWORK_ERROR_SNIPPETS` |
| `src/telegram/network-errors.ts` | Add `"timed out"` to `RECOVERABLE_MESSAGE_SNIPPETS` |
| `src/telegram/network-errors.test.ts` | Add test for grammY timeout message format |
| `src/cli/cli-name.ts` | Fix `LEGACY_CLI_NAME` to `"clawdbot"`, fix regex alternation |
| `src/cli/command-format.ts` | Fix regex alternation from `(moltbot\|moltbot)` to `(moltbot\|clawdbot)` |
| `src/infra/update-runner.ts` | Remove `restore control-ui` step |
| `src/infra/update-check.ts` | Remove `:!dist/control-ui/` pathspec exclusion |

## Test plan

- [x] `npx vitest run src/telegram/network-errors.test.ts` — 8/8 pass (includes new "timed out" test)
- [x] `npx vitest run src/infra/update-runner.test.ts` — 8/8 pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)