### PR TITLE
fix: add network connection error codes to failover classifier

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -26,6 +26,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ code: "ECONNRESET" })).toBe("timeout");
   });
 
+  it("infers timeout from network connection error codes", () => {
+    expect(resolveFailoverReasonFromError({ code: "ECONNREFUSED" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ENOTFOUND" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ENETUNREACH" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "EHOSTUNREACH" })).toBe("timeout");
+  });
+
   it("coerces failover-worthy errors into FailoverError with metadata", () => {
     const err = coerceToFailoverError("credit balance too low", {
       provider: "anthropic",

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -122,7 +122,18 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) return "timeout";
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+  if (
+    [
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ECONNRESET",
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+    ].includes(code)
+  ) {
     return "timeout";
   }
   if (isTimeoutError(err)) return "timeout";


### PR DESCRIPTION
## Summary

Fix LLM provider failover not triggering on ECONNREFUSED and other network connection errors.

## Problem

When the primary LLM provider is unreachable (e.g., Ollama server is stopped), users see connection errors instead of automatic failover to backup providers. The failover classifier did not recognize common network connectivity error codes like `ECONNREFUSED`, `ENOTFOUND`, `ENETUNREACH`, and `EHOSTUNREACH`.

## Solution

Add these network connection error codes to the failover classifier in `resolveFailoverReasonFromError()`. These errors are classified as `timeout` reason (provider unreachable), which triggers failover to the next configured provider.

## Changes

- **`src/agents/failover-error.ts`**: Added `ECONNREFUSED`, `ENOTFOUND`, `ENETUNREACH`, `EHOSTUNREACH` to the list of error codes that return `timeout` failover reason
- **`src/agents/failover-error.test.ts`**: Added test for network connection error codes

## Testing

- All existing tests pass
- Added new test case: "infers timeout from network connection error codes"
- Type checking passes

Closes #4921

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the failover classifier (`resolveFailoverReasonFromError`) to treat common Node/network connection failures (`ECONNREFUSED`, `ENOTFOUND`, `ENETUNREACH`, `EHOSTUNREACH`) as a `timeout` failover reason, aligning them with existing timeout-ish codes like `ETIMEDOUT`/`ECONNRESET`. It also adds a unit test to ensure these codes trigger the expected failover behavior, improving provider failover when the primary endpoint is unreachable (e.g., local Ollama down).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, targeted extension of an existing error-code allowlist plus a corresponding unit test; it doesn’t alter control flow outside the classifier and uses the same normalization (`toUpperCase`) as existing codes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->