### PR TITLE
fixed the bug: signal group base64 forced to lowercase 

### DIFF
--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -9,7 +9,7 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
Bug Description

When sending to a Signal group via the message tool, the base64-encoded group ID is lowercased before being passed to signal-cli. This breaks the ID since base64 is case-sensitive.

removed the toLowerCase methode from the whole id and kept it for the prefix only

closes #4537

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal target normalization so `group:<base64>` IDs are no longer forced to lowercase before being passed to `signal-cli`, preserving case sensitivity for base64 group IDs.

Change is localized to `normalizeSignalMessagingTarget` in `src/channels/plugins/normalize/signal.ts`, altering only the `group:` branch output; other target forms (`username:`, `uuid:`, bare phone numbers) remain lowercased as before.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real case-sensitivity bug, with a small chance of prefix-format regressions.
- The change is minimal and scoped to the `group:` normalization path, which correctly avoids lowercasing a base64 payload. Main remaining concern is whether callers rely on the normalized output always having a canonical lowercase `group:` prefix even when the input prefix is mixed-case.
- src/channels/plugins/normalize/signal.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->