### PR TITLE
fix: skill frontmatter fixes + description improvements (35 skills)

### DIFF
--- a/skills/bear-notes/SKILL.md
+++ b/skills/bear-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bear-notes
-description: Create, search, and manage Bear notes via grizzly CLI.
+description: Create, search, append text to, and manage Bear notes from the command line via grizzly. Use when you want to quickly save ideas, organize notes by tags, or retrieve notes without opening the Bear app.
 homepage: https://bear.app
 metadata:
   {

--- a/skills/bird/SKILL.md
+++ b/skills/bird/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bird
-description: X/Twitter CLI for reading, searching, posting, and engagement via cookies.
+description: Read, search, and post on X/Twitter via cookie-based CLI with support for bookmarks, likes, threads, and engagement. Use when you want to check tweets, trends, or your timeline from the command line without a web browser.
 homepage: https://bird.fast
 metadata:
   {

--- a/skills/blogwatcher/SKILL.md
+++ b/skills/blogwatcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blogwatcher
-description: Monitor blogs and RSS/Atom feeds for updates using the blogwatcher CLI.
+description: Monitor multiple blogs and RSS/Atom feeds for new articles, mark them as read, and track updates from the command line. Use when you want to stay notified about new blog posts from your favorite sites without visiting each one manually.
 homepage: https://github.com/Hyaxia/blogwatcher
 metadata:
   {

--- a/skills/blucli/SKILL.md
+++ b/skills/blucli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blucli
-description: BluOS CLI (blu) for discovery, playback, grouping, and volume.
+description: Discover, control, and group Bluesound and NAD speakers for playback, volume, and TuneIn radio from the command line. Use when you want to play music on your Sonos-like network speakers without touching physical controls.
 homepage: https://blucli.sh
 metadata:
   {

--- a/skills/camsnap/SKILL.md
+++ b/skills/camsnap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: camsnap
-description: Capture frames or clips from RTSP/ONVIF cameras.
+description: Capture snapshots, video clips, and motion events from configured RTSP/ONVIF security cameras via the command line. Use when you want to grab a quick screenshot from a camera, record a clip, or automate camera monitoring.
 homepage: https://camsnap.ai
 metadata:
   {

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: canvas
+description: Display HTML content on connected OpenClaw nodes (Mac, iOS, Android) via the canvas tool. Use when asked to show games, dashboards, visualizations, interactive demos, or any web content on a node's canvas view. Supports present, hide, navigate, eval, and snapshot actions.
+---
+
 # Canvas Skill
 
 Display HTML content on connected OpenClaw nodes (Mac app, iOS, Android).

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
+description: "Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels."
 metadata: {"openclaw":{"emoji":"🎮","requires":{"config":["channels.discord"]}}}
 ---
 

--- a/skills/eightctl/SKILL.md
+++ b/skills/eightctl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eightctl
-description: Control Eight Sleep pods (status, temperature, alarms, schedules).
+description: Control Eight Sleep smart bed pods to adjust temperature, manage alarms and schedules, and check pod status from the command line. Use when you want to set your bed temperature, dismiss alarms, or automate sleep routines without using the app.
 homepage: https://eightctl.sh
 metadata:
   {

--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: food-order
-description: Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA.
+description: "Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA."
 homepage: https://ordercli.sh
 metadata: {"openclaw":{"emoji":"🥡","requires":{"bins":["ordercli"]},"install":[{"id":"go","kind":"go","module":"github.com/steipete/ordercli/cmd/ordercli@latest","bins":["ordercli"],"label":"Install ordercli (go)"}]}}
 ---

--- a/skills/gemini/SKILL.md
+++ b/skills/gemini/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini
-description: Gemini CLI for one-shot Q&A, summaries, and generation.
+description: Ask Google Gemini questions, generate text, summarize content, and get answers from the command line without opening a browser. Use when you need quick AI assistance, want to process text, or prefer CLI interactions over web UIs.
 homepage: https://ai.google.dev/
 metadata:
   {

--- a/skills/gifgrep/SKILL.md
+++ b/skills/gifgrep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gifgrep
-description: Search GIF providers with CLI/TUI, download results, and extract stills/sheets.
+description: Search Giphy and Tenor for GIFs with a TUI, download results, and extract individual frames or sprite sheets for quick sharing. Use when you want to find and grab GIFs for chat, documents, or presentations from the command line.
 homepage: https://gifgrep.com
 metadata:
   {

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: "Access Gmail, Google Calendar, Drive, Contacts, Sheets, and Docs from the command line. Send emails, create events, search files, and manage spreadsheets without opening a browser. Use when you need to send emails, check calendar events, or update documents from scripts or CLI."
 homepage: https://gogcli.sh
 metadata:
   {

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imsg
-description: iMessage/SMS CLI for listing chats, history, watch, and sending.
+description: Read iMessage and SMS chat history, watch for new messages, and send messages from the command line on macOS. Use when you want to check Messages app conversations, send quick texts, or monitor chats without opening the Messages app.
 homepage: https://imsg.to
 metadata:
   {

--- a/skills/local-places/SKILL.md
+++ b/skills/local-places/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-places
-description: Search for places (restaurants, cafes, etc.) via Google Places API proxy on localhost.
+description: Search for nearby restaurants, cafes, gyms, and other places using a local Google Places API proxy with filtering by rating, price, and open status. Use when you want to find specific types of places near a location without hitting rate limits or exposing the API key.
 homepage: https://github.com/Hyaxia/local_places
 metadata:
   {

--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana-pro
-description: Generate or edit images via Gemini 3 Pro Image (Nano Banana Pro).
+description: Generate new images from text descriptions or edit existing images using Gemini 3 Pro Image with support for composition of multiple images. Use when you want to create or modify images with AI without visiting web interfaces.
 homepage: https://ai.google.dev/
 metadata:
   {

--- a/skills/nano-pdf/SKILL.md
+++ b/skills/nano-pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-pdf
-description: Edit PDFs with natural-language instructions using the nano-pdf CLI.
+description: Modify PDF pages with natural-language instructions, such as changing titles, fixing text, or adjusting layout without manually editing PDFs. Use when you want to quickly edit specific pages of a PDF document from the command line.
 homepage: https://pypi.org/project/nano-pdf/
 metadata:
   {

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion
-description: Notion API for creating and managing pages, databases, and blocks.
+description: Create, read, update, and query Notion pages, databases (data sources), and content blocks via REST API with support for custom properties. Use when you want to automate Notion workflows, sync data, or manage content programmatically from scripts.
 homepage: https://developers.notion.com
 metadata:
   {

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian
-description: Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli.
+description: Create, search, move, delete, and refactor Obsidian vault notes with wikilink updates and content management from the command line. Use when you want to automate note management, batch rename files, or integrate Obsidian with other tools.
 homepage: https://help.obsidian.md
 metadata:
   {

--- a/skills/openai-image-gen/SKILL.md
+++ b/skills/openai-image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-image-gen
-description: Batch-generate images via OpenAI Images API. Random prompt sampler + `index.html` gallery.
+description: Batch-generate images using OpenAI's DALL-E or GPT image models with random or custom prompts, producing PNG/JPEG/WebP images and an HTML gallery. Use when you want to create multiple images at once for design exploration, prototypes, or content generation.
 homepage: https://platform.openai.com/docs/api-reference/images
 metadata:
   {

--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-whisper-api
-description: Transcribe audio via OpenAI Audio Transcriptions API (Whisper).
+description: Transcribe audio files to text using OpenAI's cloud-based Whisper API with language detection, prompts, and multiple output formats. Use when you want accurate transcriptions from various audio formats with API precision.
 homepage: https://platform.openai.com/docs/guides/speech-to-text
 metadata:
   {

--- a/skills/openai-whisper/SKILL.md
+++ b/skills/openai-whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-whisper
-description: Local speech-to-text with the Whisper CLI (no API key).
+description: Transcribe audio files to text locally using OpenAI's Whisper model without needing an API key or cloud service. Use when you want to convert audio to text, translate speech, or generate subtitles offline.
 homepage: https://openai.com/research/whisper
 metadata:
   {

--- a/skills/openhue/SKILL.md
+++ b/skills/openhue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhue
-description: Control Philips Hue lights/scenes via the OpenHue CLI.
+description: "Control Philips Hue lights and scenes from the command line. Turn lights on/off, adjust brightness and color, and activate preset scenes. Use when you want to automate home lighting without touching physical switches or apps."
 homepage: https://www.openhue.io/cli
 metadata:
   {

--- a/skills/ordercli/SKILL.md
+++ b/skills/ordercli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ordercli
-description: Foodora-only CLI for checking past orders and active order status (Deliveroo WIP).
+description: Check past food delivery orders, track active order status, reorder from history, and manage Foodora deliveries via the command line. Use when you want to review order history, reorder favorite meals, or check delivery status without opening the app.
 homepage: https://ordercli.sh
 metadata:
   {

--- a/skills/peekaboo/SKILL.md
+++ b/skills/peekaboo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: peekaboo
-description: Capture and automate macOS UI with the Peekaboo CLI.
+description: Capture macOS screenshots, inspect UI elements, automate interactions (clicking, typing, dragging), and manage windows and applications from the command line. Use when you need to script UI automation, test interfaces, or perform complex desktop tasks programmatically.
 homepage: https://peekaboo.boo
 metadata:
   {

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sag
-description: ElevenLabs text-to-speech with mac-style say UX.
+description: Convert text to realistic speech using ElevenLabs with voice selection, speaking styles, and audio tags (whispers, shouts, laughs) for natural-sounding narration. Use when you want to generate spoken audio for storytelling, announcements, or adding voice to content.
 homepage: https://sag.sh
 metadata:
   {

--- a/skills/session-logs/SKILL.md
+++ b/skills/session-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-logs
-description: Search and analyze your own session logs (older/parent conversations) using jq.
+description: Search through conversation history, analyze session transcripts, extract messages by role, and calculate costs using jq from stored JSONL session logs. Use when you need to recall older conversations, find context from previous chats, or analyze past interactions.
 metadata: { "openclaw": { "emoji": "📜", "requires": { "bins": ["jq", "rg"] } } }
 ---
 

--- a/skills/sherpa-onnx-tts/SKILL.md
+++ b/skills/sherpa-onnx-tts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sherpa-onnx-tts
-description: Local text-to-speech via sherpa-onnx (offline, no cloud)
+description: Convert text to speech completely offline using sherpa-onnx without any internet connection or API keys, supporting multiple voices and languages. Use when you need private, fast text-to-speech that doesn't require cloud services or external dependencies.
 metadata:
   {
     "openclaw":

--- a/skills/songsee/SKILL.md
+++ b/skills/songsee/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: songsee
-description: Generate spectrograms and feature-panel visualizations from audio with the songsee CLI.
+description: Generate spectrograms and feature visualizations (mel, chroma, HPSS, loudness, tempogram, MFCC) from audio files for analysis and sharing. Use when you want to visualize audio characteristics, create technical documentation, or analyze music structure.
 homepage: https://github.com/steipete/songsee
 metadata:
   {

--- a/skills/sonoscli/SKILL.md
+++ b/skills/sonoscli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sonoscli
-description: Control Sonos speakers (discover/status/play/volume/group).
+description: Discover, control, and group Sonos speakers for playback, volume adjustment, queue management, and Spotify/TuneIn integration from the command line. Use when you want to manage music playback across multiple rooms without using the Sonos app.
 homepage: https://sonoscli.sh
 metadata:
   {

--- a/skills/spotify-player/SKILL.md
+++ b/skills/spotify-player/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spotify-player
-description: Terminal Spotify playback/search via spogo (preferred) or spotify_player.
+description: Search for music, control Spotify playback, switch devices, and like tracks from the command line using spogo or spotify_player. Use when you want to play music, search for songs, or manage Spotify without opening the app or web player.
 homepage: https://www.spotify.com
 metadata:
   {

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux
-description: Remote-control tmux sessions for interactive CLIs by sending keystrokes and scraping pane output.
+description: Create, control, and monitor tmux sessions by sending keystrokes, capturing output, and orchestrating interactive terminal workflows from scripts. Use when you need interactive TTY sessions for REPLs, live monitoring, or running multiple coding agents in parallel.
 metadata:
   { "openclaw": { "emoji": "🧵", "os": ["darwin", "linux"], "requires": { "bins": ["tmux"] } } }
 ---

--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trello
-description: Manage Trello boards, lists, and cards via the Trello REST API.
+description: Create, move, update, and comment on Trello cards; manage lists and boards; and automate workflows via the REST API from scripts. Use when you want to programmatically manage your Trello boards or sync Trello with other systems.
 homepage: https://developer.atlassian.com/cloud/trello/rest/
 metadata:
   {

--- a/skills/video-frames/SKILL.md
+++ b/skills/video-frames/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-frames
-description: Extract frames or short clips from videos using ffmpeg.
+description: Extract individual frames from videos at specific timestamps or create thumbnail images for quick video inspection and sharing. Use when you want to grab a frame showing something at a specific moment or create a thumbnail for documentation.
 homepage: https://ffmpeg.org
 metadata:
   {

--- a/skills/voice-call/SKILL.md
+++ b/skills/voice-call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: voice-call
-description: Start voice calls via the OpenClaw voice-call plugin.
+description: Initiate and control voice calls using Twilio, Telnyx, or Plivo providers for programmatic outbound calling and message delivery. Use when you want to make automated phone calls, deliver voice messages, or integrate phone communications into workflows.
 metadata:
   {
     "openclaw":

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weather
-description: Get current weather and forecasts (no API key required).
+description: Get current weather, detailed forecasts, and conditions for any location using free APIs (wttr.in or Open-Meteo) without API keys or registration. Use when you want to check weather, temperature, rain, forecasts, or what to wear without API setup overhead.
 homepage: https://wttr.in/:help
 metadata: { "openclaw": { "emoji": "🌤️", "requires": { "bins": ["curl"] } } }
 ---


### PR DESCRIPTION
## Summary

Fix broken YAML frontmatter in 3 skills and improve descriptions across 32 skills for better trigger accuracy.

### Structural Fixes
- **canvas**: Add missing YAML frontmatter (had no `---` delimiters at all)
- **discord**: Quote description to fix YAML colon-in-value parse error (`discord tool: send` parsed as nested mapping)
- **food-order**: Quote description to fix same YAML colon-in-value issue (`Triggers: order food`)

These work at runtime due to OpenClaw's dual parser (YAML + line-by-line fallback), but fail any standard YAML parser including the skill-creator's own validator.

### Description Improvements (32 skills)

Expanded short descriptions (<15 words) to 30-40 words with `Use when...` trigger contexts. The `description` field in frontmatter is the primary trigger mechanism — it's how the AI decides when to load a skill. Short descriptions miss activations.

**Before:**
```
description: Get current weather and forecasts (no API key required).
```

**After:**
```
description: Get current weather, detailed forecasts, and conditions for any location using free APIs (wttr.in or Open-Meteo) without API keys or registration. Use when you want to check weather, temperature, rain, forecasts, or what to wear without API setup overhead.
```

Skills updated: bear-notes, bird, blogwatcher, blucli, camsnap, eightctl, gemini, gifgrep, gog, imsg, local-places, nano-banana-pro, nano-pdf, notion, obsidian, openai-image-gen, openai-whisper, openai-whisper-api, openhue, ordercli, peekaboo, sag, session-logs, sherpa-onnx-tts, songsee, sonoscli, spotify-player, tmux, trello, video-frames, voice-call, weather

### How this was found

Built an automated [skill-evaluator](https://github.com/Terwox/openclaw/tree/fix/skill-frontmatter-and-descriptions) that checks structural quality, frontmatter validity, description length, trigger phrases, credential scanning, and more. Ran it across all 50+ bundled skills.

### Testing
- All 35 modified files pass `yaml.safe_load()` 
- All descriptions are 30+ words with trigger context
- No functional changes — description-only edits + frontmatter quoting

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes broken YAML frontmatter for `canvas`, `discord`, and `food-order`, and expands the `description` frontmatter field across ~32 skills to improve skill-trigger accuracy. These are documentation/frontmatter-only changes; they don’t modify runtime code paths, but they do improve compatibility with standard YAML tooling and validators.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; changes are limited to skill documentation/frontmatter.
- Reviewed the diffs across all touched skill markdown files. Changes are confined to YAML frontmatter `description` edits and adding missing delimiters, with no executable code changes. The only issue found is a personal hostname in an example URL inside the Canvas skill doc, which is low-risk but should be sanitized for maintainability/privacy.
- skills/canvas/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->