### PR TITLE
feat(android): add gateway token input field to settings

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -51,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val gatewayToken: StateFlow<String> = runtime.gatewayToken
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +103,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setGatewayToken(value: String) {
+    runtime.setGatewayToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -284,6 +284,7 @@ class NodeRuntime(context: Context) {
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
+  val gatewayToken: StateFlow<String> = prefs.gatewayToken
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
 
@@ -426,6 +427,10 @@ class NodeRuntime(context: Context) {
 
   fun setManualTls(value: Boolean) {
     prefs.setManualTls(value)
+  }
+
+  fun setGatewayToken(value: String) {
+    prefs.saveGatewayToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -71,6 +71,10 @@ class SecurePrefs(context: Context) {
     MutableStateFlow(prefs.getBoolean("gateway.manual.tls", true))
   val manualTls: StateFlow<Boolean> = _manualTls
 
+  private val _gatewayToken =
+    MutableStateFlow(loadGatewayToken().orEmpty())
+  val gatewayToken: StateFlow<String> = _gatewayToken
+
   private val _lastDiscoveredStableId =
     MutableStateFlow(
       prefs.getString("gateway.lastDiscoveredStableID", "") ?: "",
@@ -156,7 +160,13 @@ class SecurePrefs(context: Context) {
 
   fun saveGatewayToken(token: String) {
     val key = "gateway.token.${_instanceId.value}"
-    prefs.edit { putString(key, token.trim()) }
+    val trimmed = token.trim()
+    if (trimmed.isEmpty()) {
+      prefs.edit { remove(key) }
+    } else {
+      prefs.edit { putString(key, trimmed) }
+    }
+    _gatewayToken.value = trimmed
   }
 
   fun loadGatewayPassword(): String? {


### PR DESCRIPTION
## Problem

The Android app stores and loads a per-instance gateway token via `SecurePrefs` (`loadGatewayToken` / `saveGatewayToken`), but there is **no UI to enter or edit one**. When connecting to a gateway that requires token authentication, the app fails with:

> Gateway error: unauthorized: gateway token missing (open a tokenized dashboard URL or paste token in Control UI settings)

…and the user has no way to resolve it from the app.

## Fix

Add a **Gateway Token** text field in the Gateway section of the Settings sheet:

- **Password-masked** by default with a Show/Hide toggle for security
- **Auto-saves** on focus loss or keyboard Done action
- Stored in `EncryptedSharedPreferences` (same store as other credentials)
- Supporting text guides the user: "Paste your gateway token to authenticate" when empty, "Token saved. Reconnect to apply changes" when set
- Token is picked up automatically on the next `connect()` / `refreshGatewayConnection()` call

## Changes

| File | Change |
|------|--------|
| `SecurePrefs.kt` | Expose `gatewayToken` as `StateFlow<String>`, update flow on save |
| `NodeRuntime.kt` | Forward `gatewayToken` flow + `setGatewayToken()` setter |
| `MainViewModel.kt` | Wire through to UI layer |
| `SettingsSheet.kt` | Add `OutlinedTextField` with show/hide toggle, commit on focus loss or IME done |

## Testing

- Verified on Pixel 9 Pro Fold: token entry → save → connect → successful gateway authentication
- Token persists across app restarts (EncryptedSharedPreferences)
- Show/Hide toggle correctly masks/reveals the token

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires a per-instance gateway token from `SecurePrefs` through `NodeRuntime` and `MainViewModel` into the Settings sheet, adding a new masked “Gateway Token” input with a show/hide toggle and auto-save behavior. The intent is to let Android users authenticate to token-protected gateways without needing an external UI, and the token is then used by existing connect/refresh paths that read from secure prefs.

Notable concerns are mostly around state consistency (flow vs loader normalization) and UX/accessibility details in the Compose field (avoiding overwriting in-progress edits; making the toggle accessible).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a couple of small state/UX inconsistencies worth addressing.
- Changes are localized and follow existing patterns (prefs → runtime → viewmodel → UI). The main risk is subtle inconsistency between the token StateFlow and the persisted loader behavior when the token is blank, plus some Compose UX/accessibility edge cases that can confuse users but shouldn’t break core functionality.
- apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt; apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->