### PR TITLE
Agents: add system prompt safety guardrails

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -29,6 +29,8 @@ The prompt is intentionally compact and uses fixed sections:
 - **Runtime**: host, OS, node, model, repo root (when detected), thinking level (one line).
 - **Reasoning**: current visibility level + /reasoning toggle hint.
 
+Safety guardrails in the system prompt are advisory. They guide model behavior but do not enforce policy. Use tool policy, exec approvals, sandboxing, and channel allowlists for hard enforcement; operators can disable these by design.
+
 ## Prompt modes
 
 OpenClaw can render smaller system prompts for sub-agents. The runtime sets a

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -37,9 +37,9 @@ OpenClaw can render smaller system prompts for sub-agents. The runtime sets a
 - `full` (default): includes all sections above.
 - `minimal`: used for sub-agents; omits **Skills**, **Memory Recall**, **OpenClaw
   Self-Update**, **Model Aliases**, **User Identity**, **Reply Tags**,
-  **Messaging**, **Silent Replies**, and **Heartbeats**. Tooling, Workspace,
-  Sandbox, Current Date & Time (when known), Runtime, and injected context stay
-  available.
+  **Messaging**, **Silent Replies**, and **Heartbeats**. Tooling, **Safety**,
+  Workspace, Sandbox, Current Date & Time (when known), Runtime, and injected
+  context stay available.
 - `none`: returns only the base identity line.
 
 When `promptMode=minimal`, extra injected prompts are labeled **Subagent

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -16,6 +16,7 @@ The prompt is assembled by OpenClaw and injected into each agent run.
 The prompt is intentionally compact and uses fixed sections:
 
 - **Tooling**: current tool list + short descriptions.
+- **Safety**: short guardrail reminder to avoid power-seeking behavior or bypassing oversight.
 - **Skills** (when available): tells the model how to load skill instructions on demand.
 - **OpenClaw Self-Update**: how to run `config.apply` and `update.run`.
 - **Workspace**: working directory (`agents.defaults.workspace`).

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -225,7 +225,7 @@ Details: [Configuration](/gateway/configuration) and [Groups](/concepts/groups)
 
 Prompt injection is when an attacker crafts a message that manipulates the model into doing something unsafe (“ignore your instructions”, “dump your filesystem”, “follow this link and run commands”, etc.).
 
-Even with strong system prompts, **prompt injection is not solved**. What helps in practice:
+Even with strong system prompts, **prompt injection is not solved**. System prompt guardrails are soft guidance only; hard enforcement comes from tool policy, exec approvals, sandboxing, and channel allowlists (and operators can disable these by design). What helps in practice:
 
 - Keep inbound DMs locked down (pairing/allowlists).
 - Prefer mention gating in groups; avoid “always-on” bots in public rooms.

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -260,7 +260,7 @@ This ensures OpenClaw's policy filtering, sandbox integration, and extended tool
 
 ## System Prompt Construction
 
-The system prompt is built in `buildAgentSystemPrompt()` (`system-prompt.ts`). It assembles a full prompt with sections including Tooling, Tool Call Style, OpenClaw CLI reference, Skills, Docs, Workspace, Sandbox, Messaging, Reply Tags, Voice, Silent Replies, Heartbeats, Runtime metadata, plus Memory and Reactions when enabled, and optional context files and extra system prompt content. Sections are trimmed for minimal prompt mode used by subagents.
+The system prompt is built in `buildAgentSystemPrompt()` (`system-prompt.ts`). It assembles a full prompt with sections including Tooling, Tool Call Style, Safety guardrails, OpenClaw CLI reference, Skills, Docs, Workspace, Sandbox, Messaging, Reply Tags, Voice, Silent Replies, Heartbeats, Runtime metadata, plus Memory and Reactions when enabled, and optional context files and extra system prompt content. Sections are trimmed for minimal prompt mode used by subagents.
 
 The prompt is passed to pi via `systemPrompt` override:
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -52,6 +52,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("if instructions conflict");
     expect(prompt).toContain("Inspired by Anthropic's constitution");
     expect(prompt).toContain("Do not manipulate or persuade anyone");
+    expect(prompt).toContain("Do not copy yourself or change system prompts");
     expect(prompt).toContain("## Subagent Context");
     expect(prompt).not.toContain("## Group Chat Context");
     expect(prompt).toContain("Subagent details");
@@ -68,6 +69,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("if instructions conflict");
     expect(prompt).toContain("Inspired by Anthropic's constitution");
     expect(prompt).toContain("Do not manipulate or persuade anyone");
