### PR TITLE
refactor: update control UI assets and enhance agent tools

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -285,6 +285,9 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    dashscope: "DASHSCOPE_API_KEY",
+    volcengine: "VOLCENGINE_API_KEY",
+    deepseek: "DEEPSEEK_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) return null;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -75,6 +75,30 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+const DASHSCOPE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const VOLCENGINE_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3";
+const VOLCENGINE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+const DEEPSEEK_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -359,6 +383,125 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   };
 }
 
+function buildDashScopeProvider(): ProviderConfig {
+  return {
+    baseUrl: DASHSCOPE_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: "qwen-turbo",
+        name: "Qwen Turbo",
+        reasoning: false,
+        input: ["text"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 32768,
+        maxTokens: 8192,
+      },
+      {
+        id: "qwen-plus",
+        name: "Qwen Plus",
+        reasoning: false,
+        input: ["text"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: 8192,
+      },
+      {
+        id: "qwen-max",
+        name: "Qwen Max",
+        reasoning: false,
+        input: ["text"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 32768,
+        maxTokens: 8192,
+      },
+      {
+        id: "qwen3-max",
+        name: "Qwen 3 Max",
+        reasoning: false,
+        input: ["text"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: 8192,
+      },
+      {
+        id: "qwen3-max-2026-01-23",
+        name: "Qwen 3 Max (2026-01-23)",
+        reasoning: false,
+        input: ["text"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: 8192,
+      },
+      {
+        id: "qwen-vl-max",
+        name: "Qwen VL Max",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: DASHSCOPE_DEFAULT_COST,
+        contextWindow: 32768,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
+function buildVolcengineProvider(): ProviderConfig {
+  return {
+    baseUrl: VOLCENGINE_BASE_URL,
+    api: "openai-completions",
+    models: [
+      // Volcengine models usually require specific endpoint IDs.
+      // We provide some common ones or placeholders.
+      {
+        id: "doubao-pro-32k",
+        name: "Doubao Pro 32k",
+        reasoning: false,
+        input: ["text"],
+        cost: VOLCENGINE_DEFAULT_COST,
+        contextWindow: 32768,
+        maxTokens: 8192,
+      },
+      {
+        id: "doubao-pro-128k",
+        name: "Doubao Pro 128k",
+        reasoning: false,
+        input: ["text"],
+        cost: VOLCENGINE_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
+function buildDeepSeekProvider(): ProviderConfig {
+  return {
+    baseUrl: DEEPSEEK_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: "deepseek-chat",
+        name: "DeepSeek Chat",
+        reasoning: false,
+        input: ["text"],
+        cost: DEEPSEEK_DEFAULT_COST,
+        contextWindow: 65536,
+        maxTokens: 8192,
+      },
+      {
+        id: "deepseek-reasoner",
+        name: "DeepSeek Reasoner",
+        reasoning: true,
+        input: ["text"],
+        cost: DEEPSEEK_DEFAULT_COST,
+        contextWindow: 65536,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -416,6 +559,27 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  }
+
+  const dashscopeKey =
+    resolveEnvApiKeyVarName("dashscope") ??
+    resolveApiKeyFromProfiles({ provider: "dashscope", store: authStore });
+  if (dashscopeKey) {
+    providers.dashscope = { ...buildDashScopeProvider(), apiKey: dashscopeKey };
+  }
+
+  const volcengineKey =
+    resolveEnvApiKeyVarName("volcengine") ??
+    resolveApiKeyFromProfiles({ provider: "volcengine", store: authStore });
+  if (volcengineKey) {
+    providers.volcengine = { ...buildVolcengineProvider(), apiKey: volcengineKey };
+  }
+
+  const deepseekKey =
+    resolveEnvApiKeyVarName("deepseek") ??
+    resolveApiKeyFromProfiles({ provider: "deepseek", store: authStore });
+  if (deepseekKey) {
+    providers.deepseek = { ...buildDeepSeekProvider(), apiKey: deepseekKey };
   }
 
   return providers;

--- a/src/agents/moltbot-tools.ts
+++ b/src/agents/moltbot-tools.ts
@@ -7,6 +7,7 @@ import { createBrowserTool } from "./tools/browser-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
+import { createDateTool } from "./tools/date-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
@@ -82,6 +83,9 @@ export function createMoltbotTools(options?: {
     }),
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
+    }),
+    createDateTool({
+      config: options?.config,
     }),
     createMessageTool({
       agentAccountId: options?.agentAccountId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -307,23 +307,24 @@ export async function runEmbeddedAttempt(
       agentId: sessionAgentId,
     });
     const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-    const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
-      config: params.config,
-      agentId: sessionAgentId,
-      workspaceDir: effectiveWorkspace,
-      cwd: process.cwd(),
-      runtime: {
-        host: machineName,
-        os: `${os.type()} ${os.release()}`,
-        arch: os.arch(),
-        node: process.version,
-        model: `${params.provider}/${params.modelId}`,
-        defaultModel: defaultModelLabel,
-        channel: runtimeChannel,
-        capabilities: runtimeCapabilities,
-        channelActions,
-      },
-    });
+    const { runtimeInfo, userTimezone, userTime, userTimeFormat, userTimestampMs } =
+      buildSystemPromptParams({
+        config: params.config,
+        agentId: sessionAgentId,
+        workspaceDir: effectiveWorkspace,
+        cwd: process.cwd(),
+        runtime: {
+          host: machineName,
+          os: `${os.type()} ${os.release()}`,
+          arch: os.arch(),
+          node: process.version,
+          model: `${params.provider}/${params.modelId}`,
+          defaultModel: defaultModelLabel,
+          channel: runtimeChannel,
+          capabilities: runtimeCapabilities,
+          channelActions,
+        },
+      });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
     const promptMode = isSubagentSessionKey(params.sessionKey) ? "minimal" : "full";
     const docsPath = await resolveMoltbotDocsPath({
@@ -358,6 +359,7 @@ export async function runEmbeddedAttempt(
       userTimezone,
       userTime,
       userTimeFormat,
+      userTimestampMs,
       contextFiles,
     });
     const systemPromptReport = buildSystemPromptReport({

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -44,6 +44,7 @@ export function buildEmbeddedSystemPrompt(params: {
   userTimezone: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  userTimestampMs?: number;
   contextFiles?: EmbeddedContextFile[];
 }): string {
   return buildAgentSystemPrompt({
@@ -69,6 +70,7 @@ export function buildEmbeddedSystemPrompt(params: {
     userTimezone: params.userTimezone,
     userTime: params.userTime,
     userTimeFormat: params.userTimeFormat,
+    userTimestampMs: params.userTimestampMs,
     contextFiles: params.contextFiles,
   });
 }

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -29,6 +29,7 @@ export type SystemPromptRuntimeParams = {
   userTimezone: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  userTimestampMs?: number;
 };
 
 export function buildSystemPromptParams(params: {
@@ -43,9 +44,10 @@ export function buildSystemPromptParams(params: {
     workspaceDir: params.workspaceDir,
     cwd: params.cwd,
   });
+  const now = new Date();
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
   const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
-  const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+  const userTime = formatUserTime(now, userTimezone, userTimeFormat);
   return {
     runtimeInfo: {
       agentId: params.agentId,
@@ -55,6 +57,7 @@ export function buildSystemPromptParams(params: {
     userTimezone,
     userTime,
     userTimeFormat,
+    userTimestampMs: now.getTime(),
   };
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -49,9 +49,25 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: {
+  userTimezone?: string;
+  userTime?: string;
+  userTimestampMs?: number;
+}) {
   if (!params.userTimezone) return [];
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = [
+    "## Current Date & Time",
+    "CRITICAL: The information below represents the EXACT CURRENT TIME. Stale timestamps in conversation history MUST BE IGNORED. If you need to verify the time again, call the `date` tool.",
+    `Time zone: ${params.userTimezone}`,
+  ];
+  if (params.userTime) {
+    lines.push(`Current time: ${params.userTime}`);
+  }
+  if (params.userTimestampMs) {
+    lines.push(`Current timestamp (ms): ${params.userTimestampMs}`);
+  }
+  lines.push("");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -139,6 +155,7 @@ export function buildAgentSystemPrompt(params: {
   userTimezone?: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  userTimestampMs?: number;
   contextFiles?: EmbeddedContextFile[];
   skillsPrompt?: string;
   heartbeatPrompt?: string;
@@ -189,6 +206,7 @@ export function buildAgentSystemPrompt(params: {
     ls: "List directory contents",
     exec: "Run shell commands (pty available for TTY-required CLIs)",
     process: "Manage background exec sessions",
+    date: "Get the current system date and time",
     web_search: "Search the web (Brave API)",
     web_fetch: "Fetch and extract readable content from a URL",
     // Channel docking: add login tools here when a channel needs interactive linking.
@@ -218,6 +236,7 @@ export function buildAgentSystemPrompt(params: {
     "ls",
     "exec",
     "process",
+    "date",
     "web_search",
     "web_fetch",
     "browser",
@@ -445,6 +464,8 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
+      userTimestampMs: params.userTimestampMs,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by Moltbot and included below in Project Context.",

--- a/src/agents/tools/date-tool.ts
+++ b/src/agents/tools/date-tool.ts
@@ -1,0 +1,43 @@
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import type { ClawdbotConfig } from "../../config/config.js";
+
+const DateSchema = Type.Object({
+  timezone: Type.Optional(
+    Type.String({
+      description:
+        "Optional IANA timezone name (e.g. 'Asia/Shanghai', 'America/New_York'). Defaults to the user's configured timezone.",
+    }),
+  ),
+});
+
+export function createDateTool(options?: { config?: ClawdbotConfig }): AnyAgentTool {
+  return {
+    label: "Date & Time",
+    name: "date",
+    description:
+      "Get the current system date and time. ALWAYS call this tool when the user asks for the current time, or before scheduling any time-sensitive task. DO NOT rely on timestamps in the conversation history or your own internal clock.",
+    parameters: DateSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const configTimezone = options?.config?.agents?.defaults?.userTimezone;
+      const requestedTimezone = readStringParam(params, "timezone");
+      const timezone = resolveUserTimezone(requestedTimezone ?? configTimezone);
+      const format = resolveUserTimeFormat(options?.config?.agents?.defaults?.timeFormat);
+
+      const now = new Date();
+      const formatted = formatUserTime(now, timezone, format);
+
+      console.log(`[date-tool] Returning current time: ${formatted} (${now.toISOString()})`);
+
+      return jsonResult({
+        iso: now.toISOString(),
+        timestampMs: now.getTime(),
+        formatted,
+        timezone,
+      });
+    },
+  };
+}

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -14,6 +14,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // Check for exact matches or known prefixes/substrings for reasoning providers
   if (
     normalized === "ollama" ||
+    normalized === "deepseek" ||
     normalized === "google-gemini-cli" ||
     normalized === "google-generative-ai"
   ) {


### PR DESCRIPTION
- Replaced outdated JavaScript and CSS files in the control UI with new versions.
- Added a new date tool to the agent tools for enhanced date handling.
- Introduced new API keys and configurations for DashScope, VolcEngine, and DeepSeek providers.
- Updated system prompt parameters to include user timestamp in milliseconds for better time tracking.
- Enhanced timezone handling in session updates to default to user-configured timezone.

This update improves the overall functionality and reliability of the control UI and agent tools.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands Moltbot’s agent/runtime capabilities by:

- Adding a new `date` agent tool and surfacing current time information (formatted time + timestamp ms) into the system prompt.
- Updating system prompt parameter generation to provide a consistent `now` and include `userTimestampMs`.
- Defaulting system event timestamps to the user-configured/detected timezone (instead of host-local) when no explicit envelope timezone is configured.
- Adding implicit provider configs and env var mappings for DashScope, VolcEngine, and DeepSeek, and treating DeepSeek as a “reasoning tag” provider.

Overall this fits into the existing agent architecture by extending tool registration (`createMoltbotTools`), system prompt assembly (`buildAgentSystemPrompt` / embedded runner), and provider resolution (`resolveImplicitProviders` / env key mapping).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are additive and localized, with one minor correctness edge case noted.
- Most changes add new optional fields/tools and new provider configs without altering core control flow. The main concern found is a small truthiness check that can drop a valid timestamp value in edge cases (e.g., mocked epoch). CI/test execution wasn’t possible in this environment (no npm), so runtime verification is limited.
- src/agents/system-prompt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->