### PR TITLE
- Fix Docker arm64 image crash (`exec format error`) caused by tag race condition

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -41,12 +41,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
             type=semver,pattern={{version}},suffix=-amd64
-            type=semver,pattern={{version}},suffix=-arm64
             type=ref,event=branch,suffix=-amd64
-            type=ref,event=branch,suffix=-arm64
 
       - name: Build and push amd64 image
         id: build
@@ -90,11 +86,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{version}},suffix=-amd64
             type=semver,pattern={{version}},suffix=-arm64
-            type=ref,event=branch,suffix=-amd64
             type=ref,event=branch,suffix=-arm64
 
       - name: Build and push arm64 image


### PR DESCRIPTION
Fixes #4566

## Problem

Both `build-amd64` and `build-arm64` jobs were tagging their images with *all* architecture suffixes. This caused a race condition where whichever job finished last would overwrite the other's tags—so `main-arm64` ended up pointing to an amd64 image.

## Solution

Each architecture build job now only tags with its own suffix:
- `build-amd64` → `main-amd64`, `v*-amd64`
- `build-arm64` → `main-arm64`, `v*-arm64`

The `create-manifest` job continues to create the multi-arch manifest (`main`, `v*`) by combining both digests.

## Test plan

- [ ] Verify workflow runs successfully on push to main
- [ ] Confirm `main-arm64` image runs on arm64 host without exec format error
- [ ] Confirm `main-amd64` image runs on amd64 host
- [ ] Confirm `main` manifest auto-selects correct architecture

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.github/workflows/docker-release.yml` to prevent cross-architecture tag overwrites when building/pushing Docker images to GHCR. The amd64 and arm64 build jobs now only publish architecture-suffixed tags (e.g., `main-amd64`, `vX.Y.Z-amd64` and `main-arm64`, `vX.Y.Z-arm64`), while the `create-manifest` job continues to publish the unsuffixed tags (`main`, `vX.Y.Z`) as a multi-arch manifest composed from the two build digests.

This fits the existing release workflow by keeping per-arch images available under explicit tags, and reserving the generic tags for the final manifest list so consumers pulling `:main` or `:v*` get the correct architecture automatically.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and directly addresses the cross-arch tag overwrite issue with minimal workflow changes.
- Changes are narrowly scoped to tag generation in the release workflow and align with the intended model: arch-specific tags per build, generic tags only on the manifest list. The main residual risk is operational (manifest job failure would leave only suffixed tags), not a functional regression in the workflow itself.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->