### PR TITLE
docs: align canvas skill paths with openclaw

### DIFF
--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -38,7 +38,7 @@ The canvas host server binds based on `gateway.bind` setting:
 
 **Key insight:** The `canvasHostHostForBridge` is derived from `bridgeHost`. When bound to Tailscale, nodes receive URLs like:
 ```
-http://<tailscale-hostname>:18793/__moltbot__/canvas/<file>.html
+http://<tailscale-hostname>:18793/__openclaw__/canvas/<file>.html
 ```
 
 This is why localhost URLs don't work - the node receives the Tailscale hostname from the bridge!
@@ -55,14 +55,14 @@ This is why localhost URLs don't work - the node receives the Tailscale hostname
 
 ## Configuration
 
-In `~/.clawdbot/openclaw.json`:
+In `~/.openclaw/openclaw.json`:
 
 ```json
 {
   "canvasHost": {
     "enabled": true,
     "port": 18793,
-    "root": "/Users/you/clawd/canvas",
+    "root": "/Users/you/.openclaw/workspace/canvas",
     "liveReload": true
   },
   "gateway": {
@@ -84,7 +84,7 @@ Great for development!
 
 ### 1. Create HTML content
 
-Place files in the canvas root directory (default `~/clawd/canvas/`):
+Place files in the canvas root directory (default `~/.openclaw/workspace/canvas/`):
 
 ```bash
 cat > ~/clawd/canvas/my-game.html << 'HTML'
@@ -102,12 +102,12 @@ HTML
 
 Check how your gateway is bound:
 ```bash
-cat ~/.clawdbot/openclaw.json | jq '.gateway.bind'
+cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
-- **loopback**: `http://127.0.0.1:18793/__moltbot__/canvas/<file>.html`
-- **lan/tailnet/auto**: `http://<hostname>:18793/__moltbot__/canvas/<file>.html`
+- **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
+- **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 
 Find your Tailscale hostname:
 ```bash
@@ -130,7 +130,7 @@ canvas action:present node:<node-id> target:<full-url>
 
 **Example:**
 ```
-canvas action:present node:mac-63599bc4-b54d-4392-9048-b97abd58343a target:http://peters-mac-studio-1.sheep-coho.ts.net:18793/__moltbot__/canvas/snake.html
+canvas action:present node:mac-63599bc4-b54d-4392-9048-b97abd58343a target:http://peters-mac-studio-1.sheep-coho.ts.net:18793/__openclaw__/canvas/snake.html
 ```
 
 ### 5. Navigate, snapshot, or hide
@@ -148,9 +148,9 @@ canvas action:hide node:<node-id>
 **Cause:** URL mismatch between server bind and node expectation.
 
 **Debug steps:**
-1. Check server bind: `cat ~/.clawdbot/openclaw.json | jq '.gateway.bind'`
+1. Check server bind: `cat ~/.openclaw/openclaw.json | jq '.gateway.bind'`
 2. Check what port canvas is on: `lsof -i :18793`
-3. Test URL directly: `curl http://<hostname>:18793/__moltbot__/canvas/<file>.html`
+3. Test URL directly: `curl http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 
 **Solution:** Use the full hostname matching your bind mode, not localhost.
 
@@ -171,14 +171,14 @@ If live reload isn't working:
 
 ## URL Path Structure
 
-The canvas host serves from `/__moltbot__/canvas/` prefix:
+The canvas host serves from `/__openclaw__/canvas/` prefix:
 
 ```
-http://<host>:18793/__moltbot__/canvas/index.html  → ~/clawd/canvas/index.html
-http://<host>:18793/__moltbot__/canvas/games/snake.html → ~/clawd/canvas/games/snake.html
+http://<host>:18793/__openclaw__/canvas/index.html  → ~/.openclaw/workspace/canvas/index.html
+http://<host>:18793/__openclaw__/canvas/games/snake.html → ~/.openclaw/workspace/canvas/games/snake.html
 ```
 
-The `/__moltbot__/canvas/` prefix is defined by `CANVAS_HOST_PATH` constant.
+The `/__openclaw__/canvas/` prefix is defined by `CANVAS_HOST_PATH` constant.
 
 ## Tips
 


### PR DESCRIPTION
## Summary
- update canvas skill URLs to use the current /__openclaw__/canvas prefix
- replace ~/.clawdbot and ~/clawd examples with ~/.openclaw/workspace paths

## Test plan
- [ ] N/A (docs change)