### PR TITLE
fix(telegram): react action accepts numeric messageId and chatId

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -85,7 +85,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "react") {
-      const messageId = readStringParam(params, "messageId", {
+      const messageId = readStringOrNumberParam(params, "messageId", {
         required: true,
       });
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
@@ -94,7 +94,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         {
           action: "react",
           chatId:
-            readStringParam(params, "chatId") ?? readStringParam(params, "to", { required: true }),
+            readStringOrNumberParam(params, "chatId") ??
+            readStringOrNumberParam(params, "channelId") ??
+            readStringParam(params, "to", { required: true }),
           messageId,
           emoji,
           remove,


### PR DESCRIPTION
## Summary
- The Telegram `react` action used `readStringParam` for `messageId` and `readStringParam` for `chatId`, which rejected numeric values with a misleading "messageId required" error
- Switched to `readStringOrNumberParam` for both fields, matching the `delete` and `edit` actions in the same file
- Also aligned `chatId` resolution to check `channelId` fallback like `delete`/`edit` do

Closes #1459

## Test plan
- [x] `pnpm build` passes
- [ ] Send a react action via the message tool with a numeric `messageId` and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)