### PR TITLE
feat: change Venice default model to Kimi K2.5

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
-export const VENICE_DEFAULT_MODEL_ID = "llama-3.3-70b";
+export const VENICE_DEFAULT_MODEL_ID = "kimi-k2-5";
 export const VENICE_DEFAULT_MODEL_REF = `venice/${VENICE_DEFAULT_MODEL_ID}`;
 
 // Venice uses credit-based pricing, not per-token costs.
@@ -262,6 +262,15 @@ export const VENICE_MODEL_CATALOG = [
   },
 
   // Other anonymized models
+  {
+    id: "kimi-k2-5",
+    name: "Kimi K2.5 (via Venice)",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 262144,
+    maxTokens: 8192,
+    privacy: "anonymized",
+  },
   {
     id: "kimi-k2-thinking",
     name: "Kimi K2 Thinking (via Venice)",


### PR DESCRIPTION
## Summary

Change the Venice default model from `llama-3.3-70b` to `kimi-k2-5` (Kimi K2.5).

## Changes

- **Default model**: Updated `VENICE_DEFAULT_MODEL_ID` from `llama-3.3-70b` to `kimi-k2-5`
- **Model catalog**: Added `kimi-k2-5` entry to the static fallback catalog

## Why Kimi K2.5?

Kimi K2.5 is a significantly more capable default model:
- **256K context window** (vs 128K for Llama 3.3 70B)
- **Vision support** (multimodal text + image input)
- **Reasoning support** (built-in chain-of-thought)
- **Function calling** compatible
- **Code-optimized**

See: https://venice.ai/blog/kimi-k2-on-venice

## Testing

- `npx tsc --noEmit` passes with no errors