### PR TITLE
fix: compare base64 string length instead of decoded bytes for image size limit

### DIFF
--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -145,7 +145,6 @@ async function resizeImageBase64IfNeeded(params: {
     }
   }
 
-  const bestBase64 = smallest?.base64 ?? params.base64;
   const bestSize = smallest?.size ?? base64Length;
   const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
   const gotMb = (bestSize / (1024 * 1024)).toFixed(2);


### PR DESCRIPTION
## Summary

The Anthropic API enforces the 5MB limit on the **base64 string**, not the decoded binary. Base64 encoding inflates data by ~33%, so an image with decoded size 4MB produces a base64 string of ~5.3MB, which would pass the previous check but get rejected by the API.

## Problem

From issue #5344:
- `resizeImageBase64IfNeeded` compared `buf.byteLength` (decoded bytes) against `MAX_IMAGE_BYTES`
- An image between ~3.75MB and 5MB decoded would pass the check
- The resulting base64 string (>5MB) would be rejected by Anthropic's API
- Once the oversized image is in session history, **all subsequent messages fail**

## Fix

- Compare `params.base64.length` instead of `buf.byteLength`
- Update the resize loop to convert to base64 first before comparing size
- Add a test case specifically for this edge case

## Testing

- Added test: "resizes images where decoded bytes < limit but base64 string > limit"
- All existing tests pass

Fixes #5344

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates image sanitization so the size limit is enforced against the *base64 string length* (matching Anthropic’s 5MB check) rather than decoded byte length. The resize loop now encodes candidate JPEG outputs to base64 before comparing against the limit, and a new test covers the edge case where decoded bytes are under 5MB but base64 exceeds it.

This fits into the existing `sanitizeContentBlocksImages` pipeline by ensuring images that would otherwise poison a session history (oversized base64 payloads) get downscaled/recompressed before being sent onward.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and add test coverage, with a couple of correctness/robustness concerns.
- The core change (checking base64 length instead of decoded bytes) matches the stated API constraint and is implemented consistently through the resize loop. Main residual concerns are (1) using `.length` as a byte proxy and (2) minor dead/unused variable and potential test flakiness, none of which should break most runtimes but are worth tightening.
- src/agents/tool-images.ts (size calculation semantics), src/agents/tool-images.test.ts (test determinism)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->