### PR TITLE
fix(security): restrict local path extraction in media parser to prevent LFI

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -9,21 +9,33 @@ describe("splitMediaFromOutput", () => {
     expect(result.text).toBe("Hello world");
   });
 
-  it("captures media paths with spaces", () => {
+  it("rejects absolute media paths to prevent LFI", () => {
     const result = splitMediaFromOutput("MEDIA:/Users/pete/My File.png");
-    expect(result.mediaUrls).toEqual(["/Users/pete/My File.png"]);
-    expect(result.text).toBe("");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:/Users/pete/My File.png");
   });
 
-  it("captures quoted media paths with spaces", () => {
+  it("rejects quoted absolute media paths to prevent LFI", () => {
     const result = splitMediaFromOutput('MEDIA:"/Users/pete/My File.png"');
-    expect(result.mediaUrls).toEqual(["/Users/pete/My File.png"]);
-    expect(result.text).toBe("");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe('MEDIA:"/Users/pete/My File.png"');
   });
 
-  it("captures tilde media paths with spaces", () => {
+  it("rejects tilde media paths to prevent LFI", () => {
     const result = splitMediaFromOutput("MEDIA:~/Pictures/My File.png");
-    expect(result.mediaUrls).toEqual(["~/Pictures/My File.png"]);
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:~/Pictures/My File.png");
+  });
+
+  it("rejects directory traversal media paths to prevent LFI", () => {
+    const result = splitMediaFromOutput("MEDIA:../../etc/passwd");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:../../etc/passwd");
+  });
+
+  it("captures safe relative media paths", () => {
+    const result = splitMediaFromOutput("MEDIA:./screenshots/image.png");
+    expect(result.mediaUrls).toEqual(["./screenshots/image.png"]);
     expect(result.text).toBe("");
   });
 
@@ -43,8 +55,8 @@ describe("splitMediaFromOutput", () => {
   });
 
   it("parses MEDIA tags with leading whitespace", () => {
-    const result = splitMediaFromOutput("  MEDIA:/tmp/screenshot.png");
-    expect(result.mediaUrls).toEqual(["/tmp/screenshot.png"]);
+    const result = splitMediaFromOutput("  MEDIA:./screenshot.png");
+    expect(result.mediaUrls).toEqual(["./screenshot.png"]);
     expect(result.text).toBe("");
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -19,11 +19,9 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
   if (candidate.length > 4096) return false;
   if (!opts?.allowSpaces && /\s/.test(candidate)) return false;
   if (/^https?:\/\//i.test(candidate)) return true;
-  if (candidate.startsWith("/")) return true;
-  if (candidate.startsWith("./")) return true;
-  if (candidate.startsWith("../")) return true;
-  if (candidate.startsWith("~")) return true;
-  return false;
+
+  // Local paths: only allow safe relative paths starting with ./ that do not traverse upwards.
+  return candidate.startsWith("./") && !candidate.includes("..");
 }
 
 function unwrapQuoted(value: string): string | undefined {
@@ -85,10 +83,9 @@ export function splitMediaFromOutput(raw: string): {
       continue;
     }
 
-    foundMediaToken = true;
     const pieces: string[] = [];
     let cursor = 0;
-    let hasValidMedia = false;
+    let hasValidMediaOnLine = false;
 
     for (const match of matches) {
       const start = match.index ?? 0;
@@ -101,11 +98,14 @@ export function splitMediaFromOutput(raw: string): {
       const mediaStartIndex = media.length;
       let validCount = 0;
       const invalidParts: string[] = [];
+      let hasValidMedia = false;
       for (const part of parts) {
         const candidate = normalizeMediaSource(cleanCandidate(part));
         if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
           media.push(candidate);
           hasValidMedia = true;
+          hasValidMediaOnLine = true;
+          foundMediaToken = true;
           validCount += 1;
         } else {
           invalidParts.push(part);
@@ -130,6 +130,8 @@ export function splitMediaFromOutput(raw: string): {
         if (isValidMedia(fallback, { allowSpaces: true })) {
           media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           hasValidMedia = true;
+          hasValidMediaOnLine = true;
+          foundMediaToken = true;
           validCount = 1;
           invalidParts.length = 0;
         }
@@ -140,12 +142,19 @@ export function splitMediaFromOutput(raw: string): {
         if (isValidMedia(fallback, { allowSpaces: true })) {
           media.push(fallback);
           hasValidMedia = true;
+          hasValidMediaOnLine = true;
+          foundMediaToken = true;
           invalidParts.length = 0;
         }
       }
 
-      if (hasValidMedia && invalidParts.length > 0) {
-        pieces.push(invalidParts.join(" "));
+      if (hasValidMedia) {
+        if (invalidParts.length > 0) {
+          pieces.push(invalidParts.join(" "));
+        }
+      } else {
+        // If no valid media was found in this match, keep the original token text.
+        pieces.push(match[0]);
       }
 
       cursor = start + match[0].length;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -85,7 +85,6 @@ export function splitMediaFromOutput(raw: string): {
 
     const pieces: string[] = [];
     let cursor = 0;
-    let hasValidMediaOnLine = false;
 
     for (const match of matches) {
       const start = match.index ?? 0;
@@ -104,7 +103,6 @@ export function splitMediaFromOutput(raw: string): {
         if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
           media.push(candidate);
           hasValidMedia = true;
-          hasValidMediaOnLine = true;
           foundMediaToken = true;
           validCount += 1;
         } else {
@@ -130,7 +128,6 @@ export function splitMediaFromOutput(raw: string): {
         if (isValidMedia(fallback, { allowSpaces: true })) {
           media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           hasValidMedia = true;
-          hasValidMediaOnLine = true;
           foundMediaToken = true;
           validCount = 1;
           invalidParts.length = 0;
@@ -142,7 +139,6 @@ export function splitMediaFromOutput(raw: string): {
         if (isValidMedia(fallback, { allowSpaces: true })) {
           media.push(fallback);
           hasValidMedia = true;
-          hasValidMediaOnLine = true;
           foundMediaToken = true;
           invalidParts.length = 0;
         }


### PR DESCRIPTION
### Summary
This PR fixes a critical Local File Inclusion (LFI) vulnerability in the media parsing logic.

### Description
The 'isValidMedia' function in 'src/media/parse.ts' previously allowed absolute paths ('/'), home-relative paths ('\~'), and directory traversal ('..') to be extracted from model output (e.g., via 'MEDIA:' tokens). This allowed a malicious agent or an attacker using prompt injection to exfiltrate any file accessible to the OpenClaw process (such as '~/.clawdbot/auth-profiles.json').

This fix:
1. Restricts 'isValidMedia' to only allow 'https://' URLs and safe relative paths starting with './' (without traversal).
2. Updates 'splitMediaFromOutput' to only strip 'MEDIA:' tokens if they contain at least one valid media URL, preserving invalid tokens in the text for user visibility.
3. Updates 'src/media/parse.test.ts' to reflect these security restrictions.

### Testing
- Verified with a Proof-of-Concept that '/etc/hosts' and '~/.clawdbot/auth-profiles.json' are no longer extracted or read.
- All existing tests pass ('npm run test src/media/parse.test.ts').