### PR TITLE
feat(subagents): add allowOverride to selectively enable blocked tools

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -1,6 +1,11 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { filterToolsByPolicy, isToolAllowedByPolicyName } from "./pi-tools.policy.js";
+import {
+  filterToolsByPolicy,
+  isToolAllowedByPolicyName,
+  resolveSubagentToolPolicy,
+} from "./pi-tools.policy.js";
+import type { OpenClawConfig } from "../config/config.js";
 
 function createStubTool(name: string): AgentTool<unknown, unknown> {
   return {
@@ -32,5 +37,48 @@ describe("pi-tools.policy", () => {
 
   it("keeps apply_patch when exec is allowlisted", () => {
     expect(isToolAllowedByPolicyName("apply_patch", { allow: ["exec"] })).toBe(true);
+  });
+
+  describe("resolveSubagentToolPolicy", () => {
+    it("denies default subagent tools when no config is provided", () => {
+      const policy = resolveSubagentToolPolicy(undefined);
+      expect(policy.deny).toContain("sessions_send");
+      expect(policy.deny).toContain("memory_search");
+    });
+
+    it("allows overriding specific tools from default deny list via allowOverride", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          subagents: {
+            tools: {
+              allowOverride: ["sessions_send", "memory_search"],
+            },
+          },
+        },
+      };
+      const policy = resolveSubagentToolPolicy(cfg);
+      expect(policy.deny).not.toContain("sessions_send");
+      expect(policy.deny).not.toContain("memory_search");
+      // Other defaults should still be denied
+      expect(policy.deny).toContain("gateway");
+      expect(policy.deny).toContain("sessions_spawn");
+    });
+
+    it("merges custom deny with remaining default deny", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          subagents: {
+            tools: {
+              allowOverride: ["sessions_send"],
+              deny: ["custom_tool"],
+            },
+          },
+        },
+      };
+      const policy = resolveSubagentToolPolicy(cfg);
+      expect(policy.deny).not.toContain("sessions_send");
+      expect(policy.deny).toContain("custom_tool");
+      expect(policy.deny).toContain("gateway");
+    });
   });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -75,10 +75,10 @@ const DEFAULT_SUBAGENT_TOOL_DENY = [
 
 export function resolveSubagentToolPolicy(cfg?: OpenClawConfig): SandboxToolPolicy {
   const configured = cfg?.tools?.subagents?.tools;
-  const deny = [
-    ...DEFAULT_SUBAGENT_TOOL_DENY,
-    ...(Array.isArray(configured?.deny) ? configured.deny : []),
-  ];
+  // Allow overriding specific tools from the default deny list via allowOverride
+  const allowOverride = Array.isArray(configured?.allowOverride) ? configured.allowOverride : [];
+  const baseDeny = DEFAULT_SUBAGENT_TOOL_DENY.filter((t) => !allowOverride.includes(t));
+  const deny = [...baseDeny, ...(Array.isArray(configured?.deny) ? configured.deny : [])];
   const allow = Array.isArray(configured?.allow) ? configured.allow : undefined;
   return { allow, deny };
 }

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -438,6 +438,12 @@ export type ToolsConfig = {
     tools?: {
       allow?: string[];
       deny?: string[];
+      /**
+       * Override specific tools from the default subagent deny list.
+       * Tools listed here will be removed from the default deny list,
+       * allowing subagents to use them (e.g., ["sessions_send", "memory_search"]).
+       */
+      allowOverride?: string[];
     };
   };
   /** Sandbox tool policy defaults (deny wins). */


### PR DESCRIPTION
## Summary

Adds a new `tools.subagents.tools.allowOverride` config option that allows selectively removing tools from the default subagent deny list.

## Problem

Currently, subagents are blocked from using certain tools by default (sessions_send, memory_search, etc.) via a hardcoded deny list in `DEFAULT_SUBAGENT_TOOL_DENY`. There's no way to override this for advanced use cases where subagents legitimately need access to these tools.

## Solution

Add an `allowOverride` config option that removes specified tools from the default deny list while keeping security defaults intact for other tools.

## Example Config

```json
{
  "tools": {
    "subagents": {
      "tools": {
        "allowOverride": ["sessions_send", "memory_search"]
      }
    }
  }
}
```

## Changes

- `src/agents/pi-tools.policy.ts`: Add allowOverride logic to `resolveSubagentToolPolicy()`
- `src/config/types.tools.ts`: Add TypeScript types for the new config option
- `src/agents/pi-tools.policy.test.ts`: Add tests for allowOverride behavior

## Use Case

This enables multi-agent setups where subagents need to communicate with each other or access memory, while still maintaining the security defaults for dangerous tools like `gateway` or `sessions_spawn`.