### PR TITLE
fix: re-run sanitization after limitHistoryTurns to fix orphaned tool results

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -35,6 +35,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../pi-embedded-helpers.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import {
   ensurePiCompactionReserveTokens,
   resolveCompactionReserveTokensFloor,
@@ -421,8 +422,19 @@ export async function compactEmbeddedPiSessionDirect(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
-        if (limited.length > 0) {
-          session.agent.replaceMessages(limited);
+        // Re-run sanitization after limiting to fix any orphaned tool results or
+        // consecutive messages created by the history limit cut-off (issue #4650)
+        const postLimitRepaired = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(limited)
+          : limited;
+        const postLimitGemini = transcriptPolicy.validateGeminiTurns
+          ? validateGeminiTurns(postLimitRepaired)
+          : postLimitRepaired;
+        const postLimitValidated = transcriptPolicy.validateAnthropicTurns
+          ? validateAnthropicTurns(postLimitGemini)
+          : postLimitGemini;
+        if (postLimitValidated.length > 0) {
+          session.agent.replaceMessages(postLimitValidated);
         }
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -33,6 +33,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
+import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import {
   ensurePiCompactionReserveTokens,
@@ -536,8 +537,19 @@ export async function runEmbeddedAttempt(
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
         cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0) {
-          activeSession.agent.replaceMessages(limited);
+        // Re-run sanitization after limiting to fix any orphaned tool results or
+        // consecutive messages created by the history limit cut-off (issue #4650)
+        const postLimitRepaired = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(limited)
+          : limited;
+        const postLimitGemini = transcriptPolicy.validateGeminiTurns
+          ? validateGeminiTurns(postLimitRepaired)
+          : postLimitRepaired;
+        const postLimitValidated = transcriptPolicy.validateAnthropicTurns
+          ? validateAnthropicTurns(postLimitGemini)
+          : postLimitGemini;
+        if (postLimitValidated.length > 0) {
+          activeSession.agent.replaceMessages(postLimitValidated);
         }
       } catch (err) {
         sessionManager.flushPendingToolResults?.();


### PR DESCRIPTION
## Summary

After `limitHistoryTurns` cuts off older messages, `tool_use` blocks can be removed while their corresponding `tool_result` blocks remain, creating orphaned tool results that cause the Anthropic API to reject requests with errors like:

```
LLM request rejected: messages.18.content.1: unexpected tool_use_id found in tool_result blocks
```

Similarly, the limiting can create consecutive assistant messages that violate Gemini's format requirements.

## Fix

This fix re-runs the sanitization functions **after** `limitHistoryTurns` is applied:

1. `sanitizeToolUseResultPairing()` - drops orphaned tool results created by the cut-off
2. `validateGeminiTurns()` - merges consecutive assistant messages
3. `validateAnthropicTurns()` - merges consecutive user messages

The same fix is applied to both:
- `src/agents/pi-embedded-runner/run/attempt.ts` (main request path)
- `src/agents/pi-embedded-runner/compact.ts` (compaction path)

## Testing

- All existing tests pass
- Lint and type-check pass

Closes #4650

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded Pi runner and compaction code paths to re-run transcript sanitization after `limitHistoryTurns()` is applied. The intent is to fix cases where truncation can leave orphaned `tool_result` messages (without their preceding `tool_use`) and can create consecutive same-role turns that certain providers reject (e.g., Gemini assistant-assistant or Anthropic user-user turns). The change adds a post-limit pass of `sanitizeToolUseResultPairing()`, `validateGeminiTurns()`, and `validateAnthropicTurns()` before persisting the truncated message list back into the session.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should reduce provider request rejections by repairing transcripts after truncation.
- The change is localized to post-processing of an already-sanitized/validated transcript and uses existing, well-scoped helper functions. Main remaining risk is behavioral: `sanitizeToolUseResultPairing()` can insert synthetic tool results for missing tool calls, and re-running it after truncation could add new synthetic entries; whether that is always desired depends on `TranscriptPolicy` expectations. CI/test execution couldn't be verified in this environment (no node/pnpm available).
- src/agents/pi-embedded-runner/run/attempt.ts, src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->