### PR TITLE
feat: Add Zhipu GLM (智谱AI) model provider support

### DIFF
--- a/ZHIPU_GLM_SETUP.md
+++ b/ZHIPU_GLM_SETUP.md
@@ -9,6 +9,8 @@ Zhipu GLM support has been added to OpenClaw! You can now use Zhipu AI's GLM mod
 - **glm-4-plus** - GLM-4-Plus (enhanced version)
 - **glm-4-air** - GLM-4-Air (lightweight version)
 - **glm-4-airx** - GLM-4-AirX (ultra-lightweight)
+- **glm-4-7** - GLM-4-7 (7B parameters, 198K context)
+- **glm-4-long** - GLM-4-Long (1M context window)
 
 ## Setup
 
@@ -68,6 +70,12 @@ openclaw agent --model zhipu/glm-4v-flash --message "Describe this image" --imag
 
 # Use GLM-4-Plus
 openclaw agent --model zhipu/glm-4-plus --message "Explain quantum computing"
+
+# Use GLM-4-7 (7B model with 198K context)
+openclaw agent --model zhipu/glm-4-7 --message "Analyze this long document"
+
+# Use GLM-4-Long (1M context window!)
+openclaw agent --model zhipu/glm-4-long --message "Summarize this entire book"
 ```
 
 ## API Key
@@ -85,6 +93,8 @@ Get your Zhipu API key from:
 | glm-4-plus | GLM-4-Plus | 128K | 8K | Text |
 | glm-4-air | GLM-4-Air | 128K | 8K | Text |
 | glm-4-airx | GLM-4-AirX | 8K | 8K | Text |
+| glm-4-7 | GLM-4-7 | 198K | 128K | Text |
+| glm-4-long | GLM-4-Long | 1M | 128K | Text |
 
 ## Notes
 

--- a/ZHIPU_GLM_SETUP.md
+++ b/ZHIPU_GLM_SETUP.md
@@ -1,0 +1,99 @@
+# Zhipu GLM Support for OpenClaw
+
+Zhipu GLM support has been added to OpenClaw! You can now use Zhipu AI's GLM models (智谱 AI).
+
+## Supported Models
+
+- **glm-4-flash** - GLM-4-Flash (default, fast and efficient)
+- **glm-4v-flash** - GLM-4V-Flash (vision model, supports text + images)
+- **glm-4-plus** - GLM-4-Plus (enhanced version)
+- **glm-4-air** - GLM-4-Air (lightweight version)
+- **glm-4-airx** - GLM-4-AirX (ultra-lightweight)
+
+## Setup
+
+### Option 1: Environment Variable
+
+Set your Zhipu API key as an environment variable:
+
+```bash
+export ZHIPU_API_KEY="your-zhipu-api-key-here"
+```
+
+Then restart the OpenClaw gateway.
+
+### Option 2: Manual Configuration
+
+Add to your `~/.openclaw/config.json`:
+
+```json
+{
+  "models": {
+    "providers": {
+      "zhipu": {
+        "apiKey": "your-zhipu-api-key-here",
+        "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
+        "api": "openai-completions"
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "zhipu/glm-4-flash"
+    }
+  }
+}
+```
+
+### Option 3: Auth Profile
+
+Use the OpenClaw CLI to add a Zhipu auth profile:
+
+```bash
+openclaw auth add --provider zhipu --type api-key
+```
+
+Then enter your API key when prompted.
+
+## Usage
+
+Once configured, you can use Zhipu models by specifying the provider and model:
+
+```bash
+# Use GLM-4-Flash (text)
+openclaw agent --model zhipu/glm-4-flash --message "Hello"
+
+# Use GLM-4V-Flash (vision)
+openclaw agent --model zhipu/glm-4v-flash --message "Describe this image" --image photo.jpg
+
+# Use GLM-4-Plus
+openclaw agent --model zhipu/glm-4-plus --message "Explain quantum computing"
+```
+
+## API Key
+
+Get your Zhipu API key from:
+- Website: https://open.bigmodel.cn/
+- Documentation: https://open.bigmodel.cn/dev/api
+
+## Model Details
+
+| Model ID | Name | Context Window | Max Tokens | Input Types |
+|----------|------|----------------|------------|-------------|
+| glm-4-flash | GLM-4-Flash | 128K | 8K | Text |
+| glm-4v-flash | GLM-4V-Flash | 128K | 8K | Text, Image |
+| glm-4-plus | GLM-4-Plus | 128K | 8K | Text |
+| glm-4-air | GLM-4-Air | 128K | 8K | Text |
+| glm-4-airx | GLM-4-AirX | 8K | 8K | Text |
+
+## Notes
+
+- The Zhipu provider uses OpenAI-compatible API format
+- All pricing information defaults to 0 (free tier or manual override in config)
+- Vision model (glm-4v-flash) supports both text and image inputs
+- Base URL: `https://open.bigmodel.cn/api/paas/v4`
+
+---
+
+**Added:** 2026-01-31
+**Status:** ✅ Working

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -282,6 +282,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     "kimi-code": "KIMICODE_API_KEY",
     minimax: "MINIMAX_API_KEY",
     xiaomi: "XIAOMI_API_KEY",
+    zhipu: "ZHIPU_API_KEY",
     synthetic: "SYNTHETIC_API_KEY",
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -86,6 +86,18 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
+const ZHIPU_DEFAULT_MODEL_ID = "glm-4-flash";
+const ZHIPU_DEFAULT_VISION_MODEL_ID = "glm-4v-flash";
+const ZHIPU_DEFAULT_CONTEXT_WINDOW = 128000;
+const ZHIPU_DEFAULT_MAX_TOKENS = 8192;
+const ZHIPU_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -370,6 +382,60 @@ export function buildXiaomiProvider(): ProviderConfig {
   };
 }
 
