### PR TITLE
feat: increase WS payload limits + client-side image compression

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,5 +1,5 @@
-export const MAX_PAYLOAD_BYTES = 512 * 1024; // cap incoming frame size
-export const MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024; // per-connection send buffer limit
+export const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024; // cap incoming frame size (8 MB — images are base64-encoded)
+export const MAX_BUFFERED_BYTES = 16 * 1024 * 1024; // per-connection send buffer limit
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;


### PR DESCRIPTION
## Summary

Increase WebSocket frame/buffer limits to handle base64-encoded images, and add client-side image compression to keep payloads manageable.

## Problem

Pasting screenshots or photos into the chat UI often exceeds the 512KB WebSocket frame limit, causing silent failures. Base64 encoding inflates images by ~37%, so even a 400KB image exceeds the limit.

## Server Changes

- `MAX_PAYLOAD_BYTES`: 512KB → 8MB (accommodates base64-encoded images up to ~5.8MB raw)
- `MAX_BUFFERED_BYTES`: 1.5MB → 16MB (per-connection send buffer)

## Client Changes

- `compressImage()`: Resizes images exceeding 1568px on either dimension (matches Claude's vision input limit) and converts opaque PNGs to JPEG
- Progressive JPEG quality: starts at 0.8, steps down to 0.2 until under 4MB budget
- Alpha detection via `canvasHasAlpha()`: only preserves PNG when actual transparency exists (screenshots are opaque PNG but compress 5-10x better as JPEG)
- Paste handler pipes images through `compressImage` before creating attachments

## Testing

Linter passes clean. Tested with large Retina screenshots (4K+), photos, and transparent PNGs.

AI-assisted (Claude). Tested locally.