### PR TITLE
feat(providers): add moonshot-cn provider and expand Kimi model support

### DIFF
--- a/skills/ddd-cola-java/SKILL.md
+++ b/skills/ddd-cola-java/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: ddd-cola-java
+description: Java COLA Architecture Guide - Alibaba's Clean Object-Oriented and Layered Architecture framework. For DDD layered architecture design, code structure standards, and application architecture refactoring in Java/Spring Boot projects. Triggers on COLA, Java DDD, Spring Boot architecture, layered architecture, clean architecture, hexagonal architecture, onion architecture, code layering, module organization, Gateway pattern, Repository pattern, CQRS, architecture refactoring, separation of concerns, Maven multi-module. Automatically applies COLA directory structure and naming conventions when creating Java files.
+homepage: https://github.com/alibaba/COLA
+metadata: {"openclaw":{"emoji":"☕"}}
+---
+
+# Java COLA Architecture
+
+COLA = Clean Object-Oriented and Layered Architecture
+
+## Layered Architecture
+
+```
+                        ┌─────────────────────────────────────┐
+  Driving Adapter:      │  Browser  │  Scheduler │  MQ        │
+                        └─────────────────────────────────────┘
+                                         ↓
+  VO ←─────────────── ┌─────────────────────────────────────┐
+  (View Object)       │            Adapter Layer             │
+                      │  controller │ scheduler │ consumer   │
+                      └─────────────────────────────────────┘
+                                         ↓
+  DTO ←────────────── ┌─────────────────────────────────────┐
+  (Data Transfer      │              App Layer               │
+   Object)            │       service  │  executor           │
+                      └─────────────────────────────────────┘
+                                         ↓
+  Entity ←─────────── ┌─────────────────────────────────────┐
+                      │            Domain Layer              │
+                      │   gateway │ model │ ability          │
+                      └─────────────────────────────────────┘
+                                         ↑
+  DO ←─────────────── ┌─────────────────────────────────────┐
+  (Data Object)       │        Infrastructure Layer          │
+                      │  gatewayImpl │ mapper │ config       │
+                      └─────────────────────────────────────┘
+                                         ↓
+  Driven Adapter:     │    DB    │   Search   │    RPC      │
+```
+
+### Dependency Direction
+
+```
+Adapter → App → Domain ← Infrastructure
+              ↘      ↙
+               Client
+```
+
+| Layer | Responsibility | Implementation |
+|-------|----------------|----------------|
+| **Adapter** | Receive external requests | Controller, Scheduler, Consumer |
+| **App** | Use case orchestration | ServiceImpl, CmdExe, QryExe |
+| **Domain** | Core business logic | Entity, ValueObject, Gateway, Ability |
+| **Infrastructure** | Technical implementation | GatewayImpl, Mapper, Config |
+| **Client** | DTO definitions | Command, Query, CO, ServiceI |
+
+## Directory Structure
+
+```
+project-name/
+├── project-adapter/          # Controller
+│   └── com/company/project/web/
+├── project-app/              # Service implementation
+│   └── com/company/project/
+│       ├── command/          # *CmdExe.java
+│       │   └── query/        # *QryExe.java
+│       └── service/          # *ServiceImpl.java
+├── project-client/           # API definitions
+│   └── com/company/project/
+│       ├── api/              # *ServiceI.java
+│       └── dto/
+│           ├── command/      # *Cmd.java
+│           ├── query/        # *Qry.java
+│           └── clientobject/ # *CO.java
+├── project-domain/           # Domain layer
+│   └── com/company/project/domain/
+│       ├── {aggregate}/      # Entity, ValueObject
+│       └── gateway/          # *Gateway.java
+├── project-infrastructure/   # Infrastructure
+│   └── com/company/project/
+│       ├── gatewayimpl/      # *GatewayImpl.java
+│       └── convertor/        # *Convertor.java
+└── start/                    # Startup module
+```
+
+## Naming Conventions
+
+| Type | Suffix | Location |
+|------|--------|----------|
+| Command | `Cmd` | client/dto/command |
+| Query | `Qry` | client/dto/query |
+| Command Executor | `CmdExe` | app/command |
+| Query Executor | `QryExe` | app/command/query |
+| Client Object | `CO` | client/dto/clientobject |
+| Data Object | `DO` | infrastructure |
+| Service Interface | `ServiceI` | client/api |
+| Service Implementation | `ServiceImpl` | app/service |
+| Gateway Interface | `Gateway` | domain/gateway |
+| Gateway Implementation | `GatewayImpl` | infrastructure/gatewayimpl |
+| Converter | `Convertor` | infrastructure/convertor |
+
+## Quick Project Setup
+
+COLA provides two Archetypes:
+
+### cola-archetype-web (Web Application)
+
+For web applications with Adapter and backend services together:
+
+```bash
+mvn archetype:generate \
+    -DgroupId=com.company.project \
+    -DartifactId=my-web-app \
+    -Dversion=1.0.0-SNAPSHOT \
+    -Dpackage=com.company.project \
+    -DarchetypeArtifactId=cola-framework-archetype-web \
+    -DarchetypeGroupId=com.alibaba.cola \
+    -DarchetypeVersion=5.0.0
+```
+
+Generated structure:
+```
+my-web-app/
+├── my-web-app-adapter/      # Controller, schedulers, message listeners
+├── my-web-app-app/          # Service implementation, executors
+├── my-web-app-client/       # API interfaces, DTOs
+├── my-web-app-domain/       # Domain models, Gateway interfaces
+├── my-web-app-infrastructure/  # Gateway implementations, Mappers
+└── start/                   # Startup module
+```
+
+### cola-archetype-service (Pure Backend Service)
+
+For pure backend services (no web layer):
+
+```bash
+mvn archetype:generate \
+    -DgroupId=com.company.project \
+    -DartifactId=my-service \
+    -Dversion=1.0.0-SNAPSHOT \
+    -Dpackage=com.company.project \
+    -DarchetypeArtifactId=cola-framework-archetype-service \
+    -DarchetypeGroupId=com.alibaba.cola \
+    -DarchetypeVersion=5.0.0
+```
+
+Generated structure:
+```
+my-service/
+├── my-service-app/          # Service implementation, executors
+├── my-service-client/       # API interfaces, DTOs (for other services to call)
+├── my-service-domain/       # Domain models, Gateway interfaces
+├── my-service-infrastructure/  # Gateway implementations, Mappers
+└── start/                   # Startup module
+```
+
+## COLA Components
+
+| Component | Function |
+|-----------|----------|
+| `cola-component-dto` | Response, Command, Query, PageResponse |
+| `cola-component-exception` | BizException, SysException, ErrorCode |
+| `cola-component-catchlog-starter` | @CatchAndLog exception catching and logging |
+| `cola-component-extension-starter` | Extension point mechanism (multi-business support) |
+| `cola-component-statemachine` | State machine (order flow, etc.) |
+| `cola-component-domain-starter` | Spring-managed domain entities |
+| `cola-component-ruleengine` | Rule engine |
+| `cola-component-test-container` | Test container |
+
+## Code Templates
+
+For detailed code examples, see:
+- **DTO and Response**: [references/dto.md](references/dto.md)
+- **Service and Executors**: [references/service.md](references/service.md)
+- **Gateway Pattern**: [references/gateway.md](references/gateway.md)
+- **COLA Components**: [references/components.md](references/components.md)
+- **Complete Example**: [references/example.md](references/example.md)
+
+## Refactoring Checklist
+
+1. Create adapter/app/client/domain/infrastructure/start modules
+2. Configure Maven dependency relationships
+3. Define Command, Query, CO classes
+4. Create CmdExe/QryExe and ServiceImpl
+5. Define Gateway interfaces and GatewayImpl
+6. Create Convertor converters
+7. Migrate Controllers to adapter/web

