### PR TITLE
feat(memory): use QAT embedding model as default

### DIFF
--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -43,7 +43,8 @@ export type EmbeddingProviderOptions = {
   };
 };
 
-const DEFAULT_LOCAL_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const DEFAULT_LOCAL_MODEL =
+  "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";
 
 function canAutoSelectLocal(options: EmbeddingProviderOptions): boolean {
   const modelPath = options.local?.modelPath?.trim();


### PR DESCRIPTION
## Summary

Switch default local embedding model from `embeddinggemma-300M` to `embeddinggemma-300m-qat` (Quantization Aware Training variant).

## Why

QAT (Quantization Aware Training) models are trained with quantization in mind, which typically yields better quality embeddings compared to post-training quantization. The model size is identical (Q8_0), but the training process accounts for quantization loss.

## Changes

- Updated `DEFAULT_LOCAL_MODEL` in `src/memory/embeddings.ts`

## Testing

- [x] Build passes
- Model available on HuggingFace: `ggml-org/embeddinggemma-300m-qat-q8_0-GGUF`