### PR TITLE
fix: slug-generator respects configured default model instead of hardcoded Opus

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -45,21 +45,13 @@ function persistSubagentRuns() {
 const resumedRuns = new Set<string>();
 
 function resumeSubagentRun(runId: string) {
-  if (!runId || resumedRuns.has(runId)) {
-    return;
-  }
+  if (!runId || resumedRuns.has(runId)) return;
   const entry = subagentRuns.get(runId);
-  if (!entry) {
-    return;
-  }
-  if (entry.cleanupCompletedAt) {
-    return;
-  }
+  if (!entry) return;
+  if (entry.cleanupCompletedAt) return;
 
   if (typeof entry.endedAt === "number" && entry.endedAt > 0) {
-    if (!beginSubagentCleanup(runId)) {
-      return;
-    }
+    if (!beginSubagentCleanup(runId)) return;
     const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
     void runSubagentAnnounceFlow({
       childSessionKey: entry.childSessionKey,
@@ -90,19 +82,13 @@ function resumeSubagentRun(runId: string) {
 }
 
 function restoreSubagentRunsOnce() {
-  if (restoreAttempted) {
-    return;
-  }
+  if (restoreAttempted) return;
   restoreAttempted = true;
   try {
     const restored = loadSubagentRegistryFromDisk();
-    if (restored.size === 0) {
-      return;
-    }
+    if (restored.size === 0) return;
     for (const [runId, entry] of restored.entries()) {
-      if (!runId || !entry) {
-        continue;
-      }
+      if (!runId || !entry) continue;
       // Keep any newer in-memory entries.
       if (!subagentRuns.has(runId)) {
         subagentRuns.set(runId, entry);
@@ -125,9 +111,7 @@ function restoreSubagentRunsOnce() {
 function resolveArchiveAfterMs(cfg?: ReturnType<typeof loadConfig>) {
   const config = cfg ?? loadConfig();
   const minutes = config.agents?.defaults?.subagents?.archiveAfterMinutes ?? 60;
-  if (!Number.isFinite(minutes) || minutes <= 0) {
-    return undefined;
-  }
+  if (!Number.isFinite(minutes) || minutes <= 0) return undefined;
   return Math.max(1, Math.floor(minutes)) * 60_000;
 }
 
@@ -139,9 +123,7 @@ function resolveSubagentWaitTimeoutMs(
 }
 
 function startSweeper() {
-  if (sweeper) {
-    return;
-  }
+  if (sweeper) return;
   sweeper = setInterval(() => {
     void sweepSubagentRuns();
   }, 60_000);
@@ -149,9 +131,7 @@ function startSweeper() {
 }
 
 function stopSweeper() {
-  if (!sweeper) {
-    return;
-  }
+  if (!sweeper) return;
   clearInterval(sweeper);
   sweeper = null;
 }
@@ -160,9 +140,7 @@ async function sweepSubagentRuns() {
   const now = Date.now();
   let mutated = false;
   for (const [runId, entry] of subagentRuns.entries()) {
-    if (!entry.archiveAtMs || entry.archiveAtMs > now) {
-      continue;
-    }
+    if (!entry.archiveAtMs || entry.archiveAtMs > now) continue;
     subagentRuns.delete(runId);
     mutated = true;
     try {
@@ -175,12 +153,8 @@ async function sweepSubagentRuns() {
       // ignore
     }
   }
-  if (mutated) {
-    persistSubagentRuns();
-  }
-  if (subagentRuns.size === 0) {
-    stopSweeper();
-  }
+  if (mutated) persistSubagentRuns();
+  if (subagentRuns.size === 0) stopSweeper();
 }
 
 function ensureListener() {
@@ -189,30 +163,37 @@ function ensureListener() {
   }
   listenerStarted = true;
   listenerStop = onAgentEvent((evt) => {
-    if (!evt || evt.stream !== "lifecycle") {
-      return;
-    }
+    if (!evt || evt.stream !== "lifecycle") return;
     const entry = subagentRuns.get(evt.runId);
     if (!entry) {
       return;
     }
     const phase = evt.data?.phase;
     if (phase === "start") {
-      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+      const startedAt =
+        typeof evt.data?.startedAt === "number" ? (evt.data.startedAt as number) : undefined;
       if (startedAt) {
         entry.startedAt = startedAt;
         persistSubagentRuns();
       }
       return;
     }
-    if (phase !== "end" && phase !== "error") {
-      return;
-    }
-    const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+    if (phase !== "end" && phase !== "error") return;
+    const endedAt =
+      typeof evt.data?.endedAt === "number" ? (evt.data.endedAt as number) : Date.now();
     entry.endedAt = endedAt;
     if (phase === "error") {
-      const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      entry.outcome = { status: "error", error };
+      const error = typeof evt.data?.error === "string" ? (evt.data.error as string) : undefined;
+      const errorType =
+        typeof evt.data?.errorType === "string" ? (evt.data.errorType as string) : undefined;
+      const errorHint =
+        typeof evt.data?.errorHint === "string" ? (evt.data.errorHint as string) : undefined;
+      entry.outcome = {
+        status: "error",
+        error,
+        errorType: errorType as SubagentRunOutcome["errorType"],
+        errorHint,
+      };
     } else {
       entry.outcome = { status: "ok" };
     }
@@ -244,9 +225,7 @@ function ensureListener() {
 
 function finalizeSubagentCleanup(runId: string, cleanup: "delete" | "keep", didAnnounce: boolean) {
   const entry = subagentRuns.get(runId);
-  if (!entry) {
-    return;
-  }
+  if (!entry) return;
   if (cleanup === "delete") {
     subagentRuns.delete(runId);
     persistSubagentRuns();
@@ -264,15 +243,9 @@ function finalizeSubagentCleanup(runId: string, cleanup: "delete" | "keep", didA
 
 function beginSubagentCleanup(runId: string) {
   const entry = subagentRuns.get(runId);
-  if (!entry) {
-    return false;
-  }
-  if (entry.cleanupCompletedAt) {
-    return false;
-  }
-  if (entry.cleanupHandled) {
-    return false;
-  }
+  if (!entry) return false;
+  if (entry.cleanupCompletedAt) return false;
+  if (entry.cleanupHandled) return false;
   entry.cleanupHandled = true;
   persistSubagentRuns();
   return true;
@@ -311,9 +284,7 @@ export function registerSubagentRun(params: {
   });
   ensureListener();
   persistSubagentRuns();
-  if (archiveAfterMs) {
-    startSweeper();
-  }
+  if (archiveAfterMs) startSweeper();
   // Wait for subagent completion via gateway RPC (cross-process).
   // The in-process lifecycle listener is a fallback for embedded runs.
   void waitForSubagentCompletion(params.runId, waitTimeoutMs);
@@ -322,26 +293,17 @@ export function registerSubagentRun(params: {
 async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
   try {
     const timeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
-    const wait = await callGateway<{
-      status?: string;
-      startedAt?: number;
-      endedAt?: number;
-      error?: string;
-    }>({
+    const wait = (await callGateway({
       method: "agent.wait",
       params: {
         runId,
         timeoutMs,
       },
       timeoutMs: timeoutMs + 10_000,
-    });
-    if (wait?.status !== "ok" && wait?.status !== "error") {
-      return;
-    }
+    })) as { status?: string; startedAt?: number; endedAt?: number; error?: string };
+    if (wait?.status !== "ok" && wait?.status !== "error") return;
     const entry = subagentRuns.get(runId);
-    if (!entry) {
-      return;
-    }
+    if (!entry) return;
     let mutated = false;
     if (typeof wait.startedAt === "number") {
       entry.startedAt = wait.startedAt;
@@ -355,16 +317,11 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       entry.endedAt = Date.now();
       mutated = true;
     }
-    const waitError = typeof wait.error === "string" ? wait.error : undefined;
     entry.outcome =
-      wait.status === "error" ? { status: "error", error: waitError } : { status: "ok" };
+      wait.status === "error" ? { status: "error", error: wait.error } : { status: "ok" };
     mutated = true;
-    if (mutated) {
-      persistSubagentRuns();
-    }
-    if (!beginSubagentCleanup(runId)) {
-      return;
-    }
+    if (mutated) persistSubagentRuns();
+    if (!beginSubagentCleanup(runId)) return;
     const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
     void runSubagentAnnounceFlow({
       childSessionKey: entry.childSessionKey,
@@ -408,19 +365,13 @@ export function addSubagentRunForTests(entry: SubagentRunRecord) {
 
 export function releaseSubagentRun(runId: string) {
   const didDelete = subagentRuns.delete(runId);
-  if (didDelete) {
-    persistSubagentRuns();
-  }
-  if (subagentRuns.size === 0) {
-    stopSweeper();
-  }
+  if (didDelete) persistSubagentRuns();
+  if (subagentRuns.size === 0) stopSweeper();
 }
 
 export function listSubagentRunsForRequester(requesterSessionKey: string): SubagentRunRecord[] {
   const key = requesterSessionKey.trim();
-  if (!key) {
-    return [];
-  }
+  if (!key) return [];
   return [...subagentRuns.values()].filter((entry) => entry.requesterSessionKey === key);
 }
 

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateSlugViaLLM } from "./llm-slug-generator.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { EmbeddedPiRunResult } from "../agents/pi-embedded.js";
+
+const runEmbeddedPiAgentMock = vi.fn<
+  Parameters<typeof import("../agents/pi-embedded.js").runEmbeddedPiAgent>,
+  Promise<EmbeddedPiRunResult>
+>();
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: (...args: unknown[]) => runEmbeddedPiAgentMock(...args),
+}));
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+  });
+
+  describe("model resolution", () => {
+    it("uses configured default model from agents.defaults.model.primary", async () => {
+      // Arrange: Config with custom default model (Sonnet instead of Opus)
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-5",
+            },
+          },
+        },
+      };
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "test-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      // Act
+      await generateSlugViaLLM({
+        sessionContent: "Some conversation about testing",
+        cfg,
+      });
+
+      // Assert: Should use Sonnet, not hardcoded Opus
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      expect(callArgs).toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        config: cfg,
+      });
+    });
+
+    it("uses configured default model with custom provider", async () => {
+      // Arrange: Config with OpenRouter model
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openrouter/anthropic/claude-3.5-sonnet",
+            },
+          },
+        },
+      };
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "custom-provider-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      // Act
+      await generateSlugViaLLM({
+        sessionContent: "Testing custom provider",
+        cfg,
+      });
+
+      // Assert: Should use OpenRouter provider
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      expect(callArgs).toMatchObject({
+        provider: "openrouter",
+        model: "anthropic/claude-3.5-sonnet",
+        config: cfg,
+      });
+    });
+
+    it("falls back to DEFAULT_MODEL when no model.primary is configured", async () => {
+      // Arrange: Empty config (no custom model)
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "default-model-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      // Act
+      await generateSlugViaLLM({
+        sessionContent: "Testing default fallback",
+        cfg,
+      });
+
+      // Assert: Should fall back to DEFAULT_MODEL (claude-opus-4-5)
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      expect(callArgs).toMatchObject({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        config: cfg,
+      });
+    });
+
+    it("uses Haiku when configured as default model", async () => {
+      // Arrange: Config with Haiku as default
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-3-5-haiku-20241022",
+            },
+          },
+        },
+      };
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "haiku-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      // Act
+      await generateSlugViaLLM({
+        sessionContent: "Budget-friendly slug generation",
+        cfg,
+      });
+
+      // Assert: Should use Haiku
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      expect(callArgs).toMatchObject({
+        provider: "anthropic",
+        model: "claude-3-5-haiku-20241022",
+        config: cfg,
+      });
+    });
+  });
+
+  describe("slug generation", () => {
+    it("generates valid slug from LLM response", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "api-design" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Discussion about API design patterns",
+        cfg,
+      });
+
+      expect(slug).toBe("api-design");
+    });
+
+    it("cleans up LLM response with extra characters", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "  Bug Fix!  " }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Bug fix discussion",
+        cfg,
+      });
+
+      expect(slug).toBe("bug-fix");
+    });
+
+    it("truncates long slugs to 30 characters", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "this-is-a-very-long-slug-that-should-be-truncated-significantly" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Long discussion",
+        cfg,
+      });
+
+      // Verify length is enforced (implementation slices before final cleanup)
+      expect(slug?.length).toBeLessThanOrEqual(30);
+      expect(slug).toMatch(/^this-is-a-very-long-slug/);
+    });
+
+    it("returns null when LLM returns no payloads", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Test content",
+        cfg,
+      });
+
+      expect(slug).toBeNull();
+    });
+
+    it("returns null when LLM returns empty text", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Test content",
+        cfg,
+      });
+
+      expect(slug).toBeNull();
+    });
+
+    it("returns null when embedded agent throws error", async () => {
+      const cfg: OpenClawConfig = {};
+
+      runEmbeddedPiAgentMock.mockRejectedValue(new Error("LLM timeout"));
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "Test content",
+        cfg,
+      });
+
+      expect(slug).toBeNull();
+    });
+  });
+
+  describe("embedded agent parameters", () => {
+    it("passes correct parameters to runEmbeddedPiAgent", async () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-5",
+            },
+          },
+        },
+      };
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "test-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      await generateSlugViaLLM({
+        sessionContent: "Testing parameters",
+        cfg,
+      });
+
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+
+      // Verify all expected parameters are present
+      expect(callArgs).toMatchObject({
+        config: cfg,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        timeoutMs: 15_000,
+      });
+
+      // Verify prompt includes session content
+      expect(callArgs?.prompt).toContain("Testing parameters");
+      expect(callArgs?.prompt).toContain("1-2 word filename slug");
+
+      // Verify session parameters
+      expect(callArgs?.sessionId).toMatch(/^slug-generator-\d+$/);
+      expect(callArgs?.sessionKey).toBe("temp:slug-generator");
+      expect(callArgs?.runId).toMatch(/^slug-gen-\d+$/);
+
+      // Verify temp session file path
+      expect(callArgs?.sessionFile).toContain("openclaw-slug-");
+      expect(callArgs?.sessionFile).toContain("session.jsonl");
+    });
+
+    it("truncates session content to 2000 characters in prompt", async () => {
+      const cfg: OpenClawConfig = {};
+      const longContent = "a".repeat(3000);
+
+      runEmbeddedPiAgentMock.mockResolvedValue({
+        payloads: [{ text: "truncated-slug" }],
+        meta: { runId: "test-run", sessionId: "test-session" },
+      });
+
+      await generateSlugViaLLM({
+        sessionContent: longContent,
+        cfg,
+      });
+
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      const promptContentMatch = callArgs?.prompt.match(
+        /Conversation summary:\n([\s\S]+)\n\nReply/,
+      );
+      const extractedContent = promptContentMatch?.[1] ?? "";
+
+      expect(extractedContent.length).toBeLessThanOrEqual(2000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4315.

The `llm-slug-generator` embedded run was hardcoded to fall back to `DEFAULT_MODEL` (`claude-opus-4-5`) because it never passed a `model` param to `runEmbeddedPiAgent()`. This caused unexpected Opus billing on every `/new` command, even when users configured a different default model via `agents.defaults.model.primary`.

## Changes

- Import `resolveDefaultModelForAgent` from `model-selection.ts`
- Resolve the user's configured default model before calling `runEmbeddedPiAgent()`
- Pass the resolved model to the embedded run

When no model is configured, `runEmbeddedPiAgent` still falls back to `DEFAULT_MODEL` as before — so this is fully backward-compatible.

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- Prettier passes
- Minimal, surgical change (6 lines added)