### PR TITLE
fix(telegram): add 'timed out' to recoverable error detection

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -78,6 +78,7 @@ const NETWORK_ERROR_SNIPPETS = [
   "fetch failed",
   "network",
   "timeout",
+  "timed out",
   "socket",
   "econnreset",
   "econnrefused",

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -35,6 +35,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "network request",
   "client network socket disconnected",
   "socket hang up",
+  "timed out",
   "getaddrinfo",
 ];
 


### PR DESCRIPTION
## Summary
Fix Telegram channel exiting permanently on getUpdates timeout by adding "timed out" to recoverable error detection.

**Fixes #4617**

## AI Disclosure 🤖
This PR was developed with AI assistance (Gemini/Antigravity).

## Root Cause
The error message `Request to 'getUpdates' timed out after 30 seconds` contains "timed out", but the snippet lists only had "timeout" - no substring match occurred, bypassing retry logic.

## Changes
- **`src/telegram/monitor.ts`** - Add "timed out" to `NETWORK_ERROR_SNIPPETS`
- **`src/telegram/network-errors.ts`** - Add "timed out" to `RECOVERABLE_MESSAGE_SNIPPETS`

## Testing
- [x] TypeScript compiles without errors
- [x] Linter passes (0 warnings, 0 errors)
- [x] Test suite passes (4884 tests)
- [x] Mark as AI-assisted ✅