### PR TITLE
fix(gemini): strip JSON thoughtSignature from tool calls for Gemini 3+

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -60,6 +60,7 @@ Implementation:
 - Tool result pairing repair and synthetic tool results.
 - Turn validation (Gemini-style turn alternation).
 - Google turn ordering fixup (prepend a tiny user bootstrap if history starts with assistant).
+- Thought signature cleanup: strip non-base64 `thought_signature` and `thoughtSignature` values (keep base64).
 - Antigravity Claude: normalize thinking signatures; drop unsigned thinking blocks.
 
 **Anthropic / Minimax (Anthropic-compatible)**
@@ -70,7 +71,7 @@ Implementation:
 - Tool call id sanitization: strict9 (alphanumeric length 9).
 
 **OpenRouter Gemini**
-- Thought signature cleanup: strip non-base64 `thought_signature` values (keep base64).
+- Thought signature cleanup: strip non-base64 `thought_signature` and `thoughtSignature` values (keep base64).
 
 **Everything else**
 - Image sanitization only.

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -92,9 +92,11 @@ export function resolveTranscriptPolicy(params: {
       ? "strict"
       : undefined;
   const repairToolUseResultPairing = isGoogle || isAnthropic;
-  const sanitizeThoughtSignatures = isOpenRouterGemini
-    ? { allowBase64Only: true, includeCamelCase: true }
-    : undefined;
+  // Strip JSON-encoded thoughtSignature fields from tool calls for Gemini models.
+  // Gemini 3+ returns thoughtSignature as JSON objects (not base64), which cause
+  // "Thought signature is not valid" errors when sent back in conversation history.
+  const sanitizeThoughtSignatures =
+    isGoogle || isOpenRouterGemini ? { allowBase64Only: true, includeCamelCase: true } : undefined;
   const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
 
   return {


### PR DESCRIPTION
## Summary

Fixes the "Thought signature is not valid" error that occurs when using Gemini 3 models in multi-turn conversations with tool calls.

## Problem

Gemini 3 models now return `thoughtSignature` on tool call content blocks as JSON objects:

```json
{
  "type": "toolCall",
  "id": "tool_exec_...",
  "name": "exec",
  "arguments": {...},
  "thoughtSignature": "{\"index\":0,\"type\":\"reasoning.encrypted\",\"format\":\"google-gemini-v1\"}"
}
```

When OpenClaw sends conversation history back to the API containing these fields, Google's API rejects the request with:

```
Unable to submit request because Thought signature is not valid.
```

## Solution

Extend thought signature sanitization to apply to **all Google models** (native Google API), not just OpenRouter Gemini. This strips non-base64 `thoughtSignature` fields from tool call content blocks before sending conversation history to the API.

## Changes

- **`src/agents/transcript-policy.ts`**: Apply `sanitizeThoughtSignatures` for native Google models (`isGoogle`) in addition to OpenRouter Gemini
- **`src/agents/pi-embedded-runner.google-sanitize-thinking.test.ts`**: Add test for native Google model thought signature stripping
- **`docs/reference/transcript-hygiene.md`**: Update documentation to reflect new behavior

## Testing

- All 12 existing + new tests pass
- New test specifically verifies JSON `thoughtSignature` is stripped while valid base64 signatures are preserved

Closes #5001

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends transcript sanitization for Google-native models to strip non-base64 `thoughtSignature`/`thought_signature` fields from tool-call content blocks, addressing Gemini 3+ “Thought signature is not valid” API rejections when replaying history. It updates the transcript policy to enable `sanitizeThoughtSignatures` for `isGoogle` (in addition to OpenRouter Gemini), adds a regression test that verifies JSON signatures are removed while valid base64 is preserved, and updates the transcript hygiene docs to reflect the new behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and clear test coverage for the new sanitization behavior.
- Change is narrowly scoped to transcript policy selection (enabling an existing sanitizer for Google APIs) and includes a targeted test that asserts the intended stripping/preservation behavior. No evidence of broader behavioral regressions in the touched code; main remaining risk is around clarity of intent (Gemini-only vs all Google) rather than functionality.
- src/agents/transcript-policy.ts (ensure intent and comments match behavior)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->