### PR TITLE
fix: add per-tool-result hard cap to prevent context overflow

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -107,13 +107,13 @@ function validateHostEnv(env: Record<string, string>): void {
 }
 const DEFAULT_MAX_OUTPUT = clampNumber(
   readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
-  200_000,
+  80_000,
   1_000,
   200_000,
 );
 const DEFAULT_PENDING_MAX_OUTPUT = clampNumber(
   readEnvInt("OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS"),
-  200_000,
+  80_000,
   1_000,
   200_000,
 );

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -588,6 +588,23 @@ describe("capToolResultMessages", () => {
     expect(toolText(findToolResult(result, "t3"))).toBe("short");
   });
 
+  it("skips tool results when isToolPrunable returns false", () => {
+    const longText = "x".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: longText }),
+      makeToolResult({ toolCallId: "t2", toolName: "browser", text: longText }),
+    ];
+    // Only allow pruning "exec", not "browser"
+    const isToolPrunable = (name: string) => name === "exec";
+    const result = capToolResultMessages(messages, 100, isToolPrunable);
+    expect(result).not.toBe(messages);
+    // exec should be truncated
+    expect(toolText(findToolResult(result, "t1"))).toContain("[Tool result truncated:");
+    // browser should remain unchanged
+    expect(toolText(findToolResult(result, "t2"))).toBe(longText);
+  });
+
   it("extension applies per-result cap even when TTL has not expired", () => {
     const sessionManager = {};
 

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import {
+  capToolResultMessages,
   computeEffectiveSettings,
   default as contextPruningExtension,
   DEFAULT_CONTEXT_PRUNING_SETTINGS,
@@ -521,5 +522,119 @@ describe("context-pruning", () => {
     expect(text).toContain("abcdef");
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
+  });
+});
+
+describe("capToolResultMessages", () => {
+  it("returns the original array when no results exceed the cap", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: "short" }),
+      makeAssistant("a1"),
+    ];
+    const result = capToolResultMessages(messages, 1000);
+    expect(result).toBe(messages); // same reference
+  });
+
+  it("truncates tool results that exceed the cap", () => {
+    const longText = "abcdefghij".repeat(1000); // 10,000 chars
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: longText }),
+      makeAssistant("a1"),
+    ];
+    const result = capToolResultMessages(messages, 100);
+    expect(result).not.toBe(messages);
+    const text = toolText(findToolResult(result, "t1"));
+    expect(text.length).toBeLessThan(longText.length);
+    expect(text).toContain("[Tool result truncated:");
+    // Head portion (60% of 100 = 60 chars)
+    expect(text).toContain("abcdefghij".slice(0, 10));
+    // Tail portion
+    expect(text).toContain("ghij");
+  });
+
+  it("does not truncate when maxChars is 0 (disabled)", () => {
+    const longText = "x".repeat(100_000);
+    const messages: AgentMessage[] = [
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: longText }),
+    ];
+    const result = capToolResultMessages(messages, 0);
+    expect(result).toBe(messages);
+  });
+
+  it("skips tool results that contain images", () => {
+    const messages: AgentMessage[] = [
+      makeImageToolResult({
+        toolCallId: "t1",
+        toolName: "browser",
+        text: "x".repeat(100_000),
+      }),
+    ];
+    const result = capToolResultMessages(messages, 100);
+    expect(result).toBe(messages);
+  });
+
+  it("truncates multiple oversized results in one pass", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: "A".repeat(10_000) }),
+      makeToolResult({ toolCallId: "t2", toolName: "exec", text: "B".repeat(10_000) }),
+      makeToolResult({ toolCallId: "t3", toolName: "exec", text: "short" }),
+    ];
+    const result = capToolResultMessages(messages, 200);
+    expect(toolText(findToolResult(result, "t1"))).toContain("[Tool result truncated:");
+    expect(toolText(findToolResult(result, "t2"))).toContain("[Tool result truncated:");
+    expect(toolText(findToolResult(result, "t3"))).toBe("short");
+  });
+
+  it("extension applies per-result cap even when TTL has not expired", () => {
+    const sessionManager = {};
+
+    setContextPruningRuntime(sessionManager, {
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        maxToolResultChars: 100,
+      },
+      contextWindowTokens: 200_000,
+      isToolPrunable: () => true,
+      // TTL not expired - ratio-based pruning would be skipped
+      lastCacheTouchAt: Date.now(),
+    });
+
+    const longText = "x".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistant("a1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: longText }),
+    ];
+
+    let handler:
+      | ((
+          event: { messages: AgentMessage[] },
+          ctx: ExtensionContext,
+        ) => { messages: AgentMessage[] } | undefined)
+      | undefined;
+
+    const api = {
+      on: (name: string, fn: unknown) => {
+        if (name === "context") handler = fn as typeof handler;
+      },
+      appendEntry: (_type: string, _data?: unknown) => {},
+    } as unknown as ExtensionAPI;
+
+    contextPruningExtension(api);
+    if (!handler) throw new Error("missing context handler");
+
+    const result = handler({ messages }, {
+      model: undefined,
+      sessionManager,
+    } as unknown as ExtensionContext);
+
+    // Even though TTL hasn't expired, per-result cap should still apply
+    expect(result).toBeDefined();
+    const text = toolText(findToolResult(result!.messages, "t1"));
+    expect(text).toContain("[Tool result truncated:");
+    expect(text.length).toBeLessThan(longText.length);
   });
 });

