### PR TITLE
fix(slack): skip users.list API call when all user entries are IDs

### DIFF
--- a/src/slack/resolve-channels.test.ts
+++ b/src/slack/resolve-channels.test.ts
@@ -40,4 +40,72 @@ describe("resolveSlackChannelAllowlist", () => {
 
     expect(res[0]?.resolved).toBe(false);
   });
+
+  it("skips API call when all entries are channel IDs", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["C087C6LMAQZ", "C07EH07H1PS"],
+      client: client as never,
+    });
+
+    // Should NOT call conversations.list when all entries are channel IDs
+    expect(client.conversations.list).not.toHaveBeenCalled();
+
+    // All entries should still be resolved
+    expect(res).toHaveLength(2);
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[1]?.resolved).toBe(true);
+    expect(res[1]?.id).toBe("C07EH07H1PS");
+  });
+
+  it("calls API when entries contain a mix of IDs and names", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({
+          channels: [{ id: "C123", name: "general", is_archived: false }],
+        }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["C087C6LMAQZ", "#general"],
+      client: client as never,
+    });
+
+    // Should call conversations.list because there's a name-based entry
+    expect(client.conversations.list).toHaveBeenCalled();
+
+    expect(res).toHaveLength(2);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[1]?.id).toBe("C123");
+  });
+
+  it("handles Slack mention format without API call", async () => {
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+
+    const res = await resolveSlackChannelAllowlist({
+      token: "xoxb-test",
+      entries: ["<#C087C6LMAQZ|pbo-o4o-eng>"],
+      client: client as never,
+    });
+
+    // Should NOT call API for mention format (already has ID)
+    expect(client.conversations.list).not.toHaveBeenCalled();
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("C087C6LMAQZ");
+    expect(res[0]?.name).toBe("pbo-o4o-eng");
+  });
 });

