### PR TITLE
fix(nextcloud-talk): sign message content instead of JSON body

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -89,8 +89,11 @@ export async function sendMessageNextcloudTalk(
   }
   const bodyStr = JSON.stringify(body);
 
+  // Nextcloud expects signature on message content only, not the full JSON body.
+  // See: apps/spreed/lib/Controller/BotController.php - validateRequest() uses
+  // the extracted message field, not the raw request body.
   const { random, signature } = generateNextcloudTalkSignature({
-    body: bodyStr,
+    body: message,
     secret,
   });
 
@@ -179,8 +182,9 @@ export async function sendReactionNextcloudTalk(
   const normalizedToken = normalizeRoomToken(roomToken);
 
   const body = JSON.stringify({ reaction });
+  // Nextcloud expects signature on reaction content only, not the full JSON body.
   const { random, signature } = generateNextcloudTalkSignature({
-    body,
+    body: reaction,
     secret,
   });
 


### PR DESCRIPTION
## Summary

Fixes outbound Nextcloud Talk bot messages failing with HTTP 401 (authentication failed) due to signature mismatch.

## Problem

Nextcloud Talk's bot API expects the HMAC signature to be calculated on the message/reaction content only, not the full JSON body. OpenClaw was signing the entire JSON payload, causing all outbound messages to fail authentication.

## Root Cause

There's an asymmetry in Nextcloud's API:
- **Incoming webhooks**: Nextcloud signs the full JSON body
- **Outgoing bot messages**: Nextcloud expects signature on the extracted field value only

See Nextcloud source: `apps/spreed/lib/Controller/BotController.php` - `validateRequest()` uses the extracted message field, not the raw request body.

## Changes

- `sendMessageNextcloudTalk()`: Sign `message` instead of `bodyStr`
- `sendReactionNextcloudTalk()`: Sign `reaction` instead of `body`

## Testing

This fix has been verified in production. The entire bug report, issue filing, and this PR were submitted via Nextcloud Talk using the patched code.

## Verification Commands

```bash
# This works (signature on message content):
signature=$(echo -n "${random}Hello" | openssl dgst -sha256 -hmac "$SECRET" | cut -d' ' -f2)

# This fails (signature on JSON body):
signature=$(echo -n "${random}{\"message\":\"Hello\"}" | openssl dgst -sha256 -hmac "$SECRET" | cut -d' ' -f2)
```

Fixes #5111

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts outbound Nextcloud Talk bot request signing to match Nextcloud’s expectations: instead of HMAC-signing the full JSON request body, it now signs only the `message` (for bot messages) or `reaction` (for reactions), while still sending the same JSON payload. This aligns outbound signing behavior with Nextcloud’s BotController validation logic and resolves 401 signature-mismatch failures for outbound bot messages/reactions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to which string is fed into the existing HMAC generator for two outbound requests; request payloads and headers remain unchanged aside from signature value. No other behavior or interfaces are modified, and the new behavior matches documented Nextcloud Talk bot validation semantics described in the PR.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->