### PR TITLE
fix(config): migrate audio.transcription with any CLI command

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -134,6 +134,30 @@ describe("legacy config detection", () => {
     });
     expect(res.config?.routing).toBeUndefined();
   });
+  it("migrates audio.transcription with custom script names", async () => {
+    vi.resetModules();
+    const { migrateLegacyConfig } = await import("./config.js");
+    const res = migrateLegacyConfig({
+      audio: {
+        transcription: {
+          command: ["/home/user/.scripts/whisperx-transcribe.sh"],
+          timeoutSeconds: 120,
+        },
+      },
+    });
+    expect(res.changes).toContain("Moved audio.transcription → tools.media.audio.models.");
+    expect(res.config?.tools?.media?.audio).toEqual({
+      enabled: true,
+      models: [
+        {
+          command: "/home/user/.scripts/whisperx-transcribe.sh",
+          type: "cli",
+          timeoutSeconds: 120,
+        },
+      ],
+    });
+    expect(res.config?.audio).toBeUndefined();
+  });
   it("migrates agent config into agents.defaults and tools", async () => {
     vi.resetModules();
     const { migrateLegacyConfig } = await import("./config.js");

--- a/src/config/legacy.migrations.part-2.ts
+++ b/src/config/legacy.migrations.part-2.ts
@@ -341,39 +341,44 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_2: LegacyConfigMigration[] = [
             changes.push("Removed routing.transcribeAudio (tools.media.audio.models already set).");
           }
         } else {
-          changes.push("Removed routing.transcribeAudio (unsupported transcription CLI).");
+          changes.push("Removed routing.transcribeAudio (invalid or empty command).");
         }
         delete routing.transcribeAudio;
       }
 
-      const audio = getRecord(raw.audio);
-      if (audio?.transcription !== undefined) {
-        const mapped = mapLegacyAudioTranscription(audio.transcription);
-        if (mapped) {
-          const tools = ensureRecord(raw, "tools");
-          const media = ensureRecord(tools, "media");
-          const mediaAudio = ensureRecord(media, "audio");
-          const models = Array.isArray(mediaAudio.models) ? (mediaAudio.models as unknown[]) : [];
-          if (models.length === 0) {
-            mediaAudio.enabled = true;
-            mediaAudio.models = [mapped];
-            changes.push("Moved audio.transcription → tools.media.audio.models.");
-          } else {
-            changes.push("Removed audio.transcription (tools.media.audio.models already set).");
-          }
-          delete audio.transcription;
-          if (Object.keys(audio).length === 0) delete raw.audio;
-          else raw.audio = audio;
-        } else {
-          delete audio.transcription;
-          changes.push("Removed audio.transcription (unsupported transcription CLI).");
-          if (Object.keys(audio).length === 0) delete raw.audio;
-          else raw.audio = audio;
-        }
-      }
-
       if (Object.keys(routing).length === 0) {
         delete raw.routing;
+      }
+    },
+  },
+  {
+    id: "audio.transcription-v2",
+    describe: "Move audio.transcription to tools.media.audio.models",
+    apply: (raw, changes) => {
+      const audio = getRecord(raw.audio);
+      if (audio?.transcription === undefined) return;
+
+      const mapped = mapLegacyAudioTranscription(audio.transcription);
+      if (mapped) {
+        const tools = ensureRecord(raw, "tools");
+        const media = ensureRecord(tools, "media");
+        const mediaAudio = ensureRecord(media, "audio");
+        const models = Array.isArray(mediaAudio.models) ? (mediaAudio.models as unknown[]) : [];
+        if (models.length === 0) {
+          mediaAudio.enabled = true;
+          mediaAudio.models = [mapped];
+          changes.push("Moved audio.transcription → tools.media.audio.models.");
+        } else {
+          changes.push("Removed audio.transcription (tools.media.audio.models already set).");
+        }
+        delete audio.transcription;
+        if (Object.keys(audio).length === 0) delete raw.audio;
+        else raw.audio = audio;
+      } else {
+        delete audio.transcription;
+        changes.push("Removed audio.transcription (invalid or empty command).");
+        if (Object.keys(audio).length === 0) delete raw.audio;
+        else raw.audio = audio;
       }
     },
   },

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -41,16 +41,12 @@ export const mergeMissing = (target: Record<string, unknown>, source: Record<str
   }
 };
 
