### PR TITLE
feat: add Termux/Android support

### DIFF
--- a/TERMUX-QUICKSTART.md
+++ b/TERMUX-QUICKSTART.md
@@ -1,0 +1,132 @@
+# Moltbot Termux 快速入门指南
+
+## 🎉 补丁完成！
+
+Moltbot 现在可以在 Termux 上运行了！
+
+## 📋 已应用的补丁
+
+### 1. 原生模块存根
+- ✅ `@mariozechner/clipboard-android-arm64` - 已创建存根包
+- ✅ 日志目录支持环境变量覆盖 (`CLAWDBOT_LOG_DIR`)
+
+### 2. 创建的文件
+```
+termux-run.sh              # Termux 启动脚本
+scripts/patch-termux.sh    # 自动补丁脚本
+TERMUX.md                  # 详细文档
+node_modules/@mariozechner/clipboard-android-arm64/  # 存根包
+```
+
+## 🚀 使用方法
+
+### 基本命令
+
+```bash
+# 显示版本
+./termux-run.sh --version
+
+# 查看帮助
+./termux-run.sh --help
+
+# 运行诊断
+./termux-run.sh doctor
+
+# 配置向导
+./termux-run.sh setup
+
+# 配置网关
+./termux-run.sh config set gateway.mode local
+./termux-run.sh config set gateway.auth.token your-secret-token
+
+# 启动网关
+./termux-run.sh gateway run --port 18789
+```
+
+### 发送消息
+
+```bash
+# 发送消息
+./termux-run.sh message send --to +1234567890 --message "Hello from Termux!"
+
+# 运行 Agent
+./termux-run.sh agent --message "What is the weather today?"
+```
+
+## ⚙️ 初始设置
+
+### 1. 首次运行设置
+
+```bash
+# 运行设置向导
+./termux-run.sh setup
+
+# 或手动配置
+./termux-run.sh config set gateway.mode local
+./termux-run.sh config set gateway.auth.token my-secure-token
+```
+
+### 2. 配置模型提供商
+
+```bash
+# Anthropic Claude
+./termux-run.sh config set models.providers.anthropic.apiKey sk-ant-...
+
+# OpenAI
+./termux-run.sh config set models.providers.openai.apiKey sk-...
+```
+
+### 3. 启动网关
+
+```bash
+./termux-run.sh gateway run --port 18789
+```
+
+## 📱 支持的频道
+
+在 Termux 上可以正常使用：
+- ✅ WhatsApp (Baileys)
+- ✅ Telegram
+- ✅ Discord
+- ✅ Slack
+- ✅ Signal
+- ✅ WebChat
+
+可能不支持的频道：
+- ❌ iMessage (仅 macOS)
+- ❌ Matrix (需要原生加密模块)
+- ⚠️ Canvas (需要原生模块)
+
+## 🔧 故障排除
+
+### 问题：重新安装后缺少 clipboard 存根
+
+```bash
+bash scripts/patch-termux.sh
+```
+
+### 问题：权限错误
+
+确保使用 `./termux-run.sh` 而不是直接运行 `pnpm moltbot`
+
+### 问题：需要重新构建
+
+```bash
+pnpm build
+```
+
+## 📚 更多信息
+
+查看完整文档：
+- `TERMUX.md` - Termux 特定文档
+- `README.md` - 项目说明
+- `docs/` - 完整文档目录
+
+## 🎯 下一步
+
+1. 运行 `./termux-run.sh setup` 进行初始配置
+2. 配置你的 AI 模型 API 密钥
+3. 连接你想要的频道（WhatsApp/Telegram/Discord 等）
+4. 启动网关并开始使用！
+
+享受在 Android 上运行 Moltbot！🦞

--- a/TERMUX-QUICKSTART.md
+++ b/TERMUX-QUICKSTART.md
@@ -1,8 +1,8 @@
-# Moltbot Termux 快速入门指南
+# OpenClaw Termux 快速入门指南
 
 ## 🎉 补丁完成！
 
