### PR TITLE
fix(dependabot): update OpenClawKit path from legacy MoltbotKit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,9 +64,9 @@ updates:
           - patch
     open-pull-requests-limit: 5
 
-  # Swift Package Manager - shared MoltbotKit
+  # Swift Package Manager - shared OpenClawKit
   - package-ecosystem: swift
-    directory: /apps/shared/MoltbotKit
+    directory: /apps/shared/OpenClawKit
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Summary
Fixes dependabot Swift package monitoring for the shared OpenClawKit library.

## Problem
Dependabot config referenced `/apps/shared/MoltbotKit` which no longer exists - directory was renamed to `/apps/shared/OpenClawKit`.

## Changes
- Updated directory path: `MoltbotKit` → `OpenClawKit`
- Updated comment to match

## Test plan
- [x] Verified `/apps/shared/OpenClawKit` exists
- [x] Dependabot will now correctly monitor Swift dependencies

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Dependabot configuration for Swift Package Manager so it points at the renamed shared library directory (`/apps/shared/OpenClawKit` instead of the legacy `/apps/shared/MoltbotKit`). This aligns Dependabot’s Swift dependency scanning with the current repo layout and should restore monitoring for that shared Swift package alongside the existing entries for `/apps/macos` and `/Swabble`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward path/comment update in `.github/dependabot.yml`, and the target directory exists in the repository, so it should restore Dependabot scanning without affecting runtime code.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->