### PR TITLE
fix: prefer requesterOrigin over stale session entry in subagent announce routing

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -299,6 +299,45 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.accountId).toBe("acct-987");
   });
 
+  it("prefers requesterOrigin channel over stale session lastChannel in queued announce", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+    // Session store has stale whatsapp channel, but the requesterOrigin says bluebubbles.
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-stale",
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        queueMode: "collect",
+        queueDebounceMs: 0,
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-stale-channel",
+      requesterSessionKey: "main",
+      requesterOrigin: { channel: "bluebubbles", to: "bluebubbles:chat_guid:123" },
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    // The channel should match requesterOrigin, NOT the stale session entry.
+    expect(call?.params?.channel).toBe("bluebubbles");
+    expect(call?.params?.to).toBe("bluebubbles:chat_guid:123");
+  });
+
   it("splits collect-mode announces when accountId differs", async () => {
     const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -186,7 +186,7 @@ describe("subagent announce formatting", () => {
     });
 
     expect(didAnnounce).toBe(true);
-    await new Promise((r) => setTimeout(r, 5));
+    await expect.poll(() => agentSpy.mock.calls.length).toBe(1);
 
     const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("whatsapp");
@@ -308,7 +308,6 @@ describe("subagent announce formatting", () => {
       "agent:main:main": {
         sessionId: "session-stale",
         lastChannel: "whatsapp",
-        lastTo: "+1555",
         queueMode: "collect",
         queueDebounceMs: 0,
       },
@@ -330,7 +329,7 @@ describe("subagent announce formatting", () => {
     });
 
     expect(didAnnounce).toBe(true);
-    await new Promise((r) => setTimeout(r, 5));
+    await expect.poll(() => agentSpy.mock.calls.length).toBe(1);
 
     const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     // The channel should match requesterOrigin, NOT the stale session entry.
@@ -382,7 +381,7 @@ describe("subagent announce formatting", () => {
       outcome: { status: "ok" },
     });
 
-    await new Promise((r) => setTimeout(r, 5));
+    await expect.poll(() => agentSpy.mock.calls.length).toBe(2);
 
     const accountIds = agentSpy.mock.calls.map(
       (call) => (call[0] as { params?: Record<string, unknown> }).params?.accountId,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -93,7 +93,10 @@ function resolveAnnounceOrigin(
   entry?: DeliveryContextSource,
   requesterOrigin?: DeliveryContext,
 ): DeliveryContext | undefined {
-  return mergeDeliveryContext(deliveryContextFromSession(entry), requesterOrigin);
+  // requesterOrigin (captured at spawn time) reflects the channel the user is
+  // actually on and must take priority over the session entry, which may carry
+  // stale lastChannel / lastTo values from a previous channel interaction.
+  return mergeDeliveryContext(requesterOrigin, deliveryContextFromSession(entry));
 }
 
 async function sendAnnounce(item: AnnounceQueueItem) {


### PR DESCRIPTION
## Problem

When a subagent finishes and announces results back to the main session, the delivery routes to the wrong channel. The error:

```
Delivery failed (whatsapp to bluebubbles:chat_guid:any;-;+1234567891): Error: Unknown channel: whatsapp
```

The user only has bluebubbles configured, but the announce tries to deliver via whatsapp.

## Root Cause

In `resolveAnnounceOrigin()` (`src/agents/subagent-announce.ts`), the session entry was used as the **primary** source and `requesterOrigin` as the **fallback** when merging delivery context:

```ts
// Before (broken):
return mergeDeliveryContext(deliveryContextFromSession(entry), requesterOrigin);
```

`mergeDeliveryContext(primary, fallback)` resolves each field independently. If the session store had a stale `lastChannel` (e.g. `"whatsapp"`) from a previous interaction but no `lastTo`, the merge produced:
- `channel`: `"whatsapp"` (from stale session entry — primary)
- `to`: `"bluebubbles:chat_guid:..."` (from requesterOrigin — fallback)

This mismatch caused the delivery to attempt whatsapp with a bluebubbles address.

## Fix

Swap the merge priority so `requesterOrigin` (captured at subagent spawn time, reflecting the actual current channel) takes precedence:

```ts
// After (fixed):
return mergeDeliveryContext(requesterOrigin, deliveryContextFromSession(entry));
```

The session entry still serves as fallback for any fields not present in `requesterOrigin`.

## Testing

- Added regression test: `prefers requesterOrigin channel over stale session lastChannel in queued announce`
- All 9 existing + new tests pass