### PR TITLE
Fix runner dist entry check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Status: stable.
 - **BREAKING:** Gateway auth mode "none" is removed; gateway now requires token/password (Tailscale Serve identity still allowed).
 
 ### Fixes
+- CLI: avoid rebuilding when dist entry is fresh. (#5289) Thanks @obviyus.
 - Infra: resolve Control UI assets for npm global installs. (#4909) Thanks @YuriNachos.
 - Gateway: prevent blank token prompts from storing "undefined". (#4873) Thanks @Hisleren.
 - Telegram: use undici fetch for per-account proxy dispatcher. (#4456) Thanks @spiceoogway.

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -12,7 +12,7 @@ const compiler = compilerOverride === "tsc" ? "tsc" : "tsgo";
 const projectArgs = ["--project", "tsconfig.json"];
 
 const distRoot = path.join(cwd, "dist");
-const distEntry = path.join(distRoot, "entry.js");
+const distEntry = path.join(distRoot, "entry.mjs");
 const buildStampPath = path.join(distRoot, ".buildstamp");
 const srcRoot = path.join(cwd, "src");
 const configFiles = [path.join(cwd, "tsconfig.json"), path.join(cwd, "package.json")];


### PR DESCRIPTION
- Fix dist entry check to prevent forced rebuilds
- Speeds up pnpm openclaw startup

Tests: not run (startup check only)
