### PR TITLE
fix(windows): implement reliable gateway restart via schtasks helper

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -150,7 +150,10 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
       sessionFile: params.sessionEntry?.sessionFile,
       config: params.cfg,
     });
-    const summary = await loadCostUsageSummary({ days: 30, config: params.cfg });
+    const summary = await loadCostUsageSummary({
+      days: 30,
+      config: params.cfg,
+    });
 
     const sessionCost = formatUsd(sessionSummary?.totalCost);
     const sessionTokens = sessionSummary?.totalTokens
@@ -177,7 +180,9 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
 
     return {
       shouldContinue: false,
-      reply: { text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}` },
+      reply: {
+        text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`,
+      },
     };
   }
 
@@ -231,8 +236,9 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
+  const avoidSigusr1 = process.platform === "win32";
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
-  if (hasSigusr1Listener) {
+  if (hasSigusr1Listener && !avoidSigusr1) {
     scheduleGatewaySigusr1Restart({ reason: "/restart" });
     return {
       shouldContinue: false,
@@ -315,7 +321,10 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
     requesterSessionKey: abortTarget.key ?? params.sessionKey,
   });
 
-  return { shouldContinue: false, reply: { text: formatAbortReplyText(stopped) } };
+  return {
+    shouldContinue: false,
+    reply: { text: formatAbortReplyText(stopped) },
+  };
 };
 
 export const handleAbortTrigger: CommandHandler = async (params, allowTextCommands) => {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -1,12 +1,16 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
+  resolveGatewayWindowsTaskName,
 } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 
 export type RestartAttempt = {
   ok: boolean;
-  method: "launchctl" | "systemd" | "supervisor";
+  method: "launchctl" | "systemd" | "supervisor" | "schtasks";
   detail?: string;
   tried?: string[];
 };
@@ -93,6 +97,43 @@ export function triggerOpenClawRestart(): RestartAttempt {
   }
   const tried: string[] = [];
   if (process.platform !== "darwin") {
+    if (process.platform === "win32") {
+      const taskName = resolveGatewayWindowsTaskName(process.env.OPENCLAW_PROFILE);
+      const pid = process.pid;
+
+      // Chain commands: wait -> stop task -> kill node -> kill wrapper cmd -> start task
+      // We use '&' to ensure execution continues even if one step fails (e.g. at kill)
+      const commands = [
+        "timeout /t 2 /nobreak >nul",
+        `schtasks /End /TN "${taskName}"`,
+        `taskkill /F /PID ${pid}`,
+        `taskkill /F /IM cmd.exe /FI "WINDOWTITLE eq ${taskName}*"`,
+        `schtasks /Run /TN "${taskName}"`,
+      ];
+      const commandLine = commands.join(" & ");
+
+      try {
+        const child = spawn("cmd.exe", ["/C", commandLine], {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+        });
+        child.unref();
+
+        return {
+          ok: true,
+          method: "schtasks",
+          tried: ["cmd.exe restart chain"],
+        };
+      } catch (err) {
+        return {
+          ok: false,
+          method: "schtasks",
+          detail: err instanceof Error ? err.message : String(err),
+          tried: ["cmd.exe restart chain"],
+        };
+      }
+    }
     if (process.platform === "linux") {
       const unit = normalizeSystemdUnit(
         process.env.OPENCLAW_SYSTEMD_UNIT,


### PR DESCRIPTION
fixes #5065 

Updated /restart command to skip unreliable SIGUSR1 signals on Windows, forcing a full process restart instead.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `/restart` handling to avoid in-process `SIGUSR1` restarts on Windows (where signaling is unreliable) and instead trigger a full process restart. It introduces a Windows-specific restart path in `src/infra/restart.ts` that spawns a detached `cmd.exe` command chain using `schtasks`/`taskkill` to stop and relaunch the gateway scheduled task.

The command-session handler now selects between `SIGUSR1` scheduling vs. supervisor restart based on platform and listener presence, which keeps existing macOS/Linux behavior while making Windows use the new scheduled-task restart helper.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the Windows restart command construction has a high-impact injection risk and should be addressed first.
- Most changes are localized and align with the stated goal (avoid SIGUSR1 on Windows). However, the new `cmd.exe /C` restart chain interpolates task/profile-derived strings into a shell command, which can break in edge cases and is a security footgun if those values are attacker-influenced. There are also unused imports that may break CI depending on lint settings.
- src/infra/restart.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->