### PR TITLE
Fix: force UTF-8 for Windows exec

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -363,6 +363,9 @@ async function runExecProcess(opts: {
   let pty: PtyHandle | null = null;
   let stdin: SessionStdin | undefined;
 
+  const command =
+    process.platform === "win32" ? wrapPowerShellUtf8Command(opts.command) : opts.command;
+
   if (opts.sandbox) {
     const { child: spawned } = await spawnWithFallback({
       argv: [
@@ -399,8 +402,6 @@ async function runExecProcess(opts: {
     stdin = child.stdin;
   } else if (opts.usePty) {
     const { shell, args: shellArgs } = getShellConfig();
-    const command =
-      process.platform === "win32" ? wrapPowerShellUtf8Command(opts.command) : opts.command;
     try {
       const ptyModule = (await import("@lydell/node-pty")) as unknown as {
         spawn?: PtySpawn;
@@ -468,8 +469,6 @@ async function runExecProcess(opts: {
     }
   } else {
     const { shell, args: shellArgs } = getShellConfig();
-    const command =
-      process.platform === "win32" ? wrapPowerShellUtf8Command(opts.command) : opts.command;
     const { child: spawned } = await spawnWithFallback({
       argv: [shell, ...shellArgs, command],
       options: {

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -2,20 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-function resolvePowerShellPath(): string {
-  const systemRoot = process.env.SystemRoot || process.env.WINDIR;
-  if (systemRoot) {
-    const candidate = path.join(
-      systemRoot,
-      "System32",
-      "WindowsPowerShell",
-      "v1.0",
-      "powershell.exe",
-    );
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return "powershell.exe";
-}
+import { POWERSHELL_ARGS, resolvePowerShellPath } from "../infra/windows-shell.js";
 
 export function getShellConfig(): { shell: string; args: string[] } {
   if (process.platform === "win32") {
@@ -26,7 +13,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
     // PowerShell properly captures and redirects their output to stdout.
     return {
       shell: resolvePowerShellPath(),
-      args: ["-NoProfile", "-NonInteractive", "-Command"],
+      args: [...POWERSHELL_ARGS],
     };
   }
 

--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -1,40 +1,48 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { buildNodeShellCommand } from "./node-shell.js";
+vi.mock("./windows-shell.js", () => ({
+  POWERSHELL_ARGS: ["-NoProfile", "-NonInteractive", "-Command"],
+  resolvePowerShellPath: () => "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+  wrapPowerShellUtf8Command: (command: string) => `wrapped:${command}`,
+}));
 
 describe("buildNodeShellCommand", () => {
-  it("uses cmd.exe for win32", () => {
+  it("uses PowerShell for win32", async () => {
+    const { buildNodeShellCommand } = await import("./node-shell.js");
     expect(buildNodeShellCommand("echo hi", "win32")).toEqual([
-      "cmd.exe",
-      "/d",
-      "/s",
-      "/c",
-      "echo hi",
+      "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "wrapped:echo hi",
     ]);
   });
 
-  it("uses cmd.exe for windows labels", () => {
+  it("uses PowerShell for windows labels", async () => {
+    const { buildNodeShellCommand } = await import("./node-shell.js");
     expect(buildNodeShellCommand("echo hi", "windows")).toEqual([
-      "cmd.exe",
-      "/d",
-      "/s",
-      "/c",
-      "echo hi",
+      "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "wrapped:echo hi",
     ]);
     expect(buildNodeShellCommand("echo hi", "Windows 11")).toEqual([
-      "cmd.exe",
-      "/d",
-      "/s",
-      "/c",
-      "echo hi",
+      "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "wrapped:echo hi",
     ]);
   });
 
-  it("uses /bin/sh for darwin", () => {
+  it("uses /bin/sh for darwin", async () => {
+    const { buildNodeShellCommand } = await import("./node-shell.js");
     expect(buildNodeShellCommand("echo hi", "darwin")).toEqual(["/bin/sh", "-lc", "echo hi"]);
   });
 
-  it("uses /bin/sh when platform missing", () => {
+  it("uses /bin/sh when platform missing", async () => {
+    const { buildNodeShellCommand } = await import("./node-shell.js");
     expect(buildNodeShellCommand("echo hi")).toEqual(["/bin/sh", "-lc", "echo hi"]);
   });
 });

--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -1,9 +1,15 @@
+import {
+  POWERSHELL_ARGS,
+  resolvePowerShellPath,
+  wrapPowerShellUtf8Command,
+} from "./windows-shell.js";
+
 export function buildNodeShellCommand(command: string, platform?: string | null) {
   const normalized = String(platform ?? "")
     .trim()
     .toLowerCase();
   if (normalized.startsWith("win")) {
-    return ["cmd.exe", "/d", "/s", "/c", command];
+    return [resolvePowerShellPath(), ...POWERSHELL_ARGS, wrapPowerShellUtf8Command(command)];
   }
   return ["/bin/sh", "-lc", command];
 }

--- a/src/infra/windows-shell.test.ts
+++ b/src/infra/windows-shell.test.ts
@@ -11,4 +11,9 @@ describe("wrapPowerShellUtf8Command", () => {
     expect(result).toContain("chcp 65001");
     expect(result).toContain("; echo hi");
   });
+
+  it("preserves non-ASCII command text", () => {
+    const result = wrapPowerShellUtf8Command("dir C:/Users/测试/こんにちは");
+    expect(result).toContain("dir C:/Users/测试/こんにちは");
+  });
 });

--- a/src/infra/windows-shell.test.ts
+++ b/src/infra/windows-shell.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { wrapPowerShellUtf8Command } from "./windows-shell.js";
+
+describe("wrapPowerShellUtf8Command", () => {
+  it("prefixes utf8 console settings", () => {
+    const result = wrapPowerShellUtf8Command("echo hi");
+    expect(result).toContain("[Console]::OutputEncoding");
+    expect(result).toContain("[Console]::InputEncoding");
+    expect(result).toContain("System.Text.Encoding]::UTF8");
+    expect(result).toContain("chcp 65001");
+    expect(result).toContain("; echo hi");
+  });
+});

--- a/src/infra/windows-shell.ts
+++ b/src/infra/windows-shell.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const POWERSHELL_ARGS = ["-NoProfile", "-NonInteractive", "-Command"] as const;
+
+export function resolvePowerShellPath(): string {
+  const systemRoot = process.env.SystemRoot || process.env.WINDIR;
+  if (systemRoot) {
+    const candidate = path.join(
+      systemRoot,
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    );
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return "powershell.exe";
+}
+
+export function wrapPowerShellUtf8Command(command: string): string {
+  const preamble =
+    "$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+    "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; " +
+    "chcp 65001 > $null";
+  return `${preamble}; ${command}`;
+}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -111,6 +111,12 @@
   z-index: 10;
 }
 
+.chat-compose--dragging {
+  outline: 2px dashed var(--accent);
+  outline-offset: 6px;
+  border-radius: 12px;
+}
+
 /* Image attachments preview */
 .chat-attachments {
   display: inline-flex;
@@ -268,6 +274,10 @@
   display: flex;
   align-items: stretch;
   gap: 8px;
+}
+
+.chat-compose__file-input {
+  display: none;
 }
 
 .chat-compose .chat-compose__actions .btn {


### PR DESCRIPTION
## Summary
- wrap Windows exec commands with a UTF-8 PowerShell preamble to preserve non-ASCII paths
- reuse the Windows shell helper for node host execution
- add unit coverage for the PowerShell wrapper and Windows node shell args


Closes #5113

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR centralizes Windows shell handling by introducing `src/infra/windows-shell.ts` (PowerShell path resolution + a UTF‑8/CP65001 preamble wrapper), switches node-host execution to use PowerShell instead of `cmd.exe`, and reuses the shared PowerShell args in `getShellConfig`. It also adds unit coverage for the wrapper and node shell argv building, plus UI work for chat image attachments (paste/drag-drop/file picker) with corresponding CSS.

Main concern: the new UTF‑8 wrapper is applied for direct/PTY runs, but the docker/sandbox exec path still uses the unwrapped command, so Windows sandboxed exec may still fail on non‑ASCII paths.


<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there is one functional gap for Windows sandbox exec.
- The change is mostly additive and covered by unit tests for the new Windows shell helpers, but `runExecProcess` applies the UTF‑8 PowerShell wrapper only to direct/PTY execution while the docker/sandbox branch still uses the unwrapped command, which can leave the original Windows non‑ASCII path issue unresolved in that mode. UI additions are localized and low risk.
- src/agents/bash-tools.exec.ts (Windows sandbox exec path); ui/src/ui/views/chat.ts (drag hover state robustness)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->