### PR TITLE
Fix: Change associative array to indexed array for macos compatibility

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  declare -a seen=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
Change associative array to indexed array for macos compatibility -- (using docker)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to replace an associative array with an indexed array for macOS compatibility.

However, the script still uses `seen` with string keys (`seen["$k"]=1` and `${seen[$k]}`), which only works correctly with `declare -A`. With `declare -a`, those subscripts are treated as arithmetic and can collide (often at index 0), breaking the `upsert_env` dedupe/replace logic when multiple keys are processed.

In context, `upsert_env` is responsible for updating `.env` entries used by the Docker compose setup; if it mis-tracks which keys were written, the generated `.env` can have missing or duplicated variables, causing confusing Docker behavior.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because it breaks `upsert_env` key tracking.
- The only change swaps `declare -A` to `declare -a` but the code continues to rely on associative-array semantics; in bash this will cause key collisions and incorrect `.env` output for most inputs, which is a functional regression.
- docker-setup.sh (upsert_env / seen array logic)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->