### PR TITLE
fix(windows): resolve command execution and binary detection issues

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -77,13 +77,16 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
+  const extensions = process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
   for (const part of parts) {
-    const candidate = path.join(part, bin);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return true;
-    } catch {
-      // keep scanning
+    for (const ext of extensions) {
+      const candidate = path.join(part, bin + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        // keep scanning
+      }
     }
   }
   return false;

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -77,7 +77,12 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
-  const extensions = process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
+  const winPathExt = process.env.PATHEXT;
+  const winExtensions =
+    winPathExt !== undefined
+      ? winPathExt.split(";").filter(Boolean)
+      : [".EXE", ".CMD", ".BAT", ".COM"];
+  const extensions = process.platform === "win32" ? ["", ...winExtensions] : [""];
   for (const part of parts) {
     for (const ext of extensions) {
       const candidate = path.join(part, bin + ext);

--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -54,13 +54,16 @@ export function resolveRuntimePlatform(): string {
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
+  const extensions = process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
   for (const part of parts) {
-    const candidate = path.join(part, bin);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return true;
-    } catch {
-      // keep scanning
+    for (const ext of extensions) {
+      const candidate = path.join(part, bin + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        // keep scanning
+      }
     }
   }
   return false;

--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -54,7 +54,15 @@ export function resolveRuntimePlatform(): string {
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
-  const extensions = process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
+  const extensions =
+    process.platform === "win32"
+      ? [
+          "",
+          ...(process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+            .split(";")
+            .filter(Boolean),
+        ]
+      : [""];
   for (const part of parts) {
     for (const ext of extensions) {
       const candidate = path.join(part, bin + ext);

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -73,7 +73,11 @@ export async function runCommandWithTimeout(
     return false;
   })();
 
-  const resolvedEnv = env ? { ...process.env, ...env } : { ...process.env };
+  const resolvedEnv = Object.fromEntries(
+    Object.entries({ ...process.env, ...(env ?? {}) })
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, String(value)]),
+  );
   if (shouldSuppressNpmFund) {
     if (resolvedEnv.NPM_CONFIG_FUND == null) resolvedEnv.NPM_CONFIG_FUND = "false";
     if (resolvedEnv.npm_config_fund == null) resolvedEnv.npm_config_fund = "false";

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -85,6 +85,7 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: process.platform === "win32",
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -73,8 +73,9 @@ export async function runCommandWithTimeout(
     return false;
   })();
 
+  const mergedEnv = env ? { ...process.env, ...env } : { ...process.env };
   const resolvedEnv = Object.fromEntries(
-    Object.entries({ ...process.env, ...(env ?? {}) })
+    Object.entries(mergedEnv)
       .filter(([, value]) => value !== undefined)
       .map(([key, value]) => [key, String(value)]),
   );


### PR DESCRIPTION
This PR addresses İki critical issues encountered when running OpenClaw on Windows environments, specifically ensuring that binary files for various skills are correctly detected and executed:

1. **Binary Detection**: Enhances the `hasBinary` check to account for Windows-specific file extensions (`.exe`, `.cmd`, `.bat`). This change ensures that binary files belonging to various skills are correctly detected, which was previously failing due to missing platform-specific extensions.
2. **Command Execution**: Enables `shell: true` in the exec process for Windows to correctly handle scripts (like `.cmd` files) that cannot be spawned directly without a shell context.


### Technical Details

#### 1. Binary Detection (Extension Support)
Files: [src/agents/skills/config.ts](src/agents/skills/config.ts) and [src/hooks/config.ts](src/hooks/config.ts)
Modifies `hasBinary` to iterate through common Windows extensions when running on `win32`.

#### 2. Shell Support (Execution Context)
File: [src/process/exec.ts](src/process/exec.ts)
Adds `shell: process.platform === 'win32'` to the `spawn` options in `runCommandWithTimeout`.

### Why is this necessary?
Google Cloud SDK (`gcloud`), Go, or custom `.bat` scripts were not being detected or executed correctly on Windows. This patch removes these functionality barriers by ensuring skill binaries are found and executable via the shell.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Windows compatibility in two places: (1) `hasBinary` now checks common Windows executable extensions when scanning `PATH`, so skills/hooks gated on external binaries (e.g. `gcloud`) are detected correctly; and (2) `runCommandWithTimeout` now spawns commands with `shell: true` on win32, which allows `.cmd`/`.bat` scripts to run.

The changes fit into the existing gating/execution flow by affecting how skills/hooks decide they’re eligible (via `hasBinary`) and how the process layer invokes external tools (via `runCommandWithTimeout`).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the unconditional `shell: true` on Windows can change behavior for existing command executions.
- Binary-extension probing is a contained change and likely fixes real Windows misses; however, enabling `shell` for every spawned command on win32 can alter argument quoting and ignores `windowsVerbatimArguments`, which may break some call sites.
- src/process/exec.ts (interaction between `shell` and argument quoting / windowsVerbatimArguments)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->