### PR TITLE
feat: add native NVIDIA NIM provider integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.1.29
+## 2026.1.30
 Status: stable.
 
 ### Changes
-- Rebrand: rename the npm package/CLI to `openclaw`, add a `openclaw` compatibility shim, and move extensions to the `@openclaw/*` scope.
+- Models: add native NVIDIA NIM provider integration with 14+ models including Llama 3.1/3.3, Nemotron 70B/253B, DeepSeek R1, Kimi K2.5, Mistral Large 2, and vision-capable models.
 - Onboarding: strengthen security warning copy for beta + access control expectations.
 - Onboarding: add Venice API key to non-interactive flow. (#1893) Thanks @jonisjongithub.
 - Config: auto-migrate legacy state/config paths and keep config resolution consistent across legacy filenames.

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -21,7 +21,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "nvidia-nim";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -120,6 +121,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "API key",
     choices: ["opencode-zen"],
   },
+  {
+    value: "nvidia-nim",
+    label: "NVIDIA NIM",
+    hint: "API key (Llama, Nemotron, DeepSeek, Kimi)",
+    choices: ["nvidia-nim-api-key"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -193,6 +200,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "nvidia-nim-api-key",
+    label: "NVIDIA NIM API key",
+    hint: "Llama, Nemotron, DeepSeek, Kimi via integrate.api.nvidia.com",
   });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice.apply.nvidia-nim.ts
