### PR TITLE
fix(tts): add speed parameter to OpenAI TTS configuration

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -58,6 +58,7 @@ export type TtsConfig = {
     apiKey?: string;
     model?: string;
     voice?: string;
+    speed?: number;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -206,6 +206,7 @@ export const TtsConfigSchema = z
         apiKey: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
+        speed: z.number().min(0.25).max(4).optional(),
       })
       .strict()
       .optional(),

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -110,6 +110,7 @@ export type ResolvedTtsConfig = {
     apiKey?: string;
     model: string;
     voice: string;
+    speed?: number;
   };
   edge: {
     enabled: boolean;
@@ -282,6 +283,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       apiKey: raw.openai?.apiKey,
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
+      speed: raw.openai?.speed,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -1005,8 +1007,9 @@ async function openaiTTS(params: {
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
+  speed?: number;
 }): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, model, voice, responseFormat, timeoutMs, speed } = params;
 
   if (!isValidOpenAIModel(model)) {
     throw new Error(`Invalid model: ${model}`);
@@ -1030,6 +1033,7 @@ async function openaiTTS(params: {
         input: text,
         voice,
         response_format: responseFormat,
+        ...(speed !== undefined && { speed }),
       }),
       signal: controller.signal,
     });
@@ -1213,6 +1217,7 @@ export async function textToSpeech(params: {
           voice: openaiVoiceOverride ?? config.openai.voice,
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
+          speed: config.openai.speed,
         });
       }
 
@@ -1315,6 +1320,7 @@ export async function textToSpeechTelephony(params: {
         voice: config.openai.voice,
         responseFormat: output.format,
         timeoutMs: config.timeoutMs,
+        speed: config.openai.speed,
       });
 
       return {


### PR DESCRIPTION
## Summary
- Add configurable `speed` parameter (0.25-4.0) for OpenAI TTS API
- Parameter flows through: Zod schema → types → ResolvedTtsConfig → API call
- Uses conditional spread to preserve falsy-but-valid values (e.g., 0.25)

Fixes #4131

## Test plan
- [ ] Type check passes
- [ ] Format check passes
- [ ] Codex code review: OK
- [ ] Manual test: configure `tts.openai.speed` and verify API receives value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added configurable `speed` parameter (0.25-4.0) for OpenAI TTS API. The parameter flows correctly through the configuration stack:

- Zod schema validates the range (0.25-4.0) matching OpenAI API specs
- Type definitions updated in `TtsConfig` and `ResolvedTtsConfig`
- Configuration resolution passes through the value without applying defaults
- API call uses conditional spread `...(speed !== undefined && { speed })` to properly handle falsy-but-valid values like 0.25
- Parameter correctly passed to both standard and telephony TTS functions

The implementation follows existing patterns for optional TTS parameters and correctly preserves all valid speed values including edge cases.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The implementation is straightforward, follows established patterns, uses correct validation ranges, and properly handles edge cases with the conditional spread operator
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->