### PR TITLE
fix(reply): fix duplicate block replies by unblocking coalesced payloads

### DIFF
--- a/changelog/fragments/pr-5080.md
+++ b/changelog/fragments/pr-5080.md
@@ -1,0 +1,1 @@
+- Clarify block reply pipeline seen-check parameter naming for maintainability (#5080) (thanks @yassine20011)

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -155,7 +155,7 @@ export function createBlockReplyPipeline(params: {
         shouldAbort: () => aborted,
         onFlush: (payload) => {
           bufferedKeys.clear();
-          sendPayload(payload);
+          sendPayload(payload, true);
         },
       })
     : null;
@@ -210,6 +210,7 @@ export function createBlockReplyPipeline(params: {
       if (seenKeys.has(payloadKey) || pendingKeys.has(payloadKey) || bufferedKeys.has(payloadKey)) {
         return;
       }
+      seenKeys.add(payloadKey);
       bufferedKeys.add(payloadKey);
       coalescer.enqueue(payload);
       return;

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -90,12 +90,12 @@ export function createBlockReplyPipeline(params: {
   let didStream = false;
   let didLogTimeout = false;
 
-  const sendPayload = (payload: ReplyPayload, skipSeen?: boolean) => {
+  const sendPayload = (payload: ReplyPayload, bypassSeenCheck: boolean = false) => {
     if (aborted) {
       return;
     }
     const payloadKey = createBlockReplyPayloadKey(payload);
-    if (!skipSeen) {
+    if (!bypassSeenCheck) {
       if (seenKeys.has(payloadKey)) {
         return;
       }
@@ -155,7 +155,7 @@ export function createBlockReplyPipeline(params: {
         shouldAbort: () => aborted,
         onFlush: (payload) => {
           bufferedKeys.clear();
-          sendPayload(payload, true);
+          sendPayload(payload, /* bypassSeenCheck */ true);
         },
       })
     : null;
@@ -186,7 +186,7 @@ export function createBlockReplyPipeline(params: {
     }
     for (const payload of bufferedPayloads) {
       const finalPayload = buffer?.finalize?.(payload) ?? payload;
-      sendPayload(finalPayload, true);
+      sendPayload(finalPayload, /* bypassSeenCheck */ true);
     }
     bufferedPayloads.length = 0;
     bufferedPayloadKeys.clear();
@@ -202,7 +202,7 @@ export function createBlockReplyPipeline(params: {
     const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
     if (hasMedia) {
       void coalescer?.flush({ force: true });
-      sendPayload(payload);
+      sendPayload(payload, /* bypassSeenCheck */ false);
       return;
     }
     if (coalescer) {
@@ -215,7 +215,7 @@ export function createBlockReplyPipeline(params: {
       coalescer.enqueue(payload);
       return;
     }
-    sendPayload(payload);
+    sendPayload(payload, /* bypassSeenCheck */ false);
   };
 
   const flush = async (options?: { force?: boolean }) => {


### PR DESCRIPTION
## Summary

This PR fixes a regression in which coalesced block replies were being incorrectly blocked by the duplicate detection logic introduced to prevent double-sending.

The fix ensures that payloads flushed from the `block-reply-coalescer` bypass the seen check in 
Sendpayload. 

These payloads are marked as seen when they first enter the coalescer queue, which makes it safe.

## Related Issue
Fixes #3549 

## Changes

- `src/auto-reply/reply/block-reply-pipeline.ts`
  - Updated `createBlockReplyPipeline` to accept a `skipSeen` flag in `sendPayload`
  - Passed `true` for `skipSeen` when flushing payloads from the coalescer

## Testing

```bash
npx vitest run src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.signals-typing-block-replies.test.ts

 RUN  v4.0.18 /home/yassineamjad/moltbot

 ✓ src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.signals-typing-block-replies.test.ts (4 tests) 39ms
   ✓ runReplyAgent typing (heartbeat) (4)
     ✓ signals typing on block replies 22ms
     ✓ signals typing on tool results 4ms
     ✓ skips typing for silent tool results 1ms
     ✓ announces auto-compaction in verbose mode and tracks count 9ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  02:23:32
   Duration  3.51s (transform 1.62s, setup 1.70s, import 1.56s, tests 39ms, environment 0ms)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the block-reply pipeline’s de-duplication behavior for coalesced block replies. Specifically, payloads that are enqueued into the coalescer are now marked as `seen` at enqueue time, and when the coalescer flushes it calls `sendPayload` with a flag to bypass the `seenKeys` check so the flushed payload can still be delivered.

This fits into the existing pipeline design that tracks `seenKeys`/`pendingKeys`/`sentKeys` to prevent double-sends while preserving ordering via `sendChain` and allowing coalescing/buffering stages to batch replies.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low functional risk.
- The change is narrowly scoped to the block-reply pipeline and aligns with the stated intent: mark coalesced payloads as seen at enqueue and bypass the seen-check on flush. I did not find a clear functional regression in the new logic from the diff; the main concern is maintainability/readability of the new flag, which could be misused later.
- src/auto-reply/reply/block-reply-pipeline.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->