### PR TITLE
fix(telegram): use undici fetch for proxy to fix dispatcher option

### DIFF
--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
-import { ProxyAgent } from "undici";
+import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { wrapFetchWithAbortSignal } from "../infra/fetch.js";
 
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
   return wrapFetchWithAbortSignal((input: RequestInfo | URL, init?: RequestInit) => {
     const base = init ? { ...init } : {};
-    return fetch(input, { ...base, dispatcher: agent });
+    return undiciFetch(input, { ...base, dispatcher: agent });
   });
 }


### PR DESCRIPTION
Fixes #4038

## Problem
Telegram proxy configuration was not working because `makeProxyFetch()` was using Node.js's global `fetch` with undici's `dispatcher` option. The global `fetch` in Node.js ignores the `dispatcher` option, causing all proxy configurations to be ineffective.

## Root Cause
In `src/telegram/proxy.ts`, the code was:
```typescript
return fetch(input, { ...base, dispatcher: agent });
```

Node.js's global `fetch` (available since Node 18) is based on undici but doesn't support the `dispatcher` option in the same way as undici's exported `fetch`.

## Solution
Import and use `fetch` from undici directly:
```typescript
import { ProxyAgent, fetch as undiciFetch } from "undici";
// ...
return undiciFetch(input, { ...base, dispatcher: agent });
```

This ensures the ProxyAgent's dispatcher is properly respected for all Telegram Bot API calls.

## Testing
- ✅ Build successful (`pnpm build`)
- ✅ TypeScript compilation passes
- ✅ No changes to API surface or behavior (only fixes broken functionality)

## Impact
Users in regions where Telegram is blocked (e.g., China) will now be able to use proxy configuration as documented:
```json
{
  "channels": {
    "telegram": {
      "proxy": "http://127.0.0.1:7890"
    }
  }
}
```