### PR TITLE
hooks: use configured model for slug generator

### DIFF
--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,48 @@
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenClawConfig } from "../config/config.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+import { generateSlugViaLLM } from "./llm-slug-generator.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn(),
+}));
+
+describe("llm-slug-generator", () => {
+  it("uses the configured default model (not anthropic defaults)", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "api-design" }],
+        meta: {
+          durationMs: 1,
+          agentMeta: { sessionId: "s", provider: "openai", model: "gpt-4.1-mini" },
+        },
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: path.join(home, "workspace"),
+            model: { primary: "openai/gpt-4.1-mini" },
+          },
+        },
+      };
+
+      const slug = await generateSlugViaLLM({
+        sessionContent: "user: hello\nassistant: hi",
+        cfg,
+      });
+
+      expect(slug).toBe("api-design");
+
+      expect(runEmbeddedPiAgent).toHaveBeenCalledOnce();
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.provider).toBe("openai");
+      expect(call?.model).toBe("gpt-4.1-mini");
+    });
+  });
+});

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -26,6 +27,7 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+    const model = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -46,6 +48,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: model.provider,
+      model: model.model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
### Summary
`session-memory` can generate a human-friendly slug via an LLM call. When the provider/model is not explicitly specified, the slug generator may fall back to an Anthropic default, which is both noisy and can fail in deployments that only configure OpenAI.

### Changes
- Resolve the provider/model for slug generation from the configured defaults instead of relying on implicit fallback behavior.
- Add a regression test covering model resolution for the slug generator.

### Rationale
This avoids unintended Anthropic usage and prevents `No API key found for provider "anthropic"` errors during `/new` / `session-memory` runs when Anthropic is not configured.

### Testing
- `pnpm vitest run src/hooks/llm-slug-generator.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the session-memory slug generator to explicitly resolve the provider/model from the configured defaults (via `resolveDefaultModelForAgent`) and pass them into `runEmbeddedPiAgent`, avoiding implicit Anthropic fallback behavior. It also adds a regression test to ensure the slug generator honors the configured default model/provider (e.g., OpenAI) when Anthropic is not configured.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and covered by a focused regression test.
- The change is localized to slug generation and uses an existing model-resolution helper that already encodes repo defaults and overrides. Main risk is if callers previously relied on implicit model/provider selection inside `runEmbeddedPiAgent`, but the new behavior aligns with configured defaults and is exercised by a new unit test.
- src/hooks/llm-slug-generator.test.ts (ensuring the config shape used in the test matches supported config schemas) and src/hooks/llm-slug-generator.ts (confirming the new explicit provider/model doesn’t conflict with agent overrides).

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->