### PR TITLE
feat(line): add per-group policy override

### DIFF
--- a/src/line/config-schema.ts
+++ b/src/line/config-schema.ts
@@ -6,6 +6,7 @@ const GroupPolicySchema = z.enum(["open", "allowlist", "disabled"]);
 const LineGroupConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    policy: GroupPolicySchema.optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     requireMention: z.boolean().optional(),
     systemPrompt: z.string().optional(),

--- a/src/line/types.ts
+++ b/src/line/types.ts
@@ -45,6 +45,7 @@ export interface LineAccountConfig {
 
 export interface LineGroupConfig {
   enabled?: boolean;
+  policy?: "open" | "allowlist" | "disabled";
   allowFrom?: Array<string | number>;
   requireMention?: boolean;
   systemPrompt?: string;


### PR DESCRIPTION
## Summary

Add per-group policy overrides for the LINE channel plugin. Individual LINE groups can now override the channel-wide `groupPolicy` via a `policy` field in the `groups` config map.

## Config Example

```json
{
  "channels": {
    "line": {
      "groupPolicy": "allowlist",
      "groups": {
        "C1234...": { "policy": "open" },
        "C5678...": { "policy": "allowlist", "allowFrom": ["U1234..."] },
        "C9999...": { "policy": "disabled" }
      }
    }
  }
}
```

- `C1234...` — open to all members (overrides channel-wide allowlist)
- `C5678...` — restricted to specific senders
- `C9999...` — disabled entirely
- All other groups — fall back to channel-wide `groupPolicy: "allowlist"`

## Changes

| File | Change |
|------|--------|
| `src/line/types.ts` | Add `policy` to `LineGroupConfig` interface |
| `src/line/config-schema.ts` | Add `policy: GroupPolicySchema.optional()` to zod schema |
| `src/line/bot-handlers.ts` | Resolve per-group policy override before channel-wide default; restructure conditional flow |
| `src/line/bot-handlers.test.ts` | Add 4 test cases for per-group open/disabled/allowlist overrides and fallback |

## Design Decision

**LINE-only change.** The core `resolveChannelGroupPolicy` uses a different model (allowlist-by-presence in `groups` map), and Telegram has its own handler. Per-group policy fits naturally into LINE's existing `groups` config without touching shared infrastructure. If other channels want this pattern, it can be promoted to core later.

## Test Coverage

- Per-group `"open"` overrides channel `"allowlist"` → message allowed
- Per-group `"disabled"` overrides channel `"open"` → message blocked  
- Per-group `"allowlist"` with `allowFrom` → allowed user passes, blocked user rejected
- No per-group override → falls back to channel-wide policy
