### PR TITLE
fix(lobster): block arbitrary exec via lobsterPath/cwd (GHSA-4mhr-g7xj-cg8j)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: restore draft streaming partials. (#5543) Thanks @obviyus.
+- fix(lobster): block arbitrary exec via lobsterPath/cwd injection (GHSA-4mhr-g7xj-cg8j). (#5335) Thanks @vignesh07.
 
 ## 2026.1.30
 

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -114,6 +114,28 @@ describe("lobster plugin tool", () => {
     ).rejects.toThrow(/absolute path/);
   });
 
+  it("rejects lobsterPath that is not the lobster executable", async () => {
+    const tool = createLobsterTool(fakeApi());
+    await expect(
+      tool.execute("call2b", {
+        action: "run",
+        pipeline: "noop",
+        lobsterPath: "/bin/bash",
+      }),
+    ).rejects.toThrow(/lobster executable/);
+  });
+
+  it("rejects absolute cwd", async () => {
+    const tool = createLobsterTool(fakeApi());
+    await expect(
+      tool.execute("call2c", {
+        action: "run",
+        pipeline: "noop",
+        cwd: "/tmp",
+      }),
+    ).rejects.toThrow(/cwd must be a relative path/);
+  });
+
   it("rejects invalid JSON from lobster", async () => {
     const { binPath } = await writeFakeLobsterScript(
       `process.stdout.write("nope");\n`,

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -266,7 +266,7 @@ export function createLobsterTool(api: OpenClawPluginApi) {
       }
 
       const execPath = resolveExecutablePath(
-        typeof api.config?.lobsterPath === "string" ? api.config.lobsterPath : undefined,
+        typeof api.pluginConfig?.lobsterPath === "string" ? api.pluginConfig.lobsterPath : undefined,
       );
       const cwd = resolveCwd(params.cwd);
       const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : 20_000;


### PR DESCRIPTION
Fixes GHSA-4mhr-g7xj-cg8j.

- Disallow arbitrary executables via `lobsterPath` (must be absolute AND basename must be `lobster` / `lobster.exe|.cmd|.bat`).
- Validate `lobsterPath` exists/is a file (+ executable on posix).
- Restrict `cwd` to a *relative* path that must stay within the gateway process working directory.
- Added tests covering `/bin/bash` lobsterPath + absolute cwd.

Security impact: prevents RCE via tool parameter injection.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the Lobster tool execution path by validating `lobsterPath` and constraining `cwd` to stay within the gateway process working directory. It prevents arbitrary executable invocation (e.g. `/bin/bash`) by requiring overridden paths to be absolute, have an allowed lobster basename, and exist as an executable file (POSIX). It also adds tests to cover the new `lobsterPath` and `cwd` restrictions.

Overall this fits the plugin’s responsibility of spawning a local `lobster` subprocess while ensuring tool parameters can’t be abused to execute unintended binaries or run in attacker-controlled directories.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully improves security, with one Windows path-handling edge case worth addressing.
- The changes are localized and well-covered by tests for the new validation behavior. The main remaining risk is subtle platform-specific path normalization (Windows drive-letter/case semantics) in the `cwd` containment check, which could lead to incorrect accepts/rejects depending on environment.
- extensions/lobster/src/lobster-tool.ts (Windows path normalization in resolveCwd).

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->