### PR TITLE
feat: Kimi K2.5 native features, reasoning_content fix, subagent announce stats

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -755,6 +755,13 @@ export function createExecTool(
         throw new Error("Provide a command to start.");
       }
 
+      // Some models (e.g. Kimi K2.5) prefix commands with colons or whitespace
+      // e.g. ":which npx" instead of "which npx". Strip these artifacts.
+      params.command = params.command.replace(/^[\s:]+/, "");
+      if (!params.command) {
+        throw new Error("Provide a non-empty command to start.");
+      }
+
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -8,6 +8,7 @@ import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
+import { createImageToCodeTool } from "./tools/image-to-code-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
@@ -15,6 +16,7 @@ import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
+import { createSessionsSpawnBatchTool } from "./tools/sessions-spawn-batch-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
 import { createTtsTool } from "./tools/tts-tool.js";
@@ -60,6 +62,13 @@ export function createOpenClawTools(options?: {
         agentDir: options.agentDir,
         sandboxRoot: options?.sandboxRoot,
         modelHasVision: options?.modelHasVision,
+      })
+    : null;
+  const imageToCodeTool = options?.agentDir?.trim()
+    ? createImageToCodeTool({
+        config: options?.config,
+        agentDir: options.agentDir,
+        sandboxRoot: options?.sandboxRoot,
       })
     : null;
   const webSearchTool = createWebSearchTool({
@@ -130,6 +139,18 @@ export function createOpenClawTools(options?: {
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),
+    createSessionsSpawnBatchTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentChannel: options?.agentChannel,
+      agentAccountId: options?.agentAccountId,
+      agentTo: options?.agentTo,
+      agentThreadId: options?.agentThreadId,
+      agentGroupId: options?.agentGroupId,
+      agentGroupChannel: options?.agentGroupChannel,
+      agentGroupSpace: options?.agentGroupSpace,
+      sandboxed: options?.sandboxed,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
+    }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
       config: options?.config,
@@ -137,6 +158,7 @@ export function createOpenClawTools(options?: {
     ...(webSearchTool ? [webSearchTool] : []),
     ...(webFetchTool ? [webFetchTool] : []),
     ...(imageTool ? [imageTool] : []),
+    ...(imageToCodeTool ? [imageToCodeTool] : []),
   ];
 
   const pluginTools = resolvePluginTools({

--- a/src/agents/pi-embedded-helpers.strip-reasoning-replay-signatures.test.ts
+++ b/src/agents/pi-embedded-helpers.strip-reasoning-replay-signatures.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { stripReasoningReplaySignatures } from "./pi-embedded-helpers.js";
+
+describe("stripReasoningReplaySignatures", () => {
+  it("strips plain reasoning_content signature from thinking blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "let me think about this",
+            thinkingSignature: "reasoning_content",
+          },
+          { type: "toolCall", id: "tc_1", name: "search", arguments: {} },
+        ],
+      },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    const assistant = result[0] as any;
+    const thinkingBlock = assistant.content[0];
+    expect(thinkingBlock.thinking).toBe("let me think about this");
+    expect(thinkingBlock.thinkingSignature).toBeUndefined();
+    // Tool call is preserved
+    expect(assistant.content[1].type).toBe("toolCall");
+  });
+
+  it("strips reasoning and reasoning_text signatures too", () => {
+    for (const sig of ["reasoning", "reasoning_text"]) {
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "hmm", thinkingSignature: sig },
+            { type: "text", text: "answer" },
+          ],
+        },
+      ];
+      const result = stripReasoningReplaySignatures(input as any);
+      const block = (result[0] as any).content[0];
+      expect(block.thinkingSignature).toBeUndefined();
+    }
+  });
+
+  it("preserves OpenAI Responses API JSON reasoning signatures", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: JSON.stringify({ id: "rs_abc", type: "reasoning" }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    const block = (result[0] as any).content[0];
+    expect(block.thinkingSignature).toBe(JSON.stringify({ id: "rs_abc", type: "reasoning" }));
+  });
+
+  it("preserves object-form OpenAI reasoning signatures", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: { id: "rs_obj", type: "reasoning" },
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    const block = (result[0] as any).content[0];
+    expect(block.thinkingSignature).toEqual({ id: "rs_obj", type: "reasoning" });
+  });
+
+  it("passes through non-assistant messages unchanged", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      { role: "system", content: "you are helpful" },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    expect(result).toEqual(input);
+  });
+
+  it("passes through assistant messages without thinking blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    expect(result).toEqual(input);
+  });
+
+  it("passes through thinking blocks without thinkingSignature", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hmm" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    const result = stripReasoningReplaySignatures(input as any);
+    expect(result).toEqual(input);
+  });
+
+  it("handles empty messages array", () => {
+    expect(stripReasoningReplaySignatures([])).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -34,7 +34,10 @@ export {
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
-export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
+export {
+  downgradeOpenAIReasoningBlocks,
+  stripReasoningReplaySignatures,
+} from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -11,6 +11,7 @@ import {
   isGoogleModelApi,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
+  stripReasoningReplaySignatures,
 } from "../pi-embedded-helpers.js";
 import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { log } from "./logger.js";
@@ -335,6 +336,7 @@ export async function sanitizeSessionHistory(params: {
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedThinking)
     : sanitizedThinking;
+  const strippedReplaySignatures = stripReasoningReplaySignatures(repairedTools);
 
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
@@ -350,8 +352,8 @@ export async function sanitizeSessionHistory(params: {
     : false;
   const sanitizedOpenAI =
     isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(repairedTools)
-      : repairedTools;
+      ? downgradeOpenAIReasoningBlocks(strippedReplaySignatures)
+      : strippedReplaySignatures;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -11,7 +11,6 @@ import {
   isGoogleModelApi,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
-  stripReasoningReplaySignatures,
 } from "../pi-embedded-helpers.js";
 import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { log } from "./logger.js";
@@ -336,7 +335,6 @@ export async function sanitizeSessionHistory(params: {
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedThinking)
     : sanitizedThinking;
-  const strippedReplaySignatures = stripReasoningReplaySignatures(repairedTools);
 
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
@@ -352,8 +350,8 @@ export async function sanitizeSessionHistory(params: {
     : false;
   const sanitizedOpenAI =
     isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(strippedReplaySignatures)
-      : strippedReplaySignatures;
+      ? downgradeOpenAIReasoningBlocks(repairedTools)
+      : repairedTools;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {

--- a/src/agents/pi-embedded-runner/reasoning-content-compat.test.ts
+++ b/src/agents/pi-embedded-runner/reasoning-content-compat.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { patchReasoningContentCompat } from "./reasoning-content-compat.js";
+
+describe("patchReasoningContentCompat", () => {
+  it("adds empty reasoning_content to assistant messages that lack it", () => {
+    const params = {
+      messages: [
+        { role: "system", content: "you are helpful" },
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          reasoning_content: "let me think",
+          content: [{ type: "text", text: "hi" }],
+        },
+        { role: "user", content: "use a tool" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "tc_1", type: "function", function: { name: "search", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", content: "result", tool_call_id: "tc_1" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      ],
+    };
+
+    patchReasoningContentCompat(params);
+
+    // First assistant: already had reasoning_content — unchanged
+    expect(params.messages[2].reasoning_content).toBe("let me think");
+    // Tool-call assistant: now has empty reasoning_content
+    expect(params.messages[4].reasoning_content).toBe("");
+    // Last assistant: now has empty reasoning_content
+    expect(params.messages[6].reasoning_content).toBe("");
+    // Non-assistant messages: untouched
+    expect(params.messages[0]).not.toHaveProperty("reasoning_content");
+    expect(params.messages[1]).not.toHaveProperty("reasoning_content");
+    expect(params.messages[5]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("does nothing when no assistant message has a reasoning field", () => {
+    const params = {
+      messages: [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "hi" }],
+          tool_calls: [{ id: "tc_1", type: "function", function: { name: "fn", arguments: "{}" } }],
+        },
+        { role: "tool", content: "r", tool_call_id: "tc_1" },
+      ],
+    };
+
+    const before = JSON.parse(JSON.stringify(params));
+    patchReasoningContentCompat(params);
+    expect(params).toEqual(before);
+  });
+
+  it("detects reasoning field (not just reasoning_content)", () => {
+    const params = {
+      messages: [
+        { role: "assistant", reasoning: "thinking", content: "yes" },
+        { role: "assistant", content: null, tool_calls: [{ id: "tc_1" }] },
+      ],
+    };
+
+    patchReasoningContentCompat(params);
+
+    expect(params.messages[0].reasoning).toBe("thinking");
+    expect((params.messages[1] as Record<string, unknown>).reasoning).toBe("");
+  });
+
+  it("detects reasoning_text field", () => {
+    const params = {
+      messages: [
+        { role: "assistant", reasoning_text: "hmm", content: "ok" },
+        { role: "assistant", content: null, tool_calls: [{ id: "tc_2" }] },
+      ],
+    };
+
+    patchReasoningContentCompat(params);
+
+    expect((params.messages[1] as Record<string, unknown>).reasoning_text).toBe("");
+  });
+
+  it("handles empty messages array", () => {
+    const params = { messages: [] };
+    patchReasoningContentCompat(params);
+    expect(params.messages).toEqual([]);
+  });
+
+  it("handles params without messages", () => {
+    const params = { model: "test" };
+    patchReasoningContentCompat(params);
+    // Should not throw
+  });
+
+  it("does not add field when reasoning_content is explicitly set to empty string", () => {
+    const params = {
+      messages: [
+        { role: "assistant", reasoning_content: "", content: "yes" },
+        { role: "assistant", content: null, tool_calls: [{ id: "tc_1" }] },
+      ],
+    };
+
+    patchReasoningContentCompat(params);
+
+    // Empty string is still a defined field, so it should be detected
+    expect(params.messages[1].reasoning_content).toBe("");
+  });
+});

--- a/src/agents/pi-embedded-runner/reasoning-content-compat.ts
+++ b/src/agents/pi-embedded-runner/reasoning-content-compat.ts
@@ -1,0 +1,69 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+/**
+ * Providers like Kimi K2.5 stream thinking via `reasoning_content` but require
+ * that field to be present on **every** assistant message when thinking is enabled —
+ * including tool-call-only messages that have no thinking blocks.
+ *
+ * Pi-ai only adds `reasoning_content` to assistant messages that contain thinking blocks.
+ * This wrapper intercepts the serialized API payload via `onPayload` and ensures every
+ * assistant message includes the reasoning field when any message in the conversation uses it.
+ */
+
+/** Well-known reasoning field names used by OpenAI-compatible providers. */
+const REASONING_FIELDS = ["reasoning_content", "reasoning", "reasoning_text"];
+
+type ApiMessage = Record<string, unknown> & { role?: string };
+
+function detectReasoningField(messages: ApiMessage[]): string | null {
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const field of REASONING_FIELDS) {
+      if (field in msg && msg[field] !== undefined) {
+        return field;
+      }
+    }
+  }
+  return null;
+}
+
+function ensureReasoningFieldPresent(messages: ApiMessage[], field: string): void {
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    if (!(field in msg) || msg[field] === undefined) {
+      msg[field] = "";
+    }
+  }
+}
+
+/** @internal Exported for testing only. */
+export function patchReasoningContentCompat(params: Record<string, unknown>): void {
+  const messages = params.messages;
+  if (!Array.isArray(messages)) return;
+
+  const field = detectReasoningField(messages as ApiMessage[]);
+  if (!field) return;
+
+  ensureReasoningFieldPresent(messages as ApiMessage[], field);
+}
+
+/**
+ * Wrap a streamFn to patch serialized API payloads so that every assistant message
+ * includes the detected reasoning field (e.g. `reasoning_content`).
+ */
+export function wrapStreamFnForReasoningCompat(baseStreamFn: StreamFn): StreamFn {
+  const wrapped: StreamFn = (model, context, options) => {
+    const patchingOnPayload = (payload: unknown) => {
+      if (payload && typeof payload === "object") {
+        patchReasoningContentCompat(payload as Record<string, unknown>);
+      }
+      options?.onPayload?.(payload);
+    };
+    return baseStreamFn(model as Model<Api>, context, {
+      ...options,
+      onPayload: patchingOnPayload,
+    });
+  };
+  return wrapped;
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -56,6 +56,7 @@ import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import { isAbortError } from "../abort.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
+import { wrapStreamFnForReasoningCompat } from "../reasoning-content-compat.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import {
   logToolSchemasForGoogle,
@@ -513,6 +514,11 @@ export async function runEmbeddedAttempt(
           activeSession.agent.streamFn,
         );
       }
+
+      // Ensure every assistant message includes the provider-specific reasoning field
+      // (e.g. reasoning_content) when any message in the conversation uses it.
+      // Kimi K2.5 rejects requests where tool-call-only messages lack the field.
+      activeSession.agent.streamFn = wrapStreamFnForReasoningCompat(activeSession.agent.streamFn);
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -23,8 +23,10 @@ import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-que
 import { readLatestAssistantReply } from "./tools/agent-step.js";
 
 function formatDurationShort(valueMs?: number) {
-  if (!valueMs || !Number.isFinite(valueMs) || valueMs <= 0) return undefined;
+  if (valueMs === undefined || valueMs === null || !Number.isFinite(valueMs) || valueMs < 0)
+    return undefined;
   const totalSeconds = Math.round(valueMs / 1000);
+  if (totalSeconds === 0) return "<1s";
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
@@ -79,8 +81,8 @@ async function waitForSessionUsage(params: { sessionKey: string }) {
       typeof entry.inputTokens === "number" ||
       typeof entry.outputTokens === "number");
   if (hasTokens()) return { entry, storePath };
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
     entry = loadSessionStore(storePath)[params.sessionKey];
     if (hasTokens()) break;
   }
@@ -359,9 +361,13 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!reply) {
-      reply = await readLatestAssistantReply({
-        sessionKey: params.childSessionKey,
-      });
+      // Retry with backoff — transcript may not be flushed yet
+      for (let attempt = 0; attempt < 5 && !reply; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        reply = await readLatestAssistantReply({
+          sessionKey: params.childSessionKey,
+        });
+      }
     }
 
     if (!outcome) outcome = { status: "unknown" };

--- a/src/agents/test-helpers/fast-coding-tools.ts
+++ b/src/agents/test-helpers/fast-coding-tools.ts
@@ -9,6 +9,16 @@ const stubTool = (name: string) => ({
 
 vi.mock("../tools/image-tool.js", () => ({
   createImageTool: () => stubTool("image"),
+  resolveImageModelConfigForTool: () => null,
+  runImagePrompt: vi.fn(),
+}));
+
+vi.mock("../tools/image-to-code-tool.js", () => ({
+  createImageToCodeTool: () => null,
+}));
+
+vi.mock("../tools/sessions-spawn-batch-tool.js", () => ({
+  createSessionsSpawnBatchTool: () => stubTool("sessions_spawn_batch"),
 }));
 
 vi.mock("../tools/web-tools.js", () => ({

--- a/src/agents/test-helpers/fast-core-tools.ts
+++ b/src/agents/test-helpers/fast-core-tools.ts
@@ -17,6 +17,16 @@ vi.mock("../tools/canvas-tool.js", () => ({
 
 vi.mock("../tools/image-tool.js", () => ({
   createImageTool: () => stubTool("image"),
+  resolveImageModelConfigForTool: () => null,
+  runImagePrompt: vi.fn(),
+}));
+
+vi.mock("../tools/image-to-code-tool.js", () => ({
+  createImageToCodeTool: () => null,
+}));
+
+vi.mock("../tools/sessions-spawn-batch-tool.js", () => ({
+  createSessionsSpawnBatchTool: () => stubTool("sessions_spawn_batch"),
 }));
 
 vi.mock("../tools/web-tools.js", () => ({

--- a/src/agents/tools/image-to-code-tool.test.ts
+++ b/src/agents/tools/image-to-code-tool.test.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenClawConfig } from "../../config/config.js";
+import { __testing, createImageToCodeTool } from "./image-to-code-tool.js";
+
+const { buildCodeGenPrompt, FRAMEWORK_INSTRUCTIONS } = __testing;
+
+describe("image_to_code prompt construction", () => {
+  it("builds html prompt by default", () => {
+    const prompt = buildCodeGenPrompt({ framework: "html" });
+    expect(prompt).toContain("Framework: html");
+    expect(prompt).toContain(FRAMEWORK_INSTRUCTIONS.html);
+    expect(prompt).toContain("production-quality code");
+  });
+
+  it("builds react prompt", () => {
+    const prompt = buildCodeGenPrompt({ framework: "react" });
+    expect(prompt).toContain("Framework: react");
+    expect(prompt).toContain("React component");
+  });
+
+  it("builds vue prompt", () => {
+    const prompt = buildCodeGenPrompt({ framework: "vue" });
+    expect(prompt).toContain("Framework: vue");
+    expect(prompt).toContain("Vue 3");
+    expect(prompt).toContain("<script setup");
+  });
+
+  it("builds astro prompt", () => {
+    const prompt = buildCodeGenPrompt({ framework: "astro" });
+    expect(prompt).toContain("Framework: astro");
+    expect(prompt).toContain("Astro component");
+  });
+
+  it("builds svelte prompt", () => {
+    const prompt = buildCodeGenPrompt({ framework: "svelte" });
+    expect(prompt).toContain("Framework: svelte");
+    expect(prompt).toContain("Svelte component");
+  });
+
+  it("builds tailwind prompt", () => {
+    const prompt = buildCodeGenPrompt({ framework: "tailwind" });
+    expect(prompt).toContain("Framework: tailwind");
+    expect(prompt).toContain("Tailwind CSS");
+  });
+
+  it("includes description when provided", () => {
+    const prompt = buildCodeGenPrompt({
+      framework: "html",
+      description: "A login form with email and password",
+    });
+    expect(prompt).toContain("Additional context: A login form with email and password");
+  });
+
+  it("omits description section when not provided", () => {
+    const prompt = buildCodeGenPrompt({ framework: "html" });
+    expect(prompt).not.toContain("Additional context");
+  });
+});
+
+describe("image_to_code tool creation", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_OAUTH_TOKEN", "");
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    vi.stubEnv("COPILOT_GITHUB_TOKEN", "");
+    vi.stubEnv("GH_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null without agentDir", () => {
+    expect(createImageToCodeTool({})).toBeNull();
+  });
+
+  it("returns null when no vision model auth available", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i2c-"));
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.2" } } },
+    };
+    expect(createImageToCodeTool({ config: cfg, agentDir })).toBeNull();
+  });
+
+  it("creates tool when vision model is configured", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i2c-"));
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          imageModel: { primary: "openai/gpt-5-mini" },
+        },
+      },
+    };
+    const tool = createImageToCodeTool({ config: cfg, agentDir });
+    expect(tool).not.toBeNull();
+    expect(tool?.name).toBe("image_to_code");
+  });
+
+  it("rejects remote URLs in sandboxed mode", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i2c-sandbox-"));
+    const agentDir = path.join(stateDir, "agent");
+    const sandboxRoot = path.join(stateDir, "sandbox");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(sandboxRoot, { recursive: true });
+
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          imageModel: { primary: "openai/gpt-5-mini" },
+        },
+      },
+    };
+    const tool = createImageToCodeTool({ config: cfg, agentDir, sandboxRoot });
+    expect(tool).not.toBeNull();
+    if (!tool) throw new Error("expected tool");
+
+    await expect(
+      tool.execute("t1", { image: "https://example.com/screenshot.png" }),
+    ).rejects.toThrow(/does not allow remote URLs/i);
+  });
+
+  it("rejects sandbox-escaping paths", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i2c-sandbox-"));
+    const agentDir = path.join(stateDir, "agent");
+    const sandboxRoot = path.join(stateDir, "sandbox");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(sandboxRoot, { recursive: true });
+
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          imageModel: { primary: "openai/gpt-5-mini" },
+        },
+      },
+    };
+    const tool = createImageToCodeTool({ config: cfg, agentDir, sandboxRoot });
+    expect(tool).not.toBeNull();
+    if (!tool) throw new Error("expected tool");
+
+    await expect(tool.execute("t1", { image: "../escape.png" })).rejects.toThrow(
+      /escapes sandbox root/i,
+    );
+  });
+
+  it("defaults framework to html", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i2c-"));
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          imageModel: { primary: "openai/gpt-5-mini" },
+        },
+      },
+    };
+    const tool = createImageToCodeTool({ config: cfg, agentDir });
+    expect(tool).not.toBeNull();
+    // Tool exists and has correct name — framework default is tested at prompt level
+    expect(tool?.name).toBe("image_to_code");
+  });
+});

