### PR TITLE
feat(agents): add sendDirectAgentMessage for busy-agent-safe delivery

### DIFF
--- a/src/agents/direct-agent-message.test.ts
+++ b/src/agents/direct-agent-message.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewayMock(...args),
+}));
+
+const loadConfigMock = vi.fn();
+vi.mock("../config/config.js", () => ({
+  loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+}));
+
+const loadSessionStoreMock = vi.fn();
+const resolveAgentIdFromSessionKeyMock = vi.fn();
+const resolveStorePathMock = vi.fn();
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: (...args: unknown[]) => loadSessionStoreMock(...args),
+  resolveAgentIdFromSessionKey: (...args: unknown[]) => resolveAgentIdFromSessionKeyMock(...args),
+  resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
+}));
+
+const resolveQueueSettingsMock = vi.fn();
+vi.mock("../auto-reply/reply/queue.js", () => ({
+  resolveQueueSettings: (...args: unknown[]) => resolveQueueSettingsMock(...args),
+}));
+
+const isEmbeddedPiRunActiveMock = vi.fn();
+const queueEmbeddedPiMessageMock = vi.fn();
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: (...args: unknown[]) => isEmbeddedPiRunActiveMock(...args),
+  queueEmbeddedPiMessage: (...args: unknown[]) => queueEmbeddedPiMessageMock(...args),
+}));
+
+const enqueueAnnounceMock = vi.fn();
+vi.mock("./subagent-announce-queue.js", () => ({
+  enqueueAnnounce: (...args: unknown[]) => enqueueAnnounceMock(...args),
+}));
+
+import { sendDirectAgentMessage } from "./direct-agent-message.js";
+
+const defaultConfig = { session: { store: undefined } };
+
+function setupDefaults(entry?: Record<string, unknown>) {
+  loadConfigMock.mockReturnValue(defaultConfig);
+  resolveAgentIdFromSessionKeyMock.mockReturnValue("main");
+  resolveStorePathMock.mockReturnValue("/tmp/sessions.json");
+  const store: Record<string, unknown> = {};
+  if (entry) store["agent:main:main"] = entry;
+  loadSessionStoreMock.mockReturnValue(store);
+  resolveQueueSettingsMock.mockReturnValue({ mode: "collect" });
+  isEmbeddedPiRunActiveMock.mockReturnValue(false);
+  queueEmbeddedPiMessageMock.mockReturnValue(false);
+  callGatewayMock.mockResolvedValue({ ok: true });
+}
+
+beforeEach(() => {
+  callGatewayMock.mockReset();
+  loadConfigMock.mockReset();
+  loadSessionStoreMock.mockReset();
+  resolveAgentIdFromSessionKeyMock.mockReset();
+  resolveStorePathMock.mockReset();
+  resolveQueueSettingsMock.mockReset();
+  isEmbeddedPiRunActiveMock.mockReset();
+  queueEmbeddedPiMessageMock.mockReset();
+  enqueueAnnounceMock.mockReset();
+});
+
+describe("sendDirectAgentMessage", () => {
+  it("sends directly when agent is not busy", async () => {
+    setupDefaults({ sessionId: "sess-1", lastChannel: "clawline", lastTo: "flynn" });
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "hello",
+    });
+
+    expect(result).toEqual({ outcome: "sent" });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0][0];
+    expect(call.method).toBe("agent");
+    expect(call.expectFinal).toBe(true);
+    expect(call.timeoutMs).toBe(60_000);
+    expect(call.params.deliver).toBe(true);
+    expect(call.params.sessionKey).toBe("agent:main:main");
+    expect(call.params.channel).toBe("clawline");
+    expect(call.params.to).toBe("flynn");
+  });
+
+  it("steers when active and steer mode", async () => {
+    setupDefaults({ sessionId: "sess-1" });
+    resolveQueueSettingsMock.mockReturnValue({ mode: "steer" });
+    isEmbeddedPiRunActiveMock.mockReturnValue(true);
+    queueEmbeddedPiMessageMock.mockReturnValue(true);
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "steered msg",
+    });
+
+    expect(result).toEqual({ outcome: "steered" });
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("sess-1", "steered msg");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("queues when active and followup mode", async () => {
+    setupDefaults({ sessionId: "sess-1" });
+    resolveQueueSettingsMock.mockReturnValue({ mode: "followup" });
+    isEmbeddedPiRunActiveMock.mockReturnValue(true);
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "queued msg",
+      summaryLine: "Alert",
+    });
+
+    expect(result).toEqual({ outcome: "queued" });
+    expect(enqueueAnnounceMock).toHaveBeenCalledTimes(1);
+    const enqueueCall = enqueueAnnounceMock.mock.calls[0][0];
+    expect(enqueueCall.key).toBe("agent:main:main");
+    expect(enqueueCall.item.prompt).toBe("queued msg");
+    expect(enqueueCall.item.summaryLine).toBe("Alert");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("uses explicit deliveryContext over session store values", async () => {
+    setupDefaults({
+      sessionId: "sess-1",
+      lastChannel: "telegram",
+      lastTo: "+1234",
+    });
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+      deliveryContext: { channel: "clawline", to: "flynn" },
+    });
+
+    expect(result).toEqual({ outcome: "sent" });
+    const call = callGatewayMock.mock.calls[0][0];
+    expect(call.params.channel).toBe("clawline");
+    expect(call.params.to).toBe("flynn");
+  });
+
+  it("falls back to session store delivery context when no explicit context", async () => {
+    setupDefaults({
+      sessionId: "sess-1",
+      lastChannel: "telegram",
+      lastTo: "+1234",
+    });
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+    });
+
+    expect(result).toEqual({ outcome: "sent" });
+    const call = callGatewayMock.mock.calls[0][0];
+    expect(call.params.channel).toBe("telegram");
+    expect(call.params.to).toBe("+1234");
+  });
+
+  it("sends directly when session entry is missing", async () => {
+    setupDefaults(); // no entry
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+    });
+
+    expect(result).toEqual({ outcome: "sent" });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(isEmbeddedPiRunActiveMock).not.toHaveBeenCalled();
+  });
+
+  it("passes custom timeout to callGateway", async () => {
+    setupDefaults({ sessionId: "sess-1" });
+
+    await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+      timeoutMs: 30_000,
+    });
+
+    const call = callGatewayMock.mock.calls[0][0];
+    expect(call.timeoutMs).toBe(30_000);
+  });
+
+  it("returns error outcome when callGateway rejects", async () => {
+    setupDefaults({ sessionId: "sess-1" });
+    callGatewayMock.mockRejectedValue(new Error("connection refused"));
+
+    const result = await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+    });
+
+    expect(result).toEqual({
+      outcome: "error",
+      error: "Error: connection refused",
+    });
+  });
+
+  it("calls log callback at each stage", async () => {
+    setupDefaults({ sessionId: "sess-1" });
+    const logFn = vi.fn();
+
+    await sendDirectAgentMessage({
+      sessionKey: "agent:main:main",
+      message: "test",
+      log: logFn,
+    });
+
+    const events = logFn.mock.calls.map((c) => c[0]);
+    expect(events).toContain("direct_agent_resolve");
+    expect(events).toContain("direct_agent_sent");
+  });
+});

