### PR TITLE
feat(providers): add moonshot-cn provider and expand Kimi model support

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -295,6 +295,8 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     openrouter: "OPENROUTER_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
+    "moonshot-cn": "MOONSHOT_CN_API_KEY",
+    "kimi-code": "KIMICODE_API_KEY",
     minimax: "MINIMAX_API_KEY",
     xiaomi: "XIAOMI_API_KEY",
     synthetic: "SYNTHETIC_API_KEY",


### PR DESCRIPTION
## Summary

Add support for Moonshot China API endpoint and expand Kimi model coverage.

Closes #5321

## Changes

### New Provider
- **moonshot-cn**: `https://api.moonshot.cn/v1` (China endpoint)
- Environment variable: `MOONSHOT_CN_API_KEY`

### New Models (for both moonshot and moonshot-cn)
| Model ID | Name | Features |
|----------|------|----------|
| `kimi-k2.5` | Kimi K2.5 | multimodal (image), reasoning |
| `kimi-k2-thinking` | Kimi K2 Thinking | reasoning |
| `kimi-k2-thinking-turbo` | Kimi K2 Thinking Turbo | reasoning |
| `kimi-k2-0905-preview` | Kimi K2 0905 | - |
| `kimi-k2-0711-preview` | Kimi K2 0711 | - |
| `kimi-k2-turbo-preview` | Kimi K2 Turbo | - |

## Testing

All models tested successfully against `api.moonshot.cn`:
```
Testing kimi-k2.5...        ✅ OK
Testing kimi-k2-thinking... ✅ OK
Testing kimi-k2-thinking-turbo... ✅ OK
Testing kimi-k2-0905-preview... ✅ OK
Testing kimi-k2-0711-preview... ✅ OK
Testing kimi-k2-turbo-preview... ✅ OK
```

## API Documentation

- https://platform.moonshot.cn/docs/api/chat
- https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `moonshot-cn` provider (China endpoint) with its own env var (`MOONSHOT_CN_API_KEY`) and expands the Moonshot model catalog from a single default model to multiple Kimi K2 variants via a shared `buildMoonshotModels()` helper.

The changes integrate into the existing provider auto-discovery flow (`resolveImplicitProviders`) so the providers are automatically available when the corresponding env var or auth profile is present.

<h3>Confidence Score: 3/5</h3>

- Likely safe to merge, but the new Moonshot defaults may cause avoidable request failures depending on how `maxTokens`, `reasoning`, and `input` flags are enforced downstream.
- Provider/ENV wiring is straightforward and localized. Main concerns are the new Moonshot defaults: setting `maxTokens` equal to the full context window and enabling reasoning+vision on the default model could trigger API-side validation errors or change request formatting for existing users.
- src/agents/models-config.providers.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->