+++ b/src/commands/auth-choice.apply.nvidia-nim.ts
@@ -1,0 +1,267 @@
+import { resolveEnvApiKey } from "../agents/model-auth.js";
+import { upsertSharedEnvVar } from "../infra/env-file.js";
+import {
+  formatApiKeyPreview,
+  normalizeApiKeyInput,
+  validateApiKeyInput,
+} from "./auth-choice.api-key.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+
+const NVIDIA_NIM_BASE_URL = "https://integrate.api.nvidia.com/v1";
+const NVIDIA_NIM_DEFAULT_MODEL_ID = "nvidia/llama-3.1-nemotron-70b-instruct";
+const NVIDIA_NIM_DEFAULT_MODEL_REF = `nvidia-nim/${NVIDIA_NIM_DEFAULT_MODEL_ID}`;
+const NVIDIA_NIM_DEFAULT_COST = {
+  input: 0.0004,
+  output: 0.0006,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+// Core NVIDIA NIM models catalog
+const NVIDIA_NIM_MODEL_CATALOG = [
+  {
+    id: "meta/llama-3.1-8b-instruct",
+    name: "Llama 3.1 8B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "meta/llama-3.1-70b-instruct",
+    name: "Llama 3.1 70B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "meta/llama-3.1-405b-instruct",
+    name: "Llama 3.1 405B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "meta/llama-3.3-70b-instruct",
+    name: "Llama 3.3 70B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: NVIDIA_NIM_DEFAULT_MODEL_ID,
+    name: "Nemotron 70B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+    name: "Nemotron Ultra 253B",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "nvidia/llama-3.3-nemotron-super-49b-v1",
+    name: "Nemotron Super 49B",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "deepseek-ai/deepseek-r1",
+    name: "DeepSeek R1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    compat: { supportsReasoningEffort: true },
+  },
+  {
+    id: "deepseek-ai/deepseek-v3.2",
+    name: "DeepSeek V3.2",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 8192,
+  },
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 16384,
+    compat: { supportsReasoningEffort: true },
+  },
+  {
+    id: "meta/llama-3.2-11b-vision-instruct",
+    name: "Llama 3.2 11B Vision",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "meta/llama-3.2-90b-vision-instruct",
+    name: "Llama 3.2 90B Vision",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "mistralai/mistral-large-2-instruct",
+    name: "Mistral Large 2",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+  },
+  {
+    id: "google/gemma-2-27b-it",
+    name: "Gemma 2 27B IT",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 8192,
+    maxTokens: 8192,
+  },
+] as const;
+
+type NvidiaNimCatalogEntry = (typeof NVIDIA_NIM_MODEL_CATALOG)[number];
+
+function buildNvidiaNimModelDefinition(entry: NvidiaNimCatalogEntry) {
+  const base = {
+    id: entry.id,
+    name: entry.name,
+    reasoning: entry.reasoning,
+    input: [...entry.input],
+    cost: NVIDIA_NIM_DEFAULT_COST,
+    contextWindow: entry.contextWindow,
+    maxTokens: entry.maxTokens,
+  };
+  const compat = (entry as { compat?: { supportsReasoningEffort?: boolean } }).compat;
+  return compat ? { ...base, compat } : base;
+}
+
+function applyNvidiaNimProviderConfig(cfg: Parameters<typeof applyNvidiaNimConfig>[0]["config"]) {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[NVIDIA_NIM_DEFAULT_MODEL_REF] = {
+    ...models[NVIDIA_NIM_DEFAULT_MODEL_REF],
+    alias: models[NVIDIA_NIM_DEFAULT_MODEL_REF]?.alias ?? "Nemotron 70B",
+  };
+
+  const providers = { ...cfg.models?.providers };
+  providers["nvidia-nim"] = {
+    baseUrl: NVIDIA_NIM_BASE_URL,
+    apiKey: "${NVIDIA_API_KEY}",
+    auth: "api-key",
+    api: "openai-completions",
+    headers: { Accept: "application/json" },
+    models: NVIDIA_NIM_MODEL_CATALOG.map(buildNvidiaNimModelDefinition),
+  };
+
+  return {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      providers,
+    },
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+function applyNvidiaNimConfig(params: ApplyAuthChoiceParams): ApplyAuthChoiceResult {
+  let nextConfig = applyNvidiaNimProviderConfig(params.config);
+  let agentModelOverride: string | undefined;
+
+  const existingModel = nextConfig.agents?.defaults?.model;
+  nextConfig = {
+    ...nextConfig,
+    agents: {
+      ...nextConfig.agents,
+      defaults: {
+        ...nextConfig.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? { fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks }
+            : undefined),
+          primary: NVIDIA_NIM_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+
+  if (!params.setDefaultModel && params.agentId) {
+    agentModelOverride = NVIDIA_NIM_DEFAULT_MODEL_REF;
+  }
+
+  return { config: nextConfig, agentModelOverride };
+}
+
+export async function applyAuthChoiceNvidiaNim(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "nvidia-nim-api-key") {
+    return null;
+  }
+
+  const envKey = resolveEnvApiKey("nvidia") ?? resolveEnvApiKey("nvidia-nim");
+  if (envKey) {
+    const useExisting = await params.prompter.confirm({
+      message: `Use existing NVIDIA_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+      initialValue: true,
+    });
+    if (useExisting) {
+      const result = upsertSharedEnvVar({
+        key: "NVIDIA_API_KEY",
+        value: envKey.apiKey,
+      });
+      if (!process.env.NVIDIA_API_KEY) {
+        process.env.NVIDIA_API_KEY = envKey.apiKey;
+      }
+      await params.prompter.note(
+        `Confirmed NVIDIA_API_KEY from ${envKey.source} for NIM integration.`,
+        "NVIDIA NIM",
+      );
+      return applyNvidiaNimConfig(params);
+    }
+  }
+
+  let key: string | undefined;
+  if (params.opts?.token && params.opts?.tokenProvider === "nvidia-nim") {
+    key = params.opts.token;
+  } else {
+    key = await params.prompter.text({
+      message: "Enter NVIDIA NIM API key (from build.nvidia.com)",
+      validate: validateApiKeyInput,
+    });
+  }
+
+  const trimmed = normalizeApiKeyInput(String(key));
+  const result = upsertSharedEnvVar({
+    key: "NVIDIA_API_KEY",
+    value: trimmed,
+  });
+  process.env.NVIDIA_API_KEY = trimmed;
+
+  await params.prompter.note(
+    `Saved NVIDIA_API_KEY to ${result.path}. Models available: Llama 3.1/3.3, Nemotron 70B/253B, DeepSeek R1, Kimi K2.5`,
+    "NVIDIA NIM configured",
+  );
+
+  return applyNvidiaNimConfig(params);
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -8,6 +8,7 @@ import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot
 import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-antigravity.js";
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
+import { applyAuthChoiceNvidiaNim } from "./auth-choice.apply.nvidia-nim.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
 import { applyAuthChoiceQwenPortal } from "./auth-choice.apply.qwen-portal.js";
@@ -46,6 +47,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
     applyAuthChoiceQwenPortal,
+    applyAuthChoiceNvidiaNim,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -32,6 +32,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "nvidia-nim-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -72,6 +73,7 @@ export type OnboardOptions = {
   minimaxApiKey?: string;
   syntheticApiKey?: string;
   veniceApiKey?: string;
+  nvidiaNimApiKey?: string;
   opencodeZenApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;


### PR DESCRIPTION
Adds native NVIDIA NIM provider integration with 14+ models including:\n\n- **Llama**: 3.1 8B/70B/405B, 3.3 70B\n- **NVIDIA Nemotron**: 70B, Ultra 253B, Super 49B\n- **DeepSeek**: R1 (reasoning), V3.2\n- **Moonshot**: Kimi K2.5 (vision + reasoning)\n- **Vision**: Llama 3.2 11B/90B Vision\n- **Others**: Mistral Large 2, Gemma 2 27B\n\nFeatures:\n- OpenAI-compatible API (integrate.api.nvidia.com/v1)\n- Reasoning support (--thinking flag)\n- Vision support for multimodal models\n- Full onboarding wizard integration\n\nCloses #XXXX