### PR TITLE
Show timezone abbreviation in system prompt

### DIFF
--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -19,6 +19,24 @@ export function resolveUserTimezone(configured?: string): string {
   return host?.trim() || "UTC";
 }
 
+/**
+ * Get the timezone abbreviation (e.g., "EST", "PST", "UTC") for a given IANA timezone.
+ * Falls back to the IANA name if abbreviation cannot be determined.
+ */
+export function getTimezoneAbbreviation(timezone: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "short",
+    });
+    const parts = formatter.formatToParts(new Date());
+    const tzPart = parts.find((p) => p.type === "timeZoneName");
+    return tzPart?.value ?? timezone;
+  } catch {
+    return timezone;
+  }
+}
+
 export function resolveUserTimeFormat(preference?: TimeFormatPreference): ResolvedTimeFormat {
   if (preference === "12" || preference === "24") return preference;
   if (cachedTimeFormat) return cachedTimeFormat;

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,7 +1,7 @@
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
-import type { ResolvedTimeFormat } from "./date-time.js";
+import { getTimezoneAbbreviation, type ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 
 /**
@@ -51,7 +51,11 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
 
 function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const abbrev = getTimezoneAbbreviation(params.userTimezone);
+  // Show both IANA name and abbreviation if they differ
+  const tzDisplay =
+    abbrev !== params.userTimezone ? `${params.userTimezone} (${abbrev})` : params.userTimezone;
+  return ["## Current Date & Time", `Time zone: ${tzDisplay}`, ""];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {


### PR DESCRIPTION
Adds \getTimezoneAbbreviation()\ to convert IANA timezone names (e.g. \America/New_York\) to friendly abbreviations (e.g. \EST\).

The system prompt now shows:
\\\
Time zone: America/New_York (EST)
\\\
instead of just:
\\\
Time zone: America/New_York
\\\

This makes it easier for the AI to understand and communicate about timezones.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `getTimezoneAbbreviation()` in `src/agents/date-time.ts` and updates `buildTimeSection()` in `src/agents/system-prompt.ts` to display the user’s IANA timezone along with a short `Intl.DateTimeFormat`-derived timezone label (e.g., `America/New_York (EST)`) when they differ.

The change integrates into the system prompt construction path by enriching the existing “Current Date & Time” section, without altering other prompt sections or the timezone resolution logic.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with minor correctness/UX concerns around what `Intl` returns for “short” timezone names.
- Changes are small and localized, and use a standard `Intl.DateTimeFormat` API with a try/catch fallback. The main risk is that `timeZoneName: "short"` does not reliably produce abbreviations like `EST/PST` across environments/locales and can yield GMT offsets (e.g., `GMT-5`) or localized strings, which may reduce the intended benefit but shouldn’t break functionality.
- src/agents/date-time.ts (abbreviation semantics), src/agents/system-prompt.ts (display logic expectations)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->