### PR TITLE
fix: don't skip heartbeat for cron systemEvent jobs with empty HEARTB…

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -506,13 +506,18 @@ export async function runHeartbeatOnce(opts: {
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
-  // EXCEPTION: Don't skip for exec events - they have pending system events to process.
+  // EXCEPTION: Don't skip for exec events or cron events - they have pending system events to process.
   const isExecEventReason = opts.reason === "exec-event";
+  const isCronReason = opts.reason?.startsWith("cron:");
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason) {
+    if (
+      isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
+      !isExecEventReason &&
+      !isCronReason
+    ) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",


### PR DESCRIPTION
## Problem
Cron jobs with `kind: systemEvent` were not being processed when `HEARTBEAT.md` was empty.

The heartbeat runner skips execution when `HEARTBEAT.md` has no actionable content to save API costs. However, only `exec-event` was exempted from this optimization, while cron jobs with pending system events were incorrectly skipped.

This caused system events from cron to queue up indefinitely until a user message triggered processing.

## Solution
Add `isCronReason` check alongside `isExecEventReason` to prevent skipping heartbeat when cron jobs enqueue system events.

## Changes
- Added check for cron reasons (`opts.reason?.startsWith("cron:")`)
- Updated condition to not skip heartbeat for cron-triggered events

Fixes #5349

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the heartbeat “empty HEARTBEAT.md” optimization in `src/infra/heartbeat-runner.ts` so that the runner will not skip heartbeats when the wake reason indicates a cron-triggered run (`reason` starts with `cron:`), alongside the existing exception for `exec-event`. This aligns the skip logic with the fact that cron `systemEvent` jobs may have pending system events to process even when the heartbeat file itself is effectively empty, preventing cron-enqueued events from stalling until a user message arrives.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and consistent with existing reason-based exceptions, using a null-safe check for cron-prefixed reasons; it only broadens the set of reasons that bypass the empty-heartbeat skip, which matches the stated behavior for pending system events.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->