### PR TITLE
fix(docker): restrict default gateway bind to loopback for security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         "dist/index.js",
         "gateway",
         "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-localhost}",
+        "${OPENCLAW_GATEWAY_BIND:-loopback}",
         "--port",
         "${OPENCLAW_GATEWAY_PORT:-18789}"
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         "dist/index.js",
         "gateway",
         "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
+        "${OPENCLAW_GATEWAY_BIND:-localhost}",
         "--port",
         "${OPENCLAW_GATEWAY_PORT:-18789}"
       ]

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -31,7 +31,7 @@ export OPENCLAW_CONFIG_DIR
 export OPENCLAW_WORKSPACE_DIR
 export OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
 export OPENCLAW_BRIDGE_PORT="${OPENCLAW_BRIDGE_PORT:-18790}"
-export OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-lan}"
+export OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 export OPENCLAW_IMAGE="$IMAGE_NAME"
 export OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
 export OPENCLAW_EXTRA_MOUNTS="$EXTRA_MOUNTS"
@@ -180,7 +180,7 @@ docker build \
 echo ""
 echo "==> Onboarding (interactive)"
 echo "When prompted:"
-echo "  - Gateway bind: lan"
+echo "  - Gateway bind: loopback"
 echo "  - Gateway auth: token"
 echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"


### PR DESCRIPTION
### Problem
The gateway currently defaults to `OPENCLAW_GATEWAY_BIND=lan`, which causes port `18789` to bind to all LAN interfaces by default.

This means that simply running `docker-compose up` exposes the OpenClaw gateway to the local network without any explicit user intent. In environments such as public Wi-Fi, shared LANs, home routers with UPnP, or misconfigured VPS firewalls, this can unintentionally expose the gateway to untrusted clients.

### Impact
An exposed gateway increases the attack surface and may allow unauthorized access to the OpenClaw API, depending on deployment context and downstream authentication controls. This violates the principle of secure-by-default behavior.

### Solution
Changed the default value of `OPENCLAW_GATEWAY_BIND` to `loopback`, ensuring the gateway is only accessible from the host by default.

Users who intentionally require remote or LAN access can still explicitly opt in by setting:
- `OPENCLAW_GATEWAY_BIND=lan`
- or `OPENCLAW_GATEWAY_BIND=0.0.0.0`

This preserves existing functionality while making the default behavior safer.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the Docker default gateway bind from `lan` to `loopback` in both `docker-compose.yml` and `docker-setup.sh`, making the gateway secure-by-default (not exposed to the local network unless users opt in).

The change fits the repo’s Docker onboarding flow by ensuring `OPENCLAW_GATEWAY_BIND` now defaults to a safer value while still allowing users to explicitly override it via environment variables.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk, but has a small UX/documentation mismatch in the setup script output.
- The functional change is a simple default swap applied consistently in compose and setup script, which reduces exposure by default. The main issue found is the onboarding hint in `docker-setup.sh` still instructing `lan`, which can mislead users and undermine the security goal; otherwise there are no apparent runtime/compatibility problems in the diff.
- docker-setup.sh (printed onboarding instructions vs new default)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->