### PR TITLE
fix: support Unicode characters in hybrid search FTS query

### DIFF
--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -23,7 +23,7 @@ export type HybridKeywordResult = {
 export function buildFtsQuery(raw: string): string | null {
   const tokens =
     raw
-      .match(/[A-Za-z0-9_]+/g)
+      .match(/[\p{L}\p{N}_]+/gu)
       ?.map((t) => t.trim())
       .filter(Boolean) ?? [];
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Problem

The `buildFtsQuery` function in `src/memory/hybrid.ts` uses regex `/[A-Za-z0-9_]+/g` which only matches ASCII characters. This causes CJK (Chinese/Japanese/Korean) and other non-ASCII Unicode characters to be completely ignored during hybrid search.

**Example:** When searching for "记忆系统" (Chinese for "memory system"), the function returns `null` because no tokens are matched.

## Solution

Changed the regex to use Unicode property escapes:

```diff
- .match(/[A-Za-z0-9_]+/g)
+ .match(/[\p{L}\p{N}_]+/gu)
```

- `\p{L}` matches all Unicode letters (including CJK)
- `\p{N}` matches all Unicode numbers  
- `u` flag enables Unicode mode

## Testing

Manually verified that Chinese keywords are now properly tokenized:

```typescript
buildFtsQuery('记忆系统')  // Before: null
buildFtsQuery('记忆系统')  // After: '"记忆系统"'

buildFtsQuery('hello 世界') // Before: '"hello"'
buildFtsQuery('hello 世界') // After: '"hello" AND "世界"'
```

## Compatibility

Unicode property escapes are supported in:
- Node.js 10+ (ES2018)
- All modern browsers

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates hybrid search tokenization in `src/memory/hybrid.ts` by switching the FTS token regex from ASCII-only (`/[A-Za-z0-9_]+/g`) to a Unicode-aware pattern (`/[\p{L}\p{N}_]+/gu`). That allows CJK and other non-ASCII characters to be included in the generated FTS query, improving hybrid search recall for multilingual inputs while keeping existing behavior for ASCII terms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a single regex) and aligns with the stated bug; Unicode property escapes are broadly supported in the repo’s likely runtime targets. No behavioral changes beyond expanded token matching are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->