### PR TITLE
fix: set correct file ownership in Dockerfile (#5450)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ COPY scripts ./scripts
 
 RUN pnpm install --frozen-lockfile
 
-COPY . .
+COPY --chown=node:node . .
+
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
## Description
This PR fixes a permission issue in the Docker environment where the `node` user was unable to access files owned by `root`. 

In certain environments (especially Linux/Ubuntu), the Docker engine copies files as `root` by default. Since the application runs as the `node` user, this lead to `EACCES: permission denied` errors when scanning the `extensions` directory, even though the files were present. (To be precise, permission issues occur with all files. It just happened to error out at the extensions first.)

## Changes
- Added `--chown=node:node` to the `COPY` instruction in the `Dockerfile`.

## Related Issues
- Fixes #5450 

## Testing
- Verified on Ubuntu 22.04.
- Confirmed that the "plugin not found" error no longer occurs during the onboarding process and plugins are loaded correctly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker build to copy the repository contents into the image with `node:node` ownership to prevent runtime `EACCES` errors when the container runs as the non-root `node` user (notably affecting `extensions/` scanning in some Docker/Linux setups).

The change fits into the existing Docker hardening approach at the bottom of the `Dockerfile` where the container explicitly switches to `USER node` for runtime safety; ensuring files are owned/readable by that user avoids permission issues during onboarding/plugin loading.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but broad ownership changes may cause avoidable build/runtime permission edge cases.
- The change is small and addresses a real permission problem, but applying `--chown` to the entire context can unexpectedly alter permissions/ownership for generated artifacts and dependency trees, increasing the chance of subtle issues and rebuild churn. Limiting chown scope would reduce that risk.
- Dockerfile

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->