### PR TITLE
fix(infra): remove dead restore step for gitignored dist/control-ui/

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -112,7 +112,6 @@ describe("runGatewayUpdate", () => {
       "pnpm install": { stdout: "" },
       "pnpm build": { stdout: "" },
       "pnpm ui:build": { stdout: "" },
-      [`git -C ${tempDir} checkout -- dist/control-ui/`]: { stdout: "" },
       "pnpm openclaw doctor --non-interactive": { stdout: "" },
     });
 
@@ -126,6 +125,38 @@ describe("runGatewayUpdate", () => {
     expect(result.status).toBe("ok");
     expect(calls).toContain(`git -C ${tempDir} checkout --detach ${stableTag}`);
     expect(calls).not.toContain(`git -C ${tempDir} checkout --detach ${betaTag}`);
+  });
+
+  it("does not attempt to restore gitignored dist/control-ui/ (#4546)", async () => {
+    await fs.mkdir(path.join(tempDir, ".git"));
+    await fs.writeFile(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0", packageManager: "pnpm@8.0.0" }),
+      "utf-8",
+    );
+    const tag = "v2.0.0-1";
+    const { runner, calls } = createRunner({
+      [`git -C ${tempDir} rev-parse --show-toplevel`]: { stdout: tempDir },
+      [`git -C ${tempDir} rev-parse HEAD`]: { stdout: "abc123" },
+      [`git -C ${tempDir} status --porcelain -- :!dist/control-ui/`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --tags`]: { stdout: "" },
+      [`git -C ${tempDir} tag --list v* --sort=-v:refname`]: { stdout: `${tag}\n` },
+      [`git -C ${tempDir} checkout --detach ${tag}`]: { stdout: "" },
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      "pnpm openclaw doctor --non-interactive": { stdout: "" },
+    });
+
+    const result = await runGatewayUpdate({
+      cwd: tempDir,
+      runCommand: async (argv, _options) => runner(argv),
+      timeoutMs: 5000,
+      channel: "stable",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(calls.some((c) => c.includes("checkout -- dist/control-ui/"))).toBe(false);
   });
 
   it("skips update when no git root", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -364,7 +364,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const channel: UpdateChannel = opts.channel ?? "dev";
     const branch = channel === "dev" ? await readBranchName(runCommand, gitRoot, timeoutMs) : null;
     const needsCheckoutMain = channel === "dev" && branch !== DEV_BRANCH;
-    gitTotalSteps = channel === "dev" ? (needsCheckoutMain ? 11 : 10) : 9;
+    gitTotalSteps = channel === "dev" ? (needsCheckoutMain ? 10 : 9) : 8;
 
     const statusCheck = await runStep(
       step(
@@ -675,17 +675,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       step("ui:build", managerScriptArgs(manager, "ui:build"), gitRoot),
     );
     steps.push(uiBuildStep);
-
-    // Restore dist/control-ui/ to committed state to prevent dirty repo after update
-    // (ui:build regenerates assets with new hashes, which would block future updates)
-    const restoreUiStep = await runStep(
-      step(
-        "restore control-ui",
-        ["git", "-C", gitRoot, "checkout", "--", "dist/control-ui/"],
-        gitRoot,
-      ),
-    );
-    steps.push(restoreUiStep);
 
     const doctorStep = await runStep(
       step(


### PR DESCRIPTION
Remove the `git checkout -- dist/control-ui/` restore step from the update runner — `dist/` is gitignored so the path is never tracked, causing the step to fail and the entire update to report an error. Adds regression test.

Closes #4546

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `git checkout -- dist/control-ui/` step from the git-based update runner flow. Since `dist/` is gitignored, that restore command could fail and cause the whole update to report an error even when the actual update succeeded.

In `src/infra/update-runner.ts`, the change also updates the expected total step count used for progress reporting to reflect the removed step. In `src/infra/update-runner.test.ts`, it adjusts the existing beta-tag test expectations and adds a regression test asserting the runner no longer attempts to restore `dist/control-ui/` (issue #4546).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped: it removes a restore command that is guaranteed to fail for a gitignored path and updates the progress step count accordingly. The accompanying regression test covers the intended behavior change, and no other update logic is altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->