-Moltbot 现在可以在 Termux 上运行了！
+OpenClaw 现在可以在 Termux 上运行了！
 
 ## 📋 已应用的补丁
 
@@ -107,7 +107,7 @@ bash scripts/patch-termux.sh
 
 ### 问题：权限错误
 
-确保使用 `./termux-run.sh` 而不是直接运行 `pnpm moltbot`
+确保使用 `./termux-run.sh` 而不是直接运行 `pnpm openclaw`
 
 ### 问题：需要重新构建
 
@@ -129,4 +129,4 @@ pnpm build
 3. 连接你想要的频道（WhatsApp/Telegram/Discord 等）
 4. 启动网关并开始使用！
 
-享受在 Android 上运行 Moltbot！🦞
+享受在 Android 上运行 OpenClaw！🦞

--- a/TERMUX.md
+++ b/TERMUX.md
@@ -1,0 +1,133 @@
+# Moltbot on Termux
+
+This is a patched version of Moltbot that works on Termux (Android).
+
+## What was patched
+
+### 1. Native Module Stubs
+
+Created stub implementations for native modules that don't support Android/arm64:
+
+- **`@mariozechner/clipboard-android-arm64`**: Stub package in `node_modules/@mariozechner/clipboard-android-arm64/`
+  - Clipboard operations return safely without functionality
+  - Logs warnings when clipboard is accessed
+
+### 2. TypeScript Compiler
+
+The original `pnpm moltbot` command uses `@typescript/native-preview` (tsgo) which doesn't support Android.
+
+**Solution**: Use the pre-built JavaScript in `dist/`:
+```bash
+node moltbot.mjs [command]
+# Or use the wrapper:
+./termux-run.sh [command]
+```
+
+### 3. Limitations
+
+Some features will not work on Termux due to missing native modules:
+
+- ❌ **Clipboard operations** (from `@mariozechner/clipboard`)
+- ❌ **Native canvas** (from `@napi-rs/canvas`)
+- ❌ **Matrix channel** (from `@matrix-org/matrix-sdk-crypto-nodejs`)
+- ⚠️ **Some native extensions**
+
+Core functionality works fine:
+- ✅ CLI commands
+- ✅ Gateway (most channels)
+- ✅ Agent runtime
+- ✅ WebChat
+- ✅ WhatsApp, Telegram, Discord, Slack, etc.
+
+## Usage
+
+### Run CLI commands
+
+```bash
+# Version
+./termux-run.sh --version
+
+# Setup wizard
+./termux-run.sh setup
+
+# Gateway
+./termux-run.sh gateway run --port 18789
+
+# Agent
+./termux-run.sh agent --message "Hello"
+
+# Send messages
+./termux-run.sh message send --to +1234567890 --message "Test"
+```
+
+### Direct node (alternative)
+
+```bash
+node moltbot.mjs [command]
+```
+
+## Re-applying patches after reinstall
+
+If you reinstall dependencies (`pnpm install`), re-run the patch script:
+
+```bash
+bash scripts/patch-termux.sh
+```
+
+This will recreate the clipboard stub.
+
+## Development
+
+### Building
+
+```bash
+pnpm build
+```
+
+### Running from source
+
+Use the Termux wrapper - it will use the built `dist/` files automatically.
+
+### Testing
+
+Most tests should work, but skip tests that require native modules:
+
+```bash
+# Run tests (skip live/docker tests)
+pnpm test
+```
+
+## Troubleshooting
+
+### "Cannot find module '@mariozechner/clipboard-android-arm64'"
+
+Run the patch script:
+```bash
+bash scripts/patch-termux.sh
+```
+
+### "Cannot find module '@typescript/native-preview-...'"
+
+The Termux wrapper doesn't use this. Use `./termux-run.sh` or `node moltbot.mjs` instead of `pnpm moltbot`.
+
+### Gateway fails to start
+
+Some channels may not work due to missing native modules. Check logs:
+```bash
+./termux-run.sh logs --tail 50
+```
+
+## Recommended Channels for Termux
+
+These channels work well on Termux:
+- ✅ WhatsApp (Baileys - pure JS)
+- ✅ Telegram (grammY - pure JS)
+- ✅ Discord (discord.js - pure JS)
+- ✅ Slack (Bolt - pure JS)
+- ✅ Signal (signal-cli external process)
+- ✅ WebChat (built-in)
+
+These may have issues:
+- ⚠️ iMessage (macOS only)
+- ⚠️ Matrix (native crypto module)
+- ⚠️ Canvas (native module)

