### PR TITLE
[feat]: add LiteLLM as a provider

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -37,6 +37,7 @@ See [Venice AI](/providers/venice).
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [Qwen (OAuth)](/providers/qwen)
 - [OpenRouter](/providers/openrouter)
+- [LiteLLM (unified gateway)](/providers/litellm)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -1,0 +1,156 @@
+---
+summary: "Run OpenClaw through LiteLLM Proxy for unified model access and cost tracking"
+read_when:
+  - You want to route OpenClaw through a LiteLLM proxy
+  - You need cost tracking, logging, or model routing through LiteLLM
+---
+# LiteLLM
+
+[LiteLLM](https://litellm.ai) is an open-source LLM gateway that provides a unified API to 100+ model providers. Route OpenClaw through LiteLLM to get centralized cost tracking, logging, and the flexibility to switch backends without changing your OpenClaw config.
+
+## Why use LiteLLM with OpenClaw?
+
+- **Cost tracking** — See exactly what OpenClaw spends across all models
+- **Model routing** — Switch between Claude, GPT-4, Gemini, Bedrock without config changes
+- **Virtual keys** — Create keys with spend limits for OpenClaw
+- **Logging** — Full request/response logs for debugging
+- **Fallbacks** — Automatic failover if your primary provider is down
+
+## Quick start
+
+LiteLLM's `/v1/messages` endpoint speaks Anthropic's protocol natively — perfect for OpenClaw.
+
+### Via onboarding
+
+```bash
+openclaw onboard --auth-choice litellm-api-key
+```
+
+### Manual setup
+
+1) Start LiteLLM Proxy:
+
+```bash
+pip install 'litellm[proxy]'
+litellm --model anthropic/claude-sonnet-4-20250514
+```
+
+2) Point OpenClaw to LiteLLM:
+
+```bash
+export LITELLM_API_KEY="your-litellm-key"  # or any string if no auth
+export ANTHROPIC_API_BASE="http://localhost:4000"
+
+openclaw
+```
+
+That's it. OpenClaw now routes through LiteLLM.
+
+## Configuration
+
+### Environment variables
+
+```bash
+export LITELLM_API_KEY="sk-litellm-key"
+export ANTHROPIC_API_BASE="http://localhost:4000"
+```
+
+### Config file
+
+```json5
+{
+  env: {
+    ANTHROPIC_API_BASE: "http://localhost:4000",
+    LITELLM_API_KEY: "sk-litellm-key"
+  },
+  agents: {
+    defaults: {
+      model: { primary: "litellm/claude-sonnet-4-20250514" }
+    }
+  }
+}
+```
+
+### With custom provider entry
+
+For more control, define LiteLLM as an explicit provider:
+
+```json5
+{
+  models: {
+    providers: {
+      litellm: {
+        baseUrl: "http://localhost:4000/v1",
+        apiKey: "sk-litellm-key",
+        api: "anthropic-messages",
+        models: [
+          { id: "claude-sonnet-4-20250514", name: "Claude Sonnet" },
+          { id: "gpt-4o", name: "GPT-4o" }
+        ]
+      }
+    }
+  },
+  agents: {
+    defaults: {
+      model: { primary: "litellm/claude-sonnet-4-20250514" }
+    }
+  }
+}
+```
+
+## Virtual keys
+
+Create a dedicated key for OpenClaw with spend limits:
+
+```bash
+curl -X POST "http://localhost:4000/key/generate" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_alias": "openclaw",
+    "max_budget": 50.00,
+    "budget_duration": "monthly"
+  }'
+```
+
+Use the generated key as `LITELLM_API_KEY`.
+
+## Model routing
+
+LiteLLM can route model requests to different backends. Configure in your LiteLLM `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: claude-sonnet-4-20250514
+    litellm_params:
+      model: azure/gpt-4o
+      api_key: os.environ/AZURE_API_KEY
+```
+
+OpenClaw keeps requesting `claude-sonnet-4-20250514` — LiteLLM handles the routing.
+
+## Viewing usage
+
+Check LiteLLM's dashboard or API:
+
+```bash
+# Key info
+curl "http://localhost:4000/key/info" \
+  -H "Authorization: Bearer sk-litellm-key"
+
+# Spend logs
+curl "http://localhost:4000/spend/logs" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY"
+```
+
+## Notes
+
+- LiteLLM runs on `http://localhost:4000` by default
+- The `/v1/messages` endpoint supports streaming, tools, prompt caching, and extended thinking
+- All OpenClaw features work through LiteLLM — no limitations
+
+## See also
+
+- [LiteLLM Docs](https://docs.litellm.ai)
+- [LiteLLM /v1/messages](https://docs.litellm.ai/docs/anthropic_unified/)
+- [Model Providers](/concepts/model-providers)

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -277,6 +277,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     cerebras: "CEREBRAS_API_KEY",
     xai: "XAI_API_KEY",
     openrouter: "OPENROUTER_API_KEY",
+    litellm: "LITELLM_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
     "kimi-code": "KIMICODE_API_KEY",

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -13,6 +13,7 @@ export type AuthChoiceGroupId =
   | "google"
   | "copilot"
   | "openrouter"
+  | "litellm"
   | "ai-gateway"
   | "moonshot"
   | "zai"
@@ -91,6 +92,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["openrouter-api-key"],
   },
   {
+    value: "litellm",
+    label: "LiteLLM",
+    hint: "Unified LLM gateway (100+ providers)",
+    choices: ["litellm-api-key"],
+  },
+  {
     value: "ai-gateway",
     label: "Vercel AI Gateway",
     hint: "API key",
@@ -142,6 +149,11 @@ export function buildAuthChoiceOptions(params: {
   options.push({ value: "chutes", label: "Chutes (OAuth)" });
   options.push({ value: "openai-api-key", label: "OpenAI API key" });
   options.push({ value: "openrouter-api-key", label: "OpenRouter API key" });
+  options.push({
+    value: "litellm-api-key",
+    label: "LiteLLM API key",
+    hint: "Unified gateway for 100+ LLM providers",
+  });
   options.push({
     value: "ai-gateway-api-key",
     label: "Vercel AI Gateway API key",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -13,6 +13,7 @@ import {
 } from "../agents/venice-models.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  LITELLM_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
@@ -133,6 +134,47 @@ export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
               }
             : undefined),
           primary: OPENROUTER_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+}
+
+export function applyLitellmProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[LITELLM_DEFAULT_MODEL_REF] = {
+    ...models[LITELLM_DEFAULT_MODEL_REF],
+    alias: models[LITELLM_DEFAULT_MODEL_REF]?.alias ?? "LiteLLM",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyLitellmConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyLitellmProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: LITELLM_DEFAULT_MODEL_REF,
         },
       },
     },

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -116,6 +116,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-sonnet-4-20250514";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {
@@ -149,6 +150,18 @@ export async function setOpenrouterApiKey(key: string, agentDir?: string) {
     credential: {
       type: "api_key",
       provider: "openrouter",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setLitellmApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "litellm:default",
+    credential: {
+      type: "api_key",
+      provider: "litellm",
       key,
     },
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -7,6 +7,8 @@ export {
   applyAuthProfileConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
+  applyLitellmConfig,
+  applyLitellmProviderConfig,
   applyMoonshotConfig,
   applyMoonshotProviderConfig,
   applyOpenrouterConfig,
@@ -35,10 +37,12 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  LITELLM_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setGeminiApiKey,
   setKimiCodeApiKey,
+  setLitellmApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
   setOpencodeZenApiKey,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,7 @@ export type AuthChoice =
   | "openai-codex"
   | "openai-api-key"
   | "openrouter-api-key"
+  | "litellm-api-key"
   | "ai-gateway-api-key"
   | "moonshot-api-key"
   | "kimi-code-api-key"
@@ -63,6 +64,7 @@ export type OnboardOptions = {
   anthropicApiKey?: string;
   openaiApiKey?: string;
   openrouterApiKey?: string;
+  litellmApiKey?: string;
   aiGatewayApiKey?: string;
   moonshotApiKey?: string;
   kimiCodeApiKey?: string;


### PR DESCRIPTION
## Summary

This PR adds LiteLLM as a unified LLM gateway provider to OpenClaw. LiteLLM provides a single API to access 100+ LLM providers (Claude, GPT-4, Gemini, Bedrock, etc.) with built-in cost tracking, logging, virtual keys, and model routing.

## Usage Examples

### Via Onboarding

```bash
openclaw onboard --auth-choice litellm-api-key
```

### Environment Variables

```bash
export LITELLM_API_KEY="sk-litellm-key"
export ANTHROPIC_API_BASE="http://localhost:4000"

openclaw
```

### Configuration File

```json5
{
  env: {
    ANTHROPIC_API_BASE: "http://localhost:4000",
    LITELLM_API_KEY: "sk-litellm-key"
  },
  agents: {
    defaults: {
      model: { primary: "litellm/claude-sonnet-4-20250514" }
    }
  }
}
```

## Benefits

- Unified API access to 100+ LLM providers
- Centralized cost tracking across all models
- Virtual keys with spend limits
- Full request/response logging for debugging
- Automatic failover support
- Model routing without config changes
- Native support for Anthropic `/v1/messages` protocol