--- a/src/agents/tools/image-to-code-tool.ts
+++ b/src/agents/tools/image-to-code-tool.ts
@@ -1,0 +1,174 @@
+import { Type } from "@sinclair/typebox";
+
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveUserPath } from "../../utils.js";
+import { loadWebMedia } from "../../web/media.js";
+import { assertSandboxPath } from "../sandbox-paths.js";
+import { optionalStringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
+import { coerceImageModelConfig, decodeDataUrl } from "./image-tool.helpers.js";
+import { resolveImageModelConfigForTool, runImagePrompt } from "./image-tool.js";
+
+const SUPPORTED_FRAMEWORKS = ["html", "react", "vue", "astro", "svelte", "tailwind"] as const;
+type Framework = (typeof SUPPORTED_FRAMEWORKS)[number];
+
+const FRAMEWORK_INSTRUCTIONS: Record<Framework, string> = {
+  html: "Generate vanilla HTML and CSS. Use inline styles or a <style> block. The output should be a single self-contained HTML file.",
+  react:
+    "Generate a React component using JSX. Use CSS Modules, inline styles, or a co-located CSS approach. Export the component as the default export.",
+  vue: 'Generate a Vue 3 Single File Component (SFC) with <template>, <script setup lang="ts">, and <style scoped> sections.',
+  astro:
+    "Generate an Astro component with frontmatter (---) for imports/logic and the template below. Use scoped <style> tags.",
+  svelte:
+    'Generate a Svelte component with <script lang="ts">, the template markup, and a <style> block.',
+  tailwind:
+    "Generate HTML using Tailwind CSS utility classes. Do not use custom CSS — rely entirely on Tailwind utilities for styling.",
+};
+
+function buildCodeGenPrompt(params: { framework: Framework; description?: string }): string {
+  const frameworkInstructions = FRAMEWORK_INSTRUCTIONS[params.framework];
+  const parts = [
+    "You are an expert frontend developer. Convert the provided screenshot/mockup into clean, production-quality code.",
+    "",
+    `Framework: ${params.framework}`,
+    frameworkInstructions,
+    "",
+    "Requirements:",
+    "- Reproduce the visual layout, colors, typography, and spacing as closely as possible.",
+    "- Use semantic HTML elements where appropriate.",
+    "- Make the output responsive where reasonable.",
+    "- Output ONLY the code — no explanations, no markdown fences, no commentary.",
+  ];
+  if (params.description) {
+    parts.push("", `Additional context: ${params.description}`);
+  }
+  return parts.join("\n");
+}
+
+const ImageToCodeToolSchema = Type.Object({
+  image: Type.String(),
+  framework: optionalStringEnum(SUPPORTED_FRAMEWORKS, {
+    description: "Target framework (default: html)",
+  }),
+  description: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+});
+
+export function createImageToCodeTool(options?: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+  sandboxRoot?: string;
+}): AnyAgentTool | null {
+  const agentDir = options?.agentDir?.trim();
+  if (!agentDir) {
+    const explicit = coerceImageModelConfig(options?.config);
+    if (explicit.primary?.trim() || (explicit.fallbacks?.length ?? 0) > 0) {
+      throw new Error("createImageToCodeTool requires agentDir when enabled");
+    }
+    return null;
+  }
+  const imageModelConfig = resolveImageModelConfigForTool({
+    cfg: options?.config,
+    agentDir,
+  });
+  if (!imageModelConfig) return null;
+
+  return {
+    label: "Image to Code",
+    name: "image_to_code",
+    description:
+      "Convert a screenshot or UI mockup into code. Supports html, react, vue, astro, svelte, and tailwind frameworks.",
+    parameters: ImageToCodeToolSchema,
+    execute: async (_toolCallId, args) => {
+      const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+      const imageRawInput = typeof record.image === "string" ? record.image.trim() : "";
+      const imageRaw = imageRawInput.startsWith("@")
+        ? imageRawInput.slice(1).trim()
+        : imageRawInput;
+      if (!imageRaw) throw new Error("image required");
+
+      const framework: Framework =
+        typeof record.framework === "string" &&
+        SUPPORTED_FRAMEWORKS.includes(record.framework as Framework)
+          ? (record.framework as Framework)
+          : "html";
+      const description =
+        typeof record.description === "string" && record.description.trim()
+          ? record.description.trim()
+          : undefined;
+      const modelOverride =
+        typeof record.model === "string" && record.model.trim() ? record.model.trim() : undefined;
+
+      const isDataUrl = /^data:/i.test(imageRaw);
+      const isHttpUrl = /^https?:\/\//i.test(imageRaw);
+      const sandboxRoot = options?.sandboxRoot?.trim();
+
+      if (sandboxRoot && isHttpUrl) {
+        throw new Error("Sandboxed image_to_code does not allow remote URLs.");
+      }
+
+      // Resolve the image path (same logic as image-tool)
+      const resolvedImage = (() => {
+        if (sandboxRoot) return imageRaw;
+        if (imageRaw.startsWith("~")) return resolveUserPath(imageRaw);
+        return imageRaw;
+      })();
+
+      let resolvedPath: string | null = null;
+      if (!isDataUrl) {
+        if (sandboxRoot) {
+          const out = await assertSandboxPath({
+            filePath: resolvedImage.startsWith("file://")
+              ? resolvedImage.slice("file://".length)
+              : resolvedImage,
+            cwd: sandboxRoot,
+            root: sandboxRoot,
+          });
+          resolvedPath = out.resolved;
+        } else {
+          resolvedPath = resolvedImage.startsWith("file://")
+            ? resolvedImage.slice("file://".length)
+            : resolvedImage;
+        }
+      }
+
+      const media = isDataUrl
+        ? decodeDataUrl(resolvedImage)
+        : await loadWebMedia(resolvedPath ?? resolvedImage);
+      if (media.kind !== "image") {
+        throw new Error(`Unsupported media type: ${media.kind}`);
+      }
+
+      const mimeType =
+        ("contentType" in media && media.contentType) ||
+        ("mimeType" in media && media.mimeType) ||
+        "image/png";
+      const base64 = media.buffer.toString("base64");
+
+      const prompt = buildCodeGenPrompt({ framework, description });
+
+      const result = await runImagePrompt({
+        cfg: options?.config,
+        agentDir,
+        imageModelConfig,
+        modelOverride,
+        prompt,
+        base64,
+        mimeType,
+      });
+
+      return {
+        content: [{ type: "text", text: result.text }],
+        details: {
+          model: `${result.provider}/${result.model}`,
+          framework,
+          image: resolvedImage,
+          attempts: result.attempts,
+        },
+      };
+    },
+  };
+}
+
+// Exported for testing
+export const __testing = { buildCodeGenPrompt, FRAMEWORK_INSTRUCTIONS } as const;

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -205,7 +205,7 @@ async function resolveSandboxedImagePath(params: {
   }
 }
 
