### PR TITLE
fix: classify 404/model-not-found errors as failover reason

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -37,6 +37,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "model_not_found"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -119,6 +119,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 402) return "billing";
   if (status === 429) return "rate_limit";
   if (status === 401 || status === 403) return "auth";
+  if (status === 404) return "model_not_found";
   if (status === 408) return "timeout";
 
   const code = (getErrorCode(err) ?? "").toUpperCase();

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -38,4 +38,17 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies 404 model not found errors as model_not_found", () => {
+    expect(
+      classifyFailoverReason(
+        '{"error":{"code":404,"message":"models/gemini-1.5-pro is not found for API version v1beta, or is not supported for generateContent.","status":"NOT_FOUND"}}',
+      ),
+    ).toBe("model_not_found");
+    expect(classifyFailoverReason("404 model not found")).toBe("model_not_found");
+    expect(classifyFailoverReason("The model does not exist")).toBe("model_not_found");
+    expect(classifyFailoverReason("model is not available")).toBe("model_not_found");
+    expect(classifyFailoverReason("gemini-1.5-pro is not supported for generateContent")).toBe(
+      "model_not_found",
+    );
+  });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -24,6 +24,7 @@ export {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isImageSizeError,
+  isModelNotFoundErrorMessage,
   isOverloadedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -396,6 +396,16 @@ const ERROR_PATTERNS = {
     "messages.1.content.1.tool_use.id",
     "invalid request format",
   ],
+  modelNotFound: [
+    /\b404\b/,
+    "not found",
+    "model not found",
+    "is not found for api version",
+    "does not exist",
+    "model is not available",
+    "is not supported for",
+    "not_found",
+  ],
 } as const;
 
 const IMAGE_DIMENSION_ERROR_RE =
@@ -443,6 +453,10 @@ export function isAuthErrorMessage(raw: string): boolean {
 
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
+export function isModelNotFoundErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.modelNotFound);
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -505,6 +519,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isBillingErrorMessage(raw)) return "billing";
   if (isTimeoutErrorMessage(raw)) return "timeout";
   if (isAuthErrorMessage(raw)) return "auth";
+  if (isModelNotFoundErrorMessage(raw)) return "model_not_found";
   return null;
 }
 

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "unknown";


### PR DESCRIPTION
## Summary

Add `model_not_found` to `FailoverReason` type so that 404 errors from deprecated or unavailable models (like Google Gemini 1.5) trigger failover to alternative models instead of hanging indefinitely.

## Problem

When a configured model returns a 404 "not found" error (e.g., deprecated Google Gemini models like `gemini-1.5-pro`), the error was not classified as a failover reason, causing the embedded agent to hang indefinitely instead of falling back to alternative models.

## Solution

- Add `model_not_found` to `FailoverReason` type
- Add `model_not_found` to `AuthProfileFailureReason` type
- Add `modelNotFound` patterns to `ERROR_PATTERNS`:
  - `/\b404\b/`
  - `"not found"`
  - `"model not found"`
  - `"is not found for api version"`
  - `"does not exist"`
  - `"model is not available"`
  - `"is not supported for"`
  - `"not_found"`
- Add `isModelNotFoundErrorMessage()` helper function
- Update `classifyFailoverReason()` to check for model not found errors
- Add 404 status check in `resolveFailoverReasonFromError()`
- Export `isModelNotFoundErrorMessage` from `pi-embedded-helpers`

## Testing

- Added tests for model 404 error classification
- All existing tests pass (10 failover-related tests, 33 auth-profiles tests)

Closes #4992

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new failover classification for “model not found” situations, intended to treat 404 / deprecated-model errors as failover triggers rather than letting embedded agents stall. Concretely, it extends the `FailoverReason` and `AuthProfileFailureReason` unions with `model_not_found`, adds new error-message patterns and an `isModelNotFoundErrorMessage()` helper, wires that into `classifyFailoverReason()` and `resolveFailoverReasonFromError()`, and re-exports the helper from `pi-embedded-helpers`. A focused test was added to ensure common 404/model-not-found strings and a Gemini JSON payload map to `model_not_found`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge; one missing status mapping could cause inconsistent status reporting for the new failover reason.
- Changes are localized to failover classification logic and type unions, with tests added for the new classification. The main concern is that `resolveFailoverStatus` was not updated to include `model_not_found`, which may lead to `undefined` status values when errors are coerced into `FailoverError` without an explicit status code.
- src/agents/failover-error.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->