### PR TITLE
fix(browser): prevent stdio buffer blocking in Docker environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
 - Plugins: validate plugin/hook install paths and reject traversal-like names.
+- Browser: fix Chrome launch failure in Docker by preventing stdio buffer blocking; add Docker headless config docs. (#5044) Thanks @stephenschoettler.
 - Telegram: add download timeouts for file fetches. (#6914) Thanks @hclsys.
 - Telegram: enforce thread specs for DM vs forum sends. (#6833) Thanks @obviyus.
 - Streaming: flush block streaming on paragraph boundaries for newline chunking. (#7014)
@@ -118,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
 - Plugins: validate plugin/hook install paths and reject traversal-like names.
+- Browser: fix Chrome launch failure in Docker by preventing stdio buffer blocking; add Docker headless config docs. (#5044) Thanks @stephenschoettler.
 - Telegram: add download timeouts for file fetches. (#6914) Thanks @hclsys.
 - Telegram: enforce thread specs for DM vs forum sends. (#6833) Thanks @obviyus.
 - Streaming: flush block streaming on paragraph boundaries for newline chunking. (#7014)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -276,6 +276,35 @@ docker compose run --rm openclaw-cli channels add --channel discord --token "<to
 
 Docs: [WhatsApp](/channels/whatsapp), [Telegram](/channels/telegram), [Discord](/channels/discord)
 
+### Browser configuration (Docker)
+
+When running in Docker, browser automation requires headless mode since containers have no display. Configure this via the CLI or config file.
+
+Via CLI:
+
+```bash
+docker compose run --rm openclaw-cli config set browser.headless true
+```
+
+Or add to `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "browser": {
+    "headless": true,
+    "noSandbox": true
+  }
+}
+```
+
+Notes:
+
+- `headless: true` is required for Docker environments without a display
+- `noSandbox: true` is recommended for containerized Chrome
+- Restart the gateway after changing configuration
+
+For Playwright browser installation in custom Docker images, see [Browser Tool](/tools/browser)
+
 ### OpenAI Codex OAuth (headless Docker)
 
 If you pick OpenAI Codex OAuth in the wizard, it opens a browser URL and tries

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -1,4 +1,4 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -52,7 +52,7 @@ export type RunningChrome = {
   userDataDir: string;
   cdpPort: number;
   startedAt: number;
-  proc: ChildProcessWithoutNullStreams;
+  proc: ChildProcess;
 };
 
 function resolveBrowserExecutable(resolved: ResolvedBrowserConfig): BrowserExecutable | null {
@@ -217,14 +217,15 @@ export async function launchOpenClawChrome(
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 
-    return spawn(exe.path, args, {
-      stdio: "pipe",
+    const proc = spawn(exe.path, args, {
+      stdio: ["ignore", "ignore", "ignore"],
       env: {
         ...process.env,
         // Reduce accidental sharing with the user's env.
         HOME: os.homedir(),
       },
     });
+    return proc as unknown as ChildProcess;
   };
 
   const startedAt = Date.now();


### PR DESCRIPTION
## Summary
Fixes browser automation failures in Docker by resolving two issues preventing Chrome/Playwright from launching properly in containerized environments.

## Changes Made

### 1. Code Fix: Prevent stdio Buffer Blocking
**File:** `src/browser/chrome.ts`

Changed Chrome spawn configuration from `stdio: "pipe"` to `stdio: ["ignore", "ignore", "ignore"]`.

**Problem:** When using `stdio: "pipe"`, Chrome's stdout/stderr buffers were filling up (~64KB limit) and blocking the process, preventing CDP from becoming reachable within the 15-second timeout.

**Solution:** Discarding Chrome's output instead of piping it allows the process to run without blocking.

**Result:** CDP becomes reachable within 500ms of Chrome startup in Docker.

### 2. Documentation: Docker Headless Configuration
**Files:** `docs/install/docker.md`, `CHANGELOG.md`

Added new "Browser configuration (Docker)" section explaining that Docker environments require `browser.headless: true` since containers have no display.

Includes:
- CLI configuration command
- Config file example
- Notes on `noSandbox` setting
- Changelog entry

## Test Plan
- ✅ Tested manually in Docker with Playwright Chromium
- ✅ Chrome launches successfully with stdio fix
- ✅ CDP becomes reachable in ~500ms
- ✅ Screenshot capture works end-to-end
- ✅ Lint passed (`pnpm lint`)
- ✅ Build successful

## Testing Environment
- Docker (host network mode)
- Playwright Chromium v1208 (145.0.7632.6)
- Debian 12 (bookworm) base image
- Node v22.22.0

## Fixes
Resolves browser automation timeout issues in Docker deployments where Chrome would fail to start with "Failed to start Chrome CDP on port 18800" error.

---

🤖 First-time contributor - feedback welcome!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Chrome process spawning in `src/browser/chrome.ts` to avoid stdout/stderr pipe backpressure in containerized environments by switching `stdio` from `"pipe"` to `"ignore"`. It also documents Docker-specific browser configuration in `docs/install/docker.md` (headless + noSandbox) and adds a corresponding changelog entry.

Within the codebase, `launchClawdChrome` is responsible for starting a local Chrome instance for CDP-driven automation; changing stdio affects only process IO wiring (the code doesn’t read Chrome output today), while the CDP readiness path remains HTTP/WebSocket-based.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge.
- The behavioral change is narrow (Chrome spawn stdio wiring) and matches the observed failure mode in Docker; the codebase does not currently consume Chrome stdout/stderr, so ignoring stdio should not affect functionality. Main remaining concerns are maintainability/documentation clarity (misleading ChildProcess type cast; Docker CLI example prerequisites; missing PR reference in changelog).
- src/browser/chrome.ts (stdio/type cast), docs/install/docker.md (CLI/config-path clarity)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->