### PR TITLE
fix(discord): detect binary content in voice message text

### DIFF
--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -151,12 +151,52 @@ function buildDiscordAttachmentPlaceholder(attachments?: APIAttachment[]): strin
   return `${tag} (${count} ${suffix})`;
 }
 
+/**
+ * Check if string contains binary/non-printable characters
+ * indicating it's likely misidentified binary data.
+ *
+ * Detection strategy:
+ * 1. Null bytes (\x00) - instant binary indicator (valid text never has these)
+ * 2. Control chars (code < 32) except tab/newline/CR - suspicious if >10%
+ *
+ * Note: OGG binary decoded as UTF-8 produces lots of null bytes and control chars
+ * (see issue #4580: "杏卧Ȁ    阭" contains embedded nulls shown as spaces)
+ */
+function looksLikeBinaryData(text: string): boolean {
+  if (!text) return false;
+  // Check first 100 chars for binary indicators
+  const sample = text.slice(0, 100);
+
+  let nullCount = 0;
+  let controlCount = 0;
+
+  for (const char of sample) {
+    const code = char.charCodeAt(0);
+    if (code === 0) {
+      nullCount++;
+    } else if (code < 32 && code !== 9 && code !== 10 && code !== 13) {
+      controlCount++;
+    }
+  }
+
+  // Any null byte = definitely binary
+  if (nullCount > 0) return true;
+
+  // >10% control chars = likely binary
+  return controlCount > sample.length * 0.1;
+}
+
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
 ): string {
+  const rawContent = message.content?.trim();
+  // Skip content if it looks like binary data (misidentified MIME)
+  const hasAttachments = message.attachments && message.attachments.length > 0;
+  const contentIsBinary = hasAttachments && rawContent && looksLikeBinaryData(rawContent);
+
   const baseText =
-    message.content?.trim() ||
+    (!contentIsBinary && rawContent) ||
     buildDiscordAttachmentPlaceholder(message.attachments) ||
     message.embeds?.[0]?.description ||
     options?.fallbackText?.trim() ||
@@ -202,10 +242,14 @@ function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapsho
 
 function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): string {
   const content = snapshot.content?.trim() ?? "";
+  const hasAttachments = snapshot.attachments && snapshot.attachments.length > 0;
+  const contentIsBinary = hasAttachments && content && looksLikeBinaryData(content);
+
   const attachmentText = buildDiscordAttachmentPlaceholder(snapshot.attachments ?? undefined);
   const embed = snapshot.embeds?.[0];
   const embedText = embed?.description?.trim() || embed?.title?.trim() || "";
-  return content || attachmentText || embedText || "";
+
+  return (!contentIsBinary && content) || attachmentText || embedText || "";
 }
 
 function formatDiscordSnapshotAuthor(


### PR DESCRIPTION
## Summary
- Add `looksLikeBinaryData()` helper to detect null bytes and control characters
- Skip `message.content` if it contains binary data (misidentified MIME)
- Fall through to attachment placeholder for proper display
- Applied to both `resolveDiscordMessageText()` and `resolveDiscordSnapshotMessageText()`

Fixes #4580

## Test plan
- [ ] Type check passes
- [ ] Format check passes
- [ ] Codex code review: OK
- [ ] Manual test: send Discord voice message → should show `<media:audio>` not garbled text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an issue where Discord voice messages (OGG audio files) were incorrectly displayed as garbled text instead of the proper `<media:audio>` placeholder. The fix adds a `looksLikeBinaryData()` helper that detects null bytes and control characters in message content, allowing the code to skip misidentified binary data and fall through to the attachment placeholder logic.

The implementation samples the first 100 characters and uses two detection strategies: any null byte triggers immediate binary detection, and >10% control characters (excluding tab/newline/CR) also indicates binary content. The check is applied to both `resolveDiscordMessageText()` and `resolveDiscordSnapshotMessageText()` for consistency.

- Added binary content detection helper with clear documentation
- Applied detection to both message text resolution functions
- Properly scoped to only check when attachments are present

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-documented. Binary detection logic is sound (null bytes + control character threshold). Only checks when attachments are present, which is the correct scope. No breaking changes to existing behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->