### PR TITLE
fix(telegram): add retry logic to delivery and draft streaming

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -10,8 +10,10 @@ import { splitTelegramCaption } from "../caption.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
-import { danger, logVerbose } from "../../globals.js";
+import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createTelegramRetryRunner, type RetryRunner } from "../../infra/retry-policy.js";
+import type { RetryConfig } from "../../infra/retry.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
@@ -44,6 +46,12 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  /** Retry configuration override. */
+  retry?: RetryConfig;
+  /** Account-level retry configuration. */
+  configRetry?: RetryConfig;
+  /** Enable verbose retry logging. */
+  verbose?: boolean;
 }): Promise<{ delivered: boolean }> {
   const {
     replies,
@@ -57,6 +65,11 @@ export async function deliverReplies(params: {
     replyQuoteText,
   } = params;
   const chunkMode = params.chunkMode ?? "length";
+  const requestWithRetry = createTelegramRetryRunner({
+    retry: params.retry,
+    configRetry: params.configRetry,
+    verbose: typeof params.verbose === "boolean" ? params.verbose : shouldLogVerbose(),
+  });
   let hasReplied = false;
   let hasDelivered = false;
   const markDelivered = () => {
@@ -117,6 +130,7 @@ export async function deliverReplies(params: {
           plainText: chunk.text,
           linkPreview,
           replyMarkup: shouldAttachButtons ? replyMarkup : undefined,
+          request: requestWithRetry,
         });
         markDelivered();
         if (replyToId && !hasReplied) {
@@ -165,25 +179,37 @@ export async function deliverReplies(params: {
         }),
       };
       if (isGif) {
-        await withTelegramApiErrorLogging({
-          operation: "sendAnimation",
-          runtime,
-          fn: () => bot.api.sendAnimation(chatId, file, { ...mediaParams }),
-        });
+        await requestWithRetry(
+          () =>
+            withTelegramApiErrorLogging({
+              operation: "sendAnimation",
+              runtime,
+              fn: () => bot.api.sendAnimation(chatId, file, { ...mediaParams }),
+            }),
+          "animation",
+        );
         markDelivered();
       } else if (kind === "image") {
-        await withTelegramApiErrorLogging({
-          operation: "sendPhoto",
-          runtime,
-          fn: () => bot.api.sendPhoto(chatId, file, { ...mediaParams }),
-        });
+        await requestWithRetry(
+          () =>
+            withTelegramApiErrorLogging({
+              operation: "sendPhoto",
+              runtime,
+              fn: () => bot.api.sendPhoto(chatId, file, { ...mediaParams }),
+            }),
+          "photo",
+        );
         markDelivered();
       } else if (kind === "video") {
-        await withTelegramApiErrorLogging({
-          operation: "sendVideo",
-          runtime,
-          fn: () => bot.api.sendVideo(chatId, file, { ...mediaParams }),
-        });
+        await requestWithRetry(
+          () =>
+            withTelegramApiErrorLogging({
+              operation: "sendVideo",
+              runtime,
+              fn: () => bot.api.sendVideo(chatId, file, { ...mediaParams }),
+            }),
+          "video",
+        );
         markDelivered();
       } else if (kind === "audio") {
         const { useVoice } = resolveTelegramVoiceSend({
@@ -197,12 +223,16 @@ export async function deliverReplies(params: {
           // Switch typing indicator to record_voice before sending.
           await params.onVoiceRecording?.();
           try {
-            await withTelegramApiErrorLogging({
-              operation: "sendVoice",
-              runtime,
-              shouldLog: (err) => !isVoiceMessagesForbidden(err),
-              fn: () => bot.api.sendVoice(chatId, file, { ...mediaParams }),
-            });
+            await requestWithRetry(
+              () =>
+                withTelegramApiErrorLogging({
+                  operation: "sendVoice",
+                  runtime,
+                  shouldLog: (err) => !isVoiceMessagesForbidden(err),
+                  fn: () => bot.api.sendVoice(chatId, file, { ...mediaParams }),
+                }),
+              "voice",
+            );
             markDelivered();
           } catch (voiceErr) {
             // Fall back to text if voice messages are forbidden in this chat.
@@ -229,6 +259,7 @@ export async function deliverReplies(params: {
                 linkPreview,
                 replyMarkup,
                 replyQuoteText,
+                request: requestWithRetry,
               });
               markDelivered();
               // Skip this media item; continue with next.
@@ -238,19 +269,27 @@ export async function deliverReplies(params: {
           }
         } else {
           // Audio file - displays with metadata (title, duration) - DEFAULT
-          await withTelegramApiErrorLogging({
-            operation: "sendAudio",
-            runtime,
-            fn: () => bot.api.sendAudio(chatId, file, { ...mediaParams }),
-          });
+          await requestWithRetry(
+            () =>
+              withTelegramApiErrorLogging({
+                operation: "sendAudio",
+                runtime,
+                fn: () => bot.api.sendAudio(chatId, file, { ...mediaParams }),
+              }),
+            "audio",
+          );
           markDelivered();
         }
       } else {
-        await withTelegramApiErrorLogging({
-          operation: "sendDocument",
-          runtime,
-          fn: () => bot.api.sendDocument(chatId, file, { ...mediaParams }),
-        });
+        await requestWithRetry(
+          () =>
+            withTelegramApiErrorLogging({
+              operation: "sendDocument",
+              runtime,
+              fn: () => bot.api.sendDocument(chatId, file, { ...mediaParams }),
+            }),
+          "document",
+        );
         markDelivered();
       }
       if (replyToId && !hasReplied) {
@@ -271,6 +310,7 @@ export async function deliverReplies(params: {
             plainText: chunk.text,
             linkPreview,
             replyMarkup: i === 0 ? replyMarkup : undefined,
+            request: requestWithRetry,
           });
           markDelivered();
           if (replyToId && !hasReplied) {
@@ -440,6 +480,7 @@ async function sendTelegramVoiceFallbackText(opts: {
   linkPreview?: boolean;
   replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   replyQuoteText?: string;
+  request?: RetryRunner;
 }): Promise<boolean> {
   const chunks = opts.chunkText(opts.text);
   let hasReplied = opts.hasReplied;
@@ -454,6 +495,7 @@ async function sendTelegramVoiceFallbackText(opts: {
       plainText: chunk.text,
       linkPreview: opts.linkPreview,
       replyMarkup: i === 0 ? opts.replyMarkup : undefined,
+      request: opts.request,
     });
     if (opts.replyToId && !hasReplied) {
       hasReplied = true;
@@ -499,6 +541,7 @@ async function sendTelegramText(
     plainText?: string;
     linkPreview?: boolean;
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
+    request?: RetryRunner;
   },
 ): Promise<number | undefined> {
   const baseParams = buildTelegramSendParams({
@@ -506,40 +549,51 @@ async function sendTelegramText(
     replyQuoteText: opts?.replyQuoteText,
     messageThreadId: opts?.messageThreadId,
   });
+  const request = opts?.request;
+  const sendWithRetry = <T>(fn: () => Promise<T>, label: string): Promise<T> =>
+    request ? request(fn, label) : fn();
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
   const textMode = opts?.textMode ?? "markdown";
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
   try {
-    const res = await withTelegramApiErrorLogging({
-      operation: "sendMessage",
-      runtime,
-      shouldLog: (err) => !PARSE_ERR_RE.test(formatErrorMessage(err)),
-      fn: () =>
-        bot.api.sendMessage(chatId, htmlText, {
-          parse_mode: "HTML",
-          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
-          ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...baseParams,
+    const res = await sendWithRetry(
+      () =>
+        withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          shouldLog: (err) => !PARSE_ERR_RE.test(formatErrorMessage(err)),
+          fn: () =>
+            bot.api.sendMessage(chatId, htmlText, {
+              parse_mode: "HTML",
+              ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+              ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+              ...baseParams,
+            }),
         }),
-    });
+      "message",
+    );
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText)) {
       runtime.log?.(`telegram HTML parse failed; retrying without formatting: ${errText}`);
       const fallbackText = opts?.plainText ?? text;
-      const res = await withTelegramApiErrorLogging({
-        operation: "sendMessage",
-        runtime,
-        fn: () =>
-          bot.api.sendMessage(chatId, fallbackText, {
-            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
-            ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-            ...baseParams,
+      const res = await sendWithRetry(
+        () =>
+          withTelegramApiErrorLogging({
+            operation: "sendMessage",
+            runtime,
+            fn: () =>
+              bot.api.sendMessage(chatId, fallbackText, {
+                ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+                ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+                ...baseParams,
+              }),
           }),
-      });
+        "message-plain",
+      );
       return res.message_id;
     }
     throw err;

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -2,6 +2,8 @@ import type { Bot } from "grammy";
 
 const TELEGRAM_DRAFT_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 300;
+const TRANSIENT_ERROR_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
+const MAX_TRANSIENT_RETRIES = 2;
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
@@ -36,6 +38,8 @@ export function createTelegramDraftStream(params: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let stopped = false;
 
+  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
   const sendDraft = async (text: string) => {
     if (stopped) return;
     const trimmed = text.trimEnd();
@@ -50,13 +54,28 @@ export function createTelegramDraftStream(params: {
     if (trimmed === lastSentText) return;
     lastSentText = trimmed;
     lastSentAt = Date.now();
-    try {
-      await params.api.sendMessageDraft(chatId, draftId, trimmed, threadParams);
-    } catch (err) {
-      stopped = true;
-      params.warn?.(
-        `telegram draft stream failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+
+    let retries = 0;
+    while (retries <= MAX_TRANSIENT_RETRIES) {
+      try {
+        await params.api.sendMessageDraft(chatId, draftId, trimmed, threadParams);
+        return; // Success
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const isTransient = TRANSIENT_ERROR_RE.test(errMsg);
+        if (isTransient && retries < MAX_TRANSIENT_RETRIES) {
+          retries++;
+          const delay = Math.min(300 * Math.pow(2, retries - 1), 2000);
+          params.warn?.(
+            `telegram draft transient error, retry ${retries}/${MAX_TRANSIENT_RETRIES} in ${delay}ms: ${errMsg}`,
+          );
+          await sleep(delay);
+          continue;
+        }
+        stopped = true;
+        params.warn?.(`telegram draft stream failed: ${errMsg}`);
+        return;
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Adds retry logic to Telegram message delivery and draft streaming for improved reliability.

## Changes

### `src/telegram/bot/delivery.ts`
- Added imports for `shouldLogVerbose` and `createTelegramRetryRunner`
- Created retry runner at the start of `deliverReplies` function
- Wrapped all `bot.api.send*` calls with retry logic:
  - `sendMessage` (text messages)
  - `sendPhoto`
  - `sendVideo`
  - `sendAnimation` (GIFs)
  - `sendVoice`
  - `sendAudio`
  - `sendDocument`

### `src/telegram/draft-stream.ts`
- Added transient error detection pattern (`429|timeout|connect|reset|closed|unavailable|temporarily`)
- Added retry logic to `sendDraft` function (up to 2 retries for transient errors)
- Exponential backoff with cap at 2 seconds

## Motivation

`send.js` already has retry logic via `createTelegramRetryRunner`, but `delivery.ts` (used for bot replies) and `draft-stream.ts` (streaming drafts) did not. This creates an inconsistency where proactive sends are more resilient than bot replies.

The retry policy:
- 3 attempts by default
- 400ms-30s exponential backoff with jitter
- Retries on: 429, timeout, connect, reset, closed, unavailable errors
- Respects Telegram's `retry_after` header for rate limits

## Testing

- Follows existing patterns from `send.js`
- Uses the same `createTelegramRetryRunner` utility