### PR TITLE
fix(docs): update MiniMax plugin URL from legacy moltbot org

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -53,7 +53,7 @@ You will be prompted to select an endpoint:
 - **Global** - International users (`api.minimax.io`)
 - **CN** - Users in China (`api.minimaxi.com`)
 
-See [MiniMax OAuth plugin README](https://github.com/moltbot/moltbot/tree/main/extensions/minimax-portal-auth) for details.
+See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 
 ### MiniMax M2.1 (API key)
 


### PR DESCRIPTION
## Summary
Fixes outdated GitHub URL in MiniMax provider documentation.

## Changes
- `github.com/moltbot/moltbot` → `github.com/openclaw/openclaw`

## Test plan
- [x] Verified new URL path exists

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the MiniMax provider documentation to point the “MiniMax OAuth plugin README” link at the current `openclaw/openclaw` repository (instead of the legacy `moltbot/moltbot` org/repo), aligning the docs with the project rename/migration.

This affects only `docs/providers/minimax.md` and is isolated to a single outbound documentation link; no runtime behavior changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a one-line doc link update with no code-path impact.
- The change is limited to a single markdown link target and does not affect any build/runtime behavior. The new URL matches the current repository location and the referenced extension exists in-tree.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->