### PR TITLE
Fix openrouter/auto model

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -330,7 +330,7 @@ describe("applyAuthChoice", () => {
       provider: "openrouter",
       mode: "api_key",
     });
-    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/auto");
+    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/openrouter/auto");
 
     const authProfilePath = authProfilePathFor(requireAgentDir());
     const raw = await fs.readFile(authProfilePath, "utf8");

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -34,11 +34,11 @@ vi.mock("../agents/model-auth.js", () => ({
 }));
 
 describe("promptDefaultModel", () => {
-  it("filters internal router models from the selection list", async () => {
+  it("includes openrouter/auto model with correct key format", async () => {
     loadModelCatalog.mockResolvedValue([
       {
         provider: "openrouter",
-        id: "auto",
+        id: "openrouter/auto",
         name: "OpenRouter Auto",
       },
       {
@@ -64,7 +64,8 @@ describe("promptDefaultModel", () => {
     });
 
     const options = select.mock.calls[0]?.[0]?.options ?? [];
-    expect(options.some((opt) => opt.value === "openrouter/auto")).toBe(false);
+    // Model key is provider/model-id, so openrouter/auto becomes openrouter/openrouter/auto
+    expect(options.some((opt) => opt.value === "openrouter/openrouter/auto")).toBe(true);
     expect(options.some((opt) => opt.value === "openrouter/meta-llama/llama-3.3-70b:free")).toBe(
       true,
     );
@@ -72,11 +73,11 @@ describe("promptDefaultModel", () => {
 });
 
 describe("promptModelAllowlist", () => {
-  it("filters internal router models from the selection list", async () => {
+  it("includes openrouter/auto model with correct key format", async () => {
     loadModelCatalog.mockResolvedValue([
       {
         provider: "openrouter",
-        id: "auto",
+        id: "openrouter/auto",
         name: "OpenRouter Auto",
       },
       {
@@ -95,7 +96,10 @@ describe("promptModelAllowlist", () => {
     await promptModelAllowlist({ config, prompter });
 
     const options = multiselect.mock.calls[0]?.[0]?.options ?? [];
-    expect(options.some((opt: { value: string }) => opt.value === "openrouter/auto")).toBe(false);
+    // Model key is provider/model-id, so openrouter/auto becomes openrouter/openrouter/auto
+    expect(
+      options.some((opt: { value: string }) => opt.value === "openrouter/openrouter/auto"),
+    ).toBe(true);
     expect(
       options.some(
         (opt: { value: string }) => opt.value === "openrouter/meta-llama/llama-3.3-70b:free",

--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -17,11 +17,6 @@ const KEEP_VALUE = "__keep__";
 const MANUAL_VALUE = "__manual__";
 const PROVIDER_FILTER_THRESHOLD = 30;
 
-// Models that are internal routing features and should not be shown in selection lists.
-// These may be valid as defaults (e.g., set automatically during auth flow) but are not
-// directly callable via API and would cause "Unknown model" errors if selected manually.
-const HIDDEN_ROUTER_MODELS = new Set(["openrouter/auto"]);
-
 type PromptDefaultModelParams = {
   config: OpenClawConfig;
   prompter: WizardPrompter;
@@ -208,8 +203,6 @@ export async function promptDefaultModel(
   }) => {
     const key = modelKey(entry.provider, entry.id);
     if (seen.has(key)) return;
-    // Skip internal router models that can't be directly called via API.
-    if (HIDDEN_ROUTER_MODELS.has(key)) return;
     const hints: string[] = [];
     if (entry.name && entry.name !== entry.id) hints.push(entry.name);
     if (entry.contextWindow) hints.push(`ctx ${formatTokenK(entry.contextWindow)}`);
@@ -336,7 +329,6 @@ export async function promptModelAllowlist(params: {
   }) => {
     const key = modelKey(entry.provider, entry.id);
     if (seen.has(key)) return;
-    if (HIDDEN_ROUTER_MODELS.has(key)) return;
     const hints: string[] = [];
     if (entry.name && entry.name !== entry.id) hints.push(entry.name);
     if (entry.contextWindow) hints.push(`ctx ${formatTokenK(entry.contextWindow)}`);

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -114,7 +114,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {


### PR DESCRIPTION
Users complaining in discord that it doesn't work (it's the default openrouter model)

Looks like there was a misdiagnosis earlier due to the way prefixing works

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates how the OpenRouter “auto” model is represented across onboarding/auth flows and the model picker.

- The OpenRouter default model ref is changed to `openrouter/openrouter/auto` to match the current `modelKey(provider, id)` prefixing behavior when catalog IDs already include `openrouter/auto`.
- The model picker no longer hides router-internal entries and tests are updated to assert the new key format appears in selection options.
- Auth/onboarding tests are updated to expect the new OpenRouter default model ref when `openrouter-api-key` is selected.

These changes primarily affect the default model written to config and what appears in interactive model selection, ensuring the OpenRouter auto default can be selected/resolved under the current keying logic.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the model key format change is risky for compatibility and user-facing config semantics.
- Core changes are small and covered by updated tests, but persisting `openrouter/openrouter/auto` as the default model ref is an unusual key format that may conflict with other parts of the codebase or existing user configs expecting `openrouter/auto`. The removal of the router-model filter also changes UX and could expose uncallable entries depending on provider catalogs.
- src/commands/onboard-auth.credentials.ts, src/commands/model-picker.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->