### PR TITLE
fix(cron): pass job name as session label

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -211,6 +211,7 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
+    label: params.job.name?.trim() || undefined,
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -7,6 +7,8 @@ export function resolveCronSession(params: {
   sessionKey: string;
   nowMs: number;
   agentId: string;
+  /** Optional label for the session (e.g., cron job name). */
+  label?: string;
 }) {
   const sessionCfg = params.cfg.session;
   const storePath = resolveStorePath(sessionCfg?.store, {
@@ -31,6 +33,8 @@ export function resolveCronSession(params: {
     label: entry?.label,
     displayName: entry?.displayName,
     skillsSnapshot: entry?.skillsSnapshot,
+    // Use provided label, or preserve existing label if session already exists
+    label: params.label || entry?.label,
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession: true };
 }

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -426,7 +426,7 @@ describe("CronService", () => {
     await vi.runOnlyPendingTimersAsync();
     await waitForJobs(cron, (items) => items.some((item) => item.state.lastStatus === "error"));
 
-    expect(enqueueSystemEvent).toHaveBeenCalledWith("Cron (error): last output", {
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("isolated error test (error): last output", {
       agentId: undefined,
     });
     expect(requestHeartbeatNow).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes #5337

When cron jobs spawn isolated sessions, the session now inherits the job's name as its label, making it visible in the dashboard.

## Before / After

| Before | After |
|--------|-------|
| 🔴 Cron - Active | 🔴 Email check - Active |

## Changes

1. **`session.ts`**: Added optional `label` parameter to `resolveCronSession()`
2. **`run.ts`**: Pass `job.name` as the label when creating sessions
3. **`timer.ts`**: Use job name as the default prefix when posting results back to main session

## Behavior

- Session label = job name (if set)
- Falls back to existing label if session already exists
- Status messages also use job name: `Email check: completed` instead of `Cron: completed`
- Still respects `isolation.postToMainPrefix` if explicitly configured

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR propagates cron job names into isolated-session labeling and status reporting: `runCronIsolatedAgentTurn` now passes `job.name` into `resolveCronSession`, `resolveCronSession` stores that as the session’s `label` (falling back to an existing label), and `executeJob` uses a name-derived prefix for posting isolated job results back to the main session.

The overall shape fits the existing cron isolated-agent flow (session store + transcript per run, plus main-lane system events), but there are a couple ordering/semantics mismatches with the stated behavior (prefix precedence, and whether a session is actually “new”).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple behavioral mismatches that could prevent the intended UX from showing up reliably.
- Changes are small and localized, but (1) the post-to-main prefix precedence doesn’t match the described behavior, and (2) `resolveCronSession`’s `isNewSession` semantics look incorrect if anything relies on it. Both are fixable but could lead to confusing dashboard/status output or session tracking quirks.
- src/cron/service/timer.ts, src/cron/isolated-agent/session.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->