### PR TITLE
CLI: add --agent flag to models status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Status: stable.
 - Routing: add per-account DM session scope and document multi-account isolation. (#3095) Thanks @jarvis-sam.
 - Routing: precompile session key regexes. (#1697) Thanks @Ray0907.
 - CLI: use Node's module compile cache for faster startup. (#2808) Thanks @pi0.
+- CLI: add per-agent model status and auth order scoping. (#4780) Thanks @jlowin.
 - Auth: show copyable Google auth URL after ASCII prompt. (#1787) Thanks @robbyczgw-cla.
 - Agents: add Kimi K2.5 to the synthetic model catalog. (#4407) Thanks @manikv12.
 - TUI: avoid width overflow when rendering selection lists. (#1686) Thanks @mossein.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -27,6 +27,9 @@ When provider usage snapshots are available, the OAuth/token status section incl
 provider usage headers.
 Add `--probe` to run live auth probes against each configured provider profile.
 Probes are real requests (may consume tokens and trigger rate limits).
+Use `--agent <id>` to inspect a configured agent’s model/auth state. When omitted,
+the command uses `OPENCLAW_AGENT_DIR`/`PI_CODING_AGENT_DIR` if set, otherwise the
+configured default agent.
 
 Notes:
 - `models set <model-or-alias>` accepts `provider/model` or an alias.
@@ -44,6 +47,7 @@ Options:
 - `--probe-timeout <ms>`
 - `--probe-concurrency <n>`
 - `--probe-max-tokens <n>`
+- `--agent <id>` (configured agent id; overrides `OPENCLAW_AGENT_DIR`/`PI_CODING_AGENT_DIR`)
 
 ## Aliases + fallbacks
 

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,3 +1,5 @@
+import type { Command } from "commander";
+
 export type ManagerLookupResult<T> = {
   manager: T | null;
   error?: string;
@@ -45,4 +47,17 @@ export async function runCommandWithRuntime(
     runtime.error(String(err));
     runtime.exit(1);
   }
+}
+
+export function resolveOptionFromCommand<T>(
+  command: Command | undefined,
+  key: string,
+): T | undefined {
+  let current: Command | null | undefined = command;
+  while (current) {
+    const opts = (current.opts?.() ?? {}) as Record<string, T | undefined>;
+    if (opts[key] !== undefined) return opts[key];
+    current = current.parent ?? undefined;
+  }
+  return undefined;
 }

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const githubCopilotLoginCommand = vi.fn();
+const modelsStatusCommand = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("../commands/models.js", async () => {
   const actual = (await vi.importActual<typeof import("../commands/models.js")>(
@@ -10,10 +11,16 @@ vi.mock("../commands/models.js", async () => {
   return {
     ...actual,
     githubCopilotLoginCommand,
+    modelsStatusCommand,
   };
 });
 
 describe("models cli", () => {
+  beforeEach(() => {
+    githubCopilotLoginCommand.mockClear();
+    modelsStatusCommand.mockClear();
+  });
+
   it("registers github-copilot login command", { timeout: 60_000 }, async () => {
     const { Command } = await import("commander");
     const { registerModelsCli } = await import("./models-cli.js");
@@ -39,5 +46,52 @@ describe("models cli", () => {
       expect.objectContaining({ yes: true }),
       expect.any(Object),
     );
+  });
+
+  it("passes --agent to models status", async () => {
+    const { Command } = await import("commander");
+    const { registerModelsCli } = await import("./models-cli.js");
+
+    const program = new Command();
+    registerModelsCli(program);
+
+    await program.parseAsync(["models", "status", "--agent", "poe"], { from: "user" });
+
+    expect(modelsStatusCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "poe" }),
+      expect.any(Object),
+    );
+  });
+
+  it("passes parent --agent to models status", async () => {
+    const { Command } = await import("commander");
+    const { registerModelsCli } = await import("./models-cli.js");
+
+    const program = new Command();
+    registerModelsCli(program);
+
+    await program.parseAsync(["models", "--agent", "poe", "status"], { from: "user" });
+
+    expect(modelsStatusCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "poe" }),
+      expect.any(Object),
+    );
+  });
+
+  it("shows help for models auth without error exit", async () => {
+    const { Command } = await import("commander");
+    const { registerModelsCli } = await import("./models-cli.js");
+
+    const program = new Command();
+    program.exitOverride();
+    registerModelsCli(program);
+
+    try {
+      await program.parseAsync(["models", "auth"], { from: "user" });
+      expect.fail("expected help to exit");
+    } catch (err) {
+      const error = err as { exitCode?: number };
+      expect(error.exitCode).toBe(0);
+    }
   });
 });

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -29,7 +29,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
-import { runCommandWithRuntime } from "./cli-utils.js";
+import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
 
 function runModelsCommand(action: () => Promise<void>) {
   return runCommandWithRuntime(defaultRuntime, action);
@@ -41,7 +41,10 @@ export function registerModelsCli(program: Command) {
     .description("Model discovery, scanning, and configuration")
     .option("--status-json", "Output JSON (alias for `models status --json`)", false)
     .option("--status-plain", "Plain output (alias for `models status --plain`)", false)
-    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option(
+      "--agent <id>",
+      "Agent id to inspect (overrides OPENCLAW_AGENT_DIR/PI_CODING_AGENT_DIR)",
+    )
     .addHelpText(
       "after",
       () =>
@@ -86,8 +89,13 @@ export function registerModelsCli(program: Command) {
     .option("--probe-timeout <ms>", "Per-probe timeout in ms")
     .option("--probe-concurrency <n>", "Concurrent probes")
     .option("--probe-max-tokens <n>", "Probe max tokens (best-effort)")
-    .option("--agent <id>", "Agent id (default: configured default agent)")
-    .action(async (opts) => {
+    .option(
+      "--agent <id>",
+      "Agent id to inspect (overrides OPENCLAW_AGENT_DIR/PI_CODING_AGENT_DIR)",
+    )
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         await modelsStatusCommand(
           {
@@ -100,7 +108,7 @@ export function registerModelsCli(program: Command) {
             probeTimeout: opts.probeTimeout as string | undefined,
             probeConcurrency: opts.probeConcurrency as string | undefined,
             probeMaxTokens: opts.probeMaxTokens as string | undefined,
-            agent: opts.agent as string | undefined,
+            agent,
           },
           defaultRuntime,
         );
@@ -282,6 +290,10 @@ export function registerModelsCli(program: Command) {
   });
 
   const auth = models.command("auth").description("Manage model auth profiles");
+  auth.option("--agent <id>", "Agent id for auth order get/set/clear");
+  auth.action(() => {
+    auth.help();
+  });
 
   auth
     .command("add")
@@ -375,12 +387,14 @@ export function registerModelsCli(program: Command) {
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         await modelsAuthOrderGetCommand(
           {
             provider: opts.provider as string,
-            agent: opts.agent as string | undefined,
+            agent,
             json: Boolean(opts.json),
           },
           defaultRuntime,
@@ -394,12 +408,14 @@ export function registerModelsCli(program: Command) {
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .argument("<profileIds...>", "Auth profile ids (e.g. anthropic:default)")
-    .action(async (profileIds: string[], opts) => {
+    .action(async (profileIds: string[], opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         await modelsAuthOrderSetCommand(
           {
             provider: opts.provider as string,
-            agent: opts.agent as string | undefined,
+            agent,
             order: profileIds,
           },
           defaultRuntime,
@@ -412,12 +428,14 @@ export function registerModelsCli(program: Command) {
     .description("Clear per-agent auth order override (fall back to config/round-robin)")
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
     .option("--agent <id>", "Agent id (default: configured default agent)")
-    .action(async (opts) => {
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         await modelsAuthOrderClearCommand(
           {
             provider: opts.provider as string,
-            agent: opts.agent as string | undefined,
+            agent,
           },
           defaultRuntime,
         );

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -41,6 +41,7 @@ export function registerModelsCli(program: Command) {
     .description("Model discovery, scanning, and configuration")
     .option("--status-json", "Output JSON (alias for `models status --json`)", false)
     .option("--status-plain", "Plain output (alias for `models status --plain`)", false)
+    .option("--agent <id>", "Agent id (default: configured default agent)")
     .addHelpText(
       "after",
       () =>
@@ -85,6 +86,7 @@ export function registerModelsCli(program: Command) {
     .option("--probe-timeout <ms>", "Per-probe timeout in ms")
     .option("--probe-concurrency <n>", "Concurrent probes")
     .option("--probe-max-tokens <n>", "Probe max tokens (best-effort)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
     .action(async (opts) => {
       await runModelsCommand(async () => {
         await modelsStatusCommand(
@@ -98,6 +100,7 @@ export function registerModelsCli(program: Command) {
             probeTimeout: opts.probeTimeout as string | undefined,
             probeConcurrency: opts.probeConcurrency as string | undefined,
             probeMaxTokens: opts.probeMaxTokens as string | undefined,
+            agent: opts.agent as string | undefined,
           },
           defaultRuntime,
         );
@@ -271,6 +274,7 @@ export function registerModelsCli(program: Command) {
         {
           json: Boolean(opts?.statusJson),
           plain: Boolean(opts?.statusPlain),
+          agent: opts?.agent as string | undefined,
         },
         defaultRuntime,
       );

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -6,9 +6,9 @@ import {
 } from "../../agents/auth-profiles.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
+import { resolveKnownAgentId } from "./shared.js";
 
 function resolveTargetAgent(
   cfg: ReturnType<typeof loadConfig>,
@@ -17,7 +17,7 @@ function resolveTargetAgent(
   agentId: string;
   agentDir: string;
 } {
-  const agentId = raw?.trim() ? normalizeAgentId(raw.trim()) : resolveDefaultAgentId(cfg);
+  const agentId = resolveKnownAgentId({ cfg, rawAgentId: raw }) ?? resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   return { agentId, agentDir };
 }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -29,7 +29,8 @@ const mocks = vi.hoisted(() => {
 
   return {
     store,
-    resolveOpenClawAgentDir: vi.fn().mockReturnValue("/tmp/openclaw-agent"),
+    resolveAgentDir: vi.fn().mockReturnValue("/tmp/openclaw-agent"),
+    resolveDefaultAgentId: vi.fn().mockReturnValue("main"),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
     listProfilesForProvider: vi.fn((s: typeof store, provider: string) => {
       return Object.entries(s.profiles)
@@ -71,9 +72,18 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../agents/agent-paths.js", () => ({
-  resolveOpenClawAgentDir: mocks.resolveOpenClawAgentDir,
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentDir: mocks.resolveAgentDir,
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
 }));
+
+vi.mock("../../routing/session-key.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../routing/session-key.js")>();
+  return {
+    ...actual,
+    normalizeAgentId: (id: string) => id.toLowerCase().replace(/\s+/g, "-"),
+  };
+});
 
 vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
@@ -145,6 +155,23 @@ describe("modelsStatusCommand auth overview", () => {
     expect(
       (payload.auth.providersWithOAuth as string[]).some((e) => e.startsWith("openai-codex")),
     ).toBe(true);
+  });
+
+  it("resolves agent dir from --agent flag", async () => {
+    mocks.resolveAgentDir.mockReturnValue("/tmp/openclaw-agent-custom");
+    const localRuntime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    try {
+      await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime as never);
+      expect(mocks.resolveAgentDir).toHaveBeenCalledWith(expect.anything(), "jeremiah");
+      const payload = JSON.parse(String((localRuntime.log as vi.Mock).mock.calls[0][0]));
+      expect(payload.agentDir).toBe("/tmp/openclaw-agent-custom");
+    } finally {
+      mocks.resolveAgentDir.mockReturnValue("/tmp/openclaw-agent");
+    }
   });
 
   it("exits non-zero when auth is missing", async () => {

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -5,11 +5,14 @@ import {
   parseModelRef,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
+import { listAgentIds } from "../../agents/agent-scope.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import {
   type OpenClawConfig,
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../../config/config.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 
 export const ensureFlagCompatibility = (opts: { json?: boolean; plain?: boolean }) => {
   if (opts.json && opts.plain) {
@@ -80,6 +83,22 @@ export function normalizeAlias(alias: string): string {
     throw new Error("Alias must use letters, numbers, dots, underscores, colons, or dashes.");
   }
   return trimmed;
+}
+
+export function resolveKnownAgentId(params: {
+  cfg: OpenClawConfig;
+  rawAgentId?: string | null;
+}): string | undefined {
+  const raw = params.rawAgentId?.trim();
+  if (!raw) return undefined;
+  const agentId = normalizeAgentId(raw);
+  const knownAgents = listAgentIds(params.cfg);
+  if (!knownAgents.includes(agentId)) {
+    throw new Error(
+      `Unknown agent id "${raw}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+    );
+  }
+  return agentId;
 }
 
 export { modelKey };


### PR DESCRIPTION
`openclaw models status` always resolves the default agent's directory, so there's no way to inspect a named agent's auth profiles, models.json, or usage stats without overriding `OPENCLAW_AGENT_DIR`.

This adds `--agent <id>` to `models status` (and the bare `models` shortcut), following the same pattern already used by `models auth order get/set/clear`. When provided, the status command resolves the named agent's directory via `resolveAgentDir()` and shows that agent's auth store, profiles, and usage data.

```sh
openclaw models status --agent jeremiah
openclaw models status --agent jeremiah --json
```