### PR TITLE
fix: skip audio attachments before buffer analysis (#5382)

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -490,7 +490,7 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.BodyForCommands).toBe("audio ok");
   });
 
-  it("treats text-like audio attachments as CSV (comma wins over tabs)", async () => {
+  it("skips audio attachments with text-like content instead of leaking as file blocks", async () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const csvPath = path.join(dir, "data.mp3");
@@ -515,22 +515,26 @@ describe("applyMediaUnderstanding", () => {
 
     const result = await applyMediaUnderstanding({ ctx, cfg });
 
-    expect(result.appliedFile).toBe(true);
-    expect(ctx.Body).toContain('<file name="data.mp3" mime="text/csv">');
-    expect(ctx.Body).toContain('"a","b"\t"c"');
+    // Audio files should be skipped entirely, not leaked as text/csv file blocks
+    expect(result.appliedFile).toBeFalsy();
+    expect(ctx.Body).not.toContain("<file");
   });
 
-  it("infers TSV when tabs are present without commas", async () => {
+  it("skips OGG audio with high null-byte density instead of leaking as text/plain", async () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
-    const tsvPath = path.join(dir, "report.mp3");
-    const tsvText = "a\tb\tc\n1\t2\t3";
-    await fs.writeFile(tsvPath, tsvText);
+    const oggPath = path.join(dir, "voice.ogg");
+    // Create a buffer with >20% null bytes to trigger the UTF-16 heuristic false positive
+    const buf = Buffer.alloc(2048);
+    for (let i = 0; i < buf.length; i++) {
+      buf[i] = i % 3 === 0 ? 0x00 : 0x41 + (i % 26);
+    }
+    await fs.writeFile(oggPath, buf);
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
-      MediaPath: tsvPath,
-      MediaType: "audio/mpeg",
+      MediaPath: oggPath,
+      MediaType: "audio/ogg",
     };
     const cfg: OpenClawConfig = {
       tools: {
@@ -544,9 +548,10 @@ describe("applyMediaUnderstanding", () => {
 
     const result = await applyMediaUnderstanding({ ctx, cfg });
 
-    expect(result.appliedFile).toBe(true);
-    expect(ctx.Body).toContain('<file name="report.mp3" mime="text/tab-separated-values">');
-    expect(ctx.Body).toContain("a\tb\tc");
+    // Audio must not leak into context as a text/plain file block
+    expect(result.appliedFile).toBeFalsy();
+    expect(ctx.Body).not.toContain("<file");
+    expect(ctx.Body).not.toContain("text/plain");
   });
 
   it("escapes XML special characters in filenames to prevent injection", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -233,6 +233,9 @@ async function extractFileBlocks(params: {
     if (!forcedTextMime && (kind === "image" || kind === "video")) {
       continue;
     }
+    if (!forcedTextMime && kind === "audio") {
+      continue;
+    }
     if (!limits.allowUrl && attachment.url && !attachment.path) {
       if (shouldLogVerbose()) {
         logVerbose(`media: file attachment skipped (url disabled) index=${attachment.index}`);


### PR DESCRIPTION
## Summary
- Audio OGG files were leaking into context as `<file mime="text/plain">` blocks after transcription, consuming thousands of tokens with binary garbage
- Root cause: `resolveUtf16Charset` null-byte heuristic falsely identifies OGG binary as UTF-16, bypassing the audio skip guard
- Fix: move the `kind === "audio"` check before buffer download, alongside the existing image/video skip

Fixes #5382

## Test plan
- [x] New test: OGG buffer with high null-byte density is excluded from file blocks
- [x] `pnpm test` passes (16/16)
- [x] `pnpm lint` passes
- [x] `pnpm build` passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents audio attachments from being included in `extractFileBlocks` by skipping `kind === "audio"` attachments early (mirroring existing image/video skips), which stops certain binary audio buffers (e.g., OGG with many NUL bytes) from being misclassified as UTF-16 text and leaking into `<file ...>` blocks. It updates `src/media-understanding/apply.test.ts` to assert audio attachments (including NUL-heavy OGG and text-like buffers) are excluded from file blocks.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and clearly addresses the reported audio-to-file-block leakage.
- Change is narrowly scoped (one early-continue for audio attachments in `extractFileBlocks`) and backed by targeted tests verifying OGG/text-like audio no longer produces file blocks; no broader behavior changes for documents are introduced.
- src/media-understanding/apply.ts (ensure skipping audio in file blocks aligns with desired product behavior for text-named audio files).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->