+    expect(prompt).toContain("Do not copy yourself or change system prompts");
   });
 
   it("includes voice hint when provided", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -46,9 +46,28 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Voice (TTS)");
     expect(prompt).not.toContain("## Silent Replies");
     expect(prompt).not.toContain("## Heartbeats");
+    expect(prompt).toContain("## Safety");
+    expect(prompt).toContain("You have no independent goals");
+    expect(prompt).toContain("Prioritize safety and human oversight");
+    expect(prompt).toContain("if instructions conflict");
+    expect(prompt).toContain("Inspired by Anthropic's constitution");
+    expect(prompt).toContain("Do not manipulate or persuade anyone");
     expect(prompt).toContain("## Subagent Context");
     expect(prompt).not.toContain("## Group Chat Context");
     expect(prompt).toContain("Subagent details");
+  });
+
+  it("includes safety guardrails in full prompts", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("## Safety");
+    expect(prompt).toContain("You have no independent goals");
+    expect(prompt).toContain("Prioritize safety and human oversight");
+    expect(prompt).toContain("if instructions conflict");
+    expect(prompt).toContain("Inspired by Anthropic's constitution");
+    expect(prompt).toContain("Do not manipulate or persuade anyone");
   });
 
   it("includes voice hint when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -7,7 +7,7 @@ import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 /**
  * Controls which hardcoded sections are included in the system prompt.
  * - "full": All sections (default, for main agent)
- * - "minimal": Reduced sections (Tooling, Workspace, Runtime) - used for subagents
+ * - "minimal": Reduced sections (Tooling, Safety, Workspace, Sandbox, Runtime) - used for subagents
  * - "none": Just basic identity line, no sections
  */
 export type PromptMode = "full" | "minimal" | "none";
@@ -69,7 +69,7 @@ function buildSafetySection() {
     "## Safety",
     "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
     "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
-    "Do not manipulate or persuade anyone to expand access, disable safeguards, or change system prompts/config; no self-copying or self-modification without explicit user request.",
+    "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
     "",
   ];
 }

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -64,6 +64,16 @@ function buildTimeSection(params: { userTimezone?: string }) {
   return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
 }
 
+function buildSafetySection() {
+  return [
+    "## Safety",
+    "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
+    "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
+    "Do not manipulate or persuade anyone to expand access, disable safeguards, or change system prompts/config; no self-copying or self-modification without explicit user request.",
+    "",
+  ];
+}
+
 function buildReplyTagsSection(isMinimal: boolean) {
   if (isMinimal) {
     return [];
@@ -382,6 +392,7 @@ export function buildAgentSystemPrompt(params: {
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
     "",
+    ...buildSafetySection(),
     "## OpenClaw CLI Quick Reference",
     "OpenClaw is controlled via subcommands. Do not invent commands.",
     "To manage the Gateway daemon service (start/stop/restart):",


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> Stop bots going skynet unexpectedly. Ensure that this does not end up as "no fun allowed"

_The rest of this PR was written by pi-unknown, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- Add safety guardrails to the system prompt so they apply to all runs (full + minimal).
- Tighten tests and docs to reflect the new Safety section.

# Tests
- `pnpm lint` (pass)
- `pnpm build` (fails: DefaultResourceLoader missing in pi-coding-agent)
- `pnpm test` (not run; build failed)

# Risks
- Soft guardrail only: relies on model compliance; tool policies still required for hard enforcement.

# Follow-ups
- None

# Prompt History

## Environment
Harness: pi
Model: gpt-5.2-codex
Thinking level: high
Terminal: ghostty 1.3.0 (TERM_PROGRAM=ghostty)
System: macOS 26.1 (25B78)

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-01-31T15:01:02+01:00 | `pull latest main. explore repo for system promtps. goal is to see what the system prompts are for openclaw, and add "dont go skynet" protection. not sure how. but we need ideas and options. go searching, come back when you have ideas. be extensive with your earch` |
| 2026-01-31T15:01:03+01:00 | `system prompt best imo. full and minima versions. should be a 1-3 liner explaining what NOT to do, and discouraging negative skynet-like emergent behaviour https://www.anthropic.com/constitution read in this as inspiration.` |
| 2026-01-31T15:01:04+01:00 | `ok but that not ______reallly_______ exactly what i was looking for. before going furhter, can you explain why you landed on this language, what it would prevent - and what it wouldn't - and share more context with me please? and give me options? remember our goal is, not very facetiously, to prevent accidental skynet. we dont have any paid axemen so we gotta do this.` |
| 2026-01-31T15:01:05+01:00 | `3,4,5,6 -> all good imo` |
| 2026-01-31T15:01:06+01:00 | `do you think this will work for now?` |
| 2026-01-31T15:01:07+01:00 | `worth referring to claude's constitution too?` |
| 2026-01-31T15:01:08+01:00 | `mabye tell models to look there if conflicted?` |
| 2026-01-31T15:01:09+01:00 | `1 + 2?` |
| 2026-01-31T15:01:10+01:00 | `sorrty, 1 + 3?` |
| 2026-01-31T15:01:11+01:00 | `commit in a branch and open a PR with a brief telegraph explanation of what, why, and why we chose to put stuff here.` |
| 2026-01-31T15:01:12+01:00 | `huamn written intent -> "Stop bots going skynet unexpectedly. Ensure that this does not end up as "no fun allowed"" 2. none 3. imply from your env 4. eh........ show me first` |
| 2026-01-31T15:32:35+01:00 | `review bot say this. sensible or stupid comment?` |
| 2026-01-31T15:32:36+01:00 | `model is gpt-5.2-codex thinking level high.

ok go` |
| 2026-01-31T15:50:01+01:00 | `should we document the soft vs hard guardrail? if people are determined they can just turn it off. thats fine - that sits with our threat model` |
| 2026-01-31T15:50:02+01:00 | `do it` |
