### PR TITLE
cli: default cron run timeout to 60000ms only

### DIFF
--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -105,5 +105,6 @@ export function registerCronSimpleCommands(cron: Command) {
           defaultRuntime.exit(1);
         }
       }),
+    { timeoutDefault: "60000" },
   );
 }

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -11,11 +11,16 @@ export type GatewayRpcOpts = {
   json?: boolean;
 };
 
-export function addGatewayClientOptions(cmd: Command) {
+type GatewayClientOptionsArgs = {
+  timeoutDefault?: string;
+};
+
+export function addGatewayClientOptions(cmd: Command, args?: GatewayClientOptionsArgs) {
+  const timeoutDefault = args?.timeoutDefault ?? "10000";
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
-    .option("--timeout <ms>", "Timeout in ms", "10000")
+    .option("--timeout <ms>", "Timeout in ms", timeoutDefault)
     .option("--expect-final", "Wait for final response (agent)", false);
 }
 


### PR DESCRIPTION
Change only affects `clawdbot cron run`: add an opt-in timeout default override so cron run defaults to 60000ms while other gateway commands keep the 10000ms default.