### PR TITLE
fix(tui): truncate long media paths to prevent render crash

### DIFF
--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -21,7 +21,8 @@ function truncatePath(path: string, maxLen: number): string {
 
     // Only use this strategy if we can show meaningful dir prefix
     if (available >= 10 && filename.length < maxLen - 10) {
-      return dirPart.slice(0, available) + ".../" + filename;
+      const sep = path[lastSlash] === "\\" ? "\\" : "/";
+      return dirPart.slice(0, available) + "..." + sep + filename;
     }
   }
 

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -1,5 +1,35 @@
 import type { MsgContext } from "./templating.js";
 
+const MAX_LINE_WIDTH = 80; // Most conservative value, covers all standard terminals
+const MAX_TYPE_LEN = 20; // Defensive limit for typePart
+
+/**
+ * Truncate path while preserving filename.
+ * Handles both Unix (/) and Windows (\) separators.
+ */
+function truncatePath(path: string, maxLen: number): string {
+  // Edge case: very small maxLen
+  if (maxLen <= 10) return "...";
+  if (path.length <= maxLen) return path;
+
+  // Find last separator (/ or \)
+  const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (lastSlash > 0) {
+    const filename = path.slice(lastSlash + 1);
+    const dirPart = path.slice(0, lastSlash);
+    const available = maxLen - filename.length - 4; // ".../" = 4 chars
+
+    // Only use this strategy if we can show meaningful dir prefix
+    if (available >= 10 && filename.length < maxLen - 10) {
+      return dirPart.slice(0, available) + ".../" + filename;
+    }
+  }
+
+  // Fallback: simple truncation (ensure positive slice)
+  const sliceLen = Math.max(1, maxLen - 3);
+  return path.slice(0, sliceLen) + "...";
+}
+
 function formatMediaAttachedLine(params: {
   path: string;
   url?: string;
@@ -11,10 +41,40 @@ function formatMediaAttachedLine(params: {
     typeof params.index === "number" && typeof params.total === "number"
       ? `[media attached ${params.index}/${params.total}: `
       : "[media attached: ";
-  const typePart = params.type?.trim() ? ` (${params.type.trim()})` : "";
+
+  // Truncate type if abnormally long (defensive)
+  let typeStr = params.type?.trim() ?? "";
+  if (typeStr.length > MAX_TYPE_LEN) {
+    typeStr = typeStr.slice(0, MAX_TYPE_LEN - 3) + "...";
+  }
+  const typePart = typeStr ? ` (${typeStr})` : "";
   const urlRaw = params.url?.trim();
-  const urlPart = urlRaw ? ` | ${urlRaw}` : "";
-  return `${prefix}${params.path}${typePart}${urlPart}]`;
+
+  // Fixed parts: prefix + typePart + "]"
+  const fixedLen = prefix.length + typePart.length + 1;
+  const available = MAX_LINE_WIDTH - fixedLen;
+
+  // Guard: if no space at all, return minimal output
+  if (available <= 10) {
+    return `${prefix}...${typePart}]`;
+  }
+
+  // Strategy 1: Try to keep full path, truncate/omit URL
+  if (params.path.length <= available) {
+    // Path fits! Now check if we can include URL
+    const urlSpace = available - params.path.length - 3; // " | " = 3 chars
+    if (urlRaw && urlSpace >= 20) {
+      const truncatedUrl =
+        urlRaw.length <= urlSpace ? urlRaw : urlRaw.slice(0, urlSpace - 3) + "...";
+      return `${prefix}${params.path}${typePart} | ${truncatedUrl}]`;
+    }
+    // Path fits, no room for URL
+    return `${prefix}${params.path}${typePart}]`;
+  }
+
+  // Strategy 2: Path too long, must truncate. No URL.
+  const truncatedPath = truncatePath(params.path, available);
+  return `${prefix}${truncatedPath}${typePart}]`;
 }
 
 export function buildInboundMediaNote(ctx: MsgContext): string | undefined {


### PR DESCRIPTION
## Summary
- Add `truncatePath()` helper that preserves filename (supports both `/` and `\`)
- Limit media note lines to 80 characters (safe for all standard terminals)
- Truncation priority: keep full path → truncate/omit URL → truncate path
- Handle edge cases: very small available space, Windows paths, abnormally long type

Fixes #4818

## Test plan
- [ ] Type check passes
- [ ] Format check passes
- [ ] Codex code review: OK
- [ ] Manual test: TUI renders long audio paths without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added path truncation to prevent TUI render crashes from long media file paths. The implementation preserves filenames when truncating and handles edge cases for small terminal widths.

**Key changes:**
- Added `MAX_LINE_WIDTH = 80` constant for terminal compatibility
- Implemented `truncatePath()` helper that preserves filenames during truncation
- Added multi-strategy truncation: full path → truncate URL → truncate path
- Handles edge cases like very small available space and abnormally long type strings

**Issues found:**
- Path separator mixing: `truncatePath()` always uses `/` in truncated output, even for Windows paths with `\`
- No test coverage for the new truncation logic (long paths, Windows paths, edge cases)

<h3>Confidence Score: 4/5</h3>

- safe to merge after fixing Windows path separator issue
- the truncation logic correctly prevents TUI crashes and handles edge cases well, but the hardcoded forward slash in line 24 will produce malformed paths on Windows (mixing `\` and `/` separators)
- src/auto-reply/media-note.ts line 24 needs separator fix

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->