### PR TITLE
feat(tools): add JSON validation to write tool for .json files

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,6 +24,7 @@
     "assets/",
     "dist/",
     "docs/_layouts/",
+    "extensions/",
     "node_modules/",
     "patches/",
     "pnpm-lock.yaml/",

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -36,6 +36,7 @@ import {
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
   wrapToolParamNormalization,
+  wrapWriteToolWithJsonValidation,
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
@@ -249,10 +250,9 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      // Wrap with param normalization for Claude Code compatibility
-      return [
-        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write),
-      ];
+      // Wrap with JSON validation and param normalization for Claude Code compatibility
+      const writeTool = wrapWriteToolWithJsonValidation(createWriteTool(workspaceRoot));
+      return [wrapToolParamNormalization(writeTool, CLAUDE_PARAM_GROUPS.write)];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {


### PR DESCRIPTION
## Summary

Add JSON validation to the `write` tool for `.json` files. This prevents agents from writing malformed JSON that would cause errors on subsequent reads.

## Changes

- Add `validateJsonContent()` function to check JSON syntax before writing `.json` files
- Show helpful error message with position and context snippet when validation fails
- Apply validation in both sandbox and non-sandbox modes

## Benefits

1. **Fail fast**: Catch JSON errors immediately instead of at read time
2. **Better error messages**: Show the exact location and context of the error
3. **Safer automation**: Prevent agents from corrupting state files
4. **Explicit feedback**: Agent sees the error and can retry with corrected JSON

## Example Error

```
Invalid JSON content for /path/to/file.json:
Expected ',' or '}' after property value in JSON at position 1275

Context:
  "key": "value"
  "another": "missing comma"
                            ^
```

Closes #5419

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a JSON-syntax guardrail for the `write` tool: when writing to `*.json` paths, it attempts `JSON.parse(content)` up front and throws a more actionable error with an extracted error position and a context snippet. The wrapper is applied in both sandboxed tool construction (`createSandboxedWriteTool`) and the non-sandbox tool list assembly in `createOpenClawCodingTools`, so agents get fast feedback instead of corrupting JSON files that later fail to read/parse.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of correctness/usability edge cases in the validation wrapper and error context formatting.
- Core behavior (JSON.parse-based validation) is straightforward and scoped to `.json` writes, but the wrapper currently inspects raw params and relies on key fallbacks (`path` vs `file_path`) rather than validating the normalized param shape, which can lead to inconsistent enforcement depending on call conventions. Error context output is also fairly rough and may be less helpful than intended in common minified/multiline cases.
- src/agents/pi-tools.read.ts (validation wrapper ordering and error context formatting)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->