### PR TITLE
docs: fix GitHub branding capitalization

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -4,7 +4,7 @@ read_when:
   - You want to use GitHub Copilot as a model provider
   - You need the `openclaw models auth login-github-copilot` flow
 ---
-# Github Copilot
+# GitHub Copilot
 
 ## What is GitHub Copilot?
 


### PR DESCRIPTION
Corrects 'Github' to 'GitHub' in the Copilot provider documentation to match official branding.