### PR TITLE
feat(tts): add ElevenLabs optimizeStreamingLatency support

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -134,6 +134,11 @@
       "label": "ElevenLabs Base URL",
       "advanced": true
     },
+    "tts.elevenlabs.optimizeStreamingLatency": {
+      "label": "ElevenLabs Latency Optimization",
+      "help": "0=default, 1=normal (~50%), 2=strong (~75%), 3=max, 4=max+no normalizer",
+      "advanced": true
+    },
     "publicUrl": {
       "label": "Public Webhook URL",
       "advanced": true
@@ -442,6 +447,11 @@
               },
               "languageCode": {
                 "type": "string"
+              },
+              "optimizeStreamingLatency": {
+                "type": "integer",
+                "enum": [0, 1, 2, 3, 4],
+                "description": "Latency optimization level (0=default, 4=max optimization)"
               },
               "voiceSettings": {
                 "type": "object",

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -110,6 +110,7 @@ export const TtsConfigSchema = z
         seed: z.number().int().min(0).max(4294967295).optional(),
         applyTextNormalization: z.enum(["auto", "on", "off"]).optional(),
         languageCode: z.string().optional(),
+        optimizeStreamingLatency: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
         voiceSettings: z
           .object({
             stability: z.number().min(0).max(1).optional(),

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -45,6 +45,8 @@ export type TtsConfig = {
     seed?: number;
     applyTextNormalization?: "auto" | "on" | "off";
     languageCode?: string;
+    /** Latency optimization level (0-4). Higher = more optimization. */
+    optimizeStreamingLatency?: 0 | 1 | 2 | 3 | 4;
     voiceSettings?: {
       stability?: number;
       similarityBoost?: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -188,6 +188,7 @@ export const TtsConfigSchema = z
         seed: z.number().int().min(0).max(4294967295).optional(),
         applyTextNormalization: z.enum(["auto", "on", "off"]).optional(),
         languageCode: z.string().optional(),
+        optimizeStreamingLatency: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
         voiceSettings: z
           .object({
             stability: z.number().min(0).max(1).optional(),

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -98,6 +98,7 @@ export type ResolvedTtsConfig = {
     seed?: number;
     applyTextNormalization?: "auto" | "on" | "off";
     languageCode?: string;
+    optimizeStreamingLatency?: 0 | 1 | 2 | 3 | 4;
     voiceSettings: {
       stability: number;
       similarityBoost: number;
@@ -267,6 +268,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       seed: raw.elevenlabs?.seed,
       applyTextNormalization: raw.elevenlabs?.applyTextNormalization,
       languageCode: raw.elevenlabs?.languageCode,
+      optimizeStreamingLatency: raw.elevenlabs?.optimizeStreamingLatency,
       voiceSettings: {
         stability:
           raw.elevenlabs?.voiceSettings?.stability ?? DEFAULT_ELEVENLABS_VOICE_SETTINGS.stability,
@@ -1009,6 +1011,7 @@ async function elevenLabsTTS(params: {
   seed?: number;
   applyTextNormalization?: "auto" | "on" | "off";
   languageCode?: string;
+  optimizeStreamingLatency?: 0 | 1 | 2 | 3 | 4;
   voiceSettings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"];
   timeoutMs: number;
 }): Promise<Buffer> {
@@ -1022,6 +1025,7 @@ async function elevenLabsTTS(params: {
     seed,
     applyTextNormalization,
     languageCode,
+    optimizeStreamingLatency,
     voiceSettings,
     timeoutMs,
   } = params;
@@ -1040,6 +1044,9 @@ async function elevenLabsTTS(params: {
     const url = new URL(`${normalizeElevenLabsBaseUrl(baseUrl)}/v1/text-to-speech/${voiceId}`);
     if (outputFormat) {
       url.searchParams.set("output_format", outputFormat);
+    }
+    if (optimizeStreamingLatency != null) {
+      url.searchParams.set("optimize_streaming_latency", String(optimizeStreamingLatency));
     }
 
     const response = await fetch(url.toString(), {
@@ -1284,6 +1291,7 @@ export async function textToSpeech(params: {
           seed: seedOverride ?? config.elevenlabs.seed,
           applyTextNormalization: normalizationOverride ?? config.elevenlabs.applyTextNormalization,
           languageCode: languageOverride ?? config.elevenlabs.languageCode,
+          optimizeStreamingLatency: config.elevenlabs.optimizeStreamingLatency,
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
@@ -1377,6 +1385,7 @@ export async function textToSpeechTelephony(params: {
           seed: config.elevenlabs.seed,
           applyTextNormalization: config.elevenlabs.applyTextNormalization,
           languageCode: config.elevenlabs.languageCode,
+          optimizeStreamingLatency: config.elevenlabs.optimizeStreamingLatency,
           voiceSettings: config.elevenlabs.voiceSettings,
           timeoutMs: config.timeoutMs,
         });


### PR DESCRIPTION
## Summary

Fixes #5338

Adds support for the ElevenLabs `optimize_streaming_latency` parameter to reduce voice response latency in telephony and TTS applications.

## ElevenLabs Latency Optimization Levels

| Value | Description | Improvement |
|-------|-------------|-------------|
| 0 | Default (no optimizations) | - |
| 1 | Normal latency optimizations | ~50% |
| 2 | Strong latency optimizations | ~75% |
| 3 | Max latency optimizations | Maximum |
| 4 | Max + text normalizer off | Best latency |

## Usage

```json
{
  "messages": {
    "tts": {
      "elevenlabs": {
        "optimizeStreamingLatency": 3
      }
    }
  }
}
```

Or in voice-call plugin config:

```json
{
  "plugins": {
    "entries": {
      "voice-call": {
        "config": {
          "tts": {
            "elevenlabs": {
              "optimizeStreamingLatency": 3
            }
          }
        }
      }
    }
  }
}
```

## Changes

- `src/tts/tts.ts`: Added parameter to elevenLabsTTS function and API call
- `src/config/types.tts.ts`: Added TypeScript type definition
- `src/config/zod-schema.core.ts`: Added Zod schema validation
- `extensions/voice-call/src/config.ts`: Added to voice-call plugin schema
- `extensions/voice-call/openclaw.plugin.json`: Added JSON schema + UI hint

## Documentation

- [ElevenLabs API Reference](https://elevenlabs.io/docs/api-reference/text-to-speech/convert)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for ElevenLabs’ `optimize_streaming_latency` parameter end-to-end: new TS config types (`src/config/types.tts.ts`), validation in the core and voice-call plugin Zod schemas (`src/config/zod-schema.core.ts`, `extensions/voice-call/src/config.ts`), and wiring into the ElevenLabs request URL in the TTS implementation (`src/tts/tts.ts`). The voice-call plugin’s JSON schema/UI hints are also updated so the setting can be configured via plugin config.

Overall the change is small and well-scoped: config is resolved in `resolveTtsConfig`, then passed through to `elevenLabsTTS`, which sets `optimize_streaming_latency` as a query param when provided.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are straightforward config plumbing with minimal behavioral impact when unset.
- The new field is consistently added across type definitions, schemas, and request construction. The main concern is product/behavioral consistency: the parameter can’t be set via TTS directives and isn’t normalized like adjacent ElevenLabs options, but neither appears likely to cause runtime failures.
- src/tts/tts.ts (directive override behavior and any desired normalization/validation for the new param)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->