### PR TITLE
[AI-assisted] feat(skills): add ipinfo skill for IP geolocation

### DIFF
--- a/skills/ipinfo/SKILL.md
+++ b/skills/ipinfo/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: ipinfo
+description: Perform IP geolocation lookups using ipinfo.io API. Convert IP addresses to geographic data including city, region, country, postal code, timezone, and coordinates. Use when geolocating IPs, enriching IP data, or analyzing geographic distribution.
+homepage: https://ipinfo.io
+metadata:
+  { "openclaw": { "emoji": "🌍", "requires": { "bins": ["curl"] }, "primaryEnv": "IPINFO_TOKEN" } }
+---
+
+# IPinfo Geolocation
+
+Free IP geolocation API. No API key required for basic usage (50k requests/month), optional token for higher limits.
+
+## Configuration
+
+The `IPINFO_TOKEN` environment variable is **optional** - the skill works without it using the free tier. Configure it via the OpenClaw dashboard UI for higher rate limits, or set it manually:
+
+- **Dashboard UI**: Configure `IPINFO_TOKEN` in the OpenClaw dashboard (optional)
+- **Environment variable**: `export IPINFO_TOKEN="your-token"`
+- **Query parameter**: `?token=YOUR_TOKEN` (for one-off requests)
+
+## Quick Lookup
+
+Single IP:
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8"
+```
+
+Current IP:
+
+```bash
+curl -s "https://ipinfo.io/json"
+```
+
+With token (optional, from environment):
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8?token=${IPINFO_TOKEN}"
+```
+
+Or pass token directly:
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8?token=YOUR_TOKEN"
+```
+
+## Response Format
+
+JSON response includes:
+
+- `ip`: IP address
+- `hostname`: Reverse DNS hostname
+- `city`: City name
+- `region`: State/region
+- `country`: Two-letter country code (ISO 3166-1 alpha-2)
+- `postal`: Postal/ZIP code
+- `timezone`: IANA timezone
+- `loc`: Coordinates as "latitude,longitude"
+- `org`: Organization/ASN information
+
+## Extract Specific Fields
+
+Using `jq`:
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8" | jq -r '.city, .country, .loc'
+```
+
+Country only:
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8" | jq -r '.country'
+```
+
+Parse coordinates:
+
+```bash
+curl -s "https://ipinfo.io/8.8.8.8" | jq -r '.loc' | tr ',' '\n'
+```
+
+## Batch Processing
+
+Process multiple IPs:
+
+```bash
+for ip in 8.8.8.8 1.1.1.1 208.67.222.222; do
+  if [ -n "$IPINFO_TOKEN" ]; then
+    echo "$ip: $(curl -s "https://ipinfo.io/$ip?token=$IPINFO_TOKEN" | jq -r '.city, .country' | tr '\n' ', ')"
+  else
+    echo "$ip: $(curl -s "https://ipinfo.io/$ip" | jq -r '.city, .country' | tr '\n' ', ')"
+  fi
+done
+```
+
+## Python Usage
+
+```python
+import os
+import requests
+
+# Without token (free tier)
+response = requests.get("https://ipinfo.io/8.8.8.8")
+data = response.json()
+print(f"{data['city']}, {data['country']}")
+print(f"Coordinates: {data['loc']}")
+```
+
+With token from environment:
+
+```python
+import os
+import requests
+
+token = os.getenv("IPINFO_TOKEN")
+if token:
+    response = requests.get("https://ipinfo.io/8.8.8.8", params={"token": token})
+else:
+    response = requests.get("https://ipinfo.io/8.8.8.8")
+data = response.json()
+```
+
+Or pass token directly:
+
+```python
+response = requests.get("https://ipinfo.io/8.8.8.8", params={"token": "YOUR_TOKEN"})
+```
+
+## Rate Limits
+
+- Free tier: 50,000 requests/month, ~1 req/sec
+- With token: Higher limits based on plan
+- Configure `IPINFO_TOKEN` via OpenClaw dashboard UI or environment variable
+
+## Common Use Cases
+
+- Geolocate IP addresses
+- Enrich IP lists with location data
+- Filter IPs by country
+- Calculate distances between IPs using coordinates
+- Timezone detection for IPs


### PR DESCRIPTION
## Add ipinfo skill for IP geolocation

**AI-Assisted PR** 🤖

### What
Adds a new skill `ipinfo` that enables IP geolocation lookups using the ipinfo.io API. Converts IP addresses to geographic data including city, region, country, postal code, timezone, and coordinates.

### Why
Provides easy access to IP geolocation data without requiring API keys for basic usage. The skill works out-of-the-box with the free tier (50k requests/month) and supports optional token configuration via the dashboard UI for higher rate limits.

### Features
- IP to geographic data conversion (city, region, country, postal code, timezone, coordinates)
- Free tier support (no API key required)
- Optional `IPINFO_TOKEN` configurable via OpenClaw dashboard UI (`primaryEnv`)
- Examples for curl, jq, and Python
- Batch processing support
- Coordinate parsing examples

### Testing
- [x] **Fully tested** on remote OpenClaw instance (root@10.0.0.127)
- [x] Skill follows OpenClaw skill format conventions
- [x] Description includes proper trigger terms
- [x] Examples verified (curl, jq, Python)
- [x] No additional dependencies required (uses standard `curl`)
- [x] Works without token (free tier tested)
- [x] Token configuration tested (optional, works with/without)

### Notes
- Free tier: 50k requests/month, ~1 req/sec
- Optional token: Higher limits based on plan
- Token is optional - skill works without it
- `primaryEnv: "IPINFO_TOKEN"` enables dashboard UI configuration
- Follows same pattern as `weather` skill (no API key required) with optional token support

### Code Understanding
I understand this code, it's a skill definition file that teaches OpenClaw how to use the ipinfo.io API for IP geolocation lookups. The skill includes examples and documentation for various use cases.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `ipinfo` skill documentation file under `skills/ipinfo/` describing how to use the ipinfo.io API for IP geolocation, including optional `IPINFO_TOKEN` configuration and examples for curl/jq, batch processing, and Python usage.

This fits the codebase’s “skill definition” pattern by providing frontmatter metadata (name/description/homepage/openclaw metadata) plus a usage-oriented markdown body that the OpenClaw skill system can surface to users.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the skill frontmatter likely won’t parse/load.
- The PR only adds documentation, but the YAML frontmatter `metadata` block appears invalid (JSON-ish with trailing commas and incorrect YAML structure), which would prevent the skill system from recognizing/ingesting the skill. Remaining issues are minor example correctness problems.
- skills/ipinfo/SKILL.md (frontmatter metadata + example quoting)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->