### PR TITLE
feat(signal): add chunkDelay for typing delays between message chunks

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -47,6 +47,13 @@ export type HumanDelayConfig = {
   maxMs?: number;
 };
 
+export type ChunkDelayConfig = {
+  perCharMs?: number;
+  baseMs?: number;
+  maxMs?: number;
+  jitter?: number;
+};
+
 export type SessionSendPolicyAction = "allow" | "deny";
 export type SessionSendPolicyMatch = {
   channel?: string;

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,5 +1,6 @@
 import type {
   BlockStreamingCoalesceConfig,
+  ChunkDelayConfig,
   DmPolicy,
   GroupPolicy,
   MarkdownConfig,
@@ -84,6 +85,8 @@ export type SignalAccountConfig = {
   reactionLevel?: SignalReactionLevel;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Chunk delay config for realistic typing delays between message chunks. */
+  chunkDelay?: ChunkDelayConfig;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -239,6 +239,15 @@ export const HumanDelaySchema = z
   })
   .strict();
 
+export const ChunkDelaySchema = z
+  .object({
+    perCharMs: z.number().min(0).optional(),
+    baseMs: z.number().min(0).optional(),
+    maxMs: z.number().min(0).optional(),
+    jitter: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
 export const CliBackendSchema = z
   .object({
     command: z.string(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
+  ChunkDelaySchema,
   DmConfigSchema,
   DmPolicySchema,
   ExecutableTokenSchema,
@@ -534,6 +535,7 @@ export const SignalAccountSchemaBase = z
       .optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    chunkDelay: ChunkDelaySchema.optional(),
   })
   .strict();
 

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -1,6 +1,7 @@
 import { chunkTextWithMode, resolveChunkMode, resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/reply/history.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import type { ChunkDelayConfig } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
@@ -13,7 +14,7 @@ import { signalCheck, signalRpcRequest } from "./client.js";
 import { spawnSignalDaemon } from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
-import { sendMessageSignal } from "./send.js";
+import { sendMessageSignal, sendTypingSignal } from "./send.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
 
 type SignalReactionMessage = {
@@ -206,6 +207,34 @@ async function fetchAttachment(params: {
   return { path: saved.path, contentType: saved.contentType };
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const CHUNK_DELAY_DEFAULTS = {
+  perCharMs: 50,
+  baseMs: 800,
+  maxMs: 6000,
+  jitter: 0.25,
+};
+
+function computeChunkDelay(config: ChunkDelayConfig, chunkLength: number): number {
+  const perCharMs = config.perCharMs ?? CHUNK_DELAY_DEFAULTS.perCharMs;
+  const baseMs = config.baseMs ?? CHUNK_DELAY_DEFAULTS.baseMs;
+  const maxMs = config.maxMs ?? CHUNK_DELAY_DEFAULTS.maxMs;
+  const jitter = config.jitter ?? CHUNK_DELAY_DEFAULTS.jitter;
+
+  let delayMs = baseMs + chunkLength * perCharMs;
+  delayMs = Math.min(delayMs, maxMs);
+
+  // Apply jitter: random variance within ±jitter range
+  if (jitter > 0) {
+    const variance = delayMs * jitter;
+    delayMs += (Math.random() * 2 - 1) * variance;
+    delayMs = Math.max(0, Math.round(delayMs));
+  }
+
+  return delayMs;
+}
+
 async function deliverReplies(params: {
   replies: ReplyPayload[];
   target: string;
@@ -216,15 +245,40 @@ async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   chunkMode: "length" | "newline";
+  chunkDelay?: ChunkDelayConfig;
 }) {
-  const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
-    params;
+  const {
+    replies,
+    target,
+    baseUrl,
+    account,
+    accountId,
+    runtime,
+    maxBytes,
+    textLimit,
+    chunkMode,
+    chunkDelay,
+  } = params;
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
     if (!text && mediaList.length === 0) continue;
     if (mediaList.length === 0) {
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+      const chunks = chunkTextWithMode(text, textLimit, chunkMode);
+      let isFirst = true;
+      for (const chunk of chunks) {
+        if (!isFirst && chunkDelay) {
+          const delayMs = computeChunkDelay(chunkDelay, chunk.length);
+          if (delayMs > 0) {
+            try {
+              await sendTypingSignal(target, { baseUrl, account, accountId });
+            } catch {
+              /* typing failure is non-fatal */
+            }
+            await sleep(delayMs);
+          }
+        }
+        isFirst = false;
         await sendMessageSignal(target, chunk, {
           baseUrl,
           account,
@@ -284,6 +338,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const mediaMaxBytes = (opts.mediaMaxMb ?? accountInfo.config.mediaMaxMb ?? 8) * 1024 * 1024;
   const ignoreAttachments = opts.ignoreAttachments ?? accountInfo.config.ignoreAttachments ?? false;
   const sendReadReceipts = Boolean(opts.sendReadReceipts ?? accountInfo.config.sendReadReceipts);
+  const chunkDelay = accountInfo.config.chunkDelay;
 
   const autoStart = opts.autoStart ?? accountInfo.config.autoStart ?? !accountInfo.config.httpUrl;
   const startupTimeoutMs = Math.min(
@@ -347,6 +402,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       ignoreAttachments,
       sendReadReceipts,
       readReceiptsViaDaemon,
+      chunkDelay,
       fetchAttachment,
       deliverReplies: (params) => deliverReplies({ ...params, chunkMode }),
       resolveSignalReactionTargets,

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -207,6 +207,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+          chunkDelay: deps.chunkDelay,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -1,6 +1,7 @@
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ChunkDelayConfig } from "../../config/types.base.js";
 import type { DmPolicy, GroupPolicy, SignalReactionNotificationMode } from "../../config/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { SignalSender } from "../identity.js";
@@ -78,6 +79,7 @@ export type SignalEventHandlerDeps = {
   ignoreAttachments: boolean;
   sendReadReceipts: boolean;
   readReceiptsViaDaemon: boolean;
+  chunkDelay?: ChunkDelayConfig;
   fetchAttachment: (params: {
     baseUrl: string;
     account?: string;
@@ -95,6 +97,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
+    chunkDelay?: ChunkDelayConfig;
   }) => Promise<void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (


### PR DESCRIPTION
## what

when a long message gets split into chunks (via `chunkMode` or length splitting), they all fire at once. instant. robotic. nobody texts like that.

this adds `chunkDelay`. a config option that introduces typing delays between chunk sends. typing indicators show during the pause so the recipient sees "typing..." between messages.

## config

```json5
// enable with defaults (50ms/char, 800ms base, 6s cap, 25% jitter)
channels: { signal: { chunkDelay: {} } }

// custom tuning
channels: { signal: { chunkDelay: { perCharMs: 40, baseMs: 600 } } }

// disabled (default. just omit the key)
channels: { signal: {} }
```

presence of `chunkDelay` enables it. omit the key to disable. all fields optional with sensible defaults.

### options

| option | type | default | description |
|--------|------|---------|-------------|
| `perCharMs` | `number` | `50` | ms per character (~30 WPM) |
| `baseMs` | `number` | `800` | minimum delay between chunks |
| `maxMs` | `number` | `6000` | maximum delay cap |
| `jitter` | `0-1` | `0.25` | random variance (±25%) |

## how it works

1. agent generates full reply as usual. no change to thinking speed
2. reply gets chunked as normal (length or newline mode)
3. first chunk sends immediately
4. before each subsequent chunk: typing indicator, sleep, send
5. delay formula: `min(baseMs + chunkLength * perCharMs, maxMs) +/- jitter`

a short "yeah" gets ~800ms. a full sentence gets a few seconds. long messages cap at 6s. jitter keeps it from feeling mechanical.

## files changed (7 files, +76/-3)

- `src/config/types.base.ts`. ChunkDelayConfig type
- `src/config/zod-schema.core.ts`. ChunkDelaySchema validation
- `src/config/types.signal.ts`. added to SignalAccountConfig
- `src/config/zod-schema.providers-core.ts`. added to signal schema
- `src/signal/monitor.ts`. core delay logic + delivery changes
- `src/signal/monitor/event-handler.ts`. wire-through
- `src/signal/monitor/event-handler.types.ts`. type updates

signal-only for now. ChunkDelayConfig is generic though. easy to extend to other providers later.