### PR TITLE
fix: use STATE_DIR instead of hardcoded ~/.openclaw for identity and canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
+- State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
 - Tests: harden flaky hotspots by removing timer sleeps, consolidating onboarding provider-auth coverage, and improving memory test realism. (#11598) Thanks @gumadeiras.
 
 ## 2026.2.6

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -178,7 +178,8 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
     }
     return DEFAULT_AGENT_WORKSPACE_DIR;
   }
-  return path.join(os.homedir(), ".openclaw", `workspace-${id}`);
+  const stateDir = resolveStateDir(process.env, os.homedir);
+  return path.join(stateDir, `workspace-${id}`);
 }
 
 export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -1,9 +1,8 @@
-import os from "node:os";
 import path from "node:path";
 import { CHANNEL_IDS } from "../../channels/registry.js";
 import { STATE_DIR } from "../../config/config.js";
 
-export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(os.homedir(), ".openclaw", "sandboxes");
+export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(STATE_DIR, "sandboxes");
 
 export const DEFAULT_SANDBOX_IMAGE = "openclaw-sandbox:bookworm-slim";
 export const DEFAULT_SANDBOX_CONTAINER_PREFIX = "openclaw-sbx-";
@@ -47,7 +46,6 @@ export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
 
-const resolvedSandboxStateDir = STATE_DIR ?? path.join(os.homedir(), ".openclaw");
-export const SANDBOX_STATE_DIR = path.join(resolvedSandboxStateDir, "sandbox");
+export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");
 export const SANDBOX_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "containers.json");
 export const SANDBOX_BROWSER_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "browsers.json");

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -1,7 +1,7 @@
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveRunWorkspaceDir } from "./workspace-run.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "./workspace.js";
 
