### PR TITLE
feat(telegram): add placeholder message while processing

### DIFF
--- a/src/auto-reply/reply/placeholder.ts
+++ b/src/auto-reply/reply/placeholder.ts
@@ -1,0 +1,121 @@
+/**
+ * Placeholder message controller for chat platforms.
+ *
+ * Sends a temporary "thinking" message when processing starts,
+ * then deletes or edits it when the actual response is ready.
+ */
+
+export type PlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Show tool names as they're called. Default: false. */
+  showTools?: boolean;
+  /** Tool message format. Default: "🔧 Using {tool}..." */
+  toolMessageFormat?: string;
+};
+
+export type PlaceholderSender = {
+  send: (text: string) => Promise<{ messageId: string; chatId: string }>;
+  edit: (messageId: string, text: string) => Promise<void>;
+  delete: (messageId: string) => Promise<void>;
+};
+
+export type PlaceholderController = {
+  /** Send initial placeholder message. */
+  start: () => Promise<void>;
+  /** Update placeholder with tool usage info. */
+  onTool: (toolName: string) => Promise<void>;
+  /** Clean up placeholder (delete or leave as-is). */
+  cleanup: () => Promise<void>;
+  /** Check if placeholder is active. */
+  isActive: () => boolean;
+};
+
+const DEFAULT_MESSAGES = [
+  "😈 Thinking...",
+  "🧠 Processing...",
+  "💭 Let me think...",
+  "⚡ Working on it...",
+];
+
+const DEFAULT_TOOL_FORMAT = "🔧 Using {tool}...";
+
+export function createPlaceholderController(params: {
+  config: PlaceholderConfig;
+  sender: PlaceholderSender;
+  log?: (message: string) => void;
+}): PlaceholderController {
+  const { config, sender, log } = params;
+
+  let placeholderMessageId: string | undefined;
+  let active = false;
+  let currentToolText = "";
+
+  const messages = config.messages?.length ? config.messages : DEFAULT_MESSAGES;
+  const toolFormat = config.toolMessageFormat ?? DEFAULT_TOOL_FORMAT;
+
+  const getRandomMessage = () => {
+    const idx = Math.floor(Math.random() * messages.length);
+    return messages[idx] ?? messages[0] ?? DEFAULT_MESSAGES[0];
+  };
+
+  const start = async () => {
+    if (!config.enabled) return;
+    if (active) return;
+
+    try {
+      const text = getRandomMessage();
+      const result = await sender.send(text);
+      placeholderMessageId = result.messageId;
+      active = true;
+      log?.(`Placeholder sent: ${result.messageId}`);
+    } catch (err) {
+      log?.(`Failed to send placeholder: ${err}`);
+    }
+  };
+
+  const onTool = async (toolName: string) => {
+    if (!config.enabled || !config.showTools) return;
+    if (!active || !placeholderMessageId) return;
+
+    try {
+      currentToolText = toolFormat.replace("{tool}", toolName);
+      await sender.edit(placeholderMessageId, currentToolText);
+      log?.(`Placeholder updated: ${toolName}`);
+    } catch (err) {
+      log?.(`Failed to update placeholder: ${err}`);
+    }
+  };
+
+  const cleanup = async () => {
+    if (!active || !placeholderMessageId) return;
+
+    const shouldDelete = config.deleteOnResponse !== false;
+
+    if (shouldDelete) {
+      try {
+        await sender.delete(placeholderMessageId);
+        log?.(`Placeholder deleted: ${placeholderMessageId}`);
+      } catch (err) {
+        log?.(`Failed to delete placeholder: ${err}`);
+      }
+    }
+
+    placeholderMessageId = undefined;
+    active = false;
+    currentToolText = "";
+  };
+
+  const isActive = () => active;
+
+  return {
+    start,
+    onTool,
+    cleanup,
+    isActive,
+  };
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,23 @@ export type TelegramActionConfig = {
   sticker?: boolean;
 };
 
+/**
+ * Placeholder message config - shows a temporary "thinking" message
+ * while processing, then deletes it when the response is ready.
+ */
+export type TelegramPlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Show tool names as they're called. Default: false. */
+  showTools?: boolean;
+  /** Tool message format. Use {tool} as placeholder. Default: "🔧 Using {tool}..." */
+  toolMessageFormat?: string;
+};
+
 export type TelegramNetworkConfig = {
   /** Override Node's autoSelectFamily behavior (true = enable, false = disable). */
   autoSelectFamily?: boolean;
@@ -130,6 +147,8 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /** Placeholder message shown while processing (thinking indicator). */
+  placeholder?: TelegramPlaceholderConfig;
 };
 
 export type TelegramTopicConfig = {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -9,6 +9,7 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { clearHistoryEntriesIfEnabled } from "../auto-reply/reply/history.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import { createPlaceholderController } from "../auto-reply/reply/placeholder.js";
 import { removeAckReactionAfterReply } from "../channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../channels/logging.js";
 import { createReplyPrefixContext } from "../channels/reply-prefix.js";
@@ -20,6 +21,7 @@ import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
+import { sendMessageTelegram, deleteMessageTelegram, editMessageTelegram } from "./send.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
@@ -209,6 +211,39 @@ export const dispatchTelegramMessage = async ({
     skippedNonSilent: 0,
   };
 
+  // Create placeholder controller if enabled
+  const placeholderConfig = telegramCfg.placeholder ?? {};
+  const placeholder = createPlaceholderController({
+    config: placeholderConfig,
+    sender: {
+      send: async (text) => {
+        const result = await sendMessageTelegram(String(chatId), text, {
+          token: opts.token,
+          messageThreadId: resolvedThreadId,
+          textMode: "html",
+        });
+        return { messageId: result.messageId, chatId: result.chatId };
+      },
+      edit: async (messageId, text) => {
+        await editMessageTelegram(String(chatId), Number(messageId), text, {
+          token: opts.token,
+          textMode: "html",
+        });
+      },
+      delete: async (messageId) => {
+        await deleteMessageTelegram(String(chatId), Number(messageId), {
+          token: opts.token,
+        });
+      },
+    },
+    log: logVerbose,
+  });
+
+  // Send placeholder immediately when processing starts
+  if (placeholderConfig.enabled) {
+    await placeholder.start();
+  }
+
   const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg,
@@ -219,6 +254,8 @@ export const dispatchTelegramMessage = async ({
         if (info.kind === "final") {
           await flushDraft();
           draftStream?.stop();
+          // Clean up placeholder before sending final reply
+          await placeholder.cleanup();
         }
         const result = await deliverReplies({
           replies: [payload],


### PR DESCRIPTION
## Summary
Adds a configurable placeholder/loading indicator for Telegram that shows while the agent is processing a message, then gets deleted when the actual response is ready.

## Motivation
- Users don't know if the bot received their message and is working
- Custom loading messages add personality (e.g., '😈 Thinking...')
- Shows progress for long-running tasks

Closes #3849

## Config
```json5
channels: {
  telegram: {
    placeholder: {
      enabled: true,
      messages: ['😈 Thinking...', '🧠 Processing...', '💭 Let me think...'],
      deleteOnResponse: true,  // default: true
      showTools: false,        // future: show tool names
      toolMessageFormat: '🔧 Using {tool}...'
    }
  }
}
```

## Behavior
1. User sends message
2. Bot immediately sends placeholder (randomly selected from `messages`)
3. Agent processes and generates response
4. Bot deletes placeholder message
5. Bot sends actual response

## Implementation
- New `PlaceholderController` in `src/auto-reply/reply/placeholder.ts`
- Config type `TelegramPlaceholderConfig` in `src/config/types.telegram.ts`
- Integration in `src/telegram/bot-message-dispatch.ts`

## Future work (separate PR)
- `showTools: true` - update placeholder to show tool names as they're called
- Support for other channels (Discord, etc.)

## Testing
- [ ] Manual testing with Telegram bot
- [ ] Unit tests for PlaceholderController