### PR TITLE
feat: add session-aware outbound delivery + fix compaction race condition

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -61,6 +61,7 @@ import {
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { buildModelAliasLines, resolveModel } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
@@ -434,6 +435,32 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Run before_compaction hook
+        const messageCountBefore = session.messages.length;
+        let tokenCountBefore: number | undefined;
+        try {
+          tokenCountBefore = 0;
+          for (const message of session.messages) {
+            tokenCountBefore += estimateTokens(message);
+          }
+        } catch {
+          tokenCountBefore = undefined;
+        }
+        const hookRunner = getGlobalHookRunner();
+        const hookCtx = {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: params.messageChannel ?? params.messageProvider,
+        };
+        if (hookRunner?.hasHooks("before_compaction")) {
+          await hookRunner.runBeforeCompaction(
+            { messageCount: messageCountBefore, tokenCount: tokenCountBefore },
+            hookCtx,
+          );
+        }
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -450,6 +477,25 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Run after_compaction hook
+        const messageCountAfter = session.messages.length;
+        const compactedCount = messageCountBefore - messageCountAfter;
+        if (hookRunner?.hasHooks("after_compaction")) {
+          hookRunner
+            .runAfterCompaction(
+              {
+                messageCount: messageCountAfter,
+                tokenCount: tokensAfter,
+                compactedCount,
+              },
+              hookCtx,
+            )
+            .catch((err) => {
+              log.warn(`after_compaction hook error: ${String(err)}`);
+            });
+        }
+
         return {
           ok: true,
           compacted: true,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 
+import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
 import type { SessionEntry } from "./types.js";
 import { loadSessionStore, updateSessionStore } from "./store.js";
 import { resolveDefaultSessionStorePath, resolveSessionTranscriptPath } from "./paths.js";
@@ -108,42 +109,48 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   const sessionFile =
     entry.sessionFile?.trim() || resolveSessionTranscriptPath(entry.sessionId, params.agentId);
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  // Acquire session write lock to prevent race with compaction
+  const lock = await acquireSessionWriteLock({ sessionFile });
+  try {
+    await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
-  const sessionManager = SessionManager.open(sessionFile);
-  sessionManager.appendMessage({
-    role: "assistant",
-    content: [{ type: "text", text: mirrorText }],
-    api: "openai-responses",
-    provider: "openclaw",
-    model: "delivery-mirror",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: mirrorText }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: {
         input: 0,
         output: 0,
         cacheRead: 0,
         cacheWrite: 0,
-        total: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
       },
-    },
-    stopReason: "stop",
-    timestamp: Date.now(),
-  });
-
-  if (!entry.sessionFile || entry.sessionFile !== sessionFile) {
-    await updateSessionStore(storePath, (current) => {
-      current[sessionKey] = {
-        ...entry,
-        sessionFile,
-      };
+      stopReason: "stop",
+      timestamp: Date.now(),
     });
-  }
 
-  emitSessionTranscriptUpdate(sessionFile);
-  return { ok: true, sessionFile };
+    if (!entry.sessionFile || entry.sessionFile !== sessionFile) {
+      await updateSessionStore(storePath, (current) => {
+        current[sessionKey] = {
+          ...entry,
+          sessionFile,
+        };
+      });
+    }
+
+    emitSessionTranscriptUpdate(sessionFile);
+    return { ok: true, sessionFile };
+  } finally {
+    await lock.release();
+  }
 }

