### PR TITLE
Fix Telegram per-account token resolution when account keys aren't normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Status: stable.
 - Gateway: prevent blank token prompts from storing "undefined". (#4873) Thanks @Hisleren.
 - Telegram: use undici fetch for per-account proxy dispatcher. (#4456) Thanks @spiceoogway.
 - Telegram: fix HTML nesting for overlapping styles and links. (#4578) Thanks @ThanhNguyxn.
+- Telegram: resolve per-account bot token configs with normalized account IDs. (#5055) Thanks @jasonsschin.
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Telegram: accept numeric messageId/chatId in react action and honor channelId fallback. (#4533) Thanks @Ayush10.
 - Telegram: scope native skill commands to bound agent per bot. (#4360) Thanks @robhparker.

--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -70,4 +70,22 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("none");
     fs.rmSync(dir, { recursive: true, force: true });
   });
+
+  it("resolves per-account tokens when the config account key casing doesn't match routing normalization", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            // Note the mixed-case key; runtime accountId is normalized.
+            careyNotifications: { botToken: "acct-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg, { accountId: "careynotifications" });
+    expect(res.token).toBe("acct-token");
+    expect(res.source).toBe("config");
+  });
 });

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 export type TelegramTokenSource = "env" | "tokenFile" | "config" | "none";
@@ -25,15 +26,15 @@ export function resolveTelegramToken(
 
   // Account IDs are normalized for routing (e.g. lowercased). Config keys may not
   // be normalized, so resolve per-account config by matching normalized IDs.
-  const resolveAccountCfg = (id: string) => {
+  const resolveAccountCfg = (id: string): TelegramAccountConfig | undefined => {
     const accounts = telegramCfg?.accounts;
-    if (!accounts || typeof accounts !== "object") return undefined;
+    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) return undefined;
     // Direct hit (already normalized key)
-    const direct = (accounts as any)[id];
-    if (direct) return direct as any;
+    const direct = accounts[id];
+    if (direct) return direct;
     // Fallback: match by normalized key
-    const matchKey = Object.keys(accounts).find((k) => normalizeAccountId(k) === id);
-    return matchKey ? ((accounts as any)[matchKey] as any) : undefined;
+    const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === id);
+    return matchKey ? accounts[matchKey] : undefined;
   };
 
   const accountCfg = resolveAccountCfg(


### PR DESCRIPTION
Fixes #5054.

### What
- Resolve `channels.telegram.accounts.<accountId>` token config by matching normalized account IDs instead of direct key lookup.
- Adds a regression test covering mixed-case account keys (e.g. `careyNotifications`) with normalized runtime IDs (e.g. `careynotifications`).

### Why
`openclaw channels status` and routing normalize accountIds, but Telegram token resolution previously used `telegramCfg.accounts[normalizedId]` directly. That meant mixed-case account keys could yield `token:none` and the account would never start.
