### PR TITLE
feat(plugins): add tool_result_transform hook

### DIFF
--- a/src/agents/pi-tools.transform.ts
+++ b/src/agents/pi-tools.transform.ts
@@ -1,0 +1,205 @@
+/**
+ * Tool Result Transform Wrapper
+ *
+ * Wraps agent tools to call the tool_result_transform hook after execution,
+ * allowing plugins to PREPEND content (like warnings) to tool results before
+ * they are sent to the model.
+ *
+ * Security properties:
+ * - Append-only: hooks can only ADD content, never remove original content
+ * - Timeout: hung hooks are killed after a deadline
+ * - Validation: malformed results are rejected
+ * - Isolation: hook failures don't break tool execution
+ */
+
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+/** Default timeout for transform hooks (ms) */
+const TRANSFORM_HOOK_TIMEOUT_MS = 5000;
+
+export type ToolTransformContext = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+type ContentBlock = { type: string; [key: string]: unknown };
+
+/**
+ * Validate that content is a valid array of content blocks.
+ */
+function isValidContentArray(content: unknown): content is ContentBlock[] {
+  if (!Array.isArray(content)) return false;
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) return false;
+    if (typeof (block as Record<string, unknown>).type !== "string") return false;
+  }
+  return true;
+}
+
+/**
+ * Extract text from content blocks for size estimation.
+ */
+function estimateContentSize(content: ContentBlock[]): number {
+  let size = 0;
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      size += block.text.length;
+    }
+  }
+  return size;
+}
+
+/** Maximum size (chars) that a hook can prepend */
+const MAX_PREPEND_SIZE = 10000;
+
+/**
+ * Wrap a promise with a timeout.
+ */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutError: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(timeoutError));
+    }, timeoutMs);
+
+    promise
+      .then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      })
+      .catch((err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}
+
+/**
+ * Wrap a tool to apply the tool_result_transform hook after execution.
+ *
+ * Security model:
+ * - Hooks return content to PREPEND (not replace)
+ * - Original content is always preserved
+ * - Hooks cannot see or modify each other's prepended content
+ * - Timeout prevents hung hooks from blocking execution
+ */
+export function wrapToolWithResultTransform(
+  tool: AnyAgentTool,
+  ctx?: ToolTransformContext,
+): AnyAgentTool {
+  const execute = tool.execute;
+  if (!execute) return tool;
+
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      // Execute the original tool
+      const result = await execute(toolCallId, params, signal, onUpdate);
+
+      // Check if we have transform hooks registered
+      const hookRunner = getGlobalHookRunner();
+      if (!hookRunner?.hasHooks("tool_result_transform")) {
+        return result;
+      }
+
+      // Determine if the result is an error
+      const isError = isToolResultError(result);
+
+      try {
+        // Run the transform hook with timeout
+        const hookResult = await withTimeout(
+          hookRunner.runToolResultTransform(
+            {
+              toolName: tool.name,
+              toolCallId,
+              params: params as Record<string, unknown>,
+              // Pass a COPY of content so hooks can't mutate original
+              result: JSON.parse(JSON.stringify(result.content)),
+              isError,
+            },
+            {
+              agentId: ctx?.agentId,
+              sessionKey: ctx?.sessionKey,
+              toolName: tool.name,
+              toolCallId,
+            },
+          ),
+          TRANSFORM_HOOK_TIMEOUT_MS,
+          `tool_result_transform hook timed out after ${TRANSFORM_HOOK_TIMEOUT_MS}ms`,
+        );
+
+        // If hook returned content to prepend, validate and apply it
+        if (hookResult?.prependContent !== undefined) {
+          const prepend = hookResult.prependContent;
+
+          // Validate: must be array of content blocks
+          if (!isValidContentArray(prepend)) {
+            console.warn(`[tool_result_transform] Invalid prependContent structure, ignoring`);
+            return result;
+          }
+
+          // Validate: size limit to prevent DoS
+          const prependSize = estimateContentSize(prepend);
+          if (prependSize > MAX_PREPEND_SIZE) {
+            console.warn(
+              `[tool_result_transform] prependContent too large (${prependSize} > ${MAX_PREPEND_SIZE}), ignoring`,
+            );
+            return result;
+          }
+
+          // PREPEND hook content to original (original always preserved)
+          const originalContent = Array.isArray(result.content) ? result.content : [result.content];
+
+          return {
+            ...result,
+            content: [...prepend, ...originalContent] as AgentToolResult<unknown>["content"],
+          };
+        }
+      } catch (err) {
+        // Hook failure should not break tool execution
+        console.error(
+          `[tool_result_transform] Hook failed for ${tool.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      return result;
+    },
+  };
+}
+
+/**
+ * Check if a tool result indicates an error.
+ * Heuristic: look for error-like patterns in text content.
+ */
+function isToolResultError(result: AgentToolResult<unknown>): boolean {
+  const content = result.content;
+  if (!Array.isArray(content)) return false;
+
+  for (const block of content) {
+    if (block.type === "text" && "text" in block) {
+      const text = (block as { type: "text"; text: string }).text;
+      if (
+        text.startsWith("Error:") ||
+        text.startsWith("error:") ||
+        text.includes('"error"') ||
+        text.includes('"status": "error"')
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Wrap multiple tools with result transform.
+ */
+export function wrapToolsWithResultTransform(
+  tools: AnyAgentTool[],
+  ctx?: ToolTransformContext,
+): AnyAgentTool[] {
+  return tools.map((tool) => wrapToolWithResultTransform(tool, ctx));
+}

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -19,6 +19,7 @@ import { listChannelAgentTools } from "./channel-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
+import { wrapToolsWithResultTransform } from "./pi-tools.transform.js";
 import {
   filterToolsByPolicy,
   isToolAllowedByPolicies,
@@ -413,8 +414,16 @@ export function createOpenClawCodingTools(options?: {
     ? normalized.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))
     : normalized;
 
+  // Apply tool_result_transform hook wrapper to all tools.
+  // This allows plugins like prompt injection defenders to modify tool results
+  // before they are sent back to the model.
+  const withTransform = wrapToolsWithResultTransform(withAbort, {
+    agentId: options?.sessionKey?.split(":")?.[1],
+    sessionKey: options?.sessionKey,
+  });
+
   // NOTE: Keep canonical (lowercase) tool names here.
   // pi-ai's Anthropic OAuth transport remaps tool names to Claude Code-style names
   // on the wire and maps them back for tool dispatch.
-  return withAbort;
+  return withTransform;
 }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -30,6 +30,9 @@ import type {
   PluginHookSessionEndEvent,
   PluginHookSessionStartEvent,
   PluginHookToolContext,
+  PluginHookToolResultTransformContext,
+  PluginHookToolResultTransformEvent,
+  PluginHookToolResultTransformResult,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -52,6 +55,9 @@ export type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookAfterToolCallEvent,
+  PluginHookToolResultTransformContext,
+  PluginHookToolResultTransformEvent,
+  PluginHookToolResultTransformResult,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -309,6 +315,36 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   /**
+   * Run tool_result_transform hook.
+   *
+   * This hook runs AFTER tool execution but BEFORE the result is sent to the model.
+   * Unlike tool_result_persist (which only affects storage), this hook can modify
+   * what the model actually sees in the current turn.
+   *
+   * SECURITY MODEL:
+   * - Hooks can only PREPEND content (append-only, original always preserved)
+   * - Multiple hooks' prependContent are concatenated (not replaced)
+   * - Hooks run in priority order (higher first)
+   *
+   * Use this for security plugins like prompt injection defenders that need to
+   * add warnings the model sees immediately.
+   */
+  async function runToolResultTransform(
+    event: PluginHookToolResultTransformEvent,
+    ctx: PluginHookToolResultTransformContext,
+  ): Promise<PluginHookToolResultTransformResult | undefined> {
+    return runModifyingHook<"tool_result_transform", PluginHookToolResultTransformResult>(
+      "tool_result_transform",
+      event,
+      ctx,
+      // Concatenate prependContent from all hooks (append-only semantics)
+      (acc, next) => ({
+        prependContent: [...(acc?.prependContent ?? []), ...(next.prependContent ?? [])],
+      }),
+    );
+  }
+
+  /**
    * Run tool_result_persist hook.
    *
    * This hook is intentionally synchronous: it runs in hot paths where session
@@ -444,6 +480,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
+    runToolResultTransform,
     runToolResultPersist,
     // Session hooks
     runSessionStart,


### PR DESCRIPTION
## Summary

Adds a new plugin hook `tool_result_transform` that allows plugins to intercept and modify tool results **before** they are sent back to the model.

## Motivation

Currently, plugins can react to tool calls via `after_tool_call`, but they cannot modify what the model sees. This is problematic for security plugins that need to warn the model about potentially malicious content in tool results (e.g., prompt injection attempts in fetched web pages, emails, or file contents).

## Design

The hook follows an **append-only security model**:
- Plugins can only PREPEND content via `prependContent`
- Original tool output is always preserved
- Multiple plugins' prepended content is concatenated (not replaced)
- Plugins receive a copy of the result (cannot mutate original)

**Safety measures:**
- 5-second timeout prevents hung hooks from blocking execution
- 10KB size limit on prepended content prevents DoS
- Malformed return values are rejected with warnings
- Hook failures do not break tool execution

## API

```typescript
api.on('tool_result_transform', (event, ctx) => {
  // event: { toolName, toolCallId, params, result, isError }
  // ctx: { agentId, sessionKey, toolName, toolCallId }
  
  return {
    prependContent: [
      { type: 'text', text: '⚠️ Warning: ...' }
    ]
  };
});
```

## Use Cases

- **Prompt injection defense**: scan tool output for injection patterns and prepend warnings the model sees before the malicious content
- **Content moderation**: flag potentially harmful content in results
- **Audit logging**: annotate results with metadata
- **Rate limiting notices**: inform model of throttled responses

Similar to Claude Code's PostToolUse hook but designed for the OpenClaw plugin architecture.

## Files Changed

- `src/plugins/types.ts` — Hook type definitions
- `src/plugins/hooks.ts` — Hook runner function  
- `src/agents/pi-tools.transform.ts` — Tool wrapper (new)
- `src/agents/pi-tools.ts` — Applies wrapper to all tools