### PR TITLE
fix(agents): handle read alias required schema

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -174,13 +174,20 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
 
   if (!changed) return tool;
 
+  const nextSchema: Record<string, unknown> = {
+    ...schema,
+    properties,
+  };
+
+  if (required.length > 0) {
+    nextSchema.required = required;
+  } else if ("required" in nextSchema) {
+    delete nextSchema.required;
+  }
+
   return {
     ...tool,
-    parameters: {
-      ...schema,
-      properties,
-      ...(required.length > 0 ? { required } : {}),
-    },
+    parameters: nextSchema,
   };
 }
 


### PR DESCRIPTION
Fixed https://github.com/openclaw/openclaw/issues/2596 and tested.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `patchToolSchemaForClaudeCompatibility` in `src/agents/pi-tools.read.ts` to better handle tools whose JSON schema `required` list contains only the “original” parameter names (`path`/`oldText`/`newText`) after adding Claude-style aliases (`file_path`/`old_string`/`new_string`). Instead of always emitting `required` when non-empty, it now also *removes* the `required` key entirely when the filtered list becomes empty, preventing schemas with an empty `required: []` from being treated as invalid/overly strict by some consumers.

This fits into the tool-wrapper layer that normalizes Claude Code parameter conventions to pi-coding-agent conventions, and patches tool schemas so LLMs trained on Claude Code can call pi tools reliably.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and localized to schema-patching logic, preserves existing behavior when `required` remains non-empty, and fixes the specific edge case where an empty `required: []` would otherwise be retained/constructed. No runtime logic outside schema shaping is modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->