### PR TITLE
fix(ui): prefer session label over displayName in dropdown

### DIFF
--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -185,7 +185,7 @@ function renderRow(
   const thinkLevels = resolveThinkLevelOptions(row.modelProvider);
   const verbose = row.verboseLevel ?? "";
   const reasoning = row.reasoningLevel ?? "";
-  const displayName = row.displayName ?? row.key;
+  const displayName = row.label || row.displayName || row.key;
   const canLink = row.kind !== "global";
   const chatUrl = canLink
     ? `${pathForTab("chat", basePath)}?session=${encodeURIComponent(row.key)}`


### PR DESCRIPTION
## Summary

When using sub-agents with labels (via `sessions_spawn`), the Gateway Dashboard session dropdown displays the raw session key (e.g., `webchat:g-agent-main-subagent-b0b644c5-...`) rather than the human-readable `label` field.

## Changes

- Modified `ui/src/ui/views/sessions.ts` to prioritize `label` field over `displayName`
- Fallback chain: `label` → `displayName` → `key`

## Before

Session dropdown showed:
- `webchat:g-agent-main-subagent-b0b644c5-...`
- `webchat:g-agent-main-subagent-a1d2e3f4-...`

## After

Session dropdown now shows:
- `dept-engineering` ✅
- `dept-finance` ✅

## Testing

- [x] `pnpm lint` passes with no errors
- [ ] Manual testing (requires Gateway setup)

## Use Case

Running a department system with multiple labeled sub-agents becomes much easier when you can identify sessions by their labels rather than UUID-based keys.

Fixes #5088

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Gateway Dashboard sessions table to display a human-friendly session label in the “Key” column when available. Specifically, `renderRow` now chooses the session name using `label → displayName → key`, so labeled sub-agent sessions don’t appear as long raw session keys in the dropdown/table, while links and routing still use the underlying `row.key` for URL params.

The change is localized to `ui/src/ui/views/sessions.ts` and does not modify session identity, navigation, or patch/delete behavior—only the displayed text for the session link.

<h3>Confidence Score: 4.5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized UI-only tweak that adjusts a display fallback chain without altering session identifiers, routing, or mutation logic. The only noteworthy behavioral difference is that `label` values that are empty/whitespace will now be treated as truthy and displayed, potentially resulting in blank-looking entries, but this is limited to presentation.
- ui/src/ui/views/sessions.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->