-async function runImagePrompt(params: {
+export async function runImagePrompt(params: {
   cfg?: OpenClawConfig;
   agentDir: string;
   imageModelConfig: ImageModelConfig;

--- a/src/agents/tools/sessions-spawn-batch-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-batch-tool.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({
+    agents: { defaults: {} },
+    sessions: { main: { key: "agent:test-agent:main" } },
+  }),
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({ runId: "mock-run-id" }),
+}));
+
+vi.mock("../subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: () => "mock-system-prompt",
+}));
+
+vi.mock("../subagent-registry.js", () => ({
+  registerSubagentRun: vi.fn(),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  isSubagentSessionKey: (key: string) => key.includes(":subagent:"),
+  normalizeAgentId: (id: string) => id ?? "test-agent",
+  parseAgentSessionKey: (key: string) => {
+    const match = /^agent:([^:]+)/.exec(key);
+    return match ? { agentId: match[1] } : null;
+  },
+}));
+
+vi.mock("../../utils/delivery-context.js", () => ({
+  normalizeDeliveryContext: () => ({ channel: "discord" }),
+}));
+
+vi.mock("./sessions-helpers.js", () => ({
+  resolveMainSessionAlias: () => ({
+    mainKey: "agent:test-agent:main",
+    alias: "agent:test-agent:main",
+  }),
+  resolveInternalSessionKey: ({ key }: { key: string }) => key,
+  resolveDisplaySessionKey: ({ key }: { key: string }) => key,
+}));
+
+vi.mock("../agent-scope.js", () => ({
+  resolveAgentConfig: () => null,
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerSubagentRun } from "../subagent-registry.js";
+import { createSessionsSpawnBatchTool } from "./sessions-spawn-batch-tool.js";
+
+const mockedCallGateway = vi.mocked(callGateway);
+const mockedRegister = vi.mocked(registerSubagentRun);
+
+describe("sessions_spawn_batch tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCallGateway.mockResolvedValue({ runId: "mock-run-id" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("spawns multiple tasks in parallel", async () => {
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:main",
+    });
+    const result = await tool.execute("tc1", {
+      tasks: [
+        { task: "Research topic A" },
+        { task: "Research topic B", label: "topic-b" },
+        { task: "Research topic C" },
+      ],
+    });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+
+    expect(parsed.status).toBe("accepted");
+    expect(parsed.total).toBe(3);
+    expect(parsed.accepted).toBe(3);
+    expect(parsed.failed).toBe(0);
+    expect(parsed.results).toHaveLength(3);
+    // Each spawn calls gateway twice (sessions.patch is skipped when no model, so only "agent")
+    expect(mockedCallGateway).toHaveBeenCalledTimes(3);
+    expect(mockedRegister).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects empty tasks array", async () => {
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:main",
+    });
+    const result = await tool.execute("tc1", { tasks: [] });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+    expect(parsed.status).toBe("error");
+    expect(parsed.error).toContain("required");
+  });
+
+  it("rejects more than 10 tasks", async () => {
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:main",
+    });
+    const tasks = Array.from({ length: 11 }, (_, i) => ({ task: `Task ${i}` }));
+    const result = await tool.execute("tc1", { tasks });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+    expect(parsed.status).toBe("error");
+    expect(parsed.error).toContain("exceeds maximum");
+  });
+
+  it("blocks subagent-from-subagent spawning", async () => {
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:subagent:child-123",
+    });
+    const result = await tool.execute("tc1", {
+      tasks: [{ task: "Do something" }],
+    });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+    expect(parsed.status).toBe("forbidden");
+    expect(parsed.error).toContain("sub-agent");
+  });
+
+  it("handles partial failures gracefully", async () => {
+    let callCount = 0;
+    mockedCallGateway.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 2) throw new Error("gateway timeout");
+      return { runId: `run-${callCount}` };
+    });
+
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:main",
+    });
+    const result = await tool.execute("tc1", {
+      tasks: [{ task: "Task A" }, { task: "Task B" }, { task: "Task C" }],
+    });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+
+    expect(parsed.status).toBe("partial");
+    expect(parsed.total).toBe(3);
+    // At least some accepted, at least one failed
+    expect(parsed.accepted + parsed.failed).toBe(3);
+    expect(parsed.failed).toBeGreaterThan(0);
+  });
+
+  it("preserves label in results", async () => {
+    const tool = createSessionsSpawnBatchTool({
+      agentSessionKey: "agent:test-agent:main",
+    });
+    const result = await tool.execute("tc1", {
+      tasks: [{ task: "Task A", label: "research" }, { task: "Task B" }],
+    });
+    const parsed = JSON.parse(
+      (result.content?.find((b) => b.type === "text") as { text: string })?.text ?? "{}",
+    );
+    expect(parsed.results[0].label).toBe("research");
+    expect(parsed.results[1].label).toBeUndefined();
+  });
+});

