### PR TITLE
fix(docs): update Twitter URLs to X for consistency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -230,8 +230,8 @@ _"We're all just playing with our own prompts."_ — an AI, probably high on tok
 
 ## Credits
 
-- **Peter Steinberger** ([@steipete](https://twitter.com/steipete)) — Creator, lobster whisperer
-- **Mario Zechner** ([@badlogicc](https://twitter.com/badlogicgames)) — Pi creator, security pen-tester
+- **Peter Steinberger** ([@steipete](https://x.com/steipete)) — Creator, lobster whisperer
+- **Mario Zechner** ([@badlogicc](https://x.com/badlogicgames)) — Pi creator, security pen-tester
 - **Clawd** — The space lobster who demanded a better name
 
 ## Core Contributors


### PR DESCRIPTION
## Summary
Updates Twitter URLs to X in docs/index.md for consistency with CONTRIBUTING.md.
 
## Changes
- `twitter.com/steipete` → `x.com/steipete`
- `twitter.com/badlogicgames` → `x.com/badlogicgames`

## Test plan
- [x] Verified CONTRIBUTING.md uses x.com format
- [x] Both URLs still resolve correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the two social links in `docs/index.md`’s Credits section to use `https://x.com/...` instead of `https://twitter.com/...`, matching the convention already used in `CONTRIBUTING.md`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only updates two documentation hyperlinks.
- The change is limited to `docs/index.md` and modifies only external URLs in the Credits section; no code or configuration behavior is affected, and the markdown remains well-formed.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->