--- a/skills/ddd-cola-java/references/components.md
+++ b/skills/ddd-cola-java/references/components.md
@@ -1,0 +1,405 @@
+# COLA Components Guide
+
+## Components Overview
+
+| Component | Maven ArtifactId | Function |
+|-----------|------------------|----------|
+| DTO Component | `cola-component-dto` | Response, Command, Query, PageResponse |
+| Exception Component | `cola-component-exception` | BizException, SysException, ErrorCode |
+| CatchLog Component | `cola-component-catchlog-starter` | @CatchAndLog exception catching and logging |
+| Extension Component | `cola-component-extension-starter` | Extension point mechanism |
+| StateMachine Component | `cola-component-statemachine` | State machine |
+| Domain Component | `cola-component-domain-starter` | Spring-managed domain entities |
+| RuleEngine Component | `cola-component-ruleengine` | Rule engine |
+| Test Component | `cola-component-test-container` | Test container |
+
+---
+
+## 1. DTO Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-dto</artifactId>
+</dependency>
+```
+
+### Response Types
+
+```java
+// Basic response
+Response.buildSuccess();
+Response.buildFailure("ERROR_CODE", "Error message");
+
+// Single object response
+SingleResponse<UserCO> response = SingleResponse.of(userCO);
+
+// Multiple objects response
+MultiResponse<UserCO> response = MultiResponse.of(userList);
+
+// Paginated response
+PageResponse<UserCO> response = PageResponse.of(userList, totalCount, pageSize, pageIndex);
+```
+
+### Command 和 Query
+
+```java
+// Write operation - extends Command
+public class UserAddCmd extends Command {
+    private UserCO userCO;
+}
+
+// Read operation - extends Query
+public class UserListQry extends Query {
+    private String keyword;
+}
+
+// Paginated query - extends PageQuery
+public class UserPageQry extends PageQuery {
+    private String status;
+}
+```
+
+---
+
+## 2. Exception Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-exception</artifactId>
+</dependency>
+```
+
+### Exception Types
+
+```java
+// Business exception - User-understandable errors
+throw new BizException("USER_NOT_FOUND", "User not found");
+
+// System exception - Technical errors
+throw new SysException("DB_ERROR", "Database connection failed");
+```
+
+### Error Code Interface
+
+```java
+public enum ErrorCode implements ErrorCodeI {
+    USER_NOT_FOUND("USER_NOT_FOUND", "User not found"),
+    EMAIL_EXISTS("EMAIL_EXISTS", "Email already exists"),
+    PARAM_ERROR("PARAM_ERROR", "Parameter error");
+    
+    private String errCode;
+    private String errDesc;
+    
+    @Override
+    public String getErrCode() { return errCode; }
+    
+    @Override
+    public String getErrDesc() { return errDesc; }
+}
+
+// Usage
+throw new BizException(ErrorCode.USER_NOT_FOUND);
+```
+
+---
+
+## 3. CatchLog Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-catchlog-starter</artifactId>
+</dependency>
+```
+
+### @CatchAndLog Annotation
+
+```java
+@Service
+@CatchAndLog  // Automatically catch exceptions and log
+public class UserServiceImpl implements UserServiceI {
+    
+    @Override
+    public Response addUser(UserAddCmd cmd) {
+        // BizException → Response.buildFailure()
+        // Other exceptions → Log + System error response
+        return userAddCmdExe.execute(cmd);
+    }
+}
+```
+
+---
+
+## 4. Extension Point Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-extension-starter</artifactId>
+</dependency>
+```
+
+### Define Extension Point
+
+```java
+// Extension point interface
+public interface OrderExtPt extends ExtensionPointI {
+    void beforeCreate(Order order);
+    void afterCreate(Order order);
+    BigDecimal calculateDiscount(Order order);
+}
+```
+
+### Implement Extension Point
+
+```java
+// Normal order extension
+@Extension(bizId = "normalOrder")
+public class NormalOrderExt implements OrderExtPt {
+    @Override
+    public void beforeCreate(Order order) {
+        // Normal order logic
+    }
+    
+    @Override
+    public BigDecimal calculateDiscount(Order order) {
+        return BigDecimal.ZERO;
+    }
+}
+
+// VIP order extension
+@Extension(bizId = "vipOrder")
+public class VipOrderExt implements OrderExtPt {
+    @Override
+    public void beforeCreate(Order order) {
+        // VIP order logic
+    }
+    
+    @Override
+    public BigDecimal calculateDiscount(Order order) {
+        return order.getAmount().multiply(new BigDecimal("0.1")); // 10% discount
+    }
+}
+```
+
+### Use Extension Point
+
+```java
+@Service
+public class OrderServiceImpl {
+    
+    @Autowired
+    private ExtensionExecutor extensionExecutor;
+    
+    public void createOrder(Order order, String bizId) {
+        // Execute extension point (no return value)
+        extensionExecutor.executeVoid(
+            OrderExtPt.class, 
+            BizScenario.valueOf(bizId),
+            ext -> ext.beforeCreate(order)
+        );
+        
+        // Execute extension point (with return value)
+        BigDecimal discount = extensionExecutor.execute(
+            OrderExtPt.class,
+            BizScenario.valueOf(bizId),
+            ext -> ext.calculateDiscount(order)
+        );
+        
+        order.setDiscount(discount);
+        orderRepository.save(order);
+    }
+}
+```
+
+### BizScenario Business Scenario
+
+```java
+// Single dimension
+BizScenario.valueOf("vipOrder");
+
+// Two dimensions: bizId + useCase
+BizScenario.valueOf("vipOrder", "create");
+
+// Three dimensions: bizId + useCase + scenario
+BizScenario.valueOf("vipOrder", "create", "promotion");
+```
+
+---
+
+## 5. StateMachine Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-statemachine</artifactId>
+</dependency>
+```
+
+### Define States and Events
+
+```java
+// State enum
+public enum OrderState {
+    INIT, PAID, SHIPPED, RECEIVED, CANCELLED
+}
+
+// Event enum
+public enum OrderEvent {
+    PAY, SHIP, RECEIVE, CANCEL
+}
+```
+
+### Build State Machine
+
+```java
+@Configuration
+public class OrderStateMachineConfig {
+    
+    @Bean
+    public StateMachine<OrderState, OrderEvent, Order> orderStateMachine() {
+        StateMachineBuilder<OrderState, OrderEvent, Order> builder = 
+            StateMachineBuilderFactory.create();
+        
+        // INIT -> PAID (on PAY)
+        builder.externalTransition()
+            .from(OrderState.INIT)
+            .to(OrderState.PAID)
+            .on(OrderEvent.PAY)
+            .when(this::checkPayCondition)
+            .perform(this::doPayAction);
+        
+        // PAID -> SHIPPED (on SHIP)
+        builder.externalTransition()
+            .from(OrderState.PAID)
+            .to(OrderState.SHIPPED)
+            .on(OrderEvent.SHIP)
+            .perform(this::doShipAction);
+        
+        // SHIPPED -> RECEIVED (on RECEIVE)
+        builder.externalTransition()
+            .from(OrderState.SHIPPED)
+            .to(OrderState.RECEIVED)
+            .on(OrderEvent.RECEIVE)
+            .perform(this::doReceiveAction);
+        
+        // Any state -> CANCELLED (on CANCEL)
+        builder.externalTransitions()
+            .fromAmong(OrderState.INIT, OrderState.PAID)
+            .to(OrderState.CANCELLED)
+            .on(OrderEvent.CANCEL)
+            .perform(this::doCancelAction);
+        
+        return builder.build("orderStateMachine");
+    }
+    
+    private boolean checkPayCondition(Order order) {
+        return order.getAmount().compareTo(BigDecimal.ZERO) > 0;
+    }
+    
+    private void doPayAction(OrderState from, OrderState to, OrderEvent event, Order order) {
+        order.setPaidTime(LocalDateTime.now());
+        log.info("Order {} paid", order.getId());
+    }
+}
+```
+
+### Use State Machine
+
+```java
+@Service
+public class OrderServiceImpl {
+    
+    @Autowired
+    private StateMachine<OrderState, OrderEvent, Order> orderStateMachine;
+    
+    public void payOrder(Order order) {
+        // Trigger state transition
+        OrderState newState = orderStateMachine.fireEvent(
+            order.getState(),  // Current state
+            OrderEvent.PAY,    // Event
+            order              // Context
+        );
+        
+        order.setState(newState);
+        orderRepository.save(order);
+    }
+}
+```
+
+### Internal Transition (State Unchanged)
+
+```java
+// Internal transition: state unchanged, but action executed
+builder.internalTransition()
+    .within(OrderState.PAID)
+    .on(OrderEvent.UPDATE_ADDRESS)
+    .perform(this::doUpdateAddress);
+```
+
+---
+
+## 6. Domain Component
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-domain-starter</artifactId>
+</dependency>
+```
+
+### Spring-Managed Domain Entities
+
+```java
+@Configuration
+@EnableDomainEntity
+public class DomainConfig {
+}
+
+// Domain entities can inject Spring Beans
+@Entity
+public class Order {
+    
+    @Autowired
+    private OrderRepository orderRepository;
+    
+    @Autowired
+    private EventPublisher eventPublisher;
+    
+    public void save() {
+        orderRepository.save(this);
+        eventPublisher.publish(new OrderCreatedEvent(this));
+    }
+}
+```
+
+---
+
+## 7. Maven BOM
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.cola</groupId>
+            <artifactId>cola-components-bom</artifactId>
+            <version>5.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+---
+
+## Component Selection Guide
+
+| Scenario | Recommended Components |
+|----------|------------------------|
+| Basic project | dto + exception + catchlog |
+| Multi-business lines | + extension |
+| Complex state flow | + statemachine |
+| Domain-driven design | + domain |

