### PR TITLE
fix(telegram): guard against empty message text in sendTelegramText

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -105,7 +105,7 @@ export async function deliverReplies(params: {
       const chunks = chunkText(reply.text || "");
       for (let i = 0; i < chunks.length; i += 1) {
         const chunk = chunks[i];
-        if (!chunk) continue;
+        if (!chunk?.html?.trim()) continue;
         // Only attach buttons to the first chunk.
         const shouldAttachButtons = i === 0 && replyMarkup;
         await sendTelegramText(bot, chatId, chunk.html, runtime, {
@@ -501,6 +501,10 @@ async function sendTelegramText(
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   },
 ): Promise<number | undefined> {
+  if (!text?.trim()) {
+    logVerbose("sendTelegramText: skipping empty message");
+    return undefined;
+  }
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
     replyQuoteText: opts?.replyQuoteText,


### PR DESCRIPTION
## The Problem

Block replies occasionally fail with:
```
[telegram] block reply failed: GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message text is empty)
```

The Telegram Bot API rejects `sendMessage` calls when the `text` parameter is empty.

## Root Cause

The `sendTelegramText` function in `src/telegram/bot/delivery.ts` doesn't check if text is empty before calling `bot.api.sendMessage()`.

## The Fix

1. **Guard in sendTelegramText()** - Early return if text is empty/whitespace-only:
   ```typescript
   if (!text?.trim()) {
     logVerbose("sendTelegramText: skipping empty message");
     return undefined;
   }
   ```

2. **Strengthen chunk iteration check** - Skip chunks with empty html:
   ```typescript
   if (!chunk?.html?.trim()) continue;
   ```

## References

- Telegraf Issue #323 (same error): https://github.com/telegraf/telegraf/issues/323
- TelegramBotAPI Errors: https://github.com/TelegramBotAPI/errors

Closes #4409