### PR TITLE
chore(macos-app): Fix styles for chat window to follow MacOS theme colors

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -290,12 +290,12 @@ private struct ChatMessageBody: View {
 
     private var bubbleBorderColor: Color {
         if self.isUser {
-            return Color.white.opacity(0.12)
+            return Color.white.opacity(0.20)
         }
         if self.style == .onboarding {
             return OpenClawChatTheme.onboardingAssistantBorder
         }
-        return Color.white.opacity(0.08)
+        return Color.primary.opacity(0.06)
     }
 
     private var bubbleBorderWidth: CGFloat {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -20,8 +20,8 @@ enum OpenClawChatTheme {
         // NSColor semantic colors don't reliably resolve for arbitrary NSAppearance in SwiftPM.
         // Use explicit light/dark values so the bubble updates when the system appearance flips.
         appearance.isDarkAqua
-            ? NSColor(calibratedWhite: 0.18, alpha: 0.88)
-            : NSColor(calibratedWhite: 0.94, alpha: 0.92)
+            ? NSColor(calibratedWhite: 0.20, alpha: 0.92)
+            : NSColor(calibratedWhite: 0.96, alpha: 0.95)
     }
 
     static func resolvedOnboardingAssistantBubbleColor(for appearance: NSAppearance) -> NSColor {
@@ -50,35 +50,7 @@ enum OpenClawChatTheme {
     @ViewBuilder
     static var background: some View {
         #if os(macOS)
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-            LinearGradient(
-                colors: [
-                    Color.white.opacity(0.12),
-                    Color(nsColor: .windowBackgroundColor).opacity(0.35),
-                    Color.black.opacity(0.35),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing)
-            RadialGradient(
-                colors: [
-                    Color(nsColor: .systemOrange).opacity(0.14),
-                    .clear,
-                ],
-                center: .topLeading,
-                startRadius: 40,
-                endRadius: 320)
-            RadialGradient(
-                colors: [
-                    Color(nsColor: .systemTeal).opacity(0.12),
-                    .clear,
-                ],
-                center: .topTrailing,
-                startRadius: 40,
-                endRadius: 280)
-            Color.black.opacity(0.08)
-        }
+        Color(nsColor: .textBackgroundColor)
         #else
         Color(uiColor: .systemBackground)
         #endif
@@ -101,7 +73,7 @@ enum OpenClawChatTheme {
     }
 
     static var userBubble: Color {
-        Color(red: 127 / 255.0, green: 184 / 255.0, blue: 212 / 255.0)
+        Color.accentColor
     }
 
     static var assistantBubble: Color {
@@ -140,7 +112,7 @@ enum OpenClawChatTheme {
 
     static var composerBackground: AnyShapeStyle {
         #if os(macOS)
-        AnyShapeStyle(.ultraThinMaterial)
+        AnyShapeStyle(Color(nsColor: .controlBackgroundColor))
         #else
         AnyShapeStyle(Color(uiColor: .systemBackground))
         #endif
@@ -148,14 +120,18 @@ enum OpenClawChatTheme {
 
     static var composerField: AnyShapeStyle {
         #if os(macOS)
-        AnyShapeStyle(.thinMaterial)
+        AnyShapeStyle(Color(nsColor: .windowBackgroundColor))
         #else
         AnyShapeStyle(Color(uiColor: .secondarySystemBackground))
         #endif
     }
 
     static var composerBorder: Color {
+        #if os(macOS)
+        Color(nsColor: .separatorColor)
+        #else
         Color.white.opacity(0.12)
+        #endif
     }
 
     static var divider: Color {


### PR DESCRIPTION
Hi,

I updated the styles for the native MacOS app to follow the system theme colors and are more `Messages.app` alike, I am attaching both light and dark version screenshots of the updated stuff. 

<img width="687" height="901" alt="Screenshot 2026-01-31 at 15 35 23" src="https://github.com/user-attachments/assets/d167fc1e-b49f-4345-a331-dc683d447e75" />
<img width="687" height="901" alt="Screenshot 2026-01-31 at 15 35 34" src="https://github.com/user-attachments/assets/4989fa2d-0d13-40e4-9509-08914d281ef8" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the macOS chat UI theme to more closely follow system semantic colors and Messages-like styling. Changes include:

- Adjusted assistant bubble resolved light/dark NSColor values.
- Replaced the previous macOS background stack (materials + gradients) with a semantic system background color.
- Switched the user bubble to `Color.accentColor`.
- Updated composer background/field styles and added a macOS-specific border color based on `separatorColor`.
- Tweaked message bubble border opacities for better definition.

Overall, this fits cleanly into `OpenClawChatTheme` as the centralized styling source, with `ChatMessageViews` consuming those theme values for bubble rendering.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized to SwiftUI theming/styling.
- The diff is small and scoped to color/style constants and a single border color tweak. Main risk is visual regression or mismatch with intended macOS semantics in some appearances/accessibility modes, not functional breakage.
- apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift (background semantic choice); apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift (border color consistency)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->