--- a/src/agents/direct-agent-message.ts
+++ b/src/agents/direct-agent-message.ts
@@ -1,0 +1,199 @@
+/**
+ * Busy-agent-safe message delivery for any provider or internal caller.
+ *
+ * The gateway's agent method is two-phase: it acks immediately ("accepted")
+ * then runs the agent turn asynchronously. A bare `callGateway` without
+ * `expectFinal` resolves on the ack and closes the socket — silently losing
+ * any error from the actual turn. Worse, if the agent is already mid-turn,
+ * a second call spawns a concurrent run on the same session (no gateway-side
+ * locking), causing interleaved output and last-write-wins session corruption.
+ *
+ * This module provides `sendDirectAgentMessage`, which checks the session's
+ * embedded-run state and queue mode before deciding how to deliver, reusing
+ * the steer/queue infrastructure from `subagent-announce`.
+ */
+import crypto from "node:crypto";
+
+import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+} from "../config/sessions.js";
+import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { callGateway } from "../gateway/call.js";
+import {
+  type DeliveryContext,
+  deliveryContextFromSession,
+  mergeDeliveryContext,
+  normalizeDeliveryContext,
+} from "../utils/delivery-context.js";
+import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./pi-embedded.js";
+import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-queue.js";
+
+export type DirectAgentMessageResult = {
+  outcome: "steered" | "queued" | "sent" | "error";
+  error?: string;
+};
+
+/**
+ * Send a message to an agent session with busy-agent safety.
+ *
+ * Unlike a bare `callGateway({ method: "agent" })`, this utility checks
+ * whether the target session is already mid-turn and picks the safest
+ * delivery strategy:
+ *
+ *  1. **Steer** — if the agent is active and the session's queue mode
+ *     supports steering, injects the message into the running turn's
+ *     input stream (no new agent turn spawned).
+ *  2. **Queue** — if the agent is active but steering isn't available,
+ *     enqueues the message for delivery after the current turn drains.
+ *  3. **Send** — if the agent is idle, dispatches a direct gateway call
+ *     with `expectFinal: true` so the caller observes success/failure
+ *     (not just the "accepted" ack).
+ *
+ * The `log` callback receives structured events at every decision point
+ * for traceability (resolve → steer/queue/send → result).
+ */
+export async function sendDirectAgentMessage(params: {
+  sessionKey: string;
+  message: string;
+  deliveryContext?: DeliveryContext;
+  summaryLine?: string;
+  timeoutMs?: number;
+  log?: (event: string, detail?: Record<string, unknown>) => void;
+}): Promise<DirectAgentMessageResult> {
+  const log = params.log ?? (() => {});
+  try {
+    const cfg = loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const store = loadSessionStore(storePath);
+    const entry = store[params.sessionKey];
+    const hasEntry = Boolean(entry);
+    const sessionId = entry?.sessionId;
+
+    log("direct_agent_resolve", { sessionKey: params.sessionKey, hasEntry, sessionId });
+
+    // Merge explicit deliveryContext (primary) with session store context (fallback).
+    // Callers that know the target channel/to (e.g., alerts routed to a specific
+    // provider session) pass an explicit context; otherwise the session's last-known
+    // delivery fields are used.
+    const explicitContext = normalizeDeliveryContext(params.deliveryContext);
+    const sessionContext = deliveryContextFromSession(entry);
+    const merged = mergeDeliveryContext(explicitContext, sessionContext);
+
+    const channel = merged?.channel;
+    const to = merged?.to;
+    const accountId = merged?.accountId;
+    const threadId =
+      merged?.threadId != null && merged.threadId !== "" ? String(merged.threadId) : undefined;
+
+    // No active session → nothing to collide with; send directly.
+    if (!sessionId) {
+      await callGateway({
+        method: "agent",
+        params: {
+          sessionKey: params.sessionKey,
+          message: params.message,
+          deliver: true,
+          channel,
+          accountId,
+          to,
+          threadId,
+          idempotencyKey: crypto.randomUUID(),
+        },
+        expectFinal: true,
+        timeoutMs: params.timeoutMs ?? 60_000,
+      });
+      log("direct_agent_sent", { sessionKey: params.sessionKey, channel, to });
+      return { outcome: "sent" };
+    }
+
+    // Check whether the agent is busy and decide: steer, queue, or send.
+    const queueSettings = resolveQueueSettings({
+      cfg,
+      channel: entry?.channel ?? entry?.lastChannel,
+      sessionEntry: entry,
+    });
+    const isActive = isEmbeddedPiRunActive(sessionId);
+
+    // Steer: inject the message into the active run's input stream.
+    const shouldSteer = queueSettings.mode === "steer" || queueSettings.mode === "steer-backlog";
+    if (shouldSteer) {
+      const steered = queueEmbeddedPiMessage(sessionId, params.message);
+      if (steered) {
+        log("direct_agent_steered", { sessionKey: params.sessionKey, sessionId });
+        return { outcome: "steered" };
+      }
+    }
+
+    // Queue: agent is busy; park the message for delivery after the current turn.
+    const shouldQueue =
+      queueSettings.mode === "followup" ||
+      queueSettings.mode === "collect" ||
+      queueSettings.mode === "steer-backlog" ||
+      queueSettings.mode === "interrupt" ||
+      queueSettings.mode === "steer";
+    if (isActive && shouldQueue) {
+      enqueueAnnounce({
+        key: params.sessionKey,
+        item: {
+          prompt: params.message,
+          summaryLine: params.summaryLine,
+          enqueuedAt: Date.now(),
+          sessionKey: params.sessionKey,
+          origin: merged,
+        },
+        settings: queueSettings,
+        send: sendQueued,
+      });
+      log("direct_agent_queued", { sessionKey: params.sessionKey, sessionId });
+      return { outcome: "queued" };
+    }
+
+    // Agent idle: send directly; expectFinal waits for completion, not just the ack.
+    await callGateway({
+      method: "agent",
+      params: {
+        sessionKey: params.sessionKey,
+        message: params.message,
+        deliver: true,
+        channel,
+        accountId,
+        to,
+        threadId,
+        idempotencyKey: crypto.randomUUID(),
+      },
+      expectFinal: true,
+      timeoutMs: params.timeoutMs ?? 60_000,
+    });
+    log("direct_agent_sent", { sessionKey: params.sessionKey, channel, to });
+    return { outcome: "sent" };
+  } catch (err) {
+    log("direct_agent_error", { error: String(err) });
+    return { outcome: "error", error: String(err) };
+  }
+}
+
+/** Drain callback for enqueueAnnounce — sends with expectFinal for reliable delivery. */
+async function sendQueued(item: AnnounceQueueItem) {
+  const origin = item.origin;
+  const threadId =
+    origin?.threadId != null && origin.threadId !== "" ? String(origin.threadId) : undefined;
+  await callGateway({
+    method: "agent",
+    params: {
+      sessionKey: item.sessionKey,
+      message: item.prompt,
+      channel: origin?.channel,
+      accountId: origin?.accountId,
+      to: origin?.to,
+      threadId,
+      deliver: true,
+      idempotencyKey: crypto.randomUUID(),
+    },
+    expectFinal: true,
+    timeoutMs: 60_000,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `sendDirectAgentMessage` utility in `src/agents/direct-agent-message.ts` — a busy-agent-safe alternative to bare `callGateway({ method: "agent" })` calls
- Checks session embedded-run state and queue mode before delivering: **steer** (inject into active turn), **queue** (park for post-turn drain), or **send** (direct with `expectFinal: true`)
- Returns structured `{ outcome, error? }` instead of throwing; accepts a `log` callback for end-to-end traceability
- Reuses existing steer/queue infrastructure from `subagent-announce`; no new dependencies
- Includes 9 unit tests covering all paths: direct send, steer, queue, delivery context merging, custom timeout, error handling, and log callbacks

## Motivation

Bare `callGateway({ method: "agent" })` without `expectFinal` resolves on the gateway's "accepted" ack and closes the WebSocket before the agent turn completes — silently losing any errors. If the agent is already mid-turn, a second call spawns a concurrent run on the same session (no gateway-side locking), causing interleaved output and last-write-wins session store corruption.

Any provider or internal caller (alerts, webhooks, scheduled tasks) that needs to inject a message into an agent session can use this utility instead of rolling its own busy-agent handling.

## Test plan

- [x] All 9 unit tests pass (`src/agents/direct-agent-message.test.ts`)
- [x] All imports verified to exist in upstream/main
- [x] No provider-specific references in the utility — fully general-purpose