### PR TITLE
docs: add device pairing section to Control UI docs

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -27,6 +27,35 @@ Auth is supplied during the WebSocket handshake via:
 The dashboard settings panel lets you store a token; passwords are not persisted.
 The onboarding wizard generates a gateway token by default, so paste it here on first connect.
 
+## Device pairing (first connection)
+
+When you connect to the Control UI from a new browser or device, the Gateway
+requires a **one-time pairing approval** — even if you're on the same Tailnet
+with `gateway.auth.allowTailscale: true`. This is a security measure to prevent
+unauthorized access.
+
+**What you'll see:** "Gateway disconnected — pairing required"
+
+**To approve the device:**
+
+```bash
+# List pending requests
+openclaw devices list
+
+# Approve by request ID
+openclaw devices approve <requestId>
+```
+
+Once approved, the device is remembered and won't require re-approval unless
+you revoke it with `openclaw devices revoke`. See [Devices CLI](/cli/devices)
+for token rotation and revocation.
+
+**Notes:**
+- Local connections (`127.0.0.1`) are auto-approved.
+- Remote connections (LAN, Tailnet, etc.) require explicit approval.
+- Each browser profile generates a unique device ID, so switching browsers or
+  clearing browser data will require re-pairing.
+
 ## What it can do (today)
 - Chat with the model via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`)
 - Stream tool calls + live tool output cards in Chat (agent events)

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -47,8 +47,8 @@ openclaw devices approve <requestId>
 ```
 
 Once approved, the device is remembered and won't require re-approval unless
-you revoke it with `openclaw devices revoke`. See [Devices CLI](/cli/devices)
-for token rotation and revocation.
+you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
+[Devices CLI](/cli/devices) for token rotation and revocation.
 
 **Notes:**
 - Local connections (`127.0.0.1`) are auto-approved.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -34,7 +34,7 @@ requires a **one-time pairing approval** — even if you're on the same Tailnet
 with `gateway.auth.allowTailscale: true`. This is a security measure to prevent
 unauthorized access.
 
-**What you'll see:** "Gateway disconnected — pairing required"
+**What you'll see:** "disconnected (1008): pairing required"
 
 **To approve the device:**
 


### PR DESCRIPTION
## Summary

When connecting to the Control UI from a new browser or device, users see "Gateway disconnected — pairing required" but the docs don't explain what this means or how to resolve it.

This PR adds a "Device pairing (first connection)" section to the Control UI docs explaining:
- That new browser connections require one-time pairing approval (even with `allowTailscale: true`)
- What error message users will see
- How to approve devices using `openclaw devices list` and `openclaw devices approve`
- Notes about local auto-approval and browser profile behavior

## Context

Discovered this gap while helping a user connect via Tailscale Serve. The `cli/devices.md` documents the commands but doesn't explain *when* you need them for webchat access.

---

*PR created by Lucifer (OpenClaw assistant) on behalf of @baccula*