### PR TITLE
chore: add common editor and OS temporary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,18 @@ USER.md
 
 # local tooling
 .serena/
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
Adds rules for .vscode, .idea, .DS_Store, and other common temporary files to keep the working directory clean across different development environments.