### PR TITLE
feat: include token usage data in chat final events (#4159)

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -163,6 +163,7 @@ export function createAgentEventHandler({
     seq: number,
     jobState: "done" | "error",
     error?: unknown,
+    usage?: Record<string, unknown>,
   ) => {
     const text = chatRunState.buffers.get(clientRunId)?.trim() ?? "";
     chatRunState.buffers.delete(clientRunId);
@@ -180,6 +181,7 @@ export function createAgentEventHandler({
               timestamp: Date.now(),
             }
           : undefined,
+        usage: usage,
       };
       // Suppress webchat broadcast for heartbeat runs when showOk is false
       if (!shouldSuppressHeartbeatBroadcast(clientRunId)) {
@@ -264,6 +266,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evt.data?.usage as Record<string, unknown> | undefined,
           );
         } else {
           emitChatFinal(
@@ -272,6 +275,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evt.data?.usage as Record<string, unknown> | undefined,
           );
         }
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -149,6 +149,7 @@ function broadcastChatFinal(params: {
   runId: string;
   sessionKey: string;
   message?: Record<string, unknown>;
+  usage?: Record<string, unknown>;
 }) {
   const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
   const payload = {
@@ -157,6 +158,7 @@ function broadcastChatFinal(params: {
     seq,
     state: "final" as const,
     message: params.message,
+    usage: params.usage,
   };
   params.context.broadcast("chat", payload);
   params.context.nodeSendToSession(params.sessionKey, "chat", payload);
@@ -545,6 +547,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               runId: clientRunId,
               sessionKey: p.sessionKey,
               message,
+              usage: message?.usage as Record<string, unknown> | undefined,
             });
           }
           context.dedupe.set(`chat:${clientRunId}`, {


### PR DESCRIPTION
## Problem
Fixes #4159

External monitoring tools need to track token usage and API costs. Currently, 
they have no way to get this information from chat final events.

## Solution
Add token usage information to chat final events by:
- Extracting usage data from message objects
- Passing usage through the event pipeline
- Maintaining full backward compatibility

## Changes
- Add `usage` parameter to `broadcastChatFinal()` function
- Add `usage` parameter to `emitChatFinal()` function
- Extract usage from message objects and agent event data

## Benefits
- ✅ Enable cost tracking for API usage
- ✅ Support external monitoring tools (e.g., Crabwalk)
- ✅ Maintain backward compatibility (usage is optional)
- ✅ Minimal code changes (7 lines across 2 files)
- ✅ No new dependencies or schema changes required

## Testing
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] No TypeScript errors
- [x] No breaking changes
- [x] Backward compatible with existing clients

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change

## Related Issues
Closes #4159