### PR TITLE
fix(exec): block gateway restart when commands.restart=false

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -129,6 +129,7 @@ export type ExecToolDefaults = {
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
+  allowGatewayRestart?: boolean;
   scopeKey?: string;
   sessionKey?: string;
   messageProvider?: string;
@@ -753,6 +754,16 @@ export function createExecTool(
 
       if (!params.command) {
         throw new Error("Provide a command to start.");
+      }
+
+      // Block gateway restart commands when not allowed
+      if (defaults?.allowGatewayRestart !== true) {
+        const gatewayRestartPattern = /\b(openclaw|clawdbot|moltbot)\s+gateway\s+restart\b/i;
+        if (gatewayRestartPattern.test(params.command)) {
+          throw new Error(
+            "Gateway restart via exec is disabled. Set commands.restart=true to enable.",
+          );
+        }
       }
 
       const maxOutput = DEFAULT_MAX_OUTPUT;

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -374,3 +374,41 @@ describe("buildDockerExecArgs", () => {
     expect(args).toContain("-t");
   });
 });
+
+describe("exec tool gateway restart blocking", () => {
+  it("blocks gateway restart when allowGatewayRestart is not set", async () => {
+    const tool = createExecTool({ allowGatewayRestart: false });
+    await expect(tool.execute("call", { command: "openclaw gateway restart" })).rejects.toThrow(
+      "Gateway restart via exec is disabled",
+    );
+  });
+
+  it("blocks gateway restart with clawdbot alias", async () => {
+    const tool = createExecTool({ allowGatewayRestart: false });
+    await expect(tool.execute("call", { command: "clawdbot gateway restart" })).rejects.toThrow(
+      "Gateway restart via exec is disabled",
+    );
+  });
+
+  it("blocks gateway restart with moltbot alias", async () => {
+    const tool = createExecTool({ allowGatewayRestart: false });
+    await expect(tool.execute("call", { command: "moltbot gateway restart" })).rejects.toThrow(
+      "Gateway restart via exec is disabled",
+    );
+  });
+
+  it("allows gateway restart when allowGatewayRestart is true", async () => {
+    const tool = createExecTool({ allowGatewayRestart: true });
+    // This should not throw - the command will fail because openclaw is not installed,
+    // but it won't be blocked by the guard
+    const result = await tool.execute("call", { command: "echo 'openclaw gateway restart'" });
+    expect(result.content[0]).toHaveProperty("text");
+  });
+
+  it("allows other commands when allowGatewayRestart is false", async () => {
+    const tool = createExecTool({ allowGatewayRestart: false });
+    const result = await tool.execute("call", { command: "echo hello" });
+    expect(result.content[0]).toHaveProperty("text");
+    expect((result.content[0] as { text: string }).text).toContain("hello");
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -246,6 +246,7 @@ export function createClawdbotCodingTools(options?: {
     approvalRunningNoticeMs:
       options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
+    allowGatewayRestart: options?.config?.commands?.restart === true,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,


### PR DESCRIPTION
## Summary
- Adds a guard to the exec tool that blocks `openclaw/clawdbot/moltbot gateway restart` commands unless `commands.restart=true` in config
- This prevents agents from restarting the gateway via exec tool when the config explicitly disables it

## Test plan
- [x] Added unit tests for gateway restart blocking
- [x] Verified other commands still work when `allowGatewayRestart=false`
- [x] Verified gateway restart works when `allowGatewayRestart=true`

Fixes #4940

🤖 Generated with [Claude Code](https://claude.ai/code)