### PR TITLE
fix: Auto-discover Ollama models without requiring API key

### DIFF
--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -5,11 +5,12 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 describe("Ollama provider", () => {
-  it("should not include ollama when no API key is configured", async () => {
+  it("should not include ollama in test environment (no local discovery)", async () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const providers = await resolveImplicitProviders({ agentDir });
 
-    // Ollama requires explicit configuration via OLLAMA_API_KEY env var or profile
+    // In test environments, Ollama discovery is skipped and no API key is configured,
+    // so the provider should not be included
     expect(providers?.ollama).toBeUndefined();
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -446,12 +446,18 @@ export async function resolveImplicitProviders(params: {
     providers.xiaomi = { ...buildXiaomiProvider(), apiKey: xiaomiKey };
   }
 
-  // Ollama provider - only add if explicitly configured
+  // Ollama provider - auto-discover local models, no API key needed
   const ollamaKey =
     resolveEnvApiKeyVarName("ollama") ??
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
-  if (ollamaKey) {
-    providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  const ollamaProvider = await buildOllamaProvider();
+  // Add provider if models are discovered OR if explicitly configured with API key
+  if (ollamaProvider.models.length > 0 || ollamaKey) {
+    providers.ollama = {
+      ...ollamaProvider,
+      // Use configured key if available, otherwise use placeholder for local auth
+      apiKey: ollamaKey ?? "local",
+    };
   }
 
   return providers;


### PR DESCRIPTION
## Problem

Fixes #4544

User reported that locally installed Ollama models (like `deepseek-r1:latest`) show as "missing" in OpenClaw even though they are installed and available via `ollama list`. The CLI command `openclaw models list` shows the model with status "missing" and using it results in "Unknown model" error.

## Root Cause

Ollama is a local service that doesn't require authentication, but the code was only enabling the Ollama provider if an API key was configured. This caused locally installed Ollama models to never be discovered.

## Solution

Modified `resolveImplicitProviders()` to auto-discover Ollama models and add the provider if models are found:

- Always call `buildOllamaProvider()` to attempt discovery
- Add provider if models are discovered OR if API key is explicitly configured
- Use "local" as placeholder API key for local auth (similar to existing patterns like `QWEN_PORTAL_OAUTH_PLACEHOLDER`)
- Respect explicit API key configuration if provided (for future use cases)

## Testing

- ✅ Updated test: `models-config.providers.ollama.test.ts`
- ✅ All existing model tests pass
- ✅ Discovery is gracefully skipped in test environments

## How to Test

1. Install Ollama: `brew install ollama`
2. Pull a model: `ollama pull deepseek-r1:latest`
3. Build and install patched OpenClaw
4. Run: `openclaw models list`
5. Expected: Model shows with "Local: yes" and "Auth: yes" instead of "missing"

## Files Changed

- `src/agents/models-config.providers.ts` - Modified provider resolution logic
- `src/agents/models-config.providers.ollama.test.ts` - Updated test description