### PR TITLE
fix(commands): prevent webchat/tui from inheriting messaging channel allowFrom

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -32,6 +32,12 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
   if (direct) {
     return direct;
   }
+  // For internal channels (webchat, tui), don't fallback to configured messaging channels.
+  // These channels are always trusted and should not inherit allowFrom restrictions.
+  const provider = (ctx.Provider ?? ctx.Surface ?? "").trim().toLowerCase();
+  if (provider === "webchat" || provider === "tui") {
+    return undefined;
+  }
   const candidates = [ctx.From, ctx.To]
     .filter((value): value is string => Boolean(value?.trim()))
     .flatMap((value) => value.split(":").map((part) => part.trim()));


### PR DESCRIPTION
### Summary

Fixes `/new` and `/reset` commands being silently blocked in webchat when only one messaging channel has `allowFrom` configured.

### Problem

When only one channel (e.g., WhatsApp) has `allowFrom` configured:

```
webchat sends /new
    ↓
ctx.Provider = 'webchat' (not in channel registry)
    ↓
Fallback: find channels with allowFrom configured
    ↓
Only WhatsApp has allowFrom → return 'whatsapp'
    ↓
Webchat is now treated as WhatsApp 😱
    ↓
enforceOwner = true (WhatsApp's setting)
    ↓
User not in WhatsApp's allowFrom list
    ↓
/new silently blocked ❌
```

### Solution

Add an early return for internal channels before the fallback logic:

```typescript
// For internal channels (webchat, tui), don't fallback to configured messaging channels.
// These channels are always trusted and should not inherit allowFrom restrictions.
const provider = (ctx.Provider ?? ctx.Surface ?? "").trim().toLowerCase();
if (provider === "webchat" || provider === "tui") {
  return undefined;
}
```

### Flow After Fix

```
webchat sends /new
    ↓
ctx.Provider = 'webchat'
    ↓
Early return for internal channels → undefined
    ↓
No enforceOwner restriction
    ↓
/new works ✅
```

### Changes

```
src/auto-reply/command-auth.ts | +6 lines
```

Fixes #5347

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts provider resolution for command authorization to treat internal surfaces (`webchat`, `tui`) as trusted and **not** fall back to the “single configured allowFrom channel” heuristic. Concretely, `resolveProviderFromContext` now early-returns `undefined` when the incoming context provider/surface is `webchat` or `tui`, preventing those requests from inheriting `allowFrom` restrictions from an unrelated messaging channel (e.g., WhatsApp). This fits into the existing flow where `resolveCommandAuthorization` derives `providerId` (and the corresponding `ChannelDock`) to decide whether to enforce `enforceOwnerForCommands` based on channel config; returning `undefined` for internal channels means no dock is selected and owner enforcement does not apply.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to provider resolution, and directly addresses an incorrect fallback that misclassifies internal channels; the new early-return is straightforward and unlikely to affect external providers because it only triggers on explicit `webchat`/`tui` values when direct normalization fails.
- src/auto-reply/command-auth.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->