### PR TITLE
fix(web_search): strip perplexity/ prefix from model names

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -24,7 +24,7 @@ const MAX_SEARCH_COUNT = 10;
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
-const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
+const DEFAULT_PERPLEXITY_MODEL = "sonar-pro";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
 const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
@@ -216,7 +216,7 @@ function resolvePerplexityBaseUrl(
 function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
   const fromConfig =
     perplexity && "model" in perplexity && typeof perplexity.model === "string"
-      ? perplexity.model.trim()
+      ? perplexity.model.trim().replace(/^perplexity\\//, "")
       : "";
   return fromConfig || DEFAULT_PERPLEXITY_MODEL;
 }


### PR DESCRIPTION
Fixes #4804

## Problem

When using Perplexity as web search provider, the API returns a 400 error because OpenClaw sends the model name with a `perplexity/` prefix, but Perplexity API expects just the model name.

### Error Message
\`\`\`
Perplexity API error (400): {\\"error\\":{\\"message\\":\\"Invalid model \\'perplexity/sonar-pro\\'. Permitted models can be found in documentation at https://docs.perplexity.ai/getting-started/models.\\",\\"type\\":\\"invalid_model\\",\\"code\\":400}}
\`\`\`

### Config Used
\`\`\`json
{
  \\"tools\\": {
    \\"web\\": {
      \\"search\\": {
        \\"provider\\": \\"perplexity\\",
        \\"perplexity\\": {
          \\"apiKey\\": \\"pplx-...\",
          \\"baseUrl\\": \\"https://api.perplexity.ai\\",
          \\"model\\": \\"sonar-pro\\"
        }
      }
    }
  }
}
\`\`\`

### What Happens
- User configures model as \`"sonar-pro"\` (correct base name)
- \`resolvePerplexityModel()\` function appends \`perplexity/\` prefix via \`DEFAULT_PERPLEXITY_MODEL\`
- API receives \`perplexity/sonar-pro\` which is invalid
- Falls back to Brave Search or fails silently

## Solution

Two-part fix:

### 1. Updated default model
Changed \`DEFAULT_PERPLEXITY_MODEL\` from \`"perplexity/sonar-pro"\` to \`"sonar-pro"\` to match the base model name without provider prefix.

### 2. Strip prefix from user config
Added regex replacement to \`resolvePerplexityModel()\`:
\`\`\`typescript
perplexity.model.trim().replace(/^perplexity\\\\//, \"\")
\`\`\`

This handles both scenarios:
- **With prefix**: \`perplexity/sonar-pro\` → \`sonar-pro\` (strips prefix)
- **Without prefix**: \`sonar-pro\` → \`sonar-pro\` (keeps as-is)

### Code Changes
\`\`\`diff
-const DEFAULT_PERPLEXITY_MODEL = \"perplexity/sonar-pro\";
+const DEFAULT_PERPLEXITY_MODEL = \"sonar-pro\";

function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
   const fromConfig =
     perplexity && \\"model\\" in perplexity && typeof perplexity.model === \\"string\\"
-      ? perplexity.model.trim()
+      ? perplexity.model.trim().replace(/^perplexity\\\\//, \"\")
       : \"\";
   return fromConfig || DEFAULT_PERPLEXITY_MODEL;
}
\`\`\`

## Impact
- **Fixes 400 error** - Perplexity API now receives valid model names
- **Consistent API** - Matches Perplexity API documentation requirements
- **Better UX** - Users can configure base model names without worrying about prefixes

Fixes #4804

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Perplexity web search integration to send a plain Perplexity model name (e.g. `sonar-pro`) rather than an `perplexity/`-prefixed name that Perplexity’s direct API rejects.

Concretely, it:
- Changes the default Perplexity model from `perplexity/sonar-pro` to `sonar-pro`.
- Normalizes user-supplied Perplexity model config by trimming and stripping a leading `perplexity/` prefix.

The change is localized to `src/agents/tools/web-search.ts` and affects only the Perplexity provider path used by `runPerplexitySearch` (model passed through to `/chat/completions`).

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge.
- The change is small and localized: it only adjusts the Perplexity model string used in requests and adds a simple normalization step. No control flow changes outside the Perplexity model resolution path; main risk is minor edge cases around model name normalization.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->