### PR TITLE
fix(image): increase maxTokens from 512 to 2048 for reasoning models

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -267,9 +267,11 @@ async function runImagePrompt(params: {
       }
 
       const context = buildImageContext(params.prompt, params.base64, params.mimeType);
+      // Use 2048 tokens to support reasoning-capable vision models (e.g., Kimi K2.5)
+      // that consume internal reasoning tokens before producing output.
       const message = (await complete(model, context, {
         apiKey,
-        maxTokens: 512,
+        maxTokens: 2048,
       })) as AssistantMessage;
       const text = coerceImageAssistantText({
         message,


### PR DESCRIPTION
## Problem

The `image` tool's hardcoded `maxTokens: 512` is too low for reasoning-capable vision models like Kimi K2.5 via OpenRouter. These models use internal reasoning tokens before producing output, which can exhaust the token budget and leave the `content` field empty, resulting in "Image model returned no text" errors.

## Solution

Increase `maxTokens` from 512 to 2048. This provides sufficient headroom for reasoning while remaining conservative for typical image description tasks.

## Testing

- All 14 existing image-tool tests pass
- Type checking passes
- Linting passes

Closes #4996

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the `image` tool’s `maxTokens` passed to `complete()` from 512 to 2048 in `src/agents/tools/image-tool.ts`, to prevent reasoning-capable vision models from exhausting the generation budget before producing user-visible text. The change is localized to the non-MiniMax code path inside `runImagePrompt`, and keeps existing model selection/fallback logic intact while giving more headroom for verbose outputs/reasoning-heavy models.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge and very low risk.
- The change is a single constant adjustment (512→2048) in one `complete()` call, with no control-flow changes and clear motivation; it should only increase response budget for vision models. Risk is limited to slightly higher per-call token usage/cost on providers that honor `maxTokens`.
- No files require special attention.

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->