### PR TITLE
UI: add webchat image attachments

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -111,6 +111,12 @@
   z-index: 10;
 }
 
+.chat-compose--dragging {
+  outline: 2px dashed var(--accent);
+  outline-offset: 6px;
+  border-radius: 12px;
+}
+
 /* Image attachments preview */
 .chat-attachments {
   display: inline-flex;
@@ -268,6 +274,10 @@
   display: flex;
   align-items: stretch;
   gap: 8px;
+}
+
+.chat-compose__file-input {
+  display: none;
 }
 
 .chat-compose .chat-compose__actions .btn {


### PR DESCRIPTION
## Summary
- add a paperclip button and hidden file input so users can pick images in webchat
- support drag-and-drop image uploads with a visible drop target state
- consolidate paste/file/drop handling into a shared image attachment pipeline
- enforce image-only and size limits (5 MB) to match gateway constraints
- refresh compose placeholder to advertise paste/drop support

## Changes
- `ui/src/ui/views/chat.ts`: add image attachment picker, drag/drop handlers, and shared file-to-attachment conversion
- `ui/src/styles/chat/layout.css`: add drag-over styling and hide the file input

Closes #4041