### PR TITLE
fix(cli): use jobId instead of id in cron list output

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -141,7 +141,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
   const now = Date.now();
 
   for (const job of jobs) {
-    const idLabel = pad(job.id, CRON_ID_PAD);
+    const idLabel = pad(job.jobId ?? job.id ?? "", CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
       truncate(formatSchedule(job.schedule), CRON_SCHEDULE_PAD),


### PR DESCRIPTION
## Summary
Fixes #4373

The `moltbot cron list` command crashes with `TypeError: Cannot read properties of undefined (reading 'padEnd')` because it references `job.id` but the Gateway returns jobs with `jobId` as the canonical identifier.

## Changes
- Updated `printCronList` in `src/cli/cron-cli/shared.ts` to use `job.jobId ?? job.id ?? ""`
- Maintains backwards compatibility with any legacy code using `id`

## Testing
Before: `moltbot cron list` crashes
After: `moltbot cron list` works correctly

---
*Proactive overnight fix by Penny 🪙*