### PR TITLE
feat: add domain blocklist to protect agents from malicious sites

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -199,6 +199,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.blockedDomains": "Web Fetch Blocked Domains",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
@@ -452,6 +453,7 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
   "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
+  "tools.web.fetch.blockedDomains": "Domains to block from web_fetch (substring match against hostname).",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -196,6 +196,7 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    blockedDomains: z.array(z.string()).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Security Problem

When AI agents use `web_fetch` to retrieve content from the web, they can be directed to malicious sites (like **Moltbook.com**) that contain prompt injection attacks and adversarial content specifically designed to hijack AI agents. Currently there's no way for operators to proactively block known-bad domains at the infrastructure level.

This creates a significant security risk where:
- Agents can be tricked into visiting adversarial sites through seemingly innocent web searches  
- Malicious content can override agent instructions and compromise behavior
- No infrastructure-level protection exists against known prompt injection domains

## Solution

This PR adds a configurable `tools.web.fetch.blockedDomains` array that lets operators maintain a blocklist of domains their agent should never visit. This provides **defense-in-depth** — while the agent's cognitive security (system prompt instructions) is the first line of defense, a hard infrastructure-level block prevents the fetch from even occurring.

## Security Config Example

```json
{
  "tools": {
    "web": {
      "fetch": {
        "blockedDomains": ["moltbook.com", "promptinjection.example", "adversarial-content.site"]
      }
    }
  }
}
```

## Implementation Details

- **Early blocking**: Domains are blocked before any network calls occur
- **Substring matching**: `example.com` blocks `api.example.com`, `sub.example.com` etc.
- **Defense-in-depth**: Complements agent prompt security with infrastructure controls
- **Zero-trust approach**: Even if an agent is compromised, it can't reach blocked domains
- **Operator control**: Security teams can maintain centralized domain blocklists

## Security Benefits

✅ **Prevents prompt injection**: Blocks access to known adversarial content sources  
✅ **Infrastructure-level protection**: Hard block that can't be bypassed by compromised agents  
✅ **Proactive defense**: Stop threats before content is even retrieved  
✅ **Compliance support**: Helps meet security requirements for AI deployments  

## Error Message

When a blocked domain is accessed:
```
URL blocked by tools.web.fetch.blockedDomains configuration
```

## Files Changed

- `src/config/zod-schema.agent-runtime.ts` - Added blockedDomains to schema
- `src/config/schema.ts` - Added UI labels and help text  
- `src/infra/net/ssrf.ts` - Extended hostname blocking logic
- `src/agents/tools/web-fetch.ts` - Implemented early domain checking

This feature provides security teams with essential infrastructure controls to protect AI agents from known prompt injection and adversarial content sources.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable `tools.web.fetch.blockedDomains` setting to block web_fetch requests to particular domains. The config is wired through the tool creation into the fetch path, and the SSRF/pinning helpers are extended to accept custom blocked domains.

The main implementation risk is how blocked domains are matched: both `web-fetch.ts` and `ssrf.ts` use substring matching (`includes`) against the normalized hostname, which can overblock unrelated domains and is easy to bypass or behave unexpectedly compared to boundary-aware domain matching. There’s also a likely runtime bug where `resolvePinnedHostname` is invoked with `lookupFn=undefined`, which can break DNS lookup if `resolvePinnedHostname` calls that function later.


<h3>Confidence Score: 2/5</h3>

- This PR should not be merged as-is due to a likely runtime error and overly permissive/incorrect hostname blocking logic.
- Score reduced because `resolvePinnedHostname(..., undefined, ...)` can cause a runtime crash if the lookup function is later invoked, and because `includes`-based domain matching can both block unintended hosts and allow unintended hosts through, undermining the security/compliance goal. The rest of the changes are small and localized.
- src/agents/tools/web-fetch.ts and src/infra/net/ssrf.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->