### PR TITLE
fix: guard against undefined model.name in Ollama discovery (#5062)

### DIFF
--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { resolveImplicitProviders } from "./models-config.providers.js";
 import { mkdtempSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { discoverOllamaModels } from "./models-config.providers.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
 
 describe("Ollama provider", () => {
   it("should not include ollama when no API key is configured", async () => {
@@ -11,5 +14,76 @@ describe("Ollama provider", () => {
 
     // Ollama requires explicit configuration via OLLAMA_API_KEY env var or profile
     expect(providers?.ollama).toBeUndefined();
+  });
+});
+
+describe("discoverOllamaModels", () => {
+  const originalVitest = process.env.VITEST;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    // discoverOllamaModels returns [] when VITEST or NODE_ENV=test is set,
+    // so we temporarily clear those to exercise the real logic.
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalVitest !== undefined) {
+      process.env.VITEST = originalVitest;
+    }
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("skips models with undefined or empty names", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: "llama3:latest", modified_at: "", size: 0, digest: "" },
+          { name: undefined, modified_at: "", size: 0, digest: "" },
+          { name: "", modified_at: "", size: 0, digest: "" },
+          { name: "deepseek-r1:latest", modified_at: "", size: 0, digest: "" },
+        ],
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toHaveLength(2);
+    expect(models[0]!.id).toBe("llama3:latest");
+    expect(models[0]!.reasoning).toBe(false);
+    expect(models[1]!.id).toBe("deepseek-r1:latest");
+    expect(models[1]!.reasoning).toBe(true);
+  });
+
+  it("returns empty array when all model names are invalid", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: undefined, modified_at: "", size: 0, digest: "" },
+          { name: null, modified_at: "", size: 0, digest: "" },
+          { name: "", modified_at: "", size: 0, digest: "" },
+        ],
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toEqual([]);
+  });
+
+  it("returns empty array when fetch fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toEqual([]);
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -101,7 +101,7 @@ interface OllamaTagsResponse {
   models: OllamaModel[];
 }
 
-async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
+export async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
   // Skip Ollama discovery in test environments
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
@@ -119,20 +119,22 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
       console.warn("No Ollama models found on local instance");
       return [];
     }
-    return data.models.map((model) => {
-      const modelId = model.name;
-      const isReasoning =
-        modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
-      return {
-        id: modelId,
-        name: modelId,
-        reasoning: isReasoning,
-        input: ["text"],
-        cost: OLLAMA_DEFAULT_COST,
-        contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-      };
-    });
+    return data.models
+      .filter((model) => typeof model.name === "string" && model.name.length > 0)
+      .map((model) => {
+        const modelId = model.name;
+        const isReasoning =
+          modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
+        return {
+          id: modelId,
+          name: modelId,
+          reasoning: isReasoning,
+          input: ["text"],
+          cost: OLLAMA_DEFAULT_COST,
+          contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
+          maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+        };
+      });
   } catch (error) {
     console.warn(`Failed to discover Ollama models: ${String(error)}`);
     return [];


### PR DESCRIPTION
## Summary
- Fixes #5062 — `TypeError: Cannot read properties of undefined (reading 'includes')` in Ollama model discovery
- Adds `.filter()` before `.map()` in `discoverOllamaModels()` to skip model entries with missing or empty `name` fields
- Exports `discoverOllamaModels` for direct unit testing and adds test coverage for the edge case

## Test plan
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm test` — all 192 related tests pass; new tests cover undefined, null, and empty-string model names
- [ ] Manual verification with an Ollama instance that returns malformed model data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Guards Ollama model discovery against malformed `/api/tags` responses by filtering out entries with missing/empty `name` before deriving `id` and `reasoning` flags, preventing `TypeError` during `.includes()` checks. Also exports `discoverOllamaModels` and adds targeted Vitest coverage for invalid names and fetch failures, while keeping implicit provider resolution behavior unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are small and well-covered by tests.
- The runtime fix (filtering invalid `name` values) directly addresses the reported crash and is low risk. Main concerns are test fragility from mutating `process.env` and a type/interface mismatch that could confuse future maintainers, but neither is likely to break production behavior immediately.
- src/agents/models-config.providers.ollama.test.ts; src/agents/models-config.providers.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->