### PR TITLE
fix: handle string thread_ts from Slack properly

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -40,13 +40,13 @@ export function scheduleFollowupDrain(
             const to = item.originatingTo;
             const accountId = item.originatingAccountId;
             const threadId = item.originatingThreadId;
-            if (!channel && !to && !accountId && typeof threadId !== "number") {
+            if (!channel && !to && !accountId && threadId == null) {
               return {};
             }
             if (!isRoutableChannel(channel) || !to) {
               return { cross: true };
             }
-            const threadKey = typeof threadId === "number" ? String(threadId) : "";
+            const threadKey = threadId != null ? String(threadId) : "";
             return {
               key: [channel, to, accountId || "", threadKey].join("|"),
             };
@@ -72,7 +72,7 @@ export function scheduleFollowupDrain(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null,
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({


### PR DESCRIPTION
## Summary
Fixes #4380 - Slack thread_ts messages were being dropped because the queue drain logic used `typeof === 'number'` to check for thread IDs.

## Problem
Slack thread_ts values are strings (e.g., `'1737766124.329349'`), not numbers. The original code:
```typescript
if (typeof threadId !== 'number') // This fails for Slack string thread IDs
```

This caused valid Slack thread messages to be filtered out incorrectly.

## Solution
Changed three occurrences in `src/auto-reply/reply/queue/drain.ts`:
- Line 43: `typeof threadId !== 'number'` → `threadId == null`
- Line 49: `typeof threadId === 'number'` → `threadId != null`
- Line 75: `typeof originatingThreadId === 'number'` → `originatingThreadId != null`

## Testing
- TypeScript compiles without errors
- Existing queue tests pass (8 tests total)
- Change allows string thread IDs while still filtering undefined/null values

## Notes
This is a straightforward type check fix - no behavioral changes for existing numeric thread IDs.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates follow-up queue drain routing so Slack `thread_ts` values (strings like `"1737766124.329349"`) aren’t dropped by `typeof === "number"` checks. In `src/auto-reply/reply/queue/drain.ts`, the cross-channel key derivation and collected-run `originatingThreadId` selection now treat any non-null thread ID (string or number) as present and stringify it into the routing key, aligning with the `originatingThreadId?: string | number` type used across the queue pipeline.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, targeted fix with one edge-case worth confirming.
- The change correctly aligns drain routing with Slack’s string `thread_ts` and the existing `string | number` type. Main risk is minor behavior change if empty-string thread IDs can occur, since the new null-check treats `""` as present in one selection path.
- src/auto-reply/reply/queue/drain.ts (confirm empty-string thread ID cannot occur or should be treated as absent)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->