### PR TITLE
fix: add provider-level enforceFinalTag config to prevent text loss

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -250,7 +250,11 @@ export async function runAgentTurnWithFallback(params: {
             prompt: params.commandBody,
             extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
             ownerNumbers: params.followupRun.run.ownerNumbers,
-            enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
+            enforceFinalTag: resolveEnforceFinalTag(
+              params.followupRun.run,
+              provider,
+              params.followupRun.run.config?.models?.providers?.[provider.split("/")[0]],
+            ),
             provider,
             model,
             authProfileId,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -127,7 +127,11 @@ export async function runMemoryFlushIfNeeded(params: {
           prompt: memoryFlushSettings.prompt,
           extraSystemPrompt: flushSystemPrompt,
           ownerNumbers: params.followupRun.run.ownerNumbers,
-          enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
+          enforceFinalTag: resolveEnforceFinalTag(
+            params.followupRun.run,
+            provider,
+            params.followupRun.run.config?.models?.providers?.[provider.split("/")[0]],
+          ),
           provider,
           model,
           authProfileId,

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -3,6 +3,7 @@ import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ModelProviderConfig } from "../../config/types.models.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import type { TemplateContext } from "../templating.js";
@@ -122,5 +123,19 @@ export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPa
   return updated;
 };
 
-export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string) =>
-  Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
+export const resolveEnforceFinalTag = (
+  run: FollowupRun["run"],
+  provider: string,
+  providerConfig?: ModelProviderConfig,
+) => {
+  // Provider config takes precedence
+  if (providerConfig?.enforceFinalTag !== undefined) {
+    return providerConfig.enforceFinalTag;
+  }
+  // Then check run-level config
+  if (run.enforceFinalTag !== undefined) {
+    return run.enforceFinalTag;
+  }
+  // Finally, check provider defaults
+  return isReasoningTagProvider(provider);
+};

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -41,6 +41,7 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  enforceFinalTag?: boolean;
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -57,6 +57,7 @@ export const ModelProviderSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
+    enforceFinalTag: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Fixes text loss issue with MiniMax (and potentially other providers) when tool calls occur mid-turn in Telegram and other messaging channels.

## Problem

When using the MiniMax provider via Telegram, only the **final** text block of an assistant's response was delivered when tool calls occurred mid-turn. For example:

1. User asks agent to write to a file
2. Agent responds: "I'm going to write to a file"
3. Agent makes tool call (e.g., `write` tool)
4. Agent responds: "Done! Check Telegram."
5. **Only "Done! Check Telegram." was delivered to Telegram** — the first message was lost

The first message was present in the session transcript/TUI but never delivered to the messaging channel.

## Root Cause

MiniMax was included in `isReasoningTagProvider()` in `src/utils/provider-utils.ts`, which caused `enforceFinalTag=true` to be set. When `enforceFinalTag=true`, the `stripBlockTags()` function strips all text that is not within `<final>` tags.

However, **MiniMax does not emit `<final>` tags**, so all text from earlier assistant messages (before tool calls) was being stripped during the streaming/accumulation phase, leaving `assistantTexts` empty.

The final message still appeared via a fallback path in `buildEmbeddedRunPayloads()` that extracts text directly from the last `AssistantMessage` object, but earlier messages were permanently lost.

## Solution

Instead of removing MiniMax from the reasoning provider list globally (which might break other use cases), this PR adds a **configurable `enforceFinalTag` option** at the provider level.

### Changes

1. **Added `enforceFinalTag?: boolean` to `ModelProviderConfig`** type and schema
2. **Updated `resolveEnforceFinalTag()` logic** with precedence order:
   - Provider config (if explicitly set)
   - Run-level config (if explicitly set)
   - Provider defaults (via `isReasoningTagProvider()`)
3. **Updated call sites** to pass provider config when resolving `enforceFinalTag`

This allows users to override the default behavior per provider without code changes:

```json
{
  "models": {
    "providers": {
      "minimax": {
        "baseUrl": "https://api.minimax.io/anthropic",
        "api": "anthropic-messages",
        "enforceFinalTag": false,
        "models": [...]
      }
    }
  }
}
```

## Testing

- ✅ Tested before/after on a fresh Ubuntu 24.04 VPS with MiniMax provider via Telegram
- ✅ Verified both pre-tool and post-tool messages are now delivered correctly
- ✅ Confirmed `<think>` tag stripping still works (independent of this flag)
- ✅ Build passes without TypeScript errors

## Files Changed

- `src/config/types.models.ts` - Added `enforceFinalTag` to type
- `src/config/zod-schema.core.ts` - Added validation schema
- `src/auto-reply/reply/agent-runner-utils.ts` - Updated resolution logic
- `src/auto-reply/reply/agent-runner-execution.ts` - Pass provider config
- `src/auto-reply/reply/agent-runner-memory.ts` - Pass provider config

## Backwards Compatibility

✅ **Fully backwards compatible** - the new field is optional and defaults to existing behavior when not set.

## Related Issues

This resolves text loss issues reported with MiniMax when using messaging channels with tool calls. (example: https://discord.com/channels/1456350064065904867/1466569217141903461 )

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a provider-level `enforceFinalTag?: boolean` config knob (type + Zod schema), and updates the agent runner paths (normal turn + memory flush) to resolve `enforceFinalTag` with precedence: provider config → run-level config → provider defaults (`isReasoningTagProvider`). The intent is to prevent message text loss for providers that don’t emit `<final>` tags when tool calls occur mid-turn (e.g., MiniMax via Telegram).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the provider-level override may not work as intended for runs created via getReplyRun.
- Core changes are small and localized (type/schema + a helper + call sites), but `getReplyRun` still sets `run.enforceFinalTag` for reasoning-tag providers, which likely prevents provider-level `enforceFinalTag=false` from taking effect in the common path.
- src/auto-reply/reply/get-reply-run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->