### PR TITLE
feat: add one-liner commands for cleanup hints

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -34,13 +34,22 @@ export function renderGatewayServiceCleanupHints(
   switch (process.platform) {
     case "darwin": {
       const label = resolveGatewayLaunchAgentLabel(profile);
-      return [`launchctl bootout gui/$UID/${label}`, `rm ~/Library/LaunchAgents/${label}.plist`];
+      return [
+        `launchctl bootout gui/$UID/${label}`,
+        `rm ~/Library/LaunchAgents/${label}.plist`,
+        ``,
+        `One-liner (copy-paste):`,
+        `launchctl bootout gui/$UID/${label} && rm ~/Library/LaunchAgents/${label}.plist`,
+      ];
     }
     case "linux": {
       const unit = resolveGatewaySystemdServiceName(profile);
       return [
         `systemctl --user disable --now ${unit}.service`,
         `rm ~/.config/systemd/user/${unit}.service`,
+        ``,
+        `One-liner (copy-paste):`,
+        `systemctl --user disable --now ${unit}.service && rm ~/.config/systemd/user/${unit}.service`,
       ];
     }
     case "win32": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `renderGatewayServiceCleanupHints` (`src/daemon/inspect.ts`) to include a copy‑pasteable one-liner cleanup command for macOS (`launchctl ... && rm ...`) and Linux (`systemctl ... && rm ...`), along with a small header and spacing to make the new section readable in the CLI output.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it only changes user-facing hint strings.
- Change is localized to returning additional strings and does not affect service detection or execution paths. Main risk is downstream formatting assumptions for blank-line separators and the new header text.
- src/daemon/inspect.ts (verify how hints are rendered in the CLI/UI and whether empty strings are preserved).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->