### PR TITLE
feat(slack): Add thread.sessionPerRootMessage for isolated root message sessions

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -438,10 +438,46 @@ For fine-grained control, use these tags in agent responses:
 ## Sessions + routing
 - DMs share the `main` session (like WhatsApp/Telegram).
 - Channels map to `agent:<agentId>:slack:channel:<channelId>` sessions.
+- Thread replies use `agent:<agentId>:slack:channel:<channelId>:thread:<threadTs>` sessions.
 - Slash commands use `agent:<agentId>:slack:slash:<userId>` sessions (prefix configurable via `channels.slack.slashCommand.sessionPrefix`).
-- If Slack doesn’t provide `channel_type`, OpenClaw infers it from the channel ID prefix (`D`, `C`, `G`) and defaults to `channel` to keep session keys stable.
+- If Slack doesn't provide `channel_type`, OpenClaw infers it from the channel ID prefix (`D`, `C`, `G`) and defaults to `channel` to keep session keys stable.
 - Native command registration uses `commands.native` (global default `"auto"` → Slack off) and can be overridden per-workspace with `channels.slack.commands.native`. Text commands require standalone `/...` messages and can be disabled with `commands.text: false`. Slack slash commands are managed in the Slack app and are not removed automatically. Use `commands.useAccessGroups: false` to bypass access-group checks for commands.
 - Full command list + config: [Slash commands](/tools/slash-commands)
+
+### Thread session configuration
+Configure thread session behavior with `channels.slack.thread`:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `historyScope` | `"thread"` | Scope for thread history context. `"thread"` isolates history per thread; `"channel"` reuses channel history. |
+| `inheritParent` | `false` | If true, thread sessions inherit the parent channel transcript. |
+| `sessionPerRootMessage` | `false` | If true, each root-level channel message creates its own thread-level session. |
+
+### Isolating sessions per root message
+By default, all root-level messages in a channel share a single channel session. This can cause context pollution when multiple users or topics are discussed in the same channel.
+
+Enable `sessionPerRootMessage` to create a unique session for each root-level @mention:
+
+```json5
+{
+  channels: {
+    slack: {
+      replyToMode: "all",  // recommended: reply in threads
+      thread: {
+        sessionPerRootMessage: true
+      }
+    }
+  }
+}
+```
+
+When enabled:
+- Each root @mention creates session `agent:<agentId>:slack:channel:<channelId>:thread:<messageTs>`
+- Thread replies continue using the same session as the root message
+- Different conversations in the same channel are completely isolated
+- Works best with `replyToMode: "all"` so replies stay in threads
+
+Use case: Team channels where multiple people interact with the bot on different topics. Without this option, unrelated conversations share context and may confuse the agent.
 
 ## DM security (pairing)
 - Default: `channels.slack.dm.policy="pairing"` — unknown DM senders get a pairing code (expires after 1 hour).

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -227,10 +227,10 @@ export async function runPreparedReply(
     prefixedBodyBase,
   });
   const threadStarterBody = ctx.ThreadStarterBody?.trim();
-  const threadStarterNote =
-    isNewSession && threadStarterBody
-      ? `[Thread starter - for context]\n${threadStarterBody}`
-      : undefined;
+  // Always include thread starter when available for context, not just on new sessions
+  const threadStarterNote = threadStarterBody
+    ? `[Thread starter - for context]\n${threadStarterBody}`
+    : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -337,6 +337,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.slack.thread.sessionPerRootMessage": "Slack Session Per Root Message",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",
@@ -469,6 +470,8 @@ const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.thread.sessionPerRootMessage":
+    "If true, each root-level channel message creates its own thread-level session for complete isolation (default: false).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -73,6 +73,12 @@ export type SlackThreadConfig = {
   historyScope?: "thread" | "channel";
   /** If true, thread sessions inherit the parent channel transcript. Default: false. */
   inheritParent?: boolean;
