### PR TITLE
feat(ui): compact tool call chips with collapsible groups

### DIFF
--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1,84 +1,104 @@
-/* Tool Card Styles */
-.chat-tool-card {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px;
-  margin-top: 8px;
-  background: var(--card);
-  box-shadow: inset 0 1px 0 var(--card-highlight);
-  transition: border-color 150ms ease-out, background 150ms ease-out;
-  /* Fixed max-height to ensure cards don't expand too much */
-  max-height: 120px;
-  overflow: hidden;
+/* ── Collapsible tool call group ── */
+.chat-tool-collapse {
+  margin: 4px 0;
 }
 
-.chat-tool-card:hover {
+.chat-tool-collapse__summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  transition: border-color 120ms ease-out, background 120ms ease-out, color 120ms ease-out;
+}
+
+.chat-tool-collapse__summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-tool-collapse__summary::marker {
+  content: "";
+}
+
+.chat-tool-collapse__summary:hover {
   border-color: var(--border-strong);
   background: var(--bg-hover);
+  color: var(--text);
 }
 
-/* First tool card in a group - no top margin */
-.chat-tool-card:first-child {
-  margin-top: 0;
-}
-
-.chat-tool-card--clickable {
-  cursor: pointer;
-}
-
-.chat-tool-card--clickable:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* Header with title and chevron */
-.chat-tool-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.chat-tool-card__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 1.2;
-}
-
-.chat-tool-card__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-.chat-tool-card__icon svg {
-  width: 14px;
-  height: 14px;
+.chat-tool-collapse__summary svg {
+  width: 12px;
+  height: 12px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
+  flex-shrink: 0;
 }
 
-/* "View >" action link */
-.chat-tool-card__action {
+.chat-tool-collapse[open] .chat-tool-collapse__summary {
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+/* ── Tool Chip Styles (compact inline badges) ── */
+.chat-tool-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chat-tool-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
   font-size: 12px;
-  color: var(--accent);
-  opacity: 0.8;
-  transition: opacity 150ms ease-out;
+  line-height: 1.3;
+  color: var(--text);
+  max-width: 280px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  transition: border-color 120ms ease-out, background 120ms ease-out;
 }
 
-.chat-tool-card__action svg {
+.chat-tool-chip--clickable {
+  cursor: pointer;
+}
+
+.chat-tool-chip--clickable:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.chat-tool-chip--clickable:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.chat-tool-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.chat-tool-chip__icon svg {
   width: 12px;
   height: 12px;
   stroke: currentColor;
@@ -88,68 +108,15 @@
   stroke-linejoin: round;
 }
 
-.chat-tool-card--clickable:hover .chat-tool-card__action {
-  opacity: 1;
+.chat-tool-chip__label {
+  font-weight: 500;
+  flex-shrink: 0;
 }
 
-/* Status indicator for completed/empty results */
-.chat-tool-card__status {
-  display: inline-flex;
-  align-items: center;
-  color: var(--ok);
-}
-
-.chat-tool-card__status svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.chat-tool-card__status-text {
-  font-size: 11px;
-  margin-top: 4px;
-}
-
-.chat-tool-card__detail {
-  font-size: 12px;
+.chat-tool-chip__detail {
   color: var(--muted);
-  margin-top: 4px;
-}
-
-/* Collapsed preview - fixed height with truncation */
-.chat-tool-card__preview {
-  font-size: 11px;
-  color: var(--muted);
-  margin-top: 8px;
-  padding: 8px 10px;
-  background: var(--secondary);
-  border-radius: var(--radius-md);
-  white-space: pre-wrap;
   overflow: hidden;
-  max-height: 44px;
-  line-height: 1.4;
-  border: 1px solid var(--border);
-}
-
-.chat-tool-card--clickable:hover .chat-tool-card__preview {
-  background: var(--bg-hover);
-  border-color: var(--border-strong);
-}
-
-/* Short inline output */
-.chat-tool-card__inline {
-  font-size: 11px;
-  color: var(--text);
-  margin-top: 6px;
-  padding: 6px 8px;
-  background: var(--secondary);
-  border-radius: var(--radius-sm);
-  white-space: pre-wrap;
-  word-break: break-word;
+  text-overflow: ellipsis;
 }
 
 /* Reading Indicator */

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -3,11 +3,7 @@ import { html, nothing } from "lit";
 import { formatToolDetail, resolveToolDisplay } from "../tool-display";
 import { icons } from "../icons";
 import type { ToolCard } from "../types/chat-types";
-import { TOOL_INLINE_THRESHOLD } from "./constants";
-import {
-  formatToolOutputForSidebar,
-  getTruncatedPreview,
-} from "./tool-helpers";
+import { formatToolOutputForSidebar } from "./tool-helpers";
 import { isToolResultMessage } from "./message-normalizer";
 import { extractTextCached } from "./message-extract";
 
@@ -75,14 +71,9 @@ export function renderToolCardSidebar(
       }
     : undefined;
 
-  const isShort = hasText && (card.text?.length ?? 0) <= TOOL_INLINE_THRESHOLD;
-  const showCollapsed = hasText && !isShort;
-  const showInline = hasText && isShort;
-  const isEmpty = !hasText;
-
   return html`
-    <div
-      class="chat-tool-card ${canClick ? "chat-tool-card--clickable" : ""}"
+    <span
+      class="chat-tool-chip ${canClick ? "chat-tool-chip--clickable" : ""}"
       @click=${handleClick}
       role=${canClick ? "button" : nothing}
       tabindex=${canClick ? "0" : nothing}
@@ -93,30 +84,14 @@ export function renderToolCardSidebar(
             handleClick?.();
           }
         : nothing}
+      title=${detail ?? display.label}
     >
-      <div class="chat-tool-card__header">
-        <div class="chat-tool-card__title">
-          <span class="chat-tool-card__icon">${icons[display.icon]}</span>
-          <span>${display.label}</span>
-        </div>
-        ${canClick
-          ? html`<span class="chat-tool-card__action">${hasText ? "View" : ""} ${icons.check}</span>`
-          : nothing}
-        ${isEmpty && !canClick ? html`<span class="chat-tool-card__status">${icons.check}</span>` : nothing}
-      </div>
+      <span class="chat-tool-chip__icon">${icons[display.icon]}</span>
+      <span class="chat-tool-chip__label">${display.label}</span>
       ${detail
-        ? html`<div class="chat-tool-card__detail">${detail}</div>`
+        ? html`<span class="chat-tool-chip__detail">${detail}</span>`
         : nothing}
-      ${isEmpty
-        ? html`<div class="chat-tool-card__status-text muted">Completed</div>`
-        : nothing}
-      ${showCollapsed
-        ? html`<div class="chat-tool-card__preview mono">${getTruncatedPreview(card.text!)}</div>`
-        : nothing}
-      ${showInline
-        ? html`<div class="chat-tool-card__inline mono">${card.text}</div>`
-        : nothing}
-    </div>
+    </span>
   `;
 }
 


### PR DESCRIPTION
## Summary

Replace the large tool-card boxes with compact inline pill-shaped chips. Consecutive tool calls are batched into a collapsible `<details>` element showing the count (e.g. "🔧 5 tool calls").

## Before / After

**Before:** Each tool call renders as a full-width card with header, preview, and action link — taking significant vertical space.

**After:** Tool calls render as small inline pill chips. Consecutive batches collapse into a single line that expands on click.

## Changes

- **tool-cards.css:** Complete rewrite — `.chat-tool-card` → `.chat-tool-chip` (pill badges) + `.chat-tool-collapse` (collapsible wrapper)
- **tool-cards.ts:** Simplify `renderToolCardSidebar` to render compact `<span>` chips
- **grouped-render.ts:** New `renderGroupedMessages()` that batches chip-only messages into collapsible groups with tool count
- **chat.ts:** Add `isChipOnlyMessage()` detection, fold tool-result messages into preceding assistant groups, remove old toolresult filtering (chips are compact enough to always show)

## Testing

Linter passes clean. Tested locally with conversations containing many tool calls.

AI-assisted (Claude). Lightly tested.