### PR TITLE
Fix: Change associative array to indexed array for macOS compatibility

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  declare -a seen=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
macos default Bash versions do not support associative arrays in certain contexts -- using docker