### PR TITLE
add: bun sqlite support

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "@grammyjs/types": "^3.23.0",
     "@lit-labs/signals": "^0.2.0",
     "@lit/context": "^1.1.6",
+    "@types/bun": "^1.3.8",
     "@types/express": "^5.0.6",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
+      '@types/bun':
+        specifier: ^1.3.8
+        version: 1.3.8
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -2582,6 +2585,9 @@ packages:
   '@types/bun@1.3.6':
     resolution: {integrity: sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==}
 
+  '@types/bun@1.3.8':
+    resolution: {integrity: sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA==}
+
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
@@ -3033,6 +3039,9 @@ packages:
 
   bun-types@1.3.6:
     resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
+
+  bun-types@1.3.8:
+    resolution: {integrity: sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -6299,7 +6308,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.9
     optionalDependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
     transitivePeerDependencies:
       - debug
 
@@ -6496,7 +6505,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7279,7 +7288,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7325,7 +7334,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.1.0
       '@types/retry': 0.12.0
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -7734,6 +7743,10 @@ snapshots:
     dependencies:
       bun-types: 1.3.6
     optional: true
+
+  '@types/bun@1.3.8':
+    dependencies:
+      bun-types: 1.3.8
 
   '@types/caseless@0.12.5': {}
 
@@ -8209,6 +8222,14 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  axios@1.13.4:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.13.4(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -8288,6 +8309,10 @@ snapshots:
     dependencies:
       '@types/node': 25.1.0
     optional: true
+
+  bun-types@1.3.8:
+    dependencies:
+      '@types/node': 25.1.0
 
   bytes@3.1.2: {}
 
@@ -8773,6 +8798,8 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
+
+  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -1,4 +1,4 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqliteDatabase } from "./sqlite.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { cosineSimilarity, parseEmbedding } from "./internal.js";
 
@@ -18,7 +18,7 @@ export type SearchRowResult = {
 };
 
 export async function searchVector(params: {
-  db: DatabaseSync;
+  db: SqliteDatabase;
   vectorTable: string;
   providerModel: string;
   queryVec: number[];
@@ -94,7 +94,7 @@ export async function searchVector(params: {
 }
 
 export function listChunks(params: {
-  db: DatabaseSync;
+  db: SqliteDatabase;
   providerModel: string;
   sourceFilter: { sql: string; params: SearchSource[] };
 }): Array<{
@@ -134,7 +134,7 @@ export function listChunks(params: {
 }
 
 export async function searchKeyword(params: {
-  db: DatabaseSync;
+  db: SqliteDatabase;
   ftsTable: string;
   providerModel: string;
   query: string;

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -1,7 +1,7 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqliteDatabase } from "./sqlite.js";
 
 export function ensureMemoryIndexSchema(params: {
-  db: DatabaseSync;
+  db: SqliteDatabase;
   embeddingCacheTable: string;
   ftsTable: string;
   ftsEnabled: boolean;
@@ -83,7 +83,7 @@ export function ensureMemoryIndexSchema(params: {
 }
 
 function ensureColumn(
-  db: DatabaseSync,
+  db: SqliteDatabase,
   table: "files" | "chunks",
   column: string,
   definition: string,

--- a/src/memory/sqlite-vec.ts
+++ b/src/memory/sqlite-vec.ts
@@ -1,7 +1,7 @@
-import type { DatabaseSync } from "node:sqlite";
+import { isBunRuntime, type SqliteDatabase } from "./sqlite.js";
 
 export async function loadSqliteVecExtension(params: {
-  db: DatabaseSync;
+  db: SqliteDatabase;
   extensionPath?: string;
 }): Promise<{ ok: boolean; extensionPath?: string; error?: string }> {
   try {
@@ -9,7 +9,12 @@ export async function loadSqliteVecExtension(params: {
     const resolvedPath = params.extensionPath?.trim() ? params.extensionPath.trim() : undefined;
     const extensionPath = resolvedPath ?? sqliteVec.getLoadablePath();
 
-    params.db.enableLoadExtension(true);
+    // Node's DatabaseSync requires enabling extension loading first
+    // Bun's Database doesn't have this method and allows extensions by default
+    if (!isBunRuntime && "enableLoadExtension" in params.db) {
+      params.db.enableLoadExtension(true);
+    }
+
     if (resolvedPath) {
       params.db.loadExtension(extensionPath);
     } else {

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -3,7 +3,20 @@ import { installProcessWarningFilter } from "../infra/warnings.js";
 
 const require = createRequire(import.meta.url);
 
-export function requireNodeSqlite(): typeof import("node:sqlite") {
+export const isBunRuntime: boolean = (process.versions as { bun?: string }).bun !== undefined;
+
+/**
+ * Unified SQLite database type that works for both Bun and Node runtimes.
+ */
+export type SqliteDatabase = import("bun:sqlite").Database | import("node:sqlite").DatabaseSync;
+
+export function requireSqlite(): typeof import("bun:sqlite") | typeof import("node:sqlite") {
+  if (isBunRuntime) {
+    return require("bun:sqlite") as typeof import("bun:sqlite");
+  }
   installProcessWarningFilter();
   return require("node:sqlite") as typeof import("node:sqlite");
 }
+
+/** @deprecated Use requireSqlite instead */
+export const requireNodeSqlite = requireSqlite;

--- a/src/memory/sync-memory-files.ts
+++ b/src/memory/sync-memory-files.ts
@@ -1,4 +1,4 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqliteDatabase } from "./sqlite.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildFileEntry, listMemoryFiles, type MemoryFileEntry } from "./internal.js";
 
@@ -14,7 +14,7 @@ type ProgressState = {
 export async function syncMemoryFiles(params: {
   workspaceDir: string;
   extraPaths?: string[];
-  db: DatabaseSync;
+  db: SqliteDatabase;
   needsFullReindex: boolean;
   progress?: ProgressState;
   batchEnabled: boolean;

--- a/src/memory/sync-session-files.ts
+++ b/src/memory/sync-session-files.ts
@@ -1,5 +1,5 @@
-import type { DatabaseSync } from "node:sqlite";
 import type { SessionFileEntry } from "./session-files.js";
+import type { SqliteDatabase } from "./sqlite.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   buildSessionEntry,
@@ -18,7 +18,7 @@ type ProgressState = {
 
 export async function syncSessionFiles(params: {
   agentId: string;
-  db: DatabaseSync;
+  db: SqliteDatabase;
   needsFullReindex: boolean;
   progress?: ProgressState;
   batchEnabled: boolean;


### PR DESCRIPTION
closes #4819

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Bun runtime support for SQLite operations in the memory search system. The changes introduce runtime detection and conditional logic to handle API differences between Bun's `bun:sqlite` and Node's `node:sqlite`.

**Key changes:**
- Unified type `SqliteDatabase` that supports both Bun's `Database` and Node's `DatabaseSync`
- Runtime detection via `isBunRuntime` flag checking `process.versions.bun`
- Conditional database initialization handling the different constructor signatures
- Extension loading logic that skips `enableLoadExtension` for Bun (not available in Bun's API)
- Added `@types/bun` dependency for TypeScript support

**Minor behavioral difference:**
Bun's `Database` doesn't support the `allowExtension` option, so extensions are always allowed on Bun regardless of the `store.vector.enabled` setting. This doesn't cause issues in practice since extension loading is already guarded by the enabled check.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the changes are well-structured and follow proper runtime detection patterns
- The implementation correctly handles the API differences between Bun and Node SQLite implementations. The code uses proper type guards and runtime checks. The only minor concern is the behavioral difference in extension security (Bun always allows extensions), but this is mitigated by the existing guard logic that prevents loading extensions when disabled
- No files require special attention - the implementation is clean and follows TypeScript best practices

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->