### PR TITLE
chore(github): add CODEOWNERS for auto-review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS - Auto-assign reviewers based on file paths
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @steipete
+
+# Discord subsystem
+/src/discord/ @thewilloftheshadow
+/extensions/discord/ @thewilloftheshadow
+/docs/channels/discord.md @thewilloftheshadow
+
+# Slack subsystem
+/src/slack/ @thewilloftheshadow
+/extensions/slack/ @thewilloftheshadow
+/docs/channels/slack.md @thewilloftheshadow
+
+# Telegram subsystem
+/src/telegram/ @joshp123
+/extensions/telegram/ @joshp123
+/docs/channels/telegram.md @joshp123


### PR DESCRIPTION
## Summary
Adds CODEOWNERS file to automatically assign reviewers based on file paths.

## Motivation
With 900+ PRs, auto-assignment helps route PRs to domain experts faster, reducing review latency and maintainer burden.

## Assignments (based on CONTRIBUTING.md)
- `*` → @steipete (default)
- Discord/Slack → @thewilloftheshadow
- Telegram → @joshp123

## Test plan
- [x] Verified GitHub usernames match CONTRIBUTING.md                                                                                                                                                                                       
- [x] Path patterns match labeler.yml conventions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a `.github/CODEOWNERS` file to auto-request reviews based on path ownership. It sets a default owner for all files, and assigns specific owners for Discord, Slack, and Telegram-related source, extensions, and docs paths, aligning with the owners listed in `CONTRIBUTING.md`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is isolated to adding a CODEOWNERS file with valid, repo-root-anchored patterns and existing GitHub usernames; no runtime or build impact.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->