### PR TITLE
perf: skip redundant ui install in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Status: stable.
 - Docs: credit both contributors for Control UI refresh. (#1852) Thanks @EnzeD.
 - Docs: keep docs header sticky so navbar stays visible while scrolling. (#2445) Thanks @chenyuan99.
 - Docs: update exe.dev install instructions. (#https://github.com/openclaw/openclaw/pull/3047) Thanks @zackerthescar.
+- Build: skip redundant UI install step in the Dockerfile. (#4584) Thanks @obviyus.
 ### Breaking
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY . .
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:install
 RUN pnpm ui:build
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- remove redundant `pnpm ui:install` in Dockerfile; `ui:build` auto-installs UI deps

## Size impact
- before: 804MB
- after: 685MB
- delta: -119MB

## Testing
- docker build -t clawdbot-size:ui-skip .
