### PR TITLE
feat(tts): add outputFormat option for ElevenLabs

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -42,6 +42,8 @@ export type TtsConfig = {
     baseUrl?: string;
     voiceId?: string;
     modelId?: string;
+    /** Output format (e.g. mp3_22050_32, mp3_44100_128, pcm_16000, pcm_22050, pcm_24000). */
+    outputFormat?: string;
     seed?: number;
     applyTextNormalization?: "auto" | "on" | "off";
     languageCode?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -185,6 +185,7 @@ export const TtsConfigSchema = z
         baseUrl: z.string().optional(),
         voiceId: z.string().optional(),
         modelId: z.string().optional(),
+        outputFormat: z.string().optional(),
         seed: z.number().int().min(0).max(4294967295).optional(),
         applyTextNormalization: z.enum(["auto", "on", "off"]).optional(),
         languageCode: z.string().optional(),


### PR DESCRIPTION
## Summary

Adds configurable `outputFormat` for ElevenLabs TTS, allowing users to override the default `mp3_44100_128` format.

## Motivation

WhatsApp requires specific audio formats (24kHz, 48kbps, mono) that differ from the defaults. Currently, the ElevenLabs output format is hardcoded, making it impossible to use native TTS with WhatsApp without post-processing via ffmpeg.

## Changes

- Add `outputFormat` field to elevenlabs config in `types.tts.ts`
- Add `outputFormat` to zod schema validation in `zod-schema.core.ts`
- Use configured `outputFormat` in `tts.ts`, falling back to channel defaults
- Infer file extension from custom `outputFormat` when specified

## Example Config

```json
{
  "messages": {
    "tts": {
      "elevenlabs": {
        "outputFormat": "mp3_22050_32"
      }
    }
  }
}
```

## Testing

Tested locally with WhatsApp channel - audio now plays correctly when using a compatible output format.

## Related

ElevenLabs supported output formats: https://elevenlabs.io/docs/api-reference/text-to-speech#output-format