### PR TITLE
fix: strip null-valued optional parameters from tool calls for provider compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2564,6 +2564,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
+- Agents: strip null-valued optional parameters from tool calls for provider compatibility.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1758,6 +1758,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/Compaction: resolve `memory/YYYY-MM-DD.md` placeholders with timezone-aware runtime dates and append a `Current time:` line to memory-flush turns, preventing wrong-year memory filenames without making the system prompt time-variant. (#17603, #17633) Thanks @nicholaspapadam-wq and @vignesh07.
 - Auth/Cooldowns: auto-expire stale auth profile cooldowns when `cooldownUntil` or `disabledUntil` timestamps have passed, and reset `errorCount` so the next transient failure does not immediately escalate to a disproportionately long cooldown. Handles `cooldownUntil` and `disabledUntil` independently. (#3604) Thanks @nabbilkhan.
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
+- Agents: strip null-valued optional parameters from tool calls for provider compatibility.
 - Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.
 - Browser/Agents: when browser control service is unavailable, return explicit non-retry guidance (instead of "try again") so models do not loop on repeated browser tool calls until timeout. (#17673) Thanks @austenstone.
 - Subagents: use child-run-based deterministic announce idempotency keys across direct and queued delivery paths (with legacy queued-item fallback) to prevent duplicate announce retries without collapsing distinct same-millisecond announces. (#17150) Thanks @widingmarcus-cyber.
@@ -2564,7 +2565,6 @@ Docs: https://docs.openclaw.ai
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
-- Agents: strip null-valued optional parameters from tool calls for provider compatibility.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -1,7 +1,4 @@
-import type {
-  AgentMessage,
-  AgentToolResult,
-} from "@mariozechner/pi-agent-core";
+import type { AgentMessage, AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { ToolCallIdMode } from "../tool-call-id.js";
 import {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -1,7 +1,13 @@
-import type { AgentMessage, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type {
+  AgentMessage,
+  AgentToolResult,
+} from "@mariozechner/pi-agent-core";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { ToolCallIdMode } from "../tool-call-id.js";
-import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
+import {
+  normalizeToolCallArguments,
+  sanitizeToolCallIdsForCloudCodeAssist,
+} from "../tool-call-id.js";
 import { sanitizeContentBlocksImages } from "../tool-images.js";
 import { stripThoughtSignatures } from "./bootstrap.js";
 
@@ -57,9 +63,13 @@ export async function sanitizeSessionMessagesImages(
   const shouldSanitizeToolCallIds = options?.sanitizeToolCallIds === true;
   // We sanitize historical session messages because Anthropic can reject a request
   // if the transcript contains oversized base64 images (default max side 1200px).
-  const sanitizedIds = shouldSanitizeToolCallIds
-    ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
+  // First normalize tool call arguments (remove null properties that fail AJV validation)
+  const normalizedArgs = allowNonImageSanitization
+    ? normalizeToolCallArguments(messages)
     : messages;
+  const sanitizedIds = shouldSanitizeToolCallIds
+    ? sanitizeToolCallIdsForCloudCodeAssist(normalizedArgs, options.toolCallIdMode)
+    : normalizedArgs;
   const out: AgentMessage[] = [];
   for (const msg of sanitizedIds) {
     if (!msg || typeof msg !== "object") {

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 import {
   isValidCloudCodeAssistToolId,
+  normalizeToolCallArguments,
   sanitizeToolCallIdsForCloudCodeAssist,
 } from "./tool-call-id.js";
 
@@ -231,5 +232,217 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect(aId.length).toBe(9);
       expect(bId.length).toBe(9);
     });
+  });
+});
+
+describe("normalizeToolCallArguments", () => {
+  it("is a no-op when arguments have no null values", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "read", arguments: { path: "/tmp" } }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).toBe(input);
+  });
+
+  it("removes null-valued properties from tool call arguments", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "bash",
+            arguments: { command: "ls", timeout: null, cwd: undefined },
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    expect(toolCall.arguments).toEqual({ command: "ls" });
+    expect("timeout" in (toolCall.arguments ?? {})).toBe(false);
+    expect("cwd" in (toolCall.arguments ?? {})).toBe(false);
+  });
+
+  it("handles real Infercom/Llama 3.3 tool call with null tags array", () => {
+    // Real scenario: Llama 3.3 70B returns {"message": "hello", "recipient": "Umut", "tags": null}
+    // OpenClaw validation expects tags to be omitted or a valid array, not null
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_send_message",
+            name: "send_message",
+            arguments: { message: "hello", recipient: "Umut", tags: null },
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    // tags: null should be removed, leaving only message and recipient
+    expect(toolCall.arguments).toEqual({ message: "hello", recipient: "Umut" });
+    expect("tags" in (toolCall.arguments ?? {})).toBe(false);
+  });
+
+  it("converts undefined arguments to empty object", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "status", arguments: undefined }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("converts null arguments to empty object", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "status", arguments: null }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    expect(toolCall.arguments).toEqual({});
+  });
+
+  it("recursively removes null values in nested objects", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "config",
+            arguments: {
+              settings: {
+                enabled: true,
+                timeout: null,
+                nested: { value: "test", empty: null },
+              },
+            },
+          },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    expect(toolCall.arguments).toEqual({
+      settings: {
+        enabled: true,
+        nested: { value: "test" },
+      },
+    });
+  });
+
+  it("handles multiple tool calls in single message", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call1", name: "read", arguments: { path: "/a", extra: null } },
+          { type: "toolCall", id: "call2", name: "write", arguments: { path: "/b" } },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const tc1 = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const tc2 = assistant.content?.[1] as { arguments?: Record<string, unknown> };
+    expect(tc1.arguments).toEqual({ path: "/a" });
+    expect(tc2.arguments).toEqual({ path: "/b" });
+  });
+
+  it("handles toolUse and functionCall block types", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "call1", name: "read", arguments: { opt: null } },
+          { type: "functionCall", id: "call2", name: "write", arguments: { opt: null } },
+        ],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out).not.toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const tc1 = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const tc2 = assistant.content?.[1] as { arguments?: Record<string, unknown> };
+    expect(tc1.arguments).toEqual({});
+    expect(tc2.arguments).toEqual({});
+  });
+
+  it("preserves non-assistant messages unchanged", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "read", arguments: { opt: null } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    expect(out[0]).toBe(input[0]);
+    expect(out[2]).toBe(input[2]);
+  });
+
+  it("does not synthesize arguments when field is completely missing", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "status" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = normalizeToolCallArguments(input);
+    // Should be unchanged - no arguments field added
+    expect(out).toBe(input);
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCall = assistant.content?.[0] as Record<string, unknown>;
+    expect("arguments" in toolCall).toBe(false);
+    expect("args" in toolCall).toBe(false);
   });
 });

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -88,7 +88,14 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       const input = castAgentMessages([
         {
           role: "assistant",
-          content: [{ type: "toolCall", id: "call|item:123", name: "read", arguments: {} }],
+          content: [
+            {
+              type: "toolCall",
+              id: "call|item:123",
+              name: "read",
+              arguments: {},
+            },
+          ],
         },
         {
           role: "toolResult",
@@ -208,8 +215,18 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
         {
           role: "assistant",
           content: [
-            { type: "toolCall", id: "call_abc|item:123", name: "read", arguments: {} },
-            { type: "toolCall", id: "call_abc|item:456", name: "read", arguments: {} },
+            {
+              type: "toolCall",
+              id: "call_abc|item:123",
+              name: "read",
+              arguments: {},
+            },
+            {
+              type: "toolCall",
+              id: "call_abc|item:456",
+              name: "read",
+              arguments: {},
+            },
           ],
         },
         {
@@ -240,9 +257,16 @@ describe("normalizeToolCallArguments", () => {
     const input = [
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "call1", name: "read", arguments: { path: "/tmp" } }],
+        content: [
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "read",
+            arguments: { path: "/tmp" },
+          },
+        ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).toBe(input);
@@ -261,13 +285,15 @@ describe("normalizeToolCallArguments", () => {
           },
         ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const toolCall = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(toolCall.arguments).toEqual({ command: "ls" });
     expect("timeout" in (toolCall.arguments ?? {})).toBe(false);
     expect("cwd" in (toolCall.arguments ?? {})).toBe(false);
@@ -288,13 +314,15 @@ describe("normalizeToolCallArguments", () => {
           },
         ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const toolCall = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
     // tags: null should be removed, leaving only message and recipient
     expect(toolCall.arguments).toEqual({ message: "hello", recipient: "Umut" });
     expect("tags" in (toolCall.arguments ?? {})).toBe(false);
@@ -304,15 +332,24 @@ describe("normalizeToolCallArguments", () => {
     const input = [
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "call1", name: "status", arguments: undefined }],
+        content: [
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "status",
+            arguments: undefined,
+          },
+        ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const toolCall = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(toolCall.arguments).toEqual({});
   });
 
@@ -322,13 +359,15 @@ describe("normalizeToolCallArguments", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call1", name: "status", arguments: null }],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const toolCall = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(toolCall.arguments).toEqual({});
   });
 
@@ -351,13 +390,15 @@ describe("normalizeToolCallArguments", () => {
           },
         ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as { arguments?: Record<string, unknown> };
+    const toolCall = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(toolCall.arguments).toEqual({
       settings: {
         enabled: true,
@@ -371,18 +412,32 @@ describe("normalizeToolCallArguments", () => {
       {
         role: "assistant",
         content: [
-          { type: "toolCall", id: "call1", name: "read", arguments: { path: "/a", extra: null } },
-          { type: "toolCall", id: "call2", name: "write", arguments: { path: "/b" } },
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "read",
+            arguments: { path: "/a", extra: null },
+          },
+          {
+            type: "toolCall",
+            id: "call2",
+            name: "write",
+            arguments: { path: "/b" },
+          },
         ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const tc1 = assistant.content?.[0] as { arguments?: Record<string, unknown> };
-    const tc2 = assistant.content?.[1] as { arguments?: Record<string, unknown> };
+    const tc1 = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
+    const tc2 = assistant.content?.[1] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(tc1.arguments).toEqual({ path: "/a" });
     expect(tc2.arguments).toEqual({ path: "/b" });
   });
@@ -392,18 +447,32 @@ describe("normalizeToolCallArguments", () => {
       {
         role: "assistant",
         content: [
-          { type: "toolUse", id: "call1", name: "read", arguments: { opt: null } },
-          { type: "functionCall", id: "call2", name: "write", arguments: { opt: null } },
+          {
+            type: "toolUse",
+            id: "call1",
+            name: "read",
+            arguments: { opt: null },
+          },
+          {
+            type: "functionCall",
+            id: "call2",
+            name: "write",
+            arguments: { opt: null },
+          },
         ],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out).not.toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const tc1 = assistant.content?.[0] as { arguments?: Record<string, unknown> };
-    const tc2 = assistant.content?.[1] as { arguments?: Record<string, unknown> };
+    const tc1 = assistant.content?.[0] as {
+      arguments?: Record<string, unknown>;
+    };
+    const tc2 = assistant.content?.[1] as {
+      arguments?: Record<string, unknown>;
+    };
     expect(tc1.arguments).toEqual({});
     expect(tc2.arguments).toEqual({});
   });
@@ -413,7 +482,14 @@ describe("normalizeToolCallArguments", () => {
       { role: "user", content: "hello" },
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "call1", name: "read", arguments: { opt: null } }],
+        content: [
+          {
+            type: "toolCall",
+            id: "call1",
+            name: "read",
+            arguments: { opt: null },
+          },
+        ],
       },
       {
         role: "toolResult",
@@ -421,7 +497,7 @@ describe("normalizeToolCallArguments", () => {
         toolName: "read",
         content: [{ type: "text", text: "ok" }],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     expect(out[0]).toBe(input[0]);
@@ -434,14 +510,14 @@ describe("normalizeToolCallArguments", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call1", name: "status" }],
       },
-    ] satisfies AgentMessage[];
+    ] as unknown as AgentMessage[];
 
     const out = normalizeToolCallArguments(input);
     // Should be unchanged - no arguments field added
     expect(out).toBe(input);
 
     const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCall = assistant.content?.[0] as Record<string, unknown>;
+    const toolCall = assistant.content?.[0] as unknown as Record<string, unknown>;
     expect("arguments" in toolCall).toBe(false);
     expect("args" in toolCall).toBe(false);
   });

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -213,39 +213,76 @@ function rewriteToolResultIds(params: {
  * @param messages - The messages to sanitize
  * @param mode - "strict" (alphanumeric only) or "strict9" (alphanumeric length 9)
  */
+
+/**
+ * Check if a value is a plain object (not a class instance like Date, Map, etc.).
+ * Tool call arguments are JSON-serialized, so we only expect plain objects.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 /**
  * Recursively removes properties with null or undefined values from an object.
+ * Returns both the cleaned value and whether any changes were made.
+ *
  * This is needed because some LLMs (like DeepSeek, Llama) send explicit null values
  * for optional parameters, but TypeBox/AJV schemas expect them to be omitted.
+ *
+ * Note: Only recurses into plain objects (not class instances like Date, Map, etc.)
+ * since tool call arguments are JSON-only by design.
  */
-function removeNullProperties<T>(obj: T): T {
+function removeNullProperties<T>(obj: T): { value: T; changed: boolean } {
   if (obj === null || obj === undefined) {
-    return obj;
+    return { value: obj, changed: false };
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((item) => removeNullProperties(item)) as T;
+    let arrayChanged = false;
+    const mapped = obj.map((item) => {
+      const result = removeNullProperties(item);
+      if (result.changed) {
+        arrayChanged = true;
+      }
+      return result.value;
+    });
+    return { value: (arrayChanged ? mapped : obj) as T, changed: arrayChanged };
   }
 
-  if (typeof obj === "object") {
+  if (isPlainObject(obj)) {
+    let objectChanged = false;
     const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      if (value !== null && value !== undefined) {
-        result[key] = removeNullProperties(value);
+    for (const [key, value] of Object.entries(obj)) {
+      if (value === null || value === undefined) {
+        objectChanged = true;
+        // Skip null/undefined properties
+      } else {
+        const cleaned = removeNullProperties(value);
+        if (cleaned.changed) {
+          objectChanged = true;
+        }
+        result[key] = cleaned.value;
       }
     }
-    return result as T;
+    return { value: (objectChanged ? result : obj) as T, changed: objectChanged };
   }
 
-  return obj;
+  // Non-plain objects (Date, Map, etc.) and primitives pass through unchanged
+  return { value: obj, changed: false };
 }
 
 /**
  * Normalize tool call arguments in assistant messages.
  *
  * This function handles two cases:
- * 1. Missing or null/undefined arguments field -> converts to empty object {}
+ * 1. Existing null/undefined arguments field -> converts to empty object {}
  * 2. Arguments containing null-valued properties -> removes those properties
+ *
+ * Note: Missing arguments fields are left as-is (not synthesized).
  *
  * Some LLMs like DeepSeek and Llama send explicit null values for optional
  * parameters (e.g., { "command": "ls", "optional_param": null }), but TypeBox/AJV
@@ -258,16 +295,24 @@ export function normalizeToolCallArguments(messages: AgentMessage[]): AgentMessa
   let changed = false;
 
   const out = messages.map((msg) => {
-    if (!msg || typeof msg !== "object") return msg;
+    if (!msg || typeof msg !== "object") {
+      return msg;
+    }
     const role = (msg as { role?: unknown }).role;
-    if (role !== "assistant") return msg;
+    if (role !== "assistant") {
+      return msg;
+    }
 
     const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) return msg;
+    if (!Array.isArray(content)) {
+      return msg;
+    }
 
     let contentChanged = false;
     const nextContent = content.map((block) => {
-      if (!block || typeof block !== "object") return block;
+      if (!block || typeof block !== "object") {
+        return block;
+      }
       const rec = block as { type?: unknown; arguments?: unknown; args?: unknown };
       const type = rec.type;
 
@@ -294,11 +339,8 @@ export function normalizeToolCallArguments(messages: AgentMessage[]): AgentMessa
 
       // If arguments is an object, remove null-valued properties
       if (typeof args === "object" && !Array.isArray(args)) {
-        const cleaned = removeNullProperties(args);
-        // Check if anything actually changed
-        const argsStr = JSON.stringify(args);
-        const cleanedStr = JSON.stringify(cleaned);
-        if (argsStr !== cleanedStr) {
+        const { value: cleaned, changed: argsChanged } = removeNullProperties(args);
+        if (argsChanged) {
           contentChanged = true;
           return { ...(block as Record<string, unknown>), [argsKey]: cleaned };
         }
@@ -307,7 +349,9 @@ export function normalizeToolCallArguments(messages: AgentMessage[]): AgentMessa
       return block;
     });
 
-    if (!contentChanged) return msg;
+    if (!contentChanged) {
+      return msg;
+    }
     changed = true;
     return { ...msg, content: nextContent } as AgentMessage;
   });


### PR DESCRIPTION
## Summary

Some LLMs (e.g., certain configurations of DeepSeek, Llama) return explicit `null` values for optional tool call parameters instead of omitting them entirely. For example:

```json
{"message": "hello", "recipient": "Umut", "tags": null}
```

OpenClaw's AJV validation expects optional parameters to be omitted rather than set to `null`, causing validation failures like:

```
Validation failed: must NOT have additional properties
```

This PR adds a normalization step that strips null-valued properties from tool call arguments before validation.

## Changes

| File | Change |
|------|--------|
| `src/agents/tool-call-id.ts` | Added `normalizeToolCallArguments()` and `removeNullProperties()` functions |
| `src/agents/pi-embedded-helpers/images.ts` | Integrated normalization into message sanitization pipeline |
| `src/agents/tool-call-id.test.ts` | Added 10 new tests including real provider scenario |
| `CHANGELOG.md` | Added entry |

## How it works

- `removeNullProperties<T>()` recursively strips `null` and `undefined` values from objects
- `normalizeToolCallArguments()` processes assistant messages and cleans tool call arguments
- Handles `toolCall`, `toolUse`, and `functionCall` block types
- Preserves messages without arguments field (doesn't add empty `{}`)

**Before:** `{"tags": null}` → AJV validation error  
**After:** `{"tags": null}` → `{}` → validation passes

## Test plan

- [x] Unit tests for `normalizeToolCallArguments` (10 new tests)
- [x] Real provider scenario test with actual LLM output
- [x] All 192 tests passing
- [x] Lint passing
- [x] Build passing

🤖 Built with Claude

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a normalization pass for assistant tool-call blocks to improve cross-provider compatibility when models emit explicit `null`/`undefined` for optional tool parameters. It introduces `normalizeToolCallArguments()` (used in the session message sanitization pipeline) plus unit tests covering common and “real provider” cases, and notes the fix in the changelog.

In the existing agents pipeline, tool-call IDs are already sanitized for provider constraints; this change extends that compatibility layer to tool-call *arguments* by stripping null-valued optionals before AJV/TypeBox validation.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main behavior change is localized to tool-call argument normalization.
- Tests cover key scenarios and the change is scoped to assistant tool-call blocks, but the implementation currently treats any object as a plain object (prototype loss) and uses JSON.stringify-based change detection, which could have edge-case behavior/perf costs if non-JSON values ever appear in arguments.
- src/agents/tool-call-id.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->