### PR TITLE
feat(search): add optional proxy configuration for the web_search tool

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -107,6 +107,7 @@ crypto/prepaid).
       search: {
         enabled: true,
         provider: "perplexity",
+        proxy: "http://127.0.0.1:7890", // optional
         perplexity: {
           // API key (optional if OPENROUTER_API_KEY or PERPLEXITY_API_KEY is set)
           apiKey: "sk-or-v1-...",
@@ -160,7 +161,8 @@ Search the web using your configured provider.
         apiKey: "BRAVE_API_KEY_HERE", // optional if BRAVE_API_KEY is set
         maxResults: 5,
         timeoutSeconds: 30,
-        cacheTtlMinutes: 15
+        cacheTtlMinutes: 15,
+        proxy: "http://127.0.0.1:7890" // optional
       }
     }
   }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -124,7 +124,8 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
 }
 
 function resolveProxy(search?: WebSearchConfig): string | undefined {
-  const fromConfig = search && "proxy" in search && typeof search.proxy === "string" ? search.proxy.trim() : "";
+  const fromConfig =
+    search && "proxy" in search && typeof search.proxy === "string" ? search.proxy.trim() : "";
   return fromConfig || undefined;
 }
 
@@ -302,7 +303,7 @@ async function runPerplexitySearch(params: {
     }),
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
     dispatcher,
-  });
+  } as RequestInit);
 
   if (!res.ok) {
     const detail = await readResponseText(res);
@@ -393,7 +394,7 @@ async function runWebSearch(params: {
     },
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
     dispatcher,
-  });
+  } as RequestInit);
 
   if (!res.ok) {
     const detail = await readResponseText(res);

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,6 +170,7 @@ export const ToolsWebSearchSchema = z
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
+    proxy: z.string().optional(),
     perplexity: z
       .object({
         apiKey: z.string().optional(),


### PR DESCRIPTION
## Summary

  Adds optional proxy configuration for the web_search tool to support network environments that require proxies
  to access Brave Search API or Perplexity.

## Changes

  - Add proxy field to ToolsWebSearchSchema in src/config/zod-schema.agent-runtime.ts
  - Add resolveProxy() helper function in src/agents/tools/web-search.ts
  - Update runPerplexitySearch() and runWebSearch() to accept and use proxy parameter
  - Use undici's ProxyAgent for both Brave Search and Perplexity providers
  - Update docs/tools/web.md with proxy configuration examples

## Example Config

```json
  {
    "tools": {
      "web": {
        "search": {
          "apiKey": "YOUR_BRAVE_API_KEY",
          "proxy": "http://127.0.0.1:7890"  // supports http
        }
      }
    }
  }
```

  The proxy setting works with both Brave Search and Perplexity providers.

## Testing

  - Build passes (pnpm build)
  - All tests pass (pnpm test)
  - Verified web search works with proxy configured
  - Verified web search works without proxy (backward compatible)