### PR TITLE
fix: don't warn about expired OAuth tokens with valid refresh tokens

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -52,11 +52,39 @@ describe("buildAuthHealthSummary", () => {
     );
 
     expect(statuses["anthropic:ok"]).toBe("ok");
-    expect(statuses["anthropic:expiring"]).toBe("expiring");
-    expect(statuses["anthropic:expired"]).toBe("expired");
+    // OAuth credentials with refresh tokens are auto-renewable, so they report "ok"
+    expect(statuses["anthropic:expiring"]).toBe("ok");
+    expect(statuses["anthropic:expired"]).toBe("ok");
     expect(statuses["anthropic:api"]).toBe("static");
 
     const provider = summary.providers.find((entry) => entry.provider === "anthropic");
-    expect(provider?.status).toBe("expired");
+    expect(provider?.status).toBe("ok");
+  });
+
+  it("reports expired for OAuth without a refresh token", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "google:no-refresh": {
+          type: "oauth" as const,
+          provider: "google-antigravity",
+          access: "access",
+          refresh: "",
+          expires: now - 10_000,
+        },
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    const statuses = Object.fromEntries(
+      summary.profiles.map((profile) => [profile.profileId, profile.status]),
+    );
+
+    expect(statuses["google:no-refresh"]).toBe("expired");
   });
 });

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -123,7 +123,16 @@ function buildProfileHealth(params: {
     };
   }
 
-  const { status, remainingMs } = resolveOAuthStatus(credential.expires, now, warnAfterMs);
+  const hasRefreshToken = typeof credential.refresh === "string" && credential.refresh.length > 0;
+  const { status: rawStatus, remainingMs } = resolveOAuthStatus(
+    credential.expires,
+    now,
+    warnAfterMs,
+  );
+  // OAuth credentials with a valid refresh token auto-renew on first API call,
+  // so don't warn about access token expiration.
+  const status =
+    hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring") ? "ok" : rawStatus;
   return {
     profileId,
     provider: credential.provider,


### PR DESCRIPTION
## Summary

- OAuth credentials with a valid refresh token auto-renew on first API call
- `buildProfileHealth()` in `auth-health.ts` now checks for a refresh token before marking status as "expired" or "expiring"
- When a refresh token is present, the status is reported as "ok" instead, suppressing the unnecessary doctor warning
- Added test coverage for OAuth credentials without a refresh token (empty string)

## Test plan

- [x] Existing auth-health tests updated and passing
- [x] New test for OAuth without refresh token verifies it still reports "expired"
- [x] Build passes

Fixes #3032