### PR TITLE
fix: string/type handling and API fixes (#4537, #4380, #4373, #4547, #4629)

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -51,7 +51,15 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
 
 function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const now = new Date();
+  const dateStr = now.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: params.userTimezone,
+  });
+  return ["## Current Date & Time", dateStr, `Time zone: ${params.userTimezone}`, ""];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -40,13 +40,14 @@ export function scheduleFollowupDrain(
             const to = item.originatingTo;
             const accountId = item.originatingAccountId;
             const threadId = item.originatingThreadId;
-            if (!channel && !to && !accountId && typeof threadId !== "number") {
+            // Use != null to handle both number (legacy) and string (Slack) thread IDs
+            if (!channel && !to && !accountId && threadId == null) {
               return {};
             }
             if (!isRoutableChannel(channel) || !to) {
               return { cross: true };
             }
-            const threadKey = typeof threadId === "number" ? String(threadId) : "";
+            const threadKey = threadId != null ? String(threadId) : "";
             return {
               key: [channel, to, accountId || "", threadKey].join("|"),
             };
@@ -72,7 +73,7 @@ export function scheduleFollowupDrain(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null,
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -8,8 +8,9 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   if (!normalized) return undefined;
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
+    // Preserve case for group ID - base64 is case-sensitive
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -141,7 +141,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
   const now = Date.now();
 
   for (const job of jobs) {
-    const idLabel = pad(job.id, CRON_ID_PAD);
+    const idLabel = pad((job as { jobId?: string }).jobId ?? job.id ?? "", CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
       truncate(formatSchedule(job.schedule), CRON_SCHEDULE_PAD),


### PR DESCRIPTION
## Summary

This PR fixes 5 issues related to string/type handling and API usage:

### Fixes

1. **#4537 Signal Group ID case sensitivity**
   - File: `src/channels/plugins/normalize/signal.ts`
   - Preserve case for group ID since base64 is case-sensitive

2. **#4380 Slack thread_ts typeof check**
   - File: `src/auto-reply/reply/queue/drain.ts`
   - Use `!= null` instead of `typeof === 'number'` for thread_ts (Slack uses strings)

3. **#4373 cron list job.id crash**
   - File: `src/cli/cron-cli/shared.ts`
   - Handle `jobId/id` field name variation in cron list

4. **#4547 Nostr handleInboundMessage not a function**
   - File: `extensions/nostr/src/channel.ts`
   - Use `dispatchReplyFromConfig` instead of non-existent `handleInboundMessage`

5. **#4629 Include day of week in date/time injection**
   - File: `src/agents/system-prompt.ts`
   - Include full date with day of week in system prompt

### Testing

- All existing tests pass
- Build succeeds

Fixes #4537, #4380, #4373, #4547, #4629

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses several small but user-facing correctness issues across channels/CLI:

- Signal target normalization now preserves the case of `group:` IDs so base64 identifiers aren’t corrupted.
- Follow-up drain routing treats `originatingThreadId` as “present” when it’s non-null, accommodating Slack’s string `thread_ts`.
- Cron list output tolerates gateways returning `jobId` instead of `id`.
- The Nostr extension replaces a call to a non-existent inbound handler by wiring into the core routing/session/envelope pipeline and using `dispatchReplyFromConfig` for replies.
- Agent system prompts now include the full date (with weekday) when a user timezone is available.

Overall these changes fit existing patterns: normalize/route/dispatch logic is centralized in runtime helpers, while channel adapters translate provider events into a standard inbound context and delegate reply formatting/delivery to the core runtime.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and mostly straightforward correctness fixes.
- Most edits are small type/format fixes. The main risk is behavioral drift in the Nostr inbound path due to config caching and in follow-up drain thread-id presence semantics; neither looks immediately breaking but both merit a quick sanity check in environments where hot reload or sentinel thread IDs are used.
- extensions/nostr/src/channel.ts; src/auto-reply/reply/queue/drain.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->