### PR TITLE
fix: handle 503/overloaded errors with auto-compaction (fixes #4357)

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -142,6 +142,13 @@ vi.mock("../pi-embedded-helpers.js", async () => {
     pickFallbackThinkingLevel: vi.fn(() => null),
     isTimeoutErrorMessage: vi.fn(() => false),
     parseImageDimensionError: vi.fn(() => null),
+    isOverloadedErrorMessage: (msg?: string) => {
+      if (!msg) {
+        return false;
+      }
+      const lower = msg.toLowerCase();
+      return lower.includes("overloaded_error") || lower.includes("503");
+    },
   };
 });
 
@@ -283,5 +290,59 @@ describe("overflow compaction in run loop", () => {
     expect(mockedCompactDirect).not.toHaveBeenCalled();
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.meta.error?.kind).toBe("compaction_failure");
+  });
+
+  it("retries after successful compaction on 503/overloaded error", async () => {
+    // 503 Service Unavailable can indicate context window pressure
+    const overloadedError = new Error("503 Service Unavailable: overloaded_error");
+
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overloadedError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 150000,
+      },
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("503/overloaded error detected; attempting auto-compaction"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("auto-compaction succeeded after 503/overloaded"),
+    );
+    // Should not be an error result
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("returns error if compaction fails on 503/overloaded error", async () => {
+    const overloadedError = new Error("503 Service Unavailable: overloaded_error");
+
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({ promptError: overloadedError }),
+    );
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    // Should still have processed the error (503 is treated as overloaded, not context_overflow)
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("auto-compaction failed"));
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -34,6 +34,7 @@ import {
   isContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isOverloadedErrorMessage,
   parseImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
@@ -372,6 +373,43 @@ export async function runEmbeddedPiAgent(
 
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
+
+            // Handle 503/overloaded errors that may indicate context window pressure
+            // These errors can occur when context is near full capacity
+            if (!overflowCompactionAttempted && isOverloadedErrorMessage(errorText)) {
+              log.warn(
+                `503/overloaded error detected; attempting auto-compaction for ${provider}/${modelId}`,
+              );
+              overflowCompactionAttempted = true;
+              const compactResult = await compactEmbeddedPiSessionDirect({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                authProfileId: lastProfileId,
+                sessionFile: params.sessionFile,
+                workspaceDir: params.workspaceDir,
+                agentDir,
+                config: params.config,
+                skillsSnapshot: params.skillsSnapshot,
+                provider,
+                model: modelId,
+                thinkLevel,
+                reasoningLevel: params.reasoningLevel,
+                bashElevated: params.bashElevated,
+                extraSystemPrompt: params.extraSystemPrompt,
+                ownerNumbers: params.ownerNumbers,
+              });
+              if (compactResult.compacted) {
+                log.info(`auto-compaction succeeded after 503/overloaded for ${provider}/${modelId}; retrying prompt`);
+                continue;
+              }
+              log.warn(
+                `auto-compaction failed for ${provider}/${modelId} after 503/overloaded: ${compactResult.reason ?? "nothing to compact"}`,
+              );
+            }
+
             if (isContextOverflowError(errorText)) {
               const isCompactionFailure = isCompactionFailureError(errorText);
               // Attempt auto-compaction on context overflow (not compaction_failure)


### PR DESCRIPTION
## Summary

When token usage approaches ~85%+ of the model's context window, the API may return 503 Service Unavailable or overloaded_error instead of a specific context overflow message. This caused Clawdbot to become completely unresponsive.

## Changes

1. **src/agents/pi-embedded-runner/run.ts**:
   - Added detection for 503/overloaded errors in the error handling loop
   - When such errors are detected, attempts auto-compaction before giving up
   - Retries the prompt after successful compaction

2. **src/agents/pi-embedded-runner/run.overflow-compaction.test.ts**:
   - Added test for retry after successful compaction on 503/overloaded error
   - Added test for error case when compaction fails on 503/overloaded error

## Fixes

Fixes: openclaw/openclaw#4357

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the embedded Pi agent run loop to treat certain overload-like prompt errors as a signal of “context pressure”: when a prompt attempt fails with an overloaded error, it triggers a one-time session auto-compaction and retries the prompt instead of immediately failing. It also adds Vitest coverage for the new retry path and the failure path when compaction can’t be performed.

The change integrates into the existing `runEmbeddedPiAgent` error-handling loop (`src/agents/pi-embedded-runner/run.ts`) alongside the existing context-overflow compaction handling, reusing the same `compactEmbeddedPiSessionDirect` mechanism and the `overflowCompactionAttempted` guard to avoid repeated compaction attempts.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new behavior may not trigger in real 503-only cases due to mismatch in overload detection.
- Core change is scoped to existing prompt-error handling and guarded to attempt compaction once, but the overload/503 detection appears inconsistent with the shared helper patterns, and the new tests mock a broader matcher than production, so the main advertised fix could be ineffective without additional adjustments.
- src/agents/pi-embedded-runner/run.ts; src/agents/pi-embedded-runner/run.overflow-compaction.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->