--- a/TERMUX.md
+++ b/TERMUX.md
@@ -1,6 +1,6 @@
-# Moltbot on Termux
+# OpenClaw on Termux
 
-This is a patched version of Moltbot that works on Termux (Android).
+This is a patched version of OpenClaw that works on Termux (Android).
 
 ## What was patched
 
@@ -18,7 +18,7 @@ The original `pnpm moltbot` command uses `@typescript/native-preview` (tsgo) whi
 
 **Solution**: Use the pre-built JavaScript in `dist/`:
 ```bash
-node moltbot.mjs [command]
+node openclaw.mjs [command]
 # Or use the wrapper:
 ./termux-run.sh [command]
 ```
@@ -63,7 +63,7 @@ Core functionality works fine:
 ### Direct node (alternative)
 
 ```bash
-node moltbot.mjs [command]
+node openclaw.mjs [command]
 ```
 
 ## Re-applying patches after reinstall
@@ -108,7 +108,7 @@ bash scripts/patch-termux.sh
 
 ### "Cannot find module '@typescript/native-preview-...'"
 
-The Termux wrapper doesn't use this. Use `./termux-run.sh` or `node moltbot.mjs` instead of `pnpm moltbot`.
+The Termux wrapper doesn't use this. Use `./termux-run.sh` or `node openclaw.mjs` instead of `pnpm openclaw`.
 
 ### Gateway fails to start
 

--- a/scripts/patch-termux.sh
+++ b/scripts/patch-termux.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Termux patch script for Moltbot
+# Run this after `pnpm install` to create stubs for missing native modules
+
+set -euo pipefail
+
+echo "[moltbot-termux] Applying Termux patches..."
+
+# Create clipboard stub
+CLIPBOARD_STUB="node_modules/@mariozechner/clipboard-android-arm64"
+if [ ! -d "$CLIPBOARD_STUB" ]; then
+  echo "[moltbot-termux] Creating clipboard stub..."
+  mkdir -p "$CLIPBOARD_STUB"
+
+  cat > "$CLIPBOARD_STUB/package.json" << 'EOF'
+{
+  "name": "@mariozechner/clipboard-android-arm64",
+  "version": "0.3.0",
+  "os": ["android"],
+  "cpu": ["arm64"],
+  "main": "index.js",
+  "types": "index.d.ts"
+}
+EOF
+
+  cat > "$CLIPBOARD_STUB/index.js" << 'EOF'
+// Stub implementation for Termux/Android
+module.exports = {
+  copyText: async (text) => {
+    console.warn('[clipboard] Clipboard not available on Termux/Android');
+    return false;
+  },
+  pasteText: async () => {
+    console.warn('[clipboard] Clipboard not available on Termux/Android');
+    return '';
+  },
+  readText: async () => {
+    console.warn('[clipboard] Clipboard not available on Termux/Android');
+    return '';
+  },
+  writeText: async (text) => {
+    console.warn('[clipboard] Clipboard not available on Termux/Android');
+    return false;
+  }
+};
+EOF
+
+  cat > "$CLIPBOARD_STUB/index.d.ts" << 'EOF'
+export function copyText(text: string): Promise<boolean>;
+export function pasteText(): Promise<string>;
+export function readText(): Promise<string>;
+export function writeText(text: string): Promise<boolean>;
+EOF
+
+  echo "[moltbot-termux] Clipboard stub created at $CLIPBOARD_STUB"
+else
+  echo "[moltbot-termux] Clipboard stub already exists"
+fi
+
+echo "[moltbot-termux] Patches applied!"
+echo ""
+echo "You can now run Moltbot with:"
+echo "  ./termux-run.sh [command]"
+echo "  node moltbot.mjs [command]"

