### PR TITLE
fix: bump antigravity user agent to 1.15.8

### DIFF
--- a/src/infra/provider-usage.fetch.antigravity.ts
+++ b/src/infra/provider-usage.fetch.antigravity.ts
@@ -174,7 +174,7 @@ export async function fetchAntigravityUsage(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
-    "User-Agent": "antigravity",
+    "User-Agent": "antigravity/1.15.8",
     "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
   };
 


### PR DESCRIPTION
Bumps the antigravity user agent version to 1.15.8 to resolve 'version not supported' errors. This aligns with recent changes in the upstream proxy protocol.