### PR TITLE
feat(telegram): add topic name support for forum topics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,17 +314,17 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/imessage: {}
 
   extensions/line:
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/llm-task: {}
 
@@ -348,17 +348,17 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/mattermost: {}
 
   extensions/memory-core:
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/memory-lancedb:
     dependencies:
@@ -386,9 +386,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -397,12 +397,12 @@ importers:
 
   extensions/nostr:
     dependencies:
-      moltbot:
-        specifier: workspace:*
-        version: link:../../packages/moltbot
       nostr-tools:
         specifier: ^2.20.0
         version: 2.20.0(typescript@5.9.3)
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -439,9 +439,9 @@ importers:
         specifier: ^4.3.5
         version: 4.3.6
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/voice-call:
     dependencies:
@@ -459,9 +459,9 @@ importers:
 
   extensions/zalo:
     dependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
       undici:
         specifier: 7.19.0
         version: 7.19.0
@@ -471,9 +471,9 @@ importers:
       '@sinclair/typebox':
         specifier: 0.34.47
         version: 0.34.47
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   packages/clawdbot:
     dependencies:

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -103,6 +103,8 @@ export type MsgContext = {
   CommandTargetSessionKey?: string;
   /** Thread identifier (Telegram topic id or Matrix thread event id). */
   MessageThreadId?: string | number;
+  /** Topic name from config (Telegram forum topics). */
+  TopicName?: string;
   /** Telegram forum supergroup marker. */
   IsForum?: boolean;
   /**

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -133,6 +133,8 @@ export type TelegramAccountConfig = {
 };
 
 export type TelegramTopicConfig = {
+  /** Human-readable name for this topic (displayed in conversation context). */
+  name?: string;
   requireMention?: boolean;
   /** If specified, only load these skills for this topic. Omit = all skills; empty = no skills. */
   skills?: string[];

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -37,6 +37,7 @@ const TelegramCapabilitiesSchema = z.union([
 
 export const TelegramTopicSchema = z
   .object({
+    name: z.string().optional(),
     requireMention: z.boolean().optional(),
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -495,7 +495,9 @@ export const buildTelegramMessageContext = async ({
         forwardOrigin.date ? ` at ${new Date(forwardOrigin.date * 1000).toISOString()}` : ""
       }]\n`
     : "";
-  const groupLabel = isGroup ? buildGroupLabel(msg, chatId, resolvedThreadId) : undefined;
+  const groupLabel = isGroup
+    ? buildGroupLabel(msg, chatId, resolvedThreadId, topicConfig?.name)
+    : undefined;
   const senderName = buildSenderName(msg);
   const conversationLabel = isGroup
     ? (groupLabel ?? `group:${chatId}`)
@@ -605,6 +607,8 @@ export const buildTelegramMessageContext = async ({
     CommandAuthorized: commandAuthorized,
     // For groups: use resolvedThreadId (forum topics only); for DMs: use raw messageThreadId
     MessageThreadId: isGroup ? resolvedThreadId : messageThreadId,
+    // Topic name from config (if configured)
+    TopicName: isGroup && resolvedThreadId != null ? topicConfig?.name : undefined,
     IsForum: isForum,
     // Originating channel for reply routing.
     OriginatingChannel: "telegram" as const,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -106,9 +106,16 @@ export function buildGroupLabel(
   msg: TelegramMessage,
   chatId: number | string,
   messageThreadId?: number,
+  topicName?: string,
 ) {
   const title = msg.chat?.title;
-  const topicSuffix = messageThreadId != null ? ` topic:${messageThreadId}` : "";
+  // Include topic name if available, otherwise just show topic ID
+  const topicSuffix =
+    messageThreadId != null
+      ? topicName
+        ? ` topic:${topicName}`
+        : ` topic:${messageThreadId}`
+      : "";
   if (title) return `${title} id:${chatId}${topicSuffix}`;
   return `group:${chatId}${topicSuffix}`;
 }


### PR DESCRIPTION
## Summary
Add support for configuring human-readable names for Telegram forum topics, so the agent can understand the context of the conversation better.

## Changes
- Add `name` field to `TelegramTopicConfig` for human-readable topic names
- Update `buildGroupLabel` to display topic name instead of just ID when configured
- Add `TopicName` field to `MsgContext` for agent visibility
- Update Zod schema for config validation

## Configuration Example
```yaml
channels:
  telegram:
    groups:
      "-1234567890":
        topics:
          "37":
            name: "General Discussion"
          "42":
            name: "Tech Support"
```

## Result
With this configuration, the agent will see conversation context like:
- Before: `[Telegram MyGroup id:-1234567890 topic:37 ...]`
- After: `[Telegram MyGroup id:-1234567890 topic:General Discussion ...]`

This helps the agent understand what topic it's in without needing to look up topic IDs.

## Testing
- Type checked with `tsc --noEmit`
- Manually verified module imports work