--- a/skills/ddd-cola-java/references/dto.md
+++ b/skills/ddd-cola-java/references/dto.md
@@ -1,0 +1,105 @@
+# DTO Templates
+
+## Response Base Classes
+
+```java
+// Response - Unified response format
+public class Response extends DTO {
+    private boolean success;
+    private String errCode;
+    private String errMessage;
+    
+    public static Response buildSuccess() {
+        Response response = new Response();
+        response.setSuccess(true);
+        return response;
+    }
+    
+    public static Response buildFailure(String errCode, String errMessage) {
+        Response response = new Response();
+        response.setSuccess(false);
+        response.setErrCode(errCode);
+        response.setErrMessage(errMessage);
+        return response;
+    }
+}
+
+// SingleResponse - Single object response
+public class SingleResponse<T> extends Response {
+    private T data;
+    
+    public static <T> SingleResponse<T> of(T data) {
+        SingleResponse<T> response = new SingleResponse<>();
+        response.setSuccess(true);
+        response.setData(data);
+        return response;
+    }
+}
+
+// MultiResponse - Multiple objects response
+public class MultiResponse<T> extends Response {
+    private Collection<T> data;
+    
+    public static <T> MultiResponse<T> of(Collection<T> data) {
+        MultiResponse<T> response = new MultiResponse<>();
+        response.setSuccess(true);
+        response.setData(data);
+        return response;
+    }
+}
+
+// PageResponse - Paginated response
+public class PageResponse<T> extends Response {
+    private int totalCount;
+    private int pageSize;
+    private int pageIndex;
+    private Collection<T> data;
+}
+```
+
+## Command
+
+```java
+// client/dto/command/UserAddCmd.java
+public class UserAddCmd extends Command {
+    private UserCO userCO;
+    
+    public UserCO getUserCO() { return userCO; }
+    public void setUserCO(UserCO userCO) { this.userCO = userCO; }
+}
+```
+
+## Query
+
+```java
+// client/dto/query/UserListQry.java
+public class UserListQry extends Query {
+    private String keyword;
+    private int pageIndex = 1;
+    private int pageSize = 10;
+    
+    // getters and setters
+}
+```
+
+## Client Object (CO)
+
+```java
+// client/dto/clientobject/UserCO.java
+@Data
+public class UserCO extends DTO {
+    private Long id;
+    private String name;
+    private String email;
+    private String status;
+}
+```
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-dto</artifactId>
+</dependency>
+```

--- a/skills/ddd-cola-java/references/example.md
+++ b/skills/ddd-cola-java/references/example.md
@@ -1,0 +1,178 @@
+# Complete Example: User Management Module
+
+## Controller (Adapter Layer)
+
+```java
+// adapter/web/UserController.java
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    
+    @Autowired
+    private UserServiceI userService;
+    
+    @PostMapping
+    public Response addUser(@RequestBody UserAddCmd cmd) {
+        return userService.addUser(cmd);
+    }
+    
+    @GetMapping
+    public MultiResponse<UserCO> listUsers(UserListQry qry) {
+        return userService.listUsers(qry);
+    }
+    
+    @GetMapping("/{id}")
+    public SingleResponse<UserCO> getUser(@PathVariable Long id) {
+        UserGetQry qry = new UserGetQry();
+        qry.setUserId(id);
+        return userService.getUser(qry);
+    }
+}
+```
+
+## Maven Module Dependencies
+
+```xml
+<!-- Parent POM -->
+<modules>
+    <module>project-adapter</module>
+    <module>project-app</module>
+    <module>project-client</module>
+    <module>project-domain</module>
+    <module>project-infrastructure</module>
+    <module>start</module>
+</modules>
+
+<!-- project-adapter -->
+<dependencies>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-app</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- project-app -->
+<dependencies>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-domain</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-client</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.alibaba.cola</groupId>
+        <artifactId>cola-component-catchlog-starter</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- project-domain -->
+<dependencies>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-client</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- project-infrastructure -->
+<dependencies>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-domain</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- start -->
+<dependencies>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-adapter</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.company</groupId>
+        <artifactId>project-infrastructure</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## COLA BOM
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.cola</groupId>
+            <artifactId>cola-components-bom</artifactId>
+            <version>5.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## Exception Handling
+
+```java
+// Business exception
+throw new BizException("USER_NOT_FOUND", "User not found");
+
+// System exception
+throw new SysException("DATABASE_ERROR", "Database connection failed");
+
+// Using error code enum
+public enum ErrorCode implements ErrorCodeI {
+    USER_NOT_FOUND("USER_NOT_FOUND", "User not found"),
+    EMAIL_EXISTS("EMAIL_EXISTS", "Email already exists");
+    
+    private String errCode;
+    private String errDesc;
+}
+```
+
+## State Machine
+
+```java
+StateMachineBuilder<OrderState, OrderEvent, Order> builder = 
+    StateMachineBuilderFactory.create();
+
+builder.externalTransition()
+    .from(OrderState.CREATED)
+    .to(OrderState.PAID)
+    .on(OrderEvent.PAY)
+    .when(checkCondition())
+    .perform(doAction());
+
+StateMachine<OrderState, OrderEvent, Order> stateMachine = 
+    builder.build("orderStateMachine");
+
+// Trigger state transition
+stateMachine.fireEvent(OrderState.CREATED, OrderEvent.PAY, order);
+```
+
+## Extension Points
+
+```java
+// Define extension point interface
+public interface OrderExtPt extends ExtensionPointI {
+    void beforeCreate(Order order);
+}
+
+// Implement extension point
+@Extension(bizId = "vip", useCase = "order")
+public class VipOrderExt implements OrderExtPt {
+    @Override
+    public void beforeCreate(Order order) {
+        order.applyVipDiscount();
+    }
+}
+
+// Use extension point
+@Autowired
+private ExtensionExecutor extensionExecutor;
+
+extensionExecutor.executeVoid(OrderExtPt.class, 
+    BizScenario.valueOf("vip", "order"), 
+    ext -> ext.beforeCreate(order));
+```

