### PR TITLE
fix(compaction): include recent messages as fallback when summary unavailable

### DIFF
--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -139,4 +139,4 @@ Note: Moonshot and Kimi Coding are separate providers. Keys are not interchangea
 - Override pricing and context metadata in `models.providers` if needed.
 - If Moonshot publishes different context limits for a model, adjust
   `contextWindow` accordingly.
-- Use `https://api.moonshot.cn/v1` if you need the China endpoint.
+- Use `https://api.moonshot.ai/v1` for the international endpoint, and `https://api.moonshot.cn/v1` for the China endpoint.

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -139,4 +139,4 @@ Note: Moonshot and Kimi Coding are separate providers. Keys are not interchangea
 - Override pricing and context metadata in `models.providers` if needed.
 - If Moonshot publishes different context limits for a model, adjust
   `contextWindow` accordingly.
-- Use `https://api.moonshot.ai/v1` for the international endpoint, and `https://api.moonshot.cn/v1` for the China endpoint.
+- Use `https://api.moonshot.cn/v1` if you need the China endpoint.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -193,6 +193,12 @@ function extractMessageText(content: unknown): string {
   if (typeof content === "string") {
     return content;
   }
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const rec = content as { type?: unknown; text?: unknown };
+    if (rec.type === "text" && typeof rec.text === "string") {
+      return rec.text;
+    }
+  }
   if (!Array.isArray(content)) {
     return "";
   }
@@ -226,7 +232,7 @@ function formatRecentMessagesSection(messages: AgentMessage[]): string {
       continue;
     }
     if (text.length > MAX_MESSAGE_PREVIEW_CHARS) {
-      text = `${text.slice(0, MAX_MESSAGE_PREVIEW_CHARS)}...`;
+      text = `${text.slice(0, Math.max(0, MAX_MESSAGE_PREVIEW_CHARS - 3))}...`;
     }
     const label = role === "user" ? "**User**" : "**Assistant**";
     lines.push(`${label}: ${text.replace(/\n/g, " ").trim()}`);
@@ -430,6 +436,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 export const __testing = {
   collectToolFailures,
   formatToolFailuresSection,
+  formatRecentMessagesSection,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
   BASE_CHUNK_RATIO,


### PR DESCRIPTION
### Summary

When compaction summarization fails, include the last 10 messages as fallback context instead of leaving the agent with zero history.

### Problem

When auto-compaction triggers but summarization fails (no model available, no API key, or summarization error), the agent receives:

```
Summary unavailable due to context limits. Older messages were truncated.
```

This is effectively a **complete memory wipe** — the agent loses all context from before compaction and has no idea what was being discussed.

### Solution

Add a fallback that includes the last 10 messages from the conversation being compacted:

```
Summary unavailable due to context limits. Older messages were truncated.

## Recent Messages (fallback context)
**User**: Hey, can you help me with the billing system refactor?

**Assistant**: Of course! I see you want to refactor the billing module...

**User**: Yes, specifically the invoice generation part...
```

This ensures the model **never loses ALL context** — at minimum it has the most recent exchanges to continue the conversation coherently.

### Implementation Details

- Added `FALLBACK_RECENT_MESSAGES = 10` constant (configurable)
- Added `MAX_MESSAGE_PREVIEW_CHARS = 500` to keep fallback compact
- Added `extractMessageText()` to handle both string and block content
- Added `formatRecentMessagesSection()` to format the fallback
- Fallback includes only user/assistant messages (skips tool results)
- Newlines in messages are collapsed to spaces for readability

### Changes

```
src/agents/pi-extensions/compaction-safeguard.ts | +52/-1
```

Fixes #5224

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the compaction safeguard so that when summarization can’t run (e.g., no model/API key or summarization errors), the fallback summary includes a small “Recent Messages” section (last ~10 user/assistant messages) in addition to existing tool-failure and file-ops context. This avoids a hard context wipe when compaction occurs but summarization is unavailable, helping the agent continue the conversation coherently.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves degraded-mode behavior, with a small correctness concern around message content shapes.
- Changes are localized to fallback-summary formatting and don’t affect the normal summarization path. The main risk is that the fallback may omit messages if `AgentMessage.content` can be a single object block (not string/array), and the preview truncation slightly exceeds the configured cap.
- src/agents/pi-extensions/compaction-safeguard.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->