### PR TITLE
fix(swiftlint): update OpenClawProtocol path from legacy MoltbotProtocol

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,7 +18,7 @@ excluded:
   - coverage
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
-  - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  - apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
 
 analyzer_rules:
   - unused_declaration


### PR DESCRIPTION
## Summary
Fixes SwiftLint exclusion path for generated GatewayModels.swift.

## Problem
The exclusion path referenced `MoltbotProtocol` which no longer exists - directory was renamed to `OpenClawProtocol`.

## Changes
- Updated path: `MoltbotProtocol` → `OpenClawProtocol`

## Test plan
- [x] Verified `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift` exists

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the SwiftLint configuration to keep excluding the generated `GatewayModels.swift` file after the protocol module directory rename from `MoltbotProtocol` to `OpenClawProtocol`.

The change fits into the repo by maintaining lint signal quality in `apps/macos/Sources` (avoiding lint failures/noise from generated Swift code) while aligning `.swiftlint.yml` with the current on-disk module layout.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line config update that corrects an exclusion path; no production code changes and the new path matches the current macOS sources layout described in the PR.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->