### PR TITLE
fix: correct ARM64 Docker image tagging (issue #4566)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -41,12 +41,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{version}},suffix=-amd64
-            type=semver,pattern={{version}},suffix=-arm64
             type=ref,event=branch,suffix=-amd64
-            type=ref,event=branch,suffix=-arm64
+            type=semver,pattern={{version}},suffix=-amd64
 
       - name: Build and push amd64 image
         id: build
@@ -90,12 +86,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{version}},suffix=-amd64
-            type=semver,pattern={{version}},suffix=-arm64
-            type=ref,event=branch,suffix=-amd64
             type=ref,event=branch,suffix=-arm64
+            type=semver,pattern={{version}},suffix=-arm64
 
       - name: Build and push arm64 image
         id: build


### PR DESCRIPTION
## Summary
Fixes #4566 - ARM64 Docker images were incorrectly tagged, causing 'exec format error' when running on ARM64 hosts.

## Root Cause
The docker-release.yml workflow had both `build-amd64` and `build-arm64` jobs pushing tags for BOTH architectures:

```yaml
tags: |
  type=ref,event=branch,suffix=-amd64
  type=ref,event=branch,suffix=-arm64
  # ... (both jobs had both suffixes)
```

This caused whichever build finished last to overwrite the other's tags. Users pulling `main-arm64` images could receive AMD64 binaries, resulting in the exec format error.

## Solution
Each architecture-specific build now only pushes tags matching its platform:

**build-amd64**:
```yaml
tags: |
  type=ref,event=branch,suffix=-amd64
  type=semver,pattern={{version}},suffix=-amd64
```

**build-arm64**:
```yaml
tags: |
  type=ref,event=branch,suffix=-arm64
  type=semver,pattern={{version}},suffix=-arm64
```

The `create-manifest` job continues to create multi-arch manifests with clean tags (no suffix).

## Testing
The fix ensures:
- `main-amd64` tag contains AMD64 image only
- `main-arm64` tag contains ARM64 image only  
- `main` tag is a multi-arch manifest pointing to both

## Changes
- Modified `.github/workflows/docker-release.yml` to fix tag metadata for each arch-specific build job

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Docker image tag collisions in `.github/workflows/docker-release.yml` by ensuring each arch-specific build job (amd64 vs arm64) only publishes tags with its own architecture suffix, while the `create-manifest` job continues to publish the “clean” multi-arch tags.

This prevents the last-finished build from overwriting the other architecture’s `*-amd64`/`*-arm64` tags, which previously could result in users pulling an ARM64 tag that actually pointed to an amd64 image (and hitting `exec format error`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to tag generation in the Docker release workflow and aligns tags with the platform each job actually builds; the manifest job still produces the unsuffixed multi-arch tags. No functional application code is touched, and the diff removes the specific configuration that caused tag overwrites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->