### PR TITLE
security(crypto): replace SHA-1 with SHA-256 in all hash operations

### DIFF
--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -60,5 +60,5 @@ function primitiveToString(value: unknown): string {
 export function computeSandboxConfigHash(input: SandboxHashInput): string {
   const payload = normalizeForHash(input);
   const raw = JSON.stringify(payload);
-  return crypto.createHash("sha1").update(raw).digest("hex");
+  return crypto.createHash("sha256").update(raw).digest("hex");
 }

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -6,7 +6,7 @@ import { resolveAgentIdFromSessionKey } from "../agent-scope.js";
 
 export function slugifySessionKey(value: string) {
   const trimmed = value.trim() || "session";
-  const hash = crypto.createHash("sha1").update(trimmed).digest("hex").slice(0, 8);
+  const hash = crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 8);
   const safe = trimmed
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -47,7 +47,7 @@ export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = 
 }
 
 function shortHash(text: string, length = 8): string {
-  return createHash("sha1").update(text).digest("hex").slice(0, length);
+  return createHash("sha256").update(text).digest("hex").slice(0, length);
 }
 
 function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCallIdMode }): string {

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -27,7 +27,7 @@ async function makeEnv() {
 function resolveLockPath(env: NodeJS.ProcessEnv) {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
-  const hash = createHash("sha1").update(configPath).digest("hex").slice(0, 8);
+  const hash = createHash("sha256").update(configPath).digest("hex").slice(0, 8);
   const lockDir = resolveGatewayLockDir();
   return { lockPath: path.join(lockDir, `gateway.${hash}.lock`), configPath };
 }

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -167,7 +167,7 @@ async function readLockPayload(lockPath: string): Promise<LockPayload | null> {
 function resolveGatewayLockPath(env: NodeJS.ProcessEnv) {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
-  const hash = createHash("sha1").update(configPath).digest("hex").slice(0, 8);
+  const hash = createHash("sha256").update(configPath).digest("hex").slice(0, 8);
   const lockDir = resolveGatewayLockDir();
   const lockPath = path.join(lockDir, `gateway.${hash}.lock`);
   return { lockPath, configPath };


### PR DESCRIPTION
## Summary

- Replace all `crypto.createHash("sha1")` with `crypto.createHash("sha256")` across the codebase
- SHA-1 is cryptographically broken (collision attacks demonstrated since 2017)
- All affected hashes are ephemeral with no persistence impact

## Changed files

| File | Usage | Impact |
|------|-------|--------|
| `src/agents/sandbox/shared.ts` | Session key slugs for sandbox workspace dirs | New sessions get new dir names; old dirs are ephemeral |
| `src/agents/sandbox/config-hash.ts` | Sandbox config change detection | One-time sandbox rebuild after upgrade (normal behavior) |
| `src/agents/tool-call-id.ts` | Tool call ID deduplication | Per-session values, not persisted |
| `src/infra/gateway-lock.ts` | Gateway lock file naming | Old lock cleaned on shutdown; new lock created on start |
| `src/infra/gateway-lock.test.ts` | Test mirror of production code | Matches production change |

## Test plan

- [x] `pnpm vitest run` on affected files -- 10/10 tests pass
- [x] `pnpm lint` -- 0 warnings, 0 errors
- [x] `pnpm format` -- all files formatted correctly

lobster-biscuit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates all internal hash operations from SHA-1 to SHA-256 for improved cryptographic security.

- Replaces `crypto.createHash("sha1")` with `crypto.createHash("sha256")` in 5 files
- All affected hashes are ephemeral (sandbox config detection, session slugs, tool call IDs, gateway lock names)
- No persistence impact: old directories/locks are cleaned up on restart
- All uses extract first 8 hex chars via `.slice(0, 8)`, so output format remains compatible
- Tests updated to match (gateway-lock.test.ts)
- SHA-1 usage in `extensions/voice-call/src/webhook-security.ts` correctly remains unchanged (Twilio webhook verification requires SHA-1 per their API spec)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and security-improving. All SHA-1 to SHA-256 replacements are in ephemeral hash contexts (no persistence), the code changes are minimal and consistent, tests have been updated accordingly, and all affected code uses `.slice(0, 8)` making the output format compatible. The PR correctly excludes Twilio webhook verification which must use SHA-1 per the third-party API specification.
- No files require special attention

<sub>Last reviewed commit: 58311bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->