### PR TITLE
fix(memory-flush): use contextTokens instead of totalTokens for threshold check

### DIFF
--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -45,10 +45,10 @@ describe("memory flush settings", () => {
 });
 
 describe("shouldRunMemoryFlush", () => {
-  it("requires totalTokens and threshold", () => {
+  it("requires contextTokens and threshold", () => {
     expect(
       shouldRunMemoryFlush({
-        entry: { totalTokens: 0 },
+        entry: { contextTokens: 0 },
         contextWindowTokens: 16_000,
         reserveTokensFloor: 20_000,
         softThresholdTokens: DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
@@ -70,7 +70,7 @@ describe("shouldRunMemoryFlush", () => {
   it("skips when under threshold", () => {
     expect(
       shouldRunMemoryFlush({
-        entry: { totalTokens: 10_000 },
+        entry: { contextTokens: 10_000 },
         contextWindowTokens: 100_000,
         reserveTokensFloor: 20_000,
         softThresholdTokens: 10_000,
@@ -81,7 +81,7 @@ describe("shouldRunMemoryFlush", () => {
   it("triggers at the threshold boundary", () => {
     expect(
       shouldRunMemoryFlush({
-        entry: { totalTokens: 85 },
+        entry: { contextTokens: 85 },
         contextWindowTokens: 100,
         reserveTokensFloor: 10,
         softThresholdTokens: 5,
@@ -93,7 +93,7 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: {
-          totalTokens: 90_000,
+          contextTokens: 90_000,
           compactionCount: 2,
           memoryFlushCompactionCount: 2,
         },
@@ -107,7 +107,7 @@ describe("shouldRunMemoryFlush", () => {
   it("runs when above threshold and not flushed", () => {
     expect(
       shouldRunMemoryFlush({
-        entry: { totalTokens: 96_000, compactionCount: 1 },
+        entry: { contextTokens: 96_000, compactionCount: 1 },
         contextWindowTokens: 100_000,
         reserveTokensFloor: 5_000,
         softThresholdTokens: 2_000,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -69,19 +69,19 @@ export function resolveMemoryFlushContextWindowTokens(params: {
 }
 
 export function shouldRunMemoryFlush(params: {
-  entry?: Pick<SessionEntry, "totalTokens" | "compactionCount" | "memoryFlushCompactionCount">;
+  entry?: Pick<SessionEntry, "contextTokens" | "compactionCount" | "memoryFlushCompactionCount">;
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
 }): boolean {
-  const totalTokens = params.entry?.totalTokens;
-  if (!totalTokens || totalTokens <= 0) return false;
+  const contextTokens = params.entry?.contextTokens;
+  if (!contextTokens || contextTokens <= 0) return false;
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
   const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
   const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
   if (threshold <= 0) return false;
-  if (totalTokens < threshold) return false;
+  if (contextTokens < threshold) return false;
 
   const compactionCount = params.entry?.compactionCount ?? 0;
   const lastFlushAt = params.entry?.memoryFlushCompactionCount;

--- a/workspace
+++ b/workspace
@@ -1,0 +1,1 @@
+/home/clawdbot/tada


### PR DESCRIPTION
## Problem

`shouldRunMemoryFlush()` was using `totalTokens` from the session entry to decide if a memory flush should trigger before compaction. However, `totalTokens` is set by `session-usage.ts` with **tokens from the last turn only**, not the cumulative context size.

This caused memory flush to never trigger because it compared ~30k tokens (last turn) against the ~176k threshold, even when actual context was 188k tokens.

## Solution

Changed `shouldRunMemoryFlush()` to use `contextTokens` instead, which correctly represents the actual context window usage.

## Changes

- `src/auto-reply/reply/memory-flush.ts`: Use `contextTokens` instead of `totalTokens`
- `src/auto-reply/reply/memory-flush.test.ts`: Updated tests to match

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes pre-compaction memory flush triggering by switching the threshold check in `shouldRunMemoryFlush()` from `totalTokens` (apparently last-turn tokens) to `contextTokens` (actual context window usage), and updates the associated unit tests accordingly.

Within the auto-reply compaction/memory-flush flow, this makes flush decisions reflect the real prompt/context size so the flush can trigger when the session is near the context limit.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but includes an accidental symlink that should be removed.
- The core logic change is small and well-covered by updated tests, but the PR also introduces a `workspace` symlink to an absolute local path which will break in other environments and is likely unintended.
- workspace

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->