### PR TITLE
feat(sessions): add icon (emoji) field to sessions

### DIFF
--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -80,6 +80,7 @@ export type SessionEntry = {
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;
   label?: string;
+  icon?: string;
   displayName?: string;
   channel?: string;
   groupId?: string;

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -52,6 +52,7 @@ export const SessionsPatchParamsSchema = Type.Object(
   {
     key: NonEmptyString,
     label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
+    icon: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -561,6 +561,7 @@ export function listSessionsFromStore(params: {
         entry,
         kind: classifySessionKey(key, entry),
         label: entry?.label,
+        icon: entry?.icon,
         displayName,
         channel,
         subject,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -12,6 +12,7 @@ export type GatewaySessionRow = {
   key: string;
   kind: "direct" | "group" | "global" | "unknown";
   label?: string;
+  icon?: string;
   displayName?: string;
   derivedTitle?: string;
   lastMessagePreview?: string;

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -107,6 +107,20 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
+  if ("icon" in patch) {
+    const raw = patch.icon;
+    if (raw === null) {
+      delete next.icon;
+    } else if (raw !== undefined) {
+      const trimmed = String(raw).trim();
+      if (!trimmed) return invalid("invalid icon: empty");
+      // Allow single emoji or short string (max 2 grapheme clusters)
+      const segments = [...new Intl.Segmenter().segment(trimmed)];
+      if (segments.length > 2) return invalid("icon must be a single emoji");
+      next.icon = trimmed;
+    }
+  }
+
   if ("thinkingLevel" in patch) {
     const raw = patch.thinkingLevel;
     if (raw === null) {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -55,6 +55,7 @@ export async function patchSession(
   key: string,
   patch: {
     label?: string | null;
+    icon?: string | null;
     thinkingLevel?: string | null;
     verboseLevel?: string | null;
     reasoningLevel?: string | null;
@@ -63,6 +64,7 @@ export async function patchSession(
   if (!state.client || !state.connected) return;
   const params: Record<string, unknown> = { key };
   if ("label" in patch) params.label = patch.label;
+  if ("icon" in patch) params.icon = patch.icon;
   if ("thinkingLevel" in patch) params.thinkingLevel = patch.thinkingLevel;
   if ("verboseLevel" in patch) params.verboseLevel = patch.verboseLevel;
   if ("reasoningLevel" in patch) params.reasoningLevel = patch.reasoningLevel;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -344,6 +344,7 @@ export type GatewaySessionRow = {
   key: string;
   kind: "direct" | "group" | "global" | "unknown";
   label?: string;
+  icon?: string;
   displayName?: string;
   surface?: string;
   subject?: string;


### PR DESCRIPTION
## Summary

Adds an optional `icon` field to session entries, allowing sessions to be tagged with a single emoji for visual identification in session lists and thread UIs.

## Changes

- Add `icon` field to `SessionEntry` type and `GatewaySessionRow`
- Add `icon` to `SessionsPatchParamsSchema` (nullable, optional)
- Validate icon in `sessions-patch`: must be non-empty, max 2 grapheme clusters (using `Intl.Segmenter`)
- Expose `icon` in session list responses
- Add `icon` to `patchSession` UI controller

## Motivation

Session lists can get hard to scan with many sessions. An emoji icon provides a quick visual anchor — especially useful as a building block for auto-titled sessions where an LLM can pick a topic emoji.

## Testing

Linter passes clean. Tested locally by patching sessions with emoji values.

AI-assisted (Claude). Lightly tested.