### PR TITLE
security(web): sanitize WhatsApp accountId to prevent path traversal

### DIFF
--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveWhatsAppAuthDir } from "./accounts.js";
+
+describe("resolveWhatsAppAuthDir", () => {
+  const stubCfg = { channels: { whatsapp: { accounts: {} } } } as Parameters<
+    typeof resolveWhatsAppAuthDir
+  >[0]["cfg"];
+
+  it("sanitizes path traversal sequences in accountId", () => {
+    const { authDir } = resolveWhatsAppAuthDir({
+      cfg: stubCfg,
+      accountId: "../../../etc/passwd",
+    });
+    // Sanitized accountId must not escape the whatsapp auth directory.
+    expect(authDir).not.toContain("..");
+    expect(path.basename(authDir)).not.toContain("/");
+  });
+
+  it("sanitizes special characters in accountId", () => {
+    const { authDir } = resolveWhatsAppAuthDir({
+      cfg: stubCfg,
+      accountId: "foo/bar\\baz",
+    });
+    expect(authDir).not.toContain("foo/bar");
+    expect(authDir).not.toContain("\\");
+  });
+
+  it("returns default directory for empty accountId", () => {
+    const { authDir } = resolveWhatsAppAuthDir({
+      cfg: stubCfg,
+      accountId: "",
+    });
+    expect(authDir).toMatch(/whatsapp[/\\]default$/);
+  });
+
+  it("preserves valid accountId unchanged", () => {
+    const { authDir } = resolveWhatsAppAuthDir({
+      cfg: stubCfg,
+      accountId: "my-account-1",
+    });
+    expect(authDir).toMatch(/whatsapp[/\\]my-account-1$/);
+  });
+});

--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -1,7 +1,5 @@
 import path from "node:path";
-
 import { describe, expect, it } from "vitest";
-
 import { resolveWhatsAppAuthDir } from "./accounts.js";
 
 describe("resolveWhatsAppAuthDir", () => {

--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -24,8 +24,11 @@ describe("resolveWhatsAppAuthDir", () => {
       cfg: stubCfg,
       accountId: "foo/bar\\baz",
     });
-    expect(authDir).not.toContain("foo/bar");
-    expect(authDir).not.toContain("\\");
+    // Sprawdzaj sanityzacje na segmencie accountId, nie na calej sciezce
+    // (Windows uzywa backslash jako separator katalogow).
+    const segment = path.basename(authDir);
+    expect(segment).not.toContain("/");
+    expect(segment).not.toContain("\\");
   });
 
   it("returns default directory for empty accountId", () => {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
 import { resolveOAuthDir } from "../config/paths.js";
-import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { hasWebCredsSync } from "./auth-store.js";
 
@@ -95,7 +95,7 @@ function resolveAccountConfig(
 }
 
 function resolveDefaultAuthDir(accountId: string): string {
-  return path.join(resolveOAuthDir(), "whatsapp", accountId);
+  return path.join(resolveOAuthDir(), "whatsapp", normalizeAccountId(accountId));
 }
 
 function resolveLegacyAuthDir(): string {


### PR DESCRIPTION
## Summary

- Sanitize WhatsApp `accountId` in `resolveDefaultAuthDir()` to prevent path traversal via malicious config values (e.g. `../../../etc`)
- Reuse existing `normalizeAccountId()` from `src/routing/session-key.ts` which strips all characters except `[a-z0-9_-]`
- Add unit tests covering traversal, special characters, empty and valid inputs

## Problem

`resolveDefaultAuthDir()` in `src/web/accounts.ts` passes the `accountId` parameter directly to `path.join()` without sanitization. A malicious config with `accountId: "../../../etc"` escapes the intended directory structure. Risk increases in multi-user deployments, shared configs, and plugin systems.

## Solution

Import and apply `normalizeAccountId()` (already exported from `routing/session-key.ts`) which:
- Strips all non-alphanumeric characters except `_` and `-`
- Falls back to `"default"` for empty values
- Caps length at 64 characters

This follows the same defense-in-depth pattern already used by Telegram (`src/telegram/update-offset-store.ts`).

## Test plan

- [x] `pnpm lint` -- 0 warnings, 0 errors
- [x] `pnpm format` -- all files formatted correctly
- [x] `pnpm build` -- TypeScript compiles without errors
- [x] `pnpm vitest run src/web/accounts.test.ts` -- 4/4 tests pass
  - Path traversal `../../../etc/passwd` is sanitized
  - Special characters `/` and `\` are stripped
  - Empty accountId falls back to `"default"`
  - Valid accountId `my-account-1` is preserved

## AI Assistance Disclosure

This PR was AI-assisted. Fix follows existing codebase patterns. Human reviewed.

Fixes #2692