### PR TITLE
fix(session): normalize tool call blocks for cross-provider compatibility

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -305,6 +305,62 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+/**
+ * Normalizes tool call content blocks in assistant messages so they always use
+ * the canonical shape: `{ type: "toolCall", arguments: ... }`.
+ *
+ * Different providers persist tool calls in different shapes:
+ *   - Anthropic / pi-ai:  `{ type: "toolCall", arguments: {} }`
+ *   - Google Antigravity:  `{ type: "toolUse",  input: {} }`
+ *
+ * When a user switches providers mid-session the old shape can reach the new
+ * provider's serializer unchanged, causing validation failures (e.g. Anthropic
+ * rejects requests when the `input` field is missing on a `tool_use` block).
+ */
+function normalizeToolCallBlocks(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    const content = assistant.content;
+    if (!Array.isArray(content)) {
+      out.push(msg);
+      continue;
+    }
+
+    let contentChanged = false;
+    const nextContent = content.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const rec = block as unknown as Record<string, unknown>;
+      const type = rec.type;
+
+      if (type !== "toolCall" && type !== "toolUse" && type !== "functionCall") return block;
+
+      // Ensure `arguments` is populated — prefer existing `arguments`, fall back to `input`, default to {}.
+      const args = rec.arguments ?? rec.input ?? {};
+      if (type === "toolCall" && rec.arguments !== undefined) return block; // already canonical
+
+      contentChanged = true;
+      return { ...rec, type: "toolCall", arguments: args };
+    });
+
+    if (contentChanged) {
+      changed = true;
+      out.push({ ...assistant, content: nextContent } as typeof assistant);
+    } else {
+      out.push(msg);
+    }
+  }
+
+  return changed ? out : messages;
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -336,6 +392,12 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeToolUseResultPairing(sanitizedThinking)
     : sanitizedThinking;
 
+  // Normalize tool call content blocks so every provider serializer sees a consistent shape.
+  // Session history may contain blocks from different providers (e.g. Google Antigravity uses
+  // { type: "toolUse", input: {} } while Anthropic expects { type: "toolCall", arguments: {} }).
+  // Without this, switching providers mid-session causes "input: Field required" API rejections.
+  const normalizedTools = normalizeToolCallBlocks(repairedTools);
+
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
@@ -350,8 +412,8 @@ export async function sanitizeSessionHistory(params: {
     : false;
   const sanitizedOpenAI =
     isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(repairedTools)
-      : repairedTools;
+      ? downgradeOpenAIReasoningBlocks(normalizedTools)
+      : normalizedTools;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {


### PR DESCRIPTION
## Summary

- Fixes API validation failures when switching providers mid-session (e.g., "input: Field required")
- Adds `normalizeToolCallBlocks()` to convert all tool call variants to canonical format
- Handles `toolCall`, `toolUse`, and `functionCall` block types

## Problem

When users switch providers mid-session, the session history may contain tool call blocks in different formats:

| Provider | Format |
|----------|--------|
| Anthropic / pi-ai | `{ type: "toolCall", arguments: {} }` |
| Google Antigravity | `{ type: "toolUse", input: {} }` |

This mismatch causes the new provider's serializer to reject requests with validation errors.

## Solution

Added `normalizeToolCallBlocks()` to the session sanitization pipeline in `sanitizeSessionHistory()`. It:

1. Scans assistant message content blocks
2. Identifies tool call variants (`toolCall`, `toolUse`, `functionCall`)
3. Normalizes them to canonical `{ type: "toolCall", arguments: {} }` shape
4. Preserves all other fields via spread operator

## Test plan

- [ ] Switch from Google Antigravity to Anthropic mid-session
- [ ] Verify no "input: Field required" errors
- [ ] Verify tool calls work correctly after provider switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `normalizeToolCallBlocks()` to `sanitizeSessionHistory()` in `src/agents/pi-embedded-runner/google.ts` to rewrite provider-specific tool-call content blocks (`toolUse`, `functionCall`) into a canonical `{ type: "toolCall", arguments: ... }` shape. The intent is to prevent cross-provider API validation failures when a session history recorded under one provider is later serialized for another (e.g., switching from Google Antigravity to Anthropic).

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but normalization may still leave schema-incompatible fields on tool-call blocks.
- Change is localized and straightforward, but the normalization spreads the original block fields into the canonical block; if downstream serializers strictly validate tool-call schemas, leftover variant-only fields (e.g., `input` on a `toolCall`) can still trigger validation errors in the exact scenario this PR targets.
- src/agents/pi-embedded-runner/google.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->