### PR TITLE
fix(gateway): pass bind mode to launchd service

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -91,10 +91,14 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     }
   }
 
+  // Resolve bind mode from config (loopback is the safe default)
+  const bind = cfg.gateway?.bind ?? "loopback";
+
   const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({
     env: process.env,
     port,
     token: opts.token || cfg.gateway?.auth?.token || process.env.OPENCLAW_GATEWAY_TOKEN,
+    bind,
     runtime: runtimeRaw,
     warn: (message) => {
       if (json) warnings.push(message);

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -30,6 +30,7 @@ export async function buildGatewayInstallPlan(params: {
   port: number;
   runtime: GatewayDaemonRuntime;
   token?: string;
+  bind?: string;
   devMode?: boolean;
   nodePath?: string;
   warn?: WarnFn;
@@ -45,6 +46,7 @@ export async function buildGatewayInstallPlan(params: {
     }));
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,
+    bind: params.bind,
     dev: devMode,
     runtime: params.runtime,
     nodePath,
@@ -58,6 +60,7 @@ export async function buildGatewayInstallPlan(params: {
     env: params.env,
     port: params.port,
     token: params.token,
+    bind: params.bind,
     launchdLabel:
       process.platform === "darwin"
         ? resolveGatewayLaunchAgentLabel(params.env.OPENCLAW_PROFILE)

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -227,11 +227,15 @@ async function resolveCliProgramArguments(params: {
 
 export async function resolveGatewayProgramArguments(params: {
   port: number;
+  bind?: string;
   dev?: boolean;
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
   const gatewayArgs = ["gateway", "--port", String(params.port)];
+  if (params.bind) {
+    gatewayArgs.push("--bind", params.bind);
+  }
   return resolveCliProgramArguments({
     args: gatewayArgs,
     dev: params.dev,

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -128,9 +128,10 @@ export function buildServiceEnvironment(params: {
   env: Record<string, string | undefined>;
   port: number;
   token?: string;
+  bind?: string;
   launchdLabel?: string;
 }): Record<string, string | undefined> {
-  const { env, port, token, launchdLabel } = params;
+  const { env, port, token, bind, launchdLabel } = params;
   const profile = env.OPENCLAW_PROFILE;
   const resolvedLaunchdLabel =
     launchdLabel ||
@@ -146,6 +147,7 @@ export function buildServiceEnvironment(params: {
     OPENCLAW_CONFIG_PATH: configPath,
     OPENCLAW_GATEWAY_PORT: String(port),
     OPENCLAW_GATEWAY_TOKEN: token,
+    OPENCLAW_GATEWAY_BIND: bind,
     OPENCLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
     OPENCLAW_SYSTEMD_UNIT: systemdUnit,
     OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,


### PR DESCRIPTION
## Summary
- Passes the `--bind` argument to launchd service program arguments
- Adds `CLAWDBOT_GATEWAY_BIND` to the service environment
- Ensures that `gateway.bind: "lan"` or `gateway.bind: "auto"` configurations are respected when running as a launchd service on macOS

## Test plan
- [x] Verified bind mode is passed to program arguments
- [x] Verified bind mode is included in service environment
- [x] Existing daemon tests pass

Fixes #4947

🤖 Generated with [Claude Code](https://claude.ai/code)