### PR TITLE
fix(github): update auto-response URLs from legacy molt.bot domain

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -37,13 +37,13 @@ jobs:
                 label: "r: support",
                 close: true,
                 message:
-                  "Please use our support server https://molt.bot/discord and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.molt.bot/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
+                  "Please use our support server https://discord.gg/qkhbAGHRBT and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
               },
               {
                 label: "r: third-party-extension",
                 close: true,
                 message:
-                  "This would be better made as a third-party extension with our SDK that you maintain yourself. Docs: https://docs.molt.bot/plugin.",
+                  "This would be better made as a third-party extension with our SDK that you maintain yourself. Docs: https://docs.openclaw.ai/plugin.",
               },
             ];
 


### PR DESCRIPTION
## Summary
Updates auto-response workflow URLs from legacy domain to current OpenClaw domains.

## Changes
- Discord: `molt.bot/discord` → `discord.gg/qkhbAGHRBT`
- Docs FAQ: `docs.molt.bot/help/faq` → `docs.openclaw.ai/help/faq`
- Docs plugin: `docs.molt.bot/plugin` → `docs.openclaw.ai/plugin`

## Test plan
- [x] Verified docs paths exist (`docs/help/faq.md`, `docs/plugin.md`)
- [x] Discord link matches CONTRIBUTING.md

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the GitHub auto-response workflow messages to replace legacy `molt.bot` URLs with the current OpenClaw domains. The `r: support` response now points users to the current Discord invite and the migrated FAQ page, and the `r: third-party-extension` response points to the new plugin docs location. This keeps automated issue/PR triage responses aligned with the repository’s current support and documentation endpoints.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is limited to updating hard-coded URLs in a GitHub Actions workflow comment body; no logic, permissions, or workflow structure was modified, and repository-wide searches show the new endpoints are already used elsewhere (e.g., CONTRIBUTING.md and existing docs links).
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->