--- a/src/infra/outbound/send-to-session.test.ts
+++ b/src/infra/outbound/send-to-session.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendToSession } from "./send-to-session.js";
+
+// Mock deliverOutboundPayloads
+vi.mock("./deliver.js", () => ({
+  deliverOutboundPayloads: vi
+    .fn()
+    .mockResolvedValue([{ channel: "telegram", messageId: "123", chatId: "456" }]),
+}));
+
+describe("sendToSession", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp("/tmp/send-to-session-test-");
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("returns error when session not found", async () => {
+    // Create empty session store
+    await fs.promises.writeFile(storePath, JSON.stringify({}));
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Session not found");
+    }
+  });
+
+  it("returns error when session has no channel", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastTo: "456",
+          // no lastChannel
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No channel found");
+    }
+  });
+
+  it("returns error when session has no destination", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          // no lastTo
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No destination found");
+    }
+  });
+
+  it("delivers message when session has valid routing", async () => {
+    const { deliverOutboundPayloads } = await import("./deliver.js");
+
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "456",
+          lastAccountId: "bot1",
+          lastThreadId: "789",
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello world",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].channel).toBe("telegram");
+    }
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "456",
+        accountId: "bot1",
+        threadId: "789",
+        payloads: [{ text: "Hello world" }],
+      }),
+    );
+  });
+
+  it("skips webchat channel", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "webchat:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "webchat",
+          lastTo: "456",
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "webchat:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No channel found");
+    }
+  });
+});

--- a/src/infra/outbound/send-to-session.ts
+++ b/src/infra/outbound/send-to-session.ts
@@ -1,0 +1,138 @@
+/**
+ * Session-aware outbound delivery.
+ *
+ * Provides a unified way to send messages to the active channel for a session
+ * without needing to know the channel type or conversation details.
+ */
+
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { loadSessionStore } from "../../config/sessions/store.js";
+import type { SessionChannelId } from "../../config/sessions/types.js";
+import { deliverOutboundPayloads, type OutboundDeliveryResult } from "./deliver.js";
+import type { OutboundChannel } from "./targets.js";
+
+export type SendToSessionParams = {
+  /** The session key to send to. */
+  sessionKey: string;
+  /** The text message to send. */
+  text: string;
+  /** Optional agent ID (defaults to "main"). */
+  agentId?: string;
+  /** Optional config override (will load from disk if not provided). */
+  cfg?: OpenClawConfig;
+  /** Optional media URLs to include. */
+  mediaUrls?: string[];
+  /** If true, errors are caught and logged instead of thrown. */
+  bestEffort?: boolean;
+};
+
+export type SendToSessionResult =
+  | { ok: true; results: OutboundDeliveryResult[] }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the outbound channel from a session channel ID.
+ * Returns undefined if the channel is not a valid outbound channel.
+ */
+function resolveOutboundChannel(
+  channel: SessionChannelId | undefined,
+): Exclude<OutboundChannel, "none"> | undefined {
+  if (!channel) {
+    return undefined;
+  }
+  // webchat is not a valid outbound channel for this purpose
+  if (channel === "webchat") {
+    return undefined;
+  }
+  return channel;
+}
+
+/**
+ * Send a message to the active channel for a session.
+ *
+ * Looks up the session metadata to determine the channel, destination, and
+ * threading context, then delivers the message through the unified outbound
+ * delivery system.
+ *
+ * @example
+ * ```typescript
+ * const result = await sendToSession({
+ *   sessionKey: "telegram:123456789",
+ *   text: "🔄 Compacting context...",
+ * });
+ * if (!result.ok) {
+ *   console.error("Failed to send:", result.error);
+ * }
+ * ```
+ */
+export async function sendToSession(params: SendToSessionParams): Promise<SendToSessionResult> {
+  const { sessionKey, text, agentId, mediaUrls, bestEffort } = params;
+
+  // Load config if not provided
+  let cfg = params.cfg;
+  if (!cfg) {
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      return { ok: false, error: `Failed to load config: ${String(err)}` };
+    }
+  }
+
+  // Resolve the session store path
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+
+  // Load the session entry
+  let store: Record<string, import("../../config/sessions/types.js").SessionEntry>;
+  try {
+    store = loadSessionStore(storePath);
+  } catch (err) {
+    return { ok: false, error: `Failed to load session store: ${String(err)}` };
+  }
+
+  const entry = store[sessionKey];
+  if (!entry) {
+    return { ok: false, error: `Session not found: ${sessionKey}` };
+  }
+
+  // Extract delivery context from session
+  const channel = resolveOutboundChannel(entry.lastChannel);
+  const to = entry.lastTo;
+  const accountId = entry.lastAccountId;
+  const threadId = entry.lastThreadId;
+
+  if (!channel) {
+    return { ok: false, error: `No channel found for session: ${sessionKey}` };
+  }
+  if (!to) {
+    return { ok: false, error: `No destination found for session: ${sessionKey}` };
+  }
+
+  // Build payloads
+  const payloads: ReplyPayload[] = [];
+  if (mediaUrls?.length) {
+    for (const url of mediaUrls) {
+      payloads.push({ text: payloads.length === 0 ? text : "", mediaUrl: url });
+    }
+  } else {
+    payloads.push({ text });
+  }
+
+  // Deliver
+  try {
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel,
+      to,
+      accountId,
+      payloads,
+      threadId,
+      bestEffort,
+    });
+    return { ok: true, results };
+  } catch (err) {
+    return { ok: false, error: `Delivery failed: ${String(err)}` };
+  }
+}

