### PR TITLE
fix(gateway): add timeout to GatewayClient.request()

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -173,4 +173,50 @@ r1USnb+wUdA7Zoj/mQ==
 
     expect(String(error)).toContain("tls fingerprint mismatch");
   });
+
+  test("request times out when server never responds", async () => {
+    const port = await getFreePort();
+    wss = new WebSocketServer({ port, host: "127.0.0.1" });
+
+    // Server accepts connection but never responds to requests
+    wss.on("connection", (socket) => {
+      socket.once("message", (data) => {
+        const first = JSON.parse(rawDataToString(data)) as { id?: string };
+        const id = first.id ?? "connect";
+        const helloOk = {
+          type: "hello-ok",
+          protocol: 2,
+          server: { version: "dev", connId: "c1" },
+          features: { methods: [], events: [] },
+          snapshot: {
+            presence: [],
+            health: {},
+            stateVersion: { presence: 1, health: 1 },
+            uptimeMs: 1,
+          },
+          policy: {
+            maxPayload: 512 * 1024,
+            maxBufferedBytes: 1024 * 1024,
+            tickIntervalMs: 60000,
+          },
+        };
+        socket.send(JSON.stringify({ type: "res", id, ok: true, payload: helloOk }));
+        // After hello, ignore all further messages (don't respond)
+      });
+    });
+
+    const connected = new Promise<GatewayClient>((resolve) => {
+      const client = new GatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        onHelloOk: () => resolve(client),
+      });
+      client.start();
+    });
+
+    const client = await connected;
+    await expect(client.request("test", {}, { timeoutMs: 100 })).rejects.toThrow(
+      "Gateway request timeout for test",
+    );
+    client.stop();
+  }, 5000);
 });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -36,6 +36,7 @@ type Pending = {
   resolve: (value: unknown) => void;
   reject: (err: unknown) => void;
   expectFinal: boolean;
+  timer?: ReturnType<typeof setTimeout>;
 };
 
 export type GatewayClientOptions = {
@@ -311,6 +312,7 @@ export class GatewayClient {
         if (pending.expectFinal && status === "accepted") {
           return;
         }
+        if (pending.timer) clearTimeout(pending.timer);
         this.pending.delete(parsed.id);
         if (parsed.ok) pending.resolve(parsed.payload);
         else pending.reject(new Error(parsed.error?.message ?? "unknown error"));
@@ -342,6 +344,7 @@ export class GatewayClient {
 
   private flushPendingErrors(err: Error) {
     for (const [, p] of this.pending) {
+      if (p.timer) clearTimeout(p.timer);
       p.reject(err);
     }
     this.pending.clear();
@@ -382,7 +385,7 @@ export class GatewayClient {
   async request<T = unknown>(
     method: string,
     params?: unknown,
-    opts?: { expectFinal?: boolean },
+    opts?: { expectFinal?: boolean; timeoutMs?: number },
   ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("gateway not connected");
@@ -395,11 +398,20 @@ export class GatewayClient {
       );
     }
     const expectFinal = opts?.expectFinal === true;
+    const timeoutMs = opts?.timeoutMs ?? 30_000;
     const p = new Promise<T>((resolve, reject) => {
+      const timer =
+        timeoutMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id);
+              reject(new Error(`Gateway request timeout for ${method}`));
+            }, timeoutMs)
+          : undefined;
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),
         reject,
         expectFinal,
+        timer,
       });
     });
     this.ws.send(JSON.stringify(frame));


### PR DESCRIPTION
## Summary
- Adds a configurable timeout (default 30s) to `GatewayClient.request()` to prevent indefinite hangs
- When the gateway server never responds to a request, the timeout cleans up the pending Map entry and rejects with a clear error message
- Follows the same pattern as `IMessageRpcClient.request()` which already has proper timeout handling

## Test plan
- [x] Added integration test for request timeout
- [x] Verified timeout clears properly on successful response
- [x] Verified timers are cleared in `flushPendingErrors`

Fixes #4954

🤖 Generated with [Claude Code](https://claude.ai/code)