--- a/skills/ddd-cola-java/references/gateway.md
+++ b/skills/ddd-cola-java/references/gateway.md
@@ -1,0 +1,130 @@
+# Gateway Pattern Templates
+
+## Gateway Interface
+
+```java
+// domain/gateway/UserGateway.java
+public interface UserGateway {
+    void save(User user);
+    User getById(Long userId);
+    boolean existsByEmail(String email);
+    List<User> listByCondition(String keyword, int page, int size);
+}
+```
+
+## Gateway Implementation
+
+```java
+// infrastructure/gatewayimpl/UserGatewayImpl.java
+@Component
+public class UserGatewayImpl implements UserGateway {
+    
+    @Autowired
+    private UserMapper userMapper;
+    
+    @Autowired
+    private UserConvertor userConvertor;
+    
+    @Override
+    public void save(User user) {
+        UserDO userDO = userConvertor.toDataObject(user);
+        if (userDO.getId() == null) {
+            userMapper.insert(userDO);
+        } else {
+            userMapper.updateById(userDO);
+        }
+    }
+    
+    @Override
+    public User getById(Long userId) {
+        UserDO userDO = userMapper.selectById(userId);
+        return userConvertor.toDomain(userDO);
+    }
+    
+    @Override
+    public boolean existsByEmail(String email) {
+        return userMapper.countByEmail(email) > 0;
+    }
+    
+    @Override
+    public List<User> listByCondition(String keyword, int page, int size) {
+        List<UserDO> userDOs = userMapper.selectByCondition(keyword, (page - 1) * size, size);
+        return userDOs.stream()
+            .map(userConvertor::toDomain)
+            .collect(Collectors.toList());
+    }
+}
+```
+
+## Convertor
+
+```java
+// infrastructure/convertor/UserConvertor.java
+@Component
+public class UserConvertor {
+    
+    public UserDO toDataObject(User user) {
+        if (user == null) return null;
+        UserDO userDO = new UserDO();
+        BeanUtils.copyProperties(user, userDO);
+        return userDO;
+    }
+    
+    public User toDomain(UserDO userDO) {
+        if (userDO == null) return null;
+        User user = new User();
+        BeanUtils.copyProperties(userDO, user);
+        return user;
+    }
+    
+    public UserCO toClientObject(User user) {
+        if (user == null) return null;
+        UserCO userCO = new UserCO();
+        BeanUtils.copyProperties(user, userCO);
+        return userCO;
+    }
+}
+```
+
+## Domain Entity
+
+```java
+// domain/user/User.java
+@Data
+public class User {
+    private Long id;
+    private String name;
+    private String email;
+    private UserStatus status;
+    
+    // Domain behavior
+    public void activate() {
+        if (this.status == UserStatus.INACTIVE) {
+            this.status = UserStatus.ACTIVE;
+        }
+    }
+    
+    public void deactivate() {
+        this.status = UserStatus.INACTIVE;
+    }
+    
+    public boolean isActive() {
+        return this.status == UserStatus.ACTIVE;
+    }
+}
+```
+
+## Data Object
+
+```java
+// infrastructure/dataobject/UserDO.java
+@Data
+@TableName("users")
+public class UserDO {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String name;
+    private String email;
+    private String status;
+}
+```

