### PR TITLE
feat: include day of week in date/time context injection

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -61,7 +61,14 @@ function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const dateStr = new Date().toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: params.userTimezone,
+  });
+  return ["## Current Date & Time", dateStr, `Time zone: ${params.userTimezone}`, ""];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {


### PR DESCRIPTION
## Summary
Fixes #4629

The current date/time injection only included the timezone, which caused LLMs to frequently get the day of week wrong. This change adds the full date with day of week to the system prompt injection.

## Changes
- Modified `buildTimeSection()` in `src/agents/system-prompt.ts` to include the full date string

## Before
```
## Current Date & Time
Time zone: America/New_York
```

## After
```
## Current Date & Time
Friday, January 31, 2026
Time zone: America/New_York
```

## Testing
- All 27 tests in `system-prompt.test.ts` pass
- The existing test assertions still work because they check for `## Current Date & Time` and `Time zone:` which are preserved