--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -97,12 +97,22 @@ export async function resolveSlackChannelAllowlist(params: {
   client?: WebClient;
 }): Promise<SlackChannelResolution[]> {
   const client = params.client ?? createSlackWebClient(params.token);
-  const channels = await listSlackChannels(client);
+
+  // Pre-parse all entries to check if we need to fetch the channel list
+  const parsedEntries = params.entries.map((input) => ({
+    input,
+    parsed: parseSlackChannelMention(input),
+  }));
+
+  // Only fetch channels if at least one entry needs name-based resolution
+  const needsChannelList = parsedEntries.some(({ parsed }) => !parsed.id && parsed.name);
+  const channels = needsChannelList ? await listSlackChannels(client) : [];
+
   const results: SlackChannelResolution[] = [];
 
-  for (const input of params.entries) {
-    const parsed = parseSlackChannelMention(input);
+  for (const { input, parsed } of parsedEntries) {
     if (parsed.id) {
+      // For ID-based entries, optionally look up metadata if we already have the list
       const match = channels.find((channel) => channel.id === parsed.id);
       results.push({
         input,

--- a/src/slack/resolve-users.test.ts
+++ b/src/slack/resolve-users.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveSlackUserAllowlist } from "./resolve-users.js";
+
+describe("resolveSlackUserAllowlist", () => {
+  it("resolves by name and prefers non-deleted users", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({
+          members: [
+            { id: "U1", name: "john", deleted: true, profile: { display_name: "John" } },
+            { id: "U2", name: "john", deleted: false, profile: { display_name: "John Doe" } },
+          ],
+        }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["@john"],
+      client: client as never,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("U2");
+  });
+
+  it("keeps unresolved entries", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({ members: [] }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["@does-not-exist"],
+      client: client as never,
+    });
+
+    expect(res[0]?.resolved).toBe(false);
+  });
+
+  it("skips API call when all entries are user IDs", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({ members: [] }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["U07SQFJCAU8", "U0ABVPJ1W7P"],
+      client: client as never,
+    });
+
+    // Should NOT call users.list when all entries are user IDs
+    expect(client.users.list).not.toHaveBeenCalled();
+
+    // All entries should still be resolved
+    expect(res).toHaveLength(2);
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("U07SQFJCAU8");
+    expect(res[1]?.resolved).toBe(true);
+    expect(res[1]?.id).toBe("U0ABVPJ1W7P");
+  });
+
+  it("calls API when entries contain a mix of IDs and names", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({
+          members: [
+            { id: "U123", name: "john", deleted: false, profile: { display_name: "John" } },
+          ],
+        }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["U07SQFJCAU8", "@john"],
+      client: client as never,
+    });
+
+    // Should call users.list because there's a name-based entry
+    expect(client.users.list).toHaveBeenCalled();
+
+    expect(res).toHaveLength(2);
+    expect(res[0]?.id).toBe("U07SQFJCAU8");
+    expect(res[1]?.id).toBe("U123");
+  });
+
+  it("handles Slack mention format without API call", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({ members: [] }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["<@U07SQFJCAU8>"],
+      client: client as never,
+    });
+
+    // Should NOT call API for mention format (already has ID)
+    expect(client.users.list).not.toHaveBeenCalled();
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("U07SQFJCAU8");
+  });
+
+  it("calls API when entry is an email", async () => {
+    const client = {
+      users: {
+        list: vi.fn().mockResolvedValue({
+          members: [
+            {
+              id: "U123",
+              name: "john",
+              deleted: false,
+              profile: { display_name: "John", email: "john@example.com" },
+            },
+          ],
+        }),
+      },
+    };
+
+    const res = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["john@example.com"],
+      client: client as never,
+    });
+
+    // Should call users.list for email resolution
+    expect(client.users.list).toHaveBeenCalled();
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.id).toBe("U123");
+    expect(res[0]?.email).toBe("john@example.com");
+  });
+});

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -122,7 +122,18 @@ export async function resolveSlackUserAllowlist(params: {
   client?: WebClient;
 }): Promise<SlackUserResolution[]> {
   const client = params.client ?? createSlackWebClient(params.token);
-  const users = await listSlackUsers(client);
+
+  // Pre-parse all entries to check if we need to fetch the user list
+  const parsedEntries = params.entries.map((input) => ({
+    input,
+    parsed: parseSlackUserInput(input),
+  }));
+
+  // Only fetch user list if at least one entry needs name/email resolution
+  const needsUserList = parsedEntries.some(
+    ({ parsed }) => !parsed.id && (parsed.name || parsed.email),
+  );
+  const users = needsUserList ? await listSlackUsers(client) : [];
   const results: SlackUserResolution[] = [];
 
   for (const input of params.entries) {


### PR DESCRIPTION
## Problem

Same issue as #5305, but for user allowlists instead of channels.

When Slack users are configured using user IDs (e.g., `U07SQFJCAU8`) instead of names (e.g., `@john`), the `resolveSlackUserAllowlist` function still calls `users.list` API to fetch all users. This causes:

- **Unnecessary API calls** - User IDs don't need resolution
- **Rate limit issues** - Repeated calls trigger Slack's rate limits (30s retry loops)
- **Slow startup** - Fetching user list delays provider initialization

## Solution

Pre-parse all entries before fetching the user list. Only call `users.list` when at least one entry requires name or email-based resolution.

```typescript
const needsUserList = parsedEntries.some(
  ({ parsed }) => !parsed.id && (parsed.name || parsed.email)
);
const users = needsUserList ? await listSlackUsers(client) : [];
```

## Testing

Added 6 test cases:

- ✅ Skips API call when all entries are user IDs
- ✅ Calls API when entries contain a mix of IDs and names
- ✅ Handles Slack mention format (`<@U123>`) without API call
- ✅ Calls API when entry is an email
- ✅ Resolves by name and prefers non-deleted users
- ✅ Keeps unresolved entries

All existing tests pass.

## Impact

- **Zero breaking changes**
- **Significant performance improvement** for ID-based configurations
- **Eliminates rate limit issues** when using user IDs

## Related

- Follows same pattern as #5305 (channel optimization)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR applies the same optimization recently added for Slack channel allowlists to Slack user allowlists: it pre-parses configured entries and only calls `users.list` / `conversations.list` when at least one entry requires name/email-based resolution. Tests were expanded to cover ID-only entries, mixed ID+name cases, Slack mention formats, and email resolution.

The change fits the existing Slack allowlist resolution pattern in `src/slack/resolve-channels.ts` and `src/slack/resolve-users.ts`, reducing startup latency and avoiding Slack API rate limiting when configurations are already in canonical ID form.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and clear behavior change coverage via tests.
- The core logic change is small and well-contained (conditional Slack list calls based on input parsing), and new tests cover the key scenarios (IDs, mixed inputs, mentions, emails). The main concern is a small redundancy in `resolveSlackUserAllowlist` where entries are parsed twice, which is easy to fix but unlikely to cause functional regressions.
- src/slack/resolve-users.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->