### PR TITLE
feat(security): sanitize bot responses to prevent secret leaks

### DIFF
--- a/src/security/sanitizer.test.ts
+++ b/src/security/sanitizer.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resetSanitizerCache, sanitizeResponse } from "./sanitizer.js";
+
+describe("sanitizeResponse", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    resetSanitizerCache();
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(sanitizeResponse(null)).toBe("");
+    expect(sanitizeResponse(undefined)).toBe("");
+  });
+
+  it("redacts environment variables that look sensitive", () => {
+    process.env = { ...originalEnv, TEST_API_KEY: "super_secret_value_123" };
+
+    const input = "Here is my key: super_secret_value_123";
+    const expected = "Here is my key: ****";
+
+    expect(sanitizeResponse(input)).toBe(expected);
+  });
+
+  it("ignores short environment variables", () => {
+    process.env = { ...originalEnv, TEST_API_KEY: "short" };
+
+    const input = "The value is short here";
+    expect(sanitizeResponse(input)).toBe(input);
+  });
+
+  it("ignores environment variables without sensitive keys", () => {
+    process.env = { ...originalEnv, SOME_PATH: "not_a_secret_path" };
+    const input = "Path: not_a_secret_path";
+    expect(sanitizeResponse(input)).toBe(input);
+  });
+
+  it("redacts known secret patterns (Bearer token)", () => {
+    const input = "Header: Authorization: Bearer abcdef1234567890abcdef1234567890 end";
+
+    const output = sanitizeResponse(input);
+    expect(output).toContain("Authorization: Bearer ****");
+    expect(output).not.toContain("abcdef1234567890");
+  });
+
+  it("redacts sk- keys", () => {
+    const input = "Key: sk-1234567890abcdef1234567890";
+    const output = sanitizeResponse(input);
+    expect(output).toBe("Key: ****");
+  });
+
+  it("handles mixed redaction", () => {
+    process.env = { ...originalEnv, MY_SECRET_PASS: "hunter2_complex" };
+    const input = "My pass is hunter2_complex and my key is sk-1234567890abcdef";
+
+    const output = sanitizeResponse(input);
+    expect(output).toContain("My pass is ****");
+    expect(output).toContain("my key is ****");
+    expect(output).not.toContain("hunter2_complex");
+    expect(output).not.toContain("sk-123");
+  });
+});

--- a/src/security/sanitizer.ts
+++ b/src/security/sanitizer.ts
@@ -1,0 +1,62 @@
+import { getDefaultRedactPatterns } from "../logging/redact.js";
+
+const REPLACEMENT = "****";
+const ENV_KEY_PATTERNS = [/KEY/, /TOKEN/, /SECRET/, /PASS/, /PASSWORD/];
+const MIN_SECRET_LENGTH = 6;
+
+let cachedEnvSecrets: string[] | null = null;
+
+export function resetSanitizerCache() {
+  cachedEnvSecrets = null;
+}
+
+function getEnvSecrets(): string[] {
+  if (cachedEnvSecrets) return cachedEnvSecrets;
+
+  const secrets: string[] = [];
+  const env = process.env as Record<string, string | undefined>;
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== "string" || value.length < MIN_SECRET_LENGTH) continue;
+
+    const isSensitiveKey = ENV_KEY_PATTERNS.some((p) => p.test(key.toUpperCase()));
+    if (isSensitiveKey) {
+      secrets.push(value);
+    }
+  }
+
+  cachedEnvSecrets = secrets;
+  return secrets;
+}
+
+export function sanitizeResponse(text: string | null | undefined): string {
+  if (!text) return "";
+
+  let next = text;
+
+  const envSecrets = getEnvSecrets();
+  for (const secret of envSecrets) {
+    if (next.includes(secret)) {
+      next = next.replaceAll(secret, REPLACEMENT);
+    }
+  }
+
+  const patterns = getDefaultRedactPatterns().map((p) => new RegExp(p, "gi"));
+
+  for (const pattern of patterns) {
+    next = next.replace(pattern, (...args: any[]) => {
+      const match = args[0] as string;
+      const groups = args.slice(1, -2).filter((g) => typeof g === "string");
+
+      if (groups.length > 0) {
+        const secret = groups.at(-1)!;
+        if (secret && match.includes(secret)) {
+          return match.replace(secret, REPLACEMENT);
+        }
+      }
+      return REPLACEMENT;
+    });
+  }
+
+  return next;
+}


### PR DESCRIPTION
## Summary
This PR addresses a security vulnerability where the bot could potentially leak sensitive information (such as API keys or environment variables) in its responses, regardless of the prompt. It ensures that no sensitive credentials inadvertently leave the gateway.

## Proposed solution
Implemented a strict sanitization layer that intercepts all outgoing messages (including text, media URLs, and poll content).

- **New `sanitizer` module**:
    - Automatically identifies sensitive environment variables (based on key names like `...KEY`, `...TOKEN`, `...SECRET` and value length).
    - Uses regex patterns to detect standard secret formats (e.g., Bearer tokens, provider keys) within text.
    - Replaces all detected secrets with `****`.
- **Integration**:
    - Applied this sanitization hook in [src/gateway/server-methods/send.ts](cci:7://file:///Users/andressanchezvargas/Develop/openclaw/src/gateway/server-methods/send.ts:0:0-0:0) to filter all outgoing payloads before they are handed off to channel plugins.

## Alternatives considered
- **Reusing [src/logging/redact.ts](cci:7://file:///Users/andressanchezvargas/Develop/openclaw/src/logging/redact.ts:0:0-0:0) directly**: The logging redaction logic is designed for observability (often partially obscuring keys to allow debugging). This use case required strict, complete removal (`****`) of secrets to prevent any leakage to end-users, warranting a dedicated implementation.
- **LLM-based filtering**: A specific "check for secrets" prompt pass was considered but rejected due to latency, cost, and the potential for the filter itself to be circumvented. A deterministic code-level check is faster and more reliable for known secrets.

## Additional context
- Adds [src/security/sanitizer.ts](cci:7://file:///Users/andressanchezvargas/Develop/openclaw/src/security/sanitizer.ts:0:0-0:0)
- Adds unit tests in [src/security/sanitizer.test.ts](cci:7://file:///Users/andressanchezvargas/Develop/openclaw/src/security/sanitizer.test.ts:0:0-0:0)
- Modifies `src/gateway/server-methods/send.ts`