### PR TITLE
fix(slack): preserve case in target IDs

### DIFF
--- a/src/channels/plugins/directory-config.test.ts
+++ b/src/channels/plugins/directory-config.test.ts
@@ -31,10 +31,10 @@ describe("directory (config-backed)", () => {
       limit: null,
     });
     expect(peers?.map((e) => e.id).sort()).toEqual([
-      "user:u123",
-      "user:u234",
-      "user:u777",
-      "user:u999",
+      "user:U123",
+      "user:U234",
+      "user:U777",
+      "user:U999",
     ]);
 
     const groups = await listSlackDirectoryGroupsFromConfig({
@@ -43,7 +43,7 @@ describe("directory (config-backed)", () => {
       query: null,
       limit: null,
     });
-    expect(groups?.map((e) => e.id)).toEqual(["channel:c111"]);
+    expect(groups?.map((e) => e.id)).toEqual(["channel:C111"]);
   });
 
   it("lists Discord peers/groups from config (numeric ids only)", async () => {

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -16,7 +16,7 @@ export type MessagingTargetParseOptions = {
 };
 
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
-  return `${kind}:${id}`.toLowerCase();
+  return `${kind.toLowerCase()}:${id}`;
 }
 
 export function buildMessagingTarget(

--- a/src/slack/targets.test.ts
+++ b/src/slack/targets.test.ts
@@ -8,17 +8,17 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("<@U123>")).toMatchObject({
       kind: "user",
       id: "U123",
-      normalized: "user:u123",
+      normalized: "user:U123",
     });
     expect(parseSlackTarget("user:U456")).toMatchObject({
       kind: "user",
       id: "U456",
-      normalized: "user:u456",
+      normalized: "user:U456",
     });
     expect(parseSlackTarget("slack:U789")).toMatchObject({
       kind: "user",
       id: "U789",
-      normalized: "user:u789",
+      normalized: "user:U789",
     });
   });
 
@@ -26,12 +26,12 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("channel:C123")).toMatchObject({
       kind: "channel",
       id: "C123",
-      normalized: "channel:c123",
+      normalized: "channel:C123",
     });
     expect(parseSlackTarget("#C999")).toMatchObject({
       kind: "channel",
       id: "C999",
-      normalized: "channel:c999",
+      normalized: "channel:C999",
     });
   });
 
@@ -53,7 +53,8 @@ describe("resolveSlackChannelId", () => {
 });
 
 describe("normalizeSlackMessagingTarget", () => {
-  it("defaults raw ids to channels", () => {
-    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:c123");
+  it("defaults raw ids to channels and preserves case", () => {
+    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:C123");
+    expect(normalizeSlackMessagingTarget("C0ACC8J786L")).toBe("channel:C0ACC8J786L");
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #4751
- `normalizeTargetId()` was lowercasing entire target strings including Slack IDs
- Slack IDs are case-sensitive (e.g., `C0ACC8J786L`), so lowercasing breaks API calls
- Now only the prefix (`channel:`/`user:`) is lowercased, ID case is preserved

## Test plan
- [x] Updated existing tests to expect preserved case
- [x] All target-related tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts how messaging target IDs are normalized so that only the target kind prefix (e.g., `user:` / `channel:`) is lowercased while the ID portion preserves its original case. This avoids breaking Slack API calls where IDs are case-sensitive (e.g., `C0ACC8J786L`).

The change is localized to `src/channels/targets.ts` (`normalizeTargetId`) and the corresponding expectations in Slack parsing/normalization tests and directory-config tests were updated to reflect the preserved-case normalized forms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavior change is small and intentionally scoped: only the kind prefix is normalized while preserving ID case to match Slack’s case-sensitive identifiers. Updates are backed by targeted tests and there are no other in-repo call sites that depend on lowercasing the full normalized ID.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->