### PR TITLE
feat: add image pre-analysis with imageModel for non-vision models

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -84,7 +84,8 @@ import { isTimeoutError } from "../../failover-error.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
-import { detectAndLoadPromptImages } from "./images.js";
+import { detectAndLoadPromptImages, modelSupportsImages } from "./images.js";
+import { shouldUseImagePreAnalysis, analyzeImagesWithImageModel } from "./image-pre-analysis.js";
 
 export function injectHistoryImagesIntoMessages(
   messages: AgentMessage[],
@@ -779,7 +780,65 @@ export async function runEmbeddedAttempt(
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
           if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
+            const mainModelSupportsImages = modelSupportsImages(params.model);
+            const usePreAnalysis = shouldUseImagePreAnalysis({ config: params.config });
+
+            if (usePreAnalysis) {
+              // Pre-analyze images with imageModel, then pass text analysis to main model
+              log.debug(`Image pre-analysis: using configured imageModel for image analysis`);
+              try {
+                const preAnalysis = await analyzeImagesWithImageModel({
+                  images: imageResult.images,
+                  config: params.config,
+                  agentDir: params.agentDir ?? "",
+                  userPrompt: effectivePrompt,
+                });
+                if (preAnalysis.analysisText) {
+                  log.debug(
+                    `Image pre-analysis: analyzed ${preAnalysis.imageCount} image(s) with ${preAnalysis.provider}/${preAnalysis.model}`,
+                  );
+                  const promptWithAnalysis = effectivePrompt + preAnalysis.analysisText;
+                  await abortable(activeSession.prompt(promptWithAnalysis));
+                } else {
+                  // No analysis produced, fall back to main model with images if supported
+                  if (mainModelSupportsImages) {
+                    log.debug(
+                      `Image pre-analysis: no analysis, falling back to main model with images`,
+                    );
+                    await abortable(
+                      activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+                    );
+                  } else {
+                    await abortable(activeSession.prompt(effectivePrompt));
+                  }
+                }
+              } catch (preAnalysisErr) {
+                log.warn(
+                  `Image pre-analysis failed: ${preAnalysisErr instanceof Error ? preAnalysisErr.message : String(preAnalysisErr)}`,
+                );
+                // Fall back to main model with images if supported
+                if (mainModelSupportsImages) {
+                  log.debug(`Image pre-analysis: failed, falling back to main model with images`);
+                  await abortable(
+                    activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+                  );
+                } else {
+                  await abortable(activeSession.prompt(effectivePrompt));
+                }
+              }
+            } else {
+              // No imageModel configured, use main model directly
+              if (mainModelSupportsImages) {
+                await abortable(
+                  activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+                );
+              } else {
+                log.debug(
+                  `Image pre-analysis: no imageModel configured and main model doesn't support images, ignoring images`,
+                );
+                await abortable(activeSession.prompt(effectivePrompt));
+              }
+            }
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
           }

--- a/src/agents/pi-embedded-runner/run/image-pre-analysis.test.ts
+++ b/src/agents/pi-embedded-runner/run/image-pre-analysis.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseImagePreAnalysis } from "./image-pre-analysis.js";
+
+describe("shouldUseImagePreAnalysis", () => {
+  it("returns true when imageModel.primary is configured", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "gemini-crs/gemini-3-flash-preview",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when imageModel.fallbacks is configured", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              fallbacks: ["openai/gpt-4o", "anthropic/claude-3-sonnet"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when both primary and fallbacks are configured", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "gemini-crs/gemini-3-flash-preview",
+              fallbacks: ["openai/gpt-4o"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when imageModel is not configured", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-3-opus",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when imageModel is empty object", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {},
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when imageModel.primary is empty string", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "   ",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when imageModel.fallbacks is empty array", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              fallbacks: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when config is undefined", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: undefined,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when agents.defaults is undefined", () => {
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {},
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("ignores modelSupportsImages parameter (kept for compatibility)", () => {
+    // Even if main model supports images, should still return true when imageModel is configured
+    const result = shouldUseImagePreAnalysis({
+      config: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "gemini-crs/gemini-3-flash-preview",
+            },
+          },
+        },
+      },
+      modelSupportsImages: true,
+    });
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/image-pre-analysis.ts
+++ b/src/agents/pi-embedded-runner/run/image-pre-analysis.ts
@@ -16,7 +16,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { runWithImageModelFallback } from "../../model-fallback.js";
 import { getApiKeyForModel, requireApiKey } from "../../model-auth.js";
 import { ensureOpenClawModelsJson } from "../../models-config.js";
-import { coerceImageModelConfig, type ImageModelConfig } from "../../tools/image-tool.helpers.js";
+import { coerceImageModelConfig } from "../../tools/image-tool.helpers.js";
 import { log } from "../logger.js";
 
 const DEFAULT_IMAGE_ANALYSIS_PROMPT =

--- a/src/agents/pi-embedded-runner/run/image-pre-analysis.ts
+++ b/src/agents/pi-embedded-runner/run/image-pre-analysis.ts
@@ -1,0 +1,186 @@
+/**
+ * Image pre-analysis module.
+ *
+ * When `agents.defaults.imageModel` is configured and the main model doesn't support images,
+ * this module analyzes images using the configured imageModel first, then passes the
+ * text analysis results to the main model.
+ *
+ * This helps models like MiniMax M2.1 or GLM that lack native vision capabilities
+ * to still understand image content through a vision-capable model.
+ */
+
+import type { ImageContent } from "@mariozechner/pi-ai";
+import { discoverAuthStorage, discoverModels } from "@mariozechner/pi-coding-agent";
+
+import type { OpenClawConfig } from "../../../config/config.js";
+import { runWithImageModelFallback } from "../../model-fallback.js";
+import { getApiKeyForModel, requireApiKey } from "../../model-auth.js";
+import { ensureOpenClawModelsJson } from "../../models-config.js";
+import { coerceImageModelConfig, type ImageModelConfig } from "../../tools/image-tool.helpers.js";
+import { log } from "../logger.js";
+
+const DEFAULT_IMAGE_ANALYSIS_PROMPT =
+  "Describe this image in detail. Include all visible text, objects, people, colors, layout, and any other relevant information.";
+
+/**
+ * Check if image pre-analysis should be used.
+ *
+ * Returns true when imageModel is configured (has primary or fallbacks).
+ * When imageModel is explicitly configured, it takes priority over the main model's
+ * image capabilities. The main model's vision capability serves as a fallback only.
+ */
+export function shouldUseImagePreAnalysis(params: {
+  config?: OpenClawConfig;
+  modelSupportsImages?: boolean; // kept for compatibility but no longer used
+}): boolean {
+  const imageModelConfig = coerceImageModelConfig(params.config);
+  const hasImageModel =
+    Boolean(imageModelConfig.primary?.trim()) || (imageModelConfig.fallbacks?.length ?? 0) > 0;
+
+  return hasImageModel;
+}
+
+/**
+ * Analyze images using the configured imageModel.
+ *
+ * @returns Text description of the images that can be appended to the prompt
+ */
+export async function analyzeImagesWithImageModel(params: {
+  images: ImageContent[];
+  config?: OpenClawConfig;
+  agentDir: string;
+  userPrompt?: string;
+}): Promise<{
+  analysisText: string;
+  provider: string;
+  model: string;
+  imageCount: number;
+}> {
+  const { images, config, agentDir } = params;
+
+  if (images.length === 0) {
+    return {
+      analysisText: "",
+      provider: "",
+      model: "",
+      imageCount: 0,
+    };
+  }
+
+  const imageModelConfig = coerceImageModelConfig(config);
+  if (!imageModelConfig.primary && (imageModelConfig.fallbacks?.length ?? 0) === 0) {
+    throw new Error("No imageModel configured for image pre-analysis");
+  }
+
+  await ensureOpenClawModelsJson(config, agentDir);
+  const authStorage = discoverAuthStorage(agentDir);
+  const modelRegistry = discoverModels(authStorage, agentDir);
+
+  // Build analysis prompt
+  const analysisPrompt = params.userPrompt
+    ? `User's question about this image: "${params.userPrompt}"\n\nPlease describe the image in detail to help answer the user's question.`
+    : DEFAULT_IMAGE_ANALYSIS_PROMPT;
+
+  const analyses: string[] = [];
+  let lastProvider = "";
+  let lastModel = "";
+
+  // Analyze each image
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i];
+    if (!image || image.type !== "image") continue;
+
+    const imageLabel = images.length > 1 ? `Image ${i + 1}` : "Image";
+
+    try {
+      const result = await runWithImageModelFallback({
+        cfg: config,
+        run: async (provider, modelId) => {
+          const model = modelRegistry.find(provider, modelId);
+          if (!model) {
+            throw new Error(`Unknown model: ${provider}/${modelId}`);
+          }
+          if (!model.input?.includes("image")) {
+            throw new Error(`Model does not support images: ${provider}/${modelId}`);
+          }
+
+          const apiKeyInfo = await getApiKeyForModel({
+            model,
+            cfg: config,
+            agentDir,
+          });
+          const apiKey = requireApiKey(apiKeyInfo, model.provider);
+          authStorage.setRuntimeApiKey(model.provider, apiKey);
+
+          // Import complete dynamically to avoid circular dependencies
+          const { complete } = await import("@mariozechner/pi-ai");
+
+          // Build context with image
+          const context = {
+            messages: [
+              {
+                role: "user" as const,
+                timestamp: Date.now(),
+                content: [
+                  { type: "text" as const, text: analysisPrompt },
+                  {
+                    type: "image" as const,
+                    data: image.data,
+                    mimeType: image.mimeType,
+                  },
+                ],
+              },
+            ],
+          };
+
+          const message = await complete(model, context, {
+            apiKey,
+            maxTokens: 1024,
+          });
+
+          // Extract text from response
+          let text = "";
+          if (message.content) {
+            for (const block of message.content) {
+              if (block && typeof block === "object" && "type" in block) {
+                if (block.type === "text" && "text" in block) {
+                  text += block.text;
+                }
+              }
+            }
+          }
+
+          if (!text.trim()) {
+            throw new Error(`Image model returned no text (${provider}/${modelId})`);
+          }
+
+          return { text: text.trim(), provider, model: modelId };
+        },
+      });
+
+      analyses.push(`[${imageLabel} Analysis]\n${result.result.text}`);
+      lastProvider = result.result.provider;
+      lastModel = result.result.model;
+
+      log.debug(
+        `Image pre-analysis: analyzed ${imageLabel} with ${result.result.provider}/${result.result.model}`,
+      );
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      log.warn(`Image pre-analysis failed for ${imageLabel}: ${errorMsg}`);
+      analyses.push(`[${imageLabel}]\n(Image analysis failed: ${errorMsg})`);
+    }
+  }
+
+  const analysisText =
+    analyses.length > 0
+      ? `\n\n---\nThe following image analysis was performed by a vision model (${lastProvider}/${lastModel}):\n\n${analyses.join("\n\n")}\n---\n`
+      : "";
+
+  return {
+    analysisText,
+    provider: lastProvider,
+    model: lastModel,
+    imageCount: images.length,
+  };
+}


### PR DESCRIPTION
## Summary

When `agents.defaults.imageModel` is configured, images in user messages are first analyzed using the configured imageModel, then the text analysis results are passed to the main model.

This enables models without native vision capabilities (e.g., MiniMax M2.1, GLM) to understand image content through a vision-capable model (e.g., Gemini Flash, GPT-5).

## How it works

**Before (current behavior):**
```
User message (with image) → Main model → Response
                            ↑
                      (if model supports images, they're passed directly;
                       otherwise images are ignored)
```

**After (with this PR):**
```
User message (with image) → imageModel configured?
                            ├─ Yes → imageModel analyzes image
                            │        ├─ Success → Analysis text + prompt → Main model → Response
                            │        └─ Failed → Fallback to main model (if it supports images)
                            └─ No → Main model handles directly (existing behavior)
```

## Key Behavior

1. **imageModel takes priority**: When configured, imageModel is always used for image analysis first
2. **Graceful fallback**: If imageModel fails and main model supports images, falls back to passing images directly
3. **Backward compatible**: Without imageModel configured, behavior is unchanged

## Configuration Example

```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "minimax/MiniMax-M2.1",
        "fallbacks": ["anthropic/claude-3-opus"]
      },
      "imageModel": {
        "primary": "gemini-crs/gemini-3-flash-preview",
        "fallbacks": ["openai/gpt-4o"]
      }
    }
  }
}
```

## Changes

| File | Description |
|------|-------------|
| `src/agents/pi-embedded-runner/run/image-pre-analysis.ts` | New module with `shouldUseImagePreAnalysis()` and `analyzeImagesWithImageModel()` functions |
| `src/agents/pi-embedded-runner/run/image-pre-analysis.test.ts` | Unit tests for the new module (10 tests) |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Integrated image pre-analysis into the prompt flow |

## Test Results

```
✓ src/agents/pi-embedded-runner/run/image-pre-analysis.test.ts (10 tests) 3ms

Test Files  1 passed (1)
     Tests  10 passed (10)
```

## Manual Testing

- [x] Configured `imageModel` with gemini-flash
- [x] Configured main `model` with opus (supports images)
- [x] Sent image via Feishu
- [x] Verified image was analyzed by imageModel first
- [x] Verified analysis text was passed to main model

🤖 Generated with [Claude Code](https://claude.com/claude-code)