+  /**
+   * If true, each root-level channel message creates its own thread-level session
+   * using the message timestamp as the thread ID. This provides complete session
+   * isolation for each conversation started in a channel. Default: false.
+   */
+  sessionPerRootMessage?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -392,6 +392,7 @@ export const SlackThreadSchema = z
   .object({
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
+    sessionPerRootMessage: z.boolean().optional(),
   })
   .strict();
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -82,6 +82,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  threadSessionPerRootMessage: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -143,6 +144,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  threadSessionPerRootMessage: SlackMonitorContext["threadSessionPerRootMessage"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -387,6 +389,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    threadSessionPerRootMessage: params.threadSessionPerRootMessage,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -196,10 +196,18 @@ export async function prepareSlackMessage(params: {
   const baseSessionKey = route.sessionKey;
   const threadContext = resolveSlackThreadContext({ message, replyToMode: ctx.replyToMode });
   const threadTs = threadContext.incomingThreadTs;
+  const messageTs = threadContext.messageTs;
   const isThreadReply = threadContext.isThreadReply;
+  // When sessionPerRootMessage is enabled, use the message's own timestamp as the thread ID
+  // for root messages, giving each root-level @mention its own isolated session.
+  const effectiveThreadId = isThreadReply
+    ? threadTs
+    : ctx.threadSessionPerRootMessage && isRoom && messageTs
+      ? messageTs
+      : undefined;
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey,
-    threadId: isThreadReply ? threadTs : undefined,
+    threadId: effectiveThreadId,
     parentSessionKey: isThreadReply && ctx.threadInheritParent ? baseSessionKey : undefined,
   });
   const sessionKey = threadKeys.sessionKey;

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -118,6 +118,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const threadSessionPerRootMessage = slackCfg.thread?.sessionPerRootMessage ?? false;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -199,6 +200,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    threadSessionPerRootMessage,
     slashCommand,
     textLimit,
     ackReactionScope,


### PR DESCRIPTION
## Summary

Adds a new configuration option `thread.sessionPerRootMessage` that creates isolated thread-level sessions for each root-level Slack channel message, and fixes thread starter context to always be included.

**Problem 1:** When multiple users @mention the bot in a Slack channel, all root messages share a single channel-level session (`agent:<id>:slack:channel:<channelId>`). This causes unrelated conversations to share context, leading to confusion and incorrect responses.

**Solution 1:** When `sessionPerRootMessage` is enabled, each root message uses its own timestamp as the thread ID, creating a unique session key like `agent:<id>:slack:channel:<channelId>:thread:<messageTs>`. This provides complete session isolation per conversation.

**Problem 2:** When a bot is mentioned in an existing thread, it receives all thread messages except the parent (root) message that started the thread. The thread starter was only included on new sessions.

**Solution 2:** Always include the thread starter body in context when available, not just on new sessions. This ensures the bot always knows what the thread is about.

## Changes

### Session per root message feature
- **`src/config/types.slack.ts`**: Add `sessionPerRootMessage` boolean option to `SlackThreadConfig`
- **`src/config/zod-schema.providers-core.ts`**: Add Zod validation for the new option
- **`src/config/schema.ts`**: Add UI labels and descriptions
- **`src/slack/monitor/context.ts`**: Add `threadSessionPerRootMessage` to context type and creation
- **`src/slack/monitor/provider.ts`**: Read config option and pass to context
- **`src/slack/monitor/message-handler/prepare.ts`**: Use message timestamp as threadId for root messages when enabled
- **`docs/channels/slack.md`**: Add documentation for the new feature

### Thread starter fix
- **`src/auto-reply/reply/get-reply-run.ts`**: Remove `isNewSession` check so thread starter is always included in context

## Configuration

```json
{
  "channels": {
    "slack": {
      "replyToMode": "all",
      "thread": {
        "sessionPerRootMessage": true
      }
    }
  }
}
```

## Use Case

In a team Slack channel:
1. User A mentions bot about Topic A → creates isolated session for this thread
2. User B mentions bot about Topic B → creates separate isolated session
3. Both conversations proceed independently without context pollution
4. When mentioned in a thread, bot always sees the parent message for context

## Testing

- [x] Lint passes (`npm run lint`)
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [x] All tests pass (797 test files, 4887 tests)
- [x] Runtime testing on live Slack workspace - verified session keys are correctly structured

Example session keys after enabling:
```
agent:admin:slack:channel:c0ab0s30e6s:thread:1769807260.800979
agent:admin:slack:channel:c0ab0s30e6s:thread:1769807316.201549
agent:admin:slack:channel:c0ab0s30e6s:thread:1769807346.992099
```

## Related Issues

Closes #4895

🤖 Generated with [Claude Code](https://claude.com/claude-code)