### PR TITLE
fix(android): use explicit software provider for Ed25519 on all API levels

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -105,6 +105,10 @@ dependencies {
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
 
+  // BouncyCastle — Ed25519 fallback for API 31-32 where the platform
+  // Conscrypt provider does not yet include EdDSA algorithms.
+  implementation("org.bouncycastle:bcprov-jdk18on:1.80")
+
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")
   implementation("androidx.camera:camera-camera2:1.5.2")


### PR DESCRIPTION
## Problem

Two related Ed25519 issues on Android:

1. **API 31-32:** The platform BouncyCastle provider is stripped and lacks Ed25519 entirely.

2. **API 33+ (observed on API 35):** `KeyFactory.getInstance("Ed25519")` silently resolves to the **AndroidKeyStore** provider, which only handles hardware-backed keys. Attempting to import a PKCS8 software key fails with `InvalidKeySpecException`, breaking device identity signing.

## Fix

Adds a `softwareEd25519Provider()` helper that:

1. **Probes Conscrypt** (`AndroidOpenSSL`) first — fastest software crypto provider on modern Android, supports Ed25519 on API 33+
2. **Falls back to full BouncyCastle** (`bcprov-jdk18on`) if Conscrypt lacks Ed25519 (API 31-32)
3. **Caches the result** — provider probe runs once per process

All Ed25519 operations (key generation, PKCS8 import, signing) now route through the explicit software provider, avoiding AndroidKeyStore on every API level.

## Testing

- Pixel 9 Pro Fold (API 35): identity generation, signing, and gateway auth all succeed
- Covers API 31-36 (`minSdk=31`)

## Changes

- `DeviceIdentityStore.kt`: replaced bare `getInstance("Ed25519")` calls with explicit software provider; added Conscrypt-first resolution with BouncyCastle fallback
- `build.gradle.kts`: added `org.bouncycastle:bcprov-jdk18on:1.80` dependency
