### PR TITLE
Docs: add actionable cron quick start

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -59,37 +59,7 @@ openclaw cron add \
 
 ## Tool-call equivalents (Gateway cron tool)
 
-One-shot, main session job (system event):
-
-```json
-{
-  "name": "Reminder",
-  "schedule": { "kind": "at", "atMs": 1769961600000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
-  "payload": { "kind": "systemEvent", "text": "Reminder: check the cron docs draft" },
-  "deleteAfterRun": true
-}
-```
-
-Recurring, isolated job with delivery:
-
-```json
-{
-  "name": "Morning brief",
-  "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
-  "sessionTarget": "isolated",
-  "wakeMode": "next-heartbeat",
-  "payload": {
-    "kind": "agentTurn",
-    "message": "Summarize overnight updates.",
-    "deliver": true,
-    "channel": "slack",
-    "to": "channel:C1234567890"
-  },
-  "isolation": { "postToMainPrefix": "Cron", "postToMainMode": "summary" }
-}
-```
+For the canonical JSON shapes and examples, see [JSON schema for tool calls](/automation/cron-jobs#json-schema-for-tool-calls).
 
 ## Where cron jobs are stored
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -25,6 +25,79 @@ cron is the mechanism.
   - **Isolated**: run a dedicated agent turn in `cron:<jobId>`, optionally deliver output.
 - Wakeups are first-class: a job can request “wake now” vs “next heartbeat”.
 
+## Quick start (actionable)
+
+Create a one-shot reminder, verify it exists, and run it immediately:
+
+```bash
+openclaw cron add \
+  --name "Reminder" \
+  --at "2026-02-01T16:00:00Z" \
+  --session main \
+  --system-event "Reminder: check the cron docs draft" \
+  --wake now \
+  --delete-after-run
+
+openclaw cron list
+openclaw cron run <job-id> --force
+openclaw cron runs --id <job-id>
+```
+
+Schedule a recurring isolated job with delivery:
+
+```bash
+openclaw cron add \
+  --name "Morning brief" \
+  --cron "0 7 * * *" \
+  --tz "America/Los_Angeles" \
+  --session isolated \
+  --message "Summarize overnight updates." \
+  --deliver \
+  --channel slack \
+  --to "channel:C1234567890"
+```
+
+## Tool-call equivalents (Gateway cron tool)
+
+One-shot, main session job (system event):
+
+```json
+{
+  "name": "Reminder",
+  "schedule": { "kind": "at", "atMs": 1769961600000 },
+  "sessionTarget": "main",
+  "wakeMode": "now",
+  "payload": { "kind": "systemEvent", "text": "Reminder: check the cron docs draft" },
+  "deleteAfterRun": true
+}
+```
+
+Recurring, isolated job with delivery:
+
+```json
+{
+  "name": "Morning brief",
+  "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
+  "payload": {
+    "kind": "agentTurn",
+    "message": "Summarize overnight updates.",
+    "deliver": true,
+    "channel": "slack",
+    "to": "channel:C1234567890"
+  },
+  "isolation": { "postToMainPrefix": "Cron", "postToMainMode": "summary" }
+}
+```
+
+## Where cron jobs are stored
+
+Cron jobs are persisted on the Gateway host at `~/.openclaw/cron/jobs.json` by default.
+The Gateway loads the file into memory and writes it back on changes, so manual edits
+are only safe when the Gateway is stopped. Prefer `openclaw cron add/edit` or the cron
+tool call API for changes.
+
 ## Beginner-friendly overview
 
 Think of a cron job as: **when** to run + **what** to do.
@@ -172,6 +245,82 @@ the topic/thread into the `to` field:
 Prefixed targets like `telegram:...` / `telegram:group:...` are also accepted:
 
 - `telegram:group:-1001234567890:topic:123`
+
+## JSON schema for tool calls
+
+Use these shapes when calling Gateway `cron.*` tools directly (agent tool calls or RPC).
+CLI flags accept human durations like `20m`, but tool calls use epoch milliseconds for
+`atMs` and `everyMs` (ISO timestamps are accepted for `at` times).
+
+### cron.add params
+
+One-shot, main session job (system event):
+
+```json
+{
+  "name": "Reminder",
+  "schedule": { "kind": "at", "atMs": 1738262400000 },
+  "sessionTarget": "main",
+  "wakeMode": "now",
+  "payload": { "kind": "systemEvent", "text": "Reminder text" },
+  "deleteAfterRun": true
+}
+```
+
+Recurring, isolated job with delivery:
+
+```json
+{
+  "name": "Morning brief",
+  "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
+  "payload": {
+    "kind": "agentTurn",
+    "message": "Summarize overnight updates.",
+    "deliver": true,
+    "channel": "slack",
+    "to": "channel:C1234567890",
+    "bestEffortDeliver": true
+  },
+  "isolation": { "postToMainPrefix": "Cron", "postToMainMode": "summary" }
+}
+```
+
+Notes:
+
+- `schedule.kind`: `at` (`atMs`), `every` (`everyMs`), or `cron` (`expr`, optional `tz`).
+- `atMs` and `everyMs` are epoch milliseconds.
+- `sessionTarget` must be `"main"` or `"isolated"` and must match `payload.kind`.
+- Optional fields: `agentId`, `description`, `enabled`, `deleteAfterRun`, `isolation`.
+- `wakeMode` defaults to `"next-heartbeat"` when omitted.
+
+### cron.update params
+
+```json
+{
+  "jobId": "job-123",
+  "patch": {
+    "enabled": false,
+    "schedule": { "kind": "every", "everyMs": 3600000 }
+  }
+}
+```
+
+Notes:
+
+- `jobId` is canonical; `id` is accepted for compatibility.
+- Use `agentId: null` in the patch to clear an agent binding.
+
+### cron.run and cron.remove params
+
+```json
+{ "jobId": "job-123", "mode": "force" }
+```
+
+```json
+{ "jobId": "job-123" }
+```
 
 ## Storage & history
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -370,7 +370,7 @@ openclaw cron add \
 
 Isolated job with model and thinking override:
 
-````bash
+```bash
 openclaw cron add \
   --name "Deep analysis" \
   --cron "0 6 * * 1" \
@@ -382,6 +382,7 @@ openclaw cron add \
   --deliver \
   --channel whatsapp \
   --to "+15551234567"
+```
 
 Agent selection (multi-agent setups):
 ```bash
@@ -391,14 +392,12 @@ openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --mes
 # Switch or clear the agent on an existing job
 openclaw cron edit <jobId> --agent ops
 openclaw cron edit <jobId> --clear-agent
-````
-
-````
+```
 
 Manual run (debug):
 ```bash
 openclaw cron run <jobId> --force
-````
+```
 
 Edit an existing job (patch fields):
 


### PR DESCRIPTION
## Summary
- Add a quick-start CLI flow plus tool-call JSON equivalents for cron jobs.
- Document where cron jobs are stored and safe editing guidance.
- Fix two example inaccuracies (CLI flag and atMs value).

## Why
- Users asked for actionable docs: copy/pasteable commands + verification steps.
- Tool-call schemas were easy to misapply without a concrete payload example.
- Clarify persistence and safe editing to avoid silent overwrites.

## Compromises
- Kept examples minimal rather than exhaustively covering every schedule/payload option.
- Used a near-term ISO timestamp with matching atMs for clarity over “timeless” examples.

## Importance
- Reduces setup friction and support churn (common questions: schedule shapes, delivery routing, persistence).
- Helps agents and humans align on the canonical cron payload shapes.

## Testing
- Not run (docs-only change).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands `docs/automation/cron-jobs.md` with an actionable quick-start (copy/paste CLI commands), plus concrete JSON payload examples for calling the Gateway `cron.*` tools. It also documents persistence (where jobs are stored) and guidance around safe editing.

Main things to double-check before merging are that the JSON “equivalent” examples truly match the CLI timestamps (the current `atMs` value doesn’t), and that Markdown fences are balanced so the doc renders correctly.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but fix the doc-rendering and timestamp consistency issues first.
- Docs-only change with no runtime impact, but there are a couple of correctness issues that will mislead users (mismatched `atMs` vs `--at`) and a Markdown fence imbalance that can break rendering for the remainder of the page.
- docs/automation/cron-jobs.md (code-fence balancing; timestamp example consistency)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->