### PR TITLE
Fix: make embedded compaction wait abortable

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -815,7 +815,7 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isAbortError(err)) {
             if (!promptError) {


### PR DESCRIPTION
## Problem
When an embedded Pi run is aborted (timeout or an explicit stop), we still await `waitForCompactionRetry()`. If the underlying session never emits the expected compaction/lifecycle events, this await can hang indefinitely.

In long-running gateways, that means the teardown path may never run, potentially leaving the session transcript write lock behind and blocking the per-session command lane (e.g. a Discord channel session stops replying).

## Change
Wrap the compaction wait with the same abort controller used for the run, so abort/timeout interrupts the wait and teardown proceeds (unsubscribe, clear active run, release session file lock).

## Testing
- pnpm vitest run --config vitest.unit.config.ts src/agents/pi-embedded-runner/run/attempt.test.ts
- pnpm build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the post-run compaction wait abortable in the embedded Pi runner. Specifically, the existing `waitForCompactionRetry()` await is now wrapped in the same `runAbortController`-based `abortable(...)` helper used for prompt execution, so an explicit abort/timeout interrupts the compaction wait and allows the teardown path to continue (unsubscribe, clear active run, release session write lock).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line behavioral fix that uses an existing, local abort wrapper (`abortable`) already exercised by the prompt code path; it reduces hang risk in teardown and doesn’t alter core session logic beyond making the compaction wait interruptible.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->