### PR TITLE
fix(security): prevent gateway token from defaulting to 'undefined' string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Status: stable.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- Gateway: prevent blank token prompts from storing "undefined". (#4873) Thanks @Hisleren.
 - Telegram: use undici fetch for per-account proxy dispatcher. (#4456) Thanks @spiceoogway.
 - Telegram: fix HTML nesting for overlapping styles and links. (#4578) Thanks @ThanhNguyxn.
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  text: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+  resolveGatewayPort: vi.fn(),
+  buildGatewayAuthConfig: vi.fn(),
+  note: vi.fn(),
+  randomToken: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importActual) => {
+  const actual = await importActual<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    resolveGatewayPort: mocks.resolveGatewayPort,
+  };
+});
+
+vi.mock("./configure.shared.js", () => ({
+  text: mocks.text,
+  select: mocks.select,
+  confirm: mocks.confirm,
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+vi.mock("./configure.gateway-auth.js", () => ({
+  buildGatewayAuthConfig: mocks.buildGatewayAuthConfig,
+}));
+
+vi.mock("../infra/tailscale.js", () => ({
+  findTailscaleBinary: vi.fn(async () => undefined),
+}));
+
+vi.mock("./onboard-helpers.js", async (importActual) => {
+  const actual = await importActual<typeof import("./onboard-helpers.js")>();
+  return {
+    ...actual,
+    randomToken: mocks.randomToken,
+  };
+});
+
+import { promptGatewayConfig } from "./configure.gateway.js";
+
+describe("promptGatewayConfig", () => {
+  it("generates a token when the prompt returns undefined", async () => {
+    mocks.resolveGatewayPort.mockReturnValue(18789);
+    const selectQueue = ["loopback", "token", "off"];
+    mocks.select.mockImplementation(async () => selectQueue.shift());
+    const textQueue = ["18789", undefined];
+    mocks.text.mockImplementation(async () => textQueue.shift());
+    mocks.randomToken.mockReturnValue("generated-token");
+    mocks.buildGatewayAuthConfig.mockImplementation(({ mode, token, password }) => ({
+      mode,
+      token,
+      password,
+    }));
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const result = await promptGatewayConfig({}, runtime);
+    expect(result.token).toBe("generated-token");
+  });
+});

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -5,7 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
 import { confirm, select, text } from "./configure.shared.js";
-import { guardCancel, randomToken } from "./onboard-helpers.js";
+import { guardCancel, normalizeGatewayTokenInput, randomToken } from "./onboard-helpers.js";
 
 type GatewayAuthChoice = "token" | "password";
 
@@ -177,8 +177,7 @@ export async function promptGatewayConfig(
       }),
       runtime,
     );
-    const rawInput = tokenInput ? String(tokenInput).trim() : "";
-    gatewayToken = rawInput || randomToken();
+    gatewayToken = normalizeGatewayTokenInput(tokenInput) || randomToken();
   }
 
   if (authMode === "password") {

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -177,7 +177,8 @@ export async function promptGatewayConfig(
       }),
       runtime,
     );
-    gatewayToken = String(tokenInput).trim() || randomToken();
+    const rawInput = tokenInput ? String(tokenInput).trim() : "";
+    gatewayToken = rawInput || randomToken();
   }
 
   if (authMode === "password") {

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { openUrl, resolveBrowserOpenCommand, resolveControlUiLinks } from "./onboard-helpers.js";
+import {
+  normalizeGatewayTokenInput,
+  openUrl,
+  resolveBrowserOpenCommand,
+  resolveControlUiLinks,
+} from "./onboard-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   runCommandWithTimeout: vi.fn(async () => ({
@@ -101,5 +106,20 @@ describe("resolveControlUiLinks", () => {
     });
     expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
     expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
+});
+
+describe("normalizeGatewayTokenInput", () => {
+  it("returns empty string for undefined or null", () => {
+    expect(normalizeGatewayTokenInput(undefined)).toBe("");
+    expect(normalizeGatewayTokenInput(null)).toBe("");
+  });
+
+  it("trims string input", () => {
+    expect(normalizeGatewayTokenInput("  token  ")).toBe("token");
+  });
+
+  it("coerces non-string input to string", () => {
+    expect(normalizeGatewayTokenInput(123)).toBe("123");
   });
 });

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -119,7 +119,7 @@ describe("normalizeGatewayTokenInput", () => {
     expect(normalizeGatewayTokenInput("  token  ")).toBe("token");
   });
 