--- a/src/agents/tools/sessions-spawn-batch-tool.ts
+++ b/src/agents/tools/sessions-spawn-batch-tool.ts
@@ -1,0 +1,134 @@
+import { Type } from "@sinclair/typebox";
+
+import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { optionalStringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult } from "./common.js";
+import {
+  resolveSpawnContext,
+  spawnSingleSubagent,
+  type SpawnOpts,
+  type SpawnResult,
+} from "./sessions-spawn-core.js";
+
+const MAX_BATCH_TASKS = 10;
+
+const SessionsSpawnBatchToolSchema = Type.Object({
+  tasks: Type.Array(
+    Type.Object({
+      task: Type.String(),
+      label: Type.Optional(Type.String()),
+      model: Type.Optional(Type.String()),
+      thinking: Type.Optional(Type.String()),
+      runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+      cleanup: optionalStringEnum(["delete", "keep"] as const),
+    }),
+    { minItems: 1, maxItems: MAX_BATCH_TASKS },
+  ),
+});
+
+export type BatchSpawnResultEntry = {
+  label?: string;
+  index: number;
+} & SpawnResult;
+
+export function createSessionsSpawnBatchTool(opts?: {
+  agentSessionKey?: string;
+  agentChannel?: GatewayMessageChannel;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  agentGroupId?: string | null;
+  agentGroupChannel?: string | null;
+  agentGroupSpace?: string | null;
+  sandboxed?: boolean;
+  requesterAgentIdOverride?: string;
+}): AnyAgentTool {
+  return {
+    label: "Sessions",
+    name: "sessions_spawn_batch",
+    description:
+      "Spawn multiple background sub-agent runs in parallel. Each task runs in an isolated session. Results are announced back to the requester chat.",
+    parameters: SessionsSpawnBatchToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const rawTasks = params.tasks;
+      if (!Array.isArray(rawTasks) || rawTasks.length === 0) {
+        return jsonResult({
+          status: "error",
+          error: "tasks array is required and must not be empty",
+        });
+      }
+      if (rawTasks.length > MAX_BATCH_TASKS) {
+        return jsonResult({
+          status: "error",
+          error: `Too many tasks: ${rawTasks.length} exceeds maximum of ${MAX_BATCH_TASKS}`,
+        });
+      }
+
+      const spawnOpts: SpawnOpts = {
+        agentSessionKey: opts?.agentSessionKey,
+        agentChannel: opts?.agentChannel,
+        agentAccountId: opts?.agentAccountId,
+        agentTo: opts?.agentTo,
+        agentThreadId: opts?.agentThreadId,
+        agentGroupId: opts?.agentGroupId,
+        agentGroupChannel: opts?.agentGroupChannel,
+        agentGroupSpace: opts?.agentGroupSpace,
+        sandboxed: opts?.sandboxed,
+        requesterAgentIdOverride: opts?.requesterAgentIdOverride,
+      };
+
+      const ctx = resolveSpawnContext(spawnOpts);
+      if (ctx.forbidden) {
+        return jsonResult({ status: "forbidden", error: ctx.error });
+      }
+
+      const settled = await Promise.allSettled(
+        rawTasks.map(async (entry, index) => {
+          const t = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+          const task = typeof t.task === "string" ? t.task.trim() : "";
+          if (!task) throw new Error(`tasks[${index}].task is required`);
+
+          const label = typeof t.label === "string" ? t.label.trim() : "";
+          const model = typeof t.model === "string" ? t.model.trim() || undefined : undefined;
+          const thinking =
+            typeof t.thinking === "string" ? t.thinking.trim() || undefined : undefined;
+          const runTimeoutSeconds =
+            typeof t.runTimeoutSeconds === "number" && Number.isFinite(t.runTimeoutSeconds)
+              ? Math.max(0, Math.floor(t.runTimeoutSeconds))
+              : 0;
+          const cleanup =
+            t.cleanup === "keep" || t.cleanup === "delete"
+              ? (t.cleanup as "keep" | "delete")
+              : "keep";
+
+          const result = await spawnSingleSubagent(
+            { task, label, model, thinking, runTimeoutSeconds, cleanup },
+            ctx,
+          );
+
+          return { ...result, label: label || undefined, index } as BatchSpawnResultEntry;
+        }),
+      );
+
+      const results: BatchSpawnResultEntry[] = settled.map((outcome, index) => {
+        if (outcome.status === "fulfilled") return outcome.value;
+        const error =
+          outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+        return { status: "error" as const, error, index };
+      });
+
+      const accepted = results.filter((r) => r.status === "accepted").length;
+      const failed = results.length - accepted;
+
+      return jsonResult({
+        status: failed === 0 ? "accepted" : accepted === 0 ? "error" : "partial",
+        total: results.length,
+        accepted,
+        failed,
+        results,
+      });
+    },
+  };
+}

