### PR TITLE
fix: Telegram threadId delivery context fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Status: stable.
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Telegram: accept numeric messageId/chatId in react action and honor channelId fallback. (#4533) Thanks @Ayush10.
 - Telegram: scope native skill commands to bound agent per bot. (#4360) Thanks @robhparker.
+- Telegram: fall back to session origin thread id for delivery context when missing. (#4911) Thanks @yevhen.
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -60,7 +60,7 @@ function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
     lastChannel: entry.lastChannel,
     lastTo: entry.lastTo,
     lastAccountId: entry.lastAccountId,
-    lastThreadId: entry.lastThreadId ?? entry.origin?.threadId,
+    lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
     deliveryContext: entry.deliveryContext,
   });
   const nextDelivery = normalized.deliveryContext;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -55,7 +55,14 @@ function invalidateSessionStoreCache(storePath: string): void {
 }
 
 function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
-  const normalized = normalizeSessionDeliveryFields(entry);
+  const normalized = normalizeSessionDeliveryFields({
+    channel: entry.channel,
+    lastChannel: entry.lastChannel,
+    lastTo: entry.lastTo,
+    lastAccountId: entry.lastAccountId,
+    lastThreadId: entry.lastThreadId ?? entry.origin?.threadId,
+    deliveryContext: entry.deliveryContext,
+  });
   const nextDelivery = normalized.deliveryContext;
   const sameDelivery =
     (entry.deliveryContext?.channel ?? undefined) === nextDelivery?.channel &&

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -75,6 +75,19 @@ describe("delivery context helpers", () => {
       accountId: undefined,
       threadId: "999",
     });
+
+    expect(
+      deliveryContextFromSession({
+        channel: "telegram",
+        lastTo: " -1001 ",
+        origin: { threadId: 42 },
+      }),
+    ).toEqual({
+      channel: "telegram",
+      to: "-1001",
+      accountId: undefined,
+      threadId: 42,
+    });
   });
 
   it("normalizes delivery fields and mirrors them on session entries", () => {

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -88,6 +88,20 @@ describe("delivery context helpers", () => {
       accountId: undefined,
       threadId: 42,
     });
+
+    expect(
+      deliveryContextFromSession({
+        channel: "telegram",
+        lastTo: " -1001 ",
+        deliveryContext: { threadId: " 777 " },
+        origin: { threadId: 42 },
+      }),
+    ).toEqual({
+      channel: "telegram",
+      to: "-1001",
+      accountId: undefined,
+      threadId: "777",
+    });
   });
 
   it("normalizes delivery fields and mirrors them on session entries", () => {

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -98,7 +98,7 @@ export function deliveryContextFromSession(
     lastChannel: entry.lastChannel,
     lastTo: entry.lastTo,
     lastAccountId: entry.lastAccountId,
-    lastThreadId: entry.lastThreadId ?? entry.origin?.threadId,
+    lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
     deliveryContext: entry.deliveryContext,
   };
   return normalizeSessionDeliveryFields(source).deliveryContext;

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -90,10 +90,18 @@ export function normalizeSessionDeliveryFields(source?: DeliveryContextSessionSo
 }
 
 export function deliveryContextFromSession(
-  entry?: DeliveryContextSessionSource,
+  entry?: DeliveryContextSessionSource & { origin?: { threadId?: string | number } },
 ): DeliveryContext | undefined {
   if (!entry) return undefined;
-  return normalizeSessionDeliveryFields(entry).deliveryContext;
+  const source: DeliveryContextSessionSource = {
+    channel: entry.channel,
+    lastChannel: entry.lastChannel,
+    lastTo: entry.lastTo,
+    lastAccountId: entry.lastAccountId,
+    lastThreadId: entry.lastThreadId ?? entry.origin?.threadId,
+    deliveryContext: entry.deliveryContext,
+  };
+  return normalizeSessionDeliveryFields(source).deliveryContext;
 }
 
 export function mergeDeliveryContext(


### PR DESCRIPTION
## Problem

When a subagent finishes and announces back to the parent session, the reply lands in General instead of the original topic.

## Root cause 

deliveryContext does not include threadId:
```ts
{
  "channel": "telegram",
  "to": "-1003690210808", // chat_id only, NO topic
  "accountId": "default"
}
```

The session key contains the topic (...:topic:343), but deliveryContext.to does not.

## What was done

• Added a fallback so deliveryContext.threadId is derived from session.origin.threadId when lastThreadId is missing.
• Normalized session delivery fields to persist that thread id back into the session store.
• Added a test to cover the origin → deliveryContext threadId case.