### PR TITLE
fix(line): resolve TypeError in status command when LINE is enabled

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -4,6 +4,7 @@ import {
   LineConfigSchema,
   processLineMessage,
   type ChannelPlugin,
+  type ChannelStatusIssue,
   type OpenClawConfig,
   type LineConfig,
   type LineChannelData,
@@ -560,19 +561,26 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       lastStopAt: null,
       lastError: null,
     },
-    collectStatusIssues: ({ account }) => {
-      const issues: Array<{ level: "error" | "warning"; message: string }> = [];
-      if (!account.channelAccessToken?.trim()) {
-        issues.push({
-          level: "error",
-          message: "LINE channel access token not configured",
-        });
-      }
-      if (!account.channelSecret?.trim()) {
-        issues.push({
-          level: "error",
-          message: "LINE channel secret not configured",
-        });
+    collectStatusIssues: (accounts) => {
+      const issues: ChannelStatusIssue[] = [];
+      for (const account of accounts) {
+        const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
+        if (!account.channelAccessToken?.trim()) {
+          issues.push({
+            channel: "line",
+            accountId,
+            kind: "config",
+            message: "LINE channel access token not configured",
+          });
+        }
+        if (!account.channelSecret?.trim()) {
+          issues.push({
+            channel: "line",
+            accountId,
+            kind: "config",
+            message: "LINE channel secret not configured",
+          });
+        }
       }
       return issues;
     },


### PR DESCRIPTION
Fixes #4639.\n\nThe `collectStatusIssues` hook in the LINE extension was incorrectly expecting a destructured object `({ account })` as its first argument, while the core caller (`collectChannelStatusIssues`) passes a raw array of snapshots. This resulted in a TypeError when running `openclaw status` with the LINE channel enabled.\n\nThis PR updates the LINE extension to correctly handle the array of accounts, matching the behavior of other channel extensions like Discord and Google Chat.