### PR TITLE
Docs: fix index logo dark mode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,18 @@ read_when:
 > _"EXFOLIATE! EXFOLIATE!"_ — A space lobster, probably
 
 <p align="center">
-    <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png" />
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" width="500" />
-    </picture>
+    <img
+        src="/assets/openclaw-logo-text-dark.png"
+        alt="OpenClaw"
+        width="500"
+        class="dark:hidden"
+    />
+    <img
+        src="/assets/openclaw-logo-text.png"
+        alt="OpenClaw"
+        width="500"
+        class="hidden dark:block"
+    />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Swap the docs homepage hero logo to Mintlify theme-aware classes.
- Ensure light/dark mode images render reliably with `dark:hidden` + `dark:block`.

## Problem
The docs home page logo did not switch with the site theme toggle. In dark mode it still showed the light-mode logo (and briefly rendered no image when using `dark:inline`).

## Fix
Replace the `<picture>` / `prefers-color-scheme` approach with two images that Mintlify's Tailwind theme classes can control.

## Error fixed
Docs homepage dark mode was displaying the light-mode logo (or no logo at all), instead of the dark-mode logo.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the docs homepage hero logo to use Mintlify/Tailwind theme-aware classes (`dark:hidden` + `dark:block`) instead of a `<picture>` with `prefers-color-scheme`, aiming to reliably swap the logo when toggling light/dark mode.

<h3>Confidence Score: 3/5</h3>

- This PR is low-risk but may not achieve the intended dark/light logo swap if the assets are named consistently with their appearance.
- The change is limited to a docs markdown file, but the new `dark:hidden`/`dark:block` logic appears to reference the light and dark logo filenames in the opposite places, which would keep the incorrect logo showing per theme.
- docs/index.md (theme-specific logo src mapping)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->