### PR TITLE
Docs: update bug report template from Clawdbot to OpenClaw

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem or unexpected behavior in Clawdbot.
+about: Report a problem or unexpected behavior in OpenClaw.
 title: "[Bug]: "
 labels: bug
 ---
@@ -20,7 +20,7 @@ What did you expect to happen?
 What actually happened?
 
 ## Environment
-- Clawdbot version:
+- OpenClaw version:
 - OS:
 - Install method (pnpm/npx/docker/etc):
 


### PR DESCRIPTION
Fixed the docs for naming from Clawdbot to OpenClaw