### PR TITLE
fix(agents): provide model fallback for compaction safeguard extension

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -91,6 +91,9 @@ export function buildEmbeddedExtensionPaths(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      // Provide model as fallback for when ctx.model is undefined
+      // (ExtensionRunner not initialized during direct compaction calls)
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -7,7 +7,7 @@ export type CompactionSafeguardRuntimeValue = {
    * Fallback model for compaction summarization.
    * Used when ctx.model is undefined (ExtensionRunner not initialized).
    */
-  // biome-ignore lint/suspicious/noExplicitAny: Model API type varies by provider
+  // oxlint-disable-next-line typescript/no-explicit-any -- Model API type varies by provider
   model?: Model<any>;
 };
 

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,6 +1,14 @@
+import type { Model } from "@mariozechner/pi-ai";
+
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  /**
+   * Fallback model for compaction summarization.
+   * Used when ctx.model is undefined (ExtensionRunner not initialized).
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Model API type varies by provider
+  model?: Model<any>;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,8 +170,15 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    // Use ctx.model if available, otherwise fall back to runtime.model
+    // (needed when ExtensionRunner is not initialized during direct compaction)
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
+      console.warn(
+        "Compaction safeguard: no model available (ctx.model and runtime.model both undefined). " +
+          "Returning fallback summary.",
+      );
       return {
         compaction: {
           summary: fallbackSummary,


### PR DESCRIPTION
## Summary
- Fixes compaction safeguard extension failing when `ctx.model` is undefined
- Stores model in session-scoped runtime registry during extension setup
- Uses runtime model as fallback when ExtensionRunner is not initialized

## Problem
When `compactEmbeddedPiSessionDirect()` is called directly (not through the normal agent flow), the `ExtensionRunner` is never initialized, so `ctx.model` returns undefined. This causes the compaction safeguard extension to skip summarization entirely.

## Solution
Leverages the existing `CompactionSafeguardRuntimeValue` registry pattern:
1. Store the model alongside `maxHistoryShare` when building extension paths
2. In the extension, check `ctx.model ?? runtime?.model` to use the fallback
3. Add warning log when both sources are unavailable

## Test plan
- [x] Type check: `npx tsc -p tsconfig.json --noEmit` (no errors)
- [x] Lint: `npx oxlint --type-aware` (0 errors)
- [x] Tests: `npx vitest run src/agents/` (1062 tests passed)

Fixes #4121

---
Supersedes #4161 (rebased cleanly from main with single commit)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a compaction safeguard edge case where `compactEmbeddedPiSessionDirect()` can run without an initialized `ExtensionRunner`, leaving `ctx.model` undefined and causing summarization to be skipped.

Changes include:
- Persisting the selected model into the existing session-scoped `CompactionSafeguardRuntimeValue` registry during embedded extension setup (`src/agents/pi-embedded-runner/extensions.ts`).
- Extending the runtime value type to include an optional `model` reference (`src/agents/pi-extensions/compaction-safeguard-runtime.ts`).
- Updating the compaction safeguard extension to prefer `ctx.model` but fall back to `runtime.model`, and emitting a warning when neither source is available (`src/agents/pi-extensions/compaction-safeguard.ts`).

Overall this fits the established “runtime registry keyed by sessionManager” pattern already used for other PI extensions (e.g., context-pruning).

<h3>Confidence Score: 4/5</h3>

- This PR appears safe to merge and addresses the reported edge case without changing the main compaction flow.
- Changes are small, localized, and use an existing session-scoped runtime registry pattern. The fallback is only used when `ctx.model` is missing, and existing behavior (returning a fallback summary) remains in place when no model/api key is available. Main risk is around logging/observability and holding a model reference in session runtime, but functional impact looks low.
- src/agents/pi-extensions/compaction-safeguard.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->