### PR TITLE
fix(exec): default host to gateway when sandbox disabled

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 test("background exec is not killed when tool signal aborts", async () => {
-  const tool = createExecTool({ allowBackground: true, backgroundMs: 0 });
+  const tool = createExecTool({ allowBackground: true, backgroundMs: 0, security: "full" });
   const abortController = new AbortController();
 
   const result = await tool.execute(
@@ -44,7 +44,7 @@ test("background exec is not killed when tool signal aborts", async () => {
 });
 
 test("background exec still times out after tool signal abort", async () => {
-  const tool = createExecTool({ allowBackground: true, backgroundMs: 0 });
+  const tool = createExecTool({ allowBackground: true, backgroundMs: 0, security: "full" });
   const abortController = new AbortController();
 
   const result = await tool.execute(
@@ -81,7 +81,7 @@ test("background exec still times out after tool signal abort", async () => {
 });
 
 test("yielded background exec is not killed when tool signal aborts", async () => {
-  const tool = createExecTool({ allowBackground: true, backgroundMs: 10 });
+  const tool = createExecTool({ allowBackground: true, backgroundMs: 10, security: "full" });
   const abortController = new AbortController();
 
   const result = await tool.execute(
@@ -110,7 +110,7 @@ test("yielded background exec is not killed when tool signal aborts", async () =
 });
 
 test("yielded background exec still times out", async () => {
-  const tool = createExecTool({ allowBackground: true, backgroundMs: 10 });
+  const tool = createExecTool({ allowBackground: true, backgroundMs: 10, security: "full" });
 
   const result = await tool.execute("toolcall", {
     command: 'node -e "setTimeout(() => {}, 5000)"',

--- a/src/agents/bash-tools.exec.pty-fallback.test.ts
+++ b/src/agents/bash-tools.exec.pty-fallback.test.ts
@@ -18,7 +18,7 @@ test("exec falls back when PTY spawn fails", async () => {
   }));
 
   const { createExecTool } = await import("./bash-tools.exec");
-  const tool = createExecTool({ allowBackground: false });
+  const tool = createExecTool({ allowBackground: false, security: "full" });
   const result = await tool.execute("toolcall", {
     command: "printf ok",
     pty: true,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -823,7 +823,7 @@ export function createExecTool(
       if (elevatedRequested) {
         logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
       }
-      const configuredHost = defaults?.host ?? "sandbox";
+      const configuredHost = defaults?.host ?? (defaults?.sandbox ? "sandbox" : "gateway");
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {


### PR DESCRIPTION
## Summary
- Fixes #4689
- When `agents.defaults.sandbox.mode` is `"off"`, `tools.exec.host` now correctly defaults to `"gateway"` instead of `"sandbox"`
- Previously, exec would spawn Docker containers even with sandbox disabled, causing port conflicts and session desync

## Changes
- `bash-tools.exec.ts`: Check if sandbox config exists before defaulting to sandbox host
- Updated tests to use `security: "full"` to bypass approval (gateway exec requires approval)

## Test plan
- [x] All bash-tools tests pass
- [x] Linter passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `tools.exec.host` defaulting so that when the agent sandbox is disabled (`agents.defaults.sandbox.mode: "off"` / no sandbox config), `exec` runs on the gateway by default instead of attempting to spawn sandbox Docker containers. Tests were updated to set `security: "full"` where needed to bypass gateway approval prompts now that the default host may be `gateway`.

This change fits into the bash tools by aligning host selection (`sandbox` vs `gateway`) with the presence/absence of sandbox configuration, preventing unexpected Docker usage and associated port/session conflicts when sandboxing is turned off.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge with low functional risk.
- The core change is a small, localized defaulting tweak to exec host selection that better matches sandbox configuration, and the accompanying test updates reflect the new default. Main remaining risk is subtle behavior changes if `defaults.sandbox` can be set while sandbox mode is "off" (inconsistent config), which could still default to sandbox unexpectedly, but that seems unlikely given typical config construction.
- src/agents/bash-tools.exec.ts (host defaulting)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->