--- a/src/agents/pi-extensions/context-pruning.ts
+++ b/src/agents/pi-extensions/context-pruning.ts
@@ -7,7 +7,7 @@
 
 export { default } from "./context-pruning/extension.js";
 
-export { pruneContextMessages } from "./context-pruning/pruner.js";
+export { capToolResultMessages, pruneContextMessages } from "./context-pruning/pruner.js";
 export type {
   ContextPruningConfig,
   ContextPruningToolMatch,
@@ -16,4 +16,5 @@ export type {
 export {
   computeEffectiveSettings,
   DEFAULT_CONTEXT_PRUNING_SETTINGS,
+  DEFAULT_MAX_TOOL_RESULT_CHARS,
 } from "./context-pruning/settings.js";

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -229,7 +229,11 @@ ${tail}`;
  *
  * Returns the original array if no changes were needed.
  */
-export function capToolResultMessages(messages: AgentMessage[], maxChars: number): AgentMessage[] {
+export function capToolResultMessages(
+  messages: AgentMessage[],
+  maxChars: number,
+  isToolPrunable?: (toolName: string) => boolean,
+): AgentMessage[] {
   if (maxChars <= 0) return messages;
 
   let next: AgentMessage[] | null = null;
@@ -237,6 +241,7 @@ export function capToolResultMessages(messages: AgentMessage[], maxChars: number
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (!msg || msg.role !== "toolResult") continue;
+    if (isToolPrunable && !isToolPrunable(msg.toolName)) continue;
     if (hasImageBlocks(msg.content)) continue;
 
     const parts = collectTextSegments(msg.content);

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -222,6 +222,47 @@ ${tail}`;
   return { ...msg, content: [asText(trimmed + note)] };
 }
 
+/**
+ * Hard-cap individual tool result text content.  Runs on every turn
+ * (not TTL-gated) to prevent a single oversized result from blowing
+ * out the context window before the ratio-based pruner acts.
+ *
+ * Returns the original array if no changes were needed.
+ */
+export function capToolResultMessages(messages: AgentMessage[], maxChars: number): AgentMessage[] {
+  if (maxChars <= 0) return messages;
+
+  let next: AgentMessage[] | null = null;
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || msg.role !== "toolResult") continue;
+    if (hasImageBlocks(msg.content)) continue;
+
+    const parts = collectTextSegments(msg.content);
+    const rawLen = estimateJoinedTextLength(parts);
+    if (rawLen <= maxChars) continue;
+
+    // Keep head and tail proportional to maxChars (60% head, 40% tail).
+    const headChars = Math.max(0, Math.floor(maxChars * 0.6));
+    const tailChars = Math.max(0, maxChars - headChars);
+
+    const head = takeHeadFromJoinedText(parts, headChars);
+    const tail = takeTailFromJoinedText(parts, tailChars);
+    const truncated = `${head}\n...\n${tail}`;
+    const note = `\n\n[Tool result truncated: kept first ${headChars} and last ${tailChars} chars of ${rawLen} total.]`;
+    const capped: ToolResultMessage = {
+      ...msg,
+      content: [asText(truncated + note)],
+    };
+
+    if (!next) next = messages.slice();
+    next[i] = capped as unknown as AgentMessage;
+  }
+
+  return next ?? messages;
+}
+
 export function pruneContextMessages(params: {
   messages: AgentMessage[];
   settings: EffectiveContextPruningSettings;


### PR DESCRIPTION
## Problem

Individual tool results can be extremely large and blow out the context window before the ratio-based pruner gets a chance to act:

- `exec`: 200,000 chars (~50K tokens)
- `browser snapshot`: 80,000 chars (~20K tokens)  
- `web_fetch`: 50,000 chars

The existing context pruning (`pruneContextMessages`) is TTL-gated (5-minute cooldown) and ratio-based, meaning it only kicks in *after* the context is already 30%+ full. Multiple large tool results in a single turn can overflow the context before pruning runs.

This mirrors how Claude Code handles it: hard-truncate tool results at the boundary where they enter the context.

## Changes

### 1. Per-tool-result hard cap (`capToolResultMessages`)

New function that caps each individual tool result text to `maxToolResultChars` (default: 50,000 chars). Runs on **every context event**, independent of cache-TTL gating.

Uses 60/40 head/tail split to preserve both the beginning and end of tool output.

### 2. Extension restructured

The context pruning extension now:
1. **Always** applies per-result cap (not TTL-gated)
2. **Then** applies ratio-based pruning (TTL-gated, as before)

### 3. New config option

```json
{
  "agents": {
    "defaults": {
      "contextPruning": {
        "maxToolResultChars": 50000
      }
    }
  }
}
```

Set to `0` to disable.

### 4. Reduced exec DEFAULT_MAX_OUTPUT

From 200K to 80K chars (still overridable via `PI_BASH_MAX_OUTPUT_CHARS` env var).

## Tests

All 17 existing tests pass + 6 new tests for `capToolResultMessages`:
- No-op when results are under the cap
- Truncates oversized results with head/tail preservation
- Disabled when maxChars = 0
- Skips image-containing tool results
- Truncates multiple oversized results in one pass  
- Extension applies cap even when TTL has not expired

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a per-tool-result hard cap (`capToolResultMessages`) to truncate oversized tool outputs before they enter the context window, then keeps the existing ratio-based pruning (TTL-gated) as a second stage. It also reduces the default bash `exec` max output from 200k to 80k chars and introduces a new `maxToolResultChars` setting (0 disables) with tests covering truncation behavior and TTL interaction.

The changes fit into the existing context-pruning extension by adding an always-on “boundary truncation” step in `src/agents/pi-extensions/context-pruning/extension.ts`, ensuring large tool results can’t overflow context before the ratio-based pruner has a chance to run.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and is unlikely to introduce runtime failures.
- The change is localized to context pruning behavior with accompanying unit tests; main concern is behavioral: the new hard cap ignores existing tool allow/deny pruning rules, which could surprise configurations relying on those semantics.
- src/agents/pi-extensions/context-pruning/pruner.ts and src/agents/pi-extensions/context-pruning/extension.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->