### PR TITLE
feat(tools): add session_compact tool for agent-invoked context compaction

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -11,6 +11,7 @@ import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
+import { createSessionCompactTool } from "./tools/session-compact-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -133,6 +134,11 @@ export function createOpenClawTools(options?: {
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
       config: options?.config,
+    }),
+    createSessionCompactTool({
+      agentSessionKey: options?.agentSessionKey,
+      config: options?.config,
+      workspaceDir: options?.workspaceDir,
     }),
     ...(webSearchTool ? [webSearchTool] : []),
     ...(webFetchTool ? [webFetchTool] : []),

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -1,5 +1,8 @@
 export type { MessagingToolSend } from "./pi-embedded-messaging.js";
-export { compactEmbeddedPiSession } from "./pi-embedded-runner/compact.js";
+export {
+  compactEmbeddedPiSession,
+  compactEmbeddedPiSessionDirect,
+} from "./pi-embedded-runner/compact.js";
 export { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner/extra-params.js";
 
 export { applyGoogleTurnOrderingFix } from "./pi-embedded-runner/google.js";

--- a/src/agents/pi-embedded.ts
+++ b/src/agents/pi-embedded.ts
@@ -7,6 +7,7 @@ export type {
 export {
   abortEmbeddedPiRun,
   compactEmbeddedPiSession,
+  compactEmbeddedPiSessionDirect,
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   queueEmbeddedPiMessage,

--- a/src/agents/tools/session-compact-tool.ts
+++ b/src/agents/tools/session-compact-tool.ts
@@ -1,0 +1,282 @@
+import { Type } from "@sinclair/typebox";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  compactEmbeddedPiSession,
+  compactEmbeddedPiSessionDirect,
+  isEmbeddedPiRunActive,
+} from "../../agents/pi-embedded.js";
+import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey, DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { formatContextUsageShort, formatTokenCount } from "../../auto-reply/status.js";
+import { incrementCompactionCount } from "../../auto-reply/reply/session-updates.js";
+import type { AnyAgentTool } from "./common.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
+import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
+
+const SessionCompactToolSchema = Type.Object({
+  instructions: Type.Optional(
+    Type.String({
+      description:
+        "Optional instructions for what to focus on during compaction (e.g., 'Focus on decisions and open tasks')",
+    }),
+  ),
+  threshold: Type.Optional(
+    Type.Number({
+      description:
+        "Only compact if context usage exceeds this percentage (default: 0, meaning always compact). Set to 60 to skip compaction when context is below 60%.",
+      minimum: 0,
+      maximum: 100,
+    }),
+  ),
+});
+
+interface SessionCompactToolOpts {
+  config?: ReturnType<typeof loadConfig>;
+  agentSessionKey?: string;
+  workspaceDir?: string;
+  thinkLevel?: string;
+}
+
+function formatTimestamp(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+  return `${year}-${month}-${day}-${hours}${minutes}${seconds}`;
+}
+
+function writeCompactionFile(params: {
+  workspaceDir: string;
+  tokensBefore?: number;
+  tokensAfter?: number;
+  contextBefore?: number;
+  contextAfter?: number;
+  instructions?: string;
+}): string | null {
+  try {
+    const compactionsDir = path.join(params.workspaceDir, "memory", "compactions");
+    if (!fs.existsSync(compactionsDir)) {
+      fs.mkdirSync(compactionsDir, { recursive: true });
+    }
+
+    const timestamp = formatTimestamp();
+    const filename = `${timestamp}.md`;
+    const filepath = path.join(compactionsDir, filename);
+
+    const content = `# Context Compaction - ${new Date().toLocaleString("en-US", {
+      timeZone: "America/Los_Angeles",
+      dateStyle: "full",
+      timeStyle: "short",
+    })}
+
+## Compaction Summary
+- **Tokens before:** ${params.tokensBefore ? formatTokenCount(params.tokensBefore) : "unknown"}
+- **Tokens after:** ${params.tokensAfter ? formatTokenCount(params.tokensAfter) : "unknown"}
+- **Context before:** ${params.contextBefore ? `${params.contextBefore}%` : "unknown"}
+- **Context after:** ${params.contextAfter ? `${params.contextAfter}%` : "unknown"}
+${params.instructions ? `- **Focus:** ${params.instructions}` : ""}
+
+## Instructions
+Read this file after compaction to restore context. Add your working state below.
+
+## Active Task
+<!-- What were you working on? -->
+
+## Key Decisions
+<!-- Important decisions made this session -->
+
+## Next Steps
+<!-- What needs to happen next? -->
+`;
+
+    fs.writeFileSync(filepath, content, "utf-8");
+    return filepath;
+  } catch {
+    return null;
+  }
+}
+
+export function createSessionCompactTool(opts?: SessionCompactToolOpts): AnyAgentTool {
+  return {
+    label: "Session Compact",
+    name: "session_compact",
+    description:
+      "Compact the current session's context to free up token space. Use when context is above 60% to proactively manage memory. The compaction summarizes older conversation history while preserving recent messages. Automatically saves a compaction file to memory/compactions/ and returns the path.",
+    parameters: SessionCompactToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as { instructions?: string; threshold?: number };
+      const cfg = opts?.config ?? loadConfig();
+      const { mainKey, alias } = resolveMainSessionAlias(cfg);
+
+      const sessionKey = opts?.agentSessionKey;
+      if (!sessionKey) {
+        throw new Error("sessionKey required for compaction");
+      }
+
+      const agentId = resolveAgentIdFromSessionKey(sessionKey) || DEFAULT_AGENT_ID;
+      const storePath = resolveStorePath(cfg.session?.store, { agentId });
+      const store = loadSessionStore(storePath);
+
+      // Resolve the session entry
+      const internalKey = resolveInternalSessionKey({
+        key: sessionKey,
+        alias,
+        mainKey,
+      });
+      const entry = store[sessionKey] ?? store[internalKey];
+
+      if (!entry?.sessionId) {
+        return {
+          content: [{ type: "text", text: "⚙️ Compaction unavailable (missing session id)." }],
+          details: { ok: false, reason: "no sessionId" },
+        };
+      }
+
+      // Check threshold - skip if context is below threshold
+      const threshold = params.threshold ?? 0;
+      const contextTokens = entry.contextTokens ?? 200_000; // Default to 200k if unknown
+      const totalTokens = entry.totalTokens ?? (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0);
+      const currentContextPercent =
+        contextTokens > 0 ? Math.round((totalTokens / contextTokens) * 100) : 0;
+
+      if (threshold > 0 && currentContextPercent < threshold) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `⏭️ Compaction skipped: context at ${currentContextPercent}% is below ${threshold}% threshold.`,
+            },
+          ],
+          details: {
+            ok: true,
+            compacted: false,
+            skipped: true,
+            reason: `context ${currentContextPercent}% < threshold ${threshold}%`,
+            currentContextPercent,
+          },
+        };
+      }
+
+      const sessionId = entry.sessionId;
+
+      // If called from within an active run, use direct compaction to avoid
+      // aborting ourselves (which would prevent the tool result from being saved).
+      // Otherwise, use queued compaction for external callers.
+      const runIsActive = isEmbeddedPiRunActive(sessionId);
+
+      const configured = resolveDefaultModelForAgent({ cfg, agentId });
+      const workspaceDir = opts?.workspaceDir ?? resolveAgentDir(cfg, agentId);
+
+      const compactFn = runIsActive ? compactEmbeddedPiSessionDirect : compactEmbeddedPiSession;
+      const result = await compactFn({
+        sessionId,
+        sessionKey,
+        messageChannel: entry.lastChannel ?? entry.channel ?? "unknown",
+        groupId: entry.groupId,
+        groupChannel: entry.groupChannel,
+        groupSpace: entry.space,
+        spawnedBy: entry.spawnedBy,
+        sessionFile: resolveSessionFilePath(sessionId, entry),
+        workspaceDir,
+        config: cfg,
+        skillsSnapshot: entry.skillsSnapshot,
+        provider: entry.providerOverride ?? configured.provider,
+        model: entry.modelOverride ?? configured.model,
+        thinkLevel: (opts?.thinkLevel ?? cfg.agents?.defaults?.thinkingDefault ?? "medium") as any,
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        customInstructions: params.instructions,
+      });
+
+      const compactLabel = result.ok
+        ? result.compacted
+          ? result.result?.tokensBefore != null && result.result?.tokensAfter != null
+            ? `Compacted (${formatTokenCount(result.result.tokensBefore)} → ${formatTokenCount(result.result.tokensAfter)})`
+            : result.result?.tokensBefore
+              ? `Compacted (${formatTokenCount(result.result.tokensBefore)} before)`
+              : "Compacted"
+          : "Compaction skipped"
+        : "Compaction failed";
+
+      if (result.ok && result.compacted) {
+        await incrementCompactionCount({
+          sessionEntry: entry,
+          sessionStore: store,
+          sessionKey,
+          storePath,
+          tokensAfter: result.result?.tokensAfter,
+        });
+      }
+
+      // Calculate context percentages for the compaction file
+      const tokensAfterCompaction = result.result?.tokensAfter;
+      const contextAfterPercent =
+        contextTokens > 0 && tokensAfterCompaction
+          ? Math.round((tokensAfterCompaction / contextTokens) * 100)
+          : undefined;
+
+      // Auto-save compaction file
+      let compactionFilePath: string | null = null;
+      if (result.ok && result.compacted && workspaceDir) {
+        compactionFilePath = writeCompactionFile({
+          workspaceDir,
+          tokensBefore: result.result?.tokensBefore,
+          tokensAfter: result.result?.tokensAfter,
+          contextBefore: currentContextPercent,
+          contextAfter: contextAfterPercent,
+          instructions: params.instructions,
+        });
+      }
+
+      const newTotalTokens =
+        tokensAfterCompaction ??
+        entry.totalTokens ??
+        (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0);
+      const contextSummary = formatContextUsageShort(
+        newTotalTokens > 0 ? newTotalTokens : null,
+        entry.contextTokens ?? null,
+      );
+
+      const reason = result.reason?.trim();
+      const statusLine = reason
+        ? `${compactLabel}: ${reason} • ${contextSummary}`
+        : `${compactLabel} • ${contextSummary}`;
+
+      const fileNote = compactionFilePath
+        ? `\n\n📁 Compaction file saved: \`${compactionFilePath}\`\nRead this file to restore your working context.`
+        : "\n\nNext: Read your latest file from memory/compactions/ to restore context state.";
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `🧹 ${statusLine}${fileNote}`,
+          },
+        ],
+        details: {
+          ok: result.ok,
+          compacted: result.compacted,
+          tokensBefore: result.result?.tokensBefore,
+          tokensAfter: result.result?.tokensAfter,
+          contextBefore: currentContextPercent,
+          contextAfter: contextAfterPercent,
+          compactionFile: compactionFilePath,
+          reason: result.reason,
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Adds a new `session_compact` tool that allows agents to proactively manage their context window by compacting older conversation history while preserving recent messages.

## Features
- **Threshold parameter**: Skip compaction if context usage is below a specified percentage (e.g., `threshold: 60` only compacts if context is above 60%)
- **Instructions parameter**: Focus the compaction on specific topics (e.g., "Focus on decisions and open tasks")
- **Auto-save state**: Automatically saves compaction metadata to `memory/compactions/` for context restoration
- **Safe for active runs**: Uses direct compaction when called from within an active run to avoid deadlocks

## Use Case
Enables agents to maintain longer, more coherent sessions by intelligently summarizing older context when approaching token limits. Agents can now call `session_compact(threshold: 60)` to proactively manage their context before hitting limits.

## Changes
- `src/agents/tools/session-compact-tool.ts` - New tool implementation (282 lines)
- `src/agents/openclaw-tools.ts` - Wire up the new tool
- `src/agents/pi-embedded.ts` - Export `compactEmbeddedPiSessionDirect`
- `src/agents/pi-embedded-runner.ts` - Export `compactEmbeddedPiSessionDirect`

## Testing
- [x] Build passes (`pnpm build`)
- [x] All 192 unit tests pass (`pnpm test`)
- [x] Manual testing with agent sessions

---
*This is a fresh PR replacing #4126 which had merge conflicts.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new agent tool `session_compact` and wires it into the default OpenClaw tool set. The tool looks up the current session entry from the session store, optionally skips compaction based on a context-usage threshold, then runs Pi session compaction (using a direct variant when already inside an active run to avoid deadlocks). After compaction it increments the session’s compaction count and (when successful) writes a markdown “restore context” file under `memory/compactions/`.

Key areas to double-check are the user-facing output formatting (newlines), threshold behavior when context size is unknown, and a few small correctness/type-safety details in the compaction file and thinkLevel handling.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; issues are mostly around UX correctness and edge-case behavior.
- The new tool follows existing compaction plumbing and uses the established direct-compaction path to avoid lane deadlocks, with no broad behavioral changes elsewhere. Findings are limited to output formatting (embedded "\\n"), edge-case reporting in the saved file, and threshold behavior when contextTokens is unknown.
- src/agents/tools/session-compact-tool.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->