### PR TITLE
fix(slack): skip conversations.list API call when all channel entries are IDs

### DIFF
--- a/src/slack/resolve-channels.test.ts
+++ b/src/slack/resolve-channels.test.ts
@@ -40,4 +40,72 @@ describe("resolveSlackChannelAllowlist", () => {
 
     expect(res[0]?.resolved).toBe(false);
   });
+
+  it("skips API call when all entries are channel IDs", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["C087C6LMAQZ", "C07EH07H1PS"],
+      client: client as never,
+    });
+
+    // Should NOT call conversations.list when all entries are channel IDs
+    expect(client.conversations.list).not.toHaveBeenCalled();
+
+    // All entries should still be resolved
+    expect(res).toHaveLength(2);
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[1]?.resolved).toBe(true);
+    expect(res[1]?.id).toBe("C07EH07H1PS");
+  });
+
+  it("calls API when entries contain a mix of IDs and names", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({
+          channels: [{ id: "C123", name: "general", is_archived: false }],
+        }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["C087C6LMAQZ", "#general"],
+      client: client as never,
+    });
+
+    // Should call conversations.list because there's a name-based entry
+    expect(client.conversations.list).toHaveBeenCalled();
+
+    expect(res).toHaveLength(2);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[1]?.id).toBe("C123");
+  });
+
+  it("handles Slack mention format without API call", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["<#C087C6LMAQZ|pbo-o4o-eng>"],
+      client: client as never,
+    });
+
+    // Should NOT call API for mention format (already has ID)
+    expect(client.conversations.list).not.toHaveBeenCalled();
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[0]?.name).toBe("pbo-o4o-eng");
+  });
 });

--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -97,12 +97,22 @@ export async function resolveSlackChannelAllowlist(params: {
   client?: WebClient;
 }): Promise<SlackChannelResolution[]> {
   const client = params.client ?? createSlackWebClient(params.token);
-  const channels = await listSlackChannels(client);
+
+  // Pre-parse all entries to check if we need to fetch the channel list
+  const parsedEntries = params.entries.map((input) => ({
+    input,
+    parsed: parseSlackChannelMention(input),
+  }));
+
+  // Only fetch channels if at least one entry needs name-based resolution
+  const needsChannelList = parsedEntries.some(({ parsed }) => !parsed.id && parsed.name);
+  const channels = needsChannelList ? await listSlackChannels(client) : [];
+
   const results: SlackChannelResolution[] = [];
 
-  for (const input of params.entries) {
-    const parsed = parseSlackChannelMention(input);
+  for (const { input, parsed } of parsedEntries) {
     if (parsed.id) {
+      // For ID-based entries, optionally look up metadata if we already have the list
       const match = channels.find((channel) => channel.id === parsed.id);
       results.push({
         input,


### PR DESCRIPTION
## Problem

When Slack channels are configured using channel IDs (e.g., `C087C6LMAQZ`) instead of names (e.g., `#general`), the `resolveSlackChannelAllowlist` function still calls `conversations.list` API to fetch all channels. This causes:

1. **Unnecessary API calls** - Channel IDs don't need resolution
2. **Rate limit issues** - Repeated calls can trigger Slack's rate limits (30s retry loops)
3. **Slow startup** - Fetching channel list delays provider initialization

## Solution

Pre-parse all entries before fetching the channel list. Only call `conversations.list` when at least one entry requires name-based resolution.

```typescript
const needsChannelList = parsedEntries.some(({ parsed }) => !parsed.id && parsed.name);
const channels = needsChannelList ? await listSlackChannels(client) : [];
```

## Testing

Added 3 new test cases:
- ✅ Skips API call when all entries are channel IDs
- ✅ Calls API when entries contain a mix of IDs and names  
- ✅ Handles Slack mention format without API call

All existing tests pass.

## Impact

- Zero breaking changes
- Significant performance improvement for ID-based configurations
- Eliminates rate limit issues when using channel IDs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Optimizes Slack channel resolution by pre-parsing entries and skipping the `conversations.list` API call when all channel entries are IDs. Previously, the function always fetched the full channel list from Slack, even when all entries were already channel IDs that don't need resolution. The new logic checks if any entry requires name-based lookup (`!parsed.id && parsed.name`) before calling the API, eliminating unnecessary API calls and preventing rate limit issues for ID-based configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is a pure optimization that preserves existing behavior while eliminating unnecessary API calls. The logic is straightforward: parse all entries first, check if any require name resolution, and only fetch the channel list if needed. All edge cases are covered by comprehensive tests, and the implementation maintains backward compatibility
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->