--- a/src/agents/tools/sessions-spawn-core.ts
+++ b/src/agents/tools/sessions-spawn-core.ts
@@ -1,0 +1,283 @@
+import crypto from "node:crypto";
+
+import { formatThinkingLevels, normalizeThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import {
+  isSubagentSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
+import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { resolveAgentConfig } from "../agent-scope.js";
+import { AGENT_LANE_SUBAGENT } from "../lanes.js";
+import { buildSubagentSystemPrompt } from "../subagent-announce.js";
+import { registerSubagentRun } from "../subagent-registry.js";
+import {
+  resolveDisplaySessionKey,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./sessions-helpers.js";
+
+export type SpawnOpts = {
+  agentSessionKey?: string;
+  agentChannel?: GatewayMessageChannel;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  agentGroupId?: string | null;
+  agentGroupChannel?: string | null;
+  agentGroupSpace?: string | null;
+  sandboxed?: boolean;
+  requesterAgentIdOverride?: string;
+};
+
+export type SpawnTaskParams = {
+  task: string;
+  label?: string;
+  agentId?: string;
+  model?: string;
+  thinking?: string;
+  runTimeoutSeconds?: number;
+  cleanup?: "delete" | "keep";
+};
+
+export type SpawnResult =
+  | {
+      status: "accepted";
+      childSessionKey: string;
+      runId: string;
+      modelApplied?: boolean;
+      warning?: string;
+    }
+  | {
+      status: "forbidden" | "error";
+      error: string;
+      childSessionKey?: string;
+      runId?: string;
+    };
+
+function splitModelRef(ref?: string) {
+  if (!ref) return { provider: undefined, model: undefined };
+  const trimmed = ref.trim();
+  if (!trimmed) return { provider: undefined, model: undefined };
+  const [provider, model] = trimmed.split("/", 2);
+  if (model) return { provider, model };
+  return { provider: undefined, model: trimmed };
+}
+
+function normalizeModelSelection(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const primary = (value as { primary?: unknown }).primary;
+  if (typeof primary === "string" && primary.trim()) return primary.trim();
+  return undefined;
+}
+
+export function resolveSpawnContext(opts: SpawnOpts) {
+  const cfg = loadConfig();
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterSessionKey = opts.agentSessionKey;
+  const requesterOrigin = normalizeDeliveryContext({
+    channel: opts.agentChannel,
+    accountId: opts.agentAccountId,
+    to: opts.agentTo,
+    threadId: opts.agentThreadId,
+  });
+
+  if (typeof requesterSessionKey === "string" && isSubagentSessionKey(requesterSessionKey)) {
+    return {
+      forbidden: true as const,
+      error: "sessions_spawn is not allowed from sub-agent sessions",
+    };
+  }
+
+  const requesterInternalKey = requesterSessionKey
+    ? resolveInternalSessionKey({ key: requesterSessionKey, alias, mainKey })
+    : alias;
+  const requesterDisplayKey = resolveDisplaySessionKey({
+    key: requesterInternalKey,
+    alias,
+    mainKey,
+  });
+  const requesterAgentId = normalizeAgentId(
+    opts.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
+  );
+
+  return {
+    forbidden: false as const,
+    cfg,
+    requesterSessionKey,
+    requesterOrigin,
+    requesterInternalKey,
+    requesterDisplayKey,
+    requesterAgentId,
+    opts,
+  };
+}
+
+export async function spawnSingleSubagent(
+  params: SpawnTaskParams,
+  ctx: {
+    cfg: OpenClawConfig;
+    requesterSessionKey?: string;
+    requesterOrigin: ReturnType<typeof normalizeDeliveryContext>;
+    requesterInternalKey: string;
+    requesterDisplayKey: string;
+    requesterAgentId: string;
+    opts: SpawnOpts;
+  },
+): Promise<SpawnResult> {
+  const {
+    task,
+    label = "",
+    agentId: requestedAgentId,
+    model: modelOverride,
+    thinking: thinkingOverrideRaw,
+    runTimeoutSeconds = 0,
+    cleanup = "keep",
+  } = params;
+  const {
+    cfg,
+    requesterSessionKey,
+    requesterOrigin,
+    requesterInternalKey,
+    requesterDisplayKey,
+    opts,
+  } = ctx;
+
+  const requesterAgentId = ctx.requesterAgentId;
+  const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+
+  if (targetAgentId !== requesterAgentId) {
+    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAny = allowAgents.some((value) => value.trim() === "*");
+    const normalizedTargetId = targetAgentId.toLowerCase();
+    const allowSet = new Set(
+      allowAgents
+        .filter((value) => value.trim() && value.trim() !== "*")
+        .map((value) => normalizeAgentId(value).toLowerCase()),
+    );
+    if (!allowAny && !allowSet.has(normalizedTargetId)) {
+      const allowedText = allowAny
+        ? "*"
+        : allowSet.size > 0
+          ? Array.from(allowSet).join(", ")
+          : "none";
+      return {
+        status: "forbidden",
+        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+      };
+    }
+  }
+
+  const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
+  const spawnedByKey = requesterInternalKey;
+  const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
+  const resolvedModel =
+    normalizeModelSelection(modelOverride) ??
+    normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+    normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
+
+  let modelWarning: string | undefined;
+  let modelApplied = false;
+
+  let thinkingOverride: string | undefined;
+  if (thinkingOverrideRaw) {
+    const normalized = normalizeThinkLevel(thinkingOverrideRaw);
+    if (!normalized) {
+      const { provider, model } = splitModelRef(resolvedModel);
+      const hint = formatThinkingLevels(provider, model);
+      return {
+        status: "error",
+        error: `Invalid thinking level "${thinkingOverrideRaw}". Use one of: ${hint}.`,
+      };
+    }
+    thinkingOverride = normalized;
+  }
+
+  if (resolvedModel) {
+    try {
+      await callGateway({
+        method: "sessions.patch",
+        params: { key: childSessionKey, model: resolvedModel },
+        timeoutMs: 10_000,
+      });
+      modelApplied = true;
+    } catch (err) {
+      const messageText =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+      const recoverable =
+        messageText.includes("invalid model") || messageText.includes("model not allowed");
+      if (!recoverable) {
+        return { status: "error", error: messageText, childSessionKey };
+      }
+      modelWarning = messageText;
+    }
+  }
+
+  const childSystemPrompt = buildSubagentSystemPrompt({
+    requesterSessionKey,
+    requesterOrigin,
+    childSessionKey,
+    label: label || undefined,
+    task,
+  });
+
+  const childIdem = crypto.randomUUID();
+  let childRunId: string = childIdem;
+  try {
+    const response = (await callGateway({
+      method: "agent",
+      params: {
+        message: task,
+        sessionKey: childSessionKey,
+        channel: requesterOrigin?.channel,
+        idempotencyKey: childIdem,
+        deliver: false,
+        lane: AGENT_LANE_SUBAGENT,
+        extraSystemPrompt: childSystemPrompt,
+        thinking: thinkingOverride,
+        timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
+        label: label || undefined,
+        spawnedBy: spawnedByKey,
+        groupId: opts.agentGroupId ?? undefined,
+        groupChannel: opts.agentGroupChannel ?? undefined,
+        groupSpace: opts.agentGroupSpace ?? undefined,
+      },
+      timeoutMs: 10_000,
+    })) as { runId?: string };
+    if (typeof response?.runId === "string" && response.runId) {
+      childRunId = response.runId;
+    }
+  } catch (err) {
+    const messageText =
+      err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+    return { status: "error", error: messageText, childSessionKey, runId: childRunId };
+  }
+
+  registerSubagentRun({
+    runId: childRunId,
+    childSessionKey,
+    requesterSessionKey: requesterInternalKey,
+    requesterOrigin,
+    requesterDisplayKey,
+    task,
+    cleanup,
+    label: label || undefined,
+    runTimeoutSeconds,
+  });
+
+  return {
+    status: "accepted",
+    childSessionKey,
+    runId: childRunId,
+    modelApplied: resolvedModel ? modelApplied : undefined,
+    warning: modelWarning,
+  };
+}

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,29 +1,10 @@
-import crypto from "node:crypto";
-
 import { Type } from "@sinclair/typebox";
 
-import { formatThinkingLevels, normalizeThinkLevel } from "../../auto-reply/thinking.js";
-import { loadConfig } from "../../config/config.js";
-import { callGateway } from "../../gateway/call.js";
-import {
-  isSubagentSessionKey,
-  normalizeAgentId,
-  parseAgentSessionKey,
-} from "../../routing/session-key.js";
-import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-import { resolveAgentConfig } from "../agent-scope.js";
-import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import { optionalStringEnum } from "../schema/typebox.js";
-import { buildSubagentSystemPrompt } from "../subagent-announce.js";
-import { registerSubagentRun } from "../subagent-registry.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
-import {
-  resolveDisplaySessionKey,
-  resolveInternalSessionKey,
-  resolveMainSessionAlias,
-} from "./sessions-helpers.js";
+import { resolveSpawnContext, spawnSingleSubagent, type SpawnOpts } from "./sessions-spawn-core.js";
 
 const SessionsSpawnToolSchema = Type.Object({
   task: Type.String(),
@@ -36,26 +17,6 @@ const SessionsSpawnToolSchema = Type.Object({
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
 });
-
-function splitModelRef(ref?: string) {
-  if (!ref) return { provider: undefined, model: undefined };
-  const trimmed = ref.trim();
-  if (!trimmed) return { provider: undefined, model: undefined };
-  const [provider, model] = trimmed.split("/", 2);
-  if (model) return { provider, model };
-  return { provider: undefined, model: trimmed };
-}
-
-function normalizeModelSelection(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed || undefined;
-  }
-  if (!value || typeof value !== "object") return undefined;
-  const primary = (value as { primary?: unknown }).primary;
-  if (typeof primary === "string" && primary.trim()) return primary.trim();
-  return undefined;
-}
 
 export function createSessionsSpawnTool(opts?: {
   agentSessionKey?: string;
@@ -87,12 +48,6 @@ export function createSessionsSpawnTool(opts?: {
         params.cleanup === "keep" || params.cleanup === "delete"
           ? (params.cleanup as "keep" | "delete")
           : "keep";
-      const requesterOrigin = normalizeDeliveryContext({
-        channel: opts?.agentChannel,
-        accountId: opts?.agentAccountId,
-        to: opts?.agentTo,
-        threadId: opts?.agentThreadId,
-      });
       const runTimeoutSeconds = (() => {
         const explicit =
           typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
@@ -105,165 +60,39 @@ export function createSessionsSpawnTool(opts?: {
             : undefined;
         return legacy ?? 0;
       })();
-      let modelWarning: string | undefined;
-      let modelApplied = false;
 
-      const cfg = loadConfig();
-      const { mainKey, alias } = resolveMainSessionAlias(cfg);
-      const requesterSessionKey = opts?.agentSessionKey;
-      if (typeof requesterSessionKey === "string" && isSubagentSessionKey(requesterSessionKey)) {
-        return jsonResult({
-          status: "forbidden",
-          error: "sessions_spawn is not allowed from sub-agent sessions",
-        });
+      const spawnOpts: SpawnOpts = {
+        agentSessionKey: opts?.agentSessionKey,
+        agentChannel: opts?.agentChannel,
+        agentAccountId: opts?.agentAccountId,
+        agentTo: opts?.agentTo,
+        agentThreadId: opts?.agentThreadId,
+        agentGroupId: opts?.agentGroupId,
+        agentGroupChannel: opts?.agentGroupChannel,
+        agentGroupSpace: opts?.agentGroupSpace,
+        sandboxed: opts?.sandboxed,
+        requesterAgentIdOverride: opts?.requesterAgentIdOverride,
+      };
+
+      const ctx = resolveSpawnContext(spawnOpts);
+      if (ctx.forbidden) {
+        return jsonResult({ status: "forbidden", error: ctx.error });
       }
-      const requesterInternalKey = requesterSessionKey
-        ? resolveInternalSessionKey({
-            key: requesterSessionKey,
-            alias,
-            mainKey,
-          })
-        : alias;
-      const requesterDisplayKey = resolveDisplaySessionKey({
-        key: requesterInternalKey,
-        alias,
-        mainKey,
-      });
 
-      const requesterAgentId = normalizeAgentId(
-        opts?.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
+      const result = await spawnSingleSubagent(
+        {
+          task,
+          label,
+          agentId: requestedAgentId,
+          model: modelOverride,
+          thinking: thinkingOverrideRaw,
+          runTimeoutSeconds,
+          cleanup,
+        },
+        ctx,
       );
-      const targetAgentId = requestedAgentId
-        ? normalizeAgentId(requestedAgentId)
-        : requesterAgentId;
-      if (targetAgentId !== requesterAgentId) {
-        const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-        const allowAny = allowAgents.some((value) => value.trim() === "*");
-        const normalizedTargetId = targetAgentId.toLowerCase();
-        const allowSet = new Set(
-          allowAgents
-            .filter((value) => value.trim() && value.trim() !== "*")
-            .map((value) => normalizeAgentId(value).toLowerCase()),
-        );
-        if (!allowAny && !allowSet.has(normalizedTargetId)) {
-          const allowedText = allowAny
-            ? "*"
-            : allowSet.size > 0
-              ? Array.from(allowSet).join(", ")
-              : "none";
-          return jsonResult({
-            status: "forbidden",
-            error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
-          });
-        }
-      }
-      const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
-      const spawnedByKey = requesterInternalKey;
-      const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
-      const resolvedModel =
-        normalizeModelSelection(modelOverride) ??
-        normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
-        normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
-      let thinkingOverride: string | undefined;
-      if (thinkingOverrideRaw) {
-        const normalized = normalizeThinkLevel(thinkingOverrideRaw);
-        if (!normalized) {
-          const { provider, model } = splitModelRef(resolvedModel);
-          const hint = formatThinkingLevels(provider, model);
-          return jsonResult({
-            status: "error",
-            error: `Invalid thinking level "${thinkingOverrideRaw}". Use one of: ${hint}.`,
-          });
-        }
-        thinkingOverride = normalized;
-      }
-      if (resolvedModel) {
-        try {
-          await callGateway({
-            method: "sessions.patch",
-            params: { key: childSessionKey, model: resolvedModel },
-            timeoutMs: 10_000,
-          });
-          modelApplied = true;
-        } catch (err) {
-          const messageText =
-            err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-          const recoverable =
-            messageText.includes("invalid model") || messageText.includes("model not allowed");
-          if (!recoverable) {
-            return jsonResult({
-              status: "error",
-              error: messageText,
-              childSessionKey,
-            });
-          }
-          modelWarning = messageText;
-        }
-      }
-      const childSystemPrompt = buildSubagentSystemPrompt({
-        requesterSessionKey,
-        requesterOrigin,
-        childSessionKey,
-        label: label || undefined,
-        task,
-      });
 
-      const childIdem = crypto.randomUUID();
-      let childRunId: string = childIdem;
-      try {
-        const response = (await callGateway({
-          method: "agent",
-          params: {
-            message: task,
-            sessionKey: childSessionKey,
-            channel: requesterOrigin?.channel,
-            idempotencyKey: childIdem,
-            deliver: false,
-            lane: AGENT_LANE_SUBAGENT,
-            extraSystemPrompt: childSystemPrompt,
-            thinking: thinkingOverride,
-            timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
-            label: label || undefined,
-            spawnedBy: spawnedByKey,
-            groupId: opts?.agentGroupId ?? undefined,
-            groupChannel: opts?.agentGroupChannel ?? undefined,
-            groupSpace: opts?.agentGroupSpace ?? undefined,
-          },
-          timeoutMs: 10_000,
-        })) as { runId?: string };
-        if (typeof response?.runId === "string" && response.runId) {
-          childRunId = response.runId;
-        }
-      } catch (err) {
-        const messageText =
-          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-        return jsonResult({
-          status: "error",
-          error: messageText,
-          childSessionKey,
-          runId: childRunId,
-        });
-      }
-
-      registerSubagentRun({
-        runId: childRunId,
-        childSessionKey,
-        requesterSessionKey: requesterInternalKey,
-        requesterOrigin,
-        requesterDisplayKey,
-        task,
-        cleanup,
-        label: label || undefined,
-        runTimeoutSeconds,
-      });
-
-      return jsonResult({
-        status: "accepted",
-        childSessionKey,
-        runId: childRunId,
-        modelApplied: resolvedModel ? modelApplied : undefined,
-        warning: modelWarning,
-      });
+      return jsonResult(result);
     },
   };
 }

--- a/src/auto-reply/reply/subagents-utils.test.ts
+++ b/src/auto-reply/reply/subagents-utils.test.ts
@@ -59,4 +59,14 @@ describe("subagents utils", () => {
     expect(formatDurationShort(45_000)).toBe("45s");
     expect(formatDurationShort(65_000)).toBe("1m5s");
   });
+
+  it("formats zero duration as <1s instead of n/a", () => {
+    expect(formatDurationShort(0)).toBe("<1s");
+    expect(formatDurationShort(499)).toBe("<1s");
+  });
+
+  it("returns n/a for undefined/negative durations", () => {
+    expect(formatDurationShort(undefined)).toBe("n/a");
+    expect(formatDurationShort(-1)).toBe("n/a");
+  });
 });

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -2,8 +2,10 @@ import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import { truncateUtf16Safe } from "../../utils.js";
 
 export function formatDurationShort(valueMs?: number) {
-  if (!valueMs || !Number.isFinite(valueMs) || valueMs <= 0) return "n/a";
+  if (valueMs === undefined || valueMs === null || !Number.isFinite(valueMs) || valueMs < 0)
+    return "n/a";
   const totalSeconds = Math.round(valueMs / 1000);
+  if (totalSeconds === 0) return "<1s";
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;


### PR DESCRIPTION
## Summary

### Subagent announce stats fix (original)
- **`formatDurationShort()`**: Allow `0ms` as valid duration (sub-second tasks), display as `<1s` instead of `n/a`
- **`waitForSessionUsage()`**: Increase polling to 10x500ms (5s total) so token data persists before announce reads it
- **`readLatestAssistantReply()`**: Add retry loop (5x500ms) when transcript hasn't flushed yet

### Kimi K2.5 native features (#21)
- **`sessions_spawn_batch` tool**: Parallel batch spawning of subagents via `Promise.allSettled`. Max 10 tasks, partial failure handling, same guards as single spawn. Shared core logic extracted into `sessions-spawn-core.ts`.
- **`image_to_code` tool**: Convert screenshot/mockup to code using vision model. Supports html, react, vue, astro, svelte, tailwind frameworks. Uses existing `runImagePrompt` infrastructure.

### Kimi K2.5 reasoning_content fix
- **`wrapStreamFnForReasoningCompat()`**: Wraps `streamFn` with `onPayload` interceptor that ensures every assistant message includes the provider-specific reasoning field (e.g. `reasoning_content`) when any message in the conversation uses it. Kimi K2.5 requires this on ALL assistant messages when thinking is enabled, but pi-ai only adds it to messages with thinking blocks.
- **Model-based detection**: Force `reasoning_content` for Kimi K2.5 even on first interaction (no prior reasoning field to detect).
- **Payload-based safety net**: Also triggers when request payload has `reasoning_effort` or `thinking: { type: "enabled" }` params — bulletproof against model ID detection gaps.
- **12 unit tests** covering field detection, model hints, payload params, and edge cases.

### Exec tool hardening
- **Strip leading colons**: Kimi K2.5 sometimes prefixes tool call commands with `:` (e.g. `:which npx`). Added `params.command.replace(/^[\s:]+/, "")` to strip these artifacts before execution.

Closes #21

## Test plan

- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm build` passes (no type errors)
- [x] `pnpm test` passes (all reasoning-content-compat tests green: 12/12)
- [x] New unit tests for `sessions_spawn_batch` (5 tests)
- [x] New unit tests for `image_to_code` (10 tests)
- [x] New unit tests for `patchReasoningContentCompat` (12 tests)
- [x] Deployed to VM and verified healthy container
- [x] Verified mcporter, morgenmcp, and all MCP servers operational

🤖 Generated with [Claude Code](https://claude.com/claude-code)