### PR TITLE
fix: strip tools for Venice models without function calling support

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -208,7 +208,7 @@ export async function runEmbeddedAttempt(
     const modelHasVision = params.model.input?.includes("image") ?? false;
     // Strip tools for models that don't support function calling (e.g. certain Venice models)
     const modelSupportsFc =
-      params.provider !== "venice" || veniceModelSupportsFunctionCalling(params.modelId);
+      params.model.provider !== "venice" || veniceModelSupportsFunctionCalling(params.modelId);
     const toolsRaw =
       params.disableTools || !modelSupportsFc
         ? []

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -58,6 +58,7 @@ import {
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
+import { veniceModelSupportsFunctionCalling } from "../../venice-models.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
@@ -205,44 +206,48 @@ export async function runEmbeddedAttempt(
 
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
-    const toolsRaw = params.disableTools
-      ? []
-      : createOpenClawCodingTools({
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          sessionKey: params.sessionKey ?? params.sessionId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-        });
+    // Strip tools for models that don't support function calling (e.g. certain Venice models)
+    const modelSupportsFc =
+      params.provider !== "venice" || veniceModelSupportsFunctionCalling(params.modelId);
+    const toolsRaw =
+      params.disableTools || !modelSupportsFc
+        ? []
+        : createOpenClawCodingTools({
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
+            sandbox,
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            sessionKey: params.sessionKey ?? params.sessionId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+          });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     logToolSchemasForGoogle({ tools, provider: params.provider });
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -31,6 +31,8 @@ export type ModelDefinitionConfig = {
   maxTokens: number;
   headers?: Record<string, string>;
   compat?: ModelCompatConfig;
+  /** Whether the model supports function calling (tool use). Defaults to true if omitted. */
+  supportsFunctionCalling?: boolean;
 };
 
 export type ModelProviderConfig = {


### PR DESCRIPTION
## Problem

Venice AI models that don't support function calling (`hermes-3-llama-3.1-405b`, `venice-uncensored`, `deepseek-v3.2`) receive tools from OpenClaw unconditionally, causing Venice to reject the request with validation errors and return empty responses.

Venice's `/v1/models` endpoint correctly reports `supportsFunctionCalling: false` for these 3 models.

## Solution

1. **`src/config/types.models.ts`**: Added optional `supportsFunctionCalling?: boolean` to `ModelDefinitionConfig`
2. **`src/agents/venice-models.ts`**:
   - Marked 3 models with `supportsFunctionCalling: false` in the static catalog
   - Updated `buildVeniceModelDefinition()` to propagate the field
   - Updated `discoverVeniceModels()` to read `supportsFunctionCalling` from the Venice API for newly discovered models
   - Exported `veniceModelSupportsFunctionCalling()` helper for runtime lookups
3. **`src/agents/pi-embedded-runner/run/attempt.ts`**: When provider is `venice`, checks function calling support before creating tools — strips tools for unsupported models (same behavior as `disableTools`)

## Notes

- The pi-ai `Model` interface doesn't support custom fields, so the runtime check uses a direct catalog lookup rather than threading through the model object
- Models default to supporting function calling; only explicitly marked models are affected
- Build passes cleanly (`pnpm build`)

Co-authored-by: jonisjongithub <jonisjongithub@users.noreply.github.com>
Co-authored-by: Clawdbot <bot@clawd.bot>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `supportsFunctionCalling?: boolean` capability flag to `ModelDefinitionConfig`, annotates known Venice models that lack function calling support, propagates the flag through Venice model discovery, and uses a new `veniceModelSupportsFunctionCalling()` helper to strip tools at runtime for Venice models that can’t handle tool schemas. This prevents Venice request validation errors and empty responses caused by sending tools unconditionally.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and addresses a real provider capability mismatch, with one potential provider-id mismatch to verify.
- Changes are localized (Venice model catalog/discovery and tool creation gating) and align with Venice’s reported capabilities. Main remaining risk is whether `params.provider` vs `params.model.provider` can diverge, which could cause tools to be stripped (or not) unexpectedly.
- src/agents/pi-embedded-runner/run/attempt.ts (provider check logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->