### PR TITLE
chore(github): add labeler coverage for .github directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -148,6 +148,19 @@
       - any-glob-to-any-file:
           - "scripts/**"
 
+"ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+"github":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/*.md"
+          - ".github/*.yml"
+          - ".github/*.yaml"
+
 "docker":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
Adds auto-labeling for `.github/` directory changes with granular labels.

## Changes
- `ci` label for `.github/workflows/**` (CI/CD pipelines)
- `github` label for `.github/ISSUE_TEMPLATE/**`, `.github/*.md`, `.github/*.yml` (templates, configs)

## Test plan
- [x] Verified labeler.yml syntax is valid

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.github/labeler.yml` to add two new label rules so PRs that touch GitHub configuration are auto-labeled more granularly: `ci` for changes under `.github/workflows/**`, and `github` for issue templates and top-level `.github/*.md` / `.github/*.yml` files. This fits into the existing repository-wide labeler configuration, which already maps path globs (e.g., `docs/**`, `scripts/**`, etc.) to labels for triage automation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to path-based labeler rules and matches the existing YAML structure; main risk is only whether the intended globs/label names align with repository conventions.
- .github/labeler.yml (ensure label names/globs match desired labeling behavior)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->