### PR TITLE
Avoid exiting the gateway process on non-fatal unhandled promise rejections

### DIFF
--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -31,6 +31,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
     vi.clearAllMocks();
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
+    delete process.env.OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS;
   });
 
   afterAll(() => {
@@ -125,7 +126,20 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       expect(consoleWarnSpy).toHaveBeenCalled();
     });
 
-    it("exits on generic errors without code", () => {
+    it("does NOT exit on generic errors without code", () => {
+      const genericErr = new Error("Something went wrong");
+
+      process.emit("unhandledRejection", genericErr, Promise.resolve());
+
+      expect(exitCalls).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[openclaw] Unhandled promise rejection:",
+        expect.stringContaining("Something went wrong"),
+      );
+    });
+
+    it("exits on generic errors without code when fail-fast is enabled", () => {
+      process.env.OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS = "1";
       const genericErr = new Error("Something went wrong");
 
       process.emit("unhandledRejection", genericErr, Promise.resolve());

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -155,6 +155,12 @@ export function installUnhandledRejectionHandler(): void {
     }
 
     console.error("[openclaw] Unhandled promise rejection:", formatUncaughtError(reason));
-    process.exit(1);
+    if (
+      process.env.OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS &&
+      process.env.OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS !== "0" &&
+      process.env.OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS.toLowerCase() !== "false"
+    ) {
+      process.exit(1);
+    }
   });
 }


### PR DESCRIPTION
The gateway now stays running for generic, non-fatal unhandled promise rejections. Fatal and configuration errors still exit the process as before.

Earlier, any unhandled rejection could cause the gateway to exit, even for temporary issues like network failures. This change avoids unnecessary restarts while keeping errors visible in logs.

Fail-fast behavior can still be enabled using the `OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS` environment variable. Tests were updated to cover the new behavior.

Fixes #4764

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the gateway’s `unhandledRejection` handling to only `process.exit(1)` for fatal/configuration errors by default, while keeping the process alive for generic unhandled promise rejections (still logging them). A new env var gate (`OPENCLAW_FAIL_FAST_UNHANDLED_REJECTIONS`) re-enables the previous fail-fast behavior for generic rejections. Tests were updated to assert the non-exit default and the opt-in exit behavior.

This fits into the existing infra error classification in `src/infra/unhandled-rejections.ts` by extending the final “generic unhandled rejection” branch to be configurable, while leaving the existing fatal/config/transient-network/abort handling unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it changes exit behavior only for generic unhandled rejections and keeps strong logging/tests.
- The change is small and localized, and the updated tests cover both default non-exit and the fail-fast opt-in. Main remaining concern is env-var parsing edge cases (whitespace/casing) that could lead to unexpected fail-fast enabling in some deployments.
- src/infra/unhandled-rejections.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->