### PR TITLE
feat(plugin-sdk): Implement type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./plugin-sdk": "./dist/plugin-sdk/index.js",
+    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+    "./plugin-sdk": { "types": "./dist/plugin-sdk/index.d.ts", "default": "./dist/plugin-sdk/index.js" },
     "./plugin-sdk/*": "./dist/plugin-sdk/*",
     "./cli-entry": "./openclaw.mjs"
   },
@@ -85,7 +85,7 @@
     "docs:bin": "node scripts/build-docs-list.mjs",
     "docs:dev": "cd docs && mint dev",
     "docs:build": "cd docs && pnpm dlx --reporter append-only mint broken-links",
-    "build": "pnpm canvas:a2ui:bundle && tsc -p tsconfig.json && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts",
+    "build": "pnpm canvas:a2ui:bundle && tsc -p tsconfig.json -d && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
     "ui:install": "node scripts/ui.js install",

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -461,7 +461,7 @@ export function createDiscordNativeCommand(params: {
         preferFollowUp: false,
       });
     }
-  })();
+  })() as Command;
 }
 
 async function dispatchDiscordCommandInteraction(params: {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -60,6 +60,7 @@ export type {
 export type { ChannelConfigSchema, ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export type {
   OpenClawPluginApi,
+  OpenClawPluginDefinition,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
 } from "../plugins/types.js";

--- a/src/types/whiskeysockets-baileys.d.ts
+++ b/src/types/whiskeysockets-baileys.d.ts
@@ -369,7 +369,7 @@ declare interface MakeWASocketReturn {
   user: Contact | undefined;
   generateMessageTag: () => string;
   query: (node: BinaryNode, timeoutMs?: number) => Promise<any>;
-  waitForMessage: <T>(msgId: string, timeoutMs?: number | undefined) => Promise<T | undefined>;
+  waitForMessage: <T>(msgId: string, timeoutMs?: number) => Promise<T | undefined>;
   waitForSocketOpen: () => Promise<void>;
   sendRawMessage: (data: Uint8Array | Buffer) => Promise<void>;
   sendNode: (frame: BinaryNode) => Promise<void>;

--- a/src/types/whiskeysockets-baileys.d.ts
+++ b/src/types/whiskeysockets-baileys.d.ts
@@ -1,0 +1,398 @@
+import type {
+  AnyMessageContent,
+  AuthenticationCreds,
+  BaileysEventEmitter,
+  BaileysEventMap,
+  BinaryInfo,
+  BinaryNode,
+  BotListInfo,
+  CatalogCollection,
+  ChatModification,
+  ConnectionState,
+  Contact,
+  GetCatalogOptions,
+  GroupMetadata,
+  JidWithDevice,
+  MediaConnInfo,
+  MessageReceiptType,
+  MessageRelayOptions,
+  MessageRetryManager,
+  MessageUpsertType,
+  MiscMessageGenerationOptions,
+  NewsletterMetadata,
+  NewsletterUpdate,
+  OrderDetails,
+  ParticipantAction,
+  Product,
+  ProductCreate,
+  ProductUpdate,
+  SignalKeyStoreWithTransaction,
+  SignalRepositoryWithLIDStore,
+  USyncQuery,
+  USyncQueryResult,
+  USyncQueryResultList,
+  WABusinessProfile,
+  WAMediaUpload,
+  WAMediaUploadFunction,
+  WAMessage,
+  WAMessageKey,
+  WAPatchCreate,
+  WAPresence,
+  WAPrivacyCallValue,
+  WAPrivacyGroupAddValue,
+  WAPrivacyMessagesValue,
+  WAPrivacyOnlineValue,
+  WAPrivacyValue,
+  WAReadReceiptsValue,
+  proto,
+} from "@whiskeysockets/baileys";
+import { WebSocketClient } from "@whiskeysockets/baileys/lib/Socket/Client/websocket.js";
+import {
+  QuickReplyAction,
+  UpdateBussinesProfileProps,
+} from "@whiskeysockets/baileys/lib/Types/Bussines.js";
+import { LabelActionBody } from "@whiskeysockets/baileys/lib/Types/Label.js";
+import { ILogger } from "@whiskeysockets/baileys/lib/Utils/logger.js";
+
+declare interface MakeWASocketReturn {
+  communityMetadata: (jid: string) => Promise<GroupMetadata>;
+  communityCreate: (subject: string, body: string) => Promise<GroupMetadata | null>;
+  communityCreateGroup: (
+    subject: string,
+    participants: string[],
+    parentCommunityJid: string,
+  ) => Promise<GroupMetadata | null>;
+  communityLeave: (id: string) => Promise<void>;
+  communityUpdateSubject: (jid: string, subject: string) => Promise<void>;
+  communityLinkGroup: (groupJid: string, parentCommunityJid: string) => Promise<void>;
+  communityUnlinkGroup: (groupJid: string, parentCommunityJid: string) => Promise<void>;
+  communityFetchLinkedGroups: (jid: string) => Promise<{
+    communityJid: string;
+    isCommunity: boolean;
+    linkedGroups: {
+      id: string | undefined;
+      subject: string;
+      creation: number | undefined;
+      owner: string | undefined;
+      size: number | undefined;
+    }[];
+  }>;
+  communityRequestParticipantsList: (jid: string) => Promise<
+    {
+      [key: string]: string;
+    }[]
+  >;
+  communityRequestParticipantsUpdate: (
+    jid: string,
+    participants: string[],
+    action: "approve" | "reject",
+  ) => Promise<
+    {
+      status: string;
+      jid: string | undefined;
+    }[]
+  >;
+  communityParticipantsUpdate: (
+    jid: string,
+    participants: string[],
+    action: ParticipantAction,
+  ) => Promise<
+    {
+      status: string;
+      jid: string | undefined;
+      content: BinaryNode;
+    }[]
+  >;
+  communityUpdateDescription: (jid: string, description?: string) => Promise<void>;
+  communityInviteCode: (jid: string) => Promise<string | undefined>;
+  communityRevokeInvite: (jid: string) => Promise<string | undefined>;
+  communityAcceptInvite: (code: string) => Promise<string | undefined>;
+  communityRevokeInviteV4: (communityJid: string, invitedJid: string) => Promise<boolean>;
+  communityAcceptInviteV4: (
+    key: string | WAMessageKey,
+    inviteMessage: proto.Message.IGroupInviteMessage,
+  ) => Promise<any>;
+  communityGetInviteInfo: (code: string) => Promise<GroupMetadata>;
+  communityToggleEphemeral: (jid: string, ephemeralExpiration: number) => Promise<void>;
+  communitySettingUpdate: (
+    jid: string,
+    setting: "announcement" | "not_announcement" | "locked" | "unlocked",
+  ) => Promise<void>;
+  communityMemberAddMode: (jid: string, mode: "admin_add" | "all_member_add") => Promise<void>;
+  communityJoinApprovalMode: (jid: string, mode: "on" | "off") => Promise<void>;
+  communityFetchAllParticipating: () => Promise<{
+    [_: string]: GroupMetadata;
+  }>;
+  logger: ILogger;
+  getOrderDetails: (orderId: string, tokenBase64: string) => Promise<OrderDetails>;
+  getCatalog: ({ jid, limit, cursor }: GetCatalogOptions) => Promise<{
+    products: Product[];
+    nextPageCursor: string | undefined;
+  }>;
+  getCollections: (
+    jid?: string,
+    limit?: number,
+  ) => Promise<{
+    collections: CatalogCollection[];
+  }>;
+  productCreate: (create: ProductCreate) => Promise<Product>;
+  productDelete: (productIds: string[]) => Promise<{
+    deleted: number;
+  }>;
+  productUpdate: (productId: string, update: ProductUpdate) => Promise<Product>;
+  updateBussinesProfile: (args: UpdateBussinesProfileProps) => Promise<any>;
+  updateCoverPhoto: (photo: WAMediaUpload) => Promise<number>;
+  removeCoverPhoto: (id: string) => Promise<any>;
+  sendMessageAck: ({ tag, attrs, content }: BinaryNode, errorCode?: number) => Promise<void>;
+  sendRetryRequest: (node: BinaryNode, forceIncludeKeys?: boolean) => Promise<void>;
+  rejectCall: (callId: string, callFrom: string) => Promise<void>;
+  fetchMessageHistory: (
+    count: number,
+    oldestMsgKey: WAMessageKey,
+    oldestMsgTimestamp: number | Long,
+  ) => Promise<string>;
+  requestPlaceholderResend: (messageKey: WAMessageKey) => Promise<string | undefined>;
+  messageRetryManager: MessageRetryManager | null;
+  getPrivacyTokens: (jids: string[]) => Promise<any>;
+  assertSessions: (jids: string[], force?: boolean) => Promise<boolean>;
+  relayMessage: (
+    jid: string,
+    message: proto.IMessage,
+    options: MessageRelayOptions,
+  ) => Promise<string>;
+  sendReceipt: (
+    jid: string,
+    participant: string | undefined,
+    messageIds: string[],
+    type: MessageReceiptType,
+  ) => Promise<void>;
+  sendReceipts: (keys: WAMessageKey[], type: MessageReceiptType) => Promise<void>;
+  readMessages: (keys: WAMessageKey[]) => Promise<void>;
+  refreshMediaConn: (forceGet?: boolean) => Promise<MediaConnInfo>;
+  waUploadToServer: WAMediaUploadFunction;
+  fetchPrivacySettings: (force?: boolean) => Promise<{
+    [_: string]: string;
+  }>;
+  sendPeerDataOperationMessage: (
+    pdoMessage: proto.Message.IPeerDataOperationRequestMessage,
+  ) => Promise<string>;
+  createParticipantNodes: (
+    recipientJids: string[],
+    message: proto.IMessage,
+    extraAttrs?: BinaryNode["attrs"],
+    dsmMessage?: proto.IMessage,
+  ) => Promise<{
+    nodes: BinaryNode[];
+    shouldIncludeDeviceIdentity: boolean;
+  }>;
+  getUSyncDevices: (
+    jids: string[],
+    useCache: boolean,
+    ignoreZeroDevices: boolean,
+  ) => Promise<
+    (JidWithDevice & {
+      jid: string;
+    })[]
+  >;
+  updateMediaMessage: (message: WAMessage) => Promise<WAMessage>;
+  sendMessage: (
+    jid: string,
+    content: AnyMessageContent,
+    options?: MiscMessageGenerationOptions,
+  ) => Promise<WAMessage | undefined>;
+  newsletterCreate: (name: string, description?: string) => Promise<NewsletterMetadata>;
+  newsletterUpdate: (jid: string, updates: NewsletterUpdate) => Promise<unknown>;
+  newsletterSubscribers: (jid: string) => Promise<{ subscribers: number }>;
+  newsletterMetadata: (type: "invite" | "jid", key: string) => Promise<NewsletterMetadata | null>;
+  newsletterFollow: (jid: string) => Promise<unknown>;
+  newsletterUnfollow: (jid: string) => Promise<unknown>;
+  newsletterMute: (jid: string) => Promise<unknown>;
+  newsletterUnmute: (jid: string) => Promise<unknown>;
+  newsletterUpdateName: (jid: string, name: string) => Promise<unknown>;
+  newsletterUpdateDescription: (jid: string, description: string) => Promise<unknown>;
+  newsletterUpdatePicture: (jid: string, content: WAMediaUpload) => Promise<unknown>;
+  newsletterRemovePicture: (jid: string) => Promise<unknown>;
+  newsletterReactMessage: (jid: string, serverId: string, reaction?: string) => Promise<void>;
+  newsletterFetchMessages: (
+    jid: string,
+    count: number,
+    since: number,
+    after: number,
+  ) => Promise<any>;
+  subscribeNewsletterUpdates: (jid: string) => Promise<{ duration: string } | null>;
+  newsletterAdminCount: (jid: string) => Promise<number>;
+  newsletterChangeOwner: (jid: string, newOwnerJid: string) => Promise<void>;
+  newsletterDemote: (jid: string, userJid: string) => Promise<void>;
+  newsletterDelete: (jid: string) => Promise<void>;
+  groupMetadata: (jid: string) => Promise<GroupMetadata>;
+  groupCreate: (subject: string, participants: string[]) => Promise<GroupMetadata>;
+  groupLeave: (id: string) => Promise<void>;
+  groupUpdateSubject: (jid: string, subject: string) => Promise<void>;
+  groupRequestParticipantsList: (jid: string) => Promise<
+    {
+      [key: string]: string;
+    }[]
+  >;
+  groupRequestParticipantsUpdate: (
+    jid: string,
+    participants: string[],
+    action: "approve" | "reject",
+  ) => Promise<
+    {
+      status: string;
+      jid: string | undefined;
+    }[]
+  >;
+  groupParticipantsUpdate: (
+    jid: string,
+    participants: string[],
+    action: ParticipantAction,
+  ) => Promise<
+    {
+      status: string;
+      jid: string | undefined;
+      content: BinaryNode;
+    }[]
+  >;
+  groupUpdateDescription: (jid: string, description?: string) => Promise<void>;
+  groupInviteCode: (jid: string) => Promise<string | undefined>;
+  groupRevokeInvite: (jid: string) => Promise<string | undefined>;
+  groupAcceptInvite: (code: string) => Promise<string | undefined>;
+  groupRevokeInviteV4: (groupJid: string, invitedJid: string) => Promise<boolean>;
+  groupAcceptInviteV4: (
+    key: string | WAMessageKey,
+    inviteMessage: proto.Message.IGroupInviteMessage,
+  ) => Promise<any>;
+  groupGetInviteInfo: (code: string) => Promise<GroupMetadata>;
+  groupToggleEphemeral: (jid: string, ephemeralExpiration: number) => Promise<void>;
+  groupSettingUpdate: (
+    jid: string,
+    setting: "announcement" | "not_announcement" | "locked" | "unlocked",
+  ) => Promise<void>;
+  groupMemberAddMode: (jid: string, mode: "admin_add" | "all_member_add") => Promise<void>;
+  groupJoinApprovalMode: (jid: string, mode: "on" | "off") => Promise<void>;
+  groupFetchAllParticipating: () => Promise<{ [_: string]: GroupMetadata }>;
+  createCallLink: (
+    type: "audio" | "video",
+    event?: {
+      startTime: number;
+    },
+    timeoutMs?: number,
+  ) => Promise<string | undefined>;
+  getBotListV2: () => Promise<BotListInfo[]>;
+  processingMutex: {
+    mutex<T>(code: () => Promise<T> | T): Promise<T>;
+  };
+  upsertMessage: (msg: WAMessage, type: MessageUpsertType) => Promise<void>;
+  appPatch: (patchCreate: WAPatchCreate) => Promise<void>;
+  sendPresenceUpdate: (type: WAPresence, toJid?: string) => Promise<void>;
+  presenceSubscribe: (toJid: string, tcToken?: Buffer) => Promise<void>;
+  profilePictureUrl: (
+    jid: string,
+    type?: "preview" | "image",
+    timeoutMs?: number,
+  ) => Promise<string | undefined>;
+  fetchBlocklist: () => Promise<(string | undefined)[]>;
+  fetchStatus: (...jids: string[]) => Promise<USyncQueryResultList[] | undefined>;
+  fetchDisappearingDuration: (...jids: string[]) => Promise<USyncQueryResultList[] | undefined>;
+  updateProfilePicture: (
+    jid: string,
+    content: WAMediaUpload,
+    dimensions?: {
+      width: number;
+      height: number;
+    },
+  ) => Promise<void>;
+  removeProfilePicture: (jid: string) => Promise<void>;
+  updateProfileStatus: (status: string) => Promise<void>;
+  updateProfileName: (name: string) => Promise<void>;
+  updateBlockStatus: (jid: string, action: "block" | "unblock") => Promise<void>;
+  updateDisableLinkPreviewsPrivacy: (isPreviewsDisabled: boolean) => Promise<void>;
+  updateCallPrivacy: (value: WAPrivacyCallValue) => Promise<void>;
+  updateMessagesPrivacy: (value: WAPrivacyMessagesValue) => Promise<void>;
+  updateLastSeenPrivacy: (value: WAPrivacyValue) => Promise<void>;
+  updateOnlinePrivacy: (value: WAPrivacyOnlineValue) => Promise<void>;
+  updateProfilePicturePrivacy: (value: WAPrivacyValue) => Promise<void>;
+  updateStatusPrivacy: (value: WAPrivacyValue) => Promise<void>;
+  updateReadReceiptsPrivacy: (value: WAReadReceiptsValue) => Promise<void>;
+  updateGroupsAddPrivacy: (value: WAPrivacyGroupAddValue) => Promise<void>;
+  updateDefaultDisappearingMode: (duration: number) => Promise<void>;
+  getBusinessProfile: (jid: string) => Promise<WABusinessProfile | void>;
+  resyncAppState: (
+    collections: readonly (
+      | "critical_unblock_low"
+      | "regular_high"
+      | "regular_low"
+      | "critical_block"
+      | "regular"
+    )[],
+    isInitialSync: boolean,
+  ) => Promise<void>;
+  chatModify: (mod: ChatModification, jid: string) => Promise<void>;
+  cleanDirtyBits: (
+    type: "account_sync" | "groups",
+    fromTimestamp?: number | string,
+  ) => Promise<void>;
+  addOrEditContact: (jid: string, contact: proto.SyncActionValue.IContactAction) => Promise<void>;
+  removeContact: (jid: string) => Promise<void>;
+  addLabel: (jid: string, labels: LabelActionBody) => Promise<void>;
+  addChatLabel: (jid: string, labelId: string) => Promise<void>;
+  removeChatLabel: (jid: string, labelId: string) => Promise<void>;
+  addMessageLabel: (jid: string, messageId: string, labelId: string) => Promise<void>;
+  removeMessageLabel: (jid: string, messageId: string, labelId: string) => Promise<void>;
+  star: (
+    jid: string,
+    messages: {
+      id: string;
+      fromMe?: boolean;
+    }[],
+    star: boolean,
+  ) => Promise<void>;
+  addOrEditQuickReply: (quickReply: QuickReplyAction) => Promise<void>;
+  removeQuickReply: (timestamp: string) => Promise<void>;
+  type: "md";
+  ws: WebSocketClient;
+  ev: BaileysEventEmitter & {
+    process(handler: (events: Partial<BaileysEventMap>) => void | Promise<void>): () => void;
+    buffer(): void;
+    createBufferedFunction<A extends any[], T>(
+      work: (...args: A) => Promise<T>,
+    ): (...args: A) => Promise<T>;
+    flush(): boolean;
+    isBuffering(): boolean;
+  };
+  authState: {
+    creds: AuthenticationCreds;
+    keys: SignalKeyStoreWithTransaction;
+  };
+  signalRepository: SignalRepositoryWithLIDStore;
+  user: Contact | undefined;
+  generateMessageTag: () => string;
+  query: (node: BinaryNode, timeoutMs?: number) => Promise<any>;
+  waitForMessage: <T>(msgId: string, timeoutMs?: number | undefined) => Promise<T | undefined>;
+  waitForSocketOpen: () => Promise<void>;
+  sendRawMessage: (data: Uint8Array | Buffer) => Promise<void>;
+  sendNode: (frame: BinaryNode) => Promise<void>;
+  logout: (msg?: string) => Promise<void>;
+  end: (error: Error | undefined) => void;
+  onUnexpectedError: (err: Error, msg: string) => void;
+  uploadPreKeys: (count?: number, retryCount?: number) => Promise<void>;
+  uploadPreKeysToServerIfRequired: () => Promise<void>;
+  digestKeyBundle: () => Promise<void>;
+  rotateSignedPreKey: () => Promise<void>;
+  requestPairingCode: (phoneNumber: string, customPairingCode?: string) => Promise<string>;
+  wamBuffer: BinaryInfo;
+  waitForConnectionUpdate: (
+    check: (u: Partial<ConnectionState>) => Promise<boolean | undefined>,
+    timeoutMs?: number,
+  ) => Promise<void>;
+  sendWAMBuffer: (wamBuffer: Buffer) => Promise<any>;
+  executeUSyncQuery: (usyncQuery: USyncQuery) => Promise<USyncQueryResult | undefined>;
+  onWhatsApp: (...phoneNumber: string[]) => Promise<
+    | {
+        jid: string;
+        exists: boolean;
+      }[]
+    | undefined
+  >;
+}

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -20,6 +20,7 @@ import {
   resolveWebCredsBackupPath,
   resolveWebCredsPath,
 } from "./auth-store.js";
+import { MakeWASocketReturn } from "../types/whiskeysockets-baileys.js";
 
 export {
   getWebAuthAgeMs,
@@ -106,7 +107,7 @@ export async function createWaSocket(
   maybeRestoreCredsFromBackup(authDir);
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
-  const sock = makeWASocket({
+  const sock: MakeWASocketReturn = makeWASocket({
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
     "dist",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
-    "src/**/test-helpers.ts"
+    "src/**/test-helpers.ts",
+    "src/**/test-helpers.*.ts",
+    "src/**/*.test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Expose type declaration for `openclaw` and `openclaw/plugin-sdk`
- Specifically, this is useful for plugin / extension development

## Example

```ts
import { OpenClawPluginDefinition, emptyPluginConfigSchema } from 'openclaw/plugin-sdk'

const ExamplePlugin: OpenClawPluginDefinition = {
  id: 'claw-example',
  name: 'Example Plugin',
  description: 'This is an example plugin',
  configSchema: emptyPluginConfigSchema(),
  register(api) {
    api.logger.info('Example message')
  }
}

export default ExamplePlugin
```

## Changes
- package.json: Enable declarations in build script only (to avoid runtime issues)
- plugin-sdk: Added export of `OpenClawPluginDefinition` for convenience
- @whiskeysockets/baileys: added type declaration for `makeWASocket` return type to circumvent compiler errors
- discord: Narrow createDiscordNativeCommand return type 

## Testing
- Verified builds are working