### PR TITLE
fix(cron): keep cron list/status responsive under long cron runs

### DIFF
--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -16,7 +16,9 @@ async function makeStorePath() {
   return {
     storePath: path.join(dir, "cron", "jobs.json"),
     cleanup: async () => {
-      await fs.rm(dir, { recursive: true, force: true });
+      // In CI (esp. Windows), cron persistence can briefly keep file handles open.
+      // Use retries to avoid flaky cleanup failures (ENOTEMPTY/EBUSY).
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
     },
   };
 }

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -17,7 +17,9 @@ async function makeStorePath() {
   return {
     storePath: path.join(dir, "cron", "jobs.json"),
     cleanup: async () => {
-      await fs.rm(dir, { recursive: true, force: true });
+      // In CI (esp. Windows), cron persistence can briefly keep file handles open.
+      // Use retries to avoid flaky cleanup failures (ENOTEMPTY/EBUSY).
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
     },
   };
 }


### PR DESCRIPTION
## Why
In a local OpenClaw/Clawdbot setup, `cron.list` and `cron.status` tool calls were intermittently failing with gateway timeouts (10s / 30s) and occasional WS close 1006 while the gateway service itself was healthy.

Evidence (example excerpts):
- `/tmp/clawdbot/clawdbot-2026-01-30.log` shows repeated `[tools] cron failed: gateway timeout after 10000ms`.
- Diagnostic logs show the cron lane frequently taking ~17–24s, meaning *read* requests can queue behind long-running cron executions.

Root cause:
- `cron.list` / `cron.status` were using the same `locked(state, ...)` path as mutating operations, so they could block behind long cron execution that holds the cron lock.

## What this changes
Adds a fast-path for **read-only** operations:
- If `state.store` is already loaded, `cron.list` and `cron.status` return immediately without waiting on `locked(...)`.
- If the store is not loaded yet, behavior is unchanged (still goes through `locked(...)` + `ensureLoaded`).

This keeps cron reads responsive and reduces tool timeouts during long cron jobs.

## Safety
- Only affects `list` and `status`.
- Mutating operations (`add`, `update`, `remove`, `run`) remain locked.
- The fast-path only reads the in-memory store snapshot.

## Testing
Targeted tests relevant to cron behavior:
- `pnpm -s vitest run src/agents/tools/cron-tool.test.ts`
- `pnpm -s vitest run src/cli/cron-cli.test.ts`
- `pnpm -s vitest run src/cron/cron-protocol-conformance.test.ts`

All passed locally.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `cron.status` and `cron.list` more responsive during long-running cron executions by adding a fast-path that returns immediately when `state.store` is already loaded, avoiding contention on the cron `locked(...)` path. It also hardens a couple cron service tests by adding retries to temp directory cleanup to reduce Windows/CI flakiness.

The change fits the existing cron service architecture by keeping all mutating operations (`start/add/update/remove/run`) serialized under the cron lock while allowing read-only operations to skip the lock when possible, reducing tool gateway timeouts under load.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the new unlocked read fast-path may introduce observable inconsistencies under concurrent mutations.
- The behavioral change is small and localized to cron read ops, but it intentionally bypasses the existing lock, which can expose readers to mid-mutation state and make `status/list` non-linearizable. Tests changes are low risk.
- src/cron/service/ops.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->