### PR TITLE
fix: show actionable hint when setup-token lacks user:profile scope

### DIFF
--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -55,6 +55,21 @@ export async function applyAuthChoiceAnthropic(
       provider,
       mode: "token",
     });
+
+    // setup-token only grants user:inference scope; usage tracking (/status)
+    // requires user:profile which is only available via the full OAuth flow.
+    // See: https://github.com/anthropics/claude-code/issues/16075
+    await params.prompter.note(
+      [
+        "Note: `claude setup-token` does not include the user:profile scope.",
+        "Usage tracking in /status will not be available with this token.",
+        "To enable usage tracking, run `claude login` (full browser OAuth)",
+        "on a machine with a browser, then use `openclaw models auth paste-token`",
+        "to import the resulting token.",
+      ].join("\n"),
+      "Usage tracking limitation",
+    );
+
     return { config: nextConfig };
   }
 

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -135,6 +135,16 @@ export async function fetchClaudeUsage(
         const web = await fetchClaudeWebUsage(sessionKey, timeoutMs, fetchFn);
         if (web) return web;
       }
+
+      // No web session key fallback available — return an actionable error so users
+      // know how to fix usage tracking.
+      return {
+        provider: "anthropic",
+        displayName: PROVIDER_LABELS.anthropic,
+        windows: [],
+        error:
+          "setup-token missing user:profile scope — run `claude login` (full OAuth) to enable usage tracking",
+      };
     }
 
     const suffix = message ? `: ${message}` : "";


### PR DESCRIPTION
## Summary

When Anthropic `setup-token` auth is used for onboarding, the OAuth usage endpoint returns HTTP 403 because `setup-token` only grants `user:inference` scope — not `user:profile` which is required for usage tracking. Users see a cryptic error in `/status` with no guidance on how to fix it.

## Changes

### 1. Actionable error message (`provider-usage.fetch.claude.ts`)
When the 403 scope error occurs and no `claude.ai` web session fallback is available, return a clear error:
> `setup-token missing user:profile scope — run \`claude login\` (full OAuth) to enable usage tracking`

Previously, this fell through to the generic `HTTP 403: OAuth token does not meet scope requirement user:profile` message with no remediation guidance.

### 2. Post-onboard warning (`auth-choice.apply.anthropic.ts`)
After completing setup-token onboarding, display a note explaining:
- `setup-token` does not include `user:profile` scope
- Usage tracking in `/status` won't work with this token
- How to upgrade: run `claude login` then `openclaw models auth paste-token`

### 3. New test (`provider-usage.test.ts`)
Added test for the no-fallback scope error path, verifying the actionable error message is returned when no `CLAUDE_AI_SESSION_KEY` is available.

## Context

Closes #4614

The root cause is upstream in Claude Code CLI — `setup-token` only requests `user:inference` scope while `claude login` (full browser OAuth) requests all scopes including `user:profile`. This PR improves the user experience until/unless the upstream scope issue is resolved.

Related Claude Code issues:
- https://github.com/anthropics/claude-code/issues/16075
- https://github.com/anthropics/claude-code/issues/15243
- https://github.com/anthropics/claude-code/issues/12020