### PR TITLE
fix(agents): skip error/aborted assistant messages in transcript repair

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,6 +116,16 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Skip error/aborted assistant messages - do not extract tool calls from them
+    // as they may contain incomplete/invalid tool_use blocks that would cause
+    // orphan tool_result entries after transformMessages() drops the errored assistant
+    const stopReason = (assistant as { stopReason?: string }).stopReason;
+    if (stopReason === "error" || stopReason === "aborted") {
+      out.push(msg);
+      continue;
+    }
+
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);


### PR DESCRIPTION
## Summary

When an assistant response is interrupted mid-tool-call (`stopReason: error` or `aborted`), `repairToolUseResultPairing()` was still extracting tool calls and inserting synthetic `tool_result` entries. This caused orphan `tool_result` blocks after `transformMessages()` dropped the errored assistant, leading to permanent session corruption with `unexpected tool_use_id` API errors.

## Changes

- Modified `repairToolUseResultPairing()` in `src/agents/session-transcript-repair.ts` to skip tool call extraction for `stopReason === "error"  || "aborted"` assistant messages
- Added 4 new unit tests covering error/aborted scenarios

## Root Cause

Two safety mechanisms interacted badly:
1. `session-tool-result-guard` inserts synthetic `toolResult` for orphaned tool calls
2. `transformMessages()` drops error/aborted assistant messages but **not** their corresponding `toolResult`

This created orphaned `tool_result` entries that referenced non-existent `tool_use` blocks.

## Testing

- All 8 tests in `session-transcript-repair.test.ts` pass
- Related tests in `session-tool-result-guard.test.ts` and `pi-embedded-runner.guard.test.ts` pass

## Fixes

- #4600 - Terminated assistant with toolCall causes infinite rejection loop
- #4597 - handle stopReason 'aborted' in transcript repair
- #4475 - Session corruption when tool call aborted mid-stream
- #4814 - repairToolUseResultPairing failed to catch orphaned tool_use
- #4815 - repairToolUseResultPairing failed to catch orphaned tool_use

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `repairToolUseResultPairing()` to avoid extracting tool calls (and thus avoid inserting synthetic `toolResult` entries) from assistant messages with `stopReason: "error"` or `"aborted"`. This prevents creating orphan `toolResult` blocks later when other sanitization (`transformMessages()`) drops those assistant turns but leaves tool results behind.

Unit tests were added to ensure error/aborted assistant messages do not trigger synthetic `toolResult` insertion, while normal tool-using assistants are still repaired as before.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and directly addresses a real session-corruption failure mode.
- The change is small, localized, and covered by new unit tests for the targeted stopReason cases. Main remaining uncertainty is behavioral: skipping errored/aborted assistants could drop legitimate tool results that followed those turns, which may or may not be desired depending on how transcripts are recorded in practice.
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->