### PR TITLE
fix(agents): sanitize tool pairing after compaction and history truncation

### DIFF
--- a/src/agents/pi-embedded-runner.limithistoryturns.test.ts
+++ b/src/agents/pi-embedded-runner.limithistoryturns.test.ts
@@ -157,4 +157,51 @@ describe("limitHistoryTurns", () => {
     expect(limited[0].content).toEqual([{ type: "text", text: "second" }]);
     expect(limited[1].content).toEqual([{ type: "text", text: "response" }]);
   });
+
+  it("removes orphan toolResult after truncation", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+    const limited = limitHistoryTurns(messages, 1);
+    // Orphan toolResult should be removed since its tool_use was truncated
+    expect(limited.filter((m) => m.role === "toolResult")).toHaveLength(0);
+    expect(limited[0].role).toBe("user");
+    expect(limited[0].content).toEqual([{ type: "text", text: "second" }]);
+  });
+
+  it("preserves valid tool pairs after truncation", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "old" }] },
+      { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+      { role: "user", content: [{ type: "text", text: "new" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ];
+    const limited = limitHistoryTurns(messages, 1);
+    // Valid tool pair should be preserved
+    expect(limited.filter((m) => m.role === "toolResult")).toHaveLength(1);
+    expect(limited).toHaveLength(3); // user + assistant + toolResult
+  });
 });

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 
 const THREAD_SUFFIX_REGEX = /^(.*)(?::(?:thread|topic):\d+)$/i;
 
@@ -26,7 +27,9 @@ export function limitHistoryTurns(
     if (messages[i].role === "user") {
       userCount++;
       if (userCount > limit) {
-        return messages.slice(lastUserIndex);
+        // Clean up orphan tool_result entries that may have lost their matching
+        // tool_use after truncating older messages
+        return sanitizeToolUseResultPairing(messages.slice(lastUserIndex));
       }
       lastUserIndex = i;
     }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -11,6 +11,7 @@ import {
   resolveContextWindowTokens,
   summarizeInStages,
 } from "../compaction.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
 const FALLBACK_SUMMARY =
   "Summary unavailable due to context limits. Older messages were truncated.";
@@ -208,6 +209,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 `(${pruned.droppedMessages} messages) to fit history budget.`,
             );
             messagesToSummarize = pruned.messages;
+
+            // Clean up orphan tool_result entries that may have lost their matching tool_use
+            // after pruning older messages
+            messagesToSummarize = sanitizeToolUseResultPairing(messagesToSummarize);
 
             // Summarize dropped messages so context isn't lost
             if (pruned.droppedMessagesList.length > 0) {


### PR DESCRIPTION
## Summary

When compaction prunes older messages or `limitHistoryTurns` truncates history, `tool_result` entries can become orphaned if their matching `tool_use` was removed. This causes `unexpected tool_use_id` API errors.

## Changes

### compaction-safeguard.ts
- Call `sanitizeToolUseResultPairing()` after `pruneHistoryForContextShare()` to clean up orphan `tool_result` entries

### history.ts  
- Call `sanitizeToolUseResultPairing()` after truncating history in `limitHistoryTurns()`

### Tests
- Added 2 new tests for `limitHistoryTurns` tool pairing scenarios:
  - `removes orphan toolResult after truncation`
  - `preserves valid tool pairs after truncation`

## Root Cause

Both compaction and history truncation can remove `assistant` messages containing `tool_use` blocks while leaving their corresponding `tool_result` entries in the retained portion. This creates orphaned `tool_result` entries that reference non-existent `tool_use` blocks.

## Testing

- All 17 tests in `compaction-safeguard.test.ts` pass
- All 11 tests in `pi-embedded-runner.limithistoryturns.test.ts` pass

## Fixes

- #4739 - Compaction drops tool_use but keeps tool_result
- #4728 - Session corruption after compaction with tool calls
- #4723 - Compaction safeguard leaves orphan tool_result
- #3462 - Context compaction breaks tool pairing
- #3455 - Compaction causes unexpected tool_use_id error
- #4261 - Long session compaction corrupts transcript
- #4367 - DM history limit causes orphan tool_result
- #4323 - limitHistoryTurns breaks tool pairing
- #4650 - History truncation leaves orphan tool_result

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens transcript integrity by running `sanitizeToolUseResultPairing()` after two history-shaping operations: compaction pruning (`pruneHistoryForContextShare`) and DM history truncation (`limitHistoryTurns`). This prevents “orphan” `toolResult` entries whose matching `toolCall/tool_use` messages were removed, which can trigger strict-provider API errors like `unexpected tool_use_id`.

Changes are localized to the compaction safeguard extension and embedded runner history logic, plus two new unit tests covering tool pairing behavior during truncation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it adds a focused repair step after truncation/pruning and includes targeted tests.
- Core change is a small call-site addition to an existing transcript-repair utility in two places that can create orphan tool results. Behavior is consistent with existing repair semantics (dropping free-floating tool results). Only notable concern is that one new test doesn’t strongly assert correct pairing/order, so a narrow regression could slip through.
- src/agents/pi-embedded-runner.limithistoryturns.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->