### PR TITLE
fix(sessions): prevent displayName overwrite on outbound sends (#4683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 Status: stable.
 
 ### Changes
+- Sessions: fix displayName being overwritten by outbound message recipient instead of session owner. (#4683)
 - Rebrand: rename the npm package/CLI to `openclaw`, add a `openclaw` compatibility shim, and move extensions to the `@openclaw/*` scope.
 - Onboarding: strengthen security warning copy for beta + access control expectations.
 - Onboarding: add Venice API key to non-interactive flow. (#1893) Thanks @jonisjongithub.

--- a/src/config/sessions/metadata.test.ts
+++ b/src/config/sessions/metadata.test.ts
@@ -20,4 +20,33 @@ describe("deriveSessionMetaPatch", () => {
     expect(patch?.channel).toBe("whatsapp");
     expect(patch?.groupId).toBe("123@g.us");
   });
+
+  it("skips displayName when skipDisplayName is true", () => {
+    const patchWithDisplayName = deriveSessionMetaPatch({
+      ctx: {
+        Provider: "whatsapp",
+        ChatType: "group",
+        GroupSubject: "Family",
+        From: "123@g.us",
+      },
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(patchWithDisplayName?.displayName).toBeDefined();
+
+    const patchWithoutDisplayName = deriveSessionMetaPatch({
+      ctx: {
+        Provider: "whatsapp",
+        ChatType: "group",
+        GroupSubject: "Family",
+        From: "123@g.us",
+      },
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      skipDisplayName: true,
+    });
+    expect(patchWithoutDisplayName?.displayName).toBeUndefined();
+    // Other fields should still be present
+    expect(patchWithoutDisplayName?.subject).toBe("Family");
+    expect(patchWithoutDisplayName?.channel).toBe("whatsapp");
+    expect(patchWithoutDisplayName?.groupId).toBe("123@g.us");
+  });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -361,6 +361,8 @@ export async function recordSessionMetaFromInbound(params: {
   ctx: MsgContext;
   groupResolution?: import("./types.js").GroupKeyResolution | null;
   createIfMissing?: boolean;
+  /** Skip displayName derivation (e.g., for outbound session entries). */
+  skipDisplayName?: boolean;
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, ctx } = params;
   const createIfMissing = params.createIfMissing ?? true;
@@ -371,6 +373,7 @@ export async function recordSessionMetaFromInbound(params: {
       sessionKey,
       existing,
       groupResolution: params.groupResolution,
+      skipDisplayName: params.skipDisplayName,
     });
     if (!patch) return existing ?? null;
     if (!existing && !createIfMissing) return null;

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -850,6 +850,9 @@ export async function ensureOutboundSessionEntry(params: {
       storePath,
       sessionKey: params.route.sessionKey,
       ctx,
+      // Outbound sends should not update displayName since it represents the
+      // session owner (inbound initiator), not the last outbound recipient.
+      skipDisplayName: true,
     });
   } catch {
     // Do not block outbound sends on session meta writes.


### PR DESCRIPTION
---                                                                                                                                                                                   
# fix(sessions): prevent displayName overwrite on outbound sends                                                                                                                                                                            
  ## Summary                                                                                                                                                                            
  - Fix session `displayName` being incorrectly updated to the message recipient when using the message tool to send to a different contact                                             
  - Add `skipDisplayName` option to session metadata functions to prevent this during outbound sends                                                                                    
                                                                                                                                                                                        
 Fixes #4683                                                                                                                                                                           
                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                          
  - [x] Added unit test for `skipDisplayName` behavior in `metadata.test.ts`                                                                                                           
  ---

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `skipDisplayName` flag to session metadata derivation so outbound sends don’t overwrite a session’s `displayName` with the last recipient. The new option is threaded through `deriveGroupSessionPatch`/`deriveSessionMetaPatch`, exposed via `recordSessionMetaFromInbound`, and used by `ensureOutboundSessionEntry` during outbound message routing. A unit test is added to assert `displayName` is omitted when the flag is set, and the changelog notes the fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are tightly scoped to gating `displayName` derivation behind an explicit flag and only applied in the outbound-session entry path; no schema changes and a targeted unit test covers the new behavior. I did not find any functional regressions in the modified call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->