### PR TITLE
fix(subagent): retry with exponential backoff for reply read

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -362,9 +362,14 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!reply) {
-      reply = await readLatestAssistantReply({
-        sessionKey: params.childSessionKey,
-      });
+      // Retry with exponential backoff — transcript may not be flushed yet
+      // (NFS + parallel sub-agents can delay flushes well beyond 2.5s)
+      for (let attempt = 0; attempt < 10 && !reply; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(500 * 2 ** attempt, 5000)));
+        reply = await readLatestAssistantReply({
+          sessionKey: params.childSessionKey,
+        });
+      }
     }
 
     if (!outcome) outcome = { status: "unknown" };


### PR DESCRIPTION
## Summary

- Replaces the single-shot retry in `readLatestAssistantReply()` with exponential backoff (10 attempts, 500ms→5s cap)
- Fixes silent sub-agent failures when running parallel sub-agents on NFS-backed session storage
- Total max wait ~30s (500+1000+2000+4000+5000×6), enough for NFS flush with 6+ concurrent agents

## Problem

When `sessions_spawn_batch` runs multiple sub-agents in parallel, the transcript file may not be flushed when `readLatestAssistantReply()` first reads it. The current code does a single re-read with no delay, which is insufficient for NFS-backed storage under load. Result: sub-agents complete successfully but their output is silently lost.

## Test plan

- [x] `pnpm test` passes (4 pre-existing failures unrelated to this change)
- [ ] Manual test: `sessions_spawn_batch` with 6 tasks in Discord — all 6 should return output

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)