### PR TITLE
fix: minimax oauth minimax.md and library function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs: update MiniMax OAuth setup commands; Extensions: use OpenClaw plugin SDK for MiniMax OAuth. (#5402) Thanks @Maosghoul.
 - Discord: resolve PluralKit proxied senders for allowlists and labels. (#5838) Thanks @thewilloftheshadow.
 - Telegram: restore draft streaming partials. (#5543) Thanks @obviyus.
 - fix(lobster): block arbitrary exec via lobsterPath/cwd injection (GHSA-4mhr-g7xj-cg8j). (#5335) Thanks @vignesh07.

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -44,9 +44,9 @@ MiniMax highlights these improvements in M2.1:
 Enable the bundled OAuth plugin and authenticate:
 
 ```bash
-moltbot plugins enable minimax-portal-auth  # skip if already loaded.
-moltbot gateway restart  # restart if gateway is already running
-moltbot onboard --auth-choice minimax-portal
+openclaw plugins enable minimax-portal-auth  # skip if already loaded.
+openclaw gateway restart  # restart if gateway is already running
+openclaw onboard --auth-choice minimax-portal
 ```
 
 You will be prompted to select an endpoint:

--- a/extensions/minimax-portal-auth/index.ts
+++ b/extensions/minimax-portal-auth/index.ts
@@ -1,4 +1,4 @@
-import { emptyPluginConfigSchema } from "clawdbot/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { loginMiniMaxPortalOAuth, type MiniMaxRegion } from "./oauth.js";
 
 const PROVIDER_ID = "minimax-portal";

--- a/extensions/minimax-portal-auth/oauth.ts
+++ b/extensions/minimax-portal-auth/oauth.ts
@@ -198,7 +198,7 @@ export async function loginMiniMaxPortalOAuth(params: {
   const noteLines = [
     `Open ${verificationUrl} to approve access.`,
     `If prompted, enter the code ${oauth.user_code}.`,
-    `Interval: ${oauth.interval ?? "default (2000ms)"}, Expires in: ${oauth.expired_in}ms`,
+    `Interval: ${oauth.interval ?? "default (2000ms)"}, Expires at: ${oauth.expired_in} unix timestamp`,
   ];
   await params.note(noteLines.join("\n"), "MiniMax OAuth");
 


### PR DESCRIPTION
## Summary

Updated the README.md , modified a library function and a note

## Changes

- **docs/providers/minimax.md**: 
  - Update CLI commands from `moltbot` to `openclaw` (`plugins enable`, `gateway restart`, `onboard`)
  - Update GitHub repository link from `moltbot/moltbot` to `openclaw/openclaw`

- **extensions/minimax-portal-auth/index.ts**: 
  - Update plugin-sdk import path from `clawdbot/plugin-sdk` to `openclaw/plugin-sdk`

- **extensions/minimax-portal-auth/oauth.ts**: 
  - format note message

## Usage
openclaw plugins enable minimax-portal-auth  # skip if already loaded.
openclaw gateway restart  # restart if gateway is already running
openclaw onboard --auth-choice minimax-portal

## TESTING
1. test oauth
<img width="2024" height="526" alt="Clipboard_Screenshot_1769863890" src="https://github.com/user-attachments/assets/bbfa267c-934b-4e26-93a0-7ea36e714cf0" />
<img width="1512" height="666" alt="Clipboard_Screenshot_1769863924" src="https://github.com/user-attachments/assets/d7fdd15b-6f04-4253-9d65-336af500c787" />
2. test chat 
<img width="2976" height="1358" alt="Clipboard_Screenshot_1769864048" src="https://github.com/user-attachments/assets/58d95a7d-d184-4908-9c18-6e8fbce996d0" />
<img width="2604" height="1308" alt="Clipboard_Screenshot_1769864181" src="https://github.com/user-attachments/assets/9d758aac-5db4-4e6d-9a76-b5f78dd78847" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the MiniMax provider documentation to use the current `openclaw` CLI commands and points the MiniMax OAuth plugin README link at `openclaw/openclaw`. It also updates the `minimax-portal-auth` extension to import the plugin SDK from `openclaw/plugin-sdk` instead of the legacy `clawdbot/plugin-sdk`, aligning it with other extensions in the repo.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to a doc update and a single import path update in one extension; the new import path matches existing patterns elsewhere in the repo and is unlikely to introduce runtime behavior changes.
- extensions/minimax-portal-auth/index.ts (ensure the import path matches the published/aliased plugin SDK path in this repo’s build tooling)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->