### PR TITLE
feat(signal): add chunkDelay for realistic typing delays between message chunks

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -47,6 +47,14 @@ export type HumanDelayConfig = {
   maxMs?: number;
 };
 
+export type ChunkDelayConfig = {
+  mode?: "off" | "natural" | "custom";
+  perCharMs?: number;
+  baseMs?: number;
+  maxMs?: number;
+  jitter?: number;
+};
+
 export type SessionSendPolicyAction = "allow" | "deny";
 export type SessionSendPolicyMatch = {
   channel?: string;

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,5 +1,6 @@
 import type {
   BlockStreamingCoalesceConfig,
+  ChunkDelayConfig,
   DmPolicy,
   GroupPolicy,
   MarkdownConfig,
@@ -66,6 +67,8 @@ export type SignalAccountConfig = {
   reactionAllowlist?: Array<string | number>;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Chunk delay config for realistic typing delays between message chunks. */
+  chunkDelay?: ChunkDelayConfig;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -221,6 +221,16 @@ export const HumanDelaySchema = z
   })
   .strict();
 
+export const ChunkDelaySchema = z
+  .object({
+    mode: z.union([z.literal("off"), z.literal("natural"), z.literal("custom")]).optional(),
+    perCharMs: z.number().int().nonnegative().optional(),
+    baseMs: z.number().int().nonnegative().optional(),
+    maxMs: z.number().int().nonnegative().optional(),
+    jitter: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
 export const CliBackendSchema = z
   .object({
     command: z.string(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
+  ChunkDelaySchema,
   DmConfigSchema,
   DmPolicySchema,
   ExecutableTokenSchema,
@@ -430,6 +431,7 @@ export const SignalAccountSchemaBase = z
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    chunkDelay: ChunkDelaySchema.optional(),
   })
   .strict();
 

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -207,6 +207,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+          chunkDelay: deps.chunkDelay,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -1,6 +1,7 @@
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ClawdbotConfig } from "../../config/config.js";
+import type { ChunkDelayConfig } from "../../config/types.base.js";
 import type { DmPolicy, GroupPolicy, SignalReactionNotificationMode } from "../../config/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { SignalSender } from "../identity.js";
@@ -78,6 +79,7 @@ export type SignalEventHandlerDeps = {
   ignoreAttachments: boolean;
   sendReadReceipts: boolean;
   readReceiptsViaDaemon: boolean;
+  chunkDelay?: ChunkDelayConfig;
   fetchAttachment: (params: {
     baseUrl: string;
     account?: string;
@@ -95,6 +97,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
+    chunkDelay?: ChunkDelayConfig;
   }) => Promise<void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (


### PR DESCRIPTION
## What

When a long message is split into multiple chunks (via chunkMode or length splitting), all chunks are sent instantly. This feels spammy.

This PR adds a `chunkDelay` config option that introduces realistic delays between chunk sends, with typing indicators during the pause.

## Config

```json5
{
  channels: {
    signal: {
      chunkDelay: { mode: "natural" }
    }
  }
}
```

### Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| mode | off / natural / custom | off | Enable/disable chunk delays |
| perCharMs | number | 30 | Ms per character (~40 WPM) |
| baseMs | number | 500 | Minimum delay between chunks |
| maxMs | number | 5000 | Maximum delay cap |
| jitter | 0-1 | 0.2 | Random variance |

## How it works

1. Agent generates full reply (no change to thinking speed)
2. Reply is chunked as usual
3. First chunk sends immediately
4. Before each subsequent chunk: typing indicator → delay → send
5. Delay: min(baseMs + chunkLength * perCharMs, maxMs) ± jitter

## Files changed (7 files, +81/-3)

- Config types and schemas for ChunkDelayConfig
- Signal monitor delivery loop with delay + typing indicators
- Event handler wire-through

Signal-only for now but ChunkDelayConfig is generic for other providers.