### PR TITLE
Document requirements for postToMainMode on isolated cron jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -324,12 +324,12 @@ openclaw system event --mode now --text "Next heartbeat: check battery."
 Isolated jobs can post a summary to the agent's main session after each run,
 but this requires all of the following:
 
-1. **`wakeMode: "now"`** on the cron job (this triggers an immediate heartbeat
-   to process the queued summary — it does not cause the cron job itself to
+1. **`wakeMode: "now"`** on the cron job (CLI: `--wake now`) — this triggers an immediate heartbeat
+   to process the queued summary (it does not cause the cron job itself to
    fire immediately).
 2. **A `heartbeat` block on the agent** with a non-zero interval — without this,
    the heartbeat runner won't include the agent in its processing loop. The
-   interval can be long (e.g. `"1440m"`) since `wake: now` triggers processing
+   interval can be long (e.g. `"1440m"`) since `wakeMode: "now"` triggers processing
    on demand.
 3. **A non-empty `HEARTBEAT.md`** in the agent's workspace — if the file contains
    only comments or headers, the heartbeat skips processing, including the

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -122,6 +122,9 @@ Isolation options (only for `session=isolated`):
 - `postToMainMode`: `summary` (default) or `full`.
 - `postToMainMaxChars`: max chars when `postToMainMode=full` (default 8000).
 
+> **Note:** `postToMainMode` requires specific configuration to work — see
+> [Troubleshooting: postToMainMode not working](#posttomainmode-not-working-isolated-jobs).
+
 ### Model and thinking overrides
 
 Isolated jobs (`agentTurn`) can override the model and thinking level:
@@ -315,6 +318,22 @@ openclaw system event --mode now --text "Next heartbeat: check battery."
 - Check cron is enabled: `cron.enabled` and `OPENCLAW_SKIP_CRON`.
 - Check the Gateway is running continuously (cron runs inside the Gateway process).
 - For `cron` schedules: confirm timezone (`--tz`) vs the host timezone.
+
+### postToMainMode not working (isolated jobs)
+
+Isolated jobs can post a summary to the agent's main session after each run,
+but this requires all of the following:
+
+1. **`wakeMode: "now"`** on the cron job (this triggers an immediate heartbeat
+   to process the queued summary — it does not cause the cron job itself to
+   fire immediately).
+2. **A `heartbeat` block on the agent** with a non-zero interval — without this,
+   the heartbeat runner won't include the agent in its processing loop. The
+   interval can be long (e.g. `"1440m"`) since `wake: now` triggers processing
+   on demand.
+3. **A non-empty `HEARTBEAT.md`** in the agent's workspace — if the file contains
+   only comments or headers, the heartbeat skips processing, including the
+   summary drain. Add at least one non-comment line.
 
 ### Telegram delivers to the wrong place
 


### PR DESCRIPTION
## Summary
- Add a note under isolation options linking to troubleshooting
- Add troubleshooting section documenting the three conditions required for `postToMainMode` to work

## Detail

`postToMainMode` on isolated cron jobs silently fails unless specific conditions are met. The summary gets queued as a system event but is never drained into the main session.

**Root cause:** The heartbeat runner in `heartbeat-runner.js` skips processing when `HEARTBEAT.md` is effectively empty (only comments/headers). The empty-file check exempts `exec-event` reasons but not cron wake reasons, so cron summaries are silently dropped.

**Three conditions must all be met:**

1. `wakeMode: "now"` — triggers an immediate heartbeat after the isolated run. Without this, the queued event waits for the next scheduled heartbeat interval.

2. The agent must have a `heartbeat` block in its config with a non-zero `every` value. Without this, `resolveHeartbeatAgents()` in `heartbeat-runner.js` excludes the agent from the heartbeat processing loop entirely. The interval can be arbitrarily long (e.g. `"1440m"`) since `wake: now` triggers on demand.

3. `HEARTBEAT.md` in the agent's workspace must contain at least one non-comment, non-header line. Examples of files that cause the skip:

   ```markdown
   # HEARTBEAT.md
   # This file is empty
   ```

   ```markdown
   # HEARTBEAT.md

   ```

   A file like this will work:

   ```markdown
   # HEARTBEAT.md
   Try to be useful.
   ```

   The check is in `heartbeat-runner.js` around line 341 — `isHeartbeatContentEffectivelyEmpty()` returns true for files with only markdown headers and comments, causing an early return before system events are drained.

**Working example — cron job creation:**

```bash
openclaw cron add \
  --name "Morning briefing" \
  --cron "30 7 * * *" \
  --tz "Europe/London" \
  --session isolated \
  --agent ops \
  --message "Summarize inbox and calendar for today." \
  --wake now \
  --post-prefix "Cron" \
  --post-mode summary \
  --deliver \
  --channel discord \
  --to "user:123456789"
```

**Resulting job in `~/.openclaw/cron/jobs.json`:**

```json
{
  "id": "a1b2c3d4-...",
  "agentId": "ops",
  "name": "Morning briefing",
  "enabled": true,
  "schedule": {
    "kind": "cron",
    "expr": "30 7 * * *",
    "tz": "Europe/London"
  },
  "sessionTarget": "isolated",
  "wakeMode": "now",
  "payload": {
    "kind": "agentTurn",
    "message": "Summarize inbox and calendar for today.",
    "deliver": true,
    "channel": "discord",
    "to": "user:123456789"
  },
  "isolation": {
    "postToMainPrefix": "Cron",
    "postToMainMode": "summary",
    "postToMainMaxChars": 8000
  }
}
```

**Working example — agent config with heartbeat block:**

```json5
{
  agents: {
    list: [
      { id: "main", default: true },
      {
        id: "ops",
        workspace: "/home/user/agents/ops",
        heartbeat: {
          every: "1440m"  // 24h — only needs to be non-zero; wake: now triggers on demand
        }
      }
    ]
  }
}
```

**Possible future fix:** The empty-HEARTBEAT.md check could also check `hasSystemEvents(sessionKey)` before skipping, similar to how it already exempts `exec-event` reasons.

Claude Code helped to create this PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docs/automation/cron-jobs.md` to clarify how isolated cron jobs can post results back to the main session.

- Adds a cross-link from the isolated-job isolation options to a troubleshooting section.
- Documents three prerequisites for `postToMainMode` to work reliably (wake mode, agent heartbeat configuration, and non-empty `HEARTBEAT.md`).

This fits into the existing cron/heartbeat documentation by making an implicit runtime dependency (heartbeat processing draining queued system events) explicit for users configuring isolated cron jobs.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk (docs-only change).
- Only documentation was changed and the additions are scoped and consistent with existing cron/heartbeat concepts; the main risk is minor user confusion from mixed `wakeMode` vs `--wake` terminology.
- docs/automation/cron-jobs.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->