### PR TITLE
fix: sync google-gemini-cli-auth tokens from external CLI (#3803)

### DIFF
--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -7,6 +7,7 @@ export const LEGACY_AUTH_FILENAME = "auth.json";
 export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
 export const CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli";
 export const QWEN_CLI_PROFILE_ID = "qwen-portal:qwen-cli";
+export const GEMINI_CLI_PROFILE_ID = "google-gemini-cli:google-gemini-cli";
 
 export const AUTH_STORE_LOCK_OPTIONS = {
   retries: {


### PR DESCRIPTION
This PR implements a sync-before-refresh mechanism for the google-gemini-cli-auth plugin. It ensures that if the external Gemini CLI refreshes its tokens, Moltbot will pick them up instead of failing with an invalid single-use refresh token. This follows the same pattern as PR #2123 for Anthropic. Fixes #3803.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for syncing OAuth tokens from the external Gemini CLI before attempting an in-process refresh, to avoid failures on single-use refresh tokens that may have been rotated by the external CLI. Concretely, it introduces a Gemini CLI credentials reader/cache (`src/agents/cli-credentials.ts`), a new Gemini CLI profile ID constant, extends the external CLI sync logic to copy Gemini credentials into the auth profile store, and triggers that sync in the OAuth refresh path for Gemini CLI profiles.

This fits into the existing auth-profiles architecture by reusing the existing “external CLI sync” mechanism already used for Qwen/Claude-style flows, and keeps the canonical persisted state in `auth-profiles.json` while opportunistically importing fresher tokens from external CLIs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should improve Gemini CLI auth reliability, with only minor consistency/documentation nits.
- Changes are localized to credential ingestion/sync and the OAuth refresh path, follow an existing pattern (external CLI sync), and don’t introduce risky I/O beyond reading a JSON credentials file. Main concerns are small maintainability issues (stale comment, inconsistent gating, string-prefix check) rather than correctness regressions.
- src/agents/auth-profiles/external-cli-sync.ts and src/agents/auth-profiles/oauth.ts (sync triggering/conditions)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->