### PR TITLE
feat(hooks): add message_received and message_sent hooks to chat completions endpoint

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -5,6 +5,7 @@ import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { defaultRuntime } from "../runtime.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -200,6 +201,35 @@ export async function handleOpenAiHttpRequest(
   const runId = `chatcmpl_${randomUUID()}`;
   const deps = createDefaultDeps();
 
+  // Trigger message_received hook for API requests (enables voice logging, etc.)
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_received")) {
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: user ?? "api",
+          content: prompt.message,
+          timestamp: Date.now(),
+          metadata: {
+            apiUser: user,
+            model,
+            sessionKey,
+            source: "chat_completions",
+            runId,
+          },
+        },
+        {
+          channelId: "api",
+          accountId: undefined,
+          conversationId: sessionKey,
+        },
+      )
+      .catch((err) => {
+        // Fire-and-forget, just log errors
+        console.error(`[openai-http] message_received hook failed: ${String(err)}`);
+      });
+  }
+
   if (!stream) {
     try {
       const result = await agentCommand(
@@ -224,6 +254,24 @@ export async function handleOpenAiHttpRequest(
               .filter(Boolean)
               .join("\n\n")
           : "No response from OpenClaw.";
+
+      // Trigger message_sent hook for API responses (non-streaming only for now)
+      if (hookRunner?.hasHooks("message_sent")) {
+        void hookRunner
+          .runMessageSent(
+            {
+              to: user ?? "api",
+              content,
+              success: true,
+            },
+            {
+              channelId: "api",
+              accountId: undefined,
+              conversationId: sessionKey,
+            },
+          )
+          .catch(() => {});
+      }
 
       sendJson(res, 200, {
         id: runId,


### PR DESCRIPTION
## Summary

Adds plugin hooks for the `/v1/chat/completions` endpoint, enabling plugins to observe and react to API traffic.

## New Hooks

- **`message_received`** — Fires before agent processing, with user field, model, sessionKey, and source metadata
- **`message_sent`** — Fires after response (non-streaming only)

## Use Cases

- **Voice logging** — Log voice shortcut prompts/responses to a Discord channel
- **Analytics** — Track API usage patterns by user or source
- **Audit trails** — Record all interactions through the API endpoint
- **Custom routing** — Trigger workflows based on request metadata

## Example

A plugin can filter by the `user` field to identify specific callers:

```typescript
hooks: {
  message_received: async (payload) => {
    if (payload.metadata?.apiUser === 'voice-shortcut') {
      // Log to Discord, database, etc.
    }
  }
}
```

## Notes

- `message_sent` only fires for non-streaming responses (streaming delivers chunks progressively)
- Hooks are fire-and-forget; they don't block the response
- Uses `hasHooks()` check to avoid overhead when no plugins are listening