### PR TITLE
fix: Add UTF-8 encoding to SKILL.md read operation (fixes #4661)

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -20,7 +20,7 @@ def validate_skill(skill_path):
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding='utf-8')
     if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 


### PR DESCRIPTION
## Problem

Issue #4661 reported a `UnicodeDecodeError` when validating skills on Windows systems. The error occurred because:

1. The skill validation script reads `SKILL.md` files using `Path.read_text()` without specifying an encoding
2. On Windows systems with non-UTF-8 default encoding (e.g., GBK on Chinese Windows), Python defaults to the system encoding
3. When SKILL.md contains UTF-8 characters (like smart quotes, em dashes, or emoji), the GBK decoder fails

## Error
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x92 in position 822: illegal multibyte sequence
```

## Solution

Added explicit `encoding='utf-8'` parameter to the `read_text()` call in `quick_validate.py`:

```python
# Before
content = skill_md.read_text()

# After
content = skill_md.read_text(encoding='utf-8')
```

This ensures consistent UTF-8 handling across all platforms (Windows, macOS, Linux) regardless of system default encoding.

## Testing

- ✅ Python syntax validation passes
- ✅ One-line change, minimal risk
- ✅ Standard Python best practice for reading text files

## Related

Fixes #4661

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the skill validation helper (`skills/skill-creator/scripts/quick_validate.py`) to read `SKILL.md` with an explicit `encoding='utf-8'` when calling `Path.read_text()`. This makes skill validation consistent across platforms and prevents Windows-specific `UnicodeDecodeError` failures when the system default encoding is not UTF-8 (e.g., GBK).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line, narrowly scoped fix that removes platform-dependent default decoding for `SKILL.md` and matches the intended UTF-8 content encoding.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->