### PR TITLE
fix(session): normalize tool call blocks for cross-provider compatibility

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -321,6 +321,62 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+/**
+ * Normalizes tool call content blocks in assistant messages so they always use
+ * the canonical shape: `{ type: "toolCall", arguments: ... }`.
+ *
+ * Different providers persist tool calls in different shapes:
+ *   - Anthropic / pi-ai:  `{ type: "toolCall", arguments: {} }`
+ *   - Google Antigravity:  `{ type: "toolUse",  input: {} }`
+ *
+ * When a user switches providers mid-session the old shape can reach the new
+ * provider's serializer unchanged, causing validation failures (e.g. Anthropic
+ * rejects requests when the `input` field is missing on a `tool_use` block).
+ */
+function normalizeToolCallBlocks(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    const content = assistant.content;
+    if (!Array.isArray(content)) {
+      out.push(msg);
+      continue;
+    }
+
+    let contentChanged = false;
+    const nextContent = content.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const rec = block as unknown as Record<string, unknown>;
+      const type = rec.type;
+
+      if (type !== "toolCall" && type !== "toolUse" && type !== "functionCall") return block;
+
+      // Ensure `arguments` is populated — prefer existing `arguments`, fall back to `input`, default to {}.
+      const args = rec.arguments ?? rec.input ?? {};
+      if (type === "toolCall" && rec.arguments !== undefined) return block; // already canonical
+
+      contentChanged = true;
+      return { ...rec, type: "toolCall", arguments: args };
+    });
+
+    if (contentChanged) {
+      changed = true;
+      out.push({ ...assistant, content: nextContent } as typeof assistant);
+    } else {
+      out.push(msg);
+    }
+  }
+
+  return changed ? out : messages;
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -352,6 +408,12 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeToolUseResultPairing(sanitizedThinking)
     : sanitizedThinking;
 
+  // Normalize tool call content blocks so every provider serializer sees a consistent shape.
+  // Session history may contain blocks from different providers (e.g. Google Antigravity uses
+  // { type: "toolUse", input: {} } while Anthropic expects { type: "toolCall", arguments: {} }).
+  // Without this, switching providers mid-session causes "input: Field required" API rejections.
+  const normalizedTools = normalizeToolCallBlocks(repairedTools);
+
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
@@ -366,8 +428,8 @@ export async function sanitizeSessionHistory(params: {
     : false;
   const sanitizedOpenAI =
     isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(repairedTools)
-      : repairedTools;
+      ? downgradeOpenAIReasoningBlocks(normalizedTools)
+      : normalizedTools;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {


### PR DESCRIPTION
## Summary
- Fixes API validation failures when switching AI providers mid-session
- Normalizes tool call block formats (`toolUse`, `toolCall`, `functionCall`) to canonical shape before sending to any provider
- Prevents "input: Field required" errors when provider serializers encounter mismatched formats

## Problem
When users switch providers mid-session (e.g., from Google Antigravity to Anthropic), the session history may contain tool call blocks in different formats:
- Anthropic / pi-ai: `{ type: "toolCall", arguments: {} }`
- Google Antigravity: `{ type: "toolUse", input: {} }`

This mismatch causes API validation failures.

## Solution
Adds `normalizeToolCallBlocks()` to the session sanitization pipeline, converting all tool call variants to the canonical `{ type: "toolCall", arguments: {} }` shape.

## Test plan
- [ ] Switch from Google Antigravity to Anthropic mid-session with tool calls in history
- [ ] Verify no validation errors occur
- [ ] Confirm tool call history is preserved and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR appears to normalize tool-call blocks in the Pi embedded runner's Google provider integration so that session history remains compatible when switching between AI providers mid-session. The change introduces (or wires in) a normalization step that converts provider-specific tool call variants (e.g., `toolUse` with `input`) into a canonical shape (`toolCall` with `arguments`) before sending history to downstream providers, preventing schema validation errors like `input: Field required`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is scoped to session history normalization for tool call blocks and is intended to improve cross-provider compatibility without altering core control flow. No obvious security- or correctness-critical issues were identified from the provided context.
- src/agents/pi-embedded-runner/google.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->