### PR TITLE
fix: wrap waitForCompactionRetry in abortable to release lane lock on timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -815,7 +815,7 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isAbortError(err)) {
             if (!promptError) {


### PR DESCRIPTION
## The Bug

When a run times out during compaction, the lane lock is never released, causing all subsequent messages to queue indefinitely.

### Root Cause

In `src/agents/pi-embedded-runner/run/attempt.ts`, line ~818:

```typescript
await waitForCompactionRetry();
```

This Promise is **not wrapped in `abortable()`**, so when the timeout fires:
1. `abortRun(true)` is called, setting the abort signal
2. The `abortable(activeSession.prompt(...))` rejects immediately ✓
3. But `waitForCompactionRetry()` just returns a plain Promise waiting for compaction state flags
4. The compaction retry logic doesn't check the abort signal
5. So `waitForCompactionRetry()` **never rejects** — it waits forever
6. The `finally` block with `clearActiveEmbeddedRun()` never runs
7. Lane stays locked 💀

### Impact

This caused an 11-hour outage where 18 messages queued but never processed. The zombie run timed out at 03:05:39 but the lane lock was never released. Only a gateway restart fixed it.

### The Fix

```typescript
await abortable(waitForCompactionRetry());
```

One line change. The `abortable()` wrapper makes the Promise reject when the abort signal fires, allowing the `finally` block to run and release the lane lock.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a hang during embedded run compaction timeouts by wrapping `waitForCompactionRetry()` in `abortable()`, ensuring the abort signal can interrupt the wait and the surrounding `finally` blocks run (releasing the lane lock and allowing subsequent messages to proceed). The change fits the existing pattern in this module where long waits (`activeSession.prompt(...)`) are already wrapped in `abortable()` to respect run cancellation/timeouts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line wrap that makes an existing wait respect the abort signal, matching the surrounding cancellation pattern (`abortable(...)`) and addressing a concrete deadlock scenario without altering business logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->