### PR TITLE
fix(hooks): wire up before_compaction and after_compaction hooks

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -57,6 +57,7 @@ import {
   sanitizeSessionHistory,
   sanitizeToolsForGoogle,
 } from "./google.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
@@ -424,6 +425,24 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Run before_compaction hook
+        const hookRunner = getGlobalHookRunner();
+        const hookCtx = {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: params.messageChannel ?? params.messageProvider,
+        };
+        const messageCountBefore = session.messages?.length ?? 0;
+
+        if (hookRunner?.hasHooks("before_compaction")) {
+          await hookRunner.runBeforeCompaction(
+            { messageCount: messageCountBefore, tokenCount: undefined },
+            hookCtx,
+          );
+        }
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -440,6 +459,23 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Run after_compaction hook (fire-and-forget)
+        if (hookRunner?.hasHooks("after_compaction")) {
+          hookRunner
+            .runAfterCompaction(
+              {
+                messageCount: session.messages?.length ?? 0,
+                tokenCount: tokensAfter,
+                compactedCount: messageCountBefore - (session.messages?.length ?? 0),
+              },
+              hookCtx,
+            )
+            .catch((err) => {
+              log.error(`after_compaction hook error: ${err}`);
+            });
+        }
+
         return {
           ok: true,
           compacted: true,


### PR DESCRIPTION
## Summary

The plugin hooks `before_compaction` and `after_compaction` were fully defined and exported in `src/plugins/hooks.ts` but never actually called anywhere in the compaction flow.

This adds the missing hook calls to `compactEmbeddedPiSessionDirect` in `src/agents/pi-embedded-runner/compact.ts`.

## Changes

- Import `getGlobalHookRunner` from `../../plugins/hook-runner-global.js`
- Add `before_compaction` hook call before `session.compact()` with:
  - `messageCount`: number of messages before compaction
  - `tokenCount`: undefined (not available before compaction)
- Add `after_compaction` hook call after successful compaction with:
  - `messageCount`: number of messages after compaction
  - `tokenCount`: estimated tokens after compaction
  - `compactedCount`: number of messages removed
- The `after_compaction` hook runs fire-and-forget with error logging to avoid blocking the return

## Impact

Plugins can now register `before_compaction` and `after_compaction` hooks for use cases like:
- Notifying users when context is compacted
- Logging compaction events
- Triggering post-compaction recovery actions

## Testing

- All existing compaction tests pass (7 tests)
- All plugin tests pass (46 tests)
- Type checking passes
- Lint passes

Closes #4967

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the previously-defined plugin hooks `before_compaction` and `after_compaction` into the embedded PI session compaction flow (`compactEmbeddedPiSessionDirect`). It creates a hook context with session/agent/workspace metadata, invokes `before_compaction` before calling `session.compact()`, and triggers `after_compaction` after a successful compaction with counts and an estimated token count, with the post-hook executed asynchronously and errors logged.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge; change is localized and aligns with intended hook behavior.
- Hook wiring is straightforward and uses existing runner APIs. The main remaining concern is the fire-and-forget `after_compaction` hook potentially running after `session.dispose()` / lock release, depending on hook-runner lifecycle assumptions; also error logging could preserve stack traces better.
- src/agents/pi-embedded-runner/compact.ts (hook lifecycle and error logging)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->