--- a/skills/ddd-cola-java/references/service.md
+++ b/skills/ddd-cola-java/references/service.md
@@ -1,0 +1,108 @@
+# Service and Executor Templates
+
+## Service Interface
+
+```java
+// client/api/UserServiceI.java
+public interface UserServiceI {
+    Response addUser(UserAddCmd cmd);
+    SingleResponse<UserCO> getUser(UserGetQry qry);
+    MultiResponse<UserCO> listUsers(UserListQry qry);
+    PageResponse<UserCO> pageUsers(UserPageQry qry);
+}
+```
+
+## Command Executor
+
+```java
+// app/command/UserAddCmdExe.java
+@Component
+public class UserAddCmdExe {
+    
+    @Autowired
+    private UserGateway userGateway;
+    
+    public Response execute(UserAddCmd cmd) {
+        // 1. Parameter validation
+        if (StringUtils.isEmpty(cmd.getUserCO().getEmail())) {
+            return Response.buildFailure("PARAM_ERROR", "Email cannot be empty");
+        }
+        
+        // 2. Business logic check
+        if (userGateway.existsByEmail(cmd.getUserCO().getEmail())) {
+            return Response.buildFailure("EMAIL_EXISTS", "Email already exists");
+        }
+        
+        // 3. Create domain entity
+        User user = new User();
+        BeanUtils.copyProperties(cmd.getUserCO(), user);
+        
+        // 4. Call Gateway to persist
+        userGateway.save(user);
+        
+        return Response.buildSuccess();
+    }
+}
+```
+
+## Query Executor
+
+```java
+// app/command/query/UserListQryExe.java
+@Component
+public class UserListQryExe {
+    
+    @Autowired
+    private UserGateway userGateway;
+    
+    @Autowired
+    private UserConvertor userConvertor;
+    
+    public MultiResponse<UserCO> execute(UserListQry qry) {
+        List<User> users = userGateway.listByCondition(
+            qry.getKeyword(), qry.getPageIndex(), qry.getPageSize()
+        );
+        
+        List<UserCO> userCOs = users.stream()
+            .map(userConvertor::toClientObject)
+            .collect(Collectors.toList());
+        
+        return MultiResponse.of(userCOs);
+    }
+}
+```
+
+## Service Implementation
+
+```java
+// app/service/UserServiceImpl.java
+@Service
+@CatchAndLog  // COLA exception handling annotation
+public class UserServiceImpl implements UserServiceI {
+    
+    @Resource
+    private UserAddCmdExe userAddCmdExe;
+    
+    @Resource
+    private UserListQryExe userListQryExe;
+    
+    @Override
+    public Response addUser(UserAddCmd cmd) {
+        return userAddCmdExe.execute(cmd);
+    }
+    
+    @Override
+    public MultiResponse<UserCO> listUsers(UserListQry qry) {
+        return userListQryExe.execute(qry);
+    }
+}
+```
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cola</groupId>
+    <artifactId>cola-component-catchlog-starter</artifactId>
+</dependency>
+```

--- a/skills/ddd-cola-python/SKILL.md
+++ b/skills/ddd-cola-python/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: ddd-cola-python
+description: Python COLA Architecture Guide - Adapting Alibaba's Clean Object-Oriented and Layered Architecture to Python/Flask/FastAPI projects. For Python backend DDD layered architecture design, code structure standards, and application architecture refactoring. Triggers on Python DDD, Flask architecture, FastAPI architecture, Python layered architecture, clean architecture, hexagonal architecture, onion architecture, COLA, code layering, module organization, Gateway pattern, Repository pattern, CQRS, architecture refactoring, separation of concerns. Automatically applies COLA directory structure and naming conventions when creating Python files.
+homepage: https://github.com/alibaba/COLA
+metadata: {"openclaw":{"emoji":"🐍"}}
+---
+
+# Python COLA Architecture
+
+COLA = Clean Object-Oriented and Layered Architecture
+
+## Layered Architecture
+
+```
+Adapter → Application → Domain ← Infrastructure
+                    ↘      ↙
+                     Client
+```
+
+| Layer | Responsibility | Python Implementation |
+|-------|----------------|----------------------|
+| **Adapter** | Receive external requests | Flask Blueprint / FastAPI Router |
+| **Application** | Use case orchestration | Service, CmdExe, QryExe |
+| **Domain** | Core business logic | Entity, ValueObject, Gateway interface |
+| **Infrastructure** | Technical implementation | Gateway implementation, SQLAlchemy |
+| **Client** | DTO definitions | Command, Query, CO |
+
+## Directory Structure
+
+```
+project/
+├── adapter/routes/           # Flask Blueprint
+├── application/
+│   ├── command/              # *_cmd_exe.py
+│   ├── query/                # *_qry_exe.py
+│   └── service/              # *_service.py
+├── client/
+│   ├── api/                  # *_service_i.py (Protocol)
+│   └── dto/
+│       ├── command/          # *_cmd.py
+│       ├── query/            # *_qry.py
+│       └── co/               # *_co.py
+├── domain/
+│   ├── {aggregate}/          # entity.py, value_object.py
+│   └── gateway/              # *_gateway.py (ABC)
+├── infrastructure/
+│   ├── gateway_impl/         # *_gateway_impl.py
+│   ├── convertor/            # *_convertor.py
+│   └── repository/           # models.py
+└── app.py
+```
+
+## Naming Conventions
+
+| Type | Suffix | Location |
+|------|--------|----------|
+| Command | `_cmd` | client/dto/command |
+| Query | `_qry` | client/dto/query |
+| Command Executor | `_cmd_exe` | application/command |
+| Query Executor | `_qry_exe` | application/query |
+| Client Object | `_co` | client/dto/co |
+| Service Interface | `_service_i` | client/api |
+| Service Implementation | `_service` | application/service |
+| Gateway Interface | `_gateway` | domain/gateway |
+| Gateway Implementation | `_gateway_impl` | infrastructure/gateway_impl |
+| Converter | `_convertor` | infrastructure/convertor |
+
+## Core Principles
+
+1. **Domain layer has no dependencies** (pure Python, no framework dependencies)
+2. **Infrastructure implements Gateway interfaces defined in Domain**
+3. **Client layer is depended on by all layers (DTO definitions)**
+
+## Code Templates
+
+For detailed code examples, see:
+- **Response and DTO**: [references/dto.md](references/dto.md)
+- **Service and Executors**: [references/service.md](references/service.md)
+- **Gateway Pattern**: [references/gateway.md](references/gateway.md)
+- **Complete Example**: [references/example.md](references/example.md)
+
+## Refactoring Checklist
+
+1. Create adapter/application/client/domain/infrastructure packages
+2. Define Response, Command, Query, CO classes
+3. Create CmdExe/QryExe executors and Service
+4. Define Gateway interfaces (ABC) and implementations
+5. Create Convertor converters
+6. Migrate routes to adapter/routes
+
+## Python vs Java Comparison
+
+| Java | Python |
+|------|--------|
+| `interface` | `Protocol` or `ABC` |
+| `@Autowired` | Constructor injection |
+| `@CatchAndLog` | `@catch_and_log` decorator |
+| `@Data` | `@dataclass` |
+| `@RestController` | Flask Blueprint / FastAPI Router |

--- a/skills/ddd-cola-python/references/dto.md
+++ b/skills/ddd-cola-python/references/dto.md
@@ -1,0 +1,89 @@
+# DTO Templates
+
+## Response Base Classes
+
+```python
+# client/dto/response.py
+from dataclasses import dataclass, field
+from typing import TypeVar, Generic, List, Optional
+
+T = TypeVar('T')
+
+@dataclass
+class Response:
+    success: bool = True
+    err_code: Optional[str] = None
+    err_message: Optional[str] = None
+    
+    @classmethod
+    def build_success(cls) -> "Response":
+        return cls(success=True)
+    
+    @classmethod
+    def build_failure(cls, err_code: str, err_message: str) -> "Response":
+        return cls(success=False, err_code=err_code, err_message=err_message)
+
+@dataclass
+class SingleResponse(Response, Generic[T]):
+    data: Optional[T] = None
+    
+    @classmethod
+    def of(cls, data: T) -> "SingleResponse[T]":
+        return cls(success=True, data=data)
+
+@dataclass
+class MultiResponse(Response, Generic[T]):
+    data: List[T] = field(default_factory=list)
+    
+    @classmethod
+    def of(cls, data: List[T]) -> "MultiResponse[T]":
+        return cls(success=True, data=data)
+
+@dataclass
+class PageResponse(Response, Generic[T]):
+    data: List[T] = field(default_factory=list)
+    total_count: int = 0
+    page_size: int = 10
+    page_index: int = 1
+```
+
+## Command
+
+```python
+# client/dto/command/user_add_cmd.py
+from dataclasses import dataclass
+from client.dto.co.user_co import UserCO
+
+@dataclass
+class UserAddCmd:
+    user_co: UserCO
+```
+
+## Query
+
+```python
+# client/dto/query/user_list_qry.py
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class UserListQry:
+    keyword: Optional[str] = None
+    page_index: int = 1
+    page_size: int = 10
+```
+
+## Client Object (CO)
+
+```python
+# client/dto/co/user_co.py
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class UserCO:
+    id: Optional[str] = None
+    name: str = ""
+    email: str = ""
+    status: str = "active"
+```

--- a/skills/ddd-cola-python/references/example.md
+++ b/skills/ddd-cola-python/references/example.md
@@ -1,0 +1,141 @@
+# Complete Example: User Management Module
+
+## Routes (Adapter Layer)
+
+```python
+# adapter/routes/user_routes.py
+from flask import Blueprint, request, jsonify
+from client.dto.command.user_add_cmd import UserAddCmd
+from client.dto.query.user_list_qry import UserListQry
+from client.dto.co.user_co import UserCO
+
+# Dependency injection
+from infrastructure.gateway_impl.user_gateway_impl import UserGatewayImpl
+from infrastructure.convertor.user_convertor import UserConvertor
+from application.command.user_add_cmd_exe import UserAddCmdExe
+from application.query.user_list_qry_exe import UserListQryExe
+from application.service.user_service import UserService
+
+user_gateway = UserGatewayImpl()
+convertor = UserConvertor()
+user_add_cmd_exe = UserAddCmdExe(user_gateway)
+user_list_qry_exe = UserListQryExe(user_gateway, convertor)
+user_service = UserService(user_add_cmd_exe, user_list_qry_exe)
+
+user_bp = Blueprint('user', __name__, url_prefix='/api/users')
+
+@user_bp.route('', methods=['POST'])
+def add_user():
+    data = request.get_json()
+    user_co = UserCO(name=data.get('name', ''), email=data.get('email', ''))
+    cmd = UserAddCmd(user_co=user_co)
+    response = user_service.add_user(cmd)
+    return jsonify({"success": response.success, "errCode": response.err_code, "errMessage": response.err_message})
+
+@user_bp.route('', methods=['GET'])
+def list_users():
+    qry = UserListQry(
+        keyword=request.args.get('keyword'),
+        page_index=int(request.args.get('page', 1)),
+        page_size=int(request.args.get('size', 10)),
+    )
+    response = user_service.list_users(qry)
+    return jsonify({"success": response.success, "data": [vars(co) for co in response.data]})
+```
+
+## Data Models (Infrastructure)
+
+```python
+# infrastructure/repository/models.py
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+class UserDO(db.Model):
+    __tablename__ = 'users'
+    
+    id = db.Column(db.String(36), primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    email = db.Column(db.String(100), unique=True, nullable=False)
+    status = db.Column(db.String(20), default='active')
+```
+
+## Application Entry Point
+
+```python
+# app.py
+from flask import Flask
+from infrastructure.repository.models import db
+from adapter.routes.user_routes import user_bp
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+
+db.init_app(app)
+app.register_blueprint(user_bp)
+
+with app.app_context():
+    db.create_all()
+
+if __name__ == '__main__':
+    app.run(debug=True)
+```
+
+## Directory Structure
+
+```
+project/
+├── adapter/
+│   ├── __init__.py
+│   └── routes/
+│       ├── __init__.py
+│       └── user_routes.py
+├── application/
+│   ├── __init__.py
+│   ├── command/
+│   │   ├── __init__.py
+│   │   └── user_add_cmd_exe.py
+│   ├── query/
+│   │   ├── __init__.py
+│   │   └── user_list_qry_exe.py
+│   └── service/
+│       ├── __init__.py
+│       └── user_service.py
+├── client/
+│   ├── __init__.py
+│   ├── api/
+│   │   ├── __init__.py
+│   │   └── user_service_i.py
+│   └── dto/
+│       ├── __init__.py
+│       ├── response.py
+│       ├── command/
+│       │   ├── __init__.py
+│       │   └── user_add_cmd.py
+│       ├── query/
+│       │   ├── __init__.py
+│       │   └── user_list_qry.py
+│       └── co/
+│           ├── __init__.py
+│           └── user_co.py
+├── domain/
+│   ├── __init__.py
+│   ├── user/
+│   │   ├── __init__.py
+│   │   └── entity.py
+│   └── gateway/
+│       ├── __init__.py
+│       └── user_gateway.py
+├── infrastructure/
+│   ├── __init__.py
+│   ├── gateway_impl/
+│   │   ├── __init__.py
+│   │   └── user_gateway_impl.py
+│   ├── convertor/
+│   │   ├── __init__.py
+│   │   └── user_convertor.py
+│   └── repository/
+│       ├── __init__.py
+│       └── models.py
+└── app.py
+```

--- a/skills/ddd-cola-python/references/gateway.md
+++ b/skills/ddd-cola-python/references/gateway.md
@@ -1,0 +1,104 @@
+# Gateway Pattern Templates
+
+## Gateway Interface (ABC)
+
+```python
+# domain/gateway/user_gateway.py
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from domain.user.entity import User
+
+class UserGateway(ABC):
+    """User Gateway Interface - Defined in Domain layer"""
+    
+    @abstractmethod
+    def save(self, user: User) -> None:
+        pass
+    
+    @abstractmethod
+    def get_by_id(self, user_id: str) -> Optional[User]:
+        pass
+    
+    @abstractmethod
+    def exists_by_email(self, email: str) -> bool:
+        pass
+    
+    @abstractmethod
+    def list_by_condition(self, keyword: str = None, page: int = 1, size: int = 10) -> List[User]:
+        pass
+```
+
+## Gateway Implementation
+
+```python
+# infrastructure/gateway_impl/user_gateway_impl.py
+from typing import List, Optional
+from domain.gateway.user_gateway import UserGateway
+from domain.user.entity import User
+from infrastructure.convertor.user_convertor import UserConvertor
+from infrastructure.repository.models import UserDO, db
+
+class UserGatewayImpl(UserGateway):
+    def __init__(self):
+        self.convertor = UserConvertor()
+    
+    def save(self, user: User) -> None:
+        user_do = self.convertor.to_data_object(user)
+        db.session.add(user_do)
+        db.session.commit()
+    
+    def get_by_id(self, user_id: str) -> Optional[User]:
+        user_do = UserDO.query.get(user_id)
+        return self.convertor.to_domain(user_do) if user_do else None
+    
+    def exists_by_email(self, email: str) -> bool:
+        return UserDO.query.filter_by(email=email).count() > 0
+    
+    def list_by_condition(self, keyword: str = None, page: int = 1, size: int = 10) -> List[User]:
+        query = UserDO.query
+        if keyword:
+            query = query.filter(UserDO.name.contains(keyword))
+        user_dos = query.offset((page - 1) * size).limit(size).all()
+        return [self.convertor.to_domain(do) for do in user_dos]
+```
+
+## Convertor
+
+```python
+# infrastructure/convertor/user_convertor.py
+from domain.user.entity import User
+from client.dto.co.user_co import UserCO
+from infrastructure.repository.models import UserDO
+
+class UserConvertor:
+    def to_data_object(self, user: User) -> UserDO:
+        return UserDO(id=user.id, name=user.name, email=user.email, status=user.status)
+    
+    def to_domain(self, user_do: UserDO) -> User:
+        return User(id=user_do.id, name=user_do.name, email=user_do.email, status=user_do.status)
+    
+    def to_client_object(self, user: User) -> UserCO:
+        return UserCO(id=user.id, name=user.name, email=user.email, status=user.status)
+```
+
+## Domain Entity
+
+```python
+# domain/user/entity.py
+from dataclasses import dataclass, field
+import uuid
+
+@dataclass
+class User:
+    name: str
+    email: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    status: str = "active"
+    
+    def activate(self) -> None:
+        if self.status == "inactive":
+            self.status = "active"
+    
+    def deactivate(self) -> None:
+        self.status = "inactive"
+```

--- a/skills/ddd-cola-python/references/service.md
+++ b/skills/ddd-cola-python/references/service.md
@@ -1,0 +1,100 @@
+# Service and Executor Templates
+
+## Service Interface (Protocol)
+
+```python
+# client/api/user_service_i.py
+from typing import Protocol
+from client.dto.response import Response, SingleResponse, MultiResponse
+from client.dto.command.user_add_cmd import UserAddCmd
+from client.dto.query.user_list_qry import UserListQry
+from client.dto.co.user_co import UserCO
+
+class UserServiceI(Protocol):
+    def add_user(self, cmd: UserAddCmd) -> Response: ...
+    def get_user(self, user_id: str) -> SingleResponse[UserCO]: ...
+    def list_users(self, qry: UserListQry) -> MultiResponse[UserCO]: ...
+```
+
+## Command Executor
+
+```python
+# application/command/user_add_cmd_exe.py
+from client.dto.command.user_add_cmd import UserAddCmd
+from client.dto.response import Response
+from domain.gateway.user_gateway import UserGateway
+from domain.user.entity import User
+
+class UserAddCmdExe:
+    def __init__(self, user_gateway: UserGateway):
+        self.user_gateway = user_gateway
+    
+    def execute(self, cmd: UserAddCmd) -> Response:
+        if not cmd.user_co.email:
+            return Response.build_failure("PARAM_ERROR", "Email cannot be empty")
+        
+        if self.user_gateway.exists_by_email(cmd.user_co.email):
+            return Response.build_failure("EMAIL_EXISTS", "Email already exists")
+        
+        user = User(name=cmd.user_co.name, email=cmd.user_co.email)
+        self.user_gateway.save(user)
+        return Response.build_success()
+```
+
+## Query Executor
+
+```python
+# application/query/user_list_qry_exe.py
+from client.dto.query.user_list_qry import UserListQry
+from client.dto.response import MultiResponse
+from client.dto.co.user_co import UserCO
+from domain.gateway.user_gateway import UserGateway
+from infrastructure.convertor.user_convertor import UserConvertor
+
+class UserListQryExe:
+    def __init__(self, user_gateway: UserGateway, convertor: UserConvertor):
+        self.user_gateway = user_gateway
+        self.convertor = convertor
+    
+    def execute(self, qry: UserListQry) -> MultiResponse[UserCO]:
+        users = self.user_gateway.list_by_condition(
+            qry.keyword, qry.page_index, qry.page_size
+        )
+        user_cos = [self.convertor.to_client_object(u) for u in users]
+        return MultiResponse.of(user_cos)
+```
+
+## Service Implementation
+
+```python
+# application/service/user_service.py
+from functools import wraps
+import logging
+from client.dto.response import Response
+
+logger = logging.getLogger(__name__)
+
+def catch_and_log(func):
+    """Exception catching decorator (equivalent to Java @CatchAndLog)"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.exception(f"Error in {func.__name__}: {e}")
+            return Response.build_failure("SYSTEM_ERROR", str(e))
+    return wrapper
+
+class UserService:
+    def __init__(self, user_add_cmd_exe, user_list_qry_exe):
+        self.user_add_cmd_exe = user_add_cmd_exe
+        self.user_list_qry_exe = user_list_qry_exe
+    
+    @catch_and_log
+    def add_user(self, cmd):
+        return self.user_add_cmd_exe.execute(cmd)
+    
+    @catch_and_log
+    def list_users(self, qry):
+        return self.user_list_qry_exe.execute(qry)
+```

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -279,6 +279,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     openrouter: "OPENROUTER_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
+    "moonshot-cn": "MOONSHOT_CN_API_KEY",
     "kimi-code": "KIMICODE_API_KEY",
     minimax: "MINIMAX_API_KEY",
     xiaomi: "XIAOMI_API_KEY",

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -42,13 +42,32 @@ const XIAOMI_DEFAULT_COST = {
 };
 
 const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
+const MOONSHOT_CN_BASE_URL = "https://api.moonshot.cn/v1";
 const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2.5";
-const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
-const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
+const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 262144;
+const MOONSHOT_DEFAULT_MAX_TOKENS = 262144;
 const MOONSHOT_DEFAULT_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
+  input: 0.6,
+  output: 2.5,
+  cacheRead: 0.15,
+  cacheWrite: 0,
+};
+const MOONSHOT_THINKING_COST = {
+  input: 0.6,
+  output: 2.5,
+  cacheRead: 0.15,
+  cacheWrite: 0,
+};
+const MOONSHOT_THINKING_TURBO_COST = {
+  input: 1.15,
+  output: 8,
+  cacheRead: 0.15,
+  cacheWrite: 0,
+};
+const MOONSHOT_TURBO_COST = {
+  input: 2.4,
+  output: 10,
+  cacheRead: 0.6,
   cacheWrite: 0,
 };
 const KIMI_CODE_BASE_URL = "https://api.kimi.com/coding/v1";
@@ -279,21 +298,78 @@ function buildMinimaxProvider(): ProviderConfig {
   };
 }
 
+function buildMoonshotModels(): ProviderConfig["models"] {
+  return [
+    {
+      id: "kimi-k2.5",
+      name: "Kimi K2.5",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: MOONSHOT_DEFAULT_COST,
+      contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+    },
+    {
+      id: "kimi-k2-thinking",
+      name: "Kimi K2 Thinking",
+      reasoning: true,
+      input: ["text"],
+      cost: MOONSHOT_THINKING_COST,
+      contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+    },
+    {
+      id: "kimi-k2-thinking-turbo",
+      name: "Kimi K2 Thinking Turbo",
+      reasoning: true,
+      input: ["text"],
+      cost: MOONSHOT_THINKING_TURBO_COST,
+      contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+    },
+    {
+      id: "kimi-k2-0905-preview",
+      name: "Kimi K2 0905",
+      reasoning: false,
+      input: ["text"],
+      cost: MOONSHOT_DEFAULT_COST,
+      contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+    },
+    {
+      id: "kimi-k2-0711-preview",
+      name: "Kimi K2 0711",
+      reasoning: false,
+      input: ["text"],
+      cost: MOONSHOT_DEFAULT_COST,
+      contextWindow: 131072,
+      maxTokens: 16384,
+    },
+    {
+      id: "kimi-k2-turbo-preview",
+      name: "Kimi K2 Turbo",
+      reasoning: false,
+      input: ["text"],
+      cost: MOONSHOT_TURBO_COST,
+      contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+    },
+  ];
+}
+
 function buildMoonshotProvider(): ProviderConfig {
   return {
     baseUrl: MOONSHOT_BASE_URL,
     api: "openai-completions",
-    models: [
-      {
-        id: MOONSHOT_DEFAULT_MODEL_ID,
-        name: "Kimi K2.5",
-        reasoning: false,
-        input: ["text"],
-        cost: MOONSHOT_DEFAULT_COST,
-        contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
-      },
-    ],
+    models: buildMoonshotModels(),
+  };
+}
+
+function buildMoonshotCnProvider(): ProviderConfig {
+  return {
+    baseUrl: MOONSHOT_CN_BASE_URL,
+    api: "openai-completions",
+    models: buildMoonshotModels(),
   };
 }
 
@@ -408,6 +484,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
     providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+  }
+
+  const moonshotCnKey =
+    resolveEnvApiKeyVarName("moonshot-cn") ??
+    resolveApiKeyFromProfiles({ provider: "moonshot-cn", store: authStore });
+  if (moonshotCnKey) {
+    providers["moonshot-cn"] = { ...buildMoonshotCnProvider(), apiKey: moonshotCnKey };
   }
 
   const kimiCodeKey =


### PR DESCRIPTION
## Summary

Add support for Moonshot China API endpoint and expand Kimi model coverage.

Closes #5321

## Changes

### New Provider
- **moonshot-cn**: `https://api.moonshot.cn/v1` (China endpoint)
- Environment variable: `MOONSHOT_CN_API_KEY`

### New Models (for both moonshot and moonshot-cn)
| Model ID | Name | Features |
|----------|------|----------|
| `kimi-k2.5` | Kimi K2.5 | multimodal (image), reasoning |
| `kimi-k2-thinking` | Kimi K2 Thinking | reasoning |
| `kimi-k2-thinking-turbo` | Kimi K2 Thinking Turbo | reasoning |
| `kimi-k2-0905-preview` | Kimi K2 0905 | - |
| `kimi-k2-0711-preview` | Kimi K2 0711 | - |
| `kimi-k2-turbo-preview` | Kimi K2 Turbo | - |

## Testing

All models tested successfully against `api.moonshot.cn`:
```
Testing kimi-k2.5...        ✅ OK
Testing kimi-k2-thinking... ✅ OK
Testing kimi-k2-thinking-turbo... ✅ OK
Testing kimi-k2-0905-preview... ✅ OK
Testing kimi-k2-0711-preview... ✅ OK
Testing kimi-k2-turbo-preview... ✅ OK
```

## API Documentation

- https://platform.moonshot.cn/docs/api/chat
- https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the built-in Moonshot provider configuration by adding a `moonshot-cn` variant pointing at the China endpoint and expanding the Moonshot model catalog to include multiple Kimi K2 variants, along with updated default context/token limits and pricing metadata. It also wires a new `MOONSHOT_CN_API_KEY` env var into the provider auth resolution so the new provider can be auto-configured from env/auth profiles.

Overall the integration follows existing implicit-provider patterns (env/profile lookup, provider config builders). The main things to double-check are the updated `maxTokens` defaults and per-model capability flags, since incorrect defaults here can cause request failures or runtime errors when the client auto-populates these fields.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of configuration defaults that could cause runtime request failures if they don’t match Moonshot’s actual limits/capabilities.
- Changes are localized to provider/auth config and follow existing patterns, but `maxTokens` was raised to the full context window and model capability flags were broadened; if these don’t match the upstream API, users may hit errors with default settings.
- src/agents/models-config.providers.ts (Moonshot defaults and per-model capabilities)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->