### PR TITLE
feat(skills): resolve API keys from auth profiles

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -168,6 +168,7 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
+    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
@@ -176,10 +177,12 @@ export async function runEmbeddedAttempt(
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
+          agentDir,
         })
       : applySkillEnvOverrides({
           skills: skillEntries ?? [],
           config: params.config,
+          agentDir,
         });
 
     const skillsPrompt = resolveSkillsPromptForRun({
@@ -203,8 +206,6 @@ export async function runEmbeddedAttempt(
     )
       ? ["Reminder: commit your changes in this workspace after edits."]
       : undefined;
-
-    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -1,20 +1,81 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  type AuthProfileStore,
+} from "../auth-profiles.js";
 import { resolveSkillConfig } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
 import type { SkillEntry, SkillSnapshot } from "./types.js";
 
-export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
-  const { skills, config } = params;
+/**
+ * Maps environment variable names to their corresponding provider IDs.
+ * Used to resolve API keys from auth profiles when env vars are not set.
+ */
+const ENV_VAR_TO_PROVIDER: Record<string, string> = {
+  OPENAI_API_KEY: "openai",
+  ANTHROPIC_API_KEY: "anthropic",
+  GEMINI_API_KEY: "google",
+  GROQ_API_KEY: "groq",
+  DEEPGRAM_API_KEY: "deepgram",
+  CEREBRAS_API_KEY: "cerebras",
+  XAI_API_KEY: "xai",
+  OPENROUTER_API_KEY: "openrouter",
+  MINIMAX_API_KEY: "minimax",
+  MISTRAL_API_KEY: "mistral",
+  BRAVE_API_KEY: "brave",
+};
+
+/**
+ * Synchronously resolve an API key from auth profiles for a given env var.
+ * Only works for api_key type credentials (not OAuth which requires async refresh).
+ */
+function resolveEnvFromAuthProfileSync(
+  envKey: string,
+  store: AuthProfileStore,
+): string | undefined {
+  const provider = ENV_VAR_TO_PROVIDER[envKey];
+  if (!provider) {
+    return undefined;
+  }
+  const profileIds = listProfilesForProvider(store, provider);
+  for (const profileId of profileIds) {
+    const cred = store.profiles[profileId];
+    if (cred?.type === "api_key" && cred.key) {
+      return cred.key;
+    }
+    // For token credentials, use the token as the API key
+    if (cred?.type === "token" && cred.token) {
+      return cred.token;
+    }
+  }
+  return undefined;
+}
+
+export function applySkillEnvOverrides(params: {
+  skills: SkillEntry[];
+  config?: OpenClawConfig;
+  agentDir?: string;
+}) {
+  const { skills, config, agentDir } = params;
   const updates: Array<{ key: string; prev: string | undefined }> = [];
+
+  // Load auth profile store once for all skills
+  let authStore: AuthProfileStore | undefined;
+  try {
+    authStore = agentDir
+      ? ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false })
+      : undefined;
+  } catch {
+    // Auth store not available
+  }
 
   for (const entry of skills) {
     const skillKey = resolveSkillKey(entry.skill, entry);
     const skillConfig = resolveSkillConfig(config, skillKey);
-    if (!skillConfig) {
-      continue;
-    }
 
-    if (skillConfig.env) {
+    // Check skill-specific env config
+    if (skillConfig?.env) {
       for (const [envKey, envValue] of Object.entries(skillConfig.env)) {
         if (!envValue || process.env[envKey]) {
           continue;
@@ -24,10 +85,26 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
       }
     }
 
+    // Check skill-specific apiKey config
     const primaryEnv = entry.metadata?.primaryEnv;
-    if (primaryEnv && skillConfig.apiKey && !process.env[primaryEnv]) {
+    if (primaryEnv && skillConfig?.apiKey && !process.env[primaryEnv]) {
       updates.push({ key: primaryEnv, prev: process.env[primaryEnv] });
       process.env[primaryEnv] = skillConfig.apiKey;
+    }
+
+    // Check auth profiles for required env vars that aren't set
+    const requiredEnv = entry.metadata?.requires?.env ?? [];
+    if (authStore) {
+      for (const envKey of requiredEnv) {
+        if (process.env[envKey]) {
+          continue;
+        }
+        const apiKey = resolveEnvFromAuthProfileSync(envKey, authStore);
+        if (apiKey) {
+          updates.push({ key: envKey, prev: process.env[envKey] });
+          process.env[envKey] = apiKey;
+        }
+      }
     }
   }
 
@@ -45,20 +122,29 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
 export function applySkillEnvOverridesFromSnapshot(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
+  agentDir?: string;
 }) {
-  const { snapshot, config } = params;
+  const { snapshot, config, agentDir } = params;
   if (!snapshot) {
     return () => {};
   }
   const updates: Array<{ key: string; prev: string | undefined }> = [];
 
+  // Load auth profile store once for all skills
+  let authStore: AuthProfileStore | undefined;
+  try {
+    authStore = agentDir
+      ? ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false })
+      : undefined;
+  } catch {
+    // Auth store not available
+  }
+
   for (const skill of snapshot.skills) {
     const skillConfig = resolveSkillConfig(config, skill.name);
-    if (!skillConfig) {
-      continue;
-    }
 
-    if (skillConfig.env) {
+    // Check skill-specific env config
+    if (skillConfig?.env) {
       for (const [envKey, envValue] of Object.entries(skillConfig.env)) {
         if (!envValue || process.env[envKey]) {
           continue;
@@ -68,12 +154,25 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       }
     }
 
-    if (skill.primaryEnv && skillConfig.apiKey && !process.env[skill.primaryEnv]) {
+    // Check skill-specific apiKey config
+    if (skill.primaryEnv && skillConfig?.apiKey && !process.env[skill.primaryEnv]) {
       updates.push({
         key: skill.primaryEnv,
         prev: process.env[skill.primaryEnv],
       });
       process.env[skill.primaryEnv] = skillConfig.apiKey;
+    }
+
+    // Check auth profiles for primaryEnv if not set
+    if (skill.primaryEnv && !process.env[skill.primaryEnv] && authStore) {
+      const apiKey = resolveEnvFromAuthProfileSync(skill.primaryEnv, authStore);
+      if (apiKey) {
+        updates.push({
+          key: skill.primaryEnv,
+          prev: process.env[skill.primaryEnv],
+        });
+        process.env[skill.primaryEnv] = apiKey;
+      }
     }
   }
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -71,6 +71,8 @@ export type SkillEntry = {
 };
 
 export type SkillEligibilityContext = {
+  /** Agent directory for auth profile resolution. */
+  agentDir?: string;
   remote?: {
     platforms: string[];
     hasBin: (bin: string) => boolean;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -240,6 +240,7 @@ export async function runPreparedReply(
     isFirstTurnInSession,
     workspaceDir,
     cfg,
+    agentDir,
     skillFilter: opts?.skillFilter,
   });
   sessionEntry = skillResult.sessionEntry ?? sessionEntry;

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -161,6 +161,8 @@ export async function ensureSkillSnapshot(params: {
   isFirstTurnInSession: boolean;
   workspaceDir: string;
   cfg: OpenClawConfig;
+  /** Agent directory for auth profile resolution. */
+  agentDir?: string;
   /** If provided, only load skills with these names (for per-channel skill filtering) */
   skillFilter?: string[];
 }): Promise<{
@@ -177,6 +179,7 @@ export async function ensureSkillSnapshot(params: {
     isFirstTurnInSession,
     workspaceDir,
     cfg,
+    agentDir,
     skillFilter,
   } = params;
 
@@ -199,7 +202,7 @@ export async function ensureSkillSnapshot(params: {
         ? buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { agentDir, remote: remoteEligibility },
             snapshotVersion,
           })
         : current.skillsSnapshot;
@@ -223,7 +226,7 @@ export async function ensureSkillSnapshot(params: {
     ? buildWorkspaceSkillSnapshot(workspaceDir, {
         config: cfg,
         skillFilter,
-        eligibility: { remote: remoteEligibility },
+        eligibility: { agentDir, remote: remoteEligibility },
         snapshotVersion,
       })
     : (nextEntry?.skillsSnapshot ??
@@ -232,7 +235,7 @@ export async function ensureSkillSnapshot(params: {
         : buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { agentDir, remote: remoteEligibility },
             snapshotVersion,
           })));
   if (

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -190,7 +190,7 @@ export async function agentCommand(
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
+          eligibility: { agentDir, remote: getRemoteSkillEligibility() },
           snapshotVersion: skillsSnapshotVersion,
         })
       : sessionEntry?.skillsSnapshot;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -295,7 +295,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const skillsSnapshot = needsSkillsSnapshot
     ? buildWorkspaceSkillSnapshot(workspaceDir, {
         config: cfgWithAgentDefaults,
-        eligibility: { remote: getRemoteSkillEligibility() },
+        eligibility: { agentDir, remote: getRemoteSkillEligibility() },
         snapshotVersion: skillsSnapshotVersion,
       })
     : cronSession.sessionEntry.skillsSnapshot;


### PR DESCRIPTION
## Summary

- Skills that require env vars like `OPENAI_API_KEY` can now pull them from auth profiles stored in `~/.clawdbot/agents/<agentId>/`
- Adds `ENV_VAR_TO_PROVIDER` mapping to resolve API keys for: openai, anthropic, google, groq, deepgram, cerebras, xai, openrouter, minimax, mistral, brave
- Updates skill eligibility checks to consider auth profiles when determining if required env vars are available

## Changes

- `src/agents/skills/env-overrides.ts` - Core logic to resolve API keys from auth profiles
- `src/agents/skills/config.ts` - Check auth profiles in `shouldIncludeSkill()`
- `src/agents/skills/types.ts` - Add `agentDir` to `SkillEligibilityContext`
- Wiring in `attempt.ts`, `get-reply-run.ts`, `session-updates.ts`, `agent.ts`, `cron/run.ts`

## Test plan

- [ ] Verify skills with `requires.env` work when API key is in auth profile but not in environment
- [ ] Verify existing behavior unchanged when env vars are set directly
- [ ] Run existing skills tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the skills system so that required API-key env vars (e.g., `OPENAI_API_KEY`) can be satisfied by credentials stored in agent auth profiles (under the agent directory) rather than only by process env or `skills.entries.*.apiKey` config. It adds an env-var-to-provider mapping, threads `agentDir` through skill snapshot generation and embedded runs, and uses that context to (a) decide whether a skill is eligible and (b) temporarily set missing env vars from stored auth profiles during a run.

Overall the change fits into the existing “skill snapshot + env override” flow: eligibility determines which skills load into the prompt, and env overrides ensure the runtime environment has the credentials those skills expect.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there’s a correctness edge case in skill eligibility when `agentDir` is missing.
- The core approach (loading auth store once and applying env overrides) is straightforward and scoped. The main concern is `shouldIncludeSkill()` calling `ensureAuthProfileStore` with an undefined `agentDir`, which can make skills incorrectly ineligible in some execution contexts. A secondary concern is using `token` credentials as API keys, which may not match how tokens are represented for all providers.
- src/agents/skills/config.ts, src/agents/skills/env-overrides.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->