### PR TITLE
fix(auth): use correct OAuth credentials for google-gemini-cli refresh

### DIFF
--- a/extensions/google-gemini-cli-auth/index.ts
+++ b/extensions/google-gemini-cli-auth/index.ts
@@ -1,6 +1,6 @@
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema, type OAuthCredential } from "openclaw/plugin-sdk";
 
-import { loginGeminiCliOAuth } from "./oauth.js";
+import { loginGeminiCliOAuth, refreshGeminiCliToken } from "./oauth.js";
 
 const PROVIDER_ID = "google-gemini-cli";
 const PROVIDER_LABEL = "Gemini CLI OAuth";
@@ -24,6 +24,23 @@ const geminiCliPlugin = {
       docsPath: "/providers/models",
       aliases: ["gemini-cli"],
       envVars: ENV_VARS,
+      refreshOAuth: async (cred: OAuthCredential) => {
+        const result = await refreshGeminiCliToken({
+          refreshToken: cred.refresh,
+          projectId: cred.projectId ?? "",
+          clientId: cred.clientId,
+          clientSecret: cred.clientSecret,
+        });
+        return {
+          ...cred,
+          access: result.access,
+          refresh: result.refresh,
+          expires: result.expires,
+          projectId: result.projectId,
+          clientId: result.clientId,
+          clientSecret: result.clientSecret,
+        };
+      },
       auth: [
         {
           id: "oauth",
@@ -56,6 +73,8 @@ const geminiCliPlugin = {
                       expires: result.expires,
                       email: result.email,
                       projectId: result.projectId,
+                      clientId: result.clientId,
+                      clientSecret: result.clientSecret,
                     },
                   },
                 ],

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -25,7 +25,10 @@ export type TokenCredential = {
 export type OAuthCredential = OAuthCredentials & {
   type: "oauth";
   provider: string;
+  /** OAuth client ID used during login, needed for refresh (e.g., google-gemini-cli) */
   clientId?: string;
+  /** OAuth client secret used during login, needed for refresh (e.g., google-gemini-cli) */
+  clientSecret?: string;
   email?: string;
 };
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -117,6 +117,7 @@ export {
 export { ToolPolicySchema } from "../config/zod-schema.agent-runtime.js";
 export type { RuntimeEnv } from "../runtime.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
+export type { OAuthCredential } from "../agents/auth-profiles/types.js";
 export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 export { resolveAckReaction } from "../agents/identity.js";
 export type { ReplyPayload } from "../auto-reply/types.js";


### PR DESCRIPTION
## Problem

OAuth tokens for `google-gemini-cli` provider expire and require manual re-login. The refresh token is stored but not being used correctly because of an OAuth client credential mismatch.

## Root Cause

1. OpenClaw's extension (`extensions/google-gemini-cli-auth/oauth.ts`) uses OAuth credentials extracted from the user's locally installed Gemini CLI (via `resolveOAuthClientConfig()`) or from environment variables.
2. pi-ai's refresh function (`refreshGoogleCloudToken`) uses **hardcoded OAuth credentials** that differ from what the extension uses during login.
3. **OAuth tokens issued with one client cannot be refreshed with a different client** - this is a fundamental OAuth security feature.

## Solution

Store the OAuth client credentials used during login and use them for token refresh:

1. **Extended `OAuthCredential` type** - Added optional `clientId` and `clientSecret` fields
2. **Store credentials during login** - The extension now stores `clientId` and `clientSecret` in the credential
3. **Added `refreshGeminiCliToken`** - New function in `extensions/google-gemini-cli-auth/oauth.ts` that uses stored or resolved credentials
4. **Added `refreshOAuth` to plugin** - Plugin registration now includes custom refresh logic
5. **Updated core refresh logic** - `refreshOAuthTokenWithLock` now handles `google-gemini-cli` explicitly (similar to `chutes` and `qwen-portal`)
6. **Exported `OAuthCredential`** - Made type available to extensions via plugin-sdk

## Files Changed

- `src/agents/auth-profiles/types.ts` - Added `clientSecret` field to `OAuthCredential`
- `src/plugin-sdk/index.ts` - Export `OAuthCredential` for extension use
- `src/agents/auth-profiles/oauth.ts` - Added `refreshGeminiCliToken` helper and explicit handling
- `extensions/google-gemini-cli-auth/oauth.ts` - Added refresh function using stored credentials
- `extensions/google-gemini-cli-auth/index.ts` - Added `refreshOAuth` to plugin registration and store credentials during login

## Testing

- All auth-profiles tests pass (33 tests)
- Type checking passes
- Linting passes

Closes #4993

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes refresh-token failures for the `google-gemini-cli` OAuth provider by persisting the OAuth client credentials used during login and reusing them during refresh. It extends `OAuthCredential` with optional `clientId`/`clientSecret`, stores those fields during the extension’s login flow, and adds a provider-specific refresh path in core (`refreshOAuthTokenWithLock`) plus a `refreshOAuth` hook in the plugin.

Overall, the approach aligns with OAuth’s client binding requirements (refresh tokens must be refreshed with the same client). One correctness issue remains in core refresh handling where the refreshed credential update can drop the stored client fields, which would re-break refresh on the next cycle.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there is a functional bug that can break future refreshes for google-gemini-cli after the first refresh.
- Changes are localized and conceptually correct (store and reuse OAuth client credentials). However, core refresh persists `OAuthCredentials` only, so the stored profile can lose `clientId`, causing subsequent refresh attempts to fail. Minor inconsistency in expiry skew may also cause near-expiry token usage.
- src/agents/auth-profiles/oauth.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->