### PR TITLE
fix(providers): remove MiniMax from reasoning tag providers

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -25,10 +25,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
     return true;
   }
 
-  // Handle Minimax (M2.1 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return true;
-  }
+  // NOTE: MiniMax was previously included here but removed because:
+  // 1. MiniMax models don't reliably output <think>/<final> tags
+  // 2. enforceFinalTag=true causes all content to be stripped → "(no output)"
+  // 3. MiniMax's reasoning is handled differently (not via text stream tags)
+  // See: https://github.com/openclaw/openclaw/issues/4499
 
   return false;
 }


### PR DESCRIPTION
## Summary

Fixes #4499

MiniMax was incorrectly included in `isReasoningTagProvider()`, causing `enforceFinalTag=true` for all MiniMax runs. Since MiniMax models don't output `<think>`/`<final>` tags, this caused all streaming content to be discarded, resulting in '(no output)' in the TUI.

## Root Cause

In `src/utils/provider-utils.ts`:
```typescript
if (normalized.includes('minimax')) {
  return true;  // ← This caused the issue
}
```

This led to:
1. `enforceFinalTag=true` for all MiniMax runs
2. Streaming code only extracted content inside `<final>` tags
3. MiniMax doesn't output `<final>` tags → empty result → '(no output)'

## Why Telegram worked

Telegram sends messages through a different code path (channel outbound) that doesn't apply `enforceFinalTag` filtering.

## Why restart fixed it

After TUI restart, historical messages are loaded from the transcript, which doesn't go through the streaming filter path.

## Changes

- Removed MiniMax from `isReasoningTagProvider()`
- Added documentation explaining why MiniMax was removed

## Testing

- Verified lint and format pass
- MiniMax should now stream responses correctly in TUI

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/utils/provider-utils.ts` to stop treating MiniMax as a “reasoning tag provider” (i.e., a provider that wraps output in `<think>/<final>` tags). The intent is to prevent `enforceFinalTag=true` from stripping all streamed MiniMax output in the TUI, aligning provider capability detection with MiniMax’s actual output format.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized adjustment to provider capability detection (removing a single MiniMax branch) plus explanatory comments. It reduces incorrect filtering behavior and does not introduce new logic paths or side effects beyond changing the boolean return for MiniMax providers.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->