-const AUDIO_TRANSCRIPTION_CLI_ALLOWLIST = new Set(["whisper"]);
-
 export const mapLegacyAudioTranscription = (value: unknown): Record<string, unknown> | null => {
   const transcriber = getRecord(value);
   const command = Array.isArray(transcriber?.command) ? transcriber?.command : null;
   if (!command || command.length === 0) return null;
   const rawExecutable = String(command[0] ?? "").trim();
   if (!rawExecutable) return null;
-  const executableName = rawExecutable.split(/[\\/]/).pop() ?? rawExecutable;
-  if (!AUDIO_TRANSCRIPTION_CLI_ALLOWLIST.has(executableName)) return null;
 
   const args = command.slice(1).map((part) => String(part));
   const timeoutSeconds =


### PR DESCRIPTION
## Summary

Fixes #5017 - Custom audio transcription scripts (like `whisperx-transcribe.sh`) not working with the legacy `audio.transcription.command` config format.

## Root Cause

Two bugs were preventing custom transcription scripts from working:

1. **CLI allowlist too restrictive**: The `AUDIO_TRANSCRIPTION_CLI_ALLOWLIST` in `mapLegacyAudioTranscription()` only contained `"whisper"`, causing scripts like `whisperx-transcribe.sh` to be silently rejected during migration.

2. **Migration nested incorrectly**: The `audio.transcription` migration was nested inside `routing.config-v2`, which early-exited when no `routing` section existed. Users with only `audio.transcription` (no `routing`) never got their config migrated.

## Changes

- **`src/config/legacy.shared.ts`**: Removed `AUDIO_TRANSCRIPTION_CLI_ALLOWLIST` - the modern config format (`tools.media.audio.models`) has no such restriction, so this was only blocking legitimate legacy configs.

- **`src/config/legacy.migrations.part-2.ts`**: 
  - Extracted `audio.transcription` migration to a separate `audio.transcription-v2` migration entry
  - Updated error message from "unsupported transcription CLI" to "invalid or empty command"

- **`src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`**: Added test for custom script name migration

## Testing

```bash
# All 31 tests pass
pnpm vitest run src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
```

Verified the fix works with the exact config from the issue:
```json
{
  "audio": {
    "transcription": {
      "command": ["/home/user/.scripts/whisperx-transcribe.sh"],
      "timeoutSeconds": 120
    }
  }
}
```

Now correctly migrates to:
```json
{
  "tools": {
    "media": {
      "audio": {
        "enabled": true,
        "models": [{ "type": "cli", "command": "/home/user/.scripts/whisperx-transcribe.sh", "timeoutSeconds": 120 }]
      }
    }
  }
}
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes legacy audio transcription migration by (1) removing the transcription CLI allowlist so custom script paths are migrated, and (2) moving the `audio.transcription` migration out of the `routing.config-v2` migration so it runs even when no `routing` section exists. It also updates the “unsupported CLI” change message to “invalid or empty command” and adds a regression test covering custom script names.

These changes fit into the existing config migration pipeline (`LEGACY_CONFIG_MIGRATIONS_PART_2`) by ensuring legacy `audio.transcription`/`routing.transcribeAudio` values consistently map into the modern `tools.media.audio.models` structure and are then removed from the legacy locations.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and addresses a real migration gap with good test coverage.
- The change is localized to legacy migration helpers and adds a regression test for the reported scenario. Main residual concern is that removing the allowlist makes migration more permissive, which could migrate some malformed legacy `command` values into the new config without additional sanity checks.
- src/config/legacy.shared.ts (migration permissiveness around `command[0]` validation)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->