### PR TITLE
fix(tools): add group:web to coding profile

### DIFF
--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -61,7 +61,7 @@ const TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
     allow: ["session_status"],
   },
   coding: {
-    allow: ["group:fs", "group:runtime", "group:sessions", "group:memory", "image"],
+    allow: ["group:fs", "group:runtime", "group:sessions", "group:memory", "group:web", "image"],
   },
   messaging: {
     allow: [


### PR DESCRIPTION
## Summary
- The `coding` profile was missing `group:web`, which caused `web_fetch` and `web_search` tools to be unavailable to embedded agents even when explicitly enabled in config
- Developers using the coding profile often need to fetch documentation and search for solutions

## Problem
When using `tools.profile: "coding"` with `tools.allow: ["web_fetch", "web_search"]`, the web tools would not be exposed to the embedded agent because the coding profile's allowlist didn't include them.

The tool was being called on the gateway (visible in logs) but returned "Tool not found" because it wasn't in the agent's tool schema.

## Fix
Added `group:web` to the coding profile's allow list, which includes `web_search` and `web_fetch`.

## Test plan
- [x] Verified existing tests pass
- [x] Manual test: embedded agent with coding profile can now use web_fetch

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `coding` tool profile allowlist in `src/agents/tool-policy.ts` to include `group:web`, ensuring `web_search` and `web_fetch` are available to embedded agents when developers enable them in config. This aligns the profile’s default capabilities with common “coding” workflows that require looking up documentation or examples, and prevents “Tool not found” errors caused by the agent schema omitting web tools.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted allowlist addition (`group:web`) to an existing tool profile and does not alter tool execution logic; the main effect is enabling intended web tools in the coding profile.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->