### PR TITLE
fix: packaging and OpenAI vision format conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "./cli-entry": "./moltbot.mjs"
   },
   "bin": {
-    "moltbot": "./moltbot.mjs",
-    "clawdbot": "./moltbot.mjs"
+    "moltbot": "moltbot.mjs",
+    "clawdbot": "moltbot.mjs"
   },
   "files": [
     "dist/acp/**",


### PR DESCRIPTION
This PR addresses two issues:

1. **Fix missing bin field in package.json**: Resolves the Windows installer ENOENT error by correctly specifying the bin path without the leading `./` which can cause issues on some environments/installers.
2. **Add image format conversion in OpenAI-compatible API**: Extracts `media_type` from data URIs in OpenAI vision format and converts them to the format expected by the internal agent command, enabling vision model support via the OpenAI-compatible endpoint.

Fixes #3787 and #3781.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates packaging metadata and the OpenAI-compatible HTTP gateway.

- **Packaging:** fixes the `bin` entries in `package.json` to point at `moltbot.mjs` without a leading `./`, addressing Windows installer `ENOENT` scenarios where the relative prefix is misinterpreted.
- **OpenAI gateway:** extends `src/gateway/openai-http.ts` to recognize OpenAI “vision” message parts (`content` arrays with `type: "image_url"`) by extracting `data:`-URI images (mimeType + base64 payload) and passing them through as `images?: ImageContent[]` into `agentCommand()` for both streaming and non-streaming requests.

Overall, the change fits the codebase’s pattern of translating gateway payloads into the internal `agentCommand` input shape, but the new message filtering/parsing introduces a couple of behavior edge cases that can lead to empty prompts or silently dropped images.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but the OpenAI gateway change likely introduces an input-validation regression that can produce empty prompts or degraded history.
- The packaging change is low risk. The gateway change is small and localized, but the new role/content guard at src/gateway/openai-http.ts:107 appears incorrect versus the prior intent and can allow empty text messages into history / block image-only requests from working as intended. The remaining issues are compatibility/robustness gaps rather than outright crashes.
- src/gateway/openai-http.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->