### PR TITLE
fix(config): expand audio transcription CLI allowlist to support whisperx

### DIFF
--- a/src/config/legacy.shared.test.ts
+++ b/src/config/legacy.shared.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { mapLegacyAudioTranscription } from "./legacy.shared.js";
+
+describe("mapLegacyAudioTranscription", () => {
+  it("should migrate whisper config", () => {
+    const result = mapLegacyAudioTranscription({
+      command: ["whisper", "--model", "base"],
+      timeoutSeconds: 120,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("should migrate whisperx config", () => {
+    const result = mapLegacyAudioTranscription({
+      command: ["whisperx", "--model", "base"],
+      timeoutSeconds: 120,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("should migrate whisperx-transcribe.sh config", () => {
+    const result = mapLegacyAudioTranscription({
+      command: ["/home/user/whisperx-transcribe.sh"],
+      timeoutSeconds: 120,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("should migrate WhisperX (case insensitive)", () => {
+    const result = mapLegacyAudioTranscription({
+      command: ["WhisperX"],
+      timeoutSeconds: 60,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("should reject ffmpeg (not whisper-based)", () => {
+    const result = mapLegacyAudioTranscription({
+      command: ["ffmpeg", "-i", "input.ogg"],
+      timeoutSeconds: 60,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("should reject empty command", () => {
+    const result = mapLegacyAudioTranscription({
+      command: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("should reject null input", () => {
+    const result = mapLegacyAudioTranscription(null);
+    expect(result).toBeNull();
+  });
+});

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -41,7 +41,10 @@ export const mergeMissing = (target: Record<string, unknown>, source: Record<str
   }
 };
 
-const AUDIO_TRANSCRIPTION_CLI_ALLOWLIST = new Set(["whisper"]);
+const AUDIO_TRANSCRIPTION_CLI_PATTERNS = [/^whisper/i];
+
+const isAllowedTranscriptionCli = (name: string): boolean =>
+  AUDIO_TRANSCRIPTION_CLI_PATTERNS.some((p) => p.test(name));
 
 export const mapLegacyAudioTranscription = (value: unknown): Record<string, unknown> | null => {
   const transcriber = getRecord(value);
@@ -50,7 +53,7 @@ export const mapLegacyAudioTranscription = (value: unknown): Record<string, unkn
   const rawExecutable = String(command[0] ?? "").trim();
   if (!rawExecutable) return null;
   const executableName = rawExecutable.split(/[\\/]/).pop() ?? rawExecutable;
-  if (!AUDIO_TRANSCRIPTION_CLI_ALLOWLIST.has(executableName)) return null;
+  if (!isAllowedTranscriptionCli(executableName)) return null;
 
   const args = command.slice(1).map((part) => String(part));
   const timeoutSeconds =


### PR DESCRIPTION
## Summary

Fixes #5017

The legacy audio transcription config migration has a restrictive allowlist that only allows `whisper`. Users with `whisperx` or custom scripts like `whisperx-transcribe.sh` have their configs silently deleted during migration.

## Root Cause

```typescript
const AUDIO_TRANSCRIPTION_CLI_ALLOWLIST = new Set(["whisper"]);
```

When `mapLegacyAudioTranscription()` encounters a CLI not in this set, it returns `null`, causing the migration to delete the config.

## Changes

- Replace exact-match `Set` with regex pattern matching (`/^whisper/i`)
- Add `isAllowedTranscriptionCli()` helper function
- Add unit tests for `mapLegacyAudioTranscription()`

## Test plan

- [x] Unit tests for whisper/whisperx/whisperx-transcribe.sh variants
- [x] Unit tests for rejection cases (ffmpeg, empty, null)
- [x] `pnpm format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes legacy audio transcription config migration by broadening the CLI allowlist from an exact `"whisper"` match to a regex-based check (`/^whisper/i`), allowing `whisperx` and `whisperx-*` wrappers to migrate instead of being dropped. It also adds a Vitest unit test suite for `mapLegacyAudioTranscription()` to cover common accepted and rejected command variants.

In the config migration pipeline (see `src/config/legacy.migrations.part-2.ts`), `mapLegacyAudioTranscription()` returning `null` causes legacy values like `routing.transcribeAudio` / `audio.transcription` to be removed as unsupported, so widening the acceptance criteria directly prevents unintended config deletion for whisperx users.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should fix the reported migration issue.
- Change is localized to legacy config migration logic and adds targeted unit tests. Main remaining concern is input normalization: basename extraction can leave trailing whitespace/newlines, which can still cause valid whisper-based CLIs to be rejected and configs to be dropped during migration. I couldn’t run the test suite in this environment because `pnpm` isn’t available, so confidence is slightly reduced.
- src/config/legacy.shared.ts (normalization around executableName)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->