### PR TITLE
fix: DEFAULT_GIT_DIR in update-cli.ts to match docs

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -115,7 +115,7 @@ const DEFAULT_PACKAGE_NAME = "openclaw";
 const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
 const CLI_NAME = resolveCliName();
 const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
-const DEFAULT_GIT_DIR = path.join(os.homedir(), ".openclaw");
+const DEFAULT_GIT_DIR = path.join(os.homedir(), "openclaw");
 
 function normalizeTag(value?: string | null): string | null {
   if (!value) return null;


### PR DESCRIPTION
Update `DEFAULT_GIT_DIR` to match the docs => https://github.com/openclaw/openclaw/blob/main/docs/cli/update.md?plain=1#L63

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the default git checkout directory used by the update CLI from `~/.openclaw` to `~/openclaw`, aligning the runtime default with the documented `OPENCLAW_GIT_DIR` behavior in the update docs. The change affects only the “switch to dev” path where the CLI may create/clone a git checkout automatically when none exists and no env override is provided.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge.
- The change is a one-line constant update that aligns implementation with existing documentation; the main risk is user-facing behavior change if someone relied on the previous default directory.
- src/cli/update-cli.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->