### PR TITLE
fix(nodes-tool): add exec approval flow for agent tool run action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: allow `gpt-5.3-codex-spark` in forward-compat fallback, live model filtering, and thinking presets, and fix model-picker recognition for spark. (#14990) Thanks @L-U-C-K-Y.
 - OpenAI Codex/Auth: bridge OpenClaw OAuth profiles into `pi` `auth.json` so model discovery and models-list registry resolution can use Codex OAuth credentials. (#15184) Thanks @loiie45e.
 - Agents/Transcript policy: sanitize OpenAI/Codex tool-call ids during transcript policy normalization to prevent invalid tool-call identifiers from propagating into session history. (#15279) Thanks @divisonofficer.
+- Agents/Nodes: harden node exec approval decision handling in the `nodes` tool run path by failing closed on unexpected approval decisions, and add regression coverage for approval-required retry/deny/timeout flows. (#4726) Thanks @rmorse.
 - Models/Codex: resolve configured `openai-codex/gpt-5.3-codex-spark` through forward-compat fallback during `models list`, so it is not incorrectly tagged as missing when runtime resolution succeeds. (#15174) Thanks @loiie45e.
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
 - Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.


### PR DESCRIPTION
#### Summary

The agent-side nodes tool (`nodes-tool.ts`) did not handle the exec approval flow for `system.run` actions. When a node requires approval, the tool would fail with an unhandled `SYSTEM_RUN_DENIED` error instead of prompting the user.

This adds the same approval flow already present in the CLI `nodes run` path: try invoke, catch denial, request approval via gateway, retry with decision.

Fixes #4725

#### Repro Steps

1. Configure a node with exec approval enabled (`security: "allowlist"`, `ask: "on-miss"`)
2. Have an agent invoke `system.run` on that node via the nodes tool
3. Node responds with `SYSTEM_RUN_DENIED: approval required`
4. Tool throws unhandled error instead of requesting approval

#### Root Cause

The nodes tool's `run` action called `callGatewayTool("node.invoke", ...)` directly without handling the `SYSTEM_RUN_DENIED` sentinel. The CLI `nodes run` path already had this approval flow, but it was never added to the agent-side tool.

#### Behavior Changes

- When a node denies execution with `SYSTEM_RUN_DENIED: approval required`, the tool now creates a pending approval request via `exec.approval.request` (120s timeout)
- On approval: retries `node.invoke` with `approved: true` + `approvalDecision`
- On denial: throws `"exec denied: user denied"`
- On timeout: throws `"exec denied: approval timed out"`
- No change when nodes execute without requiring approval (direct execution as before)

#### Codebase and GitHub Search

- Searched for existing approval pattern: `bash-tools.exec.ts` lines 1125-1244 implement the same flow for gateway host
- Searched for `exec.approval.request` usage: used in `bash-tools.exec.ts` (gateway + node paths) and `discord/monitor/exec-approvals.ts`
- Reviewed `SYSTEM_RUN_DENIED` handling: exists in `node-host/runner.ts` as the sentinel for approval-required

#### Tests

- Existing approval flow tests pass: `exec-approval.test.ts`, `bash-tools.exec.approval-id.test.ts`, `nodes-cli.coverage.test.ts`
- `pnpm build` — clean
- `pnpm check` — clean (format + lint + typecheck)
- Fixed lint error: removed unnecessary type assertion flagged by `typescript-eslint(no-unnecessary-type-assertion)`

#### Manual Testing

### Prerequisites

- A paired node with exec approval enabled

### Steps

1. Agent invokes `system.run` on node with approval required → approval prompt appears in UI
2. Approve → command executes successfully
3. Deny → agent receives clear denial error
4. Agent invokes `system.run` on node without approval required → executes directly

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: AI-assisted with human review and direction
- Agent notes: lobster-biscuit. Localized change (1 file, ~62 lines added) that mirrors the established approval pattern from `bash-tools.exec.ts`.