### PR TITLE
fixes #4921: Add addtional error codes to timeout error mapping

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -24,6 +24,7 @@ describe("failover-error", () => {
   it("infers timeout from common node error codes", () => {
     expect(resolveFailoverReasonFromError({ code: "ETIMEDOUT" })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ code: "ECONNRESET" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ECONNREFUSED" })).toBe("timeout");
   });
 
   it("coerces failover-worthy errors into FailoverError with metadata", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -122,7 +122,18 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) return "timeout";
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+  if (
+    [
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ECONNRESET",
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+    ].includes(code)
+  ) {
     return "timeout";
   }
   if (isTimeoutError(err)) return "timeout";


### PR DESCRIPTION
Add `ECONNREFUSED`, `ENOTFOUND`, `ENETUNREACH`, and `EHOSTUNREACH` to timeout error mapping to allow proper failover on inaccessible LLMs.

Fixes openclaw/openclaw#4921

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the set of Node-style network error codes that are treated as a failover-worthy `"timeout"` in `resolveFailoverReasonFromError`, enabling failover when a provider is unreachable (e.g., connection refused, DNS failures, or network unreachable). A small unit test update verifies the new mapping for `ECONNREFUSED`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, localized behavior change with minimal surface area.
- The change is confined to expanding a hardcoded allowlist of error codes and adds a basic test. The main risk is semantic (treating some non-timeout network failures as "timeout"), but this aligns with the PR intent (trigger failover on unreachable providers).
- src/agents/failover-error.ts (ensure error-code semantics match desired failover policy)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->