### PR TITLE
fix(runtime): bump minimum Node.js version to 22.12.0

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -30,7 +30,8 @@ describe("resolvePreferredNodePath", () => {
       throw new Error("missing");
     });
 
-    const execFile = vi.fn().mockResolvedValue({ stdout: "22.1.0\n", stderr: "" });
+    // Node 22.12.0+ is the minimum required version
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.12.0\n", stderr: "" });
 
     const result = await resolvePreferredNodePath({
       env: {},
@@ -51,7 +52,8 @@ describe("resolvePreferredNodePath", () => {
       throw new Error("missing");
     });
 
-    const execFile = vi.fn().mockResolvedValue({ stdout: "18.19.0\n", stderr: "" });
+    // Node 22.11.x is below minimum 22.12.0
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.11.0\n", stderr: "" });
 
     const result = await resolvePreferredNodePath({
       env: {},
@@ -92,7 +94,8 @@ describe("resolveSystemNodeInfo", () => {
       throw new Error("missing");
     });
 
-    const execFile = vi.fn().mockResolvedValue({ stdout: "22.0.0\n", stderr: "" });
+    // Node 22.12.0+ is the minimum required version
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.12.0\n", stderr: "" });
 
     const result = await resolveSystemNodeInfo({
       env: {},
@@ -102,7 +105,7 @@ describe("resolveSystemNodeInfo", () => {
 
     expect(result).toEqual({
       path: darwinNode,
-      version: "22.0.0",
+      version: "22.12.0",
       supported: true,
     });
   });

--- a/src/infra/runtime-guard.test.ts
+++ b/src/infra/runtime-guard.test.ts
@@ -16,13 +16,16 @@ describe("runtime-guard", () => {
   });
 
   it("compares versions correctly", () => {
-    expect(isAtLeast({ major: 22, minor: 0, patch: 0 }, { major: 22, minor: 0, patch: 0 })).toBe(
+    expect(isAtLeast({ major: 22, minor: 12, patch: 0 }, { major: 22, minor: 12, patch: 0 })).toBe(
       true,
     );
-    expect(isAtLeast({ major: 22, minor: 1, patch: 0 }, { major: 22, minor: 0, patch: 0 })).toBe(
+    expect(isAtLeast({ major: 22, minor: 13, patch: 0 }, { major: 22, minor: 12, patch: 0 })).toBe(
       true,
     );
-    expect(isAtLeast({ major: 21, minor: 9, patch: 0 }, { major: 22, minor: 0, patch: 0 })).toBe(
+    expect(isAtLeast({ major: 22, minor: 11, patch: 0 }, { major: 22, minor: 12, patch: 0 })).toBe(
+      false,
+    );
+    expect(isAtLeast({ major: 21, minor: 9, patch: 0 }, { major: 22, minor: 12, patch: 0 })).toBe(
       false,
     );
   });
@@ -30,11 +33,12 @@ describe("runtime-guard", () => {
   it("validates runtime thresholds", () => {
     const nodeOk: RuntimeDetails = {
       kind: "node",
-      version: "22.0.0",
+      version: "22.12.0",
       execPath: "/usr/bin/node",
       pathEnv: "/usr/bin",
     };
-    const nodeOld: RuntimeDetails = { ...nodeOk, version: "21.9.0" };
+    const nodeOld: RuntimeDetails = { ...nodeOk, version: "22.11.0" };
+    const nodeTooOld: RuntimeDetails = { ...nodeOk, version: "21.9.0" };
     const unknown: RuntimeDetails = {
       kind: "unknown",
       version: null,
@@ -43,6 +47,7 @@ describe("runtime-guard", () => {
     };
     expect(runtimeSatisfies(nodeOk)).toBe(true);
     expect(runtimeSatisfies(nodeOld)).toBe(false);
+    expect(runtimeSatisfies(nodeTooOld)).toBe(false);
     expect(runtimeSatisfies(unknown)).toBe(false);
   });
 
@@ -73,7 +78,7 @@ describe("runtime-guard", () => {
     const details: RuntimeDetails = {
       ...detectRuntime(),
       kind: "node",
-      version: "22.0.0",
+      version: "22.12.0",
       execPath: "/usr/bin/node",
     };
     expect(() => assertSupportedRuntime(runtime, details)).not.toThrow();

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -9,7 +9,7 @@ type Semver = {
   patch: number;
 };
 
-const MIN_NODE: Semver = { major: 22, minor: 0, patch: 0 };
+const MIN_NODE: Semver = { major: 22, minor: 12, patch: 0 };
 
 export type RuntimeDetails = {
   kind: RuntimeKind;
@@ -88,7 +88,7 @@ export function assertSupportedRuntime(
 
   runtime.error(
     [
-      "openclaw requires Node >=22.0.0.",
+      "openclaw requires Node >=22.12.0.",
       `Detected: ${runtimeLabel} (exec: ${execLabel}).`,
       `PATH searched: ${details.pathEnv}`,
       "Install Node: https://nodejs.org/en/download",


### PR DESCRIPTION
### Summary
Aligns the runtime guard with the declared `package.json` engines requirement.

### Problem
The Matrix plugin (and potentially others) requires Node >= 22.12.0, but the runtime guard previously allowed 22.0.0+. This caused confusing errors like:

```
Cannot find module '@vector-im/matrix-bot-sdk'
```

...when the real issue was an unsupported Node version (e.g., 22.6.0).

### Changes
- Update `MIN_NODE` from 22.0.0 to 22.12.0 in `src/infra/runtime-guard.ts`
- Update error message to reflect the correct version requirement
- Update tests to validate 22.12.0 as the minimum valid version
- Add test case for versions between 22.0-22.11 (now correctly rejected)

### Testing
```bash
# With Node 22.11 or lower:
openclaw gateway
# Expected: Clear error 'openclaw requires Node >=22.12.0'

# With Node 22.12+:
openclaw gateway
# Expected: Normal startup
```

Fixes #5292
Complements #5302 (docs clarification)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the runtime guard’s minimum supported Node.js version from `22.0.0` to `22.12.0` (`src/infra/runtime-guard.ts`), aligning the CLI’s runtime enforcement with the declared `package.json` engines requirement. The guard’s error message is updated accordingly, and the associated unit tests are adjusted to assert `22.12.0` as the minimum valid version and to reject `22.11.x` and below (`src/infra/runtime-guard.test.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to a constant bump and matching test updates, with no behavioral impact beyond correctly rejecting unsupported Node versions per the repository’s declared engines requirement.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->