### PR TITLE
feat(slack): add thread.requireMention config option

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -337,6 +337,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.slack.thread.requireMention": "Slack Thread Require Mention",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",
@@ -469,6 +470,8 @@ const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.thread.requireMention":
+    "If false, skip mention gating for thread replies (allows replies without @mention in threads). Default: true (inherit parent channel's requireMention).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -471,7 +471,7 @@ const FIELD_HELP: Record<string, string> = {
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
   "channels.slack.thread.requireMention":
-    "If false, skip mention gating for thread replies (allows replies without @mention in threads). Default: true (inherit parent channel's requireMention).",
+    "Controls mention gating in threads. true (default): inherit parent channel's requireMention setting. false: always skip mention gating in threads (replies never require @mention).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -73,6 +73,8 @@ export type SlackThreadConfig = {
   historyScope?: "thread" | "channel";
   /** If true, thread sessions inherit the parent channel transcript. Default: false. */
   inheritParent?: boolean;
+  /** If false, skip mention gating for thread replies. Default: true (inherit parent channel). */
+  requireMention?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -73,7 +73,7 @@ export type SlackThreadConfig = {
   historyScope?: "thread" | "channel";
   /** If true, thread sessions inherit the parent channel transcript. Default: false. */
   inheritParent?: boolean;
-  /** If false, skip mention gating for thread replies. Default: true (inherit parent channel). */
+  /** true (default): inherit parent channel's requireMention. false: skip mention gating in all threads. */
   requireMention?: boolean;
 };
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -90,6 +90,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  threadRequireMention: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -151,6 +152,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  threadRequireMention: SlackMonitorContext["threadRequireMention"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -413,6 +415,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    threadRequireMention: params.threadRequireMention,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
+++ b/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
@@ -38,6 +38,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: "off",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadRequireMention: true,
       slashCommand: {
         enabled: false,
         name: "openclaw",
@@ -106,6 +107,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: "all",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadRequireMention: true,
       slashCommand: {
         enabled: false,
         name: "openclaw",

--- a/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
+++ b/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
@@ -40,6 +40,7 @@ describe("prepareSlackMessage sender prefix", () => {
       replyToMode: "off",
       threadHistoryScope: "channel",
       threadInheritParent: false,
+      threadRequireMention: true,
       slashCommand: { command: "/openclaw", enabled: true },
       textLimit: 2000,
       ackReactionScope: "off",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -290,8 +290,13 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
+  // Resolve base requireMention from channel config or default
+  const baseRequireMention = channelConfig?.requireMention ?? ctx.defaultRequireMention;
+  // In threads, use thread.requireMention setting:
+  // - true (default): inherit parent channel's requireMention
+  // - false: skip mention gating in threads (allow replies without @mention)
   const shouldRequireMention = isRoom
-    ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
+    ? (isThreadReply && !ctx.threadRequireMention ? false : baseRequireMention)
     : false;
 
   // Allow "control commands" to bypass mention gating if sender is authorized.

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -296,7 +296,9 @@ export async function prepareSlackMessage(params: {
   // - true (default): inherit parent channel's requireMention
   // - false: skip mention gating in threads (allow replies without @mention)
   const shouldRequireMention = isRoom
-    ? (isThreadReply && !ctx.threadRequireMention ? false : baseRequireMention)
+    ? isThreadReply && !ctx.threadRequireMention
+      ? false
+      : baseRequireMention
     : false;
 
   // Allow "control commands" to bypass mention gating if sender is authorized.

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -292,9 +292,7 @@ export async function prepareSlackMessage(params: {
 
   // Resolve base requireMention from channel config or default
   const baseRequireMention = channelConfig?.requireMention ?? ctx.defaultRequireMention;
-  // In threads, use thread.requireMention setting:
-  // - true (default): inherit parent channel's requireMention
-  // - false: skip mention gating in threads (allow replies without @mention)
+  // thread.requireMention: true (default) = inherit channel setting, false = skip gating in threads
   const shouldRequireMention = isRoom
     ? isThreadReply && !ctx.threadRequireMention
       ? false

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -119,6 +119,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const threadRequireMention = slackCfg.thread?.requireMention ?? true;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -200,6 +201,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    threadRequireMention,
     slashCommand,
     textLimit,
     ackReactionScope,


### PR DESCRIPTION
## Summary

Add a new configuration option `channels.slack.thread.requireMention` that controls whether mention gating is applied to thread replies.

## Motivation

Currently, when `requireMention: true` is set for a Slack channel, users must @mention the bot for every message, including thread replies. This creates friction in ongoing thread conversations where the context is already established.

This PR allows users to disable mention gating specifically for thread replies while still requiring mentions for new top-level messages.

## Changes

- Add `thread.requireMention` option to Slack config (`SlackThreadConfig`)
- Default: `true` (preserve existing behavior)
- When `false`: skip mention gating for thread replies

## Config Example

```json
{
  "channels": {
    "slack": {
      "channels": {
        "#general": {
          "allow": true,
          "requireMention": true
        }
      },
      "thread": {
        "requireMention": false
      }
    }
  }
}
```

With this config:
- Top-level messages in #general require @mention ✅
- Thread replies in #general do NOT require @mention ✅

## Testing

- Updated existing tests to include new parameter
- Manual testing recommended with Slack workspace

## Breaking Changes

None. Default value (`true`) preserves existing behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Slack configuration option, `channels.slack.thread.requireMention`, and threads it through the Slack monitor context so mention-gating can be skipped specifically for thread replies while preserving existing behavior by default.

Changes span:
- Config metadata (`src/config/schema.ts`) and Slack config typing (`src/config/types.slack.ts`).
- Slack monitor/provider wiring (`src/slack/monitor/provider.ts`, `src/slack/monitor/context.ts`).
- Message preparation logic to conditionally disable mention gating in thread replies (`src/slack/monitor/message-handler/prepare.ts`).
- Test updates to include the new context parameter.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the functional change is small and localized to Slack thread mention-gating.
- The implementation threads a single new boolean through provider -> context -> prepare logic and keeps default behavior unchanged. Tests were updated to account for the new context field. The main concern is a minor doc/naming ambiguity around what the default means (inherit channel setting vs enforce mention in threads).
- src/slack/monitor/message-handler/prepare.ts and src/config/schema.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->