### PR TITLE
docs: fix URLs from openclaw.bot to openclaw.ai

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -541,13 +541,13 @@ upgrades in place and rewrites the gateway service to point at the new install.
 Switch **to git install**:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git --no-onboard
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git --no-onboard
 ```
 
 Switch **to npm global**:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 Notes:

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -274,7 +274,7 @@ setup (PATH, services, permissions, auth files). Give them the **full source che
 the hackable (git) install:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
 ```
 
 This installs OpenClaw **from a git checkout**, so the agent can read the code + docs and
@@ -313,7 +313,7 @@ Install docs: [Install](/install), [Installer flags](/install/installer), [Updat
 The repo recommends running from source and using the onboarding wizard:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 openclaw onboard --install-daemon
 ```
 
@@ -470,11 +470,11 @@ https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md
 One‑liners (macOS/Linux):
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.bot/install.sh | bash -s -- --beta
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --beta
 ```
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.bot/install.sh | bash -s -- --install-method git
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --install-method git
 ```
 
 Windows installer (PowerShell):
@@ -507,7 +507,7 @@ This switches to the `main` branch and updates from source.
 2. **Hackable install (from the installer site):**
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
 ```
 
 That gives you a local repo you can edit, then update via git.
@@ -529,19 +529,19 @@ Docs: [Update](/cli/update), [Development channels](/install/development-channel
 Re-run the installer with **verbose output**:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --verbose
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --verbose
 ```
 
 Beta install with verbose:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --beta --verbose
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --beta --verbose
 ```
 
 For a hackable (git) install:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git --verbose
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git --verbose
 ```
 
 More options: [Installer flags](/install/installer).
@@ -574,7 +574,7 @@ Use the **hackable (git) install** so you have the full source and docs locally,
 your bot (or Claude/Codex) _from that folder_ so it can read the repo and answer precisely.
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
 ```
 
 More detail: [Install](/install) and [Installer flags](/install/installer).

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -39,13 +39,13 @@ Almost always a Node/npm PATH issue. Start here:
 Re-run the installer in verbose mode to see the full trace and npm output:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --verbose
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --verbose
 ```
 
 For beta installs:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --beta --verbose
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --beta --verbose
 ```
 
 You can also set `OPENCLAW_VERBOSE=1` instead of the flag.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -13,7 +13,7 @@ Use the installer unless you have a reason not to. It sets up the CLI and runs o
 ## Quick install (recommended)
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 Windows (PowerShell):
@@ -41,13 +41,13 @@ openclaw onboard --install-daemon
 Installs `openclaw` globally via npm and runs onboarding.
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 Installer flags:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --help
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --help
 ```
 
 Details: [Installer internals](/install/installer).
@@ -55,7 +55,7 @@ Details: [Installer internals](/install/installer).
 Non-interactive (skip onboarding):
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --no-onboard
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
 ```
 
 ### 2) Global install (manual)
@@ -124,10 +124,10 @@ The installer supports two methods:
 
 ```bash
 # Explicit npm
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method npm
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method npm
 
 # Install from GitHub (source checkout)
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
 ```
 
 Common flags:

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -1,7 +1,7 @@
 ---
 summary: "How the installer scripts work (install.sh + install-cli.sh), flags, and automation"
 read_when:
-  - You want to understand `openclaw.bot/install.sh`
+  - You want to understand `openclaw.ai/install.sh`
   - You want to automate installs (CI / headless)
   - You want to install from a GitHub checkout
 title: "Installer Internals"
@@ -11,14 +11,14 @@ title: "Installer Internals"
 
 OpenClaw ships two installer scripts (served from `openclaw.ai`):
 
-- `https://openclaw.bot/install.sh` — “recommended” installer (global npm install by default; can also install from a GitHub checkout)
-- `https://openclaw.bot/install-cli.sh` — non-root-friendly CLI installer (installs into a prefix with its own Node)
+- `https://openclaw.ai/install.sh` — “recommended” installer (global npm install by default; can also install from a GitHub checkout)
+- `https://openclaw.ai/install-cli.sh` — non-root-friendly CLI installer (installs into a prefix with its own Node)
 - `https://openclaw.ai/install.ps1` — Windows PowerShell installer (npm by default; optional git install)
 
 To see the current flags/behavior, run:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash -s -- --help
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --help
 ```
 
 Windows (PowerShell) help:
@@ -46,7 +46,7 @@ What it does (high level):
 If you _want_ `sharp` to link against a globally-installed libvips (or you’re debugging), set:
 
 ```bash
-SHARP_IGNORE_GLOBAL_LIBVIPS=0 curl -fsSL https://openclaw.bot/install.sh | bash
+SHARP_IGNORE_GLOBAL_LIBVIPS=0 curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 ### Discoverability / “git install” prompt
@@ -79,7 +79,7 @@ This script installs `openclaw` into a prefix (default: `~/.openclaw`) and also 
 Help:
 
 ```bash
-curl -fsSL https://openclaw.bot/install-cli.sh | bash -s -- --help
+curl -fsSL https://openclaw.ai/install-cli.sh | bash -s -- --help
 ```
 
 ## install.ps1 (Windows PowerShell)

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -116,7 +116,7 @@ If you used a profile, delete the matching task name and `~\.openclaw-<profile>\
 
 ### Normal install (install.sh / npm / pnpm / bun)
 
-If you used `https://openclaw.bot/install.sh` or `install.ps1`, the CLI was installed with `npm install -g openclaw@latest`.
+If you used `https://openclaw.ai/install.sh` or `install.ps1`, the CLI was installed with `npm install -g openclaw@latest`.
 Remove it with `npm rm -g openclaw` (or `pnpm remove -g` / `bun remove -g` if you installed that way).
 
 ### Source checkout (git clone)

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -17,7 +17,7 @@ detects existing installs, upgrades in place, and runs `openclaw doctor` when
 needed.
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 Notes:
@@ -25,7 +25,7 @@ Notes:
 - Add `--no-onboard` if you don’t want the onboarding wizard to run again.
 - For **source installs**, use:
   ```bash
-  curl -fsSL https://openclaw.bot/install.sh | bash -s -- --install-method git --no-onboard
+  curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git --no-onboard
   ```
   The installer will `git pull --rebase` **only** if the repo is clean.
 - For **global installs**, the script uses `npm install -g openclaw@latest` under the hood.

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -67,7 +67,7 @@ curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 apt install -y nodejs
 
 # Install OpenClaw
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 
 # Verify
 openclaw --version

--- a/docs/platforms/exe-dev.md
+++ b/docs/platforms/exe-dev.md
@@ -64,7 +64,7 @@ sudo apt-get install -y git curl jq ca-certificates openssl
 Run the OpenClaw install script:
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 ## 4) Setup nginx to proxy OpenClaw to port 8000

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -99,7 +99,7 @@ tailscale status
 ## 5) Install OpenClaw
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 source ~/.bashrc
 ```
 

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -112,7 +112,7 @@ sudo sysctl -p
 ### Option A: Standard Install (Recommended)
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 ### Option B: Hackable Install (For tinkering)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -48,7 +48,7 @@ When the operator says “release”, immediately do this preflight (no extra qu
 - [ ] `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke` (Docker install smoke test, fast path; required before release)
   - If the immediate previous npm release is known broken, set `OPENCLAW_INSTALL_SMOKE_PREVIOUS=<last-good-version>` or `OPENCLAW_INSTALL_SMOKE_SKIP_PREVIOUS=1` for the preinstall step.
 - [ ] (Optional) Full installer smoke (adds non-root + CLI coverage): `pnpm test:install:smoke`
-- [ ] (Optional) Installer E2E (Docker, runs `curl -fsSL https://openclaw.bot/install.sh | bash`, onboards, then runs real tool calls):
+- [ ] (Optional) Installer E2E (Docker, runs `curl -fsSL https://openclaw.ai/install.sh | bash`, onboards, then runs real tool calls):
   - `pnpm test:install:e2e:openai` (requires `OPENAI_API_KEY`)
   - `pnpm test:install:e2e:anthropic` (requires `ANTHROPIC_API_KEY`)
   - `pnpm test:install:e2e` (requires both keys; runs both providers)

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -56,7 +56,7 @@ Windows: use **WSL2** (Ubuntu recommended). WSL2 is strongly recommended; native
 ## 1) Install the CLI (recommended)
 
 ```bash
-curl -fsSL https://openclaw.bot/install.sh | bash
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 Installer options (install method, non-interactive, from GitHub): [Install](/install).


### PR DESCRIPTION
## Summary

Fixes #5323

All install script URLs in documentation were pointing to the old `openclaw.bot` domain instead of `openclaw.ai`.

## Changes

Updates **34 occurrences** across **13 files**:

| File | Changes |
|------|---------|
| docs/help/faq.md | 9 |
| docs/install/index.md | 6 |
| docs/install/installer.md | 6 |
| docs/gateway/troubleshooting.md | 2 |
| docs/help/troubleshooting.md | 2 |
| docs/install/updating.md | 2 |
| + 7 more files | 1 each |

## Verification

```bash
grep -r 'openclaw\.bot' docs/  # returns nothing after this PR
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates documentation references for the installer scripts, replacing the deprecated `openclaw.bot` domain with `openclaw.ai` across 13 docs pages (install guides, troubleshooting, platform-specific setup, and releasing checklist). This aligns the docs with the current installer hosting described in `CLAUDE.md` (installers served from `https://openclaw.ai/*`).

I didn’t find any incorrect replacements or formatting issues in the changed snippets, and a repo-wide docs search shows no remaining `openclaw.bot` references in `docs/`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a straightforward docs-only domain swap with no behavioral impact.
- All changes are simple string substitutions from `openclaw.bot` to `openclaw.ai` in documentation code blocks and prose. Diffs show no malformed URLs or broken markdown, and a search confirms `openclaw.bot` no longer appears under `docs/`.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->