### PR TITLE
chore(github): update issue templates to OpenClaw branding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem or unexpected behavior in Clawdbot.
+about: Report a problem or unexpected behavior in OpenClaw.
 title: "[Bug]: "
 labels: bug
 ---
@@ -20,7 +20,7 @@ What did you expect to happen?
 What actually happened?
 
 ## Environment
-- Clawdbot version:
+- OpenClaw version:
 - OS:
 - Install method (pnpm/npx/docker/etc):
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Onboarding
-    url: https://discord.gg/clawd
-    about: New to Clawdbot? Join Discord for setup guidance from Krill in #help.
+    url: https://discord.gg/qkhbAGHRBT
+    about: New to OpenClaw? Join Discord for setup guidance in #setup-help.
   - name: Support
-    url: https://discord.gg/clawd
-    about: Get help from Krill and the community on Discord in #help.
+    url: https://discord.gg/qkhbAGHRBT
+    about: Get help from the community on Discord in #setup-help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea or improvement for Clawdbot.
+about: Suggest an idea or improvement for OpenClaw.
 title: "[Feature]: "
 labels: enhancement
 ---
@@ -9,7 +9,7 @@ labels: enhancement
 Describe the problem you are trying to solve or the opportunity you see.
 
 ## Proposed solution
-What would you like Clawdbot to do?
+What would you like OpenClaw to do?
 
 ## Alternatives considered
 Any other approaches you have considered?


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                  
Updates issue templates from legacy "Clawdbot" branding to "OpenClaw".

## Changes
- `bug_report.md`: Clawdbot → OpenClaw
- `feature_request.md`: Clawdbot → OpenClaw
- `config.yml`: Updated Discord links to match CONTRIBUTING.md (`discord.gg/qkhbAGHRBT`), fixed channel reference to `#setup-help`

## Test plan
- [x] Verified templates render correctly in GitHub preview

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the GitHub issue templates to use OpenClaw branding instead of Clawdbot, and updates the `.github/ISSUE_TEMPLATE/config.yml` contact links to point to the current Discord invite and `#setup-help` channel.

Changes are confined to GitHub metadata/templates under `.github/ISSUE_TEMPLATE/` and do not affect runtime code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; changes are limited to GitHub issue templates and link metadata.
- Reviewed all modified templates; changes are straightforward string/link updates with no impact on application code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->