### PR TITLE
feat(telegram): notify owner when bot is added/removed from groups

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -130,6 +130,13 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /**
+   * Controls notifications when bot is added to / removed from groups:
+   * - "owner" (default): notify allowFrom users via Telegram DM
+   * - "log": log only, no notification
+   * - "off": ignore the event
+   */
+  groupMembershipNotifications?: "owner" | "log" | "off";
 };
 
 export type TelegramTopicConfig = {


### PR DESCRIPTION
## Summary
- Add `my_chat_member` handler to notify owners when bot is added to or removed from Telegram groups
- New config option `groupMembershipNotifications` to control notification behavior

## Problem
When someone adds the bot to a Telegram group, there's no notification. The owner has no visibility into where their bot exists, which is a security concern for bots with access to personal data.

## Solution
Add a handler for Telegram's `my_chat_member` update type that:
1. Detects membership status changes (member/administrator ↔ left/kicked)
2. Notifies owner(s) via Telegram DM
3. Logs the event for traceability

### Notification format
```
⚠️ Bot added to group
Group: "My Family Chat" (-100123456789)
By: John (@john_doe)
Status: left → member
```

### Configuration
```json
{
  "channels": {
    "telegram": {
      "groupMembershipNotifications": "owner"
    }
  }
}
```

Options:
- `"owner"` (default): notify `allowFrom` users via Telegram DM
- `"log"`: log only, no notification
- `"off"`: ignore the event

## Test plan
- [x] Verify handler triggers on bot added to group
- [x] Verify handler triggers on bot removed from group
- [x] Verify owner receives DM notification
- [x] Verify `"log"` mode only logs without DM
- [x] Verify `"off"` mode ignores events

Fixes #4891

🤖 Generated with [Claude Code](https://claude.com/claude-code)