### PR TITLE
docs: clarify how to open VNC (macos-vm) if it does not start automatically

### DIFF
--- a/docs/platforms/macos-vm.md
+++ b/docs/platforms/macos-vm.md
@@ -92,7 +92,15 @@ lume create openclaw --os macos --ipsw latest
 
 This downloads macOS and creates the VM. A VNC window opens automatically.
 
-Note: The download can take a while depending on your connection.
+**Note:**  
+- The download can take a while depending on your connection.  
+- In some environments, the VNC window may not open automatically after running `lume create`.  
+  If this happens, you can start the VM manually and open the VNC display with:
+  ```bash
+  lume run openclaw
+  ```
+  This will open the VNC window so you can complete the macOS Setup Assistant.  
+  Use `--no-display` if you prefer to run the VM headless.
 
 ---
 

--- a/docs/platforms/macos-vm.md
+++ b/docs/platforms/macos-vm.md
@@ -95,13 +95,15 @@ This downloads macOS and creates the VM. A VNC window opens automatically.
 Note:
 - The download can take a while depending on your connection.
 - In some environments, the VNC window may not open automatically after running `lume create`.
+  
   If this happens, you can start the VM manually and open the VNC display with:
   
   ```bash
   lume run openclaw
   ```
   
-  This will open the VNC window so you can complete the macOS Setup Assistant.  
+  This will open the VNC window so you can complete the macOS Setup Assistant.
+  
   Use `--no-display` if you prefer to run the VM headless.
 
 ---

--- a/docs/platforms/macos-vm.md
+++ b/docs/platforms/macos-vm.md
@@ -92,13 +92,15 @@ lume create openclaw --os macos --ipsw latest
 
 This downloads macOS and creates the VM. A VNC window opens automatically.
 
-**Note:**  
-- The download can take a while depending on your connection.  
-- In some environments, the VNC window may not open automatically after running `lume create`.  
+Note:
+- The download can take a while depending on your connection.
+- In some environments, the VNC window may not open automatically after running `lume create`.
   If this happens, you can start the VM manually and open the VNC display with:
+  
   ```bash
   lume run openclaw
   ```
+  
   This will open the VNC window so you can complete the macOS Setup Assistant.  
   Use `--no-display` if you prefer to run the VM headless.
 


### PR DESCRIPTION
### Background

The current macOS VM setup guide assumes that running:

```bash
lume create openclaw --os macos --ipsw latest
```

will always open a VNC window automatically so users can complete the macOS Setup Assistant.

In practice, this does not always happen.

---

### What’s changed

This PR adds a short clarification note explaining how to manually open the VNC display when it does not start automatically.

Specifically, it documents the use of:

```bash
lume run openclaw
```

to explicitly start the VM with a display and open the VNC window.

It also briefly mentions `--no-display` for users who intentionally want to run the VM headless.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the macOS VM (Lume) setup guide to explain what to do when `lume create` does not automatically open a VNC window. It adds a note that users can manually start the VM with a display via `lume run openclaw`, and reiterates `--no-display` for headless operation.

This fits the existing flow by clarifying step (2) before the “Complete Setup Assistant” section, without altering the overall quickstart steps or command sequence elsewhere in the doc.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it is a small docs-only clarification with consistent Markdown formatting.
- Reviewed the only changed file and the added block is syntactically valid Markdown (proper code fences, list nesting) and aligns with the rest of the document’s existing Lume usage (`lume run ... --no-display`). No additional issues beyond the already-discussed trailing-space formatting concerns were found.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->