--- a/scripts/patch-termux.sh
+++ b/scripts/patch-termux.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# Termux patch script for Moltbot
+# Termux patch script for OpenClaw
 # Run this after `pnpm install` to create stubs for missing native modules
 
 set -euo pipefail
 
-echo "[moltbot-termux] Applying Termux patches..."
+echo "[openclaw-termux] Applying Termux patches..."
 
 # Create clipboard stub
 CLIPBOARD_STUB="node_modules/@mariozechner/clipboard-android-arm64"
 if [ ! -d "$CLIPBOARD_STUB" ]; then
-  echo "[moltbot-termux] Creating clipboard stub..."
+  echo "[openclaw-termux] Creating clipboard stub..."
   mkdir -p "$CLIPBOARD_STUB"
 
   cat > "$CLIPBOARD_STUB/package.json" << 'EOF'
@@ -52,13 +52,13 @@ export function readText(): Promise<string>;
 export function writeText(text: string): Promise<boolean>;
 EOF
 
-  echo "[moltbot-termux] Clipboard stub created at $CLIPBOARD_STUB"
+  echo "[openclaw-termux] Clipboard stub created at $CLIPBOARD_STUB"
 else
-  echo "[moltbot-termux] Clipboard stub already exists"
+  echo "[openclaw-termux] Clipboard stub already exists"
 fi
 
-echo "[moltbot-termux] Patches applied!"
+echo "[openclaw-termux] Patches applied!"
 echo ""
-echo "You can now run Moltbot with:"
+echo "You can now run OpenClaw with:"
 echo "  ./termux-run.sh [command]"
-echo "  node moltbot.mjs [command]"
+echo "  node openclaw.mjs [command]"

