### PR TITLE
fix: L2-normalize local embedding vectors to fix semantic search

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -330,7 +330,6 @@ describe("embedding provider local fallback", () => {
 describe("local embedding L2 normalization", () => {
   afterEach(() => {
     vi.resetAllMocks();
-    vi.resetModules();
     vi.unstubAllGlobals();
     vi.doUnmock("./node-llama.js");
   });

--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -326,3 +326,126 @@ describe("embedding provider local fallback", () => {
     ).rejects.toThrow(/optional dependency node-llama-cpp/i);
   });
 });
+
+describe("local embedding L2 normalization", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.doUnmock("./node-llama.js");
+  });
+
+  it("normalizes local embeddings to magnitude ~1.0", async () => {
+    const unnormalizedVector = [2.35, 3.45, 0.63, 4.3, 1.2, 5.1, 2.8, 3.9];
+
+    vi.doMock("./node-llama.js", () => ({
+      importNodeLlamaCpp: async () => ({
+        getLlama: async () => ({
+          loadModel: vi.fn().mockResolvedValue({
+            createEmbeddingContext: vi.fn().mockResolvedValue({
+              getEmbeddingFor: vi.fn().mockResolvedValue({
+                vector: new Float32Array(unnormalizedVector),
+              }),
+            }),
+          }),
+        }),
+        resolveModelFile: async () => "/fake/model.gguf",
+        LlamaLogLevel: { error: 0 },
+      }),
+    }));
+
+    vi.resetModules();
+    const { createEmbeddingProvider } = await import("./embeddings.js");
+
+    const result = await createEmbeddingProvider({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+    });
+
+    const embedding = await result.provider.embedQuery("test query");
+
+    const magnitude = Math.sqrt(embedding.reduce((sum, x) => sum + x * x, 0));
+
+    expect(magnitude).toBeCloseTo(1.0, 5);
+  });
+
+  it("handles zero vector without division by zero", async () => {
+    const zeroVector = [0, 0, 0, 0];
+
+    vi.doMock("./node-llama.js", () => ({
+      importNodeLlamaCpp: async () => ({
+        getLlama: async () => ({
+          loadModel: vi.fn().mockResolvedValue({
+            createEmbeddingContext: vi.fn().mockResolvedValue({
+              getEmbeddingFor: vi.fn().mockResolvedValue({
+                vector: new Float32Array(zeroVector),
+              }),
+            }),
+          }),
+        }),
+        resolveModelFile: async () => "/fake/model.gguf",
+        LlamaLogLevel: { error: 0 },
+      }),
+    }));
+
+    vi.resetModules();
+    const { createEmbeddingProvider } = await import("./embeddings.js");
+
+    const result = await createEmbeddingProvider({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+    });
+
+    const embedding = await result.provider.embedQuery("test");
+
+    expect(embedding).toEqual([0, 0, 0, 0]);
+    expect(embedding.every((x) => !Number.isNaN(x))).toBe(true);
+  });
+
+  it("normalizes batch embeddings to magnitude ~1.0", async () => {
+    const unnormalizedVectors = [
+      [2.35, 3.45, 0.63, 4.3],
+      [10.0, 0.0, 0.0, 0.0],
+      [1.0, 1.0, 1.0, 1.0],
+    ];
+
+    vi.doMock("./node-llama.js", () => ({
+      importNodeLlamaCpp: async () => ({
+        getLlama: async () => ({
+          loadModel: vi.fn().mockResolvedValue({
+            createEmbeddingContext: vi.fn().mockResolvedValue({
+              getEmbeddingFor: vi
+                .fn()
+                .mockResolvedValueOnce({ vector: new Float32Array(unnormalizedVectors[0]) })
+                .mockResolvedValueOnce({ vector: new Float32Array(unnormalizedVectors[1]) })
+                .mockResolvedValueOnce({ vector: new Float32Array(unnormalizedVectors[2]) }),
+            }),
+          }),
+        }),
+        resolveModelFile: async () => "/fake/model.gguf",
+        LlamaLogLevel: { error: 0 },
+      }),
+    }));
+
+    vi.resetModules();
+    const { createEmbeddingProvider } = await import("./embeddings.js");
+
+    const result = await createEmbeddingProvider({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+    });
+
+    const embeddings = await result.provider.embedBatch(["text1", "text2", "text3"]);
+
+    for (const embedding of embeddings) {
+      const magnitude = Math.sqrt(embedding.reduce((sum, x) => sum + x * x, 0));
+      expect(magnitude).toBeCloseTo(1.0, 5);
+    }
+  });
+});

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -8,7 +8,7 @@ import { importNodeLlamaCpp } from "./node-llama.js";
 
 function l2Normalize(vec: number[]): number[] {
   const magnitude = Math.sqrt(vec.reduce((sum, x) => sum + x * x, 0));
-  if (magnitude < 1e-10) return vec;
+  if (!Number.isFinite(magnitude) || magnitude < 1e-10) return vec;
   return vec.map((x) => x / magnitude);
 }
 

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -8,7 +8,9 @@ import { importNodeLlamaCpp } from "./node-llama.js";
 
 function l2Normalize(vec: number[]): number[] {
   const magnitude = Math.sqrt(vec.reduce((sum, x) => sum + x * x, 0));
-  if (!Number.isFinite(magnitude) || magnitude < 1e-10) return vec;
+  if (!Number.isFinite(magnitude) || magnitude < 1e-10) {
+    return vec;
+  }
   return vec.map((x) => x / magnitude);
 }
 


### PR DESCRIPTION
fixes #5301

### **Problem**

The local embedding provider using `node-llama-cpp` returns raw unnormalized vectors from models like EmbeddingGemma. These vectors had magnitudes ranging from 10–15 instead of the expected 1.0. Since semantic search relies on cosine similarity, which assumes unit vectors, the search was dominated by vector magnitude rather than semantic direction. This caused the same high-magnitude chunks to rank first regardless of the query, making semantic search completely non-functional for local model users.

### **Solution**

Added an `l2Normalize()` utility function that normalizes any embedding vector to unit magnitude after inference. This is applied to both `embedQuery` and `embedBatch` outputs in the local embedding provider. A guard clause handles the zero vector case to prevent division by zero.

### **File Changes**

`src/memory/embeddings.ts`
- Added `l2Normalize()` helper function
- Applied normalization to `embedQuery` output
- Applied normalization to `embedBatch` output

`src/memory/embeddings.test.ts`
- Added test: single vector normalizes to magnitude ~1.0
- Added test: zero vector returns safely without NaN
- Added test: batch embeddings all normalize to magnitude ~1.0

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds L2 normalization for vectors returned by the local embedding provider (`node-llama-cpp`) by introducing an `l2Normalize()` helper and applying it to both `embedQuery` and `embedBatch` outputs in `src/memory/embeddings.ts`. It also adds a dedicated test suite in `src/memory/embeddings.test.ts` that mocks `./node-llama.js` to verify normalized magnitude (~1.0) for single and batch embeddings, and safe handling of the zero vector.

Overall, the change aligns local embeddings with cosine-similarity assumptions used by semantic search, preventing ranking from being dominated by vector magnitude.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it makes a targeted behavioral fix with reasonable test coverage.
- Normalization is applied in the right place (local provider output) and includes a zero-vector guard. Remaining concerns are mostly edge-case robustness (non-finite values) and minor test-suite cleanup; no obvious functional regression is introduced by the core change.
- src/memory/embeddings.ts (edge-case handling for non-finite values); src/memory/embeddings.test.ts (mock/reset hygiene)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->