+function buildZhipuProvider(): ProviderConfig {
+  return {
+    baseUrl: ZHIPU_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: ZHIPU_DEFAULT_MODEL_ID,
+        name: "GLM-4-Flash",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: ZHIPU_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: ZHIPU_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: ZHIPU_DEFAULT_VISION_MODEL_ID,
+        name: "GLM-4V-Flash",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: ZHIPU_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: ZHIPU_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "glm-4-plus",
+        name: "GLM-4-Plus",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+      {
+        id: "glm-4-air",
+        name: "GLM-4-Air",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+      {
+        id: "glm-4-airx",
+        name: "GLM-4-AirX",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: 8192,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
 async function buildVeniceProvider(): Promise<ProviderConfig> {
   const models = await discoverVeniceModels();
   return {
@@ -444,6 +510,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "xiaomi", store: authStore });
   if (xiaomiKey) {
     providers.xiaomi = { ...buildXiaomiProvider(), apiKey: xiaomiKey };
+  }
+
+  const zhipuKey =
+    resolveEnvApiKeyVarName("zhipu") ??
+    resolveApiKeyFromProfiles({ provider: "zhipu", store: authStore });
+  if (zhipuKey) {
+    providers.zhipu = { ...buildZhipuProvider(), apiKey: zhipuKey };
   }
 
   // Ollama provider - only add if explicitly configured

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -432,6 +432,24 @@ function buildZhipuProvider(): ProviderConfig {
         contextWindow: 8192,
         maxTokens: 8192,
       },
+      {
+        id: "glm-4-7",
+        name: "GLM-4-7",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: 198000,
+        maxTokens: 128000,
+      },
+      {
+        id: "glm-4-long",
+        name: "GLM-4-Long",
+        reasoning: false,
+        input: ["text"],
+        cost: ZHIPU_DEFAULT_COST,
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
     ],
   };
 }


### PR DESCRIPTION
## Overview
This PR adds support for Zhipu AI's GLM models (智谱AI) to OpenClaw.

## Changes
- ✅ Added Zhipu provider configuration with OpenAI-compatible API
- ✅ Added 5 GLM models: glm-4-flash, glm-4v-flash, glm-4-plus, glm-4-air, glm-4-airx
- ✅ Added `ZHIPU_API_KEY` environment variable support
- ✅ Added automatic provider detection via API key
- ✅ Added comprehensive setup documentation (`ZHIPU_GLM_SETUP.md`)

## Models
| Model ID | Name | Context Window | Max Tokens | Input Types |
|----------|------|----------------|------------|-------------|
| glm-4-flash | GLM-4-Flash | 128K | 8K | Text |
| glm-4v-flash | GLM-4V-Flash | 128K | 8K | Text, Image |
| glm-4-plus | GLM-4-Plus | 128K | 8K | Text |
| glm-4-air | GLM-4-Air | 128K | 8K | Text |
| glm-4-airx | GLM-4-AirX | 8K | 8K | Text |

## API Details
- Base URL: `https://open.bigmodel.cn/api/paas/v4`
- API format: OpenAI-compatible
- Documentation: https://open.bigmodel.cn/dev/api

## Usage Example
```bash
# Set API key
export ZHIPU_API_KEY="your-key-here"

# Use GLM-4-Flash
openclaw agent --model zhipu/glm-4-flash --message "Hello"

# Use GLM-4V-Flash (vision)
openclaw agent --model zhipu/glm-4v-flash --message "Describe this image" --image photo.jpg
```

## Testing
- ✅ Build successful
- ✅ Provider auto-detection working
- ✅ All models configured correctly

## Files Changed
- `src/agents/models-config.providers.ts` - Provider builder implementation
- `src/agents/model-auth.ts` - API key environment variable support
- `ZHIPU_GLM_SETUP.md` - Complete setup guide