### PR TITLE
fix: store group messages from non-allowlisted senders as context

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -190,9 +190,10 @@ export async function monitorWebInbox(options: {
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
         remoteJid,
       });
-      if (!access.allowed) continue;
+      if (!access.allowed && !access.storeForContext) continue;
+      const contextOnly = !access.allowed && access.storeForContext;
 
-      if (id && !access.isSelfChat && options.sendReadReceipts !== false) {
+      if (id && !contextOnly && !access.isSelfChat && options.sendReadReceipts !== false) {
         const participant = msg.key?.participant;
         try {
           await sock.readMessages([{ remoteJid, id, participant, fromMe: false }]);
@@ -298,6 +299,7 @@ export async function monitorWebInbox(options: {
         sendMedia,
         mediaPath,
         mediaType,
+        contextOnly,
       };
       try {
         const task = Promise.resolve(debouncer.enqueue(inboundMessage));

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -39,4 +39,6 @@ export type WebInboundMessage = {
   mediaType?: string;
   mediaUrl?: string;
   wasMentioned?: boolean;
+  /** When true, message should only be stored for group context — not trigger a reply. */
+  contextOnly?: boolean;
 };


### PR DESCRIPTION
## Problem

When `groupPolicy: "allowlist"` and a group message arrives from a sender **not** in `groupAllowFrom`, the message is completely dropped at the access-control layer (`allowed: false` → `continue`). This means the agent cannot see messages from other bots or non-allowlisted members in its `[Chat messages since your last reply - for context]` block.

The [groups docs](https://docs.molt.bot/concepts/groups) describe the flow as:

```
requireMention? yes → mentioned? no → store for context only
```

But this context-storage only happens **after** access control passes. Messages blocked by `groupAllowFrom` never reach the mention-gating/context-storage logic.

## Fix

- Added `storeForContext` flag to `InboundAccessControlResult`
- When a group message fails `groupAllowFrom` sender check, return `storeForContext: true` instead of silently dropping
- Added `contextOnly` flag to `WebInboundMessage`
- In the auto-reply on-message handler, context-only messages are stored in group history via `recordPendingHistoryEntryIfEnabled` and then return without triggering a reply
- Read receipts are skipped for context-only messages

## Impact

- Non-allowlisted group members' messages now appear in the agent's context window
- No change to who can **trigger** the agent (still controlled by `groupAllowFrom`)
- No change to DM behavior
- Clean compile, no new dependencies

## Discovered by

Testing two Moltbot instances (Kev 🦈 and Keith 🪿) in the same WhatsApp group. Keith's messages were invisible to Kev.