### PR TITLE
docs: use straight quotes for code terms in installer guide

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -37,7 +37,7 @@ What it does (high level):
 - Choose install method:
   - `npm` (default): `npm install -g openclaw@latest`
   - `git`: clone/build a source checkout and install a wrapper script
-- On Linux: avoid global npm permission errors by switching npm’s prefix to `~/.npm-global` when needed.
+- On Linux: avoid global npm permission errors by switching npm's prefix to `~/.npm-global` when needed.
 - If upgrading an existing install: runs `openclaw doctor --non-interactive` (best effort).
 - For git installs: runs `openclaw doctor --non-interactive` after install/update (best effort).
 - Mitigates `sharp` native install gotchas by defaulting `SHARP_IGNORE_GLOBAL_LIBVIPS=1` (avoids building against system libvips).
@@ -65,7 +65,7 @@ For `npm` installs, Git is *usually* not required, but some environments still e
 
 ### Why npm hits `EACCES` on fresh Linux
 
-On some Linux setups (especially after installing Node via the system package manager or NodeSource), npm’s global prefix points at a root-owned location. Then `npm install -g ...` fails with `EACCES` / `mkdir` permission errors.
+On some Linux setups (especially after installing Node via the system package manager or NodeSource), npm's global prefix points at a root-owned location. Then `npm install -g ...` fails with `EACCES` / `mkdir` permission errors.
 
 `install.sh` mitigates this by switching the prefix to:
 


### PR DESCRIPTION
Replaces curly quotes (’) with straight quotes (') for consistency in technical terms like "npm's".