### PR TITLE
docs(plugin): clarify memory-lancedb is bundled (no npm install needed)

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -39,10 +39,8 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
-/
 > **Note**: `memory-lancedb` is bundled with OpenClaw and does not need npm installation.
-> Simply enable it via config: `plugins.slots.memory = "memory-lancedb"`/
-- [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
+> Simply enable it via config: `plugins.slots.memory = "memory-lancedb"`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`
 - [Nostr](/channels/nostr) — `@openclaw/nostr`
 - [Zalo](/channels/zalo) — `@openclaw/zalo`

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -39,6 +39,9 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
+/
+> **Note**: `memory-lancedb` is bundled with OpenClaw and does not need npm installation.
+> Simply enable it via config: `plugins.slots.memory = "memory-lancedb"`/
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`
 - [Nostr](/channels/nostr) — `@openclaw/nostr`


### PR DESCRIPTION
Fixes #4806

## Problem

The plugin documentation may have suggested installing memory-lancedb plugin via `openclaw plugins install @openclaw/memory-lancedb`, which fails with npm 404. This creates confusion as users attempt installation that cannot succeed.

## Root Cause

The `memory-lancedb` plugin is **bundled** with OpenClaw and shipped in the npm package under `extensions/memory-lancedb/`. It does not exist on npm registry and should not be installed via `plugins install`.

## Solution

Added clarifying note to `docs/plugin.md`:

```
> **Note**: `memory-lancedb` is bundled with OpenClaw and does not need npm installation.
> Simply enable it via config: `plugins.slots.memory = "memory-lancedb"`
```

### Key points:
- Plugin is bundled with OpenClaw (included in npm package)
- Located in `extensions/memory-lancedb/` directory
- Enabled via config: `plugins.slots.memory = "memory-lancedb"`
- No `npm install` or `plugins install` needed

## Impact

- **Users**: Clear guidance on how to enable memory-lancedb without failed npm attempts
- **Confusion reduction**: Prevents 404 errors from attempting non-existent package install
- **Correct path**: Directs users to configuration method instead of package installation

Fixes #4806

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/plugin.md` to clarify that the `memory-lancedb` memory plugin is bundled with OpenClaw and should be enabled via `plugins.slots.memory = "memory-lancedb"` rather than installed from npm, preventing users from hitting npm 404s.

The change is localized to the “Available plugins (official)” list, adding a short note next to the existing Memory (LanceDB) entry to steer users toward configuration-based enablement instead of `openclaw plugins install`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the docs change currently contains obvious markdown artifacts that should be fixed before merging.
- The PR is a documentation-only change with low blast radius, but the introduced stray `/` characters will render incorrectly and likely confuse readers, so it needs a quick correction.
- docs/plugin.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->