-  it("coerces non-string input to string", () => {
-    expect(normalizeGatewayTokenInput(123)).toBe("123");
+  it("returns empty string for non-string input", () => {
+    expect(normalizeGatewayTokenInput(123)).toBe("");
   });
 });

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -62,6 +62,11 @@ export function randomToken(): string {
   return crypto.randomBytes(24).toString("hex");
 }
 
+export function normalizeGatewayTokenInput(value: unknown): string {
+  if (value == null) return "";
+  return String(value).trim();
+}
+
 export function printWizardHeader(runtime: RuntimeEnv) {
   const header = [
     "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄",

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -63,8 +63,8 @@ export function randomToken(): string {
 }
 
 export function normalizeGatewayTokenInput(value: unknown): string {
-  if (value == null) return "";
-  return String(value).trim();
+  if (typeof value !== "string") return "";
+  return value.trim();
 }
 
 export function printWizardHeader(runtime: RuntimeEnv) {

--- a/src/wizard/onboarding.gateway-config.test.ts
+++ b/src/wizard/onboarding.gateway-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "./prompts.js";
+
+const mocks = vi.hoisted(() => ({
+  randomToken: vi.fn(),
+}));
+
+vi.mock("../commands/onboard-helpers.js", async (importActual) => {
+  const actual = await importActual<typeof import("../commands/onboard-helpers.js")>();
+  return {
+    ...actual,
+    randomToken: mocks.randomToken,
+  };
+});
+
+vi.mock("../infra/tailscale.js", () => ({
+  findTailscaleBinary: vi.fn(async () => undefined),
+}));
+
+import { configureGatewayForOnboarding } from "./onboarding.gateway-config.js";
+
+describe("configureGatewayForOnboarding", () => {
+  it("generates a token when the prompt returns undefined", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const selectQueue = ["loopback", "token", "off"];
+    const textQueue = ["18789", undefined];
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => selectQueue.shift() as string),
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => textQueue.shift() as string),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const result = await configureGatewayForOnboarding({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: {
+        hasExisting: false,
+        port: 18789,
+        bind: "loopback",
+        authMode: "token",
+        tailscaleMode: "off",
+        token: undefined,
+        password: undefined,
+        customBindHost: undefined,
+        tailscaleResetOnExit: false,
+      },
+      prompter,
+      runtime,
+    });
+
+    expect(result.settings.gatewayToken).toBe("generated-token");
+  });
+});

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -1,4 +1,4 @@
-import { randomToken } from "../commands/onboard-helpers.js";
+import { normalizeGatewayTokenInput, randomToken } from "../commands/onboard-helpers.js";
 import type { GatewayAuthChoice } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { findTailscaleBinary } from "../infra/tailscale.js";
@@ -182,9 +182,7 @@ export async function configureGatewayForOnboarding(
         placeholder: "Needed for multi-machine or non-loopback access",
         initialValue: quickstartGateway.token ?? "",
       });
-      // FIX: Ensure undefined becomes an empty string, not "undefined" string
-      const rawInput = tokenInput ? String(tokenInput).trim() : "";
-      gatewayToken = rawInput || randomToken();
+      gatewayToken = normalizeGatewayTokenInput(tokenInput) || randomToken();
     }
   }
 

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -182,7 +182,9 @@ export async function configureGatewayForOnboarding(
         placeholder: "Needed for multi-machine or non-loopback access",
         initialValue: quickstartGateway.token ?? "",
       });
-      gatewayToken = String(tokenInput).trim() || randomToken();
+      // FIX: Ensure undefined becomes an empty string, not "undefined" string
+      const rawInput = tokenInput ? String(tokenInput).trim() : "";
+      gatewayToken = rawInput || randomToken();
     }
   }
 


### PR DESCRIPTION
## Description
Fixes a critical security vulnerability where the Gateway token would default to the literal string `"undefined"` if the user left the input blank during installation.

## Changes
- Updated `onboarding.gateway-config.ts` to ensure `tokenInput` is treated as an empty string if undefined, triggering the `randomToken()` fallback correctly.
- Applied a defensive fix in `configure.gateway.ts` to prevent similar issues.

## Testing
- Verified that leaving the token prompt blank now generates a random token instead of `"undefined"`.

Related to private security report.