### PR TITLE
fix: make @mariozechner/clipboard optional for ARM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
+    "@mariozechner/clipboard": "^0.3.0",
     "@napi-rs/canvas": "^0.1.88",
     "node-llama-cpp": "3.15.0"
   },


### PR DESCRIPTION
Fixes #4596

## Problem
Users on 32-bit ARM Linux systems (arm-gnueabihf, e.g., Raspberry Pi 32-bit OS) encounter a fatal error when starting OpenClaw:
```
Error: Cannot find module '@mariozechner/clipboard-linux-arm-gnueabihf'
```

## Root Cause
- OpenClaw depends on `@mariozechner/pi-coding-agent`
- `pi-coding-agent` has a hard dependency on `@mariozechner/clipboard`
- The clipboard package doesn't provide native binaries for `linux-arm-gnueabihf` (32-bit ARM)
- When Node.js tries to load the module, it fails because the platform-specific binary is missing

## Solution
Move `@mariozechner/clipboard` to `optionalDependencies`. This is safe because:
- OpenClaw has its own clipboard implementation in `src/infra/clipboard.ts` (uses system commands like xclip, pbcopy, wl-copy)
- OpenClaw doesn't rely on pi-coding-agent's clipboard functionality
- Other pi-coding-agent features (session management, model registry) remain unaffected

## Testing
- Installation should complete successfully on 32-bit ARM systems
- OpenClaw should start without the 'Cannot find module' error
- Clipboard functionality should work via the system commands implementation

This follows the same pattern used for other native dependencies like `@napi-rs/canvas` and `node-llama-cpp`.

cc @shifoc - Would you be able to test this on your Raspberry Pi setup?