--- a/scripts/run-termux.mjs
+++ b/scripts/run-termux.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Termux-compatible runner for Moltbot
+ *
+ * This script bypasses native module requirements that don't work on Android/Termux:
+ * - Uses tsx instead of tsgo (@typescript/native-preview doesn't support Android)
+ * - Sets environment flags to handle missing native modules gracefully
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.dirname(__dirname);
+
+const args = process.argv.slice(2);
+const env = {
+  ...process.env,
+  // Skip native preview compiler
+  CLAWDBOT_TS_COMPILER: "tsc",
+  // Disable features that require unavailable native modules
+  CLAWDBOT_DISABLE_NATIVE_CLIPBOARD: "1",
+};
+
+// Entry points to try (in order)
+const entryPoints = [
+  path.join(repoRoot, "src", "cli", "program.ts"),
+  path.join(repoRoot, "src", "index.ts"),
+];
+
+const findEntry = () => {
+  for (const entry of entryPoints) {
+    if (fs.existsSync(entry)) {
+      return entry;
+    }
+  }
+  return null;
+};
+
+const entryPoint = findEntry();
+
+if (!entryPoint) {
+  console.error("[moltbot-termux] Could not find entry point");
+  process.exit(1);
+}
+
+console.error(`[moltbot-termux] Running: ${entryPoint}`);
+
+// Use tsx to run TypeScript directly
+const tsxPath = path.join(repoRoot, "node_modules", ".bin", "tsx");
+const tsxCmd = process.platform === "win32" ? "tsx.cmd" : "tsx";
+
+const child = spawn(process.execPath, [tsxPath, entryPoint, ...args], {
+  cwd: repoRoot,
+  env,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -11,8 +11,9 @@ import { readLoggingConfig } from "./config.js";
 import { loggingState } from "./state.js";
 
 // Pin to /tmp so mac Debug UI and docs match; os.tmpdir() can be a per-user
-// randomized path on macOS which made the “Open log” button a no-op.
-export const DEFAULT_LOG_DIR = "/tmp/openclaw";
+// randomized path on macOS which made the "Open log" button a no-op.
+// Termux: Allow override via CLAWDBOT_LOG_DIR env var
+export const DEFAULT_LOG_DIR = process.env.CLAWDBOT_LOG_DIR || "/tmp/openclaw";
 export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "openclaw.log"); // legacy single-file path
 
 const LOG_PREFIX = "openclaw";

--- a/termux-run.sh
+++ b/termux-run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Termux wrapper script for Moltbot
+# This script sets up the environment and runs moltbot
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Set up writable temp directory for Termux
+TERMUX_TMP_DIR="${TMPDIR:-$HOME/.tmp}"
+export TMPDIR="$TERMUX_TMP_DIR"
+mkdir -p "$TERMUX_TMP_DIR/moltbot" 2>/dev/null || true
+
+# Set log directory to writable location
+export CLAWDBOT_LOG_DIR="$TERMUX_TMP_DIR/moltbot"
+
+# Export environment to use native Node (not tsgo)
+export CLAWDBOT_TS_COMPILER="tsc"
+export CLAWDBOT_RUNNER_LOG="1"
+
+# Run using the built JavaScript
+node moltbot.mjs "$@"

--- a/termux-run.sh
+++ b/termux-run.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
-# Termux wrapper script for Moltbot
-# This script sets up the environment and runs moltbot
+# Termux wrapper script for OpenClaw
+# This script sets up the environment and runs openclaw
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Check if CLI entrypoint exists
+if [ ! -f "./openclaw.mjs" ]; then
+    echo "Error: openclaw.mjs not found in current directory: $(pwd)"
+    echo "Please run this script from the OpenClaw repository root."
+    echo "If the project hasn't been built yet, run: pnpm build"
+    exit 1
+fi
+
 # Set up writable temp directory for Termux
 TERMUX_TMP_DIR="${TMPDIR:-$HOME/.tmp}"
 export TMPDIR="$TERMUX_TMP_DIR"
-mkdir -p "$TERMUX_TMP_DIR/moltbot" 2>/dev/null || true
+mkdir -p "$TERMUX_TMP_DIR/openclaw" 2>/dev/null || true
 
 # Set log directory to writable location
-export CLAWDBOT_LOG_DIR="$TERMUX_TMP_DIR/moltbot"
+export CLAWDBOT_LOG_DIR="$TERMUX_TMP_DIR/openclaw"
 
 # Export environment to use native Node (not tsgo)
 export CLAWDBOT_TS_COMPILER="tsc"
 export CLAWDBOT_RUNNER_LOG="1"
 
 # Run using the built JavaScript
-node moltbot.mjs "$@"
+node ./openclaw.mjs "$@"


### PR DESCRIPTION
Add comprehensive Termux support for running Moltbot on Android devices.

- `termux-run.sh`: Main wrapper script for Termux environment
  - Sets up writable temp directories
  - Configures environment variables
  - Uses pre-built JavaScript instead of tsgo compiler

- `scripts/patch-termux.sh`: Automated patching script
  - Creates stub for @mariozechner/clipboard-android-arm64
  - Patches native modules that don't support ARM64

- `scripts/run-termux.mjs`: Node.js runner for Termux

- `TERMUX.md`: Comprehensive Termux guide
  - Lists patched native modules
  - Documents limitations and workarounds
  - Usage examples

- `TERMUX-QUICKSTART.md`: Chinese quick start guide
  - Step-by-step setup instructions
  - Common commands reference

- `src/logging/logger.ts`: Support CLAWDBOT_LOG_DIR env var
  - Allows overriding log directory for Termux
  - Maintains backward compatibility with /tmp/moltbot

Features that don't work on Termux:
- Clipboard operations (from @mariozechner/clipboard)
- Native canvas (from @napi-rs/canvas)
- Matrix channel (native crypto dependencies)

Working features:
- All CLI commands
- Gateway (WhatsApp, Telegram, Discord, Slack, etc.)
- Agent runtime
- WebChat