### PR TITLE
docs(canvas): update path from legacy __moltbot__ to __openclaw__

### DIFF
--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -40,7 +40,7 @@ The canvas host server binds based on `gateway.bind` setting:
 **Key insight:** The `canvasHostHostForBridge` is derived from `bridgeHost`. When bound to Tailscale, nodes receive URLs like:
 
 ```
-http://<tailscale-hostname>:18793/__moltbot__/canvas/<file>.html
+http://<tailscale-hostname>:18793/__openclaw__/canvas/<file>.html
 ```
 
 This is why localhost URLs don't work - the node receives the Tailscale hostname from the bridge!
@@ -111,8 +111,8 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 
 Then construct the URL:
 
-- **loopback**: `http://127.0.0.1:18793/__moltbot__/canvas/<file>.html`
-- **lan/tailnet/auto**: `http://<hostname>:18793/__moltbot__/canvas/<file>.html`
+- **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
+- **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 
 Find your Tailscale hostname:
 
@@ -137,7 +137,7 @@ canvas action:present node:<node-id> target:<full-url>
 **Example:**
 
 ```
-canvas action:present node:mac-63599bc4-b54d-4392-9048-b97abd58343a target:http://peters-mac-studio-1.sheep-coho.ts.net:18793/__moltbot__/canvas/snake.html
+canvas action:present node:mac-63599bc4-b54d-4392-9048-b97abd58343a target:http://peters-mac-studio-1.sheep-coho.ts.net:18793/__openclaw__/canvas/snake.html
 ```
 
 ### 5. Navigate, snapshot, or hide
@@ -158,7 +158,7 @@ canvas action:hide node:<node-id>
 
 1. Check server bind: `cat ~/.openclaw/openclaw.json | jq '.gateway.bind'`
 2. Check what port canvas is on: `lsof -i :18793`
-3. Test URL directly: `curl http://<hostname>:18793/__moltbot__/canvas/<file>.html`
+3. Test URL directly: `curl http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 
 **Solution:** Use the full hostname matching your bind mode, not localhost.
 
@@ -180,14 +180,14 @@ If live reload isn't working:
 
 ## URL Path Structure
 
-The canvas host serves from `/__moltbot__/canvas/` prefix:
+The canvas host serves from `/__openclaw__/canvas/` prefix:
 
 ```
-http://<host>:18793/__moltbot__/canvas/index.html  → ~/clawd/canvas/index.html
-http://<host>:18793/__moltbot__/canvas/games/snake.html → ~/clawd/canvas/games/snake.html
+http://<host>:18793/__openclaw__/canvas/index.html  → ~/clawd/canvas/index.html
+http://<host>:18793/__openclaw__/canvas/games/snake.html → ~/clawd/canvas/games/snake.html
 ```
 
-The `/__moltbot__/canvas/` prefix is defined by `CANVAS_HOST_PATH` constant.
+The `/__openclaw__/canvas/` prefix is defined by `CANVAS_HOST_PATH` constant.
 
 ## Tips
 


### PR DESCRIPTION
## Summary
Fixes remaining legacy path references in canvas skill documentation.

## Problem
Most `__moltbot__` references were updated upstream, but two occurrences in the "Find your canvas host URL" section were missed. The actual code path is `/__openclaw__/canvas/` (defined in `src/canvas-host/a2ui.ts`).

## Changes
- Updated 2 remaining URL path references: `__moltbot__` → `__openclaw__`

## Test plan
- [x] Verified `CANVAS_HOST_PATH` in code is `/__openclaw__/canvas`
- [x] Rebased on latest main to resolve conflicts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Canvas skill documentation to reflect the current `CANVAS_HOST_PATH` prefix used by the canvas host server (`/__openclaw__/canvas`), replacing remaining legacy `__moltbot__` path examples in URL snippets and troubleshooting steps. This keeps the docs consistent with the runtime paths defined in `src/canvas-host/a2ui.ts` and avoids users constructing URLs that won’t resolve on the canvas host.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, consistent docs-only update.
- Changes are limited to string updates in documentation to match the current `CANVAS_HOST_PATH` (`/__openclaw__/canvas`) already defined in code. No behavioral changes or risky refactors were introduced, and the updated examples appear internally consistent across the doc.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->