### PR TITLE
fix(signal): preserve group ID case (base64 is case-sensitive)

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -29,4 +29,21 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves group ID case (base64 is case-sensitive)", () => {
+    // Signal group IDs are base64 encoded - case matters!
+    expect(
+      normalizeSignalMessagingTarget("group:BxPK6EgoD3W+hVMycAUrHIJP3BXhEFanSEHA03nIOnk="),
+    ).toBe("group:BxPK6EgoD3W+hVMycAUrHIJP3BXhEFanSEHA03nIOnk=");
+    expect(
+      normalizeSignalMessagingTarget("signal:group:BxPK6EgoD3W+hVMycAUrHIJP3BXhEFanSEHA03nIOnk="),
+    ).toBe("group:BxPK6EgoD3W+hVMycAUrHIJP3BXhEFanSEHA03nIOnk=");
+  });
+
+  it("accepts group prefixes for target detection", () => {
+    expect(looksLikeSignalTargetId("group:BxPK6EgoD3W+hVMycAUrHIJP3BXhEFanSEHA03nIOnk=")).toBe(
+      true,
+    );
+    expect(looksLikeSignalTargetId("signal:group:abc123")).toBe(true);
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -9,7 +9,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Keep group ID case-sensitive (base64 is case-sensitive for Signal groups)
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
Signal group IDs are base64 encoded and base64 is case-sensitive. Previously, normalizeSignalMessagingTarget() lowercased group IDs, causing signal-cli to fail with 'Group not found' errors.

This fix preserves the original case of group IDs while still normalizing the 'group:' prefix.

Fixes issue where sending messages/reactions to Signal groups would fail due to case-mismatch in the group identifier.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal target normalization to preserve case for `group:` IDs (which are base64 and therefore case-sensitive), while still normalizing prefixes like `signal:` and detecting group targets in `looksLikeSignalTargetId()`. Tests were extended to cover case preservation for group IDs and prefix-based detection.

Overall change fits the existing normalization utilities: it keeps the lowercasing behavior for non-group targets (usernames/UUIDs/phone-like values) while special-casing `group:` targets to avoid breaking Signal group resolution.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and fixes a real correctness bug for Signal group IDs.
- The core change is small and well-motivated (stop lowercasing base64 group IDs) and is covered by new unit tests. The main remaining concern is that group IDs are now returned verbatim, which can preserve stray whitespace and still cause lookup failures for inputs like `group: <id>`; worth tightening to avoid regressions.
- src/channels/plugins/normalize/signal.ts (group ID trimming/normalization behavior)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->