### PR TITLE
feat(agents): support PDF reading in agent read tool

### DIFF
--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -230,7 +230,7 @@ function clampText(text: string, maxChars: number): string {
   return text.slice(0, maxChars);
 }
 
-async function extractPdfContent(params: {
+export async function extractPdfContent(params: {
   buffer: Buffer;
   limits: InputFileLimits;
 }): Promise<{ text: string; images: InputImageContent[] }> {


### PR DESCRIPTION
## Summary

When the agent's `read` tool encounters a `.pdf` file, it now extracts text and images using the existing `extractPdfContent` pipeline instead of failing or returning binary data.

## Changes

- Export `extractPdfContent` from `media/input-files.ts`
- Add `handlePdfRead()` that reads the PDF buffer, extracts text + images, and returns proper tool result content blocks
- Intercept `.pdf` extension in `createOpenClawReadTool` before delegating to the base read tool
- Refactor `filePath` extraction to happen earlier so both PDF and non-PDF paths share the same variable

## Testing

Tested locally with PDF files. Linter passes clean.

AI-assisted (Claude). Lightly tested.