### PR TITLE
fix(cron): recover stale running markers

### DIFF
--- a/src/cron/service.clears-stale-running-marker.test.ts
+++ b/src/cron/service.clears-stale-running-marker.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService stale running marker recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T02:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears stale runningAtMs and records an error status", async () => {
+    const store = await makeStorePath();
+
+    const nowMs = Date.parse("2025-12-13T02:00:00.000Z");
+    // jobs.ts uses a 2-hour stale threshold; set runningAt older than that.
+    const runningAtMs = nowMs - 2 * 60 * 60 * 1000 - 1;
+
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "job-stale",
+              name: "stale run",
+              enabled: true,
+              createdAtMs: nowMs,
+              updatedAtMs: nowMs,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "next-heartbeat",
+              payload: { kind: "systemEvent", text: "hello" },
+              state: {
+                runningAtMs,
+                nextRunAtMs: nowMs - 10_000,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === "job-stale");
+
+    expect(job?.state.runningAtMs).toBeUndefined();
+    expect(job?.state.lastStatus).toBe("error");
+    expect(job?.state.lastRunAtMs).toBe(runningAtMs);
+    expect(job?.state.lastDurationMs).toBeGreaterThanOrEqual(2 * 60 * 60 * 1000);
+    expect(job?.state.lastError).toMatch(/Recovered from stale running state/i);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -55,11 +55,21 @@ export function recomputeNextRuns(state: CronServiceState) {
     }
     const runningAt = job.state.runningAtMs;
     if (typeof runningAt === "number" && now - runningAt > STUCK_RUN_MS) {
+      const durationMs = Math.max(0, now - runningAt);
       state.deps.log.warn(
-        { jobId: job.id, runningAtMs: runningAt },
-        "cron: clearing stuck running marker",
+        { jobId: job.id, runningAtMs: runningAt, durationMs },
+        "cron: clearing stale running marker (previous run likely interrupted)",
       );
       job.state.runningAtMs = undefined;
+      // Record the interrupted run so operators can see what happened.
+      // NOTE: lastRunAtMs is treated as the *start time* of the last run (see timer.ts).
+      job.state.lastRunAtMs = runningAt;
+      job.state.lastDurationMs = durationMs;
+      job.state.lastStatus = "error";
+      if (!job.state.lastError?.trim()) {
+        job.state.lastError =
+          "Recovered from stale running state (previous cron run likely interrupted by restart/crash)";
+      }
     }
     job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
   }


### PR DESCRIPTION
## What
Cron jobs can be left stuck with `state.runningAtMs` (e.g. process restart/crash mid-run). When that happens, the scheduler permanently treats the job as "already running" and will never run it again.

This PR recovers from that stale marker by clearing `runningAtMs` after the existing stuck-run threshold and recording an error status so operators can see what happened.

## Changes
- When a job's `runningAtMs` is older than the stuck-run threshold, clear the marker and set:
  - `lastStatus="error"`
  - `lastError="Recovered from stale running state…"` (if not already set)
  - `lastRunAtMs` + `lastDurationMs`
- Add unit test covering recovery on `cron.start()`.

## Why
Prevents a single interrupted run from wedging a cron job forever.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds recovery for cron jobs that were left in a stuck/running state (e.g. crash mid-run). During `recomputeNextRuns`, if `state.runningAtMs` is older than the stuck-run threshold, the code now clears the running marker and records the interrupted run (`lastRunAtMs`, `lastDurationMs`, `lastStatus="error"`, and a default `lastError` message if one isn’t already set), so the job can be scheduled again and operators can see what happened.

A new unit test writes a persisted job with an old `runningAtMs`, starts the cron service, and asserts the stale marker is cleared and the error metadata is recorded.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and a real wedged-job scenario; remaining concerns are mainly test brittleness and small naming clarity issues.
- The recovery logic is localized to `recomputeNextRuns` and matches the rest of the cron state model (timer code treats `lastRunAtMs` as start time and sets duration similarly). The added test covers the intended behavior at startup. I didn’t find a functional regression in the changed logic, but the test’s hard-coded threshold could become flaky on future refactors, and some naming/wording is slightly inconsistent.
- src/cron/service.clears-stale-running-marker.test.ts (threshold coupling); src/cron/service/jobs.ts (naming/terminology consistency).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->