### PR TITLE
feat(opencode-zen): refresh pricing and Kimi catalog

### DIFF
--- a/src/agents/opencode-zen-models.test.ts
+++ b/src/agents/opencode-zen-models.test.ts
@@ -54,10 +54,10 @@ describe("getOpencodeZenStaticFallbackModels", () => {
   it("returns an array of models", () => {
     const models = getOpencodeZenStaticFallbackModels();
     expect(Array.isArray(models)).toBe(true);
-    expect(models.length).toBe(9);
+    expect(models.length).toBe(11);
   });
 
-  it("includes Claude, GPT, Gemini, and GLM models", () => {
+  it("includes Claude, GPT, Gemini, GLM, and Kimi models", () => {
     const models = getOpencodeZenStaticFallbackModels();
     const ids = models.map((m) => m.id);
 
@@ -66,6 +66,7 @@ describe("getOpencodeZenStaticFallbackModels", () => {
     expect(ids).toContain("gpt-5.1-codex");
     expect(ids).toContain("gemini-3-pro");
     expect(ids).toContain("glm-4.7");
+    expect(ids).toContain("kimi-k2.5");
   });
 
   it("returns valid ModelDefinitionConfig objects", () => {

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -598,7 +598,7 @@ export async function applyAuthChoiceApiProviders(
         [
           "OpenCode Zen provides access to Claude, GPT, Gemini, and more models.",
           "Get your API key at: https://opencode.ai/auth",
-          "Requires an active OpenCode Zen subscription.",
+          "Billing is pay-as-you-go; add credits in the OpenCode Zen dashboard.",
         ].join("\n"),
         "OpenCode Zen",
       );


### PR DESCRIPTION
## Summary
- Refresh OpenCode Zen pricing metadata to match current Zen rates (per 1M tokens) and update onboarding note to pay-as-you-go.
- Add Kimi K2.5 + K2.5 Free.

### Pricing source
https://opencode.ai/docs/zen
