### PR TITLE
fix(agents): scope process/exec tools to sessionKey for isolation

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -212,7 +212,12 @@ export function createOpenClawCodingTools(options?: {
     providerProfilePolicy,
     providerProfileAlsoAllow,
   );
-  const scopeKey = options?.exec?.scopeKey ?? (agentId ? `agent:${agentId}` : undefined);
+  // Prefer sessionKey for process isolation scope to prevent cross-session process visibility/killing.
+  // Fallback to agentId if no sessionKey is available (e.g. legacy or global contexts).
+  const scopeKey =
+    options?.exec?.scopeKey ??
+    options?.sessionKey ??
+    (agentId ? `agent:${agentId}` : undefined);
   const subagentPolicy =
     isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
       ? resolveSubagentToolPolicy(options.config)

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -215,9 +215,7 @@ export function createOpenClawCodingTools(options?: {
   // Prefer sessionKey for process isolation scope to prevent cross-session process visibility/killing.
   // Fallback to agentId if no sessionKey is available (e.g. legacy or global contexts).
   const scopeKey =
-    options?.exec?.scopeKey ??
-    options?.sessionKey ??
-    (agentId ? `agent:${agentId}` : undefined);
+    options?.exec?.scopeKey ?? options?.sessionKey ?? (agentId ? `agent:${agentId}` : undefined);
   const subagentPolicy =
     isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
       ? resolveSubagentToolPolicy(options.config)


### PR DESCRIPTION
# Fix PR: Scope process/exec tools to sessionKey for isolation

## Summary
This PR improves process isolation by scoping `exec` and `process` tools to the `sessionKey` when available. Currently, processes are scoped to the `agentId`, which can lead to cross-session process visibility or interference (e.g., one session accidentally killing a process started by another session of the same agent).

## Repro Steps
1. Start two separate sessions (Session A and Session B) with the same agent.
2. Start a long-running background process in Session A using the `process` tool.
3. Use the `process` tool in Session B to list running processes.
4. Observe that Session B can see (and potentially kill) Session A's process because they currently share the same `scopeKey` (based on `agentId`).

## Root Cause
In `src/agents/pi-tools.ts`, the `scopeKey` in `createOpenClawCodingTools` was defaulting to `agent:${agentId}` if `options.exec.scopeKey` was not explicitly provided. This meant all sessions of the same agent shared the same process isolation scope, regardless of being distinct user interactions.

## Behavior Changes
- `scopeKey` now prefers `options.sessionKey` if provided in the tool options.
- It falls back to `agent:${agentId}` only if no `sessionKey` is available (e.g., in legacy or global contexts).
- This ensures that processes started in one session are isolated from other sessions by default, providing better security and reliability for multi-session agent usage.

## Tests
- Added logic to prefer `sessionKey` for process isolation scope.
- Verified that the fallback mechanism still supports contexts without a session key.

## Manual Testing
- Verified with subagent sessions to ensure they correctly receive an isolated process space.
- Confirmed that the `scopeKey` correctly resolves based on the provided session context.

## Evidence
The code change in `src/agents/pi-tools.ts` implements the preference:
```typescript
  // Prefer sessionKey for process isolation scope to prevent cross-session process visibility/killing.
  // Fallback to agentId if no sessionKey is available (e.g. legacy or global contexts).
  const scopeKey =
    options?.exec?.scopeKey ??
    options?.sessionKey ??
    (agentId ? `agent:${agentId}` : undefined);
```

lobster-biscuit

## Sign-Off
Models used: Claude Opus 4.5, Submitter effort: 70% human 30% AI
