### PR TITLE
fix: drop errored assistant tool calls and their orphan tool_results

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -89,6 +89,48 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(results[0]?.toolCallId).toBe("call_1");
   });
 
+  it("drops errored assistant with tool calls and their matching tool results", () => {
+    const input = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_err", name: "cron", arguments: {} }],
+        stopReason: "error",
+        errorMessage: "JSON parse error",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_err",
+        toolName: "cron",
+        content: [{ type: "text", text: "synthetic repair" }],
+        isError: true,
+      },
+      { role: "user", content: "fix this" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    // The errored assistant and its tool_result should both be dropped
+    expect(out.map((m) => m.role)).toEqual(["user", "user"]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("keeps errored assistant without tool calls", () => {
+    const input = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "partial response" }],
+        stopReason: "error",
+        errorMessage: "timeout",
+      },
+      { role: "user", content: "try again" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out).toHaveLength(3);
+    expect(out[1]?.role).toBe("assistant");
+  });
+
   it("drops orphan tool results that do not match any tool call", () => {
     const input = [
       { role: "user", content: "hello" },

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,6 +116,47 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Drop errored/aborted assistant messages that contain tool calls, along with
+    // their matching tool_results. The provider-level transform (pi-ai) also drops
+    // these assistants, but if the tool_results survive they become orphans that
+    // cause "unexpected tool_use_id" API rejections. Defence-in-depth: strip them
+    // here so downstream transforms never see the mismatch.
+    if (
+      (assistant as { stopReason?: unknown }).stopReason === "error" ||
+      (assistant as { stopReason?: unknown }).stopReason === "aborted"
+    ) {
+      const erroredToolCalls = extractToolCallsFromAssistant(assistant);
+      if (erroredToolCalls.length > 0) {
+        const erroredIds = new Set(erroredToolCalls.map((t) => t.id));
+        // Skip ahead past any matching tool_results for this errored assistant
+        let j = i + 1;
+        for (; j < messages.length; j += 1) {
+          const next = messages[j] as AgentMessage;
+          if (!next || typeof next !== "object") continue;
+          const nextRole = (next as { role?: unknown }).role;
+          if (nextRole === "assistant") break;
+          if (nextRole === "toolResult") {
+            const id = extractToolResultId(
+              next as Extract<AgentMessage, { role: "toolResult" }>,
+            );
+            if (id && erroredIds.has(id)) {
+              // Drop the orphan tool_result that matched the errored assistant
+              changed = true;
+              continue;
+            }
+          }
+          out.push(next);
+        }
+        i = j - 1;
+        changed = true;
+        continue;
+      }
+      // Errored assistant without tool calls - keep it
+      out.push(msg);
+      continue;
+    }
+
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);


### PR DESCRIPTION
## Problem

When an assistant message has `stopReason="error"` (e.g. JSON parse failure mid-stream) and contains `tool_use` blocks, the provider-level transform in `pi-ai` (`transform-messages.ts`) drops the entire assistant message. However, the matching `tool_result` messages survive in the transcript, creating orphan references that cause Anthropic API rejections:

```
messages.74.content.1: unexpected tool_use_id found in tool_result blocks: toolu_013jX8urmv6cPZ6FcY8QAeaN.
Each tool_result block must have a corresponding tool_use block in the previous message.
```

Once this happens, the session is permanently broken - every subsequent request fails with the same error until the transcript is manually repaired.

## Root Cause

Two layers handle transcript sanitization:

1. **`session-transcript-repair.ts`** (`repairToolUseResultPairing`) - pairs tool_use with tool_result, runs during context build
2. **`pi-ai/transform-messages.ts`** - drops errored/aborted assistant messages entirely

The repair in (1) correctly pairs the errored assistant's tool_use with its tool_result. But then (2) drops the assistant message while keeping the tool_result, creating an orphan that Anthropic rejects.

## Fix

Added defence-in-depth to `repairToolUseResultPairing()`: when an assistant message has `stopReason="error"` or `"aborted"` and contains tool calls, both the assistant and its matching tool_results are dropped from the sanitised output before they reach the provider transform.

Includes two new test cases covering the fix.

## Note

The upstream `pi-ai` `transform-messages.ts` has the same gap - when it skips errored assistants it should also skip their tool_results. That fix should be contributed separately to `@mariozechner/pi-ai`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens transcript repair by removing assistant turns that ended with `stopReason: "error" | "aborted"` when they include tool calls, and also removing any immediately-following matching `toolResult` blocks. This prevents provider-layer message transforms (which already drop errored/aborted assistant messages) from leaving behind orphan `toolResult` entries that cause Anthropic-style APIs to reject the request.

Changes are localized to `repairToolUseResultPairing` in `src/agents/session-transcript-repair.ts` and are covered by two new Vitest cases in `src/agents/session-transcript-repair.test.ts` verifying (1) errored assistants with tool calls are removed alongside their results, and (2) errored assistants without tool calls are preserved.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes a real transcript corruption class, with one edge case to consider around tool_results that appear later than the next assistant turn.
- The change is small, scoped, and backed by focused tests. Main risk is the new drop logic only scans until the next assistant, which may not remove matching tool_results that are displaced further down the transcript; that could reduce the effectiveness of the fix in some malformed histories.
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->