### PR TITLE
fix(discord): add gateway token to execApprovals handler

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -187,6 +187,7 @@ export type DiscordExecApprovalHandlerOpts = {
   accountId: string;
   config: DiscordExecApprovalConfig;
   gatewayUrl?: string;
+  gatewayToken?: string;
   cfg: OpenClawConfig;
   runtime?: RuntimeEnv;
   onResolve?: (id: string, decision: ExecApprovalDecision) => Promise<void>;
@@ -250,6 +251,7 @@ export class DiscordExecApprovalHandler {
 
     this.gatewayClient = new GatewayClient({
       url: this.opts.gatewayUrl ?? "ws://127.0.0.1:18789",
+      token: this.opts.gatewayToken,
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: "Discord Exec Approvals",
       mode: GATEWAY_CLIENT_MODES.BACKEND,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -434,6 +434,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         token,
         accountId: account.accountId,
         config: execApprovalsConfig,
+        gatewayToken: cfg.gateway?.auth?.token,
         cfg,
         runtime,
       })


### PR DESCRIPTION
## Summary
- Adds `gatewayToken?: string` to `DiscordExecApprovalHandlerOpts`
- Passes `token: this.opts.gatewayToken` when creating `GatewayClient`
- In `provider.ts`, resolves gateway token from `cfg.gateway?.auth?.token` and passes it to the handler

This fixes the "unauthorized: gateway token missing" error when using Discord exec approvals.

## Test plan
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] Unit tests pass (17 tests in exec-approvals.test.ts)

Closes #4944

🤖 Generated with [Claude Code](https://claude.com/claude-code)