### PR TITLE
fix: skip audio files by extension in extractFileBlocks

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -75,6 +75,20 @@ const TEXT_EXT_MIME = new Map<string, string>([
   [".xml", "application/xml"],
 ]);
 
+// Audio file extensions: skip regardless of MIME type to prevent incorrect text extraction
+const AUDIO_EXTS = new Set([
+  ".ogg",
+  ".opus",
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".oga",
+  ".weba",
+  ".webm",
+  ".aac",
+  ".flac",
+]);
+
 const XML_ESCAPE_MAP: Record<string, string> = {
   "<": "&lt;",
   ">": "&gt;",
@@ -226,6 +240,15 @@ async function extractFileBlocks(params: {
   const blocks: string[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
+      continue;
+    }
+    // Skip audio files by extension to prevent garbled text from incorrect MIME detection
+    const nameForExt = attachment.path ?? attachment.url ?? "";
+    const ext = path.extname(nameForExt).toLowerCase();
+    if (AUDIO_EXTS.has(ext)) {
+      if (shouldLogVerbose()) {
+        logVerbose(`media: file attachment skipped (audio ext ${ext}) index=${attachment.index}`);
+      }
       continue;
     }
     const forcedTextMime = resolveTextMimeFromName(attachment.path ?? attachment.url ?? "");


### PR DESCRIPTION
## Problem

Telegram sometimes sends audio files with incorrect MIME types like `text/tab-separated-values`, causing binary audio data to be parsed as text and resulting in garbled content in the prompt.

## Solution

Add extension-based detection for audio files (.ogg, .opus, .mp3, .wav, .m4a, .oga, .weba, .webm, .aac, .flac) to skip them early in `extractFileBlocks`, preventing incorrect text extraction regardless of the reported MIME type.

The audio files are still processed normally by the audio transcription pipeline - this change only prevents them from being incorrectly treated as text files.

## Changes

- Added `AUDIO_EXTS` constant with common audio file extensions
- Added extension check at the start of the attachment loop in `extractFileBlocks`
- Logs skipped audio files when verbose logging is enabled

## Testing

- Tested with Telegram voice messages (.ogg with incorrect MIME `text/tab-separated-values`)
- Verified audio transcription still works via external ASR plugin
- No impact on normal text file extraction

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `extractFileBlocks` in `src/media-understanding/apply.ts` to skip non-forced audio/video attachments earlier, preventing binary media from being decoded and included as text when upstream MIME types are wrong.

The change sits in the media-understanding apply pipeline: attachments are normalized, `extractFileBlocks` builds `<file ...>` blocks for text-like inputs, and capability runners handle image/audio/video processing separately.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new skip condition likely drops some recoverable text from misclassified video attachments.
- The change is small and localized, but it alters behavior from “skip only non-text-like audio” to “skip all non-forced video and audio” which can reduce text extraction in edge cases (text-like files labeled as video).
- src/media-understanding/apply.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->