### PR TITLE
fix(config): merge id-based arrays by id instead of replacing

### DIFF
--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -119,5 +119,23 @@ describe("applyMergePatch", () => {
       // Empty array is not id-based, so it replaces
       expect(applyMergePatch(base, patch)).toEqual({ agents: [] });
     });
+
+    it("merges top-level id-based arrays", () => {
+      const base = [
+        { id: "a", value: 1 },
+        { id: "b", value: 2 },
+      ];
+      const patch = [{ id: "a", value: 10 }];
+      expect(applyMergePatch(base, patch)).toEqual([
+        { id: "a", value: 10 },
+        { id: "b", value: 2 },
+      ]);
+    });
+
+    it("replaces top-level array if base is not id-based", () => {
+      const base = [1, 2, 3];
+      const patch = [{ id: "a", name: "A" }];
+      expect(applyMergePatch(base, patch)).toEqual([{ id: "a", name: "A" }]);
+    });
   });
 });

--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch", () => {
+  it("replaces primitive values", () => {
+    expect(applyMergePatch({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("deep merges nested objects", () => {
+    const base = { nested: { a: 1, b: 2 } };
+    const patch = { nested: { b: 3 } };
+    expect(applyMergePatch(base, patch)).toEqual({ nested: { a: 1, b: 3 } });
+  });
+
+  it("deletes keys when patch value is null", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { b: null })).toEqual({ a: 1 });
+  });
+
+  it("replaces non-id arrays entirely", () => {
+    const base = { arr: [1, 2, 3] };
+    const patch = { arr: [4, 5] };
+    expect(applyMergePatch(base, patch)).toEqual({ arr: [4, 5] });
+  });
+
+  describe("id-based array merging", () => {
+    it("merges arrays by id field", () => {
+      const base = {
+        agents: [
+          { id: "a", name: "Agent A", enabled: true },
+          { id: "b", name: "Agent B", enabled: true },
+        ],
+      };
+      const patch = {
+        agents: [{ id: "b", enabled: false }],
+      };
+      expect(applyMergePatch(base, patch)).toEqual({
+        agents: [
+          { id: "a", name: "Agent A", enabled: true },
+          { id: "b", name: "Agent B", enabled: false },
+        ],
+      });
+    });
+
+    it("appends new items with ids not in base", () => {
+      const base = {
+        agents: [{ id: "a", name: "Agent A" }],
+      };
+      const patch = {
+        agents: [{ id: "c", name: "Agent C" }],
+      };
+      expect(applyMergePatch(base, patch)).toEqual({
+        agents: [
+          { id: "a", name: "Agent A" },
+          { id: "c", name: "Agent C" },
+        ],
+      });
+    });
+
+    it("preserves base items not in patch", () => {
+      const base = {
+        list: [
+          { id: "1", value: "one" },
+          { id: "2", value: "two" },
+          { id: "3", value: "three" },
+        ],
+      };
+      const patch = {
+        list: [{ id: "2", value: "TWO" }],
+      };
+      expect(applyMergePatch(base, patch)).toEqual({
+        list: [
+          { id: "1", value: "one" },
+          { id: "2", value: "TWO" },
+          { id: "3", value: "three" },
+        ],
+      });
+    });
+
+    it("deep merges nested properties within id-matched items", () => {
+      const base = {
+        agents: [
+          {
+            id: "nova",
+            identity: { name: "Nova", theme: "Owl" },
+            model: { primary: "claude" },
+          },
+        ],
+      };
+      const patch = {
+        agents: [
+          {
+            id: "nova",
+            model: { fallbacks: ["gpt-4"] },
+          },
+        ],
+      };
+      expect(applyMergePatch(base, patch)).toEqual({
+        agents: [
+          {
+            id: "nova",
+            identity: { name: "Nova", theme: "Owl" },
+            model: { primary: "claude", fallbacks: ["gpt-4"] },
+          },
+        ],
+      });
+    });
+
+    it("replaces array if base is not id-based", () => {
+      const base = { arr: [1, 2, 3] };
+      const patch = { arr: [{ id: "a", name: "A" }] };
+      expect(applyMergePatch(base, patch)).toEqual({
+        arr: [{ id: "a", name: "A" }],
+      });
+    });
+
+    it("handles empty patch array", () => {
+      const base = { agents: [{ id: "a", name: "A" }] };
+      const patch = { agents: [] };
+      // Empty array is not id-based, so it replaces
+      expect(applyMergePatch(base, patch)).toEqual({ agents: [] });
+    });
+  });
+});

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -41,6 +41,14 @@ function mergeArraysById(
 }
 
 export function applyMergePatch(base: unknown, patch: unknown): unknown {
+  // Handle top-level id-based arrays
+  if (Array.isArray(patch) && isIdBasedArray(patch)) {
+    if (Array.isArray(base) && isIdBasedArray(base)) {
+      return mergeArraysById(base, patch);
+    }
+    return patch;
+  }
+
   if (!isPlainObject(patch)) {
     return patch;
   }

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -4,6 +4,42 @@ function isPlainObject(value: unknown): value is PlainObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Check if an array contains objects with "id" fields (like agents.list).
+ */
+function isIdBasedArray(arr: unknown[]): arr is Array<PlainObject & { id: string }> {
+  if (arr.length === 0) return false;
+  return arr.every((item) => isPlainObject(item) && typeof (item as PlainObject).id === "string");
+}
+
+/**
+ * Merge two arrays by "id" field. Patch items update/add to base items.
+ * Items in base that aren't in patch are preserved.
+ * Items in patch with id not in base are appended.
+ */
+function mergeArraysById(
+  base: Array<PlainObject & { id: string }>,
+  patch: Array<PlainObject & { id: string }>,
+): Array<PlainObject & { id: string }> {
+  const result = [...base];
+  const baseIndex = new Map(base.map((item, idx) => [item.id, idx]));
+
+  for (const patchItem of patch) {
+    const existingIdx = baseIndex.get(patchItem.id);
+    if (existingIdx !== undefined) {
+      // Merge the patch item into the existing item (deep merge)
+      result[existingIdx] = applyMergePatch(result[existingIdx], patchItem) as PlainObject & {
+        id: string;
+      };
+    } else {
+      // New item, append to the list
+      result.push(patchItem);
+    }
+  }
+
+  return result;
+}
+
 export function applyMergePatch(base: unknown, patch: unknown): unknown {
   if (!isPlainObject(patch)) {
     return patch;
@@ -20,6 +56,14 @@ export function applyMergePatch(base: unknown, patch: unknown): unknown {
       const baseValue = result[key];
       result[key] = applyMergePatch(isPlainObject(baseValue) ? baseValue : {}, value);
       continue;
+    }
+    // Handle arrays with "id" fields specially - merge by id instead of replacing
+    if (Array.isArray(value) && isIdBasedArray(value)) {
+      const baseValue = result[key];
+      if (Array.isArray(baseValue) && isIdBasedArray(baseValue)) {
+        result[key] = mergeArraysById(baseValue, value);
+        continue;
+      }
     }
     result[key] = value;
   }


### PR DESCRIPTION
## Summary

When config includes arrays of objects with `id` fields (like `agents.list`), the merge-patch now preserves existing items and merges by id rather than replacing the entire array.

**Problem:** Previously, patching a config with `agents.list` containing a single agent override would wipe out all other agents in the list.

**Solution:** Detect arrays where all items have an `id` field and merge them by matching ids:
- Existing items are deep-merged with patch items (by id)
- New items (ids not in base) are appended
- Items in base but not in patch are preserved

## Changes

- Add `isIdBasedArray()` to detect arrays containing objects with `id` fields
- Add `mergeArraysById()` to merge arrays by matching ids
- Add comprehensive test coverage for the new behavior

## Test plan

- [x] Added unit tests covering:
  - Basic id-based array merging
  - Appending new items
  - Preserving base items not in patch
  - Deep merging nested properties within matched items
  - Fallback to replacement when base isn't id-based
  - Empty array handling
- [x] Ran full test suite (`pnpm test`)

## Example

```typescript
const base = {
  agents: [
    { id: "nova", name: "Nova", model: "claude" },
    { id: "coach", name: "Coach", model: "gpt-4" }
  ]
};

const patch = {
  agents: [{ id: "nova", model: "opus" }]
};

// Before: agents = [{ id: "nova", model: "opus" }] (coach lost!)
// After:  agents = [
//   { id: "nova", name: "Nova", model: "opus" },
//   { id: "coach", name: "Coach", model: "gpt-4" }
// ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/config/merge-patch.ts` so merge-patching config objects preserves arrays of objects keyed by an `id` field (deep-merging matching ids, appending new ids, and keeping base-only items). It also adds a new Vitest suite in `src/config/merge-patch.test.ts` covering primitive replacement, object deep-merge, null deletion semantics, and the new id-based array behavior (including fallback-to-replace cases and empty arrays).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one behavioral edge case to confirm.
- The change is localized and well-covered by new unit tests for the intended id-based array merge behavior. The main concern is that id-based merging only triggers when the patch is a plain object with array-valued properties; root-level array patches (if used by any caller) will still replace entirely due to the early return for non-plain-object patches.
- src/config/merge-patch.ts (confirm whether root-level array patches are a supported use case)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->