### PR TITLE
[Slack] fix: preserve thread context for string threadId in queue drain

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -40,13 +40,14 @@ export function scheduleFollowupDrain(
             const to = item.originatingTo;
             const accountId = item.originatingAccountId;
             const threadId = item.originatingThreadId;
-            if (!channel && !to && !accountId && typeof threadId !== "number") {
+            if (!channel && !to && !accountId && threadId == null) {
               return {};
             }
             if (!isRoutableChannel(channel) || !to) {
               return { cross: true };
             }
-            const threadKey = typeof threadId === "number" ? String(threadId) : "";
+            // Support both number (Telegram topic) and string (Slack thread_ts) types
+            const threadKey = threadId != null ? String(threadId) : "";
             return {
               key: [channel, to, accountId || "", threadKey].join("|"),
             };
@@ -71,8 +72,9 @@ export function scheduleFollowupDrain(
           const originatingAccountId = items.find(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
+          // Support both number (Telegram topic) and string (Slack thread_ts) types
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null,
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({


### PR DESCRIPTION
## Summary

Fixes:
- #5233

Queued messages in Slack threads were losing their thread context and being posted to the main channel instead of the thread.

## Root Cause

In `src/auto-reply/reply/queue/drain.ts`, the `originatingThreadId` was only being handled when it was a `number` type (for Telegram topic IDs), but Slack uses **string** type thread IDs (e.g., `"1769840211.421709"`).

Three locations were checking `typeof threadId === "number"`, which caused Slack's string-based `threadId` to be ignored:

1. Line 34: Early return condition
2. Line 40: `threadKey` generation for cross-channel detection  
3. Line 74-76: `originatingThreadId` extraction from queued items

## Changes

Changed all three checks to use `!= null` instead of `typeof === "number"` to support both:
- **Number** type: Telegram topic IDs
- **String** type: Slack thread timestamps

```diff
- if (!channel && !to && !accountId && typeof threadId !== "number") {
+ if (!channel && !to && !accountId && threadId == null) {

- const threadKey = typeof threadId === "number" ? String(threadId) : "";
+ const threadKey = threadId != null ? String(threadId) : "";

- const originatingThreadId = items.find((i) => typeof i.originatingThreadId === "number")?.originatingThreadId;
+ const originatingThreadId = items.find((i) => i.originatingThreadId != null)?.originatingThreadId;
Testing
Manually tested by:

Sending multiple rapid messages in a Slack thread
Confirming all responses are now correctly posted to the thread
Verified both buggy behavior (before fix) and correct behavior (after fix)
```

## Testing
Manually tested by:

1. Sending multiple rapid messages in a Slack thread
2. Confirming all responses are now correctly posted to the thread
3. Verified both buggy behavior (before fix) and correct behavior (after fix)

<img width="1299" height="1015" alt="image" src="https://github.com/user-attachments/assets/8baad81f-9348-4561-9b03-440907a2f32a" />


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR attempts to fix Slack thread context preservation by supporting both number (Telegram) and string (Slack) thread IDs in the queue drain logic. However, **the fix is incomplete**.

## What was changed
- Line 50: `threadKey` generation now uses `threadId != null` instead of `typeof threadId === "number"`
- Lines 76-77: `originatingThreadId` extraction now uses `i.originatingThreadId != null` instead of `typeof i.originatingThreadId === "number"`

## Critical issue found
The PR description claims three locations were updated, but **line 43 was not changed**. It still checks `typeof threadId !== "number"`, which means:
- When a Slack message with a string thread ID is queued, it would still hit the early return condition
- The message would be marked as having no routing context (`return {}`)
- Cross-channel detection logic would not work correctly for Slack threads

## Impact
The bug would likely still occur because the early return check on line 43 happens before the other two fixed checks, preventing Slack threads from being processed correctly.

## Recommendation
Update line 43 to use `threadId == null` for consistency with the other two fixes.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge due to an incomplete fix that would leave the original bug partially unresolved
- The fix only addresses 2 of the 3 locations that need updating. The missed location (line 43) is an early return check that executes before the other two fixes, meaning Slack threads would still not be handled correctly. This is a critical logical error that prevents the PR from achieving its stated goal.
- src/auto-reply/reply/queue/drain.ts needs the additional fix on line 43

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->