### PR TITLE
Webchat: canonicalize main session key for /new (fix #4446)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -108,6 +108,27 @@ describe("initSessionState thread forking", () => {
 });
 
 describe("initSessionState RawBody", () => {
+  it("canonicalizes main session aliases for explicit SessionKey", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-alias-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = {
+      session: { store: storePath, mainKey: "work" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "Hello",
+        SessionKey: "main",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:work");
+    expect(result.sessionCtx.SessionKey).toBe("agent:ops:work");
+  });
+
   it("triggerBodyNormalized correctly extracts commands when Body contains context but RawBody is clean", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rawbody-"));
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import {
   DEFAULT_RESET_TRIGGERS,
+  canonicalizeMainSessionAlias,
   deriveSessionMetaPatch,
   evaluateSessionFreshness,
   type GroupKeyResolution,
@@ -187,6 +188,7 @@ export async function initSessionState(params: {
   }
 
   sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
+  sessionKey = canonicalizeMainSessionAlias({ cfg, agentId, sessionKey });
   const entry = sessionStore[sessionKey];
   const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
@@ -337,6 +339,7 @@ export async function initSessionState(params: {
 
   const sessionCtx: TemplateContext = {
     ...ctx,
+    SessionKey: sessionKey,
     // Keep BodyStripped aligned with Body (best default for agent prompts).
     // RawBody is reserved for command/directive parsing and may omit context.
     BodyStripped: formatInboundBodyWithSenderMeta({


### PR DESCRIPTION
Fixes Web UI `/new` not starting a fresh session (#4446).

Root cause: webchat often sends `SessionKey` as the `main` alias, but server-side session init didn’t canonicalize it to the real main session key. This caused resets to write to the alias while history reads from the canonical key, so the UI appeared unchanged.

## Changes 
- Canonicalize explicit `SessionKey` to the real main session key during session init
- Propagate the canonical key into the template context to keep all paths consistent
- Add a test to cover explicit `main` alias canonicalization

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Web UI `/new` not starting a fresh session by canonicalizing the “main” session alias during session initialization. In `src/auto-reply/reply/session.ts`, the resolved session key is passed through `canonicalizeMainSessionAlias(...)`, and the canonical `SessionKey` is also propagated into the template context so subsequent code paths consistently read/write the same store key. A Vitest regression test was added in `src/auto-reply/reply/session.test.ts` to assert that an explicit `SessionKey: "main"` is canonicalized to the configured main session key (including agent scoping).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; changes are narrowly scoped to session-key normalization and are covered by a regression test.
- The core change (canonicalizing the main session alias) follows an existing utility used elsewhere in the codebase and is applied immediately after `resolveSessionKey`, minimizing behavioral surface area. The additional `SessionKey` propagation into the template context aligns the in-memory/session-store key with what templates/commands see. Only minor test-harness concerns remain (environment assumptions around pnpm in CI/local), but no clear functional regression is apparent from the code changes.
- src/auto-reply/reply/session.test.ts (test environment assumptions)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->