### PR TITLE
fix bug #4366: Error: Config validation failed: plugins.slots.memory: plugin not found: memory-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY scripts ./scripts
 RUN pnpm install --frozen-lockfile
 
 COPY . .
+
+# Install memory-core dependencies (no build script needed)
+RUN cd extensions/memory-core && pnpm install
+
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
### Problem

when run ./docker-setup.sh
after configuring the api token it got below error
Error: Config validation failed: plugins.slots.memory: plugin not found: memory-core

This PR fixes the bug described in https://github.com/openclaw/openclaw/issues/4366

### Root Cause
The memory-core not included when building the image 

### Fix
update DockerFile to build memory-core

### Test
Run ./docker-setup.sh in local machine (NAS server) and verified the deployment is successful

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root `Dockerfile` to ensure the `extensions/memory-core` workspace package has its dependencies installed during the image build, preventing runtime config validation failures when `plugins.slots.memory` is set to `memory-core`.

The change fits the repo’s plugin system by making sure the default bundled memory plugin (`memory-core`) is actually present/usable in Docker builds used by `./docker-setup.sh` deployments.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported Docker build/runtime issue.
- Change is small and localized to the Docker build. Main concern is reproducibility: doing a nested `pnpm install` without `--frozen-lockfile` can drift from the repo lockfile and make builds less deterministic.
- Dockerfile

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->