### PR TITLE
docs: update molt.bot links in auto response

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -36,13 +36,13 @@ jobs:
                 label: "r: support",
                 close: true,
                 message:
-                  "Please use our support server https://molt.bot/discord and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.molt.bot/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
+                  "Please use our support server https://discord.gg/clawd and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
               },
               {
                 label: "r: third-party-extension",
                 close: true,
                 message:
-                  "This would be better made as a third-party extension with our SDK that you maintain yourself. Docs: https://docs.molt.bot/plugin.",
+                  "This would be better made as a third-party extension with our SDK that you maintain yourself. Docs: https://docs.openclaw.ai/plugin.",
               },
             ];
 


### PR DESCRIPTION
## Summary
- replace molt.bot URLs in auto-response messages with openclaw.ai links
- point support link at the current Discord invite

## Test plan
- [ ] N/A (docs/workflow text change)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `.github/workflows/auto-response.yml` GitHub Actions workflow to replace legacy `molt.bot` links in label-triggered auto-response messages with the new OpenClaw URLs (`docs.openclaw.ai`) and updates the support server link to a Discord invite.

The change is confined to the `rules` array used by the `actions/github-script@v7` step when an `r:*` label is applied to an issue or PR, so it only affects the content posted by the automation (no behavioral/workflow logic changes).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only string literals in a GitHub Actions workflow auto-response message were updated; no workflow triggers, permissions, or API calls changed, so runtime behavior is effectively unchanged aside from the link destinations.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->