### PR TITLE
fix(docs): remove invalid channels. prefix from Discord URL

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -224,4 +224,4 @@ git pull
 
 - Run `openclaw doctor` again and read the output carefully (it often tells you the fix).
 - Check: [Troubleshooting](/gateway/troubleshooting)
-- Ask in Discord: https://channels.discord.gg/clawd
+- Ask in Discord: https://discord.gg/clawd


### PR DESCRIPTION
## Summary
Fixes broken Discord link in updating.md.

## Problem
URL had invalid `channels.` prefix: `https://channels.discord.gg/clawd`

## Changes
- Removed `channels.` prefix → `https://discord.gg/clawd`

## Test plan
- [x] Verified corrected URL format is valid

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates a single documentation link in `docs/install/updating.md`, removing an invalid `channels.` subdomain so the “Ask in Discord” invite URL points to `https://discord.gg/clawd` instead of `https://channels.discord.gg/clawd`. This aligns the troubleshooting section’s Discord contact link with the expected Discord invite format and avoids directing users to a broken URL.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line docs-only fix that corrects a malformed Discord invite URL; it does not affect runtime code paths or build artifacts.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->