### PR TITLE
fix(cron,auth): pass agentId/AccountId in heartbeat chain, sync Claude CLI credentials

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -1,6 +1,7 @@
 export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
 export { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 export { formatAuthDoctorHint } from "./auth-profiles/doctor.js";
+export { resyncExternalCliOnAuthError } from "./auth-profiles/external-cli-sync.js";
 export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
 export { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 export { resolveAuthStorePathForDisplay } from "./auth-profiles/paths.js";

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -137,7 +137,10 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
         mutated = true;
         log.info("synced anthropic token from claude cli", {
           profileId: CLAUDE_CLI_PROFILE_ID,
-          expires: new Date(claudeCreds.expires).toISOString(),
+          expires:
+            typeof claudeCreds.expires === "number"
+              ? new Date(claudeCreds.expires).toISOString()
+              : "none",
         });
       }
     }

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -224,7 +224,7 @@ export function resyncExternalCliOnAuthError(store: AuthProfileStore, profileId:
 
     if (creds.type === "token") {
       const existingToken = existing?.type === "token" ? existing : undefined;
-      if (existingToken?.token === creds.token) {
+      if (existingToken?.token === creds.token && existingToken.expires === creds.expires) {
         return false;
       }
       if (typeof creds.expires === "number" && creds.expires <= now) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -94,8 +94,10 @@ async function refreshOAuthTokenWithLock(params: {
     };
     saveAuthProfileStore(store, params.agentDir);
 
-    // Keep Claude CLI credentials file in sync after refresh
-    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+    // Keep Claude CLI credentials file in sync after refresh.
+    // Check the updated store entry (not pre-refresh cred) in case the provider was relabelled.
+    const refreshedCred = store.profiles[params.profileId];
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && refreshedCred?.provider === "anthropic") {
       try {
         writeClaudeCliCredentials(result.newCredentials);
       } catch (error) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -99,7 +99,10 @@ async function refreshOAuthTokenWithLock(params: {
     const refreshedCred = store.profiles[params.profileId];
     if (params.profileId === CLAUDE_CLI_PROFILE_ID && refreshedCred?.provider === "anthropic") {
       try {
-        writeClaudeCliCredentials(result.newCredentials);
+        const written = writeClaudeCliCredentials(result.newCredentials);
+        if (!written) {
+          log.warn("write-back to claude cli returned false (file missing or structure invalid)");
+        }
       } catch (error) {
         log.warn("failed to write back refreshed credentials to claude cli", {
           error: error instanceof Error ? error.message : String(error),

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,7 +9,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { writeClaudeCliCredentials } from "../cli-credentials.js";
+import { AUTH_STORE_LOCK_OPTIONS, CLAUDE_CLI_PROFILE_ID, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -92,6 +93,17 @@ async function refreshOAuthTokenWithLock(params: {
       type: "oauth",
     };
     saveAuthProfileStore(store, params.agentDir);
+
+    // Keep Claude CLI credentials file in sync after refresh
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+      try {
+        writeClaudeCliCredentials(result.newCredentials);
+      } catch (error) {
+        log.warn("failed to write back refreshed credentials to claude cli", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     return result;
   } finally {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -11,6 +11,8 @@ import {
   markAuthProfileFailure,
   markAuthProfileGood,
   markAuthProfileUsed,
+  resyncExternalCliOnAuthError,
+  saveAuthProfileStore,
 } from "../auth-profiles.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
@@ -481,6 +483,23 @@ export async function runEmbeddedPiAgent(
               };
             }
             const promptFailoverReason = classifyFailoverReason(errorText);
+            // On auth errors, try re-syncing from external CLI before marking failure.
+            // Handles the case where Claude CLI refreshed independently, revoking our token.
+            if (promptFailoverReason === "auth" && lastProfileId) {
+              const resynced = resyncExternalCliOnAuthError(authStore, lastProfileId);
+              if (resynced) {
+                saveAuthProfileStore(authStore, agentDir);
+                try {
+                  await applyApiKeyInfo(lastProfileId);
+                  log.info("retrying with re-synced external cli credentials", {
+                    profileId: lastProfileId,
+                  });
+                  continue;
+                } catch {
+                  // re-apply failed, fall through to normal failure handling
+                }
+              }
+            }
             if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
               await markAuthProfileFailure({
                 store: authStore,
@@ -564,6 +583,22 @@ export async function runEmbeddedPiAgent(
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
 
           if (shouldRotate) {
+            // On auth errors, try re-syncing from external CLI before marking failure.
+            if (assistantFailoverReason === "auth" && lastProfileId) {
+              const resynced = resyncExternalCliOnAuthError(authStore, lastProfileId);
+              if (resynced) {
+                saveAuthProfileStore(authStore, agentDir);
+                try {
+                  await applyApiKeyInfo(lastProfileId);
+                  log.info("retrying with re-synced external cli credentials", {
+                    profileId: lastProfileId,
+                  });
+                  continue;
+                } catch {
+                  // re-apply failed, fall through to normal failure handling
+                }
+              }
+            }
             if (lastProfileId) {
               const reason =
                 timedOut || assistantFailoverReason === "timeout"

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -495,8 +495,11 @@ export async function runEmbeddedPiAgent(
                     profileId: lastProfileId,
                   });
                   continue;
-                } catch {
-                  // re-apply failed, fall through to normal failure handling
+                } catch (resyncErr) {
+                  log.warn("re-synced external cli credentials but apply failed", {
+                    profileId: lastProfileId,
+                    error: resyncErr instanceof Error ? resyncErr.message : String(resyncErr),
+                  });
                 }
               }
             }
@@ -594,8 +597,11 @@ export async function runEmbeddedPiAgent(
                     profileId: lastProfileId,
                   });
                   continue;
-                } catch {
-                  // re-apply failed, fall through to normal failure handling
+                } catch (resyncErr) {
+                  log.warn("re-synced external cli credentials but apply failed", {
+                    profileId: lastProfileId,
+                    error: resyncErr instanceof Error ? resyncErr.message : String(resyncErr),
+                  });
                 }
               }
             }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -26,7 +26,11 @@ export type CronServiceDeps = {
   cronEnabled: boolean;
   enqueueSystemEvent: (text: string, opts?: { agentId?: string }) => void;
   requestHeartbeatNow: (opts?: { reason?: string }) => void;
-  runHeartbeatOnce?: (opts?: { reason?: string }) => Promise<HeartbeatRunResult>;
+  runHeartbeatOnce?: (opts?: {
+    reason?: string;
+    agentId?: string;
+    forcedByCron?: boolean;
+  }) => Promise<HeartbeatRunResult>;
   runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<{
     status: "ok" | "error" | "skipped";
     summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -172,7 +172,11 @@ export async function executeJob(
 
         let heartbeatResult: HeartbeatRunResult;
         for (;;) {
-          heartbeatResult = await state.deps.runHeartbeatOnce({ reason });
+          heartbeatResult = await state.deps.runHeartbeatOnce({
+            reason,
+            agentId: job.agentId,
+            forcedByCron: true,
+          });
           if (
             heartbeatResult.status !== "skipped" ||
             heartbeatResult.reason !== "requests-in-flight"

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -60,6 +60,8 @@ export function buildGatewayCronService(params: {
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
+        agentId: opts?.agentId,
+        forcedByCron: opts?.forcedByCron,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -478,18 +478,20 @@ export async function runHeartbeatOnce(opts: {
   agentId?: string;
   heartbeat?: HeartbeatConfig;
   reason?: string;
+  forcedByCron?: boolean;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? loadConfig();
   const agentId = normalizeAgentId(opts.agentId ?? resolveDefaultAgentId(cfg));
   const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId);
+  const isCronWake = opts.forcedByCron === true;
   if (!heartbeatsEnabled) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+  if (!isCronWake && !isHeartbeatEnabledForAgent(cfg, agentId)) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+  if (!isCronWake && !resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
     return { status: "skipped", reason: "disabled" };
   }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -554,6 +554,10 @@ export async function runHeartbeatOnce(opts: {
     To: sender,
     Provider: hasExecCompletion ? "exec-event" : "heartbeat",
     SessionKey: sessionKey,
+    // Pass the resolved account ID so that tool calls (e.g. message send)
+    // during the heartbeat turn use the correct channel account rather than
+    // falling back to the default agent's account.
+    AccountId: delivery.accountId,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

Three bug fixes for multi-agent gateway setups:

- **fix(cron): pass agentId through wakeMode=now heartbeat chain** — `runHeartbeatOnce` was called without `agentId` from cron jobs, `server-cron.ts` didn't forward `agentId`/`forcedByCron`, and `isHeartbeatEnabledForAgent` blocked agents without explicit heartbeat config. Added `forcedByCron` flag to bypass the enabled check for cron-triggered wakes.

- **fix(auth): sync Claude CLI credentials bidirectionally** — Only Qwen CLI credentials were synced, not Claude CLI. When Claude Code independently refreshed its OAuth token, the old refresh token in `auth-profiles.json` became invalid (single-use), causing `invalid_grant` failures. Now `syncExternalCliCredentials()` reads fresh tokens from `~/.claude/.credentials.json`, and `refreshOAuthTokenWithLock()` writes back after a successful refresh.

- **fix(cron): pass AccountId in heartbeat context for correct agent delivery** — When a cron job fires for a non-default agent, the heartbeat context was missing `AccountId`, causing the message tool to fall back to the default Telegram account instead of the agent's own. Now includes `delivery.accountId` in the heartbeat context.

## Test plan

- [x] Gateway runs with multiple agents, each with their own Telegram bot
- [x] Heartbeats fire correctly for non-default agents (verified via `journalctl` logs)
- [x] Claude CLI credential sync observed in logs: `[agents/auth-profiles] synced anthropic credentials from claude cli`
- [x] Non-default agent cron wakes deliver to the correct Telegram account
- [x] Running in production on a multi-agent gateway for ~8 hours with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes several multi-agent gateway edge cases:

- Cron wake-ups now propagate `agentId` through the `runHeartbeatOnce` call chain and can bypass the per-agent heartbeat enable/interval checks when explicitly forced by cron.
- Heartbeat runs now include `AccountId` in the message context, ensuring tool calls during heartbeat use the correct channel account for non-default agents.
- Auth profile syncing now supports Claude CLI credentials bidirectionally: external Claude CLI tokens can be imported into `auth-profiles`, and refreshed OAuth credentials can be written back to the Claude CLI credential store.

Overall, the changes fit cleanly into existing cron/heartbeat/auth-profile plumbing by threading a small amount of additional context (`agentId`, `forcedByCron`, `AccountId`) through existing dependency boundaries.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; changes are localized and align with the stated multi-agent fixes.
- I reviewed the modified cron/heartbeat/auth-profile flow and the new parameters are consistently threaded through the call chain. The main remaining concerns are minor: logging assumes an always-valid `expires` in the Claude token branch, and the auth store lock scope includes an external write-back call that could increase lock contention.
- src/agents/auth-profiles/external-cli-sync.ts, src/agents/auth-profiles/oauth.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->