--- a/src/infra/outbound/send-to-session.ts
+++ b/src/infra/outbound/send-to-session.ts
@@ -11,8 +11,11 @@ import { loadConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store.js";
 import type { SessionChannelId } from "../../config/sessions/types.js";
+import {
+  isDeliverableMessageChannel,
+  type DeliverableMessageChannel,
+} from "../../utils/message-channel.js";
 import { deliverOutboundPayloads, type OutboundDeliveryResult } from "./deliver.js";
-import type { OutboundChannel } from "./targets.js";
 
 export type SendToSessionParams = {
   /** The session key to send to. */
@@ -35,16 +38,16 @@ export type SendToSessionResult =
 
 /**
  * Resolve the outbound channel from a session channel ID.
- * Returns undefined if the channel is not a valid outbound channel.
+ * Returns undefined if the channel is not a valid deliverable channel.
  */
 function resolveOutboundChannel(
   channel: SessionChannelId | undefined,
-): Exclude<OutboundChannel, "none"> | undefined {
+): DeliverableMessageChannel | undefined {
   if (!channel) {
     return undefined;
   }
-  // webchat is not a valid outbound channel for this purpose
-  if (channel === "webchat") {
+  // Use proper deliverable channel check instead of type cast
+  if (!isDeliverableMessageChannel(channel)) {
     return undefined;
   }
   return channel;

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -69,6 +69,7 @@ import { resolveDiscordChannelAllowlist } from "../../discord/resolve-channels.j
 import { resolveDiscordUserAllowlist } from "../../discord/resolve-users.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../discord/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { sendToSession } from "../../infra/outbound/send-to-session.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
@@ -337,6 +338,9 @@ export function createPluginRuntime(): PluginRuntime {
         buildTemplateMessageFromPayload,
         monitorLineProvider,
       },
+    },
+    outbound: {
+      sendToSession,
     },
     logging: {
       shouldLogVerbose,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -73,6 +73,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type SendToSession = typeof import("../../infra/outbound/send-to-session.js").sendToSession;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -347,6 +348,9 @@ export type PluginRuntime = {
       buildTemplateMessageFromPayload: BuildTemplateMessageFromPayload;
       monitorLineProvider: MonitorLineProvider;
     };
+  };
+  outbound: {
+    sendToSession: SendToSession;
   };
   logging: {
     shouldLogVerbose: ShouldLogVerbose;


### PR DESCRIPTION
## Summary

### 1. Session-aware outbound delivery for plugins
- Adds `sendToSession` function to enable plugins to send messages to the active channel for a session
- Resolves channel, destination, and threading context from session metadata
- Routes through the unified `deliverOutboundPayloads` system
- Exposes via `runtime.outbound.sendToSession()` in the plugin runtime

### 2. Compaction hook invocations
- Invokes `runBeforeCompaction` and `runAfterCompaction` hooks in `compactEmbeddedPiSessionDirect()`
- These hooks were defined but never called - now plugins can react to compaction events

### 3. Fix delivery race condition with compaction
- Adds session write lock to `appendAssistantMessageToSessionTranscript()`
- Prevents race condition where delivery appends to transcript while compaction modifies session
- Now both operations coordinate via the existing session write lock

## Test plan
- [x] Added unit tests for sendToSession covering: session not found, no channel, no destination, valid routing, webchat skip
- [x] `pnpm lint` passes
- [x] Existing test suite passes (800+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)