### PR TITLE
Gateway warn on public IP binding to prevent accidental exposure

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -48,7 +48,8 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
     const publicIPs = getPublicIPs();
     const hasPublicIP = publicIPs.length > 0;
     const isBindingToPublicIP =
-      resolvedBindHost === "0.0.0.0" || !isPrivateIP(resolvedBindHost);
+      resolvedBindHost === "0.0.0.0" ||
+      (resolvedBindHost !== "::" && !isPrivateIP(resolvedBindHost));
 
     if (!hasSharedSecret) {
       const authFixLines =

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -45,8 +45,15 @@ export function isPrivateIPv6(ip: string): boolean {
   const lower = ip.toLowerCase();
   // fc00::/7 (unique local) - starts with fc or fd
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
-  // fe80::/10 (link-local)
-  if (lower.startsWith("fe80")) return true;
+  // fe80::/10 (link-local) - first hextet in [0xfe80, 0xfebf]
+  {
+    const colonIndex = lower.indexOf(":");
+    const firstHextetStr = colonIndex === -1 ? lower : lower.slice(0, colonIndex);
+    const firstHextet = parseInt(firstHextetStr, 16);
+    if (!Number.isNaN(firstHextet) && firstHextet >= 0xfe80 && firstHextet <= 0xfebf) {
+      return true;
+    }
+  }
   // ::1 (loopback)
   if (lower === "::1") return true;
   // ::ffff: mapped IPv4 - check the IPv4 portion

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -70,8 +70,11 @@ export function isPrivateIPv6(ip: string): boolean {
 export function isPrivateIP(ip: string): boolean {
   if (!ip) return false;
   const trimmed = ip.trim();
-  if (trimmed.includes(":")) return isPrivateIPv6(trimmed);
-  return isPrivateIPv4(trimmed);
+  const version = net.isIP(trimmed);
+  if (version === 6) return isPrivateIPv6(trimmed);
+  if (version === 4) return isPrivateIPv4(trimmed);
+  // Not a valid IP address string; treat as not private.
+  return false;
 }
 
 /**

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -1,6 +1,91 @@
 import net from "node:net";
+import os from "node:os";
 
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
+
+/**
+ * Check if an IPv4 address is in a private range (RFC 1918 + loopback + link-local).
+ *
+ * Private ranges:
+ * - 10.0.0.0/8
+ * - 172.16.0.0/12
+ * - 192.168.0.0/16
+ * - 127.0.0.0/8 (loopback)
+ * - 169.254.0.0/16 (link-local)
+ */
+export function isPrivateIPv4(ip: string): boolean {
+  // 10.0.0.0/8
+  if (ip.startsWith("10.")) return true;
+  // 172.16.0.0/12 (172.16.x.x - 172.31.x.x)
+  if (ip.startsWith("172.")) {
+    const parts = ip.split(".");
+    if (parts.length >= 2) {
+      const second = parseInt(parts[1], 10);
+      if (!Number.isNaN(second) && second >= 16 && second <= 31) return true;
+    }
+  }
+  // 192.168.0.0/16
+  if (ip.startsWith("192.168.")) return true;
+  // 127.0.0.0/8 (loopback)
+  if (ip.startsWith("127.")) return true;
+  // 169.254.0.0/16 (link-local)
+  if (ip.startsWith("169.254.")) return true;
+  return false;
+}
+
+/**
+ * Check if an IPv6 address is in a private/local range.
+ *
+ * Private ranges:
+ * - fc00::/7 (unique local addresses - fc00:: and fd00::)
+ * - fe80::/10 (link-local)
+ * - ::1 (loopback)
+ */
+export function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  // fc00::/7 (unique local) - starts with fc or fd
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // fe80::/10 (link-local)
+  if (lower.startsWith("fe80")) return true;
+  // ::1 (loopback)
+  if (lower === "::1") return true;
+  // ::ffff: mapped IPv4 - check the IPv4 portion
+  if (lower.startsWith("::ffff:")) {
+    const ipv4Part = ip.slice("::ffff:".length);
+    return isPrivateIPv4(ipv4Part);
+  }
+  return false;
+}
+
+/**
+ * Check if an IP address (v4 or v6) is private/local.
+ */
+export function isPrivateIP(ip: string): boolean {
+  if (!ip) return false;
+  const trimmed = ip.trim();
+  if (trimmed.includes(":")) return isPrivateIPv6(trimmed);
+  return isPrivateIPv4(trimmed);
+}
+
+/**
+ * Get all public (non-private) IP addresses from network interfaces.
+ * Useful for warning users when they bind to 0.0.0.0 on a machine with public IPs.
+ */
+export function getPublicIPs(): string[] {
+  const interfaces = os.networkInterfaces();
+  const publicIPs: string[] = [];
+
+  for (const name of Object.keys(interfaces)) {
+    for (const iface of interfaces[name] ?? []) {
+      if (iface.internal) continue;
+      if (!isPrivateIP(iface.address)) {
+        publicIPs.push(iface.address);
+      }
+    }
+  }
+
+  return publicIPs;
+}
 
 export function isLoopbackAddress(ip: string | undefined): boolean {
   if (!ip) return false;

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -51,7 +51,7 @@ export function isPrivateIPv6(ip: string): boolean {
   if (lower === "::1") return true;
   // ::ffff: mapped IPv4 - check the IPv4 portion
   if (lower.startsWith("::ffff:")) {
-    const ipv4Part = ip.slice("::ffff:".length);
+    const ipv4Part = lower.slice("::ffff:".length);
     return isPrivateIPv4(ipv4Part);
   }
   return false;

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -3,6 +3,7 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import type { loadConfig } from "../config/config.js";
 import { getResolvedLoggerSettings } from "../logging.js";
+import { getPublicIPs, isPrivateIP } from "./net.js";
 
 export function logGatewayStartup(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -36,5 +37,61 @@ export function logGatewayStartup(params: {
   params.log.info(`log file: ${getResolvedLoggerSettings().file}`);
   if (params.isNixMode) {
     params.log.info("gateway: running in Nix mode (config managed externally)");
+  }
+
+  // Warn if binding to 0.0.0.0 or a public IP
+  warnIfPublicBind(params.bindHost, params.port, params.log);
+}
+
+/**
+ * Warn if the gateway is binding to an address that exposes it to the public internet.
+ * This is how installations end up on Shodan - users deploy on a VPS, bind to 0.0.0.0
+ * or a public interface, and expose their gateway to the internet.
+ */
+function warnIfPublicBind(
+  bindAddress: string,
+  port: number,
+  log: { info: (msg: string, meta?: Record<string, unknown>) => void },
+): void {
+  // 0.0.0.0 or :: binds to all interfaces
+  if (bindAddress === "0.0.0.0" || bindAddress === "::" || bindAddress === "") {
+    const publicIPs = getPublicIPs();
+    if (publicIPs.length > 0) {
+      const warning = [
+        "",
+        chalk.bgYellow.black(" WARNING ") + chalk.yellow(" Gateway exposed on public interface(s)"),
+        chalk.dim("─".repeat(60)),
+        `  Bind: ${chalk.cyan(`${bindAddress}:${port}`)}`,
+        `  Public IPs: ${chalk.red(publicIPs.join(", "))}`,
+        "",
+        chalk.dim("  This is how installations end up on Shodan."),
+        "",
+        chalk.dim("  If intentional: ensure HTTPS + strong auth"),
+        chalk.dim("  Recommended: use VPN/Tailscale or loopback + reverse proxy"),
+        chalk.dim("─".repeat(60)),
+        "",
+      ].join("\n");
+      log.info(warning, { consoleMessage: warning });
+    }
+    return;
+  }
+
+  // Specific IP bind - check if it's a public IP
+  if (!isPrivateIP(bindAddress)) {
+    const warning = [
+      "",
+      chalk.bgYellow.black(" WARNING ") + chalk.yellow(" Gateway binding to public IP"),
+      chalk.dim("─".repeat(60)),
+      `  Bind: ${chalk.red(`${bindAddress}:${port}`)}`,
+      "",
+      chalk.dim("  Binding to a public IP exposes your gateway to anyone"),
+      chalk.dim("  on the internet who scans your IP."),
+      "",
+      chalk.dim("  Recommended: bind to 127.0.0.1 and use a reverse proxy,"),
+      chalk.dim("  or use VPN/Tailscale for remote access."),
+      chalk.dim("─".repeat(60)),
+      "",
+    ].join("\n");
+    log.info(warning, { consoleMessage: warning });
   }
 }

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -53,8 +53,28 @@ function warnIfPublicBind(
   port: number,
   log: { info: (msg: string, meta?: Record<string, unknown>) => void },
 ): void {
+  // Empty bind address likely indicates a configuration error, not an intentional all-interfaces bind.
+  if (bindAddress === "") {
+    const warning = [
+      "",
+      chalk.bgYellow.black(" WARNING ") + chalk.yellow(" Empty bind address"),
+      chalk.dim("─".repeat(60)),
+      `  Bind: ${chalk.cyan(`(empty):${port}`)}`,
+      "",
+      chalk.dim("  The gateway was started without an explicit bind address."),
+      chalk.dim("  This may indicate a configuration error or missing setting."),
+      "",
+      chalk.dim("  Recommended: set an explicit bind address such as 127.0.0.1,"),
+      chalk.dim("  or 0.0.0.0/:: if you intend to bind on all interfaces."),
+      chalk.dim("─".repeat(60)),
+      "",
+    ].join("\n");
+    log.info(warning, { consoleMessage: warning });
+    return;
+  }
+
   // 0.0.0.0 or :: binds to all interfaces
-  if (bindAddress === "0.0.0.0" || bindAddress === "::" || bindAddress === "") {
+  if (bindAddress === "0.0.0.0" || bindAddress === "::") {
     const publicIPs = getPublicIPs();
     if (publicIPs.length > 0) {
       const warning = [


### PR DESCRIPTION
  ## Summary
  - Add warning when gateway binds to public IP addresses
  - Add doctor check for public IP exposure
  - Add `isPrivateIP()` / `getPublicIPs()` utilities to `src/gateway/net.ts`

  ## Motivation
  Users deploying on VPS/cloud instances sometimes bind to `0.0.0.0` or a public interface without realizing      
  they're exposing their gateway to the internet. This is how installations end up on Shodan.

  The recent security release added auth hardening (great!), but a user with weak/default auth + public binding is
   still at risk. This adds a prominent warning at startup and enhances the doctor check to catch this
  misconfiguration.

  ## Changes
  - `src/gateway/net.ts`: Add `isPrivateIPv4()`, `isPrivateIPv6()`, `isPrivateIP()`, `getPublicIPs()`
  - `src/gateway/server-startup-log.ts`: Add `warnIfPublicBind()` check at startup
  - `src/commands/doctor-security.ts`: Enhance network exposure diagnostic with public IP detection

  ## Testing
  - [x] Tested locally with `--bind lan` on a machine with public IP
  - [x] Verified warning appears in logs
  - [x] Verified doctor reports the issue

  ## AI-Assisted
  This PR was developed with Claude assistance.