### PR TITLE
docs(install): fix broken Ansible repo links (404)

### DIFF
--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -8,19 +8,19 @@ read_when:
 
 # Ansible Installation
 
-The recommended way to deploy OpenClaw to production servers is via **[openclaw-ansible](https://github.com/openclaw/openclaw-ansible)** — an automated installer with security-first architecture.
+The recommended way to deploy OpenClaw to production servers is via **[clawdbot-ansible](https://github.com/openclaw/clawdbot-ansible)** — an automated installer with security-first architecture.
 
 ## Quick Start
 
 One-command install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openclaw/clawdbot-ansible/main/install.sh | bash
 ```
 
-> **📦 Full guide: [github.com/openclaw/openclaw-ansible](https://github.com/openclaw/openclaw-ansible)**
+> **📦 Full guide: [github.com/openclaw/clawdbot-ansible](https://github.com/openclaw/clawdbot-ansible)**
 >
-> The openclaw-ansible repo is the source of truth for Ansible deployment. This page is a quick overview.
+> The clawdbot-ansible repo is the source of truth for Ansible deployment. This page is a quick overview.
 
 ## What You Get
 
@@ -117,8 +117,8 @@ If you prefer manual control over the automation:
 sudo apt update && sudo apt install -y ansible git
 
 # 2. Clone repository
-git clone https://github.com/openclaw/openclaw-ansible.git
-cd openclaw-ansible
+git clone https://github.com/openclaw/clawdbot-ansible.git
+cd clawdbot-ansible
 
 # 3. Install Ansible collections
 ansible-galaxy collection install -r requirements.yml
@@ -137,7 +137,7 @@ The Ansible installer sets up OpenClaw for manual updates. See [Updating](/insta
 To re-run the Ansible playbook (e.g., for configuration changes):
 
 ```bash
-cd openclaw-ansible
+cd clawdbot-ansible
 ./run-playbook.sh
 ```
 
@@ -193,13 +193,13 @@ openclaw channels login
 ## Advanced Configuration
 
 For detailed security architecture and troubleshooting:
-- [Security Architecture](https://github.com/openclaw/openclaw-ansible/blob/main/docs/security.md)
-- [Technical Details](https://github.com/openclaw/openclaw-ansible/blob/main/docs/architecture.md)
-- [Troubleshooting Guide](https://github.com/openclaw/openclaw-ansible/blob/main/docs/troubleshooting.md)
+- [Security Architecture](https://github.com/openclaw/clawdbot-ansible/blob/main/docs/security.md)
+- [Technical Details](https://github.com/openclaw/clawdbot-ansible/blob/main/docs/architecture.md)
+- [Troubleshooting Guide](https://github.com/openclaw/clawdbot-ansible/blob/main/docs/troubleshooting.md)
 
 ## Related
 
-- [openclaw-ansible](https://github.com/openclaw/openclaw-ansible) — full deployment guide
+- [clawdbot-ansible](https://github.com/openclaw/clawdbot-ansible) — full deployment guide
 - [Docker](/install/docker) — containerized gateway setup
 - [Sandboxing](/gateway/sandboxing) — agent sandbox configuration
 - [Multi-Agent Sandbox & Tools](/multi-agent-sandbox-tools) — per-agent isolation


### PR DESCRIPTION
## Summary
- Fix all broken links in Ansible documentation that pointed to non-existent `openclaw/openclaw-ansible`
- Update to correct repository: `openclaw/clawdbot-ansible`

## Changes
- Updated 11 occurrences of the incorrect repo URL/name across `docs/install/ansible.md`

## Test plan
- [x] Verify links resolve correctly: https://github.com/openclaw/clawdbot-ansible ✅
- [x] Check all URLs in the document point to valid resources

Fixes #4851

🤖 Generated with [Claude Code](https://claude.com/claude-code)