### PR TITLE
feat: per-user DM roles and permissions for WhatsApp and other channels

### DIFF
--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -78,6 +78,10 @@ export type FollowupRun = {
     ownerNumbers?: string[];
     extraSystemPrompt?: string;
     enforceFinalTag?: boolean;
+    /** Per-user DM role (from dms config). */
+    dmRole?: string;
+    /** Whether this user requires owner confirmation before agent acts. */
+    dmRequireOwnerConfirmation?: boolean;
   };
 };
 

--- a/src/config/dm-config-schema.test.ts
+++ b/src/config/dm-config-schema.test.ts
@@ -52,9 +52,7 @@ describe("DmConfigSchema", () => {
   });
 
   it("rejects unknown fields (strict mode)", () => {
-    expect(() =>
-      DmConfigSchema.parse({ role: "owner", unknownField: true }),
-    ).toThrow();
+    expect(() => DmConfigSchema.parse({ role: "owner", unknownField: true })).toThrow();
   });
 
   it("rejects invalid role value", () => {

--- a/src/config/dm-config-schema.test.ts
+++ b/src/config/dm-config-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { DmConfigSchema, DmRoleSchema } from "./zod-schema.core.js";
+
+describe("DmRoleSchema", () => {
+  it("accepts valid roles", () => {
+    for (const role of ["owner", "elevated", "family", "limited", "default"]) {
+      expect(DmRoleSchema.parse(role)).toBe(role);
+    }
+  });
+
+  it("rejects invalid roles", () => {
+    expect(() => DmRoleSchema.parse("admin")).toThrow();
+    expect(() => DmRoleSchema.parse("")).toThrow();
+    expect(() => DmRoleSchema.parse(123)).toThrow();
+  });
+});
+
+describe("DmConfigSchema", () => {
+  it("parses minimal config (empty)", () => {
+    const result = DmConfigSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("parses historyLimit only (backward compat)", () => {
+    const result = DmConfigSchema.parse({ historyLimit: 50 });
+    expect(result.historyLimit).toBe(50);
+  });
+
+  it("parses full config with all fields", () => {
+    const input = {
+      historyLimit: 20,
+      role: "family",
+      tools: {
+        allow: ["message"],
+        deny: ["exec", "browser"],
+      },
+      requireOwnerConfirmation: true,
+      systemPromptSuffix: "This is a family member. Confirm before acting.",
+    };
+    const result = DmConfigSchema.parse(input);
+    expect(result.role).toBe("family");
+    expect(result.tools).toEqual({ allow: ["message"], deny: ["exec", "browser"] });
+    expect(result.requireOwnerConfirmation).toBe(true);
+    expect(result.systemPromptSuffix).toBe("This is a family member. Confirm before acting.");
+  });
+
+  it("parses owner role without optional fields", () => {
+    const result = DmConfigSchema.parse({ role: "owner" });
+    expect(result.role).toBe("owner");
+    expect(result.requireOwnerConfirmation).toBeUndefined();
+    expect(result.systemPromptSuffix).toBeUndefined();
+  });
+
+  it("rejects unknown fields (strict mode)", () => {
+    expect(() =>
+      DmConfigSchema.parse({ role: "owner", unknownField: true }),
+    ).toThrow();
+  });
+
+  it("rejects invalid role value", () => {
+    expect(() => DmConfigSchema.parse({ role: "superadmin" })).toThrow();
+  });
+
+  it("rejects invalid tools structure", () => {
+    expect(() => DmConfigSchema.parse({ tools: { allow: "not-an-array" } })).toThrow();
+  });
+
+  it("parses tools with alsoAllow", () => {
+    const result = DmConfigSchema.parse({
+      tools: { allow: ["jira"], alsoAllow: ["github"] },
+    });
+    expect(result.tools).toEqual({ allow: ["jira"], alsoAllow: ["github"] });
+  });
+});

--- a/src/config/dm-user-config.test.ts
+++ b/src/config/dm-user-config.test.ts
@@ -19,9 +19,7 @@ describe("resolveDmUserConfig", () => {
 
   it("returns undefined when sender has no DM config", () => {
     const cfg = makeConfig({ "+1234": { role: "owner" } });
-    expect(
-      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+9999" }),
-    ).toBeUndefined();
+    expect(resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+9999" })).toBeUndefined();
   });
 
   it("resolves owner role", () => {
@@ -86,16 +84,12 @@ describe("resolveDmUserConfig", () => {
 
   it("returns undefined when channel config is missing", () => {
     const cfg = { channels: {} } as unknown as OpenClawConfig;
-    expect(
-      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" }),
-    ).toBeUndefined();
+    expect(resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" })).toBeUndefined();
   });
 
   it("returns undefined when channels is missing entirely", () => {
     const cfg = {} as unknown as OpenClawConfig;
-    expect(
-      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" }),
-    ).toBeUndefined();
+    expect(resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" })).toBeUndefined();
   });
 
   it("resolves from account-level dms when accountId provided", () => {

--- a/src/config/dm-user-config.test.ts
+++ b/src/config/dm-user-config.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { resolveDmUserConfig } from "./dm-user-config.js";
+import type { OpenClawConfig } from "./config.js";
+
+function makeConfig(dms: Record<string, any>, channel = "whatsapp"): OpenClawConfig {
+  return {
+    channels: {
+      [channel]: { dms },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("resolveDmUserConfig", () => {
+  it("returns undefined when no senderId provided", () => {
+    const cfg = makeConfig({ "+1234": { role: "owner" } });
+    expect(resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: null })).toBeUndefined();
+    expect(resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: undefined })).toBeUndefined();
+  });
+
+  it("returns undefined when sender has no DM config", () => {
+    const cfg = makeConfig({ "+1234": { role: "owner" } });
+    expect(
+      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+9999" }),
+    ).toBeUndefined();
+  });
+
+  it("resolves owner role", () => {
+    const cfg = makeConfig({ "+1234": { role: "owner" } });
+    const result = resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" });
+    expect(result).toEqual({
+      role: "owner",
+      tools: undefined,
+      requireOwnerConfirmation: false,
+      systemPromptSuffix: undefined,
+      historyLimit: undefined,
+    });
+  });
+
+  it("resolves family role with owner confirmation", () => {
+    const cfg = makeConfig({
+      "+5555": {
+        role: "family",
+        requireOwnerConfirmation: true,
+        systemPromptSuffix: "This is mom. Always confirm with owner.",
+      },
+    });
+    const result = resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+5555" });
+    expect(result).toEqual({
+      role: "family",
+      tools: undefined,
+      requireOwnerConfirmation: true,
+      systemPromptSuffix: "This is mom. Always confirm with owner.",
+      historyLimit: undefined,
+    });
+  });
+
+  it("resolves elevated role with tools", () => {
+    const cfg = makeConfig({
+      "+4444": {
+        role: "elevated",
+        tools: { allow: ["jira", "github"], deny: ["exec"] },
+        systemPromptSuffix: "Co-founder. Can create Jira tasks.",
+      },
+    });
+    const result = resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+4444" });
+    expect(result).toEqual({
+      role: "elevated",
+      tools: { allow: ["jira", "github"], deny: ["exec"] },
+      requireOwnerConfirmation: false,
+      systemPromptSuffix: "Co-founder. Can create Jira tasks.",
+      historyLimit: undefined,
+    });
+  });
+
+  it("defaults role to 'default' when not specified", () => {
+    const cfg = makeConfig({ "+1234": { historyLimit: 10 } });
+    const result = resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" });
+    expect(result).toEqual({
+      role: "default",
+      tools: undefined,
+      requireOwnerConfirmation: false,
+      systemPromptSuffix: undefined,
+      historyLimit: 10,
+    });
+  });
+
+  it("returns undefined when channel config is missing", () => {
+    const cfg = { channels: {} } as unknown as OpenClawConfig;
+    expect(
+      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when channels is missing entirely", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    expect(
+      resolveDmUserConfig({ cfg, channel: "whatsapp", senderId: "+1234" }),
+    ).toBeUndefined();
+  });
+
+  it("resolves from account-level dms when accountId provided", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            myaccount: {
+              dms: {
+                "+1234": { role: "elevated", systemPromptSuffix: "account-level" },
+              },
+            },
+          },
+          dms: {
+            "+1234": { role: "limited", systemPromptSuffix: "channel-level" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    // Account-level takes priority
+    const result = resolveDmUserConfig({
+      cfg,
+      channel: "whatsapp",
+      senderId: "+1234",
+      accountId: "myaccount",
+    });
+    expect(result?.role).toBe("elevated");
+    expect(result?.systemPromptSuffix).toBe("account-level");
+  });
+
+  it("falls back to channel-level dms when accountId has no match", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            other: {
+              dms: { "+9999": { role: "owner" } },
+            },
+          },
+          dms: {
+            "+1234": { role: "family", systemPromptSuffix: "channel fallback" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveDmUserConfig({
+      cfg,
+      channel: "whatsapp",
+      senderId: "+1234",
+      accountId: "nonexistent",
+    });
+    expect(result?.role).toBe("family");
+    expect(result?.systemPromptSuffix).toBe("channel fallback");
+  });
+});

--- a/src/config/dm-user-config.ts
+++ b/src/config/dm-user-config.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig } from "./config.js";
+import type { DmConfig, DmRole } from "./types.messages.js";
+
+export type ResolvedDmUserConfig = {
+  role: DmRole;
+  tools?: DmConfig["tools"];
+  requireOwnerConfirmation: boolean;
+  systemPromptSuffix?: string;
+  historyLimit?: number;
+};
+
+/**
+ * Resolve per-user DM config for a given sender from the channel config.
+ *
+ * Looks up `channels.<channel>.dms[senderId]` (or account-level dms)
+ * and returns a normalized config with defaults applied.
+ */
+export function resolveDmUserConfig(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  senderId?: string | null;
+  accountId?: string | null;
+}): ResolvedDmUserConfig | undefined {
+  const { cfg, channel, senderId } = params;
+  if (!senderId) return undefined;
+
+  const dmConfig = resolveDmConfigEntry(cfg, channel, senderId, params.accountId);
+  if (!dmConfig) return undefined;
+
+  return {
+    role: dmConfig.role ?? "default",
+    tools: dmConfig.tools,
+    requireOwnerConfirmation: dmConfig.requireOwnerConfirmation ?? false,
+    systemPromptSuffix: dmConfig.systemPromptSuffix,
+    historyLimit: dmConfig.historyLimit,
+  };
+}
+
+function resolveDmConfigEntry(
+  cfg: OpenClawConfig,
+  channel: string,
+  senderId: string,
+  accountId?: string | null,
+): DmConfig | undefined {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") return undefined;
+
+  const channelConfig = (channels as Record<string, unknown>)[channel];
+  if (!channelConfig || typeof channelConfig !== "object" || Array.isArray(channelConfig))
+    return undefined;
+
+  const typed = channelConfig as {
+    accounts?: Record<string, { dms?: Record<string, DmConfig> }>;
+    dms?: Record<string, DmConfig>;
+  };
+
+  // Check account-level dms first
+  if (accountId) {
+    const normalizedAccountId = accountId.trim().toLowerCase();
+    const accounts = typed.accounts;
+    if (accounts) {
+      const accountKey =
+        Object.keys(accounts).find((k) => k.toLowerCase() === normalizedAccountId) ?? "";
+      const accountDms = accounts[accountKey]?.dms;
+      if (accountDms?.[senderId]) return accountDms[senderId];
+    }
+  }
+
+  // Fall back to channel-level dms
+  return typed.dms?.[senderId];
+}

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -6,8 +6,23 @@ export type GroupChatConfig = {
   historyLimit?: number;
 };
 
+/** Per-user role for DM access control. */
+export type DmRole = "owner" | "elevated" | "family" | "limited" | "default";
+
 export type DmConfig = {
   historyLimit?: number;
+  /** User role for access control / prompt injection. */
+  role?: DmRole;
+  /** Tool access policy for this user (allow/deny lists). */
+  tools?: {
+    allow?: string[];
+    alsoAllow?: string[];
+    deny?: string[];
+  };
+  /** If true, the agent must get owner approval before executing actions for this user. */
+  requireOwnerConfirmation?: boolean;
+  /** Extra system prompt text injected when this user is chatting. */
+  systemPromptSuffix?: string;
 };
 
 export type QueueConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -89,9 +89,22 @@ export const GroupChatSchema = z
   .strict()
   .optional();
 
+export const DmRoleSchema = z.enum(["owner", "elevated", "family", "limited", "default"]);
+
 export const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),
+    role: DmRoleSchema.optional(),
+    tools: z
+      .object({
+        allow: z.array(z.string()).optional(),
+        alsoAllow: z.array(z.string()).optional(),
+        deny: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    requireOwnerConfirmation: z.boolean().optional(),
+    systemPromptSuffix: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Adds per-phone-number (per-user) role-based access control for DM channels (WhatsApp, Discord, Telegram, Slack, etc.).

## Problem

Currently, `allowFrom` is a flat list — you're either allowed to talk to the bot or you're not. There's no way to assign different permissions to different contacts.

Real-world use cases require granular control:
- **Owner** — full access, the bot executes everything
- **Co-founder/colleague** — elevated access, can create Jira tasks, check project status directly
- **Family members** — can relay messages, but the bot always confirms with the owner before acting
- **Clients** — scoped access to specific features (e.g., meeting transcripts only)
- **Test users** — limited to a single use case (e.g., a booking agent experiment)

Same bot. Same number. Completely different permissions per contact.

## What's implemented

### Extended `DmConfig` with:
- `role`: `"owner" | "elevated" | "family" | "limited" | "default"` — defines the user's permission level
- `requireOwnerConfirmation`: `boolean` — if true, the agent must get owner approval before acting on this user's requests
- `systemPromptSuffix`: `string` — injected into the system prompt when this user is chatting (e.g., "This is a family member. Always confirm with owner before acting.")
- `tools`: `{ allow?, alsoAllow?, deny? }` — per-user tool access policy

### Configuration example:
```json
{
  "channels": {
    "whatsapp": {
      "allowFrom": ["+1234567890", "+0987654321"],
      "dms": {
        "+1234567890": {
          "role": "owner"
        },
        "+0987654321": {
          "role": "family",
          "requireOwnerConfirmation": true,
          "systemPromptSuffix": "This is a family member. Always confirm with owner before acting on their requests."
        }
      }
    }
  }
}
```

### Files changed:
- `src/config/types.messages.ts` — Extended DmConfig type
- `src/config/zod-schema.core.ts` — Zod validation for new fields
- `src/auto-reply/reply/get-reply-run.ts` — Wired into message pipeline
- `src/auto-reply/reply/queue/types.ts` — Queue run params

### Files created:
- `src/config/dm-user-config.ts` — Resolver module
- `src/config/dm-user-config.test.ts` — 10 tests
- `src/config/dm-config-schema.test.ts` — 10 tests

## Design decisions
- Extended existing `DmConfig` rather than a new type — keeps the `dms: Record<string, DmConfig>` pattern intact across all channels
- `systemPromptSuffix` injected via existing `extraSystemPrompt` flow — minimal change
- `tools` follows the same shape as `GroupToolPolicyConfig` for consistency
- Account-level DM config takes priority over channel-level (matching group policy pattern)
- Role and confirmation flags passed through queue params for future tool-gating

## Backward compatible
All new fields are optional. Existing configs work unchanged.

---
Author: Bartłomiej Głowacki (thebartglowacki@gmail.com)