### PR TITLE
fix(process): add lane cleanup to prevent memory exhaustion

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -157,10 +157,10 @@ export function getLaneCount(): number {
 }
 
 /**
- * Check if a lane is idle (no queued tasks and no active tasks).
+ * Check if a lane is idle (no queued tasks, no active tasks, and not draining).
  */
 function isLaneIdle(state: LaneState): boolean {
-  return state.queue.length === 0 && state.active === 0;
+  return state.queue.length === 0 && state.active === 0 && !state.draining;
 }
 
 /**
@@ -168,8 +168,8 @@ function isLaneIdle(state: LaneState): boolean {
  * Only removes if the lane exists and is idle (no queued or active tasks).
  * Returns true if the lane was removed, false otherwise.
  */
-export function removeLane(lane: string): boolean {
-  const cleaned = lane.trim() || CommandLane.Main;
+export function removeLane(lane?: string): boolean {
+  const cleaned = (lane ?? "").trim() || CommandLane.Main;
   // Never remove the main lane - it should always exist
   if (cleaned === (CommandLane.Main as string)) {
     return false;

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -171,7 +171,7 @@ function isLaneIdle(state: LaneState): boolean {
 export function removeLane(lane: string): boolean {
   const cleaned = lane.trim() || CommandLane.Main;
   // Never remove the main lane - it should always exist
-  if (cleaned === CommandLane.Main) {
+  if (cleaned === (CommandLane.Main as string)) {
     return false;
   }
   const state = lanes.get(cleaned);
@@ -204,7 +204,7 @@ export function clearCommandLane(lane: string = CommandLane.Main, removeWhenIdle
   const removed = state.queue.length;
   state.queue.length = 0;
   // Auto-remove the lane entry if it's now idle and not the main lane
-  if (removeWhenIdle && isLaneIdle(state) && cleaned !== CommandLane.Main) {
+  if (removeWhenIdle && isLaneIdle(state) && cleaned !== (CommandLane.Main as string)) {
     lanes.delete(cleaned);
     diag.debug(`clearCommandLane: lane=${cleaned} removed (idle after clear)`);
   }
@@ -220,7 +220,7 @@ export function pruneIdleLanes(): number {
   let pruned = 0;
   for (const [lane, state] of lanes.entries()) {
     // Never remove the main lane
-    if (lane === CommandLane.Main) {
+    if (lane === (CommandLane.Main as string)) {
       continue;
     }
     if (isLaneIdle(state)) {


### PR DESCRIPTION
## Summary

Fixes #5264

The command queue `lanes` Map was growing unbounded during long-running gateway sessions. Lanes were created for each unique session key but never removed, causing memory exhaustion (OOM) over time.

## Changes

Added lane lifecycle management:
- `removeLane(lane: string)`: Explicitly remove a lane if it's idle
- `getLaneCount()`: Returns current lane count (for monitoring/alerting)
- `pruneIdleLanes()`: Batch removal of all idle lanes
- `isLaneIdle(state)`: Internal helper to check lane state
- Modified `clearCommandLane()`: Now auto-removes lane when it becomes idle (default behavior)

## Safety measures

- **Main lane protected**: The `main` lane is never removed (always exists)
- **Active tasks protected**: Lanes with queued or active tasks are not removed
- **Backward compatible**: Existing callers get automatic cleanup; can opt out with `removeWhenIdle=false`
- **Diagnostic logging**: Lane removal events are logged for debugging

## API Changes

```typescript
// New functions
export function removeLane(lane: string): boolean;
export function getLaneCount(): number;
export function pruneIdleLanes(): number;

// Modified signature (backward compatible)
export function clearCommandLane(lane?: string, removeWhenIdle?: boolean): number;
//                                              ^^^^^^^^^^^^^^^ new optional param, defaults to true
```

## Testing

- No breaking changes to existing tests
- New functions can be tested independently
- Auto-cleanup is transparent to existing callers

## Impact

- **Memory**: Lanes are now cleaned up automatically, preventing unbounded growth
- **Performance**: Cleanup happens during existing `clearCommandLane()` calls
- **Observability**: `getLaneCount()` enables monitoring lane growth

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds lifecycle management for the in-process command queue lanes (`lanes: Map<string, LaneState>`) to prevent unbounded growth during long-running sessions. It introduces `getLaneCount()`, `removeLane()`, and `pruneIdleLanes()`, plus an internal `isLaneIdle()` helper, and updates `clearCommandLane()` to optionally delete a lane entry when it becomes idle (defaulting to removal).

Overall this fits cleanly with the existing queue design (per-lane `queue` + `active` with `drainLane()` pumping work) and should address the memory-growth issue.

Notable points to consider:
- `removeLane(lane: string)` will throw if a caller passes a non-string at runtime (e.g., `undefined`); other call sites in the repo often deal with `string | undefined` lane keys.
- `isLaneIdle()` doesn’t consider `draining`, so lanes can be removed while a drain cycle is still in progress (even with `queue=0` and `active=0`), which makes lifecycle semantics a bit inconsistent.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real memory-growth issue, with a couple of lifecycle edge cases worth tightening.
- Changes are localized to the lane bookkeeping in `src/process/command-queue.ts` and are consistent with the existing lane queue model. The main risks are around lane removal semantics (input assumptions for `removeLane` and the idle predicate not including `draining`), which could cause surprising behavior in rare timing windows or if called with optional lane values.
- src/process/command-queue.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->