### PR TITLE
feat(heartbeat): add jitter option for randomized intervals

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -18,6 +18,7 @@ surface anything that needs attention without spamming you.
 3. Decide where heartbeat messages should go (`target: "last"` is the default).
 4. Optional: enable heartbeat reasoning delivery for transparency.
 5. Optional: restrict heartbeats to active hours (local time).
+6. Optional: add jitter for more natural, less predictable timing.
 
 Example config:
 
@@ -27,6 +28,7 @@ Example config:
     defaults: {
       heartbeat: {
         every: "30m",
+        jitter: "5m",           // optional: randomize ±5m for more natural timing
         target: "last",
         // activeHours: { start: "08:00", end: "24:00" },
         // includeReasoning: true, // optional: send separate `Reasoning:` message too
@@ -80,6 +82,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
     defaults: {
       heartbeat: {
         every: "30m",           // default: 30m (0m disables)
+        jitter: "5m",           // optional: randomize interval ±5m (25-35m actual)
         model: "anthropic/claude-opus-4-5",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
         target: "last",         // last | none | <channel id> (core or plugin, e.g. "bluebubbles")
@@ -136,6 +139,7 @@ Example: two agents, only the second agent runs heartbeats.
 ### Field notes
 
 - `every`: heartbeat interval (duration string; default unit = minutes).
+- `jitter`: optional randomization range (duration string; default unit = minutes). When set, actual interval = `every ± random(jitter)`. Example: `every: "30m"`, `jitter: "5m"` → heartbeats run between 25-35 minutes apart. This makes heartbeat timing less predictable and more natural.
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
 - `session`: optional session key for heartbeat runs.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -165,6 +165,12 @@ export type AgentDefaultsConfig = {
   heartbeat?: {
     /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
     every?: string;
+    /**
+     * Random jitter added to each heartbeat interval (duration string, default unit: minutes).
+     * The actual interval will be: every + random(-jitter, +jitter).
+     * Example: every="30m" jitter="5m" → heartbeat runs between 25-35 minutes.
+     */
+    jitter?: string;
     /** Optional active-hours window (local time); heartbeats run only inside this window. */
     activeHours?: {
       /** Start time (24h, HH:MM). Inclusive. */


### PR DESCRIPTION
## Summary

Adds a new `jitter` config option to heartbeat settings that randomizes the interval timing, making heartbeat scheduling less predictable and more natural.

## Motivation

Fixed-interval heartbeats can feel robotic and predictable. Adding jitter makes the agent's periodic check-ins feel more human-like and organic.

## Changes

- Added `jitter` field to `HeartbeatConfig` type (`types.agent-defaults.ts`)
- Added `resolveHeartbeatJitterMs()` to parse jitter duration from config
- Added `applyJitter()` helper that applies random offset in range `[-jitter, +jitter]`
- Updated `resolveNextDue()` to apply jitter on each scheduling
- Updated docs with jitter examples and field notes

## Usage

```json5
{
  agents: {
    defaults: {
      heartbeat: {
        every: "30m",
        jitter: "5m"  // randomize ±5m → 25-35 min actual
      }
    }
  }
}
```

## Testing

- [ ] Manual testing with various jitter values
- [ ] Verify jitter applies on initial scheduling and after each heartbeat run
- [ ] Verify jitter of 0 or missing behaves like before (no change)