### PR TITLE
Gateway: tolerate transient network failures(#4425)  AI-assisted PR

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -100,6 +100,24 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for MediaFetchError with fetch_failed code", () => {
+    const error = Object.assign(new Error("media fetch failed"), {
+      name: "MediaFetchError",
+      code: "fetch_failed",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for MediaFetchError that wraps a network cause", () => {
+    const cause = Object.assign(new Error("timeout"), { code: "ETIMEDOUT" });
+    const error = Object.assign(new Error("media fetch failed"), {
+      name: "MediaFetchError",
+      code: "fetch_failed",
+      cause,
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false for regular errors without network codes", () => {
     expect(isTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -78,6 +78,16 @@ function isConfigError(err: unknown): boolean {
 export function isTransientNetworkError(err: unknown): boolean {
   if (!err) return false;
 
+  if (err && typeof err === "object") {
+    const name = "name" in err ? String(err.name) : "";
+    const code = extractErrorCodeWithCause(err);
+    if (name === "MediaFetchError" && code === "fetch_failed") {
+      const cause = getErrorCause(err);
+      if (cause && cause !== err) return isTransientNetworkError(cause);
+      return true;
+    }
+  }
+
   const code = extractErrorCodeWithCause(err);
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
 


### PR DESCRIPTION
Prevents crash loops when external API requests (e.g., Telegram media fetches) fail transiently.   Fixes #4425

  - Preserve network error causes in MediaFetchError so transient failures are classified correctly.
  - Treat MediaFetchError(fetch_failed) as transient in the global unhandled-rejection handler.
  - Add a Telegram-specific unhandled rejection handler to suppress recoverable network errors.
  - Add tests to cover transient classification for MediaFetchError.