@@ -93,7 +93,9 @@ describe("resolveRunWorkspaceDir", () => {
 
     expect(result.agentId).toBe("research");
     expect(result.agentIdSource).toBe("explicit");
-    expect(result.workspaceDir).toBe(path.resolve(os.homedir(), ".openclaw", "workspace-research"));
+    expect(result.workspaceDir).toBe(
+      path.resolve(resolveStateDir(process.env), "workspace-research"),
+    );
   });
 
   it("throws for malformed agent session keys even when config has a default agent", () => {

--- a/src/canvas-host/server.state-dir.test.ts
+++ b/src/canvas-host/server.state-dir.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../runtime.js";
+
+describe("canvas host state dir defaults", () => {
+  let previousStateDir: string | undefined;
+  let previousLegacyStateDir: string | undefined;
+
+  beforeEach(() => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    previousLegacyStateDir = process.env.CLAWDBOT_STATE_DIR;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    if (previousLegacyStateDir === undefined) {
+      delete process.env.CLAWDBOT_STATE_DIR;
+    } else {
+      process.env.CLAWDBOT_STATE_DIR = previousLegacyStateDir;
+    }
+  });
+
+  it("uses OPENCLAW_STATE_DIR for the default canvas root", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-state-"));
+    const stateDir = path.join(tempRoot, "state");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    delete process.env.CLAWDBOT_STATE_DIR;
+    vi.resetModules();
+
+    const { createCanvasHostHandler } = await import("./server.js");
+    const handler = await createCanvasHostHandler({
+      runtime: defaultRuntime,
+      allowInTests: true,
+    });
+
+    try {
+      const expectedRoot = await fs.realpath(path.join(stateDir, "canvas"));
+      const actualRoot = await fs.realpath(handler.rootDir);
+      expect(actualRoot).toBe(expectedRoot);
+      const indexPath = path.join(expectedRoot, "index.html");
+      const indexContents = await fs.readFile(indexPath, "utf8");
+      expect(indexContents).toContain("OpenClaw Canvas");
+    } finally {
+      await handler.close();
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/canvas-host/server.state-dir.test.ts
+++ b/src/canvas-host/server.state-dir.test.ts
@@ -3,35 +3,28 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
+import {
+  restoreStateDirEnv,
+  setStateDirEnv,
+  snapshotStateDirEnv,
+} from "../test-helpers/state-dir-env.js";
 
 describe("canvas host state dir defaults", () => {
-  let previousStateDir: string | undefined;
-  let previousLegacyStateDir: string | undefined;
+  let envSnapshot: ReturnType<typeof snapshotStateDirEnv>;
 
   beforeEach(() => {
-    previousStateDir = process.env.OPENCLAW_STATE_DIR;
-    previousLegacyStateDir = process.env.CLAWDBOT_STATE_DIR;
+    envSnapshot = snapshotStateDirEnv();
   });
 
   afterEach(() => {
     vi.resetModules();
-    if (previousStateDir === undefined) {
-      delete process.env.OPENCLAW_STATE_DIR;
-    } else {
-      process.env.OPENCLAW_STATE_DIR = previousStateDir;
-    }
-    if (previousLegacyStateDir === undefined) {
-      delete process.env.CLAWDBOT_STATE_DIR;
-    } else {
-      process.env.CLAWDBOT_STATE_DIR = previousLegacyStateDir;
-    }
+    restoreStateDirEnv(envSnapshot);
   });
 
   it("uses OPENCLAW_STATE_DIR for the default canvas root", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-state-"));
     const stateDir = path.join(tempRoot, "state");
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-    delete process.env.CLAWDBOT_STATE_DIR;
+    setStateDirEnv(stateDir);
     vi.resetModules();
 
     const { createCanvasHostHandler } = await import("./server.js");

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -7,7 +7,6 @@ import http, { type IncomingMessage, type Server, type ServerResponse } from "no
 import path from "node:path";
 import { type WebSocket, WebSocketServer } from "ws";
 import type { RuntimeEnv } from "../runtime.js";
-
 import { STATE_DIR } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -4,10 +4,11 @@ import chokidar from "chokidar";
 import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import os from "node:os";
 import path from "node:path";
 import { type WebSocket, WebSocketServer } from "ws";
 import type { RuntimeEnv } from "../runtime.js";
+
+import { STATE_DIR } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
@@ -235,7 +236,7 @@ async function prepareCanvasRoot(rootDir: string) {
 }
 
 function resolveDefaultCanvasRoot(): string {
-  const candidates = [path.join(os.homedir(), ".openclaw", "canvas")];
+  const candidates = [path.join(STATE_DIR, "canvas")];
   const existing = candidates.find((dir) => {
     try {
       return fsSync.statSync(dir).isDirectory();

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -15,6 +15,7 @@ import {
   resolveUpdateAvailability,
 } from "../commands/status.update.js";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import { trimLogTail } from "../infra/restart-sentinel.js";
 import { parseSemver } from "../infra/runtime-guard.js";
@@ -126,7 +127,6 @@ const DEFAULT_PACKAGE_NAME = "openclaw";
 const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
 const CLI_NAME = resolveCliName();
 const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
-const DEFAULT_GIT_DIR = path.join(os.homedir(), ".openclaw");
 
 function normalizeTag(value?: string | null): string | null {
   if (!value) {
@@ -313,7 +313,7 @@ function resolveGitInstallDir(): string {
 }
 
 function resolveDefaultGitDir(): string {
-  return DEFAULT_GIT_DIR;
+  return resolveStateDir(process.env, os.homedir);
 }
 
 function resolveNodeRunner(): string {

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -687,7 +687,12 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  Object.defineProperty(process, 'noDeprecation', { value: true, writable: true, enumerable: true, configurable: true });
+  Object.defineProperty(process, "noDeprecation", {
+    value: true,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -687,12 +687,7 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  Object.defineProperty(process, "noDeprecation", {
-    value: true,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
+  process.noDeprecation = true;
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -687,7 +687,7 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  process.noDeprecation = true;
+  Object.defineProperty(process, 'noDeprecation', { value: true, writable: true, enumerable: true, configurable: true });
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import {
   applyAgentBindings,
   applyAgentConfig,
@@ -43,7 +44,9 @@ describe("agents helpers", () => {
     const work = summaries.find((summary) => summary.id === "work");
 
     expect(main).toBeTruthy();
-    expect(main?.workspace).toBe(path.join(os.homedir(), ".openclaw", "workspace-main"));
+    expect(main?.workspace).toBe(
+      path.join(resolveStateDir(process.env, os.homedir), "workspace-main"),
+    );
     expect(main?.bindings).toBe(1);
     expect(main?.model).toBe("anthropic/claude");
     expect(main?.agentDir.endsWith(path.join("agents", "main", "agent"))).toBe(true);

--- a/src/hooks/bundled/command-logger/handler.ts
+++ b/src/hooks/bundled/command-logger/handler.ts
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { HookHandler } from "../../hooks.js";
+import { resolveStateDir } from "../../../config/paths.js";
 
 /**
  * Log all command events to a file
@@ -39,7 +40,7 @@ const logCommand: HookHandler = async (event) => {
 
   try {
     // Create log directory
-    const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
+    const stateDir = resolveStateDir(process.env, os.homedir);
     const logDir = path.join(stateDir, "logs");
     await fs.mkdir(logDir, { recursive: true });
 

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { HookHandler } from "../../hooks.js";
 import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { resolveStateDir } from "../../../config/paths.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
@@ -79,7 +80,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
     const workspaceDir = cfg
       ? resolveAgentWorkspaceDir(cfg, agentId)
-      : path.join(os.homedir(), ".openclaw", "workspace");
+      : path.join(resolveStateDir(process.env, os.homedir), "workspace");
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("device identity state dir defaults", () => {
+  let previousStateDir: string | undefined;
+  let previousLegacyStateDir: string | undefined;
+
+  beforeEach(() => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    previousLegacyStateDir = process.env.CLAWDBOT_STATE_DIR;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    if (previousLegacyStateDir === undefined) {
+      delete process.env.CLAWDBOT_STATE_DIR;
+    } else {
+      process.env.CLAWDBOT_STATE_DIR = previousLegacyStateDir;
+    }
+  });
+
+  it("writes the default identity file under OPENCLAW_STATE_DIR", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-identity-state-"));
+    const stateDir = path.join(tempRoot, "state");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    delete process.env.CLAWDBOT_STATE_DIR;
+    vi.resetModules();
+
+    const { loadOrCreateDeviceIdentity } = await import("./device-identity.js");
+    const identity = loadOrCreateDeviceIdentity();
+
+    try {
+      const identityPath = path.join(stateDir, "identity", "device.json");
+      const raw = JSON.parse(await fs.readFile(identityPath, "utf8")) as { deviceId?: string };
+      expect(raw.deviceId).toBe(identity.deviceId);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -2,35 +2,28 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  restoreStateDirEnv,
+  setStateDirEnv,
+  snapshotStateDirEnv,
+} from "../test-helpers/state-dir-env.js";
 
 describe("device identity state dir defaults", () => {
-  let previousStateDir: string | undefined;
-  let previousLegacyStateDir: string | undefined;
+  let envSnapshot: ReturnType<typeof snapshotStateDirEnv>;
 
   beforeEach(() => {
-    previousStateDir = process.env.OPENCLAW_STATE_DIR;
-    previousLegacyStateDir = process.env.CLAWDBOT_STATE_DIR;
+    envSnapshot = snapshotStateDirEnv();
   });
 
   afterEach(() => {
     vi.resetModules();
-    if (previousStateDir === undefined) {
-      delete process.env.OPENCLAW_STATE_DIR;
-    } else {
-      process.env.OPENCLAW_STATE_DIR = previousStateDir;
-    }
-    if (previousLegacyStateDir === undefined) {
-      delete process.env.CLAWDBOT_STATE_DIR;
-    } else {
-      process.env.CLAWDBOT_STATE_DIR = previousLegacyStateDir;
-    }
+    restoreStateDirEnv(envSnapshot);
   });
 
   it("writes the default identity file under OPENCLAW_STATE_DIR", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-identity-state-"));
     const stateDir = path.join(tempRoot, "state");
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-    delete process.env.CLAWDBOT_STATE_DIR;
+    setStateDirEnv(stateDir);
     vi.resetModules();
 
     const { loadOrCreateDeviceIdentity } = await import("./device-identity.js");

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -1,7 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+
+import { STATE_DIR } from "../config/paths.js";
 
 export type DeviceIdentity = {
   deviceId: string;
@@ -17,7 +18,7 @@ type StoredIdentity = {
   createdAtMs: number;
 };
 
-const DEFAULT_DIR = path.join(os.homedir(), ".openclaw", "identity");
+const DEFAULT_DIR = path.join(STATE_DIR, "identity");
 const DEFAULT_FILE = path.join(DEFAULT_DIR, "device.json");
 
 function ensureDir(filePath: string) {

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-
 import { STATE_DIR } from "../config/paths.js";
 
 export type DeviceIdentity = {

--- a/src/test-helpers/state-dir-env.ts
+++ b/src/test-helpers/state-dir-env.ts
@@ -1,0 +1,29 @@
+type StateDirEnvSnapshot = {
+  openclawStateDir: string | undefined;
+  clawdbotStateDir: string | undefined;
+};
+
+export function snapshotStateDirEnv(): StateDirEnvSnapshot {
+  return {
+    openclawStateDir: process.env.OPENCLAW_STATE_DIR,
+    clawdbotStateDir: process.env.CLAWDBOT_STATE_DIR,
+  };
+}
+
+export function restoreStateDirEnv(snapshot: StateDirEnvSnapshot): void {
+  if (snapshot.openclawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = snapshot.openclawStateDir;
+  }
+  if (snapshot.clawdbotStateDir === undefined) {
+    delete process.env.CLAWDBOT_STATE_DIR;
+  } else {
+    process.env.CLAWDBOT_STATE_DIR = snapshot.clawdbotStateDir;
+  }
+}
+
+export function setStateDirEnv(stateDir: string): void {
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  delete process.env.CLAWDBOT_STATE_DIR;
+}


### PR DESCRIPTION
## Problem

`device-identity.ts` and `canvas-host/server.ts` use hardcoded `path.join(os.homedir(), '.openclaw', ...)` for identity and canvas directories, ignoring `OPENCLAW_STATE_DIR` env var and the `resolveStateDir()` logic from `config/paths.ts`.

This causes `~/.openclaw/identity` and `~/.openclaw/canvas` to be created even when state dir is overridden or resolved to a different location.

## Fix

Import `STATE_DIR` from `config/paths.ts` and use it instead of the hardcoded path.

## Files Changed

- `src/infra/device-identity.ts` — `DEFAULT_DIR` now uses `STATE_DIR`
- `src/canvas-host/server.ts` — `resolveDefaultCanvasRoot()` now uses `STATE_DIR`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR replaces hardcoded `~/.openclaw/...` paths with `STATE_DIR` from `src/config/paths.ts` for both the device identity storage (`src/infra/device-identity.ts`) and the canvas host default root (`src/canvas-host/server.ts`). This aligns these subsystems with the existing state-dir resolution logic (including `OPENCLAW_STATE_DIR` overrides and legacy dir detection), preventing new directories from being created under `~/.openclaw` when a custom state directory is configured.

It also updates `src/cli/update-cli.ts` to set `process.noDeprecation` via `Object.defineProperty` before running the update flow.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and primarily standardizes path resolution to respect STATE_DIR.
- Changes are small and localized (swapping hardcoded paths for `STATE_DIR`). The only questionable change is the new `Object.defineProperty(process, "noDeprecation", …)` usage, which is non-essential and slightly increases surface area for subtle behavior differences, but is unlikely to break typical runtimes.
- src/cli/update-cli.ts (process.noDeprecation descriptor change)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->