### PR TITLE
feat(ui): add ui-zh-CN visual configuration page and workspace-editor…

### DIFF
--- a/extensions/workspace-editor/index.ts
+++ b/extensions/workspace-editor/index.ts
@@ -1,0 +1,367 @@
+/**
+ * workspace-editor plugin
+ * 工作区编辑器插件
+ *
+ * Registers Gateway RPC methods for listing, reading and writing workspace
+ * bootstrap files (SOUL.md, IDENTITY.md, TOOLS.md, USER.md, etc.).
+ * 注册 Gateway RPC 方法，用于列出、读取和写入工作区启动文件
+ * （SOUL.md, IDENTITY.md, TOOLS.md, USER.md 等）
+ *
+ * The plugin resolves the workspace directory for the requested agent (or the
+ * default agent) and restricts file access to a known whitelist.
+ * 插件会解析请求的 agent（或默认 agent）的工作区目录，
+ * 并将文件访问限制在已知的白名单内
+ *
+ * 同时提供技能文件（SKILL.md）的列出、读取、写入、创建和删除功能
+ * Also provides skill file (SKILL.md) listing, reading, writing, creating and deleting
+ */
+import type { MoltbotPluginApi } from "openclaw/plugin-sdk";
+import {
+  listWorkspaceFiles,
+  readWorkspaceFile,
+  writeWorkspaceFile,
+} from "./workspace-files.js";
+import {
+  listSkillFiles,
+  readSkillFile,
+  writeSkillFile,
+  createSkill,
+  deleteSkill,
+  type SkillSource,
+} from "./skills-files.js";
+
+const plugin = {
+  id: "workspace-editor",
+  name: "Workspace Editor",
+  description: "Read/write workspace bootstrap files via Gateway RPC",
+
+  /**
+   * Register plugin methods
+   * 注册插件方法
+   */
+  register(api: MoltbotPluginApi) {
+    // ── workspace.files.list ──────────────────────────────────────────
+    // 列出工作区文件 / List workspace files
+    api.registerGatewayMethod(
+      "workspace.files.list",
+      async ({ params, respond }) => {
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await listWorkspaceFiles(api.config, agentId);
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "WORKSPACE_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── workspace.file.read ───────────────────────────────────────────
+    // 读取工作区文件 / Read workspace file
+    api.registerGatewayMethod(
+      "workspace.file.read",
+      async ({ params, respond }) => {
+        // 验证必需的 fileName 参数 / Validate required fileName parameter
+        const fileName =
+          typeof params.fileName === "string" ? params.fileName.trim() : "";
+        if (!fileName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "fileName is required",
+          });
+          return;
+        }
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await readWorkspaceFile(api.config, fileName, agentId);
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "WORKSPACE_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── workspace.file.write ──────────────────────────────────────────
+    // 写入工作区文件 / Write workspace file
+    api.registerGatewayMethod(
+      "workspace.file.write",
+      async ({ params, respond }) => {
+        // 验证必需的 fileName 参数 / Validate required fileName parameter
+        const fileName =
+          typeof params.fileName === "string" ? params.fileName.trim() : "";
+        if (!fileName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "fileName is required",
+          });
+          return;
+        }
+        // 获取文件内容（默认为空字符串）/ Get file content (default to empty string)
+        const content =
+          typeof params.content === "string" ? params.content : "";
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await writeWorkspaceFile(
+            api.config,
+            fileName,
+            content,
+            agentId,
+          );
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "WORKSPACE_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // =========================================================================
+    // Skills 文件操作 / Skills file operations
+    // =========================================================================
+
+    // ── skills.files.list ───────────────────────────────────────────────
+    // 列出可编辑的技能文件 / List editable skill files
+    api.registerGatewayMethod(
+      "skills.files.list",
+      async ({ params, respond }) => {
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          // 解析可选的 source 过滤参数 / Parse optional source filter parameter
+          const sourceFilter =
+            typeof params.source === "string" &&
+            (params.source === "managed" || params.source === "workspace")
+              ? (params.source as SkillSource)
+              : undefined;
+          const result = await listSkillFiles(api.config, agentId, sourceFilter);
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "SKILLS_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── skills.file.read ────────────────────────────────────────────────
+    // 读取技能文件 (SKILL.md) / Read skill file (SKILL.md)
+    api.registerGatewayMethod(
+      "skills.file.read",
+      async ({ params, respond }) => {
+        // 验证必需的 skillName 参数 / Validate required skillName parameter
+        const skillName =
+          typeof params.skillName === "string" ? params.skillName.trim() : "";
+        if (!skillName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "skillName is required",
+          });
+          return;
+        }
+        // 验证必需的 source 参数 / Validate required source parameter
+        const source =
+          typeof params.source === "string" ? params.source.trim() : "";
+        if (!source || (source !== "managed" && source !== "workspace")) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: 'source is required and must be "managed" or "workspace"',
+          });
+          return;
+        }
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await readSkillFile(
+            api.config,
+            skillName,
+            source,
+            agentId,
+          );
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "SKILLS_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── skills.file.write ───────────────────────────────────────────────
+    // 写入技能文件 (SKILL.md) / Write skill file (SKILL.md)
+    api.registerGatewayMethod(
+      "skills.file.write",
+      async ({ params, respond }) => {
+        // 验证必需的 skillName 参数 / Validate required skillName parameter
+        const skillName =
+          typeof params.skillName === "string" ? params.skillName.trim() : "";
+        if (!skillName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "skillName is required",
+          });
+          return;
+        }
+        // 验证必需的 source 参数 / Validate required source parameter
+        const source =
+          typeof params.source === "string" ? params.source.trim() : "";
+        if (!source || (source !== "managed" && source !== "workspace")) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: 'source is required and must be "managed" or "workspace"',
+          });
+          return;
+        }
+        // 获取文件内容（默认为空字符串）/ Get file content (default to empty string)
+        const content =
+          typeof params.content === "string" ? params.content : "";
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await writeSkillFile(
+            api.config,
+            skillName,
+            content,
+            source,
+            agentId,
+          );
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "SKILLS_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── skills.file.create ──────────────────────────────────────────────
+    // 创建新技能 / Create new skill
+    api.registerGatewayMethod(
+      "skills.file.create",
+      async ({ params, respond }) => {
+        // 验证必需的 skillName 参数 / Validate required skillName parameter
+        const skillName =
+          typeof params.skillName === "string" ? params.skillName.trim() : "";
+        if (!skillName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "skillName is required",
+          });
+          return;
+        }
+        // 验证必需的 source 参数 / Validate required source parameter
+        const source =
+          typeof params.source === "string" ? params.source.trim() : "";
+        if (!source || (source !== "managed" && source !== "workspace")) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: 'source is required and must be "managed" or "workspace"',
+          });
+          return;
+        }
+        // 获取可选的初始内容 / Get optional initial content
+        const content =
+          typeof params.content === "string" ? params.content : undefined;
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await createSkill(
+            api.config,
+            skillName,
+            source,
+            content,
+            agentId,
+          );
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "SKILLS_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+
+    // ── skills.file.delete ──────────────────────────────────────────────
+    // 删除技能 / Delete skill
+    api.registerGatewayMethod(
+      "skills.file.delete",
+      async ({ params, respond }) => {
+        // 验证必需的 skillName 参数 / Validate required skillName parameter
+        const skillName =
+          typeof params.skillName === "string" ? params.skillName.trim() : "";
+        if (!skillName) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: "skillName is required",
+          });
+          return;
+        }
+        // 验证必需的 source 参数 / Validate required source parameter
+        const source =
+          typeof params.source === "string" ? params.source.trim() : "";
+        if (!source || (source !== "managed" && source !== "workspace")) {
+          respond(false, undefined, {
+            code: "INVALID_REQUEST",
+            message: 'source is required and must be "managed" or "workspace"',
+          });
+          return;
+        }
+        try {
+          // 解析可选的 agentId 参数 / Parse optional agentId parameter
+          const agentId =
+            typeof params.agentId === "string"
+              ? params.agentId.trim() || undefined
+              : undefined;
+          const result = await deleteSkill(
+            api.config,
+            skillName,
+            source,
+            agentId,
+          );
+          respond(true, result, undefined);
+        } catch (err) {
+          respond(false, undefined, {
+            code: "SKILLS_ERROR",
+            message: String(err),
+          });
+        }
+      },
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/workspace-editor/openclaw.plugin.json
+++ b/extensions/workspace-editor/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "workspace-editor",
+  "name": "Workspace Editor",
+  "description": "Gateway RPC methods for reading and writing workspace files (SOUL.md, IDENTITY.md, etc.)",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/workspace-editor/package.json
+++ b/extensions/workspace-editor/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/workspace-editor",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Gateway RPC methods for reading and writing workspace files (SOUL.md, IDENTITY.md, etc.)",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  }
+}

--- a/extensions/workspace-editor/skills-files.ts
+++ b/extensions/workspace-editor/skills-files.ts
@@ -1,0 +1,603 @@
+/**
+ * Skills 文件操作
+ * Skills file operations
+ *
+ * 支持读取、写入、列出和创建 skills 目录中的 SKILL.md 文件
+ * Supports reading, writing, listing and creating SKILL.md files in skills directories
+ *
+ * 仅允许操作 managed 和 workspace 来源的技能（可写目录）
+ * Only managed and workspace sources are allowed (writable directories)
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import type { MoltbotConfig } from "openclaw/plugin-sdk";
+
+// ───────────────────────────────────────────────────────────────────────────
+// 常量定义 / Constants
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 技能文件名
+ * Skill file name
+ */
+const SKILL_FILE_NAME = "SKILL.md";
+
+/**
+ * 技能名称验证正则（只允许小写字母、数字和连字符）
+ * Skill name validation regex (only lowercase letters, numbers and hyphens)
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+/**
+ * 可编辑的技能来源
+ * Editable skill sources
+ */
+export type SkillSource = "managed" | "workspace";
+
+// ───────────────────────────────────────────────────────────────────────────
+// 类型定义 / Type definitions
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 技能文件信息
+ * Skill file information
+ */
+export type SkillFileInfo = {
+  name: string;              // 技能名称 / Skill name
+  path: string;              // SKILL.md 完整路径 / Full path to SKILL.md
+  source: SkillSource;       // 来源 / Source
+  exists: boolean;           // 是否存在 / Whether file exists
+  size: number;              // 文件大小（字节）/ File size in bytes
+  modifiedAt: number | null; // 最后修改时间戳 / Last modified timestamp
+};
+
+/**
+ * 列出技能文件的结果
+ * Result of listing skill files
+ */
+export type SkillFilesListResult = {
+  managedDir: string;        // managed 技能目录 / Managed skills directory
+  workspaceDir: string;      // workspace 技能目录 / Workspace skills directory
+  skills: SkillFileInfo[];   // 技能列表 / Skill list
+};
+
+/**
+ * 读取技能文件的结果
+ * Result of reading a skill file
+ */
+export type SkillFileReadResult = {
+  name: string;              // 技能名称 / Skill name
+  path: string;              // 完整路径 / Full path
+  source: SkillSource;       // 来源 / Source
+  exists: boolean;           // 是否存在 / Whether file exists
+  content: string;           // 文件内容 / File content
+};
+
+/**
+ * 写入技能文件的结果
+ * Result of writing a skill file
+ */
+export type SkillFileWriteResult = {
+  ok: boolean;               // 是否成功 / Whether successful
+  path: string;              // 完整路径 / Full path
+  bytesWritten: number;      // 写入字节数 / Bytes written
+};
+
+/**
+ * 创建技能的结果
+ * Result of creating a skill
+ */
+export type SkillFileCreateResult = {
+  ok: boolean;               // 是否成功 / Whether successful
+  name: string;              // 技能名称 / Skill name
+  path: string;              // SKILL.md 完整路径 / Full path to SKILL.md
+  source: SkillSource;       // 来源 / Source
+};
+
+/**
+ * 删除技能的结果
+ * Result of deleting a skill
+ */
+export type SkillFileDeleteResult = {
+  ok: boolean;               // 是否成功 / Whether successful
+  name: string;              // 技能名称 / Skill name
+  path: string;              // 已删除目录路径 / Deleted directory path
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// 目录解析 / Directory resolution
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 解析配置目录（~/.openclaw）
+ * Resolve config directory (~/.openclaw)
+ *
+ * 与核心代码 src/utils.ts 保持一致：始终使用 ~/.openclaw
+ * Consistent with core code src/utils.ts: always use ~/.openclaw
+ */
+function resolveConfigDir(): string {
+  const override =
+    process.env.OPENCLAW_STATE_DIR?.trim() ||
+    process.env.CLAWDBOT_STATE_DIR?.trim();
+  if (override) {
+    return override.startsWith("~")
+      ? path.join(os.homedir(), override.slice(1))
+      : override;
+  }
+  // 始终使用 .openclaw（与核心代码一致）
+  // Always use .openclaw (consistent with core code)
+  return path.join(os.homedir(), ".openclaw");
+}
+
+/**
+ * 解析默认工作区目录
+ * Resolve default workspace directory
+ *
+ * 与核心代码保持一致：~/.openclaw/workspace
+ * Consistent with core code: ~/.openclaw/workspace
+ */
+function resolveDefaultWorkspaceDir(): string {
+  return path.join(os.homedir(), ".openclaw", "workspace");
+}
+
+/**
+ * 解析 Agent 的工作区目录
+ * Resolve workspace directory for an agent
+ *
+ * 与核心代码保持一致的解析逻辑
+ * Consistent with core code resolution logic
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 工作区目录 / Workspace directory
+ */
+function resolveAgentWorkspaceDir(
+  config: MoltbotConfig,
+  agentId?: string,
+): string {
+  const agents = config.agents as
+    | {
+        list?: Array<{ id?: string; workspace?: string; default?: boolean }>;
+        defaults?: { workspace?: string };
+      }
+    | undefined;
+  const list = agents?.list ?? [];
+
+  // 查找指定的 agent 或默认 agent
+  // Find the specified agent or default agent
+  const agent = agentId
+    ? list.find((a) => a.id === agentId)
+    : list.find((a) => a.default) ?? list[0];
+
+  // 如果找到 agent 并且有 workspace 配置
+  // If agent found and has workspace config
+  if (agent?.workspace?.trim()) {
+    let workspaceDir = agent.workspace.trim();
+    if (workspaceDir.startsWith("~")) {
+      workspaceDir = path.join(os.homedir(), workspaceDir.slice(1));
+    }
+    return workspaceDir;
+  }
+
+  // 检查 agents.defaults.workspace（与核心代码一致）
+  // Check agents.defaults.workspace (consistent with core code)
+  const defaultsWorkspace = agents?.defaults?.workspace?.trim();
+  if (defaultsWorkspace) {
+    let workspaceDir = defaultsWorkspace;
+    if (workspaceDir.startsWith("~")) {
+      workspaceDir = path.join(os.homedir(), workspaceDir.slice(1));
+    }
+    return workspaceDir;
+  }
+
+  return resolveDefaultWorkspaceDir();
+}
+
+/**
+ * 解析 managed 和 workspace 技能目录
+ * Resolve managed and workspace skills directories
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 两个技能目录路径 / Both skills directory paths
+ */
+function resolveSkillDirs(
+  config: MoltbotConfig,
+  agentId?: string,
+): { managedDir: string; workspaceDir: string } {
+  const configDir = resolveConfigDir();
+  const workspaceBase = resolveAgentWorkspaceDir(config, agentId);
+
+  return {
+    managedDir: path.join(configDir, "skills"),
+    workspaceDir: path.join(workspaceBase, "skills"),
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 安全验证 / Security validation
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 验证技能名称是否合法
+ * Validate skill name
+ *
+ * @param skillName - 技能名称 / Skill name
+ * @throws 如果名称无效则抛出错误 / Throws error if name is invalid
+ */
+function validateSkillName(skillName: string): void {
+  // 防止路径遍历攻击 / Prevent path traversal attacks
+  if (skillName.includes("/") || skillName.includes("\\") || skillName.includes("..")) {
+    throw new Error(`无效的技能名称（包含非法字符）: ${skillName}`);
+  }
+
+  // 验证名称格式 / Validate name format
+  if (!SKILL_NAME_PATTERN.test(skillName)) {
+    throw new Error(
+      `无效的技能名称格式: ${skillName}。技能名称只能包含小写字母、数字和连字符，且不能以连字符开头或结尾`,
+    );
+  }
+}
+
+/**
+ * 验证技能来源是否可编辑
+ * Validate skill source is editable
+ *
+ * @param source - 技能来源 / Skill source
+ * @throws 如果来源不可编辑则抛出错误 / Throws error if source is not editable
+ */
+function validateSource(source: string): asserts source is SkillSource {
+  if (source !== "managed" && source !== "workspace") {
+    throw new Error(
+      `不支持的技能来源: ${source}。仅支持 "managed" 和 "workspace"`,
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 列出技能文件 / List skill files
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 扫描目录中的技能
+ * Scan skills in a directory
+ *
+ * @param dir - 技能目录 / Skills directory
+ * @param source - 来源标识 / Source identifier
+ * @returns 技能文件信息列表 / List of skill file info
+ */
+async function scanSkillsInDir(
+  dir: string,
+  source: SkillSource,
+): Promise<SkillFileInfo[]> {
+  const skills: SkillFileInfo[] = [];
+
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      // 只处理目录（每个技能是一个目录）
+      // Only process directories (each skill is a directory)
+      if (!entry.isDirectory()) continue;
+
+      // 跳过隐藏目录和无效名称
+      // Skip hidden directories and invalid names
+      if (entry.name.startsWith(".")) continue;
+      if (!SKILL_NAME_PATTERN.test(entry.name)) continue;
+
+      const skillDir = path.join(dir, entry.name);
+      const skillFilePath = path.join(skillDir, SKILL_FILE_NAME);
+
+      let exists = false;
+      let size = 0;
+      let modifiedAt: number | null = null;
+
+      try {
+        const stat = await fs.stat(skillFilePath);
+        exists = stat.isFile();
+        size = stat.size;
+        modifiedAt = stat.mtimeMs;
+      } catch {
+        // SKILL.md 不存在
+        // SKILL.md doesn't exist
+      }
+
+      skills.push({
+        name: entry.name,
+        path: skillFilePath,
+        source,
+        exists,
+        size,
+        modifiedAt,
+      });
+    }
+  } catch {
+    // 目录不存在或无法读取
+    // Directory doesn't exist or cannot be read
+  }
+
+  return skills;
+}
+
+/**
+ * 列出所有可编辑的技能文件
+ * List all editable skill files
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @param sourceFilter - 可选的来源过滤 / Optional source filter
+ * @returns 技能列表结果 / Skill list result
+ */
+export async function listSkillFiles(
+  config: MoltbotConfig,
+  agentId?: string,
+  sourceFilter?: SkillSource,
+): Promise<SkillFilesListResult> {
+  const { managedDir, workspaceDir } = resolveSkillDirs(config, agentId);
+
+  let skills: SkillFileInfo[] = [];
+
+  // 扫描 managed 技能 / Scan managed skills
+  if (!sourceFilter || sourceFilter === "managed") {
+    const managedSkills = await scanSkillsInDir(managedDir, "managed");
+    skills = skills.concat(managedSkills);
+  }
+
+  // 扫描 workspace 技能 / Scan workspace skills
+  if (!sourceFilter || sourceFilter === "workspace") {
+    const workspaceSkills = await scanSkillsInDir(workspaceDir, "workspace");
+    skills = skills.concat(workspaceSkills);
+  }
+
+  // 按名称排序，workspace 优先（覆盖 managed）
+  // Sort by name, workspace first (overrides managed)
+  skills.sort((a, b) => {
+    const nameCompare = a.name.localeCompare(b.name);
+    if (nameCompare !== 0) return nameCompare;
+    // workspace 排在 managed 前面
+    // workspace comes before managed
+    return a.source === "workspace" ? -1 : 1;
+  });
+
+  return {
+    managedDir,
+    workspaceDir,
+    skills,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 读取技能文件 / Read skill file
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 读取技能的 SKILL.md 文件内容
+ * Read SKILL.md file content of a skill
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param skillName - 技能名称 / Skill name
+ * @param source - 技能来源 / Skill source
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 读取结果 / Read result
+ */
+export async function readSkillFile(
+  config: MoltbotConfig,
+  skillName: string,
+  source: string,
+  agentId?: string,
+): Promise<SkillFileReadResult> {
+  // 验证参数 / Validate parameters
+  validateSkillName(skillName);
+  validateSource(source);
+
+  const { managedDir, workspaceDir } = resolveSkillDirs(config, agentId);
+  const baseDir = source === "managed" ? managedDir : workspaceDir;
+  const filePath = path.join(baseDir, skillName, SKILL_FILE_NAME);
+
+  let exists = false;
+  let content = "";
+
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+    exists = true;
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+    // 文件不存在 - 返回空内容
+    // File doesn't exist - return empty content
+  }
+
+  return {
+    name: skillName,
+    path: filePath,
+    source,
+    exists,
+    content,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 写入技能文件 / Write skill file
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 写入技能的 SKILL.md 文件
+ * Write SKILL.md file for a skill
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param skillName - 技能名称 / Skill name
+ * @param content - 文件内容 / File content
+ * @param source - 技能来源 / Skill source
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 写入结果 / Write result
+ */
+export async function writeSkillFile(
+  config: MoltbotConfig,
+  skillName: string,
+  content: string,
+  source: string,
+  agentId?: string,
+): Promise<SkillFileWriteResult> {
+  // 验证参数 / Validate parameters
+  validateSkillName(skillName);
+  validateSource(source);
+
+  const { managedDir, workspaceDir } = resolveSkillDirs(config, agentId);
+  const baseDir = source === "managed" ? managedDir : workspaceDir;
+  const skillDir = path.join(baseDir, skillName);
+  const filePath = path.join(skillDir, SKILL_FILE_NAME);
+
+  // 确保技能目录存在 / Ensure skill directory exists
+  await fs.mkdir(skillDir, { recursive: true });
+
+  // 写入文件 / Write file
+  await fs.writeFile(filePath, content, "utf-8");
+
+  return {
+    ok: true,
+    path: filePath,
+    bytesWritten: Buffer.byteLength(content, "utf-8"),
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 创建技能 / Create skill
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 默认技能模板
+ * Default skill template
+ */
+const DEFAULT_SKILL_TEMPLATE = `---
+name: "{{SKILL_NAME}}"
+emoji:
+description: 在此描述技能的功能
+homepage:
+requirements:
+  bins: []
+  env: []
+  config: []
+  os: []
+  anyBins: []
+install: []
+---
+
+# {{SKILL_NAME}}
+
+在此编写技能的详细说明，指导 Agent 如何使用此技能。
+
+## 用法
+
+描述典型的使用场景和命令。
+
+## 示例
+
+提供具体的示例。
+`;
+
+/**
+ * 创建新技能
+ * Create a new skill
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param skillName - 技能名称 / Skill name
+ * @param source - 技能来源 / Skill source
+ * @param content - 可选的初始内容（默认使用模板）/ Optional initial content (uses template by default)
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 创建结果 / Create result
+ */
+export async function createSkill(
+  config: MoltbotConfig,
+  skillName: string,
+  source: string,
+  content?: string,
+  agentId?: string,
+): Promise<SkillFileCreateResult> {
+  // 验证参数 / Validate parameters
+  validateSkillName(skillName);
+  validateSource(source);
+
+  const { managedDir, workspaceDir } = resolveSkillDirs(config, agentId);
+  const baseDir = source === "managed" ? managedDir : workspaceDir;
+  const skillDir = path.join(baseDir, skillName);
+  const filePath = path.join(skillDir, SKILL_FILE_NAME);
+
+  // 检查技能是否已存在 / Check if skill already exists
+  try {
+    await fs.access(skillDir);
+    throw new Error(`技能 "${skillName}" 已存在于 ${source} 目录`);
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+    // 目录不存在，可以创建
+    // Directory doesn't exist, can create
+  }
+
+  // 创建技能目录 / Create skill directory
+  await fs.mkdir(skillDir, { recursive: true });
+
+  // 使用提供的内容或默认模板 / Use provided content or default template
+  const fileContent =
+    content ?? DEFAULT_SKILL_TEMPLATE.replace(/\{\{SKILL_NAME\}\}/g, skillName);
+
+  // 写入 SKILL.md / Write SKILL.md
+  await fs.writeFile(filePath, fileContent, "utf-8");
+
+  return {
+    ok: true,
+    name: skillName,
+    path: filePath,
+    source,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 删除技能 / Delete skill
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * 删除技能
+ * Delete a skill
+ *
+ * @param config - Moltbot 配置 / Moltbot configuration
+ * @param skillName - 技能名称 / Skill name
+ * @param source - 技能来源 / Skill source
+ * @param agentId - 可选的 Agent ID / Optional agent ID
+ * @returns 删除结果 / Delete result
+ */
+export async function deleteSkill(
+  config: MoltbotConfig,
+  skillName: string,
+  source: string,
+  agentId?: string,
+): Promise<SkillFileDeleteResult> {
+  // 验证参数 / Validate parameters
+  validateSkillName(skillName);
+  validateSource(source);
+
+  const { managedDir, workspaceDir } = resolveSkillDirs(config, agentId);
+  const baseDir = source === "managed" ? managedDir : workspaceDir;
+  const skillDir = path.join(baseDir, skillName);
+
+  // 检查技能目录是否存在 / Check if skill directory exists
+  try {
+    await fs.access(skillDir);
+  } catch {
+    throw new Error(`技能 "${skillName}" 不存在于 ${source} 目录`);
+  }
+
+  // 递归删除技能目录 / Recursively delete skill directory
+  await fs.rm(skillDir, { recursive: true, force: true });
+
+  return {
+    ok: true,
+    name: skillName,
+    path: skillDir,
+  };
+}

--- a/extensions/workspace-editor/workspace-files.ts
+++ b/extensions/workspace-editor/workspace-files.ts
@@ -1,0 +1,426 @@
+/**
+ * Workspace file operations for the workspace-editor plugin.
+ * 工作区文件操作
+ *
+ * Supports reading, writing and listing bootstrap files in the agent workspace.
+ * 支持读取、写入和列出 agent 工作区中的启动文件
+ *
+ * Access is restricted to a whitelist of known filenames.
+ * 访问仅限于已知文件名的白名单
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import type { MoltbotConfig } from "openclaw/plugin-sdk";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Whitelist of allowed workspace filenames
+// 允许访问的工作区文件白名单
+// ───────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_FILES = new Set([
+  "SOUL.md",       // Agent 灵魂/核心人格定义
+  "IDENTITY.md",   // Agent 身份信息
+  "TOOLS.md",      // Agent 工具说明
+  "USER.md",       // 用户信息
+  "HEARTBEAT.md",  // 心跳/定时任务配置
+  "BOOTSTRAP.md",  // 启动配置
+  "MEMORY.md",     // 记忆文件（大写）
+  "memory.md",     // 记忆文件（小写）
+  "AGENTS.md",     // 多 Agent 配置
+]);
+
+// ───────────────────────────────────────────────────────────────────────────
+// Memory directory support / memory 目录支持
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Memory directory name
+ * 记忆目录名称
+ */
+const MEMORY_DIR = "memory";
+
+/**
+ * Pattern for memory file names (YYYY-MM-DD.md)
+ * 记忆文件名模式（YYYY-MM-DD.md）
+ */
+const MEMORY_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}\.md$/;
+
+/**
+ * Check if a filename is a valid memory directory file
+ * 检查文件名是否为有效的 memory 目录文件
+ *
+ * @param fileName - Filename to check (e.g., "memory/2026-01-30.md")
+ * @returns true if valid memory file path
+ */
+function isMemoryFilePath(fileName: string): boolean {
+  if (!fileName.startsWith(`${MEMORY_DIR}/`)) {
+    return false;
+  }
+  const baseName = fileName.slice(MEMORY_DIR.length + 1);
+  return MEMORY_FILE_PATTERN.test(baseName);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Type definitions / 类型定义
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Information about a workspace file
+ * 工作区文件信息
+ */
+export type WorkspaceFileInfo = {
+  name: string;           // 文件名 / Filename
+  path: string;           // 完整路径 / Full path
+  exists: boolean;        // 是否存在 / Whether file exists
+  size: number;           // 文件大小（字节）/ File size in bytes
+  modifiedAt: number | null; // 最后修改时间戳 / Last modified timestamp
+};
+
+/**
+ * Result of listing workspace files
+ * 列出工作区文件的结果
+ */
+export type WorkspaceFilesListResult = {
+  workspaceDir: string;   // 工作区目录 / Workspace directory
+  agentId: string;        // Agent ID
+  files: WorkspaceFileInfo[]; // 文件列表 / File list
+};
+
+/**
+ * Result of reading a workspace file
+ * 读取工作区文件的结果
+ */
+export type WorkspaceFileReadResult = {
+  name: string;           // 文件名 / Filename
+  path: string;           // 完整路径 / Full path
+  exists: boolean;        // 是否存在 / Whether file exists
+  content: string;        // 文件内容 / File content
+};
+
+/**
+ * Result of writing a workspace file
+ * 写入工作区文件的结果
+ */
+export type WorkspaceFileWriteResult = {
+  ok: boolean;            // 是否成功 / Whether successful
+  path: string;           // 完整路径 / Full path
+  bytesWritten: number;   // 写入字节数 / Bytes written
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Resolve workspace directory / 解析工作区目录
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Get default workspace directory
+ * 获取默认工作区目录
+ *
+ * 与核心代码保持一致：~/.openclaw/workspace
+ * Consistent with core code: ~/.openclaw/workspace
+ */
+function resolveDefaultWorkspaceDir(): string {
+  return path.join(os.homedir(), ".openclaw", "workspace");
+}
+
+/**
+ * Resolve workspace directory for a specific agent
+ * 解析特定 agent 的工作区目录
+ *
+ * @param config - Moltbot configuration / Moltbot 配置
+ * @param agentId - Optional agent ID / 可选的 agent ID
+ * @returns Workspace directory and resolved agent ID / 工作区目录和解析后的 agent ID
+ */
+function resolveAgentWorkspaceDir(
+  config: MoltbotConfig,
+  agentId?: string,
+): { workspaceDir: string; resolvedAgentId: string } {
+  const agents = config.agents as
+    | {
+        list?: Array<{ id?: string; workspace?: string; default?: boolean }>;
+        defaults?: { workspace?: string };
+      }
+    | undefined;
+  const list = agents?.list ?? [];
+
+  // Find the specified agent or the default one
+  // 查找指定的 agent 或默认 agent
+  const agent = agentId
+    ? list.find((a) => a.id === agentId)
+    : list.find((a) => a.default) ?? list[0];
+
+  // 如果找到 agent 并且有 workspace 配置
+  // If agent found and has workspace config
+  if (agent?.workspace?.trim()) {
+    let workspaceDir = agent.workspace.trim();
+    if (workspaceDir.startsWith("~")) {
+      workspaceDir = path.join(os.homedir(), workspaceDir.slice(1));
+    }
+    return {
+      workspaceDir,
+      resolvedAgentId: agent.id ?? "main",
+    };
+  }
+
+  // 检查 agents.defaults.workspace（与核心代码一致）
+  // Check agents.defaults.workspace (consistent with core code)
+  const defaultsWorkspace = agents?.defaults?.workspace?.trim();
+  if (defaultsWorkspace) {
+    let workspaceDir = defaultsWorkspace;
+    if (workspaceDir.startsWith("~")) {
+      workspaceDir = path.join(os.homedir(), workspaceDir.slice(1));
+    }
+    return {
+      workspaceDir,
+      resolvedAgentId: agent?.id ?? agentId ?? "main",
+    };
+  }
+
+  return {
+    workspaceDir: resolveDefaultWorkspaceDir(),
+    resolvedAgentId: agent?.id ?? agentId ?? "main",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Security: validate filename / 安全性：验证文件名
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate filename against whitelist and path traversal attacks
+ * 验证文件名是否在白名单内，并防止路径遍历攻击
+ *
+ * @param fileName - Filename to validate / 要验证的文件名
+ * @throws Error if filename is invalid / 如果文件名无效则抛出错误
+ */
+function validateFileName(fileName: string): void {
+  // Reject path traversal attacks / 拒绝路径遍历攻击
+  if (fileName.includes("\\") || fileName.includes("..")) {
+    throw new Error(`Invalid filename: ${fileName}`);
+  }
+
+  // Check if it's a memory directory file (memory/YYYY-MM-DD.md)
+  // 检查是否为 memory 目录文件
+  if (isMemoryFilePath(fileName)) {
+    return; // Valid memory file path / 有效的 memory 文件路径
+  }
+
+  // Reject other paths with slashes / 拒绝其他包含斜杠的路径
+  if (fileName.includes("/")) {
+    throw new Error(`Invalid filename: ${fileName}`);
+  }
+
+  // Must be in whitelist / 必须在白名单内
+  if (!ALLOWED_FILES.has(fileName)) {
+    throw new Error(
+      `File not allowed: ${fileName}. Allowed files: ${[...ALLOWED_FILES].join(", ")}, memory/YYYY-MM-DD.md`,
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// List workspace files / 列出工作区文件
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * List all workspace files (from whitelist)
+ * 列出所有工作区文件（从白名单）
+ *
+ * Returns information about each file, including whether it exists.
+ * 返回每个文件的信息，包括是否存在。
+ *
+ * @param config - Moltbot configuration / Moltbot 配置
+ * @param agentId - Optional agent ID / 可选的 agent ID
+ * @returns List result with files / 包含文件的列表结果
+ */
+export async function listWorkspaceFiles(
+  config: MoltbotConfig,
+  agentId?: string,
+): Promise<WorkspaceFilesListResult> {
+  const { workspaceDir, resolvedAgentId } = resolveAgentWorkspaceDir(
+    config,
+    agentId,
+  );
+
+  const files: WorkspaceFileInfo[] = [];
+
+  // Check each file in the whitelist / 检查白名单中的每个文件
+  for (const name of ALLOWED_FILES) {
+    const filePath = path.join(workspaceDir, name);
+    let exists = false;
+    let size = 0;
+    let modifiedAt: number | null = null;
+
+    try {
+      const stat = await fs.stat(filePath);
+      exists = stat.isFile();
+      size = stat.size;
+      modifiedAt = stat.mtimeMs;
+    } catch {
+      // File does not exist / 文件不存在
+    }
+
+    files.push({
+      name,
+      path: filePath,
+      exists,
+      size,
+      modifiedAt,
+    });
+  }
+
+  // Scan memory/ directory for dated files / 扫描 memory/ 目录获取日期文件
+  const memoryDir = path.join(workspaceDir, MEMORY_DIR);
+  try {
+    const memoryFiles = await fs.readdir(memoryDir);
+    for (const fileName of memoryFiles) {
+      // Only include files matching YYYY-MM-DD.md pattern
+      // 仅包含匹配 YYYY-MM-DD.md 模式的文件
+      if (!MEMORY_FILE_PATTERN.test(fileName)) {
+        continue;
+      }
+
+      const filePath = path.join(memoryDir, fileName);
+      const relativeName = `${MEMORY_DIR}/${fileName}`;
+
+      try {
+        const stat = await fs.stat(filePath);
+        if (stat.isFile()) {
+          files.push({
+            name: relativeName,
+            path: filePath,
+            exists: true,
+            size: stat.size,
+            modifiedAt: stat.mtimeMs,
+          });
+        }
+      } catch {
+        // Skip files that can't be stat'd / 跳过无法获取状态的文件
+      }
+    }
+  } catch {
+    // memory/ directory does not exist - that's fine
+    // memory/ 目录不存在 - 没关系
+  }
+
+  // Sort: existing files first, then by category, then alphabetically
+  // 排序：已存在的文件优先，按类别分组，然后按字母顺序
+  files.sort((a, b) => {
+    if (a.exists && !b.exists) return -1;
+    if (!a.exists && b.exists) return 1;
+
+    // Group memory/ files together at the end
+    // 将 memory/ 文件放在末尾
+    const aIsMemory = a.name.startsWith(`${MEMORY_DIR}/`);
+    const bIsMemory = b.name.startsWith(`${MEMORY_DIR}/`);
+    if (aIsMemory && !bIsMemory) return 1;
+    if (!aIsMemory && bIsMemory) return -1;
+
+    // Within memory files, sort by date descending (newest first)
+    // memory 文件内部按日期倒序排列（最新的在前）
+    if (aIsMemory && bIsMemory) {
+      return b.name.localeCompare(a.name);
+    }
+
+    return a.name.localeCompare(b.name);
+  });
+
+  return {
+    workspaceDir,
+    agentId: resolvedAgentId,
+    files,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Read workspace file / 读取工作区文件
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read content of a workspace file
+ * 读取工作区文件内容
+ *
+ * @param config - Moltbot configuration / Moltbot 配置
+ * @param fileName - Name of file to read / 要读取的文件名
+ * @param agentId - Optional agent ID / 可选的 agent ID
+ * @returns Read result with content / 包含内容的读取结果
+ */
+export async function readWorkspaceFile(
+  config: MoltbotConfig,
+  fileName: string,
+  agentId?: string,
+): Promise<WorkspaceFileReadResult> {
+  // Validate filename against whitelist / 验证文件名是否在白名单内
+  validateFileName(fileName);
+
+  const { workspaceDir } = resolveAgentWorkspaceDir(config, agentId);
+  const filePath = path.join(workspaceDir, fileName);
+
+  let exists = false;
+  let content = "";
+
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+    exists = true;
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+    // File does not exist - return empty content
+    // 文件不存在 - 返回空内容
+  }
+
+  return {
+    name: fileName,
+    path: filePath,
+    exists,
+    content,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Write workspace file / 写入工作区文件
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Write content to a workspace file
+ * 写入内容到工作区文件
+ *
+ * Creates the file if it doesn't exist, or overwrites if it does.
+ * 如果文件不存在则创建，如果存在则覆盖。
+ *
+ * @param config - Moltbot configuration / Moltbot 配置
+ * @param fileName - Name of file to write / 要写入的文件名
+ * @param content - Content to write / 要写入的内容
+ * @param agentId - Optional agent ID / 可选的 agent ID
+ * @returns Write result / 写入结果
+ */
+export async function writeWorkspaceFile(
+  config: MoltbotConfig,
+  fileName: string,
+  content: string,
+  agentId?: string,
+): Promise<WorkspaceFileWriteResult> {
+  // Validate filename against whitelist / 验证文件名是否在白名单内
+  validateFileName(fileName);
+
+  const { workspaceDir } = resolveAgentWorkspaceDir(config, agentId);
+  const filePath = path.join(workspaceDir, fileName);
+
+  // Ensure directory exists / 确保目录存在
+  // For memory/ files, also create the memory subdirectory
+  // 对于 memory/ 文件，同时创建 memory 子目录
+  const fileDir = path.dirname(filePath);
+  await fs.mkdir(fileDir, { recursive: true });
+
+  // Write file / 写入文件
+  await fs.writeFile(filePath, content, "utf-8");
+
+  return {
+    ok: true,
+    path: filePath,
+    bytesWritten: Buffer.byteLength(content, "utf-8"),
+  };
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3,3 +3,4 @@
 @import "./styles/layout.mobile.css";
 @import "./styles/components.css";
 @import "./styles/config.css";
+@import "./ui-zh-CN/styles/model-config.css";

--- a/ui/src/ui-zh-CN/README.md
+++ b/ui/src/ui-zh-CN/README.md
@@ -1,0 +1,656 @@
+项目主要解决 配置繁琐，权限安全问题，提供了可视化配置页面，持续更新。
+
+1. Providers - LLM 提供商和模型管理
+2. Agent - 代理默认参数和会话模型覆盖
+3. Gateway - 网关网络设置（端口、绑定、认证）
+4. Channels - 19+ 消息通道统一配置
+5. Workspace - 工作区文件编辑器（SOUL.md、IDENTITY.md 等）
+6. Permissions - 命令执行权限和工具权限管理
+
+---
+
+## 一、目录结构
+
+
+因为 moltbot 每天都在更新，不想建分支了，本目录用于存放前端修改，避免与主仓库的文件产生冲突。
+
+更新方式 暂存本地更改，拉取后恢复
+```git
+git stash # 暂存本地更改
+git pull origin main # 拉取远程更新
+git stash pop # 恢复本地更改（可能需要手动解决冲突）
+```
+
+
+```
+ui-zh-CN/
+├── README.md                              # 模块说明文档
+├── INTEGRATION.md                         # 集成点记录文档
+├── views/                                 # 视图层
+│   └── model-config.ts                   # 顶层视图，组装侧边栏和内容区域
+├── controllers/                           # 控制器层
+│   ├── model-config.ts                   # 核心控制器（1700+ 行，40+ 导出函数）
+│   └── workspace.ts                      # 工作区文件操作辅助
+├── components/                            # UI 组件
+│   ├── config-sidebar.ts                 # 左侧导航栏（6 个配置区域）
+│   ├── providers-content.ts              # LLM 提供商管理
+│   ├── agent-content.ts                  # 代理默认参数 + 会话模型管理
+│   ├── gateway-content.ts                # 网关网络设置
+│   ├── channels-content.ts               # 消息通道配置（19+ 通道）
+│   ├── workspace-content.ts              # 工作区启动文件编辑器
+│   └── permissions-content.ts            # 命令执行权限 + 工具权限
+├── types/                                 # 类型定义
+│   ├── config-sections.ts                # 配置区域类型
+│   └── channel-config.ts                 # 通道配置类型（19+ 通道定义）
+└── docs/                                  # 设计文档
+    ├── ANALYSIS-permissions.md           # 权限功能分析
+    └── DESIGN-provider-rename.md         # 供应商重命名设计方案
+```
+
+---
+
+## 二、架构设计
+
+### 2.1 分层架构
+
+模块采用 MVC 分层架构：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         View 层                              │
+│  views/model-config.ts - 顶层视图组装                        │
+├─────────────────────────────────────────────────────────────┤
+│                      Component 层                            │
+│  components/*.ts - UI 组件（纯渲染，无副作用）                 │
+├─────────────────────────────────────────────────────────────┤
+│                     Controller 层                            │
+│  controllers/model-config.ts - 业务逻辑、状态管理、API 调用    │
+├─────────────────────────────────────────────────────────────┤
+│                       Type 层                                │
+│  types/*.ts - 类型定义                                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 数据流
+
+```
+Gateway RPC ──► Controller ──► State ──► View (props) ──► Components
+    ▲                                         │
+    │                                         ▼
+    └──────────── UI Events (callbacks) ◄─────┘
+```
+
+1. **加载阶段**：Controller 通过 Gateway RPC 获取配置
+2. **渲染阶段**：State 作为 props 传递给 View，Components 渲染 UI
+3. **交互阶段**：UI 事件触发 callbacks，修改 Controller state
+4. **保存阶段**：Controller 构建更新，发送到 Gateway
+
+---
+
+## 三、功能模块说明
+
+### 3.1 Providers（提供商管理）
+
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img14@main/2026/01/30/1769739854704-11fe00ba-4faf-469e-b276-9a0a7f1f1bb8.png)
+
+**文件**：`components/providers-content.ts`
+
+**功能**：管理 LLM 模型提供商和模型配置。
+
+**核心能力**：
+- 添加/删除/重命名提供商
+- 配置提供商 Base URL 和 API Key
+- 选择 API 协议（OpenAI 兼容 / Anthropic 协议）
+- 添加/删除模型
+- 配置模型参数：上下文窗口、最大 tokens、推理能力
+
+**数据结构**：
+```typescript
+interface ProviderConfig {
+  baseUrl: string;
+  apiKey: string;
+  api: "openai-completions" | "anthropic-messages";
+  models: ModelConfig[];
+}
+
+interface ModelConfig {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  contextWindow: number;
+  maxTokens: number;
+  input?: string[];      // 支持的输入类型
+  cost?: { input: number; output: number };
+}
+```
+
+**解决的问题**：
+- 避免手动编辑 JSON 配置文件
+- 提供表单校验，防止无效配置
+- 可视化展示模型参数，便于对比和调整
+
+---
+
+
+### 3.2 Agent（代理设置）
+
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img7@main/2026/01/30/1769739910169-a2a59d26-dba2-48a5-b698-5992ce03ec3b.png)
+
+
+**文件**：`components/agent-content.ts`
+
+**功能**：配置代理运行时默认值和会话级模型覆盖。
+
+**代理默认值配置**：
+
+| 字段 | 说明 | 示例值 |
+|------|------|--------|
+| model.primary | 主模型选择 | `modelscope/qwen-max` |
+| maxConcurrent | 最大并发请求数 | 5 |
+| subagents.maxConcurrent | 子代理并发数 | 3 |
+| workspace | 工作空间目录 | `~/workspace` |
+| contextPruning.mode | 上下文裁剪模式 | `cache-ttl` / `token-limit` |
+| compaction.mode | 压缩模式 | `safeguard` / `aggressive` |
+
+**会话模型管理**：
+- 查看所有活跃会话
+- 为每个会话单独设置模型覆盖
+- 显示最后更新时间
+- 点击会话名称可跳转到对应聊天
+
+**API 调用**：
+- `sessions.list` - 获取会话列表
+- `sessions.patch` - 更新会话模型覆盖
+
+---
+
+### 3.3 Gateway（网关配置）
+
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img17@main/2026/01/30/1769740158099-b9932a50-3046-4be8-af71-afe7cbeb0d23.png)
+
+
+**文件**：`components/gateway-content.ts`
+
+**功能**：配置网关网络设置。
+
+**配置项**：
+
+| 字段 | 说明 | 选项 |
+|------|------|------|
+| port | 端口号 | 1-65535 |
+| bind | 绑定模式 | loopback / LAN / auto |
+| auth.mode | 认证模式 | token / password / none |
+| auth.token | 认证凭据 | 字符串 |
+
+**安全性考虑**：
+- 默认绑定 loopback，仅本机可访问
+- 支持 token 认证，防止未授权访问
+- UI 隐藏敏感信息（密码字段使用 password 类型）
+
+---
+
+### 3.4 Channels（通道配置）
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img6@main/2026/01/30/1769739948515-cbda86e3-289a-41c6-8c17-3339fa11566e.png)
+
+**文件**：`components/channels-content.ts`、`types/channel-config.ts`
+
+**功能**：支持 19+ 消息通道的可视化配置。
+
+**支持的通道**：
+
+| 类型 | 通道列表 |
+|------|----------|
+| 内置通道 | Telegram, Discord, Slack, WhatsApp, Signal, Google Chat, iMessage, MS Teams |
+| 扩展通道 | WeChat, Matrix, Mattermost, Nostr, LINE, Twitch, BlueBubbles, Zalo, Nextcloud Talk, Tlon |
+
+**每个通道的通用配置**：
+- `enabled` - 启用/禁用开关
+- `dmPolicy` - DM 访问策略（pairing / allowlist / open / disabled）
+- `groupPolicy` - 群组访问策略（open / disabled / allowlist）
+- `allowFrom` / `groupAllowFrom` - 允许列表
+- `historyLimit` / `dmHistoryLimit` - 历史记录限制
+- `mediaMaxMb` - 媒体大小限制
+
+**特定通道配置示例（Telegram）**：
+```typescript
+interface TelegramChannelConfig {
+  botToken?: string;
+  tokenFile?: string;
+  streamMode?: "off" | "partial" | "block";
+  chunkMode?: "length" | "newline";
+  reactionNotifications?: "off" | "own" | "all" | "allowlist";
+}
+```
+
+**解决的问题**：
+- 统一管理 19+ 通道配置，避免分散在多个配置文件
+- 字段级别的校验和说明
+- 敏感信息（token、secret）使用密码字段
+
+---
+
+### 3.5 Workspace（工作区文件）
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img4@main/2026/01/30/1769739977362-785d8a48-1241-4df0-8ac7-14400192a473.png)
+
+**文件**：`components/workspace-content.ts`、`controllers/workspace.ts`
+
+**功能**：可视化编辑代理工作区的启动文件。
+
+**支持的文件（白名单）**：
+
+| 文件名 | 用途 |
+|--------|------|
+| SOUL.md | Agent 灵魂/核心人格定义 |
+| IDENTITY.md | Agent 身份信息 |
+| TOOLS.md | Agent 工具说明 |
+| USER.md | 用户信息 |
+| HEARTBEAT.md | 心跳/定时任务配置 |
+| BOOTSTRAP.md | 启动配置 |
+| MEMORY.md / memory.md | 记忆文件 |
+| AGENTS.md | 多 Agent 配置 |
+
+**编辑器功能**：
+- 三种模式切换：编辑 / 预览 / 分屏
+- Markdown 实时预览（使用安全的 iframe srcdoc 渲染）
+- 未保存更改提示（文件名旁显示红点）
+- 文件不存在时自动创建
+
+**API 调用**：
+- `workspace.files.list` - 获取工作区文件列表
+- `workspace.file.read` - 读取文件内容
+- `workspace.file.write` - 写入文件内容
+
+**安全性**：
+- 仅允许访问白名单内的文件
+- 防止路径遍历攻击（文件名校验）
+- 通过 Gateway RPC 进行文件操作（不直接访问文件系统）
+
+---
+
+### 3.6 Permissions（权限管理）
+
+**文件**：`components/permissions-content.ts`、`docs/ANALYSIS-permissions.md`
+
+**功能**：双标签页权限管理系统，包括命令执行权限和工具权限。
+
+#### 3.6.1 命令执行权限（Exec Tab）
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img0@main/2026/01/30/1769740071716-0ef49eb2-2dd8-41b2-af6c-151d287f0d56.png)
+
+
+**目标选择**：
+- 本地网关：配置在本机执行命令的权限
+- 远程节点：配置在远程设备（如树莓派）执行命令的权限
+
+**作用域配置**：
+- 全局默认：应用于所有 Agent 的默认策略
+- 通配符 (*)：匹配所有未单独配置的 Agent
+- 特定 Agent：为指定 Agent 配置独立策略
+
+**安全策略配置**：
+
+| 配置项 | 选项 | 说明 |
+|--------|------|------|
+| security | deny / allowlist / full | 安全模式 |
+| ask | off / on-miss / always | 用户确认方式 |
+| askFallback | deny / allowlist / full | UI 不可用时的回退策略 |
+| autoAllowSkills | true / false | 自动允许技能 CLI |
+
+**允许列表**：
+- 使用 glob 模式匹配命令（如 `git *`、`npm run *`）
+- 显示最后使用时间和命令
+- 支持添加/删除规则
+
+**数据结构**：
+```typescript
+interface ExecApprovalsFile {
+  version: number;
+  defaults?: ExecApprovalsDefaults;
+  agents?: Record<string, ExecApprovalsAgent>;
+}
+
+interface ExecApprovalsAgent {
+  security?: "deny" | "allowlist" | "full";
+  ask?: "off" | "on-miss" | "always";
+  askFallback?: "deny" | "allowlist" | "full";
+  autoAllowSkills?: boolean;
+  allowlist?: ExecAllowlistEntry[];
+}
+```
+
+#### 3.6.2 工具权限（Tools Tab）
+
+![](https://fastly.jsdelivr.net/gh/bucketio/img11@main/2026/01/30/1769740023072-45c45c88-5198-435b-8382-7178450f3ca8.png)
+**预设配置档案**：
+
+| 档案 | 说明 |
+|------|------|
+| minimal | 仅 session_status |
+| coding | 文件+运行时+会话+记忆+image |
+| messaging | 消息+部分会话工具 |
+| full | 所有工具 |
+
+**工具分组**：
+
+| 分组 | 工具列表 |
+|------|----------|
+| group:fs | read, write, edit, apply_patch |
+| group:runtime | exec, process |
+| group:web | web_search, web_fetch |
+| group:ui | browser, canvas |
+| group:sessions | sessions_list, sessions_history, sessions_send, sessions_spawn, session_status |
+| group:memory | memory_search, memory_get |
+| group:automation | cron, gateway |
+| group:messaging | message |
+| group:nodes | nodes |
+
+**独立工具**：tts, image, agents_list
+
+**权限控制方式**：
+- 按分组批量启用/禁用
+- 单独控制每个工具
+- 支持全局配置和 Agent 级别覆盖
+
+---
+
+## 四、如何解决权限安全问题
+
+### 4.1 分层安全模型
+
+模块实现了三层安全控制：
+
+```
+┌─────────────────────────────────────────┐
+│  第一层：UI 访问控制                      │
+│  - Gateway 认证（token/password）        │
+│  - 绑定模式限制（loopback/LAN）           │
+└─────────────────────────────────────────┘
+                    ▼
+┌─────────────────────────────────────────┐
+│  第二层：命令执行权限                      │
+│  - deny/allowlist/full 安全模式          │
+│  - 用户确认机制                          │
+│  - 通配符和 Agent 级别配置                │
+└─────────────────────────────────────────┘
+                    ▼
+┌─────────────────────────────────────────┐
+│  第三层：工具权限                         │
+│  - 预设档案（最小权限原则）                │
+│  - 分组控制                              │
+│  - 单工具禁用                            │
+└─────────────────────────────────────────┘
+```
+
+### 4.2 关键安全特性
+
+**命令执行安全**：
+
+1. **默认拒绝策略**：`security` 默认值为 `deny`，所有命令默认被拒绝
+2. **白名单机制**：`allowlist` 模式下，只有明确允许的命令才能执行
+3. **用户确认**：`ask` 配置允许每次执行前提示用户确认
+4. **回退策略**：UI 不可用时，`askFallback` 控制是否执行
+
+**工具权限安全**：
+
+1. **最小权限原则**：默认使用 `minimal` 档案
+2. **分组隔离**：不同功能分组独立控制
+3. **deny 列表**：可以明确禁用特定工具或分组
+
+**工作区文件安全**：
+
+1. **白名单文件**：仅允许访问预定义的文件列表
+2. **路径校验**：防止路径遍历攻击
+3. **RPC 代理**：所有文件操作通过 Gateway RPC，不直接访问文件系统
+
+**敏感信息保护**：
+
+1. **密码字段**：API Key、Token 等使用 password 类型输入
+2. **数据脱敏**：`exec.approvals.get` 返回时自动移除 `socket.token`
+3. **配置隔离**：权限配置与主配置分离存储
+
+### 4.3 乐观并发控制
+
+配置更新使用 `baseHash` 机制防止并发冲突：
+
+```typescript
+// 保存时携带 baseHash
+await client.request("config.set", {
+  raw: configContent,
+  baseHash: state.modelConfigHash,  // 加载时获取的 hash
+});
+
+// 权限配置同样使用 baseHash
+await client.request("exec.approvals.set", {
+  file: permissionsConfig,
+  baseHash: state.execApprovalsSnapshot.hash,
+});
+```
+
+---
+
+## 五、如何解决配置复杂性问题
+
+### 5.1 可视化配置界面
+
+**传统方式的问题**：
+- 需要手动编辑 JSON/YAML 配置文件
+- 容易出现语法错误
+- 字段含义不清楚
+- 需要查阅文档了解可选值
+
+**解决方案**：
+
+1. **表单化配置**：所有配置项转换为表单字段
+2. **下拉选择**：枚举类型使用 select 组件
+3. **开关控制**：布尔值使用 toggle 组件
+4. **实时校验**：输入时即时校验格式
+
+### 5.2 分区导航
+
+将复杂配置分为 6 个独立区域：
+
+```
+┌─────────────────┬───────────────────────────────────────────┐
+│   Config        │                                           │
+│   Sidebar       │         [Dynamic Content Section]         │
+│                 │                                           │
+│   ○ Providers   │   当前选中区域的配置表单                    │
+│   ○ Agent       │                                           │
+│   ○ Gateway     │   - 表单字段                               │
+│   ○ Channels    │   - 下拉选择                               │
+│   ○ Workspace   │   - 开关控制                               │
+│   ○ Permissions │                                           │
+│                 │                                           │
+└─────────────────┴───────────────────────────────────────────┘
+```
+
+用户可以专注于当前关心的配置区域，不被其他配置干扰。
+
+### 5.3 层级配置简化
+
+**传统 JSON 配置**：
+```json
+{
+  "models": {
+    "providers": {
+      "openai": {
+        "baseUrl": "https://api.openai.com/v1",
+        "apiKey": "sk-xxx",
+        "api": "openai-completions",
+        "models": [...]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "openai/gpt-4" },
+      "maxConcurrent": 5
+    }
+  }
+}
+```
+
+**UI 简化后**：
+- Providers 区域：直接编辑提供商配置
+- Agent 区域：直接选择主模型、设置并发数
+- 无需了解 JSON 嵌套结构
+
+### 5.4 配置继承与覆盖
+
+**问题**：不同 Agent 可能需要不同的配置，但大部分配置相同。
+
+**解决方案**：
+
+1. **全局默认**：配置 `defaults` 作为基础
+2. **通配符 (*)**：匹配所有未单独配置的 Agent
+3. **特定 Agent**：仅配置需要覆盖的字段
+
+UI 清晰展示继承关系：
+```
+安全模式: [使用默认 (deny) ▼]
+用户确认: [使用默认 (on-miss) ▼]
+```
+
+### 5.5 变更检测与保存
+
+**问题**：配置修改后容易忘记保存，或不清楚哪些修改了。
+
+**解决方案**：
+
+1. **实时变更检测**：`hasModelConfigChanges()` 比较当前值与原始值
+2. **未保存提示**：标题栏显示未保存标记
+3. **保存/应用分离**：
+    - Save：仅保存配置，不重启服务
+    - Apply：保存并重启相关服务
+
+### 5.6 通道配置统一管理
+
+**问题**：19+ 通道配置分散，每个通道字段不同。
+
+**解决方案**：
+
+1. **元数据驱动**：每个通道定义 `ChannelMeta`，包含：
+    - 通道 ID、标签、图标、描述
+    - 配置字段定义（类型、选项、验证规则）
+
+2. **动态表单生成**：根据元数据自动生成配置表单
+
+```typescript
+const CHANNEL_METADATA: ChannelMeta[] = [
+  {
+    id: "telegram",
+    label: "Telegram",
+    icon: "send",
+    description: "Telegram Bot 消息通道",
+    configFields: [
+      { key: "botToken", label: "Bot Token", type: "password", required: true },
+      { key: "streamMode", label: "流式模式", type: "select", options: [...] },
+      // ...
+    ],
+  },
+  // ...
+];
+```
+
+### 5.7 工作区文件编辑
+
+**问题**：
+- 需要 SSH 或文件管理器访问服务器
+- 不同文件用途不清楚
+- 编辑后需要手动确认格式
+
+**解决方案**：
+
+1. **内置编辑器**：直接在 UI 中编辑
+2. **文件说明**：每个文件旁显示用途描述
+3. **Markdown 预览**：支持编辑/预览/分屏模式
+4. **自动创建**：文件不存在时保存后自动创建
+
+---
+
+## 六、技术实现细节
+
+### 6.1 技术栈
+
+- **UI 框架**：Lit (Web Components)
+- **构建工具**：Vite
+- **类型系统**：TypeScript
+- **通信协议**：WebSocket RPC
+
+### 6.2 状态管理
+
+使用 Lit 的 `@state()` 装饰器管理组件状态：
+
+```typescript
+@state() modelConfigLoading = false;
+@state() modelConfigProviders: Record<string, ProviderConfig> = {};
+@state() permissionsDirty = false;
+// ...
+```
+
+### 6.3 Gateway RPC 方法
+
+| 方法 | 说明 |
+|------|------|
+| `config.get` | 获取完整配置快照 |
+| `config.set` | 保存配置（不重启服务） |
+| `config.apply` | 保存并应用配置（重启相关服务） |
+| `sessions.list` | 获取会话列表 |
+| `sessions.patch` | 更新会话模型覆盖 |
+| `exec.approvals.get` | 获取本地网关执行权限配置 |
+| `exec.approvals.set` | 保存本地网关执行权限配置 |
+| `exec.approvals.node.get` | 获取远程节点执行权限配置 |
+| `exec.approvals.node.set` | 保存远程节点执行权限配置 |
+| `workspace.files.list` | 获取工作区文件列表 |
+| `workspace.file.read` | 读取工作区文件内容 |
+| `workspace.file.write` | 写入工作区文件内容 |
+
+---
+
+## 七、扩展指南
+
+### 7.1 添加新的配置区域
+
+1. 在 `types/config-sections.ts` 中添加新的 `ConfigSectionId`
+2. 创建新的 content 组件 `components/xxx-content.ts`
+3. 在 `views/model-config.ts` 的 `renderContentSection()` 中添加路由
+4. 在 `config-sidebar.ts` 的 `SECTIONS` 中添加导航项
+5. 在 `controllers/model-config.ts` 中添加数据提取和保存逻辑
+
+### 7.2 添加新的消息通道
+
+1. 在 `types/channel-config.ts` 中添加通道配置类型
+2. 在 `components/channels-content.ts` 的 `CHANNEL_METADATA` 中添加元数据
+3. 定义字段 schema（支持 toggle、text、password、number、select、array 类型）
+
+### 7.3 添加新的工作区文件
+
+1. 在 Gateway 后端的 `ALLOWED_FILES` 白名单中添加文件名
+2. 文件将自动出现在工作区编辑器的文件列表中
+
+---
+
+## 八、总结
+
+**权限安全**：
+1. 分层安全模型（网关认证 -> 命令执行权限 -> 工具权限）
+2. 默认拒绝策略 + 白名单机制
+3. 用户确认机制
+4. 工作区文件白名单
+5. 敏感信息保护
+6. 乐观并发控制
+
+**配置简化**：
+1. 可视化表单替代 JSON 编辑
+2. 分区导航聚焦配置
+3. 层级配置继承与覆盖
+4. 实时变更检测
+5. 通道配置统一管理
+6. 内置 Markdown 编辑器
+
+---

--- a/ui/src/ui-zh-CN/components/agent-content.ts
+++ b/ui/src/ui-zh-CN/components/agent-content.ts
@@ -1,0 +1,352 @@
+/**
+ * Agent 设置配置内容组件
+ * Agent settings configuration content component
+ *
+ * 右侧面板 - Agent 默认参数 + 会话模型管理
+ * Right panel - Agent default parameters + session model management
+ */
+import { html, nothing } from "lit";
+import type { AgentDefaults } from "../views/model-config";
+import type { SessionRow, SessionsListResult } from "../controllers/model-config";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SVG 图标 / SVG Icons
+// ─────────────────────────────────────────────────────────────────────────────
+
+const icons = {
+  agent: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"></path><circle cx="8" cy="14" r="1"></circle><circle cx="16" cy="14" r="1"></circle></svg>`,
+  settings: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>`,
+  sessions: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>`,
+  refresh: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>`,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 中文标签 / Chinese Labels
+// ─────────────────────────────────────────────────────────────────────────────
+
+const LABELS = {
+  // Agent 设置标题 / Agent settings title
+  agentTitle: "Agent 设置",
+  agentDesc: "配置 Agent 的运行参数和会话管理",
+  // 默认参数 / Default parameters
+  defaultsTitle: "默认参数",
+  defaultsDesc: "设置 Agent 运行时的默认参数",
+  primaryModel: "主模型",
+  maxConcurrent: "最大并发",
+  subagentConcurrent: "子 Agent 并发",
+  workspace: "工作目录",
+  contextPruning: "上下文裁剪",
+  compactionMode: "压缩模式",
+  pruneCacheTtl: "缓存 TTL",
+  pruneTokenLimit: "Token 限制",
+  compactSafeguard: "保守模式",
+  compactAggressive: "激进模式",
+  // 会话相关 / Session related
+  sessionsTitle: "会话模型管理",
+  sessionsDesc: "为每个会话指定使用的模型 (per-session model override)",
+  sessionKey: "会话",
+  sessionModel: "模型",
+  sessionUpdated: "最后更新",
+  defaultModel: "默认模型",
+  inheritDefault: "继承默认",
+  noSessions: "暂无会话",
+  loading: "加载中...",
+  refresh: "刷新",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 类型定义 / Type Definitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AgentContentProps = {
+  // Agent 默认设置 / Agent default settings
+  agentDefaults: AgentDefaults;
+  availableModels: Array<{ id: string; name: string; provider: string }>;
+  onAgentDefaultsUpdate: (path: string[], value: unknown) => void;
+  // 会话管理 / Session management
+  sessionsLoading: boolean;
+  sessionsResult: SessionsListResult | null;
+  sessionsError: string | null;
+  onSessionsRefresh: () => void;
+  onSessionModelChange: (sessionKey: string, model: string | null) => void;
+  onSessionNavigate: (sessionKey: string) => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 辅助函数 / Helper Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 格式化时间为相对时间
+ * Format timestamp to relative time
+ */
+function formatAgo(ts: number): string {
+  const now = Date.now();
+  const diff = now - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "刚刚";
+  if (mins < 60) return `${mins} 分钟前`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  return `${days} 天前`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 渲染函数 / Render Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 渲染单个会话行
+ * Render a single session row
+ */
+function renderSessionRow(
+  session: SessionRow,
+  availableModels: AgentContentProps["availableModels"],
+  defaultModel: { provider: string | null; model: string | null },
+  onModelChange: (sessionKey: string, model: string | null) => void,
+  onNavigate: (sessionKey: string) => void,
+) {
+  const displayName = session.displayName ?? session.label ?? session.key;
+  const currentModel = session.model
+    ? `${session.modelProvider ?? ""}/${session.model}`.replace(/^\//, "")
+    : "";
+  const defaultModelId = defaultModel.model
+    ? `${defaultModel.provider ?? ""}/${defaultModel.model}`.replace(/^\//, "")
+    : "";
+
+  return html`
+    <div class="session-row">
+      <div class="session-row__key" title=${session.key}>
+        <a
+          class="session-row__link"
+          href="javascript:void(0)"
+          @click=${(e: Event) => {
+            e.preventDefault();
+            onNavigate(session.key);
+          }}
+        >${displayName}</a>
+        ${session.kind !== "direct"
+          ? html`<span class="session-row__kind">${session.kind}</span>`
+          : nothing}
+      </div>
+      <div class="session-row__model">
+        <select
+          class="mc-select mc-select--sm"
+          @change=${(e: Event) => {
+            const value = (e.target as HTMLSelectElement).value;
+            onModelChange(session.key, value || null);
+          }}
+        >
+          <option value="" ?selected=${!currentModel}>${LABELS.inheritDefault}${defaultModelId ? ` (${defaultModelId})` : ""}</option>
+          ${availableModels.map(
+            (m) => html`<option value=${m.id} ?selected=${m.id === currentModel}>${m.name} (${m.provider})</option>`,
+          )}
+        </select>
+      </div>
+      <div class="session-row__updated">
+        ${session.updatedAt ? formatAgo(session.updatedAt) : "-"}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染会话列表
+ * Render sessions list
+ */
+function renderSessionsList(props: AgentContentProps) {
+  const sessions = props.sessionsResult?.sessions ?? [];
+  const defaults = props.sessionsResult?.defaults ?? { modelProvider: null, model: null };
+
+  return html`
+    <div class="mc-section">
+      <div class="mc-section__header">
+        <div class="mc-section__icon">${icons.sessions}</div>
+        <div class="mc-section__titles">
+          <h3 class="mc-section__title">${LABELS.sessionsTitle}</h3>
+          <p class="mc-section__desc">${LABELS.sessionsDesc}</p>
+        </div>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.sessionsLoading}
+          @click=${props.onSessionsRefresh}
+          title=${LABELS.refresh}
+        >
+          ${icons.refresh}
+          ${props.sessionsLoading ? LABELS.loading : LABELS.refresh}
+        </button>
+      </div>
+
+      ${props.sessionsError
+        ? html`<div class="mc-error">${props.sessionsError}</div>`
+        : nothing}
+
+      <div class="sessions-list">
+        ${sessions.length > 0
+          ? html`
+              <div class="sessions-list__header">
+                <div class="sessions-list__col sessions-list__col--key">${LABELS.sessionKey}</div>
+                <div class="sessions-list__col sessions-list__col--model">${LABELS.sessionModel}</div>
+                <div class="sessions-list__col sessions-list__col--updated">${LABELS.sessionUpdated}</div>
+              </div>
+              <div class="sessions-list__body">
+                ${sessions.map((session) =>
+                  renderSessionRow(session, props.availableModels, defaults, props.onSessionModelChange, props.onSessionNavigate),
+                )}
+              </div>
+            `
+          : html`<div class="mc-empty">${props.sessionsLoading ? LABELS.loading : LABELS.noSessions}</div>`}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染默认参数设置
+ * Render default parameters settings
+ */
+function renderDefaultsSection(props: AgentContentProps) {
+  const defaults = props.agentDefaults;
+
+  return html`
+    <div class="mc-section">
+      <div class="mc-section__header">
+        <div class="mc-section__icon">${icons.settings}</div>
+        <div class="mc-section__titles">
+          <h3 class="mc-section__title">${LABELS.defaultsTitle}</h3>
+          <p class="mc-section__desc">${LABELS.defaultsDesc}</p>
+        </div>
+      </div>
+      <div class="mc-card">
+        <div class="mc-card__content">
+          <!-- 模型和工作目录 / Model and workspace -->
+          <div class="mc-form-row mc-form-row--2col">
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.primaryModel}</span>
+              <select
+                class="mc-select"
+                @change=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(
+                    ["model", "primary"],
+                    (e.target as HTMLSelectElement).value,
+                  )}
+              >
+                <option value="" ?selected=${!defaults.model?.primary}>-- 选择模型 --</option>
+                ${props.availableModels.map(
+                  (m) => html`<option value=${m.id} ?selected=${m.id === defaults.model?.primary}>${m.name} (${m.provider})</option>`,
+                )}
+              </select>
+            </label>
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.workspace}</span>
+              <input
+                type="text"
+                class="mc-input"
+                .value=${defaults.workspace ?? ""}
+                placeholder="/path/to/workspace"
+                @input=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(["workspace"], (e.target as HTMLInputElement).value)}
+              />
+            </label>
+          </div>
+          <!-- 并发设置 / Concurrency settings -->
+          <div class="mc-form-row mc-form-row--2col">
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.maxConcurrent}</span>
+              <input
+                type="number"
+                class="mc-input"
+                .value=${String(defaults.maxConcurrent ?? 4)}
+                min="1"
+                max="32"
+                @input=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(
+                    ["maxConcurrent"],
+                    Number((e.target as HTMLInputElement).value),
+                  )}
+              />
+            </label>
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.subagentConcurrent}</span>
+              <input
+                type="number"
+                class="mc-input"
+                .value=${String(defaults.subagents?.maxConcurrent ?? 8)}
+                min="1"
+                max="32"
+                @input=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(
+                    ["subagents", "maxConcurrent"],
+                    Number((e.target as HTMLInputElement).value),
+                  )}
+              />
+            </label>
+          </div>
+          <!-- 上下文管理 / Context management -->
+          <div class="mc-form-row mc-form-row--2col">
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.contextPruning}</span>
+              <select
+                class="mc-select"
+                .value=${defaults.contextPruning?.mode ?? "cache-ttl"}
+                @change=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(
+                    ["contextPruning", "mode"],
+                    (e.target as HTMLSelectElement).value,
+                  )}
+              >
+                <option value="cache-ttl">${LABELS.pruneCacheTtl}</option>
+                <option value="token-limit">${LABELS.pruneTokenLimit}</option>
+              </select>
+            </label>
+            <label class="mc-field">
+              <span class="mc-field__label">${LABELS.compactionMode}</span>
+              <select
+                class="mc-select"
+                .value=${defaults.compaction?.mode ?? "safeguard"}
+                @change=${(e: Event) =>
+                  props.onAgentDefaultsUpdate(
+                    ["compaction", "mode"],
+                    (e.target as HTMLSelectElement).value,
+                  )}
+              >
+                <option value="safeguard">${LABELS.compactSafeguard}</option>
+                <option value="aggressive">${LABELS.compactAggressive}</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 主渲染函数 / Main Render Function
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 渲染 Agent 设置内容
+ * Render Agent settings content
+ */
+export function renderAgentContent(props: AgentContentProps) {
+  return html`
+    <div class="config-content">
+      <div class="config-content__header">
+        <div class="config-content__icon">${icons.agent}</div>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">${LABELS.agentTitle}</h2>
+          <p class="config-content__desc">${LABELS.agentDesc}</p>
+        </div>
+      </div>
+      <div class="config-content__body">
+        <!-- 默认设置区块 / Default settings section -->
+        ${renderDefaultsSection(props)}
+
+        <!-- 会话模型管理 / Session model management -->
+        ${renderSessionsList(props)}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/channels-content.ts
+++ b/ui/src/ui-zh-CN/components/channels-content.ts
@@ -1,0 +1,694 @@
+/**
+ * 通道配置内容组件
+ * 右侧面板 - 消息通道详细配置
+ */
+import { html, nothing } from "lit";
+import type {
+  ChannelMeta,
+  ChannelConfigField,
+  ChannelsConfigData,
+} from "../types/channel-config";
+
+// SVG 图标
+const icons = {
+  channel: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>`,
+  telegram: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>`,
+  discord: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>`,
+  slack: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>`,
+  whatsapp: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>`,
+  signal: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 3.6c4.636 0 8.4 3.764 8.4 8.4 0 4.636-3.764 8.4-8.4 8.4-4.636 0-8.4-3.764-8.4-8.4 0-4.636 3.764-8.4 8.4-8.4zm0 1.2c-3.978 0-7.2 3.222-7.2 7.2s3.222 7.2 7.2 7.2 7.2-3.222 7.2-7.2-3.222-7.2-7.2-7.2z"/></svg>`,
+  googlechat: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.372 0 0 5.373 0 12s5.372 12 12 12 12-5.373 12-12S18.628 0 12 0zm5.25 7.5H18v6.75c0 .412-.338.75-.75.75h-4.5v1.5h4.5c1.242 0 2.25-1.008 2.25-2.25V6.75c0-1.242-1.008-2.25-2.25-2.25H6.75C5.508 4.5 4.5 5.508 4.5 6.75v4.5h1.5v-4.5c0-.412.338-.75.75-.75h10.5z"/></svg>`,
+  imessage: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 5.813 2 10.5c0 2.338 1.125 4.45 2.953 5.953-.285 1.465-.897 2.758-1.803 3.708a.75.75 0 00.53 1.28c2.138-.04 4.024-.654 5.54-1.586A12.59 12.59 0 0012 20c5.523 0 10-3.813 10-8.5S17.523 2 12 2z"/></svg>`,
+  msteams: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.215 0c-.193 0-.379.084-.508.229L.221 11.71a.692.692 0 00-.221.508c0 .193.083.378.229.508l10.485 10.977c.129.146.315.229.508.229.193 0 .378-.083.507-.229l10.486-10.977a.692.692 0 00.229-.508.692.692 0 00-.221-.508L11.723.229A.692.692 0 0011.215 0z"/></svg>`,
+  wechat: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 01.213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 00.167-.054l1.903-1.114a.864.864 0 01.717-.098 10.16 10.16 0 002.837.403c.276 0 .543-.027.811-.05-.857-2.578.157-4.972 1.932-6.446 1.703-1.415 3.882-1.98 5.853-1.838-.576-3.583-4.196-6.348-8.596-6.348zM5.785 5.991c.642 0 1.162.529 1.162 1.18a1.17 1.17 0 01-1.162 1.178A1.17 1.17 0 014.623 7.17c0-.651.52-1.18 1.162-1.18zm5.813 0c.642 0 1.162.529 1.162 1.18a1.17 1.17 0 01-1.162 1.178 1.17 1.17 0 01-1.162-1.178c0-.651.52-1.18 1.162-1.18zm5.34 2.867c-1.797-.052-3.746.512-5.28 1.786-1.72 1.428-2.687 3.72-1.78 6.22.942 2.453 3.666 4.229 6.884 4.229.826 0 1.622-.12 2.361-.336a.722.722 0 01.598.082l1.584.926a.272.272 0 00.14.045c.134 0 .24-.111.24-.247 0-.06-.023-.12-.038-.177l-.327-1.233a.582.582 0 01-.023-.156.49.49 0 01.201-.398C23.024 18.48 24 16.82 24 14.98c0-3.21-2.931-5.837-6.656-6.088-.181-.013-.363-.019-.547-.017l.14-.017zm-2.89 3.04c.535 0 .969.44.969.982a.976.976 0 01-.969.983.976.976 0 01-.969-.983c0-.542.434-.982.97-.982zm4.844 0c.535 0 .969.44.969.982a.976.976 0 01-.969.983.976.976 0 01-.969-.983c0-.542.434-.982.97-.982z"/></svg>`,
+  matrix: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M.632.55v22.9H2.28V24H0V0h2.28v.55zm7.043 7.26v1.157h.033c.309-.443.683-.784 1.117-1.024.433-.245.936-.365 1.5-.365.54 0 1.033.107 1.481.314.448.208.785.582 1.02 1.108.254-.374.6-.706 1.034-.992.434-.287.95-.43 1.546-.43.453 0 .872.056 1.26.167.388.11.716.286.993.53.276.245.489.559.646.951.152.392.23.863.23 1.417v5.728h-2.349V11.52c0-.286-.01-.559-.032-.812a1.755 1.755 0 00-.18-.66 1.106 1.106 0 00-.438-.448c-.194-.11-.457-.166-.785-.166-.332 0-.6.064-.803.189a1.38 1.38 0 00-.48.499 1.946 1.946 0 00-.231.696 5.56 5.56 0 00-.06.785v4.768h-2.35v-4.8c0-.254-.004-.503-.018-.752a2.074 2.074 0 00-.143-.688 1.052 1.052 0 00-.415-.503c-.194-.128-.482-.19-.868-.19-.12 0-.283.024-.488.074a1.56 1.56 0 00-.546.247 1.505 1.505 0 00-.43.497c-.112.203-.168.479-.168.817v5.298H4.743V7.81zm14.256-.55v22.9H24V24h-2.28V0h2.28v.55z"/></svg>`,
+  mattermost: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12.081 0C7.048-.031 2.48 3.236.856 8.237c-1.727 5.32.464 11.063 5.25 13.756.673.379 1.127.675 1.606.933.143-.645.27-1.296.397-1.958.04-.21-.043-.298-.203-.396-1.658-.979-2.924-2.359-3.694-4.139C2.541 12.45 3.747 7.7 7.452 5.02c4.173-3.02 9.968-2.395 13.378 1.425 3.247 3.638 3.443 9.103.487 13.004a9.47 9.47 0 01-4.691 3.377c-.083.032-.16.076-.333.16.118.537.24 1.072.369 1.606l.063.274c.175-.038.347-.069.518-.105 5.602-1.182 9.534-5.88 9.752-11.66C27.242 6.682 22.088.862 15.632.123c-.596-.068-1.2-.1-1.805-.123h-1.746zm1.015 3.142c-.585.003-1.163.07-1.745.17-.066.011-.138.129-.135.195.035.757.085 1.514.144 2.27.011.1.09.204.166.27.926.782 1.482 1.778 1.644 2.972.223 1.63-.406 2.933-1.722 3.972-.299.236-.615.452-.933.683.121.565.232 1.11.367 1.65.047.185.08.404.195.537a.965.965 0 00.519.282c.393.064.755-.05 1.057-.312.312-.27.609-.558.912-.84.313-.29.62-.39 1.022-.204.397.182.797.358 1.197.531.36.157.557.082.735-.264.187-.361.368-.728.518-1.106.145-.366.1-.562-.22-.792-.389-.28-.779-.56-1.186-.815-.348-.219-.425-.412-.304-.8.198-.638.326-1.298.417-1.96.074-.536.063-1.087.052-1.63-.008-.438-.213-.694-.64-.759a10.276 10.276 0 00-2.06-.05z"/></svg>`,
+  nostr: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm4.5 16.5h-9v-1.5h9v1.5zm0-3h-9v-1.5h9V13.5zm0-3h-9V9h9v1.5z"/></svg>`,
+  line: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>`,
+  twitch: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/></svg>`,
+  bluebubbles: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15l-5-5 1.41-1.41L11 14.17l7.59-7.59L20 8l-9 9z"/></svg>`,
+  zalo: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.5 16.5h-11v-1.5l7-7H6.5V6.5h11v1.5l-7 7h5z"/></svg>`,
+  nextcloud: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12.018 6.537c-2.5 0-4.6 1.712-5.241 4.015-.56-1.055-1.66-1.773-2.925-1.773-1.837 0-3.327 1.49-3.327 3.327s1.49 3.327 3.327 3.327c1.265 0 2.365-.718 2.925-1.773.641 2.303 2.741 4.015 5.241 4.015 2.503 0 4.604-1.716 5.244-4.022.561 1.057 1.662 1.78 2.93 1.78 1.838 0 3.328-1.49 3.328-3.327s-1.49-3.327-3.328-3.327c-1.268 0-2.369.723-2.93 1.78-.64-2.306-2.741-4.022-5.244-4.022"/></svg>`,
+  tlon: html`<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>`,
+  settings: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>`,
+  check: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
+  x: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+  externalLink: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>`,
+};
+
+// DM/Group 策略选项
+const DM_POLICY_OPTIONS = [
+  { value: "pairing", label: "配对模式" },
+  { value: "allowlist", label: "白名单" },
+  { value: "open", label: "开放" },
+  { value: "disabled", label: "禁用" },
+];
+
+const GROUP_POLICY_OPTIONS = [
+  { value: "open", label: "开放" },
+  { value: "allowlist", label: "白名单" },
+  { value: "disabled", label: "禁用" },
+];
+
+// 通道元数据定义 - 基于实际代码库
+export const CHANNEL_METADATA: ChannelMeta[] = [
+  // ===== 内置通道 =====
+  {
+    id: "telegram",
+    label: "Telegram",
+    icon: "telegram",
+    description: "Telegram Bot 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/telegram",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "botToken", label: "Bot Token", type: "password", placeholder: "123456:ABC-DEF...", required: true, section: "auth" },
+      { key: "tokenFile", label: "Token 文件路径", type: "text", placeholder: "/path/to/token", section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "streamMode", label: "流式模式", type: "select", options: [
+        { value: "off", label: "关闭" },
+        { value: "partial", label: "部分" },
+        { value: "block", label: "块" },
+      ], section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "群组历史记录限制", type: "number", placeholder: "50", section: "history" },
+      { key: "dmHistoryLimit", label: "DM 历史记录限制", type: "number", placeholder: "50", section: "history" },
+      { key: "linkPreview", label: "显示链接预览", type: "toggle", section: "messaging" },
+      { key: "reactionLevel", label: "表情回应级别", type: "select", options: [
+        { value: "off", label: "关闭" },
+        { value: "ack", label: "确认" },
+        { value: "minimal", label: "最小" },
+        { value: "extensive", label: "详细" },
+      ], section: "messaging" },
+    ],
+  },
+  {
+    id: "discord",
+    label: "Discord",
+    icon: "discord",
+    description: "Discord Bot 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/discord",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "token", label: "Bot Token", type: "password", placeholder: "MTIzNDU2Nzg5...", required: true, section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "服务器策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "allowBots", label: "允许机器人消息", type: "toggle", section: "access" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "2000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+      { key: "dmHistoryLimit", label: "DM 历史记录限制", type: "number", placeholder: "50", section: "history" },
+      { key: "maxLinesPerMessage", label: "每条消息最大行数", type: "number", placeholder: "17", section: "messaging" },
+    ],
+  },
+  {
+    id: "slack",
+    label: "Slack",
+    icon: "slack",
+    description: "Slack App 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/slack",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "mode", label: "连接模式", type: "select", options: [
+        { value: "socket", label: "Socket Mode" },
+        { value: "http", label: "HTTP Mode" },
+      ], section: "basic" },
+      { key: "botToken", label: "Bot Token", type: "password", placeholder: "xoxb-...", required: true, section: "auth" },
+      { key: "appToken", label: "App Token", type: "password", placeholder: "xapp-...", section: "auth" },
+      { key: "userToken", label: "User Token", type: "password", placeholder: "xoxp-...", section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "频道策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+      { key: "allowBots", label: "允许机器人消息", type: "toggle", section: "access" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp",
+    icon: "whatsapp",
+    description: "WhatsApp Web 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/whatsapp",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "authDir", label: "认证目录", type: "text", placeholder: "~/.clawdbot/whatsapp-auth", section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "sendReadReceipts", label: "发送已读回执", type: "toggle", section: "messaging" },
+      { key: "selfChatMode", label: "自聊模式", type: "select", options: [
+        { value: "off", label: "关闭" },
+        { value: "forward", label: "转发" },
+        { value: "local", label: "本地" },
+      ], section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "50", section: "messaging" },
+      { key: "debounceMs", label: "防抖延迟 (ms)", type: "number", placeholder: "1000", section: "advanced" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "signal",
+    label: "Signal",
+    icon: "signal",
+    description: "Signal 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/signal",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "account", label: "账号 (E.164)", type: "text", placeholder: "+1234567890", required: true, section: "auth" },
+      { key: "httpUrl", label: "HTTP URL", type: "text", placeholder: "http://localhost:8080", section: "daemon" },
+      { key: "httpHost", label: "HTTP Host", type: "text", placeholder: "127.0.0.1", section: "daemon" },
+      { key: "httpPort", label: "HTTP Port", type: "number", placeholder: "8080", section: "daemon" },
+      { key: "cliPath", label: "CLI 路径", type: "text", placeholder: "signal-cli", section: "daemon" },
+      { key: "autoStart", label: "自动启动守护进程", type: "toggle", section: "daemon" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "sendReadReceipts", label: "发送已读回执", type: "toggle", section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "googlechat",
+    label: "Google Chat",
+    icon: "googlechat",
+    description: "Google Chat 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/googlechat",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "serviceAccountFile", label: "服务账号文件", type: "text", placeholder: "/path/to/service-account.json", section: "auth" },
+      { key: "webhookPath", label: "Webhook 路径", type: "text", placeholder: "/googlechat", section: "webhook" },
+      { key: "webhookUrl", label: "Webhook URL", type: "text", placeholder: "https://your-domain.com/googlechat", section: "webhook" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "Space 策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+      { key: "typingIndicator", label: "输入指示器", type: "select", options: [
+        { value: "none", label: "无" },
+        { value: "message", label: "消息" },
+        { value: "reaction", label: "表情" },
+      ], section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "imessage",
+    label: "iMessage",
+    icon: "imessage",
+    description: "iMessage 消息通道 (仅 macOS)",
+    docsUrl: "https://docs.molt.bot/channels/imessage",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "cliPath", label: "CLI 路径", type: "text", placeholder: "imsg", section: "cli" },
+      { key: "dbPath", label: "数据库路径", type: "text", placeholder: "~/Library/Messages/chat.db", section: "cli" },
+      { key: "remoteHost", label: "远程主机", type: "text", placeholder: "user@192.168.64.3", section: "cli" },
+      { key: "service", label: "服务类型", type: "select", options: [
+        { value: "imessage", label: "iMessage" },
+        { value: "sms", label: "SMS" },
+        { value: "auto", label: "自动" },
+      ], section: "basic" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "includeAttachments", label: "包含附件", type: "toggle", section: "messaging" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "25", section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "msteams",
+    label: "MS Teams",
+    icon: "msteams",
+    description: "Microsoft Teams 消息通道",
+    docsUrl: "https://docs.molt.bot/channels/msteams",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "appId", label: "App ID", type: "text", placeholder: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", required: true, section: "auth" },
+      { key: "appPassword", label: "App Password", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "tenantId", label: "Tenant ID", type: "text", placeholder: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "团队策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+      { key: "replyStyle", label: "回复样式", type: "select", options: [
+        { value: "thread", label: "线程回复" },
+        { value: "top-level", label: "顶层回复" },
+      ], section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "100", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+
+  // ===== 扩展通道 =====
+  {
+    id: "wechat",
+    label: "WeChat",
+    icon: "wechat",
+    description: "微信消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/wechat",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "name", label: "账户名称", type: "text", placeholder: "我的微信", section: "basic" },
+      { key: "baseUrl", label: "API 地址", type: "text", placeholder: "https://wechat-robot.example.com", required: true, section: "api" },
+      { key: "apiToken", label: "API Token", type: "password", placeholder: "ae3d7737-6eeb-48d0-...", section: "api" },
+      { key: "tokenFile", label: "Token 文件路径", type: "text", placeholder: "/path/to/token", section: "api" },
+      { key: "robotId", label: "机器人 ID", type: "number", placeholder: "5", required: true, section: "api" },
+      { key: "defaultAccount", label: "默认账户", type: "text", placeholder: "account-id", section: "basic" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+      { key: "allowFrom", label: "允许的用户 (wxid)", type: "array", placeholder: "wxid_xxx", description: "每行一个微信 ID", section: "access" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "25", section: "messaging" },
+      { key: "polling.pollingIntervalMs", label: "轮询间隔 (ms)", type: "number", placeholder: "3000", section: "polling" },
+      { key: "polling.pollContactIds", label: "轮询联系人 ID", type: "array", placeholder: "wxid_xxx 或 123@chatroom", description: "每行一个联系人/群聊 ID", section: "polling" },
+      { key: "polling.pollAllContacts", label: "轮询所有联系人", type: "toggle", section: "polling" },
+      { key: "polling.maxPollContacts", label: "最大轮询联系人数", type: "number", placeholder: "100", section: "polling" },
+    ],
+  },
+  {
+    id: "matrix",
+    label: "Matrix",
+    icon: "matrix",
+    description: "Matrix 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/matrix",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "homeserver", label: "Homeserver URL", type: "text", placeholder: "https://matrix.org", required: true, section: "auth" },
+      { key: "userId", label: "用户 ID", type: "text", placeholder: "@bot:matrix.org", required: true, section: "auth" },
+      { key: "accessToken", label: "Access Token", type: "password", placeholder: "...", section: "auth" },
+      { key: "password", label: "密码", type: "password", placeholder: "...", section: "auth" },
+      { key: "encryption", label: "启用加密", type: "toggle", section: "basic" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "房间策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "autoJoin", label: "自动加入", type: "select", options: [
+        { value: "always", label: "总是" },
+        { value: "allowlist", label: "白名单" },
+        { value: "off", label: "关闭" },
+      ], section: "access" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "25", section: "messaging" },
+    ],
+  },
+  {
+    id: "mattermost",
+    label: "Mattermost",
+    icon: "mattermost",
+    description: "Mattermost 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/mattermost",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "baseUrl", label: "服务器地址", type: "text", placeholder: "https://mattermost.example.com", required: true, section: "auth" },
+      { key: "botToken", label: "Bot Token", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "频道策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+    ],
+  },
+  {
+    id: "nostr",
+    label: "Nostr",
+    icon: "nostr",
+    description: "Nostr 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/nostr",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "privateKey", label: "私钥 (hex/nsec)", type: "password", placeholder: "nsec1...", required: true, section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+    ],
+  },
+  {
+    id: "line",
+    label: "LINE",
+    icon: "line",
+    description: "LINE 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/line",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "channelAccessToken", label: "Channel Access Token", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "channelSecret", label: "Channel Secret", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+    ],
+  },
+  {
+    id: "twitch",
+    label: "Twitch",
+    icon: "twitch",
+    description: "Twitch 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/twitch",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "username", label: "用户名", type: "text", placeholder: "bot_username", required: true, section: "auth" },
+      { key: "accessToken", label: "OAuth Access Token", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "clientId", label: "Client ID", type: "text", placeholder: "...", section: "auth" },
+      { key: "channel", label: "频道名称", type: "text", placeholder: "channel_name", required: true, section: "basic" },
+      { key: "requireMention", label: "需要 @提及", type: "toggle", section: "access" },
+    ],
+  },
+  {
+    id: "bluebubbles",
+    label: "BlueBubbles",
+    icon: "bluebubbles",
+    description: "BlueBubbles iMessage 通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/bluebubbles",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "serverUrl", label: "服务器 URL", type: "text", placeholder: "http://localhost:1234", required: true, section: "auth" },
+      { key: "password", label: "服务器密码", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "webhookPath", label: "Webhook 路径", type: "text", placeholder: "/bluebubbles", section: "webhook" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "群组策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "sendReadReceipts", label: "发送已读回执", type: "toggle", section: "messaging" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "zalo",
+    label: "Zalo",
+    icon: "zalo",
+    description: "Zalo OA 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/zalo",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "botToken", label: "Bot Token", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "tokenFile", label: "Token 文件路径", type: "text", placeholder: "/path/to/token", section: "auth" },
+      { key: "webhookUrl", label: "Webhook URL", type: "text", placeholder: "https://...", section: "webhook" },
+      { key: "webhookSecret", label: "Webhook Secret", type: "password", placeholder: "...", section: "webhook" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "mediaMaxMb", label: "最大媒体大小 (MB)", type: "number", placeholder: "25", section: "messaging" },
+    ],
+  },
+  {
+    id: "nextcloud-talk",
+    label: "Nextcloud Talk",
+    icon: "nextcloud",
+    description: "Nextcloud Talk 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/nextcloud-talk",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "baseUrl", label: "Nextcloud URL", type: "text", placeholder: "https://nextcloud.example.com", required: true, section: "auth" },
+      { key: "botSecret", label: "Bot Secret", type: "password", placeholder: "...", section: "auth" },
+      { key: "apiUser", label: "API 用户", type: "text", placeholder: "bot_user", section: "auth" },
+      { key: "apiPassword", label: "API 密码", type: "password", placeholder: "...", section: "auth" },
+      { key: "dmPolicy", label: "DM 策略", type: "select", options: DM_POLICY_OPTIONS, section: "access" },
+      { key: "groupPolicy", label: "房间策略", type: "select", options: GROUP_POLICY_OPTIONS, section: "access" },
+      { key: "textChunkLimit", label: "文本块限制", type: "number", placeholder: "4000", section: "messaging" },
+      { key: "historyLimit", label: "历史记录限制", type: "number", placeholder: "50", section: "history" },
+    ],
+  },
+  {
+    id: "tlon",
+    label: "Tlon (Urbit)",
+    icon: "tlon",
+    description: "Tlon/Urbit 消息通道 (扩展)",
+    docsUrl: "https://docs.molt.bot/channels/tlon",
+    configFields: [
+      { key: "enabled", label: "启用", type: "toggle", section: "basic" },
+      { key: "ship", label: "Ship 名称", type: "text", placeholder: "~sampel-palnet", required: true, section: "auth" },
+      { key: "url", label: "Ship URL", type: "text", placeholder: "http://localhost:8080", required: true, section: "auth" },
+      { key: "code", label: "认证码", type: "password", placeholder: "...", required: true, section: "auth" },
+      { key: "autoDiscoverChannels", label: "自动发现频道", type: "toggle", section: "basic" },
+    ],
+  },
+];
+
+// 配置区块分组
+const CONFIG_SECTIONS = [
+  { id: "basic", label: "基本设置" },
+  { id: "auth", label: "认证配置" },
+  { id: "api", label: "API 配置" },
+  { id: "webhook", label: "Webhook 配置" },
+  { id: "daemon", label: "守护进程" },
+  { id: "cli", label: "CLI 配置" },
+  { id: "polling", label: "轮询配置" },
+  { id: "access", label: "访问控制" },
+  { id: "messaging", label: "消息设置" },
+  { id: "history", label: "历史记录" },
+  { id: "advanced", label: "高级设置" },
+];
+
+function getChannelIcon(iconName: string) {
+  return icons[iconName as keyof typeof icons] ?? icons.channel;
+}
+
+export type ChannelsContentProps = {
+  channelsConfig: ChannelsConfigData;
+  selectedChannel: string | null;
+  onChannelSelect: (channelId: string) => void;
+  onChannelConfigUpdate: (channelId: string, field: string, value: unknown) => void;
+  onNavigateToChannels: () => void;
+};
+
+/**
+ * 渲染通道列表
+ */
+function renderChannelList(props: ChannelsContentProps) {
+  return html`
+    <div class="channel-list">
+      ${CHANNEL_METADATA.map((channel) => {
+        const config = props.channelsConfig[channel.id] as Record<string, unknown> | undefined;
+        const enabled = config?.enabled !== false;
+        const isSelected = props.selectedChannel === channel.id;
+
+        return html`
+          <button
+            class="channel-list__item ${isSelected ? "channel-list__item--active" : ""} ${enabled ? "" : "channel-list__item--disabled"}"
+            @click=${() => props.onChannelSelect(channel.id)}
+          >
+            <span class="channel-list__icon ${enabled ? "channel-list__icon--enabled" : ""}">${getChannelIcon(channel.icon)}</span>
+            <span class="channel-list__content">
+              <span class="channel-list__label">${channel.label}</span>
+              <span class="channel-list__status">${enabled ? "已启用" : "已禁用"}</span>
+            </span>
+            <span class="channel-list__indicator">
+              ${enabled ? icons.check : icons.x}
+            </span>
+          </button>
+        `;
+      })}
+    </div>
+  `;
+}
+
+/**
+ * 解析嵌套路径值，支持 "polling.pollingIntervalMs" 形式的 key
+ */
+function resolveNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+/**
+ * 渲染配置字段
+ */
+function renderConfigField(
+  channel: ChannelMeta,
+  field: ChannelConfigField,
+  value: unknown,
+  props: ChannelsContentProps,
+) {
+  const handleChange = (newValue: unknown) => {
+    props.onChannelConfigUpdate(channel.id, field.key, newValue);
+  };
+
+  switch (field.type) {
+    case "toggle":
+      return html`
+        <label class="mc-toggle-field">
+          <span class="mc-toggle-field__label">${field.label}</span>
+          <div class="mc-toggle">
+            <input
+              type="checkbox"
+              .checked=${Boolean(value)}
+              @change=${(e: Event) => handleChange((e.target as HTMLInputElement).checked)}
+            />
+            <span class="mc-toggle__track"></span>
+          </div>
+        </label>
+      `;
+
+    case "array":
+      // 数组类型：用 textarea，每行一个值
+      const arrayValue = Array.isArray(value) ? value : [];
+      const textValue = arrayValue.join("\n");
+      return html`
+        <label class="mc-field">
+          <span class="mc-field__label">${field.label}</span>
+          ${field.description ? html`<span class="mc-field__desc">${field.description}</span>` : nothing}
+          <textarea
+            class="mc-textarea"
+            rows="3"
+            placeholder=${field.placeholder ?? ""}
+            .value=${textValue}
+            @input=${(e: Event) => {
+              const text = (e.target as HTMLTextAreaElement).value;
+              const items = text.split("\n").map((s) => s.trim()).filter((s) => s.length > 0);
+              handleChange(items.length > 0 ? items : undefined);
+            }}
+          ></textarea>
+        </label>
+      `;
+
+    case "select":
+      return html`
+        <label class="mc-field">
+          <span class="mc-field__label">${field.label}</span>
+          <select
+            class="mc-select"
+            @change=${(e: Event) => handleChange((e.target as HTMLSelectElement).value)}
+          >
+            <option value="" ?selected=${!value}>-- 选择 --</option>
+            ${field.options?.map(
+              (opt) => html`<option value=${opt.value} ?selected=${String(value) === opt.value}>${opt.label}</option>`,
+            )}
+          </select>
+        </label>
+      `;
+
+    case "password":
+      return html`
+        <label class="mc-field">
+          <span class="mc-field__label">${field.label}${field.required ? " *" : ""}</span>
+          <input
+            type="password"
+            class="mc-input"
+            .value=${String(value ?? "")}
+            placeholder=${field.placeholder ?? ""}
+            @input=${(e: Event) => handleChange((e.target as HTMLInputElement).value)}
+          />
+        </label>
+      `;
+
+    case "number":
+      return html`
+        <label class="mc-field">
+          <span class="mc-field__label">${field.label}</span>
+          <input
+            type="number"
+            class="mc-input"
+            .value=${String(value ?? "")}
+            placeholder=${field.placeholder ?? ""}
+            @input=${(e: Event) => handleChange(Number((e.target as HTMLInputElement).value) || undefined)}
+          />
+        </label>
+      `;
+
+    default:
+      return html`
+        <label class="mc-field">
+          <span class="mc-field__label">${field.label}${field.required ? " *" : ""}</span>
+          <input
+            type="text"
+            class="mc-input"
+            .value=${String(value ?? "")}
+            placeholder=${field.placeholder ?? ""}
+            @input=${(e: Event) => handleChange((e.target as HTMLInputElement).value)}
+          />
+        </label>
+      `;
+  }
+}
+
+/**
+ * 渲染通道配置详情
+ */
+function renderChannelDetail(props: ChannelsContentProps) {
+  if (!props.selectedChannel) {
+    return html`
+      <div class="channel-detail__empty">
+        <div class="channel-detail__empty-icon">${icons.channel}</div>
+        <div class="channel-detail__empty-text">选择一个通道查看配置</div>
+      </div>
+    `;
+  }
+
+  const channel = CHANNEL_METADATA.find((c) => c.id === props.selectedChannel);
+  if (!channel) return nothing;
+
+  const config = (props.channelsConfig[channel.id] ?? {}) as Record<string, unknown>;
+
+  // 按 section 分组字段
+  const fieldsBySection = new Map<string, ChannelConfigField[]>();
+  for (const field of channel.configFields) {
+    const section = field.section ?? "basic";
+    if (!fieldsBySection.has(section)) {
+      fieldsBySection.set(section, []);
+    }
+    fieldsBySection.get(section)!.push(field);
+  }
+
+  return html`
+    <div class="channel-detail">
+      <div class="channel-detail__header">
+        <div class="channel-detail__icon">${getChannelIcon(channel.icon)}</div>
+        <div class="channel-detail__titles">
+          <h3 class="channel-detail__title">${channel.label}</h3>
+          <p class="channel-detail__desc">${channel.description}</p>
+        </div>
+        ${channel.docsUrl
+          ? html`
+              <a
+                class="channel-detail__docs"
+                href=${channel.docsUrl}
+                target="_blank"
+                rel="noreferrer"
+                title="查看文档"
+              >
+                ${icons.externalLink}
+              </a>
+            `
+          : nothing}
+      </div>
+
+      <div class="channel-detail__body">
+        ${CONFIG_SECTIONS.filter((section) => fieldsBySection.has(section.id)).map(
+          (section) => html`
+            <div class="channel-detail__section">
+              <h4 class="channel-detail__section-title">${section.label}</h4>
+              <div class="channel-detail__fields">
+                ${fieldsBySection.get(section.id)!.map((field) =>
+                  renderConfigField(channel, field, resolveNestedValue(config, field.key), props),
+                )}
+              </div>
+            </div>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染通道配置内容
+ */
+export function renderChannelsContent(props: ChannelsContentProps) {
+  return html`
+    <div class="config-content config-content--channels">
+      <div class="config-content__header">
+        <div class="config-content__icon">${icons.channel}</div>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">通道配置</h2>
+          <p class="config-content__desc">配置消息通道（Telegram、Discord、WhatsApp 等）</p>
+        </div>
+        <button class="mc-btn" @click=${props.onNavigateToChannels}>
+          ${icons.externalLink}
+          <span>通道管理</span>
+        </button>
+      </div>
+
+      <div class="channels-layout">
+        <div class="channels-layout__sidebar">
+          ${renderChannelList(props)}
+        </div>
+        <div class="channels-layout__content">
+          ${renderChannelDetail(props)}
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/config-sidebar.ts
+++ b/ui/src/ui-zh-CN/components/config-sidebar.ts
@@ -1,0 +1,130 @@
+/**
+ * 配置侧边栏组件
+ * Config sidebar component
+ *
+ * 左侧导航菜单，用于切换不同的配置区块
+ * Left navigation menu for switching between config sections
+ */
+import { html, nothing } from "lit";
+import type { ConfigSection } from "../types/config-sections";
+
+// SVG 图标 / Icons
+const icons = {
+  provider: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>`,
+  agent: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"></path><circle cx="8" cy="14" r="1"></circle><circle cx="16" cy="14" r="1"></circle></svg>`,
+  gateway: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>`,
+  channel: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>`,
+  settings: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>`,
+  permissions: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path><path d="M9 12l2 2 4-4"></path></svg>`,
+  // 工作区/文件夹图标 / Workspace/folder icon
+  workspace: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>`,
+  // 技能图标 (闪电) / Skills icon (zap/lightning)
+  skills: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>`,
+  // 定时任务图标 (时钟) / Cron icon (clock)
+  cron: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>`,
+};
+
+// 配置区块定义 / Config sections definition
+export const CONFIG_SECTIONS: ConfigSection[] = [
+  {
+    id: "providers",
+    label: "模型供应商",
+    icon: "provider",
+    description: "配置 LLM 模型供应商",
+  },
+  {
+    id: "agent",
+    label: "Agent 设置",
+    icon: "agent",
+    description: "Agent 默认参数",
+  },
+  {
+    id: "workspace",
+    label: "工作区文件",
+    icon: "workspace",
+    description: "提示词和身份文件",
+  },
+  {
+    id: "gateway",
+    label: "Gateway 设置",
+    icon: "gateway",
+    description: "网关端口和认证",
+  },
+  {
+    id: "channels",
+    label: "通道配置",
+    icon: "channel",
+    description: "消息通道设置",
+  },
+  {
+    id: "permissions",
+    label: "权限管理",
+    icon: "permissions",
+    description: "命令执行和访问权限",
+  },
+  {
+    id: "skills",
+    label: "技能管理",
+    icon: "skills",
+    description: "管理技能白名单和配置",
+  },
+  {
+    id: "cron",
+    label: "定时任务",
+    icon: "cron",
+    description: "管理定时任务调度",
+  },
+];
+
+function getIcon(iconName: string) {
+  return icons[iconName as keyof typeof icons] ?? icons.settings;
+}
+
+export type ConfigSidebarProps = {
+  activeSection: string;
+  onSectionChange: (sectionId: string) => void;
+  hasChanges?: boolean;
+  connected?: boolean;
+};
+
+/**
+ * 渲染配置侧边栏
+ */
+export function renderConfigSidebar(props: ConfigSidebarProps) {
+  return html`
+    <aside class="config-sidebar">
+      <div class="config-sidebar__header">
+        <h2 class="config-sidebar__title">配置管理</h2>
+        ${props.hasChanges
+          ? html`<span class="config-sidebar__badge">未保存</span>`
+          : nothing}
+      </div>
+      <nav class="config-sidebar__nav">
+        ${CONFIG_SECTIONS.map((section) => {
+          const isActive = props.activeSection === section.id;
+          return html`
+            <button
+              class="config-sidebar__item ${isActive ? "config-sidebar__item--active" : ""}"
+              @click=${() => props.onSectionChange(section.id)}
+              title=${section.description}
+            >
+              <span class="config-sidebar__item-icon">${getIcon(section.icon)}</span>
+              <span class="config-sidebar__item-content">
+                <span class="config-sidebar__item-label">${section.label}</span>
+                <span class="config-sidebar__item-desc">${section.description}</span>
+              </span>
+            </button>
+          `;
+        })}
+      </nav>
+      <div class="config-sidebar__footer">
+        <div class="config-sidebar__status">
+          <span class="config-sidebar__status-dot ${props.connected ? "config-sidebar__status-dot--ok" : ""}"></span>
+          <span class="config-sidebar__status-text">
+            ${props.connected ? "已连接" : "未连接"}
+          </span>
+        </div>
+      </div>
+    </aside>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/cron-content.ts
+++ b/ui/src/ui-zh-CN/components/cron-content.ts
@@ -1,0 +1,1036 @@
+/**
+ * Cron 定时任务内容组件
+ * Cron scheduled task content component
+ */
+import { html, nothing } from "lit";
+import type { CronJob } from "../../ui/types";
+import type { CronFormState } from "../../ui/ui-types";
+import type { CronContentProps } from "../types/cron-config";
+import { formatMs } from "../../ui/format";
+import {
+  formatCronPayload,
+  formatCronSchedule,
+  formatCronState,
+  formatNextRun,
+} from "../../ui/presenter";
+
+// 中文标签 / Chinese labels
+const LABELS = {
+  // 页面标题
+  title: "定时任务",
+  desc: "配置和管理 Gateway 定时任务调度",
+
+  // 状态卡片
+  schedulerStatus: "调度器状态",
+  enabled: "已启用",
+  disabled: "已禁用",
+  jobCount: "任务数量",
+  nextWake: "下次唤醒",
+  nJobs: (n: number) => `${n} 个任务`,
+
+  // 操作按钮
+  refresh: "刷新",
+  refreshing: "刷新中...",
+
+  // 表单
+  newJob: "新建任务",
+  name: "任务名称",
+  namePlaceholder: "输入任务名称",
+  description: "任务描述",
+  descriptionPlaceholder: "可选：描述任务用途",
+  agentId: "Agent ID",
+  agentIdPlaceholder: "留空使用默认 Agent",
+  enabledLabel: "启用任务",
+
+  // 调度类型
+  schedule: "调度方式",
+  scheduleAt: "指定时间",
+  scheduleEvery: "循环间隔",
+  scheduleCron: "Cron 表达式",
+  runAt: "运行时间",
+  every: "每隔",
+  everyUnit: "时间单位",
+  minutes: "分钟",
+  hours: "小时",
+  days: "天",
+  cronExpr: "Cron 表达式",
+  cronExprPlaceholder: "0 7 * * *",
+  cronTz: "时区",
+  cronTzPlaceholder: "如: Asia/Shanghai",
+
+  // 会话和唤醒
+  sessionTarget: "会话类型",
+  sessionMain: "主会话",
+  sessionIsolated: "隔离会话",
+  wakeMode: "唤醒方式",
+  wakeModeNextHeartbeat: "下次心跳",
+  wakeModeNow: "立即执行",
+
+  // 负载类型
+  payloadKind: "任务类型",
+  payloadSystemEvent: "系统事件",
+  payloadAgentTurn: "Agent 执行",
+  payloadText: "消息内容",
+  payloadTextPlaceholder: "输入要执行的消息或命令",
+
+  // Agent 执行选项
+  deliver: "投递消息",
+  channel: "投递通道",
+  channelLast: "上次活跃通道",
+  to: "接收者",
+  toPlaceholder: "+1555... 或 chat id",
+  timeoutSeconds: "超时时间（秒）",
+  postToMainPrefix: "回写前缀",
+  postToMainPrefixPlaceholder: "隔离会话结果回写到主会话的前缀",
+
+  // 提交
+  addJob: "添加任务",
+  adding: "添加中...",
+  editJob: "编辑任务",
+  updateJob: "保存修改",
+  updating: "保存中...",
+
+  // 任务列表
+  jobsList: "任务列表",
+  noJobs: "暂无定时任务",
+  noJobsHint: "点击右上方「新建任务」按钮创建第一个定时任务",
+
+  // 任务卡片
+  enableJob: "启用",
+  disableJob: "禁用",
+  runNow: "立即运行",
+  viewRuns: "运行记录",
+  deleteJob: "删除",
+
+  // 任务详情
+  lastStatus: "上次状态",
+  nextRun: "下次运行",
+  lastRun: "上次运行",
+  statusOk: "成功",
+  statusError: "失败",
+  statusSkipped: "跳过",
+  statusNA: "无",
+
+  // 运行历史
+  runHistory: "运行历史",
+  selectJobToViewRuns: "选择任务查看运行历史",
+  noRuns: "暂无运行记录",
+  duration: "耗时",
+
+  // 删除确认
+  deleteConfirmTitle: "确认删除",
+  deleteConfirmDesc: (name: string) => `确定要删除任务 "${name}" 吗？此操作不可撤销。`,
+  cancel: "取消",
+  confirm: "确认删除",
+
+  // 错误
+  error: "错误",
+};
+
+// 图标
+const icons = {
+  clock: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="20" height="20"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>`,
+  plus: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`,
+  edit: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>`,
+  play: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>`,
+  trash: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>`,
+  chevronDown: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="6 9 12 15 18 9"></polyline></svg>`,
+  check: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
+  x: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+  alertCircle: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>`,
+  refresh: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>`,
+};
+
+/**
+ * 默认表单状态
+ */
+const DEFAULT_FORM: CronFormState = {
+  name: "",
+  description: "",
+  agentId: "",
+  enabled: true,
+  scheduleKind: "every",
+  scheduleAt: "",
+  everyAmount: "30",
+  everyUnit: "minutes",
+  cronExpr: "0 7 * * *",
+  cronTz: "",
+  sessionTarget: "main",
+  wakeMode: "next-heartbeat",
+  payloadKind: "systemEvent",
+  payloadText: "",
+  deliver: false,
+  channel: "last",
+  to: "",
+  timeoutSeconds: "",
+  postToMainPrefix: "",
+};
+
+// 空函数，用于回调默认值
+const noop = () => {};
+
+/**
+ * 获取安全的回调函数
+ */
+function getSafeCallbacks(props: CronContentProps) {
+  return {
+    onFormChange: props.onFormChange ?? noop,
+    onRefresh: props.onRefresh ?? noop,
+    onAdd: props.onAdd ?? noop,
+    onUpdate: props.onUpdate ?? noop,
+    onToggle: props.onToggle ?? noop,
+    onRun: props.onRun ?? noop,
+    onRemove: props.onRemove ?? noop,
+    onLoadRuns: props.onLoadRuns ?? noop,
+    onExpandJob: props.onExpandJob ?? noop,
+    onDeleteConfirm: props.onDeleteConfirm ?? noop,
+    onShowCreateModal: props.onShowCreateModal ?? noop,
+    onEdit: props.onEdit ?? noop,
+  };
+}
+
+/**
+ * 构建通道选项列表
+ */
+function buildChannelOptions(props: CronContentProps): string[] {
+  const channels = props.channels ?? [];
+  const options = ["last", ...channels.filter(Boolean)];
+  const form = props.form ?? DEFAULT_FORM;
+  const current = form.channel?.trim();
+  if (current && !options.includes(current)) {
+    options.push(current);
+  }
+  const seen = new Set<string>();
+  return options.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+/**
+ * 解析通道显示标签
+ */
+function resolveChannelLabel(props: CronContentProps, channel: string): string {
+  if (channel === "last") return LABELS.channelLast;
+  const meta = props.channelMeta?.find((entry) => entry.id === channel);
+  if (meta?.label) return meta.label;
+  return props.channelLabels?.[channel] ?? channel;
+}
+
+/**
+ * 渲染调度器状态卡片
+ */
+function renderStatusCard(props: CronContentProps) {
+  const status = props.status;
+  return html`
+    <div class="cron-status-card">
+      <div class="cron-status-card__item">
+        <div class="cron-status-card__label">${LABELS.schedulerStatus}</div>
+        <div class="cron-status-card__value ${status?.enabled ? "cron-status-card__value--ok" : ""}">
+          ${status ? (status.enabled ? LABELS.enabled : LABELS.disabled) : "—"}
+        </div>
+      </div>
+      <div class="cron-status-card__item">
+        <div class="cron-status-card__label">${LABELS.jobCount}</div>
+        <div class="cron-status-card__value">
+          ${status ? LABELS.nJobs(status.jobs ?? 0) : "—"}
+        </div>
+      </div>
+      <div class="cron-status-card__item">
+        <div class="cron-status-card__label">${LABELS.nextWake}</div>
+        <div class="cron-status-card__value" style="font-size: 14px;">
+          ${formatNextRun(status?.nextWakeAtMs ?? null)}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染调度类型字段
+ */
+function renderScheduleFields(props: CronContentProps) {
+  const form = props.form ?? DEFAULT_FORM;
+  const { onFormChange } = getSafeCallbacks(props);
+
+  return html`
+    <!-- 调度类型切换 -->
+    <div class="cron-schedule-tabs">
+      <button
+        class="cron-schedule-tab ${form.scheduleKind === "every" ? "cron-schedule-tab--active" : ""}"
+        @click=${() => onFormChange({ scheduleKind: "every" })}
+      >
+        ${LABELS.scheduleEvery}
+      </button>
+      <button
+        class="cron-schedule-tab ${form.scheduleKind === "at" ? "cron-schedule-tab--active" : ""}"
+        @click=${() => onFormChange({ scheduleKind: "at" })}
+      >
+        ${LABELS.scheduleAt}
+      </button>
+      <button
+        class="cron-schedule-tab ${form.scheduleKind === "cron" ? "cron-schedule-tab--active" : ""}"
+        @click=${() => onFormChange({ scheduleKind: "cron" })}
+      >
+        ${LABELS.scheduleCron}
+      </button>
+    </div>
+
+    <!-- 调度参数 -->
+    ${form.scheduleKind === "at"
+      ? html`
+          <div class="mc-field">
+            <label class="mc-field__label">${LABELS.runAt}</label>
+            <input
+              type="datetime-local"
+              class="mc-input"
+              .value=${form.scheduleAt}
+              @input=${(e: Event) =>
+                onFormChange({ scheduleAt: (e.target as HTMLInputElement).value })}
+            />
+          </div>
+        `
+      : form.scheduleKind === "every"
+        ? html`
+            <div class="cron-form-grid">
+              <div class="mc-field">
+                <label class="mc-field__label">${LABELS.every}</label>
+                <input
+                  type="number"
+                  class="mc-input"
+                  min="1"
+                  .value=${form.everyAmount}
+                  @input=${(e: Event) =>
+                    onFormChange({ everyAmount: (e.target as HTMLInputElement).value })}
+                />
+              </div>
+              <div class="mc-field">
+                <label class="mc-field__label">${LABELS.everyUnit}</label>
+                <select
+                  class="mc-select"
+                  .value=${form.everyUnit}
+                  @change=${(e: Event) =>
+                    onFormChange({
+                      everyUnit: (e.target as HTMLSelectElement).value as CronFormState["everyUnit"],
+                    })}
+                >
+                  <option value="minutes">${LABELS.minutes}</option>
+                  <option value="hours">${LABELS.hours}</option>
+                  <option value="days">${LABELS.days}</option>
+                </select>
+              </div>
+            </div>
+          `
+        : html`
+            <div class="cron-form-grid">
+              <div class="mc-field">
+                <label class="mc-field__label">${LABELS.cronExpr}</label>
+                <input
+                  type="text"
+                  class="mc-input"
+                  placeholder=${LABELS.cronExprPlaceholder}
+                  .value=${form.cronExpr}
+                  @input=${(e: Event) =>
+                    onFormChange({ cronExpr: (e.target as HTMLInputElement).value })}
+                />
+              </div>
+              <div class="mc-field">
+                <label class="mc-field__label">${LABELS.cronTz}</label>
+                <input
+                  type="text"
+                  class="mc-input"
+                  placeholder=${LABELS.cronTzPlaceholder}
+                  .value=${form.cronTz}
+                  @input=${(e: Event) =>
+                    onFormChange({ cronTz: (e.target as HTMLInputElement).value })}
+                />
+              </div>
+            </div>
+          `}
+  `;
+}
+
+/**
+ * 渲染新建/编辑任务弹窗
+ */
+function renderCreateModal(props: CronContentProps) {
+  if (!props.showCreateModal) return nothing;
+
+  const isEditMode = !!props.editJobId;
+  const form = props.form ?? DEFAULT_FORM;
+  const channelOptions = buildChannelOptions(props);
+  const { onFormChange, onAdd, onUpdate, onShowCreateModal } = getSafeCallbacks(props);
+
+  const handleClose = () => {
+    onShowCreateModal(false);
+  };
+
+  const handleSubmit = async () => {
+    if (isEditMode) {
+      await onUpdate();
+    } else {
+      await onAdd();
+    }
+    // 成功后关闭弹窗（如果没有错误）
+    if (!props.error) {
+      onShowCreateModal(false);
+    }
+  };
+
+  const modalTitle = isEditMode ? LABELS.editJob : LABELS.newJob;
+  const submitLabel = isEditMode
+    ? (props.busy ? LABELS.updating : LABELS.updateJob)
+    : (props.busy ? LABELS.adding : LABELS.addJob);
+
+  return html`
+    <div class="cron-confirm-modal" @click=${handleClose}>
+      <div class="cron-create-modal__content" @click=${(e: Event) => e.stopPropagation()}>
+        <div class="cron-create-modal__header">
+          <div class="cron-create-modal__title">
+            ${isEditMode ? icons.edit : icons.clock}
+            <span>${modalTitle}</span>
+          </div>
+          <button class="cron-create-modal__close" @click=${handleClose}>
+            ${icons.x}
+          </button>
+        </div>
+
+        <div class="cron-create-modal__body">
+          <!-- 基本信息 -->
+          <div class="cron-form-grid" style="margin-bottom: 16px;">
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.name}</label>
+              <input
+                type="text"
+                class="mc-input"
+                placeholder=${LABELS.namePlaceholder}
+                .value=${form.name}
+                @input=${(e: Event) =>
+                  onFormChange({ name: (e.target as HTMLInputElement).value })}
+              />
+            </div>
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.description}</label>
+              <input
+                type="text"
+                class="mc-input"
+                placeholder=${LABELS.descriptionPlaceholder}
+                .value=${form.description}
+                @input=${(e: Event) =>
+                  onFormChange({ description: (e.target as HTMLInputElement).value })}
+              />
+            </div>
+          </div>
+
+          <div class="cron-form-grid" style="margin-bottom: 16px;">
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.agentId}</label>
+              <select
+                class="mc-select"
+                .value=${form.agentId || props.defaultAgentId || ""}
+                @change=${(e: Event) =>
+                  onFormChange({ agentId: (e.target as HTMLSelectElement).value })}
+              >
+                <option value="">${LABELS.agentIdPlaceholder}</option>
+                ${(props.agents ?? []).map(
+                  (agent) =>
+                    html`<option value=${agent.id}>
+                      ${agent.name ?? agent.identity?.name ?? agent.id}${agent.default ? " (默认)" : ""}
+                    </option>`,
+                )}
+              </select>
+            </div>
+            <div class="mc-field" style="justify-content: center;">
+              <label class="mc-toggle-field">
+                <span class="mc-toggle-field__label">${LABELS.enabledLabel}</span>
+                <div class="mc-toggle">
+                  <input
+                    type="checkbox"
+                    .checked=${form.enabled}
+                    @change=${(e: Event) =>
+                      onFormChange({ enabled: (e.target as HTMLInputElement).checked })}
+                  />
+                  <span class="mc-toggle__track"></span>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          <!-- 调度类型 -->
+          ${renderScheduleFields(props)}
+
+          <!-- 会话和唤醒方式 -->
+          <div class="cron-form-grid" style="margin-top: 16px; margin-bottom: 16px;">
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.sessionTarget}</label>
+              <select
+                class="mc-select"
+                .value=${form.sessionTarget}
+                @change=${(e: Event) => {
+                  const newTarget = (e.target as HTMLSelectElement).value as CronFormState["sessionTarget"];
+                  // main 会话只能使用 systemEvent 类型
+                  if (newTarget === "main" && form.payloadKind === "agentTurn") {
+                    onFormChange({
+                      sessionTarget: newTarget,
+                      payloadKind: "systemEvent",
+                    });
+                  } else {
+                    onFormChange({ sessionTarget: newTarget });
+                  }
+                }}
+              >
+                <option value="main">${LABELS.sessionMain}</option>
+                <option value="isolated">${LABELS.sessionIsolated}</option>
+              </select>
+            </div>
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.wakeMode}</label>
+              <select
+                class="mc-select"
+                .value=${form.wakeMode}
+                @change=${(e: Event) =>
+                  onFormChange({
+                    wakeMode: (e.target as HTMLSelectElement).value as CronFormState["wakeMode"],
+                  })}
+              >
+                <option value="next-heartbeat">${LABELS.wakeModeNextHeartbeat}</option>
+                <option value="now">${LABELS.wakeModeNow}</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- 任务类型 -->
+          <div class="mc-field" style="margin-bottom: 16px;">
+            <label class="mc-field__label">${LABELS.payloadKind}</label>
+            <select
+              class="mc-select"
+              .value=${form.payloadKind}
+              @change=${(e: Event) =>
+                onFormChange({
+                  payloadKind: (e.target as HTMLSelectElement).value as CronFormState["payloadKind"],
+                })}
+            >
+              <option value="systemEvent">${LABELS.payloadSystemEvent}</option>
+              <option value="agentTurn" ?disabled=${form.sessionTarget === "main"}>
+                ${LABELS.payloadAgentTurn}${form.sessionTarget === "main" ? " (仅限隔离会话)" : ""}
+              </option>
+            </select>
+          </div>
+
+          <!-- 消息内容 -->
+          <div class="mc-field" style="margin-bottom: 16px;">
+            <label class="mc-field__label">${LABELS.payloadText}</label>
+            <textarea
+              class="mc-textarea"
+              rows="3"
+              placeholder=${LABELS.payloadTextPlaceholder}
+              .value=${form.payloadText}
+              @input=${(e: Event) =>
+                onFormChange({ payloadText: (e.target as HTMLTextAreaElement).value })}
+            ></textarea>
+          </div>
+
+          <!-- Agent 执行选项 -->
+          ${form.payloadKind === "agentTurn"
+            ? html`
+                <div class="cron-form-grid" style="margin-bottom: 16px;">
+                  <div class="mc-field" style="justify-content: center;">
+                    <label class="mc-toggle-field">
+                      <span class="mc-toggle-field__label">${LABELS.deliver}</span>
+                      <div class="mc-toggle">
+                        <input
+                          type="checkbox"
+                          .checked=${form.deliver}
+                          @change=${(e: Event) =>
+                            onFormChange({ deliver: (e.target as HTMLInputElement).checked })}
+                        />
+                        <span class="mc-toggle__track"></span>
+                      </div>
+                    </label>
+                  </div>
+                  <div class="mc-field">
+                    <label class="mc-field__label">${LABELS.channel}</label>
+                    <select
+                      class="mc-select"
+                      .value=${form.channel || "last"}
+                      @change=${(e: Event) =>
+                        onFormChange({
+                          channel: (e.target as HTMLSelectElement).value,
+                        })}
+                    >
+                      ${channelOptions.map(
+                        (channel) =>
+                          html`<option value=${channel}>${resolveChannelLabel(props, channel)}</option>`,
+                      )}
+                    </select>
+                  </div>
+                </div>
+
+                <div class="cron-form-grid" style="margin-bottom: 16px;">
+                  <div class="mc-field">
+                    <label class="mc-field__label">${LABELS.to}</label>
+                    <input
+                      type="text"
+                      class="mc-input"
+                      placeholder=${LABELS.toPlaceholder}
+                      .value=${form.to}
+                      @input=${(e: Event) =>
+                        onFormChange({ to: (e.target as HTMLInputElement).value })}
+                    />
+                  </div>
+                  <div class="mc-field">
+                    <label class="mc-field__label">${LABELS.timeoutSeconds}</label>
+                    <input
+                      type="number"
+                      class="mc-input"
+                      min="0"
+                      .value=${form.timeoutSeconds}
+                      @input=${(e: Event) =>
+                        onFormChange({ timeoutSeconds: (e.target as HTMLInputElement).value })}
+                    />
+                  </div>
+                </div>
+
+                ${form.sessionTarget === "isolated"
+                  ? html`
+                      <div class="mc-field" style="margin-bottom: 16px;">
+                        <label class="mc-field__label">${LABELS.postToMainPrefix}</label>
+                        <input
+                          type="text"
+                          class="mc-input"
+                          placeholder=${LABELS.postToMainPrefixPlaceholder}
+                          .value=${form.postToMainPrefix}
+                          @input=${(e: Event) =>
+                            onFormChange({ postToMainPrefix: (e.target as HTMLInputElement).value })}
+                        />
+                      </div>
+                    `
+                  : nothing}
+              `
+            : nothing}
+
+          <!-- 错误提示 -->
+          ${props.error
+            ? html`
+                <div class="cron-error-banner">
+                  ${icons.alertCircle}
+                  <span>${props.error}</span>
+                </div>
+              `
+            : nothing}
+        </div>
+
+        <div class="cron-create-modal__footer">
+          <button class="mc-btn" @click=${handleClose}>
+            ${LABELS.cancel}
+          </button>
+          <button
+            class="mc-btn mc-btn--primary"
+            ?disabled=${props.busy}
+            @click=${handleSubmit}
+          >
+            ${submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染任务状态徽章
+ */
+function renderJobBadge(job: CronJob) {
+  if (job.state?.runningAtMs) {
+    return html`<span class="cron-job-card__badge cron-job-card__badge--running">运行中</span>`;
+  }
+  if (job.enabled) {
+    return html`<span class="cron-job-card__badge cron-job-card__badge--enabled">${LABELS.enabled}</span>`;
+  }
+  return html`<span class="cron-job-card__badge cron-job-card__badge--disabled">${LABELS.disabled}</span>`;
+}
+
+/**
+ * 渲染任务详情
+ */
+function renderJobDetails(job: CronJob, props: CronContentProps) {
+  const state = job.state;
+  const lastStatusText =
+    state?.lastStatus === "ok"
+      ? LABELS.statusOk
+      : state?.lastStatus === "error"
+        ? LABELS.statusError
+        : state?.lastStatus === "skipped"
+          ? LABELS.statusSkipped
+          : LABELS.statusNA;
+  const { onToggle, onRun, onLoadRuns, onDeleteConfirm, onEdit } = getSafeCallbacks(props);
+
+  return html`
+    <div class="cron-job-card__details">
+      <div class="cron-job-card__meta">
+        <div class="cron-job-card__meta-item">
+          <span class="cron-job-card__meta-label">${LABELS.sessionTarget}</span>
+          <span class="cron-job-card__meta-value">
+            ${job.sessionTarget === "main" ? LABELS.sessionMain : LABELS.sessionIsolated}
+          </span>
+        </div>
+        <div class="cron-job-card__meta-item">
+          <span class="cron-job-card__meta-label">${LABELS.wakeMode}</span>
+          <span class="cron-job-card__meta-value">
+            ${job.wakeMode === "now" ? LABELS.wakeModeNow : LABELS.wakeModeNextHeartbeat}
+          </span>
+        </div>
+        <div class="cron-job-card__meta-item">
+          <span class="cron-job-card__meta-label">${LABELS.lastStatus}</span>
+          <span class="cron-job-card__meta-value">${lastStatusText}</span>
+        </div>
+        <div class="cron-job-card__meta-item">
+          <span class="cron-job-card__meta-label">${LABELS.nextRun}</span>
+          <span class="cron-job-card__meta-value">
+            ${state?.nextRunAtMs ? formatMs(state.nextRunAtMs) : "—"}
+          </span>
+        </div>
+        ${job.agentId
+          ? html`
+              <div class="cron-job-card__meta-item">
+                <span class="cron-job-card__meta-label">Agent</span>
+                <span class="cron-job-card__meta-value">${job.agentId}</span>
+              </div>
+            `
+          : nothing}
+        ${job.description
+          ? html`
+              <div class="cron-job-card__meta-item" style="grid-column: 1 / -1;">
+                <span class="cron-job-card__meta-label">${LABELS.description}</span>
+                <span class="cron-job-card__meta-value">${job.description}</span>
+              </div>
+            `
+          : nothing}
+      </div>
+
+      <div class="cron-job-card__actions">
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.busy}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            onEdit(job);
+          }}
+        >
+          ${icons.edit}
+          ${LABELS.editJob}
+        </button>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.busy}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            onToggle(job, !job.enabled);
+          }}
+        >
+          ${job.enabled ? LABELS.disableJob : LABELS.enableJob}
+        </button>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.busy}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            onRun(job);
+          }}
+        >
+          ${icons.play}
+          ${LABELS.runNow}
+        </button>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.busy}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            onLoadRuns(job.id);
+          }}
+        >
+          ${LABELS.viewRuns}
+        </button>
+        <button
+          class="mc-btn mc-btn--sm mc-btn--danger"
+          ?disabled=${props.busy}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            onDeleteConfirm(job.id);
+          }}
+        >
+          ${icons.trash}
+          ${LABELS.deleteJob}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染单个任务卡片
+ */
+function renderJobCard(job: CronJob, props: CronContentProps) {
+  const isExpanded = props.expandedJobId === job.id;
+  const isSelected = props.runsJobId === job.id;
+  const { onExpandJob } = getSafeCallbacks(props);
+
+  return html`
+    <div
+      class="cron-job-card ${isSelected ? "cron-job-card--selected" : ""}"
+    >
+      <div
+        class="cron-job-card__header"
+        @click=${() => onExpandJob(isExpanded ? null : job.id)}
+      >
+        <div class="cron-job-card__info">
+          <div class="cron-job-card__name">${job.name}</div>
+          <div class="cron-job-card__schedule">${formatCronSchedule(job)}</div>
+          <div class="cron-job-card__payload" style="font-size: 12px; color: var(--muted); margin-top: 4px;">
+            ${formatCronPayload(job)}
+          </div>
+        </div>
+        <div class="cron-job-card__status">
+          ${renderJobBadge(job)}
+          <span class="cron-job-card__chevron" style="transform: rotate(${isExpanded ? "180deg" : "0deg"}); transition: transform 0.2s ease;">
+            ${icons.chevronDown}
+          </span>
+        </div>
+      </div>
+      ${isExpanded ? renderJobDetails(job, props) : nothing}
+    </div>
+  `;
+}
+
+/**
+ * 渲染任务列表
+ */
+function renderJobsList(props: CronContentProps) {
+  const jobs = props.jobs ?? [];
+  if (jobs.length === 0) {
+    return html`
+      <div class="cron-empty">
+        <div class="cron-empty__icon">${icons.clock}</div>
+        <div class="cron-empty__text">${LABELS.noJobs}</div>
+        <div style="font-size: 13px;">${LABELS.noJobsHint}</div>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="cron-jobs-list">
+      ${jobs.map((job) => renderJobCard(job, props))}
+    </div>
+  `;
+}
+
+/**
+ * 渲染运行历史
+ */
+function renderRunHistory(props: CronContentProps) {
+  if (!props.runsJobId) {
+    return html`
+      <div class="cron-form-section">
+        <div class="cron-form-section__title">
+          <span>${LABELS.runHistory}</span>
+        </div>
+        <div class="cron-empty" style="padding: 24px;">
+          <div style="font-size: 13px; color: var(--muted);">${LABELS.selectJobToViewRuns}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  const jobs = props.jobs ?? [];
+  const runs = props.runs ?? [];
+  const selectedJob = jobs.find((j) => j.id === props.runsJobId);
+  const jobName = selectedJob?.name ?? props.runsJobId;
+
+  return html`
+    <div class="cron-form-section">
+      <div class="cron-form-section__title">
+        <span>${LABELS.runHistory}: ${jobName}</span>
+      </div>
+      ${runs.length === 0
+        ? html`
+            <div class="cron-empty" style="padding: 24px;">
+              <div style="font-size: 13px; color: var(--muted);">${LABELS.noRuns}</div>
+            </div>
+          `
+        : html`
+            <div class="cron-runs-list">
+              ${runs.map((entry) => renderRunItem(entry))}
+            </div>
+          `}
+    </div>
+  `;
+}
+
+/**
+ * 渲染运行记录项
+ */
+function renderRunItem(entry: { ts: number; status: string; durationMs?: number; error?: string; summary?: string }) {
+  const statusIcon =
+    entry.status === "ok"
+      ? icons.check
+      : entry.status === "error"
+        ? icons.x
+        : icons.alertCircle;
+  const dotClass =
+    entry.status === "ok"
+      ? "cron-run-item__dot--ok"
+      : entry.status === "error"
+        ? "cron-run-item__dot--error"
+        : "cron-run-item__dot--skipped";
+
+  return html`
+    <div class="cron-run-item">
+      <div class="cron-run-item__status">
+        <span class="cron-run-item__dot ${dotClass}"></span>
+        <span style="font-weight: 500;">${entry.status}</span>
+        ${entry.summary ? html`<span style="color: var(--muted); margin-left: 8px;">${entry.summary}</span>` : nothing}
+      </div>
+      <div style="text-align: right;">
+        <div style="font-size: 13px;">${formatMs(entry.ts)}</div>
+        ${entry.durationMs != null
+          ? html`<div style="font-size: 12px; color: var(--muted);">${LABELS.duration}: ${entry.durationMs}ms</div>`
+          : nothing}
+        ${entry.error
+          ? html`<div style="font-size: 12px; color: var(--danger); margin-top: 4px;">${entry.error}</div>`
+          : nothing}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染删除确认弹窗
+ */
+function renderDeleteConfirmModal(props: CronContentProps) {
+  if (!props.deleteConfirmJobId) return nothing;
+
+  const jobs = props.jobs ?? [];
+  const job = jobs.find((j) => j.id === props.deleteConfirmJobId);
+  if (!job) return nothing;
+
+  const { onDeleteConfirm, onRemove } = getSafeCallbacks(props);
+
+  return html`
+    <div class="cron-confirm-modal" @click=${() => onDeleteConfirm(null)}>
+      <div class="cron-confirm-modal__content" @click=${(e: Event) => e.stopPropagation()}>
+        <div class="cron-confirm-modal__title">${LABELS.deleteConfirmTitle}</div>
+        <div class="cron-confirm-modal__desc">${LABELS.deleteConfirmDesc(job.name)}</div>
+        <div class="cron-confirm-modal__actions">
+          <button class="mc-btn" @click=${() => onDeleteConfirm(null)}>
+            ${LABELS.cancel}
+          </button>
+          <button
+            class="mc-btn mc-btn--danger"
+            ?disabled=${props.busy}
+            @click=${() => {
+              onRemove(job);
+              onDeleteConfirm(null);
+            }}
+          >
+            ${LABELS.confirm}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染 Cron 内容主组件
+ */
+export function renderCronContent(props: CronContentProps) {
+  const jobs = props.jobs ?? [];
+  const { onRefresh, onShowCreateModal } = getSafeCallbacks(props);
+
+  return html`
+    <div class="config-content">
+      <!-- 页面头部 -->
+      <div class="config-content__header">
+        <span class="config-content__icon">${icons.clock}</span>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">${LABELS.title}</h2>
+          <p class="config-content__desc">${LABELS.desc}</p>
+        </div>
+        <div style="margin-left: auto; display: flex; gap: 8px;">
+          <button
+            class="mc-btn"
+            ?disabled=${props.loading}
+            @click=${onRefresh}
+          >
+            ${icons.refresh}
+            ${props.loading ? LABELS.refreshing : LABELS.refresh}
+          </button>
+          <button
+            class="mc-btn mc-btn--primary"
+            @click=${() => onShowCreateModal(true)}
+          >
+            ${icons.plus}
+            ${LABELS.newJob}
+          </button>
+        </div>
+      </div>
+
+      <!-- 状态卡片 -->
+      ${renderStatusCard(props)}
+
+      <!-- 使用提示 -->
+      <div class="cron-tip-card">
+        <div class="cron-tip-card__title">${icons.alertCircle} 字段说明</div>
+        <table class="cron-tip-card__table">
+          <tbody>
+            <tr>
+              <td class="cron-tip-card__term">会话类型</td>
+              <td class="cron-tip-card__def"><b>主会话</b> 在 Agent 主对话中执行，仅支持系统事件；<b>隔离会话</b> 在独立临时会话中执行，支持 Agent 执行</td>
+            </tr>
+            <tr>
+              <td class="cron-tip-card__term">唤醒方式</td>
+              <td class="cron-tip-card__def"><b>下次心跳</b> 等待下一个调度周期执行；<b>立即执行</b> 触发后马上运行</td>
+            </tr>
+            <tr>
+              <td class="cron-tip-card__term">任务类型</td>
+              <td class="cron-tip-card__def"><b>系统事件</b> 发送系统级消息；<b>Agent 执行</b> 让 Agent 处理并可投递到通道（仅隔离会话可用）</td>
+            </tr>
+            <tr>
+              <td class="cron-tip-card__term">投递消息</td>
+              <td class="cron-tip-card__def">开启后 Agent 回复将发送到选定的通道和接收者</td>
+            </tr>
+            <tr>
+              <td class="cron-tip-card__term">回写前缀</td>
+              <td class="cron-tip-card__def">隔离会话完成后将结果写回主会话时添加的前缀文本</td>
+            </tr>
+            <tr>
+              <td class="cron-tip-card__term">调度方式</td>
+              <td class="cron-tip-card__def"><b>循环间隔</b> 按固定间隔重复；<b>指定时间</b> 某时间点执行一次；<b>Cron</b> 用 cron 语法灵活定义</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 任务列表 -->
+      <div class="cron-form-section">
+        <div class="cron-form-section__title">
+          <span>${LABELS.jobsList}</span>
+          <span style="margin-left: auto; font-size: 12px; font-weight: 400; color: var(--muted);">
+            ${jobs.length} 个任务
+          </span>
+        </div>
+        ${renderJobsList(props)}
+      </div>
+
+      <!-- 运行历史 -->
+      ${renderRunHistory(props)}
+
+      <!-- 新建任务弹窗 -->
+      ${renderCreateModal(props)}
+
+      <!-- 删除确认弹窗 -->
+      ${renderDeleteConfirmModal(props)}
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/gateway-content.ts
+++ b/ui/src/ui-zh-CN/components/gateway-content.ts
@@ -1,0 +1,110 @@
+/**
+ * Gateway 设置配置内容组件
+ * 右侧面板 - 网关端口和认证
+ */
+import { html } from "lit";
+import type { GatewayConfig } from "../views/model-config";
+
+// SVG 图标
+const icons = {
+  gateway: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>`,
+};
+
+// 中文标签
+const LABELS = {
+  gatewayTitle: "Gateway 设置",
+  gatewayDesc: "配置网关端口、认证和网络绑定",
+  port: "端口",
+  bindMode: "绑定模式",
+  authMode: "认证模式",
+  authToken: "认证令牌",
+  bindLoopback: "仅本机 (127.0.0.1)",
+  bindLan: "局域网 (0.0.0.0)",
+  bindAuto: "自动选择",
+  authToken_: "Token 认证",
+  authPassword: "密码认证",
+  authNone: "无认证",
+};
+
+export type GatewayContentProps = {
+  gatewayConfig: GatewayConfig;
+  onGatewayUpdate: (path: string[], value: unknown) => void;
+};
+
+/**
+ * 渲染 Gateway 设置内容
+ */
+export function renderGatewayContent(props: GatewayContentProps) {
+  const gateway = props.gatewayConfig;
+
+  return html`
+    <div class="config-content">
+      <div class="config-content__header">
+        <div class="config-content__icon">${icons.gateway}</div>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">${LABELS.gatewayTitle}</h2>
+          <p class="config-content__desc">${LABELS.gatewayDesc}</p>
+        </div>
+      </div>
+      <div class="config-content__body">
+        <div class="mc-card">
+          <div class="mc-card__content">
+            <div class="mc-form-row mc-form-row--2col">
+              <label class="mc-field">
+                <span class="mc-field__label">${LABELS.port}</span>
+                <input
+                  type="number"
+                  class="mc-input"
+                  .value=${String(gateway.port ?? 18789)}
+                  min="1"
+                  max="65535"
+                  @input=${(e: Event) =>
+                    props.onGatewayUpdate(["port"], Number((e.target as HTMLInputElement).value))}
+                />
+              </label>
+              <label class="mc-field">
+                <span class="mc-field__label">${LABELS.bindMode}</span>
+                <select
+                  class="mc-select"
+                  .value=${gateway.bind ?? "loopback"}
+                  @change=${(e: Event) =>
+                    props.onGatewayUpdate(["bind"], (e.target as HTMLSelectElement).value)}
+                >
+                  <option value="loopback">${LABELS.bindLoopback}</option>
+                  <option value="lan">${LABELS.bindLan}</option>
+                  <option value="auto">${LABELS.bindAuto}</option>
+                </select>
+              </label>
+            </div>
+            <div class="mc-form-row mc-form-row--2col">
+              <label class="mc-field">
+                <span class="mc-field__label">${LABELS.authMode}</span>
+                <select
+                  class="mc-select"
+                  .value=${gateway.auth?.mode ?? "token"}
+                  @change=${(e: Event) =>
+                    props.onGatewayUpdate(["auth", "mode"], (e.target as HTMLSelectElement).value)}
+                >
+                  <option value="token">${LABELS.authToken_}</option>
+                  <option value="password">${LABELS.authPassword}</option>
+                  <option value="none">${LABELS.authNone}</option>
+                </select>
+              </label>
+              <label class="mc-field">
+                <span class="mc-field__label">${LABELS.authToken}</span>
+                <input
+                  type="password"
+                  class="mc-input"
+                  .value=${gateway.auth?.token ?? ""}
+                  placeholder="••••••••"
+                  @input=${(e: Event) =>
+                    props.onGatewayUpdate(["auth", "token"], (e.target as HTMLInputElement).value)}
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/permissions-content.ts
+++ b/ui/src/ui-zh-CN/components/permissions-content.ts
@@ -1,0 +1,1162 @@
+/**
+ * 权限管理内容组件
+ * 管理命令执行权限和访问控制
+ */
+import { html, nothing } from "lit";
+import type {
+  ToolProfileId,
+  ToolPolicyConfig,
+  ToolsConfig,
+  AgentWithTools,
+  PermissionsTabId,
+  ExecApprovalsTarget,
+  ExecApprovalsTargetNode,
+} from "../controllers/model-config";
+
+// 类型定义
+export type ExecSecurity = "deny" | "allowlist" | "full";
+export type ExecAsk = "off" | "on-miss" | "always";
+
+export type ExecApprovalsDefaults = {
+  security?: string;
+  ask?: string;
+  askFallback?: string;
+  autoAllowSkills?: boolean;
+};
+
+export type ExecApprovalsAllowlistEntry = {
+  id?: string;
+  pattern: string;
+  lastUsedAt?: number;
+  lastUsedCommand?: string;
+  lastResolvedPath?: string;
+};
+
+export type ExecApprovalsAgent = ExecApprovalsDefaults & {
+  allowlist?: ExecApprovalsAllowlistEntry[];
+};
+
+export type ExecApprovalsFile = {
+  version?: number;
+  socket?: { path?: string };
+  defaults?: ExecApprovalsDefaults;
+  agents?: Record<string, ExecApprovalsAgent>;
+};
+
+export type ExecApprovalsSnapshot = {
+  path: string;
+  exists: boolean;
+  hash: string;
+  file: ExecApprovalsFile;
+};
+
+export type AgentOption = {
+  id: string;
+  name?: string;
+  isDefault?: boolean;
+};
+
+export type PermissionsContentProps = {
+  // 加载状态
+  loading: boolean;
+  saving: boolean;
+  dirty: boolean;
+  connected: boolean;
+
+  // 标签页状态
+  activeTab: PermissionsTabId;
+  onTabChange: (tab: PermissionsTabId) => void;
+
+  // Exec Approvals 目标选择
+  execTarget: ExecApprovalsTarget;
+  execTargetNodeId: string | null;
+  execTargetNodes: ExecApprovalsTargetNode[];
+  onExecTargetChange: (target: ExecApprovalsTarget, nodeId: string | null) => void;
+
+  // Exec Approvals 数据
+  execApprovalsSnapshot: ExecApprovalsSnapshot | null;
+  execApprovalsForm: ExecApprovalsFile | null;
+  selectedAgent: string | null;
+  agents: AgentOption[];
+
+  // 回调函数
+  onLoad: () => void;
+  onSave: () => void;
+  onSelectAgent: (agentId: string | null) => void;
+  onAddAgent: (agentId: string) => void;
+  onRemoveAgent: (agentId: string) => void;
+  onPatch: (path: Array<string | number>, value: unknown) => void;
+  onRemove: (path: Array<string | number>) => void;
+  onAddAllowlistEntry: (agentId: string) => void;
+  onRemoveAllowlistEntry: (agentId: string, index: number) => void;
+
+  // 工具权限数据
+  toolsConfig: ToolsConfig | null;
+  agentToolsConfigs: AgentWithTools[];
+  toolsAgents: AgentOption[];
+  toolsSelectedAgent: string | null;
+  toolsExpanded: boolean;
+
+  // 工具权限回调
+  onToolsSelectAgent: (agentId: string | null) => void;
+  onToolsToggleExpanded: () => void;
+  onToolsUpdateGlobal: (field: keyof ToolPolicyConfig, value: unknown) => void;
+  onToolsUpdateAgent: (agentId: string, field: keyof ToolPolicyConfig, value: unknown) => void;
+  onToolsAddGlobalDeny: (entry: string) => void;
+  onToolsRemoveGlobalDeny: (entry: string) => void;
+  onToolsAddAgentDeny: (agentId: string, entry: string) => void;
+  onToolsRemoveAgentDeny: (agentId: string, entry: string) => void;
+  onToolsToggleDeny: (tool: string, denied: boolean) => void;
+};
+
+// 常量
+const EXEC_APPROVALS_DEFAULT_SCOPE = "__defaults__";
+
+const SECURITY_OPTIONS: Array<{ value: ExecSecurity; label: string; description: string }> = [
+  { value: "deny", label: "拒绝", description: "拒绝所有命令执行" },
+  { value: "allowlist", label: "允许列表", description: "仅允许白名单中的命令" },
+  { value: "full", label: "完全允许", description: "允许所有命令执行" },
+];
+
+const ASK_OPTIONS: Array<{ value: ExecAsk; label: string; description: string }> = [
+  { value: "off", label: "关闭", description: "不提示用户确认" },
+  { value: "on-miss", label: "未匹配时", description: "命令不在白名单时提示" },
+  { value: "always", label: "总是", description: "每次执行都提示确认" },
+];
+
+// 工具描述定义
+const TOOL_DESCRIPTIONS: Record<string, string> = {
+  // 文件操作
+  read: "读取文件内容（文本或图片），支持分页读取大文件",
+  write: "创建或覆盖文件，自动创建父目录",
+  edit: "精确替换文件中的文本内容",
+  apply_patch: "应用补丁文件修改",
+  // 命令执行
+  exec: "执行 Shell 命令，支持后台运行和交互式终端",
+  process: "管理运行中的进程（列表/状态/日志/终止）",
+  // 网络访问
+  web_search: "使用 Brave 搜索 API 进行网络搜索",
+  web_fetch: "抓取 URL 内容并转换为 Markdown",
+  browser: "控制浏览器（打开/导航/截图/操作）",
+  // 设备与展示
+  nodes: "管理配对设备（通知/拍照/录制/定位）",
+  canvas: "展示内容到画布（演示/截图/执行JS）",
+  // 定时任务
+  cron: "管理定时任务（添加/修改/删除/执行）",
+  // 消息通信
+  message: "发送消息到指定目标或广播",
+  tts: "文字转语音，返回音频文件",
+  // 图像分析
+  image: "使用视觉模型分析图片内容",
+  // 系统管理
+  gateway: "系统管理（重启/配置/更新）",
+  // 会话管理
+  sessions_list: "列出所有会话",
+  sessions_history: "获取会话的消息历史",
+  sessions_send: "向其他会话发送消息",
+  sessions_spawn: "启动子代理执行任务",
+  session_status: "查看/设置会话状态",
+  agents_list: "列出可用于 spawn 的代理",
+  // 记忆系统
+  memory_search: "语义搜索记忆文件",
+  memory_get: "读取记忆文件指定行",
+};
+
+// 工具分组定义
+const TOOL_GROUPS: Record<string, { label: string; desc: string; tools: string[] }> = {
+  "group:fs": { label: "文件系统", desc: "文件读写和编辑操作", tools: ["read", "write", "edit", "apply_patch"] },
+  "group:runtime": { label: "运行时", desc: "命令执行和进程管理", tools: ["exec", "process"] },
+  "group:web": { label: "网络", desc: "网络搜索和内容抓取", tools: ["web_search", "web_fetch"] },
+  "group:ui": { label: "界面", desc: "浏览器和画布控制", tools: ["browser", "canvas"] },
+  "group:sessions": { label: "会话", desc: "会话和子代理管理", tools: ["sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "session_status"] },
+  "group:memory": { label: "记忆", desc: "记忆搜索和读取", tools: ["memory_search", "memory_get"] },
+  "group:automation": { label: "自动化", desc: "定时任务和系统管理", tools: ["cron", "gateway"] },
+  "group:messaging": { label: "消息", desc: "消息发送和广播", tools: ["message"] },
+  "group:nodes": { label: "设备", desc: "配对设备控制", tools: ["nodes"] },
+};
+
+const STANDALONE_TOOLS: Array<{ id: string; label: string }> = [
+  { id: "tts", label: "语音合成" },
+  { id: "image", label: "图像分析" },
+  { id: "agents_list", label: "代理列表" },
+];
+
+const TOOL_PROFILES: Array<{ value: ToolProfileId; label: string; description: string }> = [
+  { value: "minimal", label: "最小", description: "仅 session_status" },
+  { value: "coding", label: "编程", description: "文件+运行时+会话+记忆+image" },
+  { value: "messaging", label: "消息", description: "消息+部分会话工具" },
+  { value: "full", label: "完整", description: "所有工具" },
+];
+
+const TOOLS_DEFAULT_SCOPE = "__global__";
+
+// 辅助函数
+function normalizeSecurity(value?: string): ExecSecurity {
+  if (value === "allowlist" || value === "full" || value === "deny") return value;
+  return "deny";
+}
+
+function normalizeAsk(value?: string): ExecAsk {
+  if (value === "always" || value === "off" || value === "on-miss") return value;
+  return "on-miss";
+}
+
+function resolveDefaults(form: ExecApprovalsFile | null): {
+  security: ExecSecurity;
+  ask: ExecAsk;
+  askFallback: ExecSecurity;
+  autoAllowSkills: boolean;
+} {
+  const defaults = form?.defaults ?? {};
+  return {
+    security: normalizeSecurity(defaults.security),
+    ask: normalizeAsk(defaults.ask),
+    askFallback: normalizeSecurity(defaults.askFallback ?? "deny"),
+    autoAllowSkills: Boolean(defaults.autoAllowSkills ?? false),
+  };
+}
+
+function formatAgo(ts: number | null | undefined): string {
+  if (!ts) return "从未";
+  const now = Date.now();
+  const diff = now - ts;
+  if (diff < 60000) return "刚刚";
+  if (diff < 3600000) return `${Math.floor(diff / 60000)} 分钟前`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)} 小时前`;
+  return `${Math.floor(diff / 86400000)} 天前`;
+}
+
+/**
+ * 渲染权限管理内容
+ */
+export function renderPermissionsContent(props: PermissionsContentProps) {
+  return html`
+    <div class="permissions-content">
+      <!-- 顶部标签切换 -->
+      <div class="permissions-tabs-header">
+        <button
+          class="permissions-main-tab ${props.activeTab === "exec" ? "permissions-main-tab--active" : ""}"
+          @click=${() => props.onTabChange("exec")}
+        >
+          <span class="permissions-main-tab__icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="4 17 10 11 4 5"></polyline>
+              <line x1="12" y1="19" x2="20" y2="19"></line>
+            </svg>
+          </span>
+          <span class="permissions-main-tab__text">命令执行权限</span>
+        </button>
+        <button
+          class="permissions-main-tab ${props.activeTab === "tools" ? "permissions-main-tab--active" : ""}"
+          @click=${() => props.onTabChange("tools")}
+        >
+          <span class="permissions-main-tab__icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
+            </svg>
+          </span>
+          <span class="permissions-main-tab__text">工具权限</span>
+        </button>
+      </div>
+
+      <!-- 内容区域 -->
+      ${props.activeTab === "exec"
+        ? renderExecPermissionsContent(props)
+        : renderToolsPermissionsSection(props)}
+    </div>
+  `;
+}
+
+/**
+ * 渲染执行目标选择器
+ */
+function renderExecTargetSection(props: PermissionsContentProps) {
+  const isGateway = props.execTarget === "gateway";
+  const hasNodes = props.execTargetNodes.length > 0;
+
+  return html`
+    <div class="permissions-section permissions-target-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">执行目标</h4>
+          <p class="permissions-section__desc">
+            选择要配置的执行目标：本地网关或远程节点。
+          </p>
+        </div>
+      </div>
+
+      <div class="permissions-target">
+        <!-- 目标类型选择 -->
+        <div class="permissions-target__type">
+          <label class="permissions-target__label">目标类型</label>
+          <div class="permissions-target__options">
+            <label class="permissions-radio">
+              <input
+                type="radio"
+                name="exec-target"
+                value="gateway"
+                .checked=${isGateway}
+                @change=${() => {
+                  if (props.dirty) {
+                    const confirmed = confirm("有未保存的更改，切换目标将丢失这些更改。是否继续？");
+                    if (!confirmed) return;
+                  }
+                  props.onExecTargetChange("gateway", null);
+                }}
+              />
+              <span class="permissions-radio__mark"></span>
+              <span class="permissions-radio__text">本地网关</span>
+            </label>
+            <label class="permissions-radio">
+              <input
+                type="radio"
+                name="exec-target"
+                value="node"
+                .checked=${!isGateway}
+                ?disabled=${!hasNodes}
+                @change=${() => {
+                  if (props.dirty) {
+                    const confirmed = confirm("有未保存的更改，切换目标将丢失这些更改。是否继续？");
+                    if (!confirmed) return;
+                  }
+                  const firstNode = props.execTargetNodes[0]?.id ?? null;
+                  props.onExecTargetChange("node", firstNode);
+                }}
+              />
+              <span class="permissions-radio__mark"></span>
+              <span class="permissions-radio__text">远程节点</span>
+              ${!hasNodes ? html`<span class="permissions-radio__hint">（无可用节点）</span>` : nothing}
+            </label>
+          </div>
+        </div>
+
+        <!-- 节点选择（仅在远程节点模式下显示） -->
+        ${!isGateway
+          ? html`
+              <div class="permissions-target__node">
+                <label class="permissions-target__label">选择节点</label>
+                <select
+                  class="permissions-select"
+                  ?disabled=${props.saving || !hasNodes}
+                  @change=${(event: Event) => {
+                    const target = event.target as HTMLSelectElement;
+                    const nodeId = target.value || null;
+                    if (props.dirty) {
+                      const confirmed = confirm("有未保存的更改，切换节点将丢失这些更改。是否继续？");
+                      if (!confirmed) {
+                        target.value = props.execTargetNodeId ?? "";
+                        return;
+                      }
+                    }
+                    props.onExecTargetChange("node", nodeId);
+                  }}
+                >
+                  ${props.execTargetNodes.map(
+                    (node) =>
+                      html`<option value=${node.id} ?selected=${props.execTargetNodeId === node.id}>
+                        ${node.label}
+                      </option>`,
+                  )}
+                </select>
+              </div>
+            `
+          : nothing}
+
+        <!-- 目标说明 -->
+        <div class="permissions-target__info">
+          ${isGateway
+            ? html`
+                <div class="permissions-info-box">
+                  <span class="permissions-info-box__icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <circle cx="12" cy="12" r="10"></circle>
+                      <line x1="12" y1="16" x2="12" y2="12"></line>
+                      <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                    </svg>
+                  </span>
+                  <span class="permissions-info-box__text">
+                    <strong>本地网关</strong>：配置在本机执行命令的权限。所有通过此网关执行的命令都将受此配置控制。
+                  </span>
+                </div>
+              `
+            : html`
+                <div class="permissions-info-box">
+                  <span class="permissions-info-box__icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <circle cx="12" cy="12" r="10"></circle>
+                      <line x1="12" y1="16" x2="12" y2="12"></line>
+                      <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                    </svg>
+                  </span>
+                  <span class="permissions-info-box__text">
+                    <strong>远程节点</strong>：配置在远程设备执行命令的权限。选择的节点必须支持 exec approvals 功能。
+                  </span>
+                </div>
+              `}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染命令执行权限内容
+ */
+function renderExecPermissionsContent(props: PermissionsContentProps) {
+  const form = props.execApprovalsForm ?? props.execApprovalsSnapshot?.file ?? null;
+  const ready = Boolean(form);
+  const defaults = resolveDefaults(form);
+  const selectedScope = props.selectedAgent ?? EXEC_APPROVALS_DEFAULT_SCOPE;
+  const isDefaults = selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE;
+
+  return html`
+    <!-- 头部说明 -->
+    <div class="permissions-header">
+      <h3 class="permissions-title">命令执行权限</h3>
+      <p class="permissions-desc">
+        配置命令执行的安全策略、用户确认方式和允许列表。这些设置控制 Agent 执行系统命令的权限。
+      </p>
+    </div>
+
+    <!-- 目标选择器 -->
+    ${renderExecTargetSection(props)}
+
+    ${!ready
+      ? html`
+          <div class="permissions-empty">
+            ${props.loading
+              ? html`<p>正在加载权限配置...</p>`
+              : html`<p>权限配置加载中，请稍候...</p>`}
+          </div>
+        `
+      : html`
+          <!-- Agent 选择器 -->
+          ${renderAgentSelector(props, selectedScope)}
+
+          <!-- 策略配置 -->
+          ${renderPolicySection(props, form, defaults, selectedScope, isDefaults)}
+
+          <!-- 允许列表（仅非默认 Agent 显示） -->
+          ${!isDefaults ? renderAllowlistSection(props, form, selectedScope) : nothing}
+        `}
+  `;
+}
+
+/**
+ * 渲染 Agent 选择器
+ */
+function renderAgentSelector(props: PermissionsContentProps, selectedScope: string) {
+  const form = props.execApprovalsForm ?? props.execApprovalsSnapshot?.file ?? null;
+  const hasWildcard = form?.agents?.["*"] != null;
+  const isWildcardSelected = selectedScope === "*";
+
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">作用域</h4>
+          <p class="permissions-section__desc">选择要配置的 Agent，或配置全局默认设置。</p>
+        </div>
+        <div class="permissions-section__actions">
+          ${!hasWildcard
+            ? html`
+                <button
+                  class="mc-btn mc-btn--sm"
+                  ?disabled=${props.saving}
+                  @click=${() => props.onAddAgent("*")}
+                  title="添加通配符规则，匹配所有 Agent"
+                >
+                  + 通配符 (*)
+                </button>
+              `
+            : nothing}
+          <button
+            class="mc-btn mc-btn--sm"
+            ?disabled=${props.saving}
+            @click=${() => {
+              const id = prompt("请输入 Agent ID:");
+              if (id?.trim()) {
+                props.onAddAgent(id.trim());
+              }
+            }}
+          >
+            + 新建 Agent
+          </button>
+        </div>
+      </div>
+      <div class="permissions-tabs">
+        <button
+          class="permissions-tab ${selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE ? "permissions-tab--active" : ""}"
+          @click=${() => props.onSelectAgent(null)}
+        >
+          全局默认
+        </button>
+        ${hasWildcard
+          ? html`
+              <button
+                class="permissions-tab permissions-tab--wildcard ${isWildcardSelected ? "permissions-tab--active" : ""}"
+                @click=${() => props.onSelectAgent("*")}
+              >
+                * 通配符
+                <span class="permissions-tab__badge">匹配所有</span>
+              </button>
+            `
+          : nothing}
+        ${props.agents
+          .filter((agent) => agent.id !== "*")
+          .map((agent) => {
+            const label = agent.name?.trim() ? `${agent.name} (${agent.id})` : agent.id;
+            const isActive = selectedScope === agent.id;
+            const hasConfig = form?.agents?.[agent.id] != null;
+            return html`
+              <button
+                class="permissions-tab ${isActive ? "permissions-tab--active" : ""}"
+                @click=${() => props.onSelectAgent(agent.id)}
+              >
+                ${label}
+                ${agent.isDefault ? html`<span class="permissions-tab__badge">默认</span>` : nothing}
+                ${hasConfig && !agent.isDefault
+                  ? html`<span class="permissions-tab__badge permissions-tab__badge--config">已配置</span>`
+                  : nothing}
+              </button>
+            `;
+          })}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染策略配置
+ */
+function renderPolicySection(
+  props: PermissionsContentProps,
+  form: ExecApprovalsFile | null,
+  defaults: ReturnType<typeof resolveDefaults>,
+  selectedScope: string,
+  isDefaults: boolean,
+) {
+  const agent = !isDefaults
+    ? ((form?.agents ?? {})[selectedScope] as Record<string, unknown> | undefined) ?? {}
+    : {};
+  const basePath = isDefaults ? ["defaults"] : ["agents", selectedScope];
+
+  const agentSecurity = typeof agent.security === "string" ? agent.security : undefined;
+  const agentAsk = typeof agent.ask === "string" ? agent.ask : undefined;
+  const agentAskFallback = typeof agent.askFallback === "string" ? agent.askFallback : undefined;
+
+  const securityValue = isDefaults ? defaults.security : agentSecurity ?? "__default__";
+  const askValue = isDefaults ? defaults.ask : agentAsk ?? "__default__";
+  const askFallbackValue = isDefaults ? defaults.askFallback : agentAskFallback ?? "__default__";
+
+  const autoOverride = typeof agent.autoAllowSkills === "boolean" ? agent.autoAllowSkills : undefined;
+  const autoEffective = autoOverride ?? defaults.autoAllowSkills;
+  const autoIsDefault = autoOverride == null;
+
+  // 判断是否可以删除此 Agent 配置
+  const hasAgentConfig = !isDefaults && form?.agents?.[selectedScope] != null;
+  const isWildcard = selectedScope === "*";
+
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">安全策略</h4>
+          <p class="permissions-section__desc">
+            ${isDefaults
+              ? "配置全局默认的安全策略。"
+              : isWildcard
+                ? "配置通配符规则，匹配所有未单独配置的 Agent。"
+                : `配置 ${selectedScope} Agent 的安全策略。`}
+          </p>
+        </div>
+        ${hasAgentConfig
+          ? html`
+              <button
+                class="mc-btn mc-btn--sm mc-btn--danger"
+                ?disabled=${props.saving}
+                @click=${() => {
+                  if (confirm(`确定要删除 ${isWildcard ? "通配符" : selectedScope} 的配置吗？`)) {
+                    props.onRemoveAgent(selectedScope);
+                  }
+                }}
+              >
+                删除配置
+              </button>
+            `
+          : nothing}
+      </div>
+
+      <div class="permissions-policy-grid">
+        <!-- 安全模式 -->
+        <div class="permissions-policy-item">
+          <div class="permissions-policy-item__header">
+            <span class="permissions-policy-item__title">安全模式</span>
+            <span class="permissions-policy-item__desc">
+              ${isDefaults ? "默认的安全级别。" : `默认: ${defaults.security}`}
+            </span>
+          </div>
+          <select
+            class="permissions-select"
+            ?disabled=${props.saving}
+            @change=${(event: Event) => {
+              const target = event.target as HTMLSelectElement;
+              const value = target.value;
+              if (!isDefaults && value === "__default__") {
+                props.onRemove([...basePath, "security"]);
+              } else {
+                props.onPatch([...basePath, "security"], value);
+              }
+            }}
+          >
+            ${!isDefaults
+              ? html`<option value="__default__" ?selected=${securityValue === "__default__"}>
+                  使用默认 (${defaults.security})
+                </option>`
+              : nothing}
+            ${SECURITY_OPTIONS.map(
+              (option) =>
+                html`<option value=${option.value} ?selected=${securityValue === option.value}>
+                  ${option.label} - ${option.description}
+                </option>`,
+            )}
+          </select>
+        </div>
+
+        <!-- 用户确认 -->
+        <div class="permissions-policy-item">
+          <div class="permissions-policy-item__header">
+            <span class="permissions-policy-item__title">用户确认</span>
+            <span class="permissions-policy-item__desc">
+              ${isDefaults ? "何时提示用户确认。" : `默认: ${defaults.ask}`}
+            </span>
+          </div>
+          <select
+            class="permissions-select"
+            ?disabled=${props.saving}
+            @change=${(event: Event) => {
+              const target = event.target as HTMLSelectElement;
+              const value = target.value;
+              if (!isDefaults && value === "__default__") {
+                props.onRemove([...basePath, "ask"]);
+              } else {
+                props.onPatch([...basePath, "ask"], value);
+              }
+            }}
+          >
+            ${!isDefaults
+              ? html`<option value="__default__" ?selected=${askValue === "__default__"}>
+                  使用默认 (${defaults.ask})
+                </option>`
+              : nothing}
+            ${ASK_OPTIONS.map(
+              (option) =>
+                html`<option value=${option.value} ?selected=${askValue === option.value}>
+                  ${option.label} - ${option.description}
+                </option>`,
+            )}
+          </select>
+        </div>
+
+        <!-- 确认失败回退 -->
+        <div class="permissions-policy-item">
+          <div class="permissions-policy-item__header">
+            <span class="permissions-policy-item__title">确认失败回退</span>
+            <span class="permissions-policy-item__desc">
+              ${isDefaults ? "UI 确认不可用时的处理方式。" : `默认: ${defaults.askFallback}`}
+            </span>
+          </div>
+          <select
+            class="permissions-select"
+            ?disabled=${props.saving}
+            @change=${(event: Event) => {
+              const target = event.target as HTMLSelectElement;
+              const value = target.value;
+              if (!isDefaults && value === "__default__") {
+                props.onRemove([...basePath, "askFallback"]);
+              } else {
+                props.onPatch([...basePath, "askFallback"], value);
+              }
+            }}
+          >
+            ${!isDefaults
+              ? html`<option value="__default__" ?selected=${askFallbackValue === "__default__"}>
+                  使用默认 (${defaults.askFallback})
+                </option>`
+              : nothing}
+            ${SECURITY_OPTIONS.map(
+              (option) =>
+                html`<option value=${option.value} ?selected=${askFallbackValue === option.value}>
+                  ${option.label}
+                </option>`,
+            )}
+          </select>
+        </div>
+
+        <!-- 自动允许技能 CLI -->
+        <div class="permissions-policy-item">
+          <div class="permissions-policy-item__header">
+            <span class="permissions-policy-item__title">自动允许技能 CLI</span>
+            <span class="permissions-policy-item__desc">
+              ${isDefaults
+                ? "自动允许 Gateway 注册的技能可执行文件。"
+                : autoIsDefault
+                  ? `使用默认 (${defaults.autoAllowSkills ? "开启" : "关闭"})`
+                  : `覆盖 (${autoEffective ? "开启" : "关闭"})`}
+            </span>
+          </div>
+          <div class="permissions-checkbox-row">
+            <label class="permissions-checkbox">
+              <input
+                type="checkbox"
+                ?disabled=${props.saving}
+                .checked=${autoEffective}
+                @change=${(event: Event) => {
+                  const target = event.target as HTMLInputElement;
+                  props.onPatch([...basePath, "autoAllowSkills"], target.checked);
+                }}
+              />
+              <span>启用</span>
+            </label>
+            ${!isDefaults && !autoIsDefault
+              ? html`
+                  <button
+                    class="mc-btn mc-btn--sm"
+                    ?disabled=${props.saving}
+                    @click=${() => props.onRemove([...basePath, "autoAllowSkills"])}
+                  >
+                    使用默认
+                  </button>
+                `
+              : nothing}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染允许列表
+ */
+function renderAllowlistSection(
+  props: PermissionsContentProps,
+  form: ExecApprovalsFile | null,
+  selectedScope: string,
+) {
+  const agent = (form?.agents ?? {})[selectedScope] as ExecApprovalsAgent | undefined;
+  const allowlist = Array.isArray(agent?.allowlist) ? agent.allowlist : [];
+
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">命令允许列表</h4>
+          <p class="permissions-section__desc">
+            配置允许执行的命令模式。使用 glob 模式匹配命令（不区分大小写）。
+          </p>
+        </div>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.saving}
+          @click=${() => props.onAddAllowlistEntry(selectedScope)}
+        >
+          添加规则
+        </button>
+      </div>
+
+      <div class="permissions-allowlist">
+        ${allowlist.length === 0
+          ? html`
+              <div class="permissions-allowlist__empty">
+                <p>暂无允许列表规则。</p>
+                <p class="muted">点击"添加规则"来添加允许执行的命令模式。</p>
+              </div>
+            `
+          : allowlist.map((entry, index) =>
+              renderAllowlistEntry(props, entry, selectedScope, index),
+            )}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染允许列表条目
+ */
+function renderAllowlistEntry(
+  props: PermissionsContentProps,
+  entry: ExecApprovalsAllowlistEntry,
+  selectedScope: string,
+  index: number,
+) {
+  const lastUsed = formatAgo(entry.lastUsedAt);
+  const pattern = entry.pattern?.trim() || "";
+
+  return html`
+    <div class="permissions-allowlist__item">
+      <div class="permissions-allowlist__item-main">
+        <div class="permissions-allowlist__item-pattern">
+          <input
+            type="text"
+            class="permissions-input"
+            placeholder="例如: git *, npm run *, /usr/bin/*"
+            .value=${pattern}
+            ?disabled=${props.saving}
+            @input=${(event: Event) => {
+              const target = event.target as HTMLInputElement;
+              props.onPatch(
+                ["agents", selectedScope, "allowlist", index, "pattern"],
+                target.value,
+              );
+            }}
+          />
+        </div>
+        <div class="permissions-allowlist__item-meta">
+          <span class="muted">最后使用: ${lastUsed}</span>
+          ${entry.lastUsedCommand
+            ? html`<span class="mono muted" title=${entry.lastUsedCommand}>
+                ${entry.lastUsedCommand.length > 50
+                  ? entry.lastUsedCommand.slice(0, 50) + "..."
+                  : entry.lastUsedCommand}
+              </span>`
+            : nothing}
+        </div>
+      </div>
+      <div class="permissions-allowlist__item-actions">
+        <button
+          class="mc-btn mc-btn--sm mc-btn--danger"
+          ?disabled=${props.saving}
+          @click=${() => props.onRemoveAllowlistEntry(selectedScope, index)}
+        >
+          删除
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+// ============================================
+// 工具权限管理相关函数
+// ============================================
+
+/**
+ * 渲染工具权限管理区块
+ */
+function renderToolsPermissionsSection(props: PermissionsContentProps) {
+  const selectedScope = props.toolsSelectedAgent ?? TOOLS_DEFAULT_SCOPE;
+  const isGlobal = selectedScope === TOOLS_DEFAULT_SCOPE;
+
+  // 获取当前作用域的配置
+  const globalConfig = props.toolsConfig ?? {};
+  const agentConfig = !isGlobal
+    ? props.agentToolsConfigs.find((a) => a.id === selectedScope)?.tools ?? {}
+    : {};
+  const currentConfig = isGlobal ? globalConfig : agentConfig;
+
+  return html`
+    <div class="permissions-header">
+      <h3 class="permissions-title">工具权限</h3>
+      <p class="permissions-desc">
+        配置 Agent 可以使用的工具。可以选择预设配置档案，或单独控制每个工具的启用/禁用状态。
+      </p>
+    </div>
+
+    <!-- 工具作用域选择器 -->
+    ${renderToolsScopeSelector(props, selectedScope)}
+
+    <!-- 配置档案选择 -->
+    ${renderToolsProfileSection(props, currentConfig, selectedScope, isGlobal, globalConfig)}
+
+    <!-- 工具列表（带开关） -->
+    ${renderToolsListSection(props, currentConfig, selectedScope, isGlobal)}
+  `;
+}
+
+/**
+ * 渲染工具作用域选择器
+ */
+function renderToolsScopeSelector(props: PermissionsContentProps, selectedScope: string) {
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">作用域</h4>
+          <p class="permissions-section__desc">选择要配置的 Agent，或配置全局默认设置。</p>
+        </div>
+      </div>
+      <div class="permissions-tabs">
+        <button
+          class="permissions-tab ${selectedScope === TOOLS_DEFAULT_SCOPE ? "permissions-tab--active" : ""}"
+          @click=${() => props.onToolsSelectAgent(null)}
+        >
+          全局默认
+        </button>
+        ${props.toolsAgents.map((agent) => {
+          const label = agent.name?.trim() ? `${agent.name} (${agent.id})` : agent.id;
+          const isActive = selectedScope === agent.id;
+          return html`
+            <button
+              class="permissions-tab ${isActive ? "permissions-tab--active" : ""}"
+              @click=${() => props.onToolsSelectAgent(agent.id)}
+            >
+              ${label}
+              ${agent.isDefault ? html`<span class="permissions-tab__badge">默认</span>` : nothing}
+            </button>
+          `;
+        })}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染配置档案选择
+ */
+function renderToolsProfileSection(
+  props: PermissionsContentProps,
+  currentConfig: ToolPolicyConfig,
+  selectedScope: string,
+  isGlobal: boolean,
+  globalConfig: ToolPolicyConfig,
+) {
+  const profileValue = currentConfig.profile ?? (isGlobal ? undefined : "__default__");
+  const globalProfile = globalConfig.profile;
+
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">配置档案</h4>
+          <p class="permissions-section__desc">
+            ${isGlobal
+              ? "选择预设的工具配置档案，或留空使用默认配置。"
+              : globalProfile
+                ? `全局档案: ${globalProfile}`
+                : "全局未设置档案，使用系统默认"}
+          </p>
+        </div>
+      </div>
+      <div class="permissions-policy-grid">
+        <div class="permissions-policy-item">
+          <div class="permissions-policy-item__header">
+            <span class="permissions-policy-item__title">工具档案</span>
+            <span class="permissions-policy-item__desc">
+              选择预设的工具权限集合
+            </span>
+          </div>
+          <select
+            class="permissions-select"
+            ?disabled=${props.saving}
+            @change=${(event: Event) => {
+              const target = event.target as HTMLSelectElement;
+              const value = target.value;
+              if (isGlobal) {
+                props.onToolsUpdateGlobal("profile", value || undefined);
+              } else if (value === "__default__") {
+                props.onToolsUpdateAgent(selectedScope, "profile", undefined);
+              } else {
+                props.onToolsUpdateAgent(selectedScope, "profile", value || undefined);
+              }
+            }}
+          >
+            ${!isGlobal
+              ? html`<option value="__default__" ?selected=${profileValue === "__default__"}>
+                  使用全局设置${globalProfile ? ` (${globalProfile})` : ""}
+                </option>`
+              : html`<option value="" ?selected=${!profileValue}>
+                  未设置（使用系统默认）
+                </option>`}
+            ${TOOL_PROFILES.map(
+              (profile) =>
+                html`<option value=${profile.value} ?selected=${profileValue === profile.value}>
+                  ${profile.label} - ${profile.description}
+                </option>`,
+            )}
+          </select>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染工具列表（带开关）
+ */
+function renderToolsListSection(
+  props: PermissionsContentProps,
+  currentConfig: ToolPolicyConfig,
+  selectedScope: string,
+  isGlobal: boolean,
+) {
+  const denyList = currentConfig.deny ?? [];
+  const totalTools = Object.values(TOOL_GROUPS).reduce(
+    (sum, group) => sum + group.tools.length,
+    0,
+  ) + STANDALONE_TOOLS.length;
+
+  // 检查工具是否被禁用
+  const isToolDenied = (toolId: string): boolean => {
+    // 直接禁用
+    if (denyList.includes(toolId)) return true;
+    // 通过分组禁用
+    for (const [groupId, group] of Object.entries(TOOL_GROUPS)) {
+      if (group.tools.includes(toolId) && denyList.includes(groupId)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // 检查分组是否被禁用
+  const isGroupDenied = (groupId: string): boolean => {
+    return denyList.includes(groupId);
+  };
+
+  // 切换工具禁用状态
+  const handleToolToggle = (toolId: string, currentlyDenied: boolean) => {
+    if (currentlyDenied) {
+      // 启用工具（从 deny 列表移除）
+      if (isGlobal) {
+        props.onToolsRemoveGlobalDeny(toolId);
+      } else {
+        props.onToolsRemoveAgentDeny(selectedScope, toolId);
+      }
+    } else {
+      // 禁用工具（添加到 deny 列表）
+      if (isGlobal) {
+        props.onToolsAddGlobalDeny(toolId);
+      } else {
+        props.onToolsAddAgentDeny(selectedScope, toolId);
+      }
+    }
+  };
+
+  // 切换分组禁用状态
+  const handleGroupToggle = (groupId: string, currentlyDenied: boolean) => {
+    if (currentlyDenied) {
+      if (isGlobal) {
+        props.onToolsRemoveGlobalDeny(groupId);
+      } else {
+        props.onToolsRemoveAgentDeny(selectedScope, groupId);
+      }
+    } else {
+      if (isGlobal) {
+        props.onToolsAddGlobalDeny(groupId);
+      } else {
+        props.onToolsAddAgentDeny(selectedScope, groupId);
+      }
+    }
+  };
+
+  return html`
+    <div class="permissions-section">
+      <div class="permissions-section__header">
+        <div>
+          <h4 class="permissions-section__title">工具列表</h4>
+          <p class="permissions-section__desc">
+            共 ${totalTools} 个工具，使用开关控制启用/禁用状态。
+          </p>
+        </div>
+        <button
+          class="mc-btn mc-btn--sm"
+          @click=${props.onToolsToggleExpanded}
+        >
+          ${props.toolsExpanded ? "收起" : "展开"}
+        </button>
+      </div>
+
+      ${props.toolsExpanded
+        ? html`
+            <div class="tools-list">
+              ${Object.entries(TOOL_GROUPS).map(([groupId, group]) => {
+                const groupDenied = isGroupDenied(groupId);
+                return html`
+                  <div class="tools-group ${groupDenied ? "tools-group--denied" : ""}">
+                    <div class="tools-group__header">
+                      <div class="tools-group__info">
+                        <span class="tools-group__name">${group.label}</span>
+                        <span class="tools-group__desc">${group.desc}</span>
+                      </div>
+                      <div class="tools-group__toggle">
+                        <span class="tools-group__count">${group.tools.length} 个工具</span>
+                        <label class="mc-toggle">
+                          <input
+                            type="checkbox"
+                            .checked=${!groupDenied}
+                            ?disabled=${props.saving}
+                            @change=${() => handleGroupToggle(groupId, groupDenied)}
+                          />
+                          <span class="mc-toggle__track"></span>
+                        </label>
+                      </div>
+                    </div>
+                    <div class="tools-group__items">
+                      ${group.tools.map((toolId) => {
+                        const denied = isToolDenied(toolId);
+                        const desc = TOOL_DESCRIPTIONS[toolId] ?? "";
+                        return html`
+                          <div class="tools-item ${denied ? "tools-item--denied" : ""}">
+                            <div class="tools-item__info">
+                              <span class="tools-item__name">${toolId}</span>
+                              <span class="tools-item__desc">${desc}</span>
+                            </div>
+                            <label class="mc-toggle mc-toggle--sm">
+                              <input
+                                type="checkbox"
+                                .checked=${!denied}
+                                ?disabled=${props.saving || groupDenied}
+                                @change=${() => handleToolToggle(toolId, denied)}
+                              />
+                              <span class="mc-toggle__track"></span>
+                            </label>
+                          </div>
+                        `;
+                      })}
+                    </div>
+                  </div>
+                `;
+              })}
+
+              <!-- 独立工具 -->
+              <div class="tools-group">
+                <div class="tools-group__header">
+                  <div class="tools-group__info">
+                    <span class="tools-group__name">独立工具</span>
+                    <span class="tools-group__desc">不属于任何分组的工具</span>
+                  </div>
+                  <div class="tools-group__toggle">
+                    <span class="tools-group__count">${STANDALONE_TOOLS.length} 个工具</span>
+                  </div>
+                </div>
+                <div class="tools-group__items">
+                  ${STANDALONE_TOOLS.map((tool) => {
+                    const denied = isToolDenied(tool.id);
+                    const desc = TOOL_DESCRIPTIONS[tool.id] ?? "";
+                    return html`
+                      <div class="tools-item ${denied ? "tools-item--denied" : ""}">
+                        <div class="tools-item__info">
+                          <span class="tools-item__name">${tool.id}</span>
+                          <span class="tools-item__label">${tool.label}</span>
+                          <span class="tools-item__desc">${desc}</span>
+                        </div>
+                        <label class="mc-toggle mc-toggle--sm">
+                          <input
+                            type="checkbox"
+                            .checked=${!denied}
+                            ?disabled=${props.saving}
+                            @change=${() => handleToolToggle(tool.id, denied)}
+                          />
+                          <span class="mc-toggle__track"></span>
+                        </label>
+                      </div>
+                    `;
+                  })}
+                </div>
+              </div>
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/providers-content.ts
+++ b/ui/src/ui-zh-CN/components/providers-content.ts
@@ -1,0 +1,923 @@
+/**
+ * 模型供应商配置内容组件
+ * 右侧面板 - 供应商管理
+ */
+import { html, nothing } from "lit";
+import type { ProviderConfig, ModelConfig, ModelApi, AuthMode } from "../views/model-config";
+
+// SVG 图标
+const icons = {
+  provider: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>`,
+  add: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`,
+  trash: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>`,
+  chevron: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>`,
+  settings: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>`,
+  info: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>`,
+  close: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+};
+
+// API 协议配置
+const API_PROTOCOLS: Array<{ value: ModelApi; label: string; hint: string }> = [
+  { value: "openai-completions", label: "OpenAI Completions", hint: "OpenAI 兼容 API（大多数供应商）" },
+  { value: "openai-responses", label: "OpenAI Responses", hint: "OpenAI 新版 Responses API" },
+  { value: "anthropic-messages", label: "Anthropic Messages", hint: "Anthropic Claude API" },
+  { value: "google-generative-ai", label: "Google Generative AI", hint: "Google Gemini API" },
+  { value: "github-copilot", label: "GitHub Copilot", hint: "GitHub Copilot 模型" },
+  { value: "bedrock-converse-stream", label: "AWS Bedrock", hint: "AWS Bedrock Converse API" },
+];
+
+// 认证模式配置
+const AUTH_MODES: Array<{ value: AuthMode; label: string; hint: string }> = [
+  { value: "api-key", label: "API Key", hint: "标准 API 密钥认证" },
+  { value: "aws-sdk", label: "AWS SDK", hint: "使用 AWS 凭证（IAM / 环境变量）" },
+  { value: "oauth", label: "OAuth", hint: "OAuth 令牌认证" },
+  { value: "token", label: "Bearer Token", hint: "Bearer Token 认证" },
+];
+
+// 中文标签
+const LABELS = {
+  providersTitle: "模型供应商",
+  providersDesc: "配置 LLM 模型供应商，支持 OpenAI、Anthropic、Google、AWS Bedrock 等",
+  addProvider: "添加供应商",
+  providerName: "供应商名称",
+  providerNamePlaceholder: "输入供应商名称，如: openai、my-ollama",
+  providerBaseUrl: "API 地址",
+  providerBaseUrlPlaceholder: "https://api.example.com/v1",
+  providerApiKey: "API 密钥",
+  providerApiKeyPlaceholder: "sk-... 或 ${ENV_VAR}",
+  providerProtocol: "API 协议",
+  providerAuth: "认证方式",
+  providerHeaders: "自定义 Headers",
+  headersHint: "可选：添加额外的请求头",
+  addHeader: "添加 Header",
+  headerKey: "Header 名称",
+  headerValue: "Header 值",
+  noProviders: "尚未配置任何模型供应商",
+  modelId: "模型 ID",
+  modelName: "显示名称",
+  modelReasoning: "推理模型",
+  modelContext: "上下文",
+  modelMaxTokens: "最大输出",
+  modelInput: "输入类型",
+  inputText: "文本",
+  inputImage: "图片",
+  addModel: "添加模型",
+  modelCount: "个模型",
+  advancedConfig: "高级配置",
+  showAdvanced: "显示高级选项",
+  hideAdvanced: "隐藏高级选项",
+  modelCost: "成本配置",
+  costInput: "输入",
+  costOutput: "输出",
+  costCacheRead: "缓存读",
+  costCacheWrite: "缓存写",
+  costUnit: "$/M tokens",
+  modelCompat: "兼容性配置",
+  compatStore: "Store",
+  compatDeveloper: "Developer Role",
+  compatReasoning: "Reasoning Effort",
+  compatMaxTokens: "max_tokens 字段",
+  maxTokensField: "max_tokens",
+  maxCompletionTokensField: "max_completion_tokens",
+  // 弹窗相关
+  createProvider: "创建供应商",
+  cancel: "取消",
+  confirm: "确认创建",
+};
+
+// 新建供应商表单状态
+export type ProviderFormState = {
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  api: ModelApi;
+  auth: AuthMode;
+};
+
+// 默认表单状态
+const DEFAULT_PROVIDER_FORM: ProviderFormState = {
+  name: "",
+  baseUrl: "",
+  apiKey: "",
+  api: "openai-completions",
+  auth: "api-key",
+};
+
+export type ProvidersContentProps = {
+  providers: Record<string, ProviderConfig>;
+  expandedProviders: Set<string>;
+  // 新建供应商弹窗状态
+  showAddModal?: boolean;
+  addForm?: ProviderFormState;
+  addError?: string | null;
+  // 回调函数
+  onProviderToggle: (key: string) => void;
+  onProviderAdd: () => void;
+  onProviderRemove: (key: string) => void;
+  onProviderRename: (oldKey: string, newKey: string) => void;
+  onProviderUpdate: (key: string, field: string, value: unknown) => void;
+  onModelAdd: (providerKey: string) => void;
+  onModelRemove: (providerKey: string, modelIndex: number) => void;
+  onModelUpdate: (providerKey: string, modelIndex: number, field: string, value: unknown) => void;
+  // 弹窗回调
+  onShowAddModal?: (show: boolean) => void;
+  onAddFormChange?: (patch: Partial<ProviderFormState>) => void;
+  onAddConfirm?: () => void;
+};
+
+/**
+ * 渲染模型行
+ */
+function renderModelRow(
+  providerKey: string,
+  index: number,
+  model: ModelConfig,
+  props: ProvidersContentProps,
+) {
+  const hasText = model.input?.includes("text") ?? true;
+  const hasImage = model.input?.includes("image") ?? false;
+
+  const handleInputChange = (type: "text" | "image", checked: boolean) => {
+    const currentInput = model.input ?? ["text"];
+    let newInput: Array<"text" | "image">;
+    if (checked) {
+      newInput = [...new Set([...currentInput, type])];
+    } else {
+      newInput = currentInput.filter((t) => t !== type);
+      if (newInput.length === 0) newInput = ["text"]; // 至少保留文本
+    }
+    props.onModelUpdate(providerKey, index, "input", newInput);
+  };
+
+  return html`
+    <div class="mc-model-row">
+      <div class="mc-model-row__main">
+        <div class="mc-model-row__field mc-model-row__field--id">
+          <label class="mc-field mc-field--sm">
+            <span class="mc-field__label">${LABELS.modelId}</span>
+            <input
+              type="text"
+              class="mc-input mc-input--sm"
+              .value=${model.id}
+              @input=${(e: Event) =>
+                props.onModelUpdate(providerKey, index, "id", (e.target as HTMLInputElement).value)}
+            />
+          </label>
+        </div>
+        <div class="mc-model-row__field mc-model-row__field--name">
+          <label class="mc-field mc-field--sm">
+            <span class="mc-field__label">${LABELS.modelName}</span>
+            <input
+              type="text"
+              class="mc-input mc-input--sm"
+              .value=${model.name}
+              @input=${(e: Event) =>
+                props.onModelUpdate(providerKey, index, "name", (e.target as HTMLInputElement).value)}
+            />
+          </label>
+        </div>
+        <div class="mc-model-row__field mc-model-row__field--context">
+          <label class="mc-field mc-field--sm">
+            <span class="mc-field__label">${LABELS.modelContext}</span>
+            <input
+              type="number"
+              class="mc-input mc-input--sm"
+              .value=${String(model.contextWindow)}
+              @input=${(e: Event) =>
+                props.onModelUpdate(
+                  providerKey,
+                  index,
+                  "contextWindow",
+                  Number((e.target as HTMLInputElement).value),
+                )}
+            />
+          </label>
+        </div>
+        <div class="mc-model-row__field mc-model-row__field--tokens">
+          <label class="mc-field mc-field--sm">
+            <span class="mc-field__label">${LABELS.modelMaxTokens}</span>
+            <input
+              type="number"
+              class="mc-input mc-input--sm"
+              .value=${String(model.maxTokens)}
+              @input=${(e: Event) =>
+                props.onModelUpdate(
+                  providerKey,
+                  index,
+                  "maxTokens",
+                  Number((e.target as HTMLInputElement).value),
+                )}
+            />
+          </label>
+        </div>
+        <div class="mc-model-row__field mc-model-row__field--input">
+          <div class="mc-field mc-field--sm">
+            <span class="mc-field__label">${LABELS.modelInput}</span>
+            <div class="mc-checkbox-group">
+              <label class="mc-checkbox">
+                <input
+                  type="checkbox"
+                  .checked=${hasText}
+                  @change=${(e: Event) => handleInputChange("text", (e.target as HTMLInputElement).checked)}
+                />
+                <span>${LABELS.inputText}</span>
+              </label>
+              <label class="mc-checkbox">
+                <input
+                  type="checkbox"
+                  .checked=${hasImage}
+                  @change=${(e: Event) => handleInputChange("image", (e.target as HTMLInputElement).checked)}
+                />
+                <span>${LABELS.inputImage}</span>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="mc-model-row__field mc-model-row__field--reasoning">
+          <label class="mc-toggle-field">
+            <span class="mc-toggle-field__label">${LABELS.modelReasoning}</span>
+            <div class="mc-toggle">
+              <input
+                type="checkbox"
+                .checked=${model.reasoning}
+                @change=${(e: Event) =>
+                  props.onModelUpdate(
+                    providerKey,
+                    index,
+                    "reasoning",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+              />
+              <span class="mc-toggle__track"></span>
+            </div>
+          </label>
+        </div>
+      </div>
+      <button
+        class="mc-icon-btn mc-icon-btn--danger mc-model-row__remove"
+        title="删除模型"
+        @click=${() => props.onModelRemove(providerKey, index)}
+      >
+        ${icons.trash}
+      </button>
+    </div>
+    ${renderModelAdvanced(providerKey, index, model, props)}
+  `;
+}
+
+/**
+ * 渲染模型高级配置（成本和兼容性）
+ */
+function renderModelAdvanced(
+  providerKey: string,
+  index: number,
+  model: ModelConfig,
+  props: ProvidersContentProps,
+) {
+  const cost = model.cost ?? { input: 0, output: 0 };
+  const compat = model.compat ?? {};
+
+  return html`
+    <div class="mc-model-advanced">
+      <details class="mc-model-advanced__details">
+        <summary class="mc-model-advanced__summary">
+          ${icons.settings}
+          <span>${LABELS.advancedConfig}</span>
+        </summary>
+        <div class="mc-model-advanced__content">
+          <!-- 成本配置 -->
+          <div class="mc-model-advanced__section">
+            <div class="mc-model-advanced__section-title">${LABELS.modelCost}</div>
+            <div class="mc-model-advanced__grid">
+              <label class="mc-field mc-field--sm">
+                <span class="mc-field__label">${LABELS.costInput}</span>
+                <div class="mc-input-with-unit">
+                  <input
+                    type="number"
+                    class="mc-input mc-input--sm"
+                    step="0.01"
+                    .value=${String(cost.input ?? 0)}
+                    @input=${(e: Event) =>
+                      props.onModelUpdate(providerKey, index, "cost", {
+                        ...cost,
+                        input: Number((e.target as HTMLInputElement).value),
+                      })}
+                  />
+                  <span class="mc-input-unit">${LABELS.costUnit}</span>
+                </div>
+              </label>
+              <label class="mc-field mc-field--sm">
+                <span class="mc-field__label">${LABELS.costOutput}</span>
+                <div class="mc-input-with-unit">
+                  <input
+                    type="number"
+                    class="mc-input mc-input--sm"
+                    step="0.01"
+                    .value=${String(cost.output ?? 0)}
+                    @input=${(e: Event) =>
+                      props.onModelUpdate(providerKey, index, "cost", {
+                        ...cost,
+                        output: Number((e.target as HTMLInputElement).value),
+                      })}
+                  />
+                  <span class="mc-input-unit">${LABELS.costUnit}</span>
+                </div>
+              </label>
+              <label class="mc-field mc-field--sm">
+                <span class="mc-field__label">${LABELS.costCacheRead}</span>
+                <div class="mc-input-with-unit">
+                  <input
+                    type="number"
+                    class="mc-input mc-input--sm"
+                    step="0.01"
+                    .value=${String(cost.cacheRead ?? 0)}
+                    @input=${(e: Event) =>
+                      props.onModelUpdate(providerKey, index, "cost", {
+                        ...cost,
+                        cacheRead: Number((e.target as HTMLInputElement).value),
+                      })}
+                  />
+                  <span class="mc-input-unit">${LABELS.costUnit}</span>
+                </div>
+              </label>
+              <label class="mc-field mc-field--sm">
+                <span class="mc-field__label">${LABELS.costCacheWrite}</span>
+                <div class="mc-input-with-unit">
+                  <input
+                    type="number"
+                    class="mc-input mc-input--sm"
+                    step="0.01"
+                    .value=${String(cost.cacheWrite ?? 0)}
+                    @input=${(e: Event) =>
+                      props.onModelUpdate(providerKey, index, "cost", {
+                        ...cost,
+                        cacheWrite: Number((e.target as HTMLInputElement).value),
+                      })}
+                  />
+                  <span class="mc-input-unit">${LABELS.costUnit}</span>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          <!-- 兼容性配置 -->
+          <div class="mc-model-advanced__section">
+            <div class="mc-model-advanced__section-title">${LABELS.modelCompat}</div>
+            <div class="mc-model-advanced__compat">
+              <label class="mc-checkbox">
+                <input
+                  type="checkbox"
+                  .checked=${compat.supportsStore ?? false}
+                  @change=${(e: Event) =>
+                    props.onModelUpdate(providerKey, index, "compat", {
+                      ...compat,
+                      supportsStore: (e.target as HTMLInputElement).checked,
+                    })}
+                />
+                <span>${LABELS.compatStore}</span>
+              </label>
+              <label class="mc-checkbox">
+                <input
+                  type="checkbox"
+                  .checked=${compat.supportsDeveloperRole ?? false}
+                  @change=${(e: Event) =>
+                    props.onModelUpdate(providerKey, index, "compat", {
+                      ...compat,
+                      supportsDeveloperRole: (e.target as HTMLInputElement).checked,
+                    })}
+                />
+                <span>${LABELS.compatDeveloper}</span>
+              </label>
+              <label class="mc-checkbox">
+                <input
+                  type="checkbox"
+                  .checked=${compat.supportsReasoningEffort ?? false}
+                  @change=${(e: Event) =>
+                    props.onModelUpdate(providerKey, index, "compat", {
+                      ...compat,
+                      supportsReasoningEffort: (e.target as HTMLInputElement).checked,
+                    })}
+                />
+                <span>${LABELS.compatReasoning}</span>
+              </label>
+              <div class="mc-compat-select">
+                <span class="mc-compat-select__label">${LABELS.compatMaxTokens}:</span>
+                <select
+                  class="mc-select mc-select--sm"
+                  @change=${(e: Event) =>
+                    props.onModelUpdate(providerKey, index, "compat", {
+                      ...compat,
+                      maxTokensField: (e.target as HTMLSelectElement).value as "max_tokens" | "max_completion_tokens",
+                    })}
+                >
+                  <option value="max_tokens" .selected=${(compat.maxTokensField ?? "max_tokens") === "max_tokens"}>${LABELS.maxTokensField}</option>
+                  <option value="max_completion_tokens" .selected=${compat.maxTokensField === "max_completion_tokens"}>${LABELS.maxCompletionTokensField}</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+  `;
+}
+
+/**
+ * 渲染 Headers 编辑器
+ */
+function renderHeadersEditor(
+  providerKey: string,
+  headers: Record<string, string> | undefined,
+  props: ProvidersContentProps,
+) {
+  const entries = Object.entries(headers ?? {});
+
+  const handleAddHeader = () => {
+    const newHeaders = { ...(headers ?? {}), "": "" };
+    props.onProviderUpdate(providerKey, "headers", newHeaders);
+  };
+
+  const handleRemoveHeader = (key: string) => {
+    const newHeaders = { ...(headers ?? {}) };
+    delete newHeaders[key];
+    props.onProviderUpdate(providerKey, "headers", Object.keys(newHeaders).length > 0 ? newHeaders : undefined);
+  };
+
+  const handleHeaderChange = (oldKey: string, newKey: string, value: string) => {
+    const newHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers ?? {})) {
+      if (k === oldKey) {
+        if (newKey) newHeaders[newKey] = value;
+      } else {
+        newHeaders[k] = v;
+      }
+    }
+    props.onProviderUpdate(providerKey, "headers", Object.keys(newHeaders).length > 0 ? newHeaders : undefined);
+  };
+
+  return html`
+    <div class="mc-headers-section">
+      <div class="mc-headers-section__header">
+        <span class="mc-headers-section__title">${LABELS.providerHeaders}</span>
+        <button class="mc-btn mc-btn--sm" @click=${handleAddHeader}>
+          ${icons.add} ${LABELS.addHeader}
+        </button>
+      </div>
+      ${entries.length === 0
+        ? html`<div class="mc-headers-section__hint">${LABELS.headersHint}</div>`
+        : html`
+            <div class="mc-headers-list">
+              ${entries.map(
+                ([key, value]) => html`
+                  <div class="mc-header-row">
+                    <input
+                      type="text"
+                      class="mc-input mc-input--sm"
+                      placeholder=${LABELS.headerKey}
+                      .value=${key}
+                      @input=${(e: Event) =>
+                        handleHeaderChange(key, (e.target as HTMLInputElement).value, value)}
+                    />
+                    <input
+                      type="text"
+                      class="mc-input mc-input--sm"
+                      placeholder=${LABELS.headerValue}
+                      .value=${value}
+                      @input=${(e: Event) =>
+                        handleHeaderChange(key, key, (e.target as HTMLInputElement).value)}
+                    />
+                    <button
+                      class="mc-icon-btn mc-icon-btn--danger mc-icon-btn--sm"
+                      @click=${() => handleRemoveHeader(key)}
+                    >
+                      ${icons.trash}
+                    </button>
+                  </div>
+                `,
+              )}
+            </div>
+          `}
+    </div>
+  `;
+}
+
+/**
+ * 获取协议标签
+ */
+function getProtocolLabel(api: ModelApi): string {
+  const protocol = API_PROTOCOLS.find((p) => p.value === api);
+  return protocol?.label ?? api;
+}
+
+/**
+ * 渲染供应商卡片
+ */
+function renderProviderCard(
+  key: string,
+  provider: ProviderConfig,
+  expanded: boolean,
+  props: ProvidersContentProps,
+) {
+  const protocolLabel = getProtocolLabel(provider.api);
+  const authMode = provider.auth ?? "api-key";
+  const showApiKey = authMode === "api-key" || authMode === "token";
+
+  return html`
+    <div class="mc-provider-card ${expanded ? "mc-provider-card--expanded" : ""}">
+      <div
+        class="mc-provider-card__header"
+        @click=${() => props.onProviderToggle(key)}
+      >
+        <div class="mc-provider-card__info">
+          <div class="mc-provider-card__icon">${icons.provider}</div>
+          <div class="mc-provider-card__details">
+            <div class="mc-provider-card__name">${key}</div>
+            <div class="mc-provider-card__meta">
+              <span class="mc-provider-card__protocol">${protocolLabel}</span>
+              <span class="mc-provider-card__count">${provider.models.length} ${LABELS.modelCount}</span>
+            </div>
+          </div>
+        </div>
+        <div class="mc-provider-card__actions">
+          <button
+            class="mc-icon-btn mc-icon-btn--danger"
+            title="删除供应商"
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              props.onProviderRemove(key);
+            }}
+          >
+            ${icons.trash}
+          </button>
+          <span class="mc-provider-card__chevron ${expanded ? "mc-provider-card__chevron--open" : ""}">
+            ${icons.chevron}
+          </span>
+        </div>
+      </div>
+
+      ${expanded
+        ? html`
+            <div class="mc-provider-card__content">
+              <div class="mc-form-section">
+                <div class="mc-form-row">
+                  <label class="mc-field">
+                    <span class="mc-field__label">${LABELS.providerName}</span>
+                    <input
+                      type="text"
+                      class="mc-input"
+                      .value=${key}
+                      @blur=${(e: Event) => {
+                        const newKey = (e.target as HTMLInputElement).value.trim();
+                        if (newKey && newKey !== key) {
+                          props.onProviderRename(key, newKey);
+                        }
+                      }}
+                      @keydown=${(e: KeyboardEvent) => {
+                        if (e.key === "Enter") {
+                          (e.target as HTMLInputElement).blur();
+                        }
+                      }}
+                    />
+                  </label>
+                </div>
+                <div class="mc-form-row">
+                  <label class="mc-field">
+                    <span class="mc-field__label">${LABELS.providerBaseUrl}</span>
+                    <input
+                      type="text"
+                      class="mc-input"
+                      .value=${provider.baseUrl}
+                      placeholder="https://api.example.com/v1"
+                      @input=${(e: Event) =>
+                        props.onProviderUpdate(key, "baseUrl", (e.target as HTMLInputElement).value)}
+                    />
+                  </label>
+                </div>
+                <div class="mc-form-row mc-form-row--2col">
+                  <label class="mc-field">
+                    <span class="mc-field__label">${LABELS.providerProtocol}</span>
+                    <select
+                      class="mc-select"
+                      @change=${(e: Event) =>
+                        props.onProviderUpdate(key, "api", (e.target as HTMLSelectElement).value)}
+                    >
+                      ${API_PROTOCOLS.map(
+                        (p) => html`<option value=${p.value} title=${p.hint} .selected=${provider.api === p.value}>${p.label}</option>`,
+                      )}
+                    </select>
+                  </label>
+                  <label class="mc-field">
+                    <span class="mc-field__label">${LABELS.providerAuth}</span>
+                    <select
+                      class="mc-select"
+                      @change=${(e: Event) =>
+                        props.onProviderUpdate(key, "auth", (e.target as HTMLSelectElement).value)}
+                    >
+                      ${AUTH_MODES.map(
+                        (a) => html`<option value=${a.value} title=${a.hint} .selected=${(provider.auth ?? "api-key") === a.value}>${a.label}</option>`,
+                      )}
+                    </select>
+                  </label>
+                </div>
+                ${showApiKey
+                  ? html`
+                      <div class="mc-form-row">
+                        <label class="mc-field">
+                          <span class="mc-field__label">${LABELS.providerApiKey}</span>
+                          <input
+                            type="password"
+                            class="mc-input"
+                            .value=${provider.apiKey ?? ""}
+                            placeholder="sk-... 或 ${`\${ENV_VAR}`}"
+                            @input=${(e: Event) =>
+                              props.onProviderUpdate(key, "apiKey", (e.target as HTMLInputElement).value)}
+                          />
+                        </label>
+                      </div>
+                    `
+                  : nothing}
+                ${renderHeadersEditor(key, provider.headers, props)}
+              </div>
+
+              <div class="mc-models-section">
+                <div class="mc-models-header">
+                  <span class="mc-models-title">模型列表</span>
+                  <button
+                    class="mc-btn mc-btn--sm"
+                    @click=${() => props.onModelAdd(key)}
+                  >
+                    ${icons.add}
+                    <span>${LABELS.addModel}</span>
+                  </button>
+                </div>
+                <div class="mc-models-list">
+                  ${provider.models.map((model, idx) =>
+                    renderModelRow(key, idx, model, props),
+                  )}
+                </div>
+              </div>
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+/**
+ * 渲染添加供应商弹窗
+ */
+function renderAddProviderModal(props: ProvidersContentProps) {
+  if (!props.showAddModal) return nothing;
+
+  const form = props.addForm ?? DEFAULT_PROVIDER_FORM;
+  const onFormChange = props.onAddFormChange ?? (() => {});
+  const onShowAddModal = props.onShowAddModal ?? (() => {});
+  const onAddConfirm = props.onAddConfirm ?? (() => {});
+  const showApiKey = form.auth === "api-key" || form.auth === "token";
+
+  const handleClose = () => {
+    onShowAddModal(false);
+  };
+
+  const handleSubmit = () => {
+    onAddConfirm();
+  };
+
+  return html`
+    <div class="cron-confirm-modal" @click=${handleClose}>
+      <div class="cron-create-modal__content" @click=${(e: Event) => e.stopPropagation()}>
+        <div class="cron-create-modal__header">
+          <div class="cron-create-modal__title">
+            ${icons.provider}
+            <span>${LABELS.createProvider}</span>
+          </div>
+          <button class="cron-create-modal__close" @click=${handleClose}>
+            ${icons.close}
+          </button>
+        </div>
+
+        <div class="cron-create-modal__body">
+          <!-- 供应商名称 -->
+          <div class="mc-field" style="margin-bottom: 16px;">
+            <label class="mc-field__label">${LABELS.providerName}</label>
+            <input
+              type="text"
+              class="mc-input"
+              placeholder=${LABELS.providerNamePlaceholder}
+              .value=${form.name}
+              @input=${(e: Event) =>
+                onFormChange({ name: (e.target as HTMLInputElement).value })}
+            />
+          </div>
+
+          <!-- API 地址 -->
+          <div class="mc-field" style="margin-bottom: 16px;">
+            <label class="mc-field__label">${LABELS.providerBaseUrl}</label>
+            <input
+              type="text"
+              class="mc-input"
+              placeholder=${LABELS.providerBaseUrlPlaceholder}
+              .value=${form.baseUrl}
+              @input=${(e: Event) =>
+                onFormChange({ baseUrl: (e.target as HTMLInputElement).value })}
+            />
+          </div>
+
+          <!-- API 协议和认证方式 -->
+          <div class="cron-form-grid" style="margin-bottom: 16px;">
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.providerProtocol}</label>
+              <select
+                class="mc-select"
+                @change=${(e: Event) =>
+                  onFormChange({ api: (e.target as HTMLSelectElement).value as ModelApi })}
+              >
+                ${API_PROTOCOLS.map(
+                  (p) => html`<option value=${p.value} title=${p.hint} .selected=${form.api === p.value}>${p.label}</option>`,
+                )}
+              </select>
+            </div>
+            <div class="mc-field">
+              <label class="mc-field__label">${LABELS.providerAuth}</label>
+              <select
+                class="mc-select"
+                @change=${(e: Event) =>
+                  onFormChange({ auth: (e.target as HTMLSelectElement).value as AuthMode })}
+              >
+                ${AUTH_MODES.map(
+                  (a) => html`<option value=${a.value} title=${a.hint} .selected=${form.auth === a.value}>${a.label}</option>`,
+                )}
+              </select>
+            </div>
+          </div>
+
+          <!-- API 密钥 -->
+          ${showApiKey
+            ? html`
+                <div class="mc-field" style="margin-bottom: 16px;">
+                  <label class="mc-field__label">${LABELS.providerApiKey}</label>
+                  <input
+                    type="password"
+                    class="mc-input"
+                    placeholder=${LABELS.providerApiKeyPlaceholder}
+                    .value=${form.apiKey}
+                    @input=${(e: Event) =>
+                      onFormChange({ apiKey: (e.target as HTMLInputElement).value })}
+                  />
+                </div>
+              `
+            : nothing}
+
+          <!-- 错误提示 -->
+          ${props.addError
+            ? html`
+                <div class="cron-error-banner">
+                  ${icons.info}
+                  <span>${props.addError}</span>
+                </div>
+              `
+            : nothing}
+        </div>
+
+        <div class="cron-create-modal__footer">
+          <button class="mc-btn" @click=${handleClose}>
+            ${LABELS.cancel}
+          </button>
+          <button
+            class="mc-btn mc-btn--primary"
+            ?disabled=${!form.name.trim()}
+            @click=${handleSubmit}
+          >
+            ${LABELS.confirm}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染供应商配置内容
+ */
+export function renderProvidersContent(props: ProvidersContentProps) {
+  const providerKeys = Object.keys(props.providers);
+  const onShowAddModal = props.onShowAddModal ?? (() => {});
+
+  // 兼容旧逻辑：如果没有提供 onShowAddModal，则直接调用 onProviderAdd
+  const handleAddClick = () => {
+    if (props.onShowAddModal) {
+      onShowAddModal(true);
+    } else {
+      props.onProviderAdd();
+    }
+  };
+
+  return html`
+    <div class="config-content">
+      <div class="config-content__header">
+        <div class="config-content__icon">${icons.provider}</div>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">${LABELS.providersTitle}</h2>
+          <p class="config-content__desc">${LABELS.providersDesc}</p>
+        </div>
+        <button class="mc-btn mc-btn--primary" @click=${handleAddClick}>
+          ${icons.add}
+          <span>${LABELS.addProvider}</span>
+        </button>
+      </div>
+
+      <!-- 字段说明提示卡 -->
+      <details class="cron-tip-card cron-tip-card--collapsible">
+        <summary class="cron-tip-card__title">
+          ${icons.info}
+          <span>配置说明</span>
+          ${icons.chevron}
+        </summary>
+        <div class="cron-tip-card__content">
+          <div class="cron-tip-card__section">
+            <div class="cron-tip-card__section-title">供应商配置</div>
+            <table class="cron-tip-card__table">
+              <tr>
+                <td class="cron-tip-card__term">API 地址</td>
+                <td class="cron-tip-card__def">供应商的 API 端点 URL，如 <b>https://api.openai.com/v1</b></td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">API 协议</td>
+                <td class="cron-tip-card__def">选择 API 格式：<b>OpenAI</b>（大多数兼容）、<b>Anthropic</b>、<b>Google</b>、<b>Bedrock</b> 等</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">认证方式</td>
+                <td class="cron-tip-card__def"><b>API Key</b>（标准密钥）、<b>AWS SDK</b>（IAM 凭证）、<b>OAuth</b>、<b>Token</b></td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">API 密钥</td>
+                <td class="cron-tip-card__def">填入密钥或使用 <b>\${ENV_VAR}</b> 引用环境变量</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">自定义 Headers</td>
+                <td class="cron-tip-card__def">可选，添加额外请求头（如 <b>x-api-version</b>）</td>
+              </tr>
+            </table>
+          </div>
+          <div class="cron-tip-card__section">
+            <div class="cron-tip-card__section-title">模型配置</div>
+            <table class="cron-tip-card__table">
+              <tr>
+                <td class="cron-tip-card__term">模型 ID</td>
+                <td class="cron-tip-card__def">发送给 API 的模型标识符，如 <b>gpt-4o</b>、<b>claude-3-opus</b></td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">显示名称</td>
+                <td class="cron-tip-card__def">在 UI 中展示的友好名称</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">上下文窗口</td>
+                <td class="cron-tip-card__def">模型支持的最大上下文长度（tokens）</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">最大输出</td>
+                <td class="cron-tip-card__def">单次请求的最大输出 tokens 数</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">输入类型</td>
+                <td class="cron-tip-card__def">模型支持的输入：<b>文本</b>（必选）、<b>图片</b>（多模态）</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">推理模型</td>
+                <td class="cron-tip-card__def">启用后支持 reasoning effort 参数（如 o1/o3 系列）</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">成本配置</td>
+                <td class="cron-tip-card__def">每百万 tokens 的价格（输入/输出/缓存读/缓存写）</td>
+              </tr>
+              <tr>
+                <td class="cron-tip-card__term">兼容性</td>
+                <td class="cron-tip-card__def">API 特性支持：Store、Developer Role、max_tokens 字段名</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </details>
+
+      <div class="config-content__body">
+        ${providerKeys.length === 0
+          ? html`<div class="mc-empty">${LABELS.noProviders}</div>`
+          : html`
+              <div class="mc-providers-grid">
+                ${providerKeys.map((key) =>
+                  renderProviderCard(
+                    key,
+                    props.providers[key],
+                    props.expandedProviders.has(key),
+                    props,
+                  ),
+                )}
+              </div>
+            `}
+      </div>
+
+      <!-- 添加供应商弹窗 -->
+      ${renderAddProviderModal(props)}
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/skills-content.ts
+++ b/ui/src/ui-zh-CN/components/skills-content.ts
@@ -1,0 +1,1324 @@
+/**
+ * 技能管理内容组件
+ * Skills management content component
+ *
+ * 管理技能白名单、启用/禁用、API Key 配置等
+ */
+import { html, nothing } from "lit";
+import type {
+  SkillsContentProps,
+  SkillStatusEntry,
+  SkillStatusReport,
+  SkillSourceFilter,
+  SkillStatusFilter,
+  SkillGroup,
+  SkillMessage,
+  SkillEditState,
+  SkillEditorState,
+  SkillCreateState,
+  SkillDeleteState,
+  EditableSkillSource,
+  SkillEditorMode,
+} from "../types/skills-config";
+
+// ─── 辅助函数 / Helper functions ────────────────────────────────────────────
+
+/**
+ * 按来源分组技能
+ */
+function groupSkillsBySource(skills: SkillStatusEntry[]): SkillGroup[] {
+  const groups: Record<string, SkillStatusEntry[]> = {
+    "openclaw-bundled": [],
+    "openclaw-managed": [],
+    "openclaw-workspace": [],
+  };
+
+  for (const skill of skills) {
+    const source = skill.source || "openclaw-workspace";
+    if (!groups[source]) groups[source] = [];
+    groups[source].push(skill);
+  }
+
+  const result: SkillGroup[] = [];
+  if (groups["openclaw-bundled"].length > 0) {
+    result.push({
+      id: "bundled",
+      label: `内置技能 (${groups["openclaw-bundled"].length})`,
+      skills: groups["openclaw-bundled"],
+    });
+  }
+  if (groups["openclaw-managed"].length > 0) {
+    result.push({
+      id: "managed",
+      label: `本地技能 (${groups["openclaw-managed"].length})`,
+      skills: groups["openclaw-managed"],
+    });
+  }
+  if (groups["openclaw-workspace"].length > 0) {
+    result.push({
+      id: "workspace",
+      label: `工作区技能 (${groups["openclaw-workspace"].length})`,
+      skills: groups["openclaw-workspace"],
+    });
+  }
+  return result;
+}
+
+/**
+ * 过滤技能列表
+ */
+function filterSkills(
+  skills: SkillStatusEntry[],
+  filter: string,
+  sourceFilter: SkillSourceFilter,
+  statusFilter: SkillStatusFilter,
+): SkillStatusEntry[] {
+  let filtered = skills;
+
+  // 文本搜索
+  if (filter.trim()) {
+    const q = filter.trim().toLowerCase();
+    filtered = filtered.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.skillKey.toLowerCase().includes(q),
+    );
+  }
+
+  // 来源过滤
+  if (sourceFilter !== "all") {
+    const sourceMap: Record<string, string> = {
+      bundled: "openclaw-bundled",
+      managed: "openclaw-managed",
+      workspace: "openclaw-workspace",
+    };
+    const targetSource = sourceMap[sourceFilter];
+    if (targetSource) {
+      filtered = filtered.filter((s) => s.source === targetSource);
+    }
+  }
+
+  // 状态过滤
+  if (statusFilter === "eligible") {
+    filtered = filtered.filter((s) => s.eligible);
+  } else if (statusFilter === "blocked") {
+    filtered = filtered.filter((s) => !s.eligible);
+  } else if (statusFilter === "disabled") {
+    filtered = filtered.filter((s) => s.disabled);
+  }
+
+  return filtered;
+}
+
+/**
+ * 将完整来源名称转换为短格式（用于 RPC）
+ * Convert full source name to short format (for RPC)
+ */
+function toShortSource(source: string): EditableSkillSource | null {
+  if (source === "openclaw-managed") return "managed";
+  if (source === "openclaw-workspace") return "workspace";
+  return null;
+}
+
+/**
+ * 截断文本
+ */
+function clampText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + "...";
+}
+
+/**
+ * 高亮搜索文本 (Phase 4)
+ * Highlight search text in content
+ */
+function highlightText(text: string, query: string): ReturnType<typeof html> {
+  if (!query.trim()) return html`${text}`;
+
+  const q = query.trim().toLowerCase();
+  const lowerText = text.toLowerCase();
+  const index = lowerText.indexOf(q);
+
+  if (index === -1) return html`${text}`;
+
+  const before = text.slice(0, index);
+  const match = text.slice(index, index + q.length);
+  const after = text.slice(index + q.length);
+
+  return html`${before}<mark class="skills-highlight">${match}</mark>${after}`;
+}
+
+/**
+ * 计算技能统计 (Phase 4)
+ * Calculate skill statistics
+ */
+function calculateStats(skills: SkillStatusEntry[]) {
+  return {
+    total: skills.length,
+    eligible: skills.filter(s => s.eligible).length,
+    blocked: skills.filter(s => !s.eligible && !s.disabled).length,
+    disabled: skills.filter(s => s.disabled).length,
+    bundled: skills.filter(s => s.source === "openclaw-bundled").length,
+    managed: skills.filter(s => s.source === "openclaw-managed").length,
+    workspace: skills.filter(s => s.source === "openclaw-workspace").length,
+  };
+}
+
+// ─── 技能优先级说明 / Skill priority explanation ────────────────────────────
+
+/**
+ * 渲染技能优先级说明
+ * Render skill priority explanation
+ */
+function renderPriorityExplanation() {
+  return html`
+    <div class="skills-priority-info">
+      <div class="skills-priority-info__header">
+        <span class="skills-priority-info__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"></circle>
+            <line x1="12" y1="16" x2="12" y2="12"></line>
+            <line x1="12" y1="8" x2="12.01" y2="8"></line>
+          </svg>
+        </span>
+        <span class="skills-priority-info__title">技能加载优先级</span>
+      </div>
+      <div class="skills-priority-info__content">
+        <p class="skills-priority-info__desc">
+          当多个来源存在同名技能时，高优先级来源会覆盖低优先级来源的技能定义：
+        </p>
+        <ol class="skills-priority-info__list">
+          <li>
+            <span class="skills-priority-info__source">额外目录</span>
+            <span class="skills-priority-info__priority">最低优先级</span>
+          </li>
+          <li>
+            <span class="skills-priority-info__source">内置技能</span>
+            <span class="skills-priority-info__priority">openclaw-bundled</span>
+          </li>
+          <li>
+            <span class="skills-priority-info__source">本地技能</span>
+            <span class="skills-priority-info__priority">~/.openclaw/skills/</span>
+          </li>
+          <li>
+            <span class="skills-priority-info__source">工作区技能</span>
+            <span class="skills-priority-info__priority skills-priority-info__priority--high">最高优先级</span>
+          </li>
+        </ol>
+        <p class="skills-priority-info__note">
+          例如：如果内置技能和工作区技能都定义了 "git" 技能，Agent 将使用工作区版本。
+        </p>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 主渲染函数 / Main render function ──────────────────────────────────────
+
+export function renderSkillsContent(props: SkillsContentProps) {
+  const skills = props.report?.skills ?? [];
+  const filtered = filterSkills(skills, props.filter, props.sourceFilter, props.statusFilter);
+  const groups = groupSkillsBySource(filtered);
+  const stats = calculateStats(skills);
+
+  return html`
+    <div class="skills-content">
+      <!-- 头部 -->
+      <div class="skills-header">
+        <div class="skills-header__info">
+          <h3 class="skills-title">技能管理</h3>
+          <p class="skills-desc">管理 Agent 可用的技能、白名单和安装配置</p>
+        </div>
+        <div class="skills-header__actions">
+          <!-- 创建技能按钮 -->
+          <button
+            class="mc-btn mc-btn--sm"
+            @click=${() => props.onCreateOpen()}
+          >
+            + 新建技能
+          </button>
+          <button
+            class="mc-btn mc-btn--sm"
+            ?disabled=${props.loading}
+            @click=${props.onRefresh}
+          >
+            ${props.loading ? "加载中..." : "刷新"}
+          </button>
+          ${props.hasChanges
+            ? html`
+                <button
+                  class="mc-btn mc-btn--sm primary"
+                  ?disabled=${props.saving}
+                  @click=${props.onSave}
+                >
+                  ${props.saving ? "保存中..." : "保存配置"}
+                </button>
+              `
+            : nothing}
+        </div>
+      </div>
+
+      <!-- 统计摘要 (Phase 4) -->
+      ${skills.length > 0 ? renderStatsBar(stats) : nothing}
+
+      <!-- 技能优先级说明 -->
+      ${renderPriorityExplanation()}
+
+      <!-- 全局设置 -->
+      ${renderGlobalSettings(props)}
+
+      <!-- 筛选栏 -->
+      ${renderFilterBar(props, skills.length, filtered.length)}
+
+      <!-- 错误提示 -->
+      ${props.error
+        ? html`<div class="skills-error">${props.error}</div>`
+        : nothing}
+
+      <!-- 技能列表 -->
+      ${props.loading && !props.report
+        ? html`<div class="skills-loading">正在加载技能列表...</div>`
+        : groups.length === 0
+          ? html`<div class="skills-empty">没有找到匹配的技能</div>`
+          : groups.map((group) => renderSkillGroup(group, props))}
+    </div>
+
+    <!-- 编辑器弹窗 -->
+    ${props.editorState.open ? renderEditorModal(props) : nothing}
+
+    <!-- 创建技能弹窗 -->
+    ${props.createState.open ? renderCreateModal(props) : nothing}
+
+    <!-- 删除确认弹窗 -->
+    ${props.deleteState.open ? renderDeleteModal(props) : nothing}
+  `;
+}
+
+// ─── 统计摘要 (Phase 4) / Stats bar ─────────────────────────────────────────
+
+type SkillStats = {
+  total: number;
+  eligible: number;
+  blocked: number;
+  disabled: number;
+  bundled: number;
+  managed: number;
+  workspace: number;
+};
+
+function renderStatsBar(stats: SkillStats) {
+  return html`
+    <div class="skills-stats">
+      <div class="skills-stats__item">
+        <span class="skills-stats__value">${stats.total}</span>
+        <span class="skills-stats__label">总计</span>
+      </div>
+      <div class="skills-stats__divider"></div>
+      <div class="skills-stats__item skills-stats__item--ok">
+        <span class="skills-stats__value">${stats.eligible}</span>
+        <span class="skills-stats__label">可用</span>
+      </div>
+      <div class="skills-stats__item skills-stats__item--warn">
+        <span class="skills-stats__value">${stats.blocked}</span>
+        <span class="skills-stats__label">受阻</span>
+      </div>
+      <div class="skills-stats__item skills-stats__item--disabled">
+        <span class="skills-stats__value">${stats.disabled}</span>
+        <span class="skills-stats__label">已禁用</span>
+      </div>
+      <div class="skills-stats__divider"></div>
+      <div class="skills-stats__item">
+        <span class="skills-stats__value">${stats.bundled}</span>
+        <span class="skills-stats__label">内置</span>
+      </div>
+      <div class="skills-stats__item">
+        <span class="skills-stats__value">${stats.managed}</span>
+        <span class="skills-stats__label">本地</span>
+      </div>
+      <div class="skills-stats__item">
+        <span class="skills-stats__value">${stats.workspace}</span>
+        <span class="skills-stats__label">工作区</span>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 全局设置 / Global settings ─────────────────────────────────────────────
+
+function renderGlobalSettings(props: SkillsContentProps) {
+  const extraDirs = props.config?.load?.extraDirs ?? [];
+  const extraDirsText = extraDirs.join("\n");
+
+  return html`
+    <div class="skills-section skills-global-settings">
+      <div class="skills-section__header">
+        <h4 class="skills-section__title">全局设置</h4>
+      </div>
+      <div class="skills-settings-grid">
+        <!-- 白名单模式 -->
+        <div class="skills-setting-item">
+          <div class="skills-setting-item__header">
+            <span class="skills-setting-item__title">内置技能模式</span>
+            <span class="skills-setting-item__desc">控制内置技能的启用方式</span>
+          </div>
+          <div class="skills-radio-group">
+            <label class="skills-radio">
+              <input
+                type="radio"
+                name="allowlist-mode"
+                value="all"
+                .checked=${props.allowlistMode === "all"}
+                @change=${() => props.onAllowlistModeChange("all")}
+              />
+              <span class="skills-radio__mark"></span>
+              <span class="skills-radio__text">允许全部</span>
+            </label>
+            <label class="skills-radio">
+              <input
+                type="radio"
+                name="allowlist-mode"
+                value="whitelist"
+                .checked=${props.allowlistMode === "whitelist"}
+                @change=${() => props.onAllowlistModeChange("whitelist")}
+              />
+              <span class="skills-radio__mark"></span>
+              <span class="skills-radio__text">仅白名单</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- 安装偏好 -->
+        <div class="skills-setting-item">
+          <div class="skills-setting-item__header">
+            <span class="skills-setting-item__title">安装偏好</span>
+            <span class="skills-setting-item__desc">技能依赖的安装方式</span>
+          </div>
+          <select
+            class="skills-select"
+            .value=${props.config?.install?.preferBrew ? "true" : "false"}
+            @change=${(e: Event) => {
+              const value = (e.target as HTMLSelectElement).value === "true";
+              props.onGlobalSettingChange("preferBrew", value);
+            }}
+          >
+            <option value="true">优先使用 Homebrew</option>
+            <option value="false">使用默认方式</option>
+          </select>
+        </div>
+
+        <!-- Node 包管理器 -->
+        <div class="skills-setting-item">
+          <div class="skills-setting-item__header">
+            <span class="skills-setting-item__title">Node 包管理器</span>
+            <span class="skills-setting-item__desc">用于安装 Node.js 技能依赖</span>
+          </div>
+          <select
+            class="skills-select"
+            .value=${props.config?.install?.nodeManager ?? "npm"}
+            @change=${(e: Event) => {
+              const value = (e.target as HTMLSelectElement).value;
+              props.onGlobalSettingChange("nodeManager", value);
+            }}
+          >
+            <option value="npm">npm</option>
+            <option value="pnpm">pnpm</option>
+            <option value="yarn">yarn</option>
+            <option value="bun">bun</option>
+          </select>
+        </div>
+
+        <!-- 文件监视 -->
+        <div class="skills-setting-item">
+          <div class="skills-setting-item__header">
+            <span class="skills-setting-item__title">文件监视</span>
+            <span class="skills-setting-item__desc">自动重载技能文件变更</span>
+          </div>
+          <label class="skills-checkbox">
+            <input
+              type="checkbox"
+              .checked=${props.config?.load?.watch ?? false}
+              @change=${(e: Event) => {
+                const checked = (e.target as HTMLInputElement).checked;
+                props.onGlobalSettingChange("watch", checked);
+              }}
+            />
+            <span class="skills-checkbox__text">启用文件监视</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- 额外技能目录 -->
+      <div class="skills-extra-dirs">
+        <div class="skills-extra-dirs__header">
+          <span class="skills-extra-dirs__title">额外技能目录</span>
+          <span class="skills-extra-dirs__desc">每行一个目录路径</span>
+        </div>
+        <textarea
+          class="skills-extra-dirs__textarea"
+          placeholder="/path/to/skills&#10;/another/skills/dir"
+          .value=${extraDirsText}
+          @change=${(e: Event) => {
+            const text = (e.target as HTMLTextAreaElement).value;
+            const dirs = text
+              .split("\n")
+              .map((d) => d.trim())
+              .filter((d) => d.length > 0);
+            props.onExtraDirsChange(dirs);
+          }}
+        ></textarea>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 筛选栏 / Filter bar ────────────────────────────────────────────────────
+
+function renderFilterBar(props: SkillsContentProps, total: number, shown: number) {
+  return html`
+    <div class="skills-filter">
+      <div class="skills-filter__search">
+        <input
+          type="text"
+          class="skills-filter__input"
+          placeholder="搜索技能..."
+          .value=${props.filter}
+          @input=${(e: Event) =>
+            props.onFilterChange((e.target as HTMLInputElement).value)}
+        />
+      </div>
+      <div class="skills-filter__selects">
+        <select
+          class="skills-filter__select"
+          .value=${props.sourceFilter}
+          @change=${(e: Event) =>
+            props.onSourceFilterChange(
+              (e.target as HTMLSelectElement).value as SkillSourceFilter,
+            )}
+        >
+          <option value="all">全部来源</option>
+          <option value="bundled">内置技能</option>
+          <option value="managed">本地技能</option>
+          <option value="workspace">工作区技能</option>
+        </select>
+        <select
+          class="skills-filter__select"
+          .value=${props.statusFilter}
+          @change=${(e: Event) =>
+            props.onStatusFilterChange(
+              (e.target as HTMLSelectElement).value as SkillStatusFilter,
+            )}
+        >
+          <option value="all">全部状态</option>
+          <option value="eligible">可用</option>
+          <option value="blocked">受阻</option>
+          <option value="disabled">已禁用</option>
+        </select>
+      </div>
+      <div class="skills-filter__count">
+        显示 ${shown} / ${total}
+      </div>
+    </div>
+  `;
+}
+
+// ─── 技能分组 / Skill group ─────────────────────────────────────────────────
+
+function renderSkillGroup(group: SkillGroup, props: SkillsContentProps) {
+  const isExpanded = props.expandedGroups.has(group.id);
+
+  return html`
+    <div class="skills-group ${isExpanded ? "skills-group--expanded" : ""}">
+      <div
+        class="skills-group__header"
+        @click=${() => props.onGroupToggle(group.id)}
+      >
+        <span class="skills-group__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="${isExpanded ? "6 9 12 15 18 9" : "9 6 15 12 9 18"}"></polyline>
+          </svg>
+        </span>
+        <span class="skills-group__label">${group.label}</span>
+      </div>
+      ${isExpanded
+        ? html`
+            <div class="skills-group__body">
+              ${group.skills.map((skill) => renderSkillItem(skill, props))}
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+// ─── 技能条目 / Skill item ──────────────────────────────────────────────────
+
+function renderSkillItem(skill: SkillStatusEntry, props: SkillsContentProps) {
+  const isBusy = props.busySkill === skill.skillKey;
+  const message = props.messages[skill.skillKey];
+  const edit = props.edits[skill.skillKey];
+  const isBundled = skill.source === "openclaw-bundled";
+  const isEditable = skill.source === "openclaw-managed" || skill.source === "openclaw-workspace";
+  const inAllowlist = edit?.inAllowlist ?? props.allowlistDraft.has(skill.skillKey);
+  const canInstall = skill.install.length > 0 && skill.missing.bins.length > 0;
+  const isSelected = props.selectedSkill === skill.skillKey;
+
+  // 缺失项
+  const missing = [
+    ...skill.missing.bins.map((b) => `bin:${b}`),
+    ...skill.missing.anyBins.map((b) => `anyBin:${b}`),
+    ...skill.missing.env.map((e) => `env:${e}`),
+    ...skill.missing.config.map((c) => `config:${c}`),
+    ...skill.missing.os.map((o) => `os:${o}`),
+  ];
+
+  // 状态原因
+  const reasons: string[] = [];
+  if (skill.disabled) reasons.push("已禁用");
+  if (skill.blockedByAllowlist) reasons.push("被白名单阻止");
+
+  // 检查是否有额外环境变量需要配置
+  const hasExtraEnv = (skill.requirements?.env ?? []).filter(e => e !== skill.primaryEnv).length > 0;
+
+  return html`
+    <div
+      class="skills-item ${skill.eligible ? "skills-item--eligible" : "skills-item--blocked"} ${skill.disabled ? "skills-item--disabled" : ""} ${isSelected ? "skills-item--expanded" : ""}"
+    >
+      <div class="skills-item__main">
+        <div class="skills-item__header">
+          <span class="skills-item__name">
+            ${skill.emoji ? `${skill.emoji} ` : ""}${highlightText(skill.name, props.filter)}
+          </span>
+          ${isBundled && props.allowlistMode === "whitelist"
+            ? html`
+                <label class="skills-allowlist-toggle" title="加入白名单">
+                  <input
+                    type="checkbox"
+                    .checked=${inAllowlist}
+                    @change=${(e: Event) => {
+                      const checked = (e.target as HTMLInputElement).checked;
+                      props.onAllowlistToggle(skill.skillKey, checked);
+                    }}
+                  />
+                  <span class="skills-allowlist-toggle__icon">
+                    ${inAllowlist ? "✓" : ""}
+                  </span>
+                </label>
+              `
+            : nothing}
+          <!-- 展开/折叠按钮 -->
+          <button
+            class="mc-icon-btn skills-item__expand-btn"
+            title="${isSelected ? "收起详情" : "展开详情"}"
+            @click=${() => props.onSkillSelect(isSelected ? null : skill.skillKey)}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="${isSelected ? "18 15 12 9 6 15" : "6 9 12 15 18 9"}"></polyline>
+            </svg>
+          </button>
+        </div>
+        <div class="skills-item__desc">${highlightText(clampText(skill.description, 120), props.filter)}</div>
+        <div class="skills-item__chips">
+          <span class="skills-chip">${skill.source}</span>
+          <span class="skills-chip ${skill.eligible ? "skills-chip--ok" : "skills-chip--warn"}">
+            ${skill.eligible ? "可用" : "受阻"}
+          </span>
+          ${skill.disabled
+            ? html`<span class="skills-chip skills-chip--warn">已禁用</span>`
+            : nothing}
+        </div>
+        ${missing.length > 0
+          ? html`
+              <div class="skills-item__missing">
+                缺失: ${missing.join(", ")}
+              </div>
+            `
+          : nothing}
+        ${reasons.length > 0
+          ? html`
+              <div class="skills-item__reasons">
+                原因: ${reasons.join(", ")}
+              </div>
+            `
+          : nothing}
+      </div>
+
+      <div class="skills-item__actions">
+        <!-- 启用/禁用按钮 -->
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${isBusy}
+          @click=${() => props.onSkillToggle(skill.skillKey, skill.disabled)}
+        >
+          ${skill.disabled ? "启用" : "禁用"}
+        </button>
+
+        <!-- 安装按钮 -->
+        ${canInstall
+          ? html`
+              <button
+                class="mc-btn mc-btn--sm"
+                ?disabled=${isBusy}
+                @click=${() =>
+                  props.onInstall(skill.skillKey, skill.name, skill.install[0].id)}
+              >
+                ${isBusy ? "安装中..." : skill.install[0].label}
+              </button>
+            `
+          : nothing}
+
+        <!-- 编辑按钮（仅 managed 和 workspace 技能）-->
+        ${isEditable
+          ? html`
+              <button
+                class="mc-btn mc-btn--sm"
+                ?disabled=${isBusy}
+                @click=${() =>
+                  props.onEditorOpen(
+                    skill.skillKey,
+                    skill.name,
+                    toShortSource(skill.source) as EditableSkillSource
+                  )}
+              >
+                编辑
+              </button>
+              <button
+                class="mc-btn mc-btn--sm mc-btn--danger"
+                ?disabled=${isBusy}
+                @click=${() =>
+                  props.onDeleteOpen(
+                    skill.skillKey,
+                    skill.name,
+                    toShortSource(skill.source) as EditableSkillSource
+                  )}
+              >
+                删除
+              </button>
+            `
+          : nothing}
+
+        <!-- 消息提示 -->
+        ${message ? renderSkillMessage(message) : nothing}
+
+        <!-- 安装进度指示器 (Phase 4) -->
+        ${isBusy && canInstall ? renderInstallProgress(skill.name) : nothing}
+
+        <!-- API Key 输入 -->
+        ${skill.primaryEnv ? renderApiKeyInput(skill, props, isBusy) : nothing}
+      </div>
+
+      <!-- 展开区域：环境变量和配置编辑器 -->
+      ${isSelected
+        ? html`
+            <div class="skills-item__details">
+              <!-- 基本信息 -->
+              <div class="skills-detail-section">
+                <div class="skills-detail-section__title">基本信息</div>
+                <div class="skills-detail-info">
+                  <div class="skills-detail-row">
+                    <span class="skills-detail-label">技能键:</span>
+                    <span class="skills-detail-value mono">${skill.skillKey}</span>
+                  </div>
+                  <div class="skills-detail-row">
+                    <span class="skills-detail-label">路径:</span>
+                    <span class="skills-detail-value mono">${clampText(skill.filePath, 60)}</span>
+                  </div>
+                  ${skill.homepage
+                    ? html`
+                        <div class="skills-detail-row">
+                          <span class="skills-detail-label">主页:</span>
+                          <a class="skills-detail-link" href="${skill.homepage}" target="_blank" rel="noreferrer">
+                            ${skill.homepage}
+                          </a>
+                        </div>
+                      `
+                    : nothing}
+                  <!-- SKILL.md 文档链接 (Phase 4) -->
+                  ${skill.filePath ? renderSkillDocsLink(skill.filePath) : nothing}
+                </div>
+              </div>
+
+              <!-- 环境变量编辑器 -->
+              ${hasExtraEnv ? renderEnvEditor(skill, props) : nothing}
+
+              <!-- 自定义配置编辑器 -->
+              ${renderConfigEditor(skill, props)}
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+// ─── 消息提示 / Message display ─────────────────────────────────────────────
+
+function renderSkillMessage(message: SkillMessage) {
+  return html`
+    <div
+      class="skills-message ${message.kind === "error" ? "skills-message--error" : "skills-message--success"}"
+    >
+      ${message.message}
+    </div>
+  `;
+}
+
+// ─── 安装进度指示器 (Phase 4) / Installation progress indicator ─────────────
+
+function renderInstallProgress(skillName: string) {
+  return html`
+    <div class="skills-progress">
+      <div class="skills-progress__header">
+        <span class="skills-progress__title">正在安装 ${skillName}</span>
+        <span class="skills-progress__status">请稍候...</span>
+      </div>
+      <div class="skills-progress__bar">
+        <div class="skills-progress__fill skills-progress__fill--indeterminate"></div>
+      </div>
+      <div class="skills-progress__message">
+        正在下载并安装依赖项，这可能需要几分钟时间...
+      </div>
+    </div>
+  `;
+}
+
+// ─── SKILL.md 文档预览 (Phase 4) / SKILL.md document preview ────────────────
+
+function renderSkillDocsLink(filePath: string) {
+  // 计算 SKILL.md 路径（与技能文件同目录）
+  const dirPath = filePath.replace(/\/[^/]+$/, "");
+  const skillMdPath = `${dirPath}/SKILL.md`;
+
+  return html`
+    <div class="skills-detail-row">
+      <span class="skills-detail-label">文档:</span>
+      <span class="skills-detail-value">
+        <a class="skills-docs-preview__link" href="file://${skillMdPath}" target="_blank" rel="noreferrer" title="查看 SKILL.md">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+            <line x1="16" y1="13" x2="8" y2="13"></line>
+            <line x1="16" y1="17" x2="8" y2="17"></line>
+            <polyline points="10 9 9 9 8 9"></polyline>
+          </svg>
+          SKILL.md
+        </a>
+      </span>
+    </div>
+  `;
+}
+
+// ─── API Key 输入 / API Key input ───────────────────────────────────────────
+
+function renderApiKeyInput(
+  skill: SkillStatusEntry,
+  props: SkillsContentProps,
+  isBusy: boolean,
+) {
+  const edit = props.edits[skill.skillKey];
+  const apiKey = edit?.apiKey ?? "";
+
+  return html`
+    <div class="skills-apikey">
+      <label class="skills-apikey__label">${skill.primaryEnv}</label>
+      <div class="skills-apikey__row">
+        <input
+          type="password"
+          class="skills-apikey__input"
+          placeholder="输入 API Key"
+          .value=${apiKey}
+          @input=${(e: Event) =>
+            props.onSkillApiKeyChange(
+              skill.skillKey,
+              (e.target as HTMLInputElement).value,
+            )}
+        />
+        <button
+          class="mc-btn mc-btn--sm primary"
+          ?disabled=${isBusy || !apiKey.trim()}
+          @click=${() => props.onSkillApiKeySave(skill.skillKey)}
+        >
+          保存
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 环境变量编辑器 / Environment variable editor ────────────────────────────
+
+function renderEnvEditor(
+  skill: SkillStatusEntry,
+  props: SkillsContentProps,
+) {
+  const edit = props.edits[skill.skillKey];
+  const envEntries = Object.entries(edit?.env ?? {});
+  const requiredEnvs = skill.requirements?.env ?? [];
+
+  // 合并已有环境变量和需求环境变量
+  const allEnvKeys = new Set([
+    ...requiredEnvs,
+    ...envEntries.map(([k]) => k),
+  ]);
+
+  // 过滤掉 primaryEnv（已在 API Key 输入中处理）
+  const otherEnvKeys = [...allEnvKeys].filter(k => k !== skill.primaryEnv);
+
+  if (otherEnvKeys.length === 0) return nothing;
+
+  return html`
+    <div class="skills-env-editor">
+      <div class="skills-env-editor__header">
+        <span class="skills-env-editor__title">环境变量</span>
+      </div>
+      <div class="skills-env-editor__list">
+        ${otherEnvKeys.map((envKey) => {
+          const value = edit?.env?.[envKey] ?? "";
+          const isRequired = requiredEnvs.includes(envKey);
+          const isMissing = skill.missing?.env?.includes(envKey);
+
+          return html`
+            <div class="skills-env-row ${isMissing ? "skills-env-row--missing" : ""}">
+              <div class="skills-env-row__key">
+                <span class="skills-env-row__label">${envKey}</span>
+                ${isRequired
+                  ? html`<span class="skills-env-row__badge">必需</span>`
+                  : nothing}
+              </div>
+              <div class="skills-env-row__value">
+                <input
+                  type="password"
+                  class="skills-env-row__input"
+                  placeholder="输入值..."
+                  .value=${value}
+                  @input=${(e: Event) =>
+                    props.onSkillEnvChange(
+                      skill.skillKey,
+                      envKey,
+                      (e.target as HTMLInputElement).value,
+                    )}
+                />
+                ${!isRequired
+                  ? html`
+                      <button
+                        class="mc-icon-btn mc-icon-btn--danger"
+                        title="移除"
+                        @click=${() => props.onSkillEnvRemove(skill.skillKey, envKey)}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <line x1="18" y1="6" x2="6" y2="18"></line>
+                          <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
+                      </button>
+                    `
+                  : nothing}
+              </div>
+            </div>
+          `;
+        })}
+      </div>
+    </div>
+  `;
+}
+
+// ─── 自定义配置编辑器 / Custom config editor ─────────────────────────────────
+
+function renderConfigEditor(
+  skill: SkillStatusEntry,
+  props: SkillsContentProps,
+) {
+  const edit = props.edits[skill.skillKey];
+  const configJson = edit?.config
+    ? JSON.stringify(edit.config, null, 2)
+    : "{}";
+
+  return html`
+    <div class="skills-config-editor">
+      <div class="skills-config-editor__header">
+        <span class="skills-config-editor__title">自定义配置</span>
+        <span class="skills-config-editor__hint">JSON 格式</span>
+      </div>
+      <textarea
+        class="skills-config-editor__textarea"
+        placeholder='{"key": "value"}'
+        .value=${configJson}
+        @change=${(e: Event) => {
+          const text = (e.target as HTMLTextAreaElement).value;
+          try {
+            const parsed = JSON.parse(text);
+            props.onSkillConfigChange(skill.skillKey, parsed);
+          } catch {
+            // 忽略无效 JSON
+          }
+        }}
+      ></textarea>
+    </div>
+  `;
+}
+
+// =========================================================================
+// 弹窗组件 / Modal components (Phase 5-6)
+// =========================================================================
+
+// ─── 编辑器弹窗 / Editor modal ───────────────────────────────────────────────
+
+/**
+ * 渲染技能编辑器弹窗
+ * Render skill editor modal
+ */
+function renderEditorModal(props: SkillsContentProps) {
+  const { editorState } = props;
+  const hasChanges = editorState.content !== editorState.original;
+
+  return html`
+    <div class="skills-modal-overlay" @click=${props.onEditorClose}>
+      <div class="skills-modal skills-editor-modal" @click=${(e: Event) => e.stopPropagation()}>
+        <!-- 弹窗头部 -->
+        <div class="skills-modal__header">
+          <div class="skills-modal__title">
+            <span class="skills-modal__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+              </svg>
+            </span>
+            编辑技能: ${editorState.skillName}
+          </div>
+          <button class="skills-modal__close" @click=${props.onEditorClose}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+
+        <!-- 工具栏 -->
+        <div class="skills-editor__toolbar">
+          <div class="skills-editor__mode-tabs">
+            <button
+              class="skills-editor__mode-tab ${editorState.mode === "edit" ? "active" : ""}"
+              @click=${() => props.onEditorModeChange("edit")}
+            >
+              编辑
+            </button>
+            <button
+              class="skills-editor__mode-tab ${editorState.mode === "preview" ? "active" : ""}"
+              @click=${() => props.onEditorModeChange("preview")}
+            >
+              预览
+            </button>
+            <button
+              class="skills-editor__mode-tab ${editorState.mode === "split" ? "active" : ""}"
+              @click=${() => props.onEditorModeChange("split")}
+            >
+              分屏
+            </button>
+          </div>
+          <div class="skills-editor__info">
+            <span class="skills-editor__source">${editorState.source}</span>
+            ${hasChanges ? html`<span class="skills-editor__dirty">未保存</span>` : nothing}
+          </div>
+        </div>
+
+        <!-- 编辑器内容 -->
+        <div class="skills-modal__body skills-editor__body">
+          ${editorState.loading
+            ? html`<div class="skills-editor__loading">加载中...</div>`
+            : editorState.error
+              ? html`<div class="skills-editor__error">${editorState.error}</div>`
+              : renderEditorContent(props)}
+        </div>
+
+        <!-- 底部按钮 -->
+        <div class="skills-modal__footer">
+          <button class="mc-btn" @click=${props.onEditorClose}>
+            取消
+          </button>
+          <button
+            class="mc-btn primary"
+            ?disabled=${editorState.saving || !hasChanges}
+            @click=${props.onEditorSave}
+          >
+            ${editorState.saving ? "保存中..." : "保存更改"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * 渲染编辑器内容区域（根据模式）
+ * Render editor content area (based on mode)
+ */
+function renderEditorContent(props: SkillsContentProps) {
+  const { editorState } = props;
+
+  switch (editorState.mode) {
+    case "edit":
+      return html`
+        <div class="skills-editor__pane skills-editor__pane--full">
+          <textarea
+            class="skills-editor__textarea"
+            .value=${editorState.content}
+            @input=${(e: Event) =>
+              props.onEditorContentChange((e.target as HTMLTextAreaElement).value)}
+            placeholder="# 技能名称\n\n在此编写技能说明..."
+          ></textarea>
+        </div>
+      `;
+    case "preview":
+      return html`
+        <div class="skills-editor__pane skills-editor__pane--full skills-editor__preview">
+          ${renderMarkdownPreview(editorState.content)}
+        </div>
+      `;
+    case "split":
+      return html`
+        <div class="skills-editor__split">
+          <div class="skills-editor__pane">
+            <textarea
+              class="skills-editor__textarea"
+              .value=${editorState.content}
+              @input=${(e: Event) =>
+                props.onEditorContentChange((e.target as HTMLTextAreaElement).value)}
+              placeholder="# 技能名称\n\n在此编写技能说明..."
+            ></textarea>
+          </div>
+          <div class="skills-editor__divider"></div>
+          <div class="skills-editor__pane skills-editor__preview">
+            ${renderMarkdownPreview(editorState.content)}
+          </div>
+        </div>
+      `;
+    default:
+      return nothing;
+  }
+}
+
+/**
+ * 简单的 Markdown 预览（仅处理基本格式）
+ * Simple markdown preview (basic formatting only)
+ */
+function renderMarkdownPreview(content: string) {
+  // 简单处理：将内容按行分割，处理标题和代码块
+  const lines = content.split("\n");
+  const elements: ReturnType<typeof html>[] = [];
+  let inCodeBlock = false;
+  let codeContent = "";
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      if (inCodeBlock) {
+        elements.push(html`<pre class="skills-preview__code">${codeContent}</pre>`);
+        codeContent = "";
+        inCodeBlock = false;
+      } else {
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeContent += line + "\n";
+      continue;
+    }
+
+    if (line.startsWith("### ")) {
+      elements.push(html`<h4 class="skills-preview__h4">${line.slice(4)}</h4>`);
+    } else if (line.startsWith("## ")) {
+      elements.push(html`<h3 class="skills-preview__h3">${line.slice(3)}</h3>`);
+    } else if (line.startsWith("# ")) {
+      elements.push(html`<h2 class="skills-preview__h2">${line.slice(2)}</h2>`);
+    } else if (line.startsWith("---")) {
+      elements.push(html`<hr class="skills-preview__hr" />`);
+    } else if (line.startsWith("- ")) {
+      elements.push(html`<li class="skills-preview__li">${line.slice(2)}</li>`);
+    } else if (line.trim()) {
+      elements.push(html`<p class="skills-preview__p">${line}</p>`);
+    }
+  }
+
+  return html`<div class="skills-preview__content">${elements}</div>`;
+}
+
+// ─── 创建技能弹窗 / Create skill modal ───────────────────────────────────────
+
+/**
+ * 渲染创建技能弹窗
+ * Render create skill modal
+ */
+function renderCreateModal(props: SkillsContentProps) {
+  const { createState } = props;
+
+  return html`
+    <div class="skills-modal-overlay" @click=${props.onCreateClose}>
+      <div class="skills-modal skills-create-modal" @click=${(e: Event) => e.stopPropagation()}>
+        <!-- 弹窗头部 -->
+        <div class="skills-modal__header">
+          <div class="skills-modal__title">
+            <span class="skills-modal__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="12" y1="8" x2="12" y2="16"></line>
+                <line x1="8" y1="12" x2="16" y2="12"></line>
+              </svg>
+            </span>
+            新建技能
+          </div>
+          <button class="skills-modal__close" @click=${props.onCreateClose}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+
+        <!-- 弹窗内容 -->
+        <div class="skills-modal__body">
+          ${createState.error
+            ? html`<div class="skills-create__error">${createState.error}</div>`
+            : nothing}
+
+          <div class="skills-create__field">
+            <label class="skills-create__label">技能名称</label>
+            <input
+              type="text"
+              class="skills-create__input ${createState.nameError ? "error" : ""}"
+              placeholder="my-skill"
+              .value=${createState.name}
+              @input=${(e: Event) =>
+                props.onCreateNameChange((e.target as HTMLInputElement).value)}
+            />
+            ${createState.nameError
+              ? html`<div class="skills-create__field-error">${createState.nameError}</div>`
+              : html`<div class="skills-create__hint">仅允许小写字母、数字和连字符</div>`}
+          </div>
+
+          <div class="skills-create__field">
+            <label class="skills-create__label">创建位置</label>
+            <div class="skills-create__radio-group">
+              <label class="skills-create__radio">
+                <input
+                  type="radio"
+                  name="create-source"
+                  value="workspace"
+                  .checked=${createState.source === "workspace"}
+                  @change=${() => props.onCreateSourceChange("workspace")}
+                />
+                <span class="skills-create__radio-mark"></span>
+                <span class="skills-create__radio-text">
+                  <strong>工作区技能</strong>
+                  <small>仅当前项目可用</small>
+                </span>
+              </label>
+              <label class="skills-create__radio">
+                <input
+                  type="radio"
+                  name="create-source"
+                  value="managed"
+                  .checked=${createState.source === "managed"}
+                  @change=${() => props.onCreateSourceChange("managed")}
+                />
+                <span class="skills-create__radio-mark"></span>
+                <span class="skills-create__radio-text">
+                  <strong>本地技能</strong>
+                  <small>所有项目可用</small>
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <!-- 底部按钮 -->
+        <div class="skills-modal__footer">
+          <button class="mc-btn" @click=${props.onCreateClose}>
+            取消
+          </button>
+          <button
+            class="mc-btn primary"
+            ?disabled=${createState.creating || !!createState.nameError || !createState.name.trim()}
+            @click=${props.onCreateConfirm}
+          >
+            ${createState.creating ? "创建中..." : "创建技能"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 删除确认弹窗 / Delete confirmation modal ────────────────────────────────
+
+/**
+ * 渲染删除确认弹窗
+ * Render delete confirmation modal
+ */
+function renderDeleteModal(props: SkillsContentProps) {
+  const { deleteState } = props;
+
+  return html`
+    <div class="skills-modal-overlay" @click=${props.onDeleteClose}>
+      <div class="skills-modal skills-delete-modal" @click=${(e: Event) => e.stopPropagation()}>
+        <!-- 弹窗头部 -->
+        <div class="skills-modal__header skills-modal__header--danger">
+          <div class="skills-modal__title">
+            <span class="skills-modal__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="3 6 5 6 21 6"></polyline>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                <line x1="10" y1="11" x2="10" y2="17"></line>
+                <line x1="14" y1="11" x2="14" y2="17"></line>
+              </svg>
+            </span>
+            删除技能
+          </div>
+          <button class="skills-modal__close" @click=${props.onDeleteClose}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+
+        <!-- 弹窗内容 -->
+        <div class="skills-modal__body">
+          ${deleteState.error
+            ? html`<div class="skills-delete__error">${deleteState.error}</div>`
+            : nothing}
+
+          <div class="skills-delete__warning">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+              <line x1="12" y1="9" x2="12" y2="13"></line>
+              <line x1="12" y1="17" x2="12.01" y2="17"></line>
+            </svg>
+            <span>此操作不可撤销</span>
+          </div>
+
+          <p class="skills-delete__message">
+            确定要删除技能 <strong>${deleteState.skillName}</strong> 吗？
+          </p>
+          <p class="skills-delete__info">
+            技能目录及其所有文件将被永久删除。
+          </p>
+        </div>
+
+        <!-- 底部按钮 -->
+        <div class="skills-modal__footer">
+          <button class="mc-btn" @click=${props.onDeleteClose}>
+            取消
+          </button>
+          <button
+            class="mc-btn mc-btn--danger"
+            ?disabled=${deleteState.deleting}
+            @click=${props.onDeleteConfirm}
+          >
+            ${deleteState.deleting ? "删除中..." : "确认删除"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/components/workspace-content.ts
+++ b/ui/src/ui-zh-CN/components/workspace-content.ts
@@ -1,0 +1,639 @@
+/**
+ * 工作区文件管理内容组件
+ * Workspace file management content component
+ *
+ * 右侧面板 - 文件列表 + 编辑器 + 预览
+ * Right panel - File list + Editor + Preview
+ */
+import { html, nothing } from "lit";
+
+// ─── 类型定义 / Types ──────────────────────────────────────────────────────
+
+/** 工作区文件信息 / Workspace file info */
+export type WorkspaceFileInfo = {
+  name: string;
+  path: string;
+  exists: boolean;
+  size: number;
+  modifiedAt: number | null;
+};
+
+/** Agent 选项 / Agent option */
+export type WorkspaceAgentOption = {
+  id: string;
+  name?: string;
+  default?: boolean;
+};
+
+/** 组件属性 / Component props */
+export type WorkspaceContentProps = {
+  /** 文件列表 / File list */
+  files: WorkspaceFileInfo[];
+  /** 当前工作区目录 / Current workspace directory */
+  workspaceDir: string;
+  /** 当前 Agent ID */
+  agentId: string;
+  /** 可用的 Agent 列表 / Available agents */
+  agents: WorkspaceAgentOption[];
+  /** 当前选中的文件名 / Currently selected file name */
+  selectedFile: string | null;
+  /** 编辑器内容 / Editor content */
+  editorContent: string;
+  /** 原始内容（用于变更检测）/ Original content (for change detection) */
+  originalContent: string;
+  /** 是否正在加载 / Loading state */
+  loading: boolean;
+  /** 是否正在保存 / Saving state */
+  saving: boolean;
+  /** 错误信息 / Error message */
+  error: string | null;
+  /** 编辑模式：edit=编辑, preview=预览, split=分屏 / Editor mode */
+  editorMode: "edit" | "preview" | "split";
+  /** 展开的文件夹集合 / Set of expanded folders */
+  expandedFolders?: Set<string>;
+
+  // 回调函数 / Callbacks
+  /** 选择文件 / Select file */
+  onFileSelect: (fileName: string) => void;
+  /** 编辑器内容变更 / Editor content changed */
+  onContentChange: (content: string) => void;
+  /** 保存文件 / Save file */
+  onFileSave: () => void;
+  /** 刷新文件列表 / Refresh file list */
+  onRefresh: () => void;
+  /** 切换编辑模式 / Toggle editor mode */
+  onModeChange: (mode: "edit" | "preview" | "split") => void;
+  /** 创建新文件 / Create new file */
+  onFileCreate: (fileName: string) => void;
+  /** 切换文件夹展开状态 / Toggle folder expansion */
+  onFolderToggle?: (folderName: string) => void;
+  /** 切换 Agent / Switch agent */
+  onAgentChange?: (agentId: string) => void;
+};
+
+// ─── SVG 图标 / Icons ──────────────────────────────────────────────────────
+
+const icons = {
+  // 文件夹图标 / Folder icon
+  folder: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>`,
+  // 文件图标 / File icon
+  file: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>`,
+  // 编辑图标 / Edit icon
+  edit: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>`,
+  // 预览图标 / Eye icon
+  eye: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>`,
+  // 分屏图标 / Split icon
+  split: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="12" y1="3" x2="12" y2="21"></line></svg>`,
+  // 保存图标 / Save icon
+  save: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>`,
+  // 刷新图标 / Refresh icon
+  refresh: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>`,
+  // 加号图标 / Plus icon
+  plus: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`,
+  // 展开箭头 / Chevron right (collapsed)
+  chevronRight: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>`,
+  // 收起箭头 / Chevron down (expanded)
+  chevronDown: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>`,
+};
+
+// ─── 中文标签 / Labels ──────────────────────────────────────────────────────
+
+const LABELS = {
+  title: "工作区文件",
+  desc: "管理 Agent 的提示词、身份和记忆文件",
+  filesTitle: "文件列表",
+  editorTitle: "文件编辑器",
+  previewTitle: "预览",
+  noFileSelected: "请从左侧选择一个文件",
+  fileNotExist: "文件不存在，保存后将创建",
+  loading: "加载中...",
+  saving: "保存中...",
+  save: "保存",
+  refresh: "刷新",
+  create: "创建",
+  editMode: "编辑",
+  previewMode: "预览",
+  splitMode: "分屏",
+  unsaved: "未保存",
+  path: "路径",
+  size: "大小",
+  modified: "修改时间",
+  workspaceDir: "工作区目录",
+};
+
+// ─── 文件描述映射 / File description map ────────────────────────────────────
+
+const FILE_DESCRIPTIONS: Record<string, string> = {
+  "SOUL.md": "人格定义 - 行为准则、语气风格、道德边界",
+  "IDENTITY.md": "身份信息 - 名称、表情、头像、类型",
+  "TOOLS.md": "工具说明 - 可用工具的使用文档",
+  "USER.md": "用户身份 - 用户的上下文信息",
+  "HEARTBEAT.md": "心跳消息 - 周期性提醒内容",
+  "BOOTSTRAP.md": "引导文件 - 启动时加载的初始内容",
+  "MEMORY.md": "持久记忆 - Agent 的长期记忆",
+  "memory.md": "持久记忆 (小写) - Agent 的长期记忆",
+  "AGENTS.md": "Agent 配置 - 多 Agent 协作设置",
+};
+
+/**
+ * 获取文件描述，支持 memory/ 目录下的日期文件
+ * Get file description, supports dated files in memory/ directory
+ */
+function getFileDescription(fileName: string): string {
+  // Check static descriptions first
+  if (FILE_DESCRIPTIONS[fileName]) {
+    return FILE_DESCRIPTIONS[fileName];
+  }
+
+  // Handle memory/ directory files (memory/YYYY-MM-DD.md)
+  if (fileName.startsWith("memory/")) {
+    const dateMatch = fileName.match(/^memory\/(\d{4})-(\d{2})-(\d{2})\.md$/);
+    if (dateMatch) {
+      const [, year, month, day] = dateMatch;
+      return `每日日志 - ${year}年${month}月${day}日的记录`;
+    }
+    return "每日日志 - 日期记录文件";
+  }
+
+  return "";
+}
+
+// ─── 辅助函数 / Helpers ─────────────────────────────────────────────────────
+
+/** 格式化文件大小 / Format file size */
+function formatSize(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** 格式化时间 / Format time */
+function formatTime(ts: number | null): string {
+  if (!ts) return "-";
+  const d = new Date(ts);
+  return d.toLocaleString("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * 简易 Markdown → HTML 渲染
+ * Simple Markdown to HTML renderer
+ * 支持标题、粗体、斜体、代码块、列表
+ */
+function renderMarkdownToHtml(md: string): string {
+  if (!md) return '<p class="ws-preview__empty">文件为空</p>';
+
+  let result = md
+    // 转义 HTML / Escape HTML
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  // 代码块 / Code blocks
+  result = result.replace(
+    /```(\w*)\n([\s\S]*?)```/g,
+    '<pre class="ws-preview__code"><code>$2</code></pre>',
+  );
+
+  // 行内代码 / Inline code
+  result = result.replace(/`([^`]+)`/g, '<code class="ws-preview__inline-code">$1</code>');
+
+  // 标题 / Headings
+  result = result.replace(/^### (.+)$/gm, '<h3 class="ws-preview__h3">$1</h3>');
+  result = result.replace(/^## (.+)$/gm, '<h2 class="ws-preview__h2">$1</h2>');
+  result = result.replace(/^# (.+)$/gm, '<h1 class="ws-preview__h1">$1</h1>');
+
+  // 粗体和斜体 / Bold and italic
+  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
+
+  // 无序列表 / Unordered lists
+  result = result.replace(/^[-*] (.+)$/gm, '<li class="ws-preview__li">$1</li>');
+
+  // 水平线 / Horizontal rule
+  result = result.replace(/^---$/gm, '<hr class="ws-preview__hr">');
+
+  // 段落 / Paragraphs (lines that are not already wrapped)
+  const lines = result.split("\n");
+  const processed: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (
+      !trimmed ||
+      trimmed.startsWith("<h") ||
+      trimmed.startsWith("<pre") ||
+      trimmed.startsWith("<li") ||
+      trimmed.startsWith("<hr") ||
+      trimmed.startsWith("</")
+    ) {
+      processed.push(line);
+    } else {
+      processed.push(`<p class="ws-preview__p">${line}</p>`);
+    }
+  }
+
+  return processed.join("\n");
+}
+
+// ─── 文件分组 / Group files by directory ──────────────────────────────────
+
+type FileGroup = {
+  /** 文件夹名称（null 表示根目录）/ Folder name (null = root) */
+  folder: string | null;
+  /** 文件夹描述 / Folder description */
+  desc: string;
+  /** 文件列表 / File list */
+  files: WorkspaceFileInfo[];
+};
+
+const FOLDER_DESCRIPTIONS: Record<string, string> = {
+  memory: "每日日志 - 按日期存放的记录文件",
+};
+
+/**
+ * 将文件列表按目录分组
+ * Group file list by directory
+ */
+function groupFilesByFolder(files: WorkspaceFileInfo[]): FileGroup[] {
+  const rootFiles: WorkspaceFileInfo[] = [];
+  const folderMap = new Map<string, WorkspaceFileInfo[]>();
+
+  for (const file of files) {
+    const slashIdx = file.name.indexOf("/");
+    if (slashIdx === -1) {
+      rootFiles.push(file);
+    } else {
+      const folder = file.name.slice(0, slashIdx);
+      if (!folderMap.has(folder)) {
+        folderMap.set(folder, []);
+      }
+      folderMap.get(folder)!.push(file);
+    }
+  }
+
+  const groups: FileGroup[] = [];
+
+  // Root files first / 根目录文件优先
+  if (rootFiles.length > 0) {
+    groups.push({ folder: null, desc: "", files: rootFiles });
+  }
+
+  // Then folders / 然后是文件夹
+  for (const [folder, folderFiles] of folderMap) {
+    groups.push({
+      folder,
+      desc: FOLDER_DESCRIPTIONS[folder] ?? "",
+      files: folderFiles,
+    });
+  }
+
+  return groups;
+}
+
+// ─── 渲染单个文件项 / Render single file item ──────────────────────────────
+
+function renderFileItem(
+  file: WorkspaceFileInfo,
+  props: WorkspaceContentProps,
+  hasChanges: boolean,
+  indent = false,
+) {
+  const isSelected = props.selectedFile === file.name;
+  const desc = getFileDescription(file.name);
+  // For indented items, only show the base name / 缩进项只显示基础文件名
+  const displayName = indent && file.name.includes("/")
+    ? file.name.slice(file.name.lastIndexOf("/") + 1)
+    : file.name;
+
+  return html`
+    <button
+      class="ws-file-item ${isSelected ? "ws-file-item--active" : ""} ${!file.exists ? "ws-file-item--missing" : ""} ${indent ? "ws-file-item--indent" : ""}"
+      @click=${() => props.onFileSelect(file.name)}
+      title=${file.path}
+    >
+      <span class="ws-file-item__icon">${icons.file}</span>
+      <span class="ws-file-item__info">
+        <span class="ws-file-item__name">
+          ${displayName}
+          ${!file.exists
+            ? html`<span class="ws-file-item__badge ws-file-item__badge--new">新建</span>`
+            : nothing}
+          ${isSelected && hasChanges
+            ? html`<span class="ws-file-item__badge ws-file-item__badge--unsaved">${LABELS.unsaved}</span>`
+            : nothing}
+        </span>
+        <span class="ws-file-item__desc">${desc}</span>
+        ${file.exists
+          ? html`<span class="ws-file-item__meta">${formatSize(file.size)} · ${formatTime(file.modifiedAt)}</span>`
+          : nothing}
+      </span>
+    </button>
+  `;
+}
+
+// ─── 渲染文件列表 / Render file list ──────────────────────────────────────
+
+function renderFileList(props: WorkspaceContentProps) {
+  const hasChanges = !!(
+    props.selectedFile && props.editorContent !== props.originalContent
+  );
+  const groups = groupFilesByFolder(props.files);
+  const expandedFolders = props.expandedFolders ?? new Set<string>();
+
+  return html`
+    <div class="ws-file-list">
+      <div class="ws-file-list__header">
+        <div class="ws-file-list__title">${LABELS.filesTitle}</div>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.loading}
+          @click=${() => {
+            const today = new Date();
+            const yyyy = today.getFullYear();
+            const mm = String(today.getMonth() + 1).padStart(2, "0");
+            const dd = String(today.getDate()).padStart(2, "0");
+            props.onFileCreate(`memory/${yyyy}-${mm}-${dd}.md`);
+          }}
+          title="创建今日日志"
+        >
+          ${icons.plus}
+        </button>
+        <button
+          class="mc-btn mc-btn--sm"
+          ?disabled=${props.loading}
+          @click=${props.onRefresh}
+          title=${LABELS.refresh}
+        >
+          ${icons.refresh}
+        </button>
+      </div>
+      <div class="ws-file-list__body">
+        ${groups.map((group) => {
+          // Root files: render directly / 根目录文件直接渲染
+          if (group.folder === null) {
+            return group.files.map((file) =>
+              renderFileItem(file, props, hasChanges, false),
+            );
+          }
+
+          // Folder group: render as collapsible / 文件夹：渲染为可展开
+          const folderName = group.folder;
+          const isExpanded = expandedFolders.has(folderName);
+          const fileCount = group.files.length;
+          // Check if any child is selected / 检查是否有子文件被选中
+          const hasSelectedChild = group.files.some(
+            (f) => f.name === props.selectedFile,
+          );
+
+          return html`
+            <button
+              class="ws-folder-item ${hasSelectedChild ? "ws-folder-item--has-active" : ""}"
+              @click=${() => props.onFolderToggle?.(folderName)}
+              title="${folderName}/ (${fileCount} 个文件)"
+            >
+              <span class="ws-folder-item__chevron">
+                ${isExpanded ? icons.chevronDown : icons.chevronRight}
+              </span>
+              <span class="ws-folder-item__icon">${icons.folder}</span>
+              <span class="ws-folder-item__info">
+                <span class="ws-folder-item__name">
+                  ${folderName}/
+                  <span class="ws-folder-item__count">${fileCount}</span>
+                </span>
+                ${group.desc
+                  ? html`<span class="ws-folder-item__desc">${group.desc}</span>`
+                  : nothing}
+              </span>
+            </button>
+            ${isExpanded
+              ? group.files.map((file) =>
+                  renderFileItem(file, props, hasChanges, true),
+                )
+              : nothing}
+          `;
+        })}
+      </div>
+      <!-- 工作区目录显示 / Workspace dir display -->
+      <div class="ws-file-list__footer">
+        <span class="ws-file-list__dir-label">${LABELS.workspaceDir}</span>
+        <span class="ws-file-list__dir-path" title=${props.workspaceDir}>${props.workspaceDir}</span>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 渲染编辑器工具栏 / Render editor toolbar ────────────────────────────────
+
+function renderEditorToolbar(props: WorkspaceContentProps) {
+  const hasChanges = props.editorContent !== props.originalContent;
+
+  return html`
+    <div class="ws-editor__toolbar">
+      <div class="ws-editor__toolbar-left">
+        <span class="ws-editor__filename">${props.selectedFile ?? ""}</span>
+        ${hasChanges
+          ? html`<span class="ws-editor__unsaved-dot" title=${LABELS.unsaved}></span>`
+          : nothing}
+      </div>
+      <div class="ws-editor__toolbar-right">
+        <!-- 模式切换 / Mode toggle -->
+        <div class="ws-editor__mode-group">
+          <button
+            class="ws-editor__mode-btn ${props.editorMode === "edit" ? "ws-editor__mode-btn--active" : ""}"
+            @click=${() => props.onModeChange("edit")}
+            title=${LABELS.editMode}
+          >${icons.edit}</button>
+          <button
+            class="ws-editor__mode-btn ${props.editorMode === "split" ? "ws-editor__mode-btn--active" : ""}"
+            @click=${() => props.onModeChange("split")}
+            title=${LABELS.splitMode}
+          >${icons.split}</button>
+          <button
+            class="ws-editor__mode-btn ${props.editorMode === "preview" ? "ws-editor__mode-btn--active" : ""}"
+            @click=${() => props.onModeChange("preview")}
+            title=${LABELS.previewMode}
+          >${icons.eye}</button>
+        </div>
+        <!-- 保存按钮 / Save button -->
+        <button
+          class="mc-btn mc-btn--sm mc-btn--primary"
+          ?disabled=${!hasChanges || props.saving}
+          @click=${props.onFileSave}
+        >
+          ${icons.save}
+          ${props.saving ? LABELS.saving : LABELS.save}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+// ─── 渲染编辑器 / Render editor ─────────────────────────────────────────────
+
+function renderEditor(props: WorkspaceContentProps) {
+  if (!props.selectedFile) {
+    return html`
+      <div class="ws-editor__empty">
+        <div class="ws-editor__empty-icon">${icons.file}</div>
+        <div class="ws-editor__empty-text">${LABELS.noFileSelected}</div>
+      </div>
+    `;
+  }
+
+  const showEditor = props.editorMode === "edit" || props.editorMode === "split";
+  const showPreview = props.editorMode === "preview" || props.editorMode === "split";
+
+  return html`
+    ${renderEditorToolbar(props)}
+    ${props.error
+      ? html`<div class="mc-error">${props.error}</div>`
+      : nothing}
+    <div class="ws-editor__panels ${props.editorMode === "split" ? "ws-editor__panels--split" : ""}">
+      ${showEditor
+        ? html`
+            <div class="ws-editor__edit-panel">
+              <textarea
+                class="ws-editor__textarea"
+                .value=${props.editorContent}
+                @input=${(e: Event) =>
+                  props.onContentChange(
+                    (e.target as HTMLTextAreaElement).value,
+                  )}
+                placeholder="在此输入内容..."
+                spellcheck="false"
+              ></textarea>
+            </div>
+          `
+        : nothing}
+      ${showPreview
+        ? html`
+            <div class="ws-editor__preview-panel">
+              <div class="ws-preview">
+                ${renderMarkdownPreview(props.editorContent)}
+              </div>
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+/**
+ * 渲染 Markdown 预览（使用 unsafeHTML 代替）
+ * Render Markdown preview
+ *
+ * 为了避免依赖 lit 的 unsafeHTML 指令，使用 iframe srcdoc
+ * To avoid dependency on lit's unsafeHTML directive, use iframe srcdoc
+ */
+function renderMarkdownPreview(content: string) {
+  const htmlContent = renderMarkdownToHtml(content);
+  // 使用 srcdoc iframe 来安全渲染 HTML
+  // Use srcdoc iframe to safely render HTML
+  const fullHtml = `<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px;
+    line-height: 1.7;
+    color: #e0e0e0;
+    background: transparent;
+    margin: 0;
+    padding: 4px;
+    word-wrap: break-word;
+  }
+  @media (prefers-color-scheme: light) {
+    body { color: #333; }
+  }
+  h1 { font-size: 1.6em; margin: 0.8em 0 0.4em; border-bottom: 1px solid rgba(128,128,128,0.3); padding-bottom: 0.3em; }
+  h2 { font-size: 1.3em; margin: 0.7em 0 0.3em; }
+  h3 { font-size: 1.1em; margin: 0.6em 0 0.3em; }
+  p { margin: 0.4em 0; }
+  pre { background: rgba(0,0,0,0.3); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px; }
+  code { font-family: "SF Mono", "Fira Code", monospace; font-size: 0.9em; }
+  p code { background: rgba(0,0,0,0.2); padding: 2px 5px; border-radius: 3px; }
+  li { margin: 0.2em 0; margin-left: 1.2em; }
+  hr { border: none; border-top: 1px solid rgba(128,128,128,0.3); margin: 1em 0; }
+  strong { font-weight: 600; }
+</style>
+</head>
+<body>${htmlContent}</body>
+</html>`;
+
+  return html`<iframe
+    class="ws-preview__iframe"
+    srcdoc=${fullHtml}
+    sandbox="allow-same-origin"
+    frameborder="0"
+  ></iframe>`;
+}
+
+// ─── 主渲染函数 / Main render function ──────────────────────────────────────
+
+/**
+ * 渲染 Agent 选择器
+ * Render agent selector
+ */
+function renderAgentSelector(props: WorkspaceContentProps) {
+  // 如果没有多个 agent 或没有回调，不显示选择器
+  if (!props.agents || props.agents.length <= 1 || !props.onAgentChange) {
+    return nothing;
+  }
+
+  return html`
+    <div class="ws-agent-selector">
+      <label class="ws-agent-selector__label">Agent:</label>
+      <select
+        class="ws-agent-selector__select"
+        .value=${props.agentId}
+        @change=${(e: Event) => {
+          const select = e.target as HTMLSelectElement;
+          props.onAgentChange?.(select.value);
+        }}
+      >
+        ${props.agents.map(
+          (agent) => html`
+            <option value=${agent.id} ?selected=${agent.id === props.agentId}>
+              ${agent.name || agent.id}${agent.default ? " (默认)" : ""}
+            </option>
+          `,
+        )}
+      </select>
+    </div>
+  `;
+}
+
+/**
+ * 渲染工作区文件管理内容
+ * Render workspace file management content
+ */
+export function renderWorkspaceContent(props: WorkspaceContentProps) {
+  return html`
+    <div class="config-content">
+      <div class="config-content__header">
+        <div class="config-content__icon">${icons.folder}</div>
+        <div class="config-content__titles">
+          <h2 class="config-content__title">${LABELS.title}</h2>
+          <p class="config-content__desc">${LABELS.desc}</p>
+        </div>
+        ${renderAgentSelector(props)}
+      </div>
+      <div class="ws-layout">
+        <!-- 左侧文件列表 / Left file list -->
+        ${renderFileList(props)}
+        <!-- 右侧编辑器 / Right editor -->
+        <div class="ws-editor">
+          ${props.loading
+            ? html`<div class="ws-editor__loading">${LABELS.loading}</div>`
+            : renderEditor(props)}
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui-zh-CN/controllers/model-config.ts
+++ b/ui/src/ui-zh-CN/controllers/model-config.ts
@@ -1,0 +1,2008 @@
+/**
+ * 模型配置控制器
+ * Model config controller
+ *
+ * 处理模型配置页面的数据加载和保存
+ * Handles loading and saving of model config page data
+ */
+import type { GatewayBrowserClient } from "../../ui/gateway";
+import type { CronJob, CronStatus, CronRunLogEntry, ChannelUiMetaEntry } from "../../ui/types";
+import type { CronFormState } from "../../ui/ui-types";
+import { DEFAULT_CRON_FORM } from "../../ui/app-defaults";
+import {
+  loadCronStatus as loadCronStatusBase,
+  loadCronJobs as loadCronJobsBase,
+  addCronJob as addCronJobBase,
+  toggleCronJob as toggleCronJobBase,
+  runCronJob as runCronJobBase,
+  removeCronJob as removeCronJobBase,
+  loadCronRuns as loadCronRunsBase,
+  type CronState,
+} from "../../ui/controllers/cron";
+import type {
+  ProviderConfig,
+  AgentDefaults,
+  GatewayConfig,
+  ModelConfig,
+} from "../views/model-config";
+import type { ConfigSectionId } from "../types/config-sections";
+import type { ChannelsConfigData } from "../types/channel-config";
+import type { ProviderFormState } from "../components/providers-content";
+import type {
+  ExecApprovalsSnapshot,
+  ExecApprovalsFile,
+  ExecApprovalsAllowlistEntry,
+  AgentOption,
+} from "../components/permissions-content";
+import type { WorkspaceFileInfo } from "../components/workspace-content";
+
+// 重新导出权限相关类型 / Re-export permission types
+export type {
+  ExecApprovalsSnapshot,
+  ExecApprovalsFile,
+  ExecApprovalsAllowlistEntry,
+  AgentOption,
+} from "../components/permissions-content";
+
+// 重新导出工作区文件类型 / Re-export workspace file types
+export type { WorkspaceFileInfo } from "../components/workspace-content";
+
+// 会话相关类型
+export type SessionRow = {
+  key: string;
+  kind: "direct" | "group" | "global" | "unknown";
+  label?: string;
+  displayName?: string;
+  updatedAt: number | null;
+  model?: string;
+  modelProvider?: string;
+  thinkingLevel?: string;
+};
+
+export type SessionsListResult = {
+  ts: number;
+  path: string;
+  count: number;
+  defaults: {
+    modelProvider: string | null;
+    model: string | null;
+  };
+  sessions: SessionRow[];
+};
+
+// ============================================
+// 工具权限类型定义
+// ============================================
+
+export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+
+export type ToolPolicyConfig = {
+  profile?: ToolProfileId;
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+};
+
+export type ToolsConfig = ToolPolicyConfig & {
+  // 其他工具配置字段可以后续扩展
+};
+
+export type AgentToolsConfig = ToolPolicyConfig;
+
+// 每个 Agent 的工具配置
+export type AgentWithTools = {
+  id: string;
+  name?: string;
+  default?: boolean;
+  tools?: AgentToolsConfig;
+};
+
+export type PermissionsTabId = "exec" | "tools";
+
+// Agent 身份配置类型
+export type AgentIdentityConfig = {
+  name?: string;
+  theme?: string;
+  emoji?: string;
+  avatar?: string;
+};
+
+// Agent 列表条目类型
+export type AgentIdentityEntry = {
+  id: string;
+  name?: string;
+  default?: boolean;
+  workspace?: string;
+  identity?: AgentIdentityConfig;
+};
+
+export type ModelConfigState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  lastError: string | null;
+
+  // 模型配置数据
+  modelConfigLoading: boolean;
+  modelConfigSaving: boolean;
+  modelConfigApplying: boolean;
+  modelConfigProviders: Record<string, ProviderConfig>;
+  modelConfigAgentDefaults: AgentDefaults;
+  modelConfigGateway: GatewayConfig;
+  modelConfigExpandedProviders: Set<string>;
+  modelConfigOriginal: {
+    providers: Record<string, ProviderConfig>;
+    agentDefaults: AgentDefaults;
+    gateway: GatewayConfig;
+    channels: ChannelsConfigData | null;
+  } | null;
+  // 完整配置快照（用于保存）
+  modelConfigFullSnapshot: Record<string, unknown> | null;
+  modelConfigHash: string | null;
+  // 当前选中的配置区块
+  modelConfigActiveSection: ConfigSectionId;
+  // 通道配置
+  modelConfigChannelsConfig: ChannelsConfigData | null;
+  modelConfigSelectedChannel: string | null;
+
+  // 会话管理状态 (用于 Agent 设置页)
+  agentSessionsLoading: boolean;
+  agentSessionsResult: SessionsListResult | null;
+  agentSessionsError: string | null;
+
+  // 权限管理状态
+  permissionsLoading: boolean;
+  permissionsSaving: boolean;
+  permissionsDirty: boolean;
+  execApprovalsSnapshot: ExecApprovalsSnapshot | null;
+  execApprovalsForm: ExecApprovalsFile | null;
+  permissionsSelectedAgent: string | null;
+  permissionsActiveTab: PermissionsTabId;
+
+  // 工具权限状态
+  toolsConfig: ToolsConfig | null;
+  toolsConfigOriginal: ToolsConfig | null;
+  agentToolsConfigs: AgentWithTools[];
+  agentToolsConfigsOriginal: AgentWithTools[];
+  toolsSelectedAgent: string | null;  // null = 全局, string = agent id
+  toolsExpanded: boolean;
+
+  // Agent 身份配置状态 / Agent identity config state
+  modelConfigAgentsList: AgentIdentityEntry[];
+  modelConfigAgentsListOriginal: AgentIdentityEntry[];
+  modelConfigSelectedAgentId: string | null;
+
+  // 工作区文件状态 / Workspace file state
+  workspaceFiles: WorkspaceFileInfo[];
+  workspaceDir: string;
+  workspaceAgentId: string;
+  workspaceSelectedFile: string | null;
+  workspaceEditorContent: string;
+  workspaceOriginalContent: string;
+  workspaceLoading: boolean;
+  workspaceSaving: boolean;
+  workspaceError: string | null;
+  workspaceEditorMode: "edit" | "preview" | "split";
+
+  // 定时任务状态 / Cron state
+  cronLoading: boolean;
+  cronBusy: boolean;
+  cronError: string | null;
+  cronStatus: CronStatus | null;
+  cronJobs: CronJob[];
+  cronForm: CronFormState;
+  cronChannels: string[];
+  cronChannelLabels: Record<string, string>;
+  cronChannelMeta: ChannelUiMetaEntry[];
+  cronRunsJobId: string | null;
+  cronRuns: CronRunLogEntry[];
+  cronExpandedJobId: string | null;
+  cronDeleteConfirmJobId: string | null;
+
+  // 添加供应商弹窗状态 / Add provider modal state
+  addProviderModalShow: boolean;
+  addProviderForm: ProviderFormState;
+  addProviderError: string | null;
+};
+
+/**
+ * 从配置快照中提取模型供应商数据
+ */
+function extractProviders(
+  config: Record<string, unknown>,
+): Record<string, ProviderConfig> {
+  const models = config.models as Record<string, unknown> | undefined;
+  if (!models) return {};
+
+  const providers = models.providers as Record<string, unknown> | undefined;
+  if (!providers) return {};
+
+  const result: Record<string, ProviderConfig> = {};
+
+  for (const [key, value] of Object.entries(providers)) {
+    if (!value || typeof value !== "object") continue;
+
+    const provider = value as Record<string, unknown>;
+    const modelsArray = provider.models as Array<Record<string, unknown>> | undefined;
+
+    result[key] = {
+      baseUrl: (provider.baseUrl as string) ?? "",
+      apiKey: (provider.apiKey as string) ?? "",
+      auth: provider.auth as ProviderConfig["auth"],
+      api: (provider.api as ProviderConfig["api"]) ?? "openai-completions",
+      headers: provider.headers as Record<string, string> | undefined,
+      models: (modelsArray ?? []).map((m) => ({
+        id: (m.id as string) ?? "",
+        name: (m.name as string) ?? "",
+        reasoning: (m.reasoning as boolean) ?? false,
+        input: (m.input as Array<"text" | "image">) ?? ["text"],
+        contextWindow: (m.contextWindow as number) ?? 128000,
+        maxTokens: (m.maxTokens as number) ?? 4096,
+        cost: m.cost as ModelConfig["cost"],
+        compat: m.compat as ModelConfig["compat"],
+      })),
+    };
+  }
+
+  return result;
+}
+
+/**
+ * 从配置快照中提取 Agent 默认设置
+ */
+function extractAgentDefaults(config: Record<string, unknown>): AgentDefaults {
+  const agents = config.agents as Record<string, unknown> | undefined;
+  if (!agents) return {};
+
+  const defaults = agents.defaults as Record<string, unknown> | undefined;
+  if (!defaults) return {};
+
+  return {
+    maxConcurrent: defaults.maxConcurrent as number | undefined,
+    subagents: defaults.subagents as AgentDefaults["subagents"],
+    workspace: defaults.workspace as string | undefined,
+    model: defaults.model as AgentDefaults["model"],
+    contextPruning: defaults.contextPruning as AgentDefaults["contextPruning"],
+    compaction: defaults.compaction as AgentDefaults["compaction"],
+  };
+}
+
+/**
+ * 从配置快照中提取 Gateway 配置
+ */
+function extractGatewayConfig(config: Record<string, unknown>): GatewayConfig {
+  const gateway = config.gateway as Record<string, unknown> | undefined;
+  if (!gateway) return {};
+
+  return {
+    port: gateway.port as number | undefined,
+    bind: gateway.bind as string | undefined,
+    auth: gateway.auth as GatewayConfig["auth"],
+  };
+}
+
+/**
+ * 从配置快照中提取通道配置
+ */
+function extractChannelsConfig(config: Record<string, unknown>): ChannelsConfigData {
+  const channels = config.channels as Record<string, unknown> | undefined;
+  if (!channels) return {};
+
+  return channels as ChannelsConfigData;
+}
+
+/**
+ * 从配置快照中提取全局工具配置
+ */
+function extractToolsConfig(config: Record<string, unknown>): ToolsConfig {
+  const tools = config.tools as Record<string, unknown> | undefined;
+  if (!tools) return {};
+
+  return {
+    profile: tools.profile as ToolProfileId | undefined,
+    allow: tools.allow as string[] | undefined,
+    alsoAllow: tools.alsoAllow as string[] | undefined,
+    deny: tools.deny as string[] | undefined,
+  };
+}
+
+/**
+ * 从配置快照中提取每个 Agent 的工具配置
+ */
+function extractAgentToolsConfigs(config: Record<string, unknown>): AgentWithTools[] {
+  const agents = config.agents as Record<string, unknown> | undefined;
+  if (!agents) return [];
+
+  const list = agents.list as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(list)) return [];
+
+  return list
+    .filter((entry) => entry && typeof entry === "object")
+    .map((entry) => {
+      const tools = entry.tools as Record<string, unknown> | undefined;
+      return {
+        id: (entry.id as string) ?? "",
+        name: entry.name as string | undefined,
+        default: entry.default as boolean | undefined,
+        tools: tools ? {
+          profile: tools.profile as ToolProfileId | undefined,
+          allow: tools.allow as string[] | undefined,
+          alsoAllow: tools.alsoAllow as string[] | undefined,
+          deny: tools.deny as string[] | undefined,
+        } : undefined,
+      };
+    })
+    .filter((entry) => entry.id);
+}
+
+/**
+ * 从配置快照中提取 Agent 列表（含身份信息）
+ * 如果配置中没有 agents.list，则创建一个默认的 "main" agent
+ */
+function extractAgentsList(config: Record<string, unknown>): AgentIdentityEntry[] {
+  const agents = config.agents as Record<string, unknown> | undefined;
+
+  const list = agents?.list as Array<Record<string, unknown>> | undefined;
+
+  // 如果有 agents.list，从中提取
+  if (Array.isArray(list) && list.length > 0) {
+    return list
+      .filter((entry) => entry && typeof entry === "object" && entry.id)
+      .map((entry) => {
+        const identity = entry.identity as Record<string, unknown> | undefined;
+        return {
+          id: (entry.id as string) ?? "",
+          name: entry.name as string | undefined,
+          default: entry.default as boolean | undefined,
+          workspace: entry.workspace as string | undefined,
+          identity: identity ? {
+            name: identity.name as string | undefined,
+            theme: identity.theme as string | undefined,
+            emoji: identity.emoji as string | undefined,
+            avatar: identity.avatar as string | undefined,
+          } : undefined,
+        };
+      });
+  }
+
+  // 如果没有 agents.list，创建一个默认的 "main" agent
+  // 这样用户仍然可以配置默认 agent 的身份
+  return [{
+    id: "main",
+    name: "Main Agent",
+    default: true,
+  }];
+}
+
+/**
+ * 获取可用模型列表
+ */
+export function getAvailableModels(
+  providers: Record<string, ProviderConfig>,
+): Array<{ id: string; name: string; provider: string }> {
+  const models: Array<{ id: string; name: string; provider: string }> = [];
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    for (const model of provider.models) {
+      models.push({
+        id: `${providerKey}/${model.id}`,
+        name: model.name,
+        provider: providerKey,
+      });
+    }
+  }
+
+  return models;
+}
+
+/**
+ * 检查配置是否有更改（包括主配置和权限配置）
+ */
+export function hasModelConfigChanges(state: ModelConfigState): boolean {
+  // 检查权限配置是否有更改
+  if (state.permissionsDirty) return true;
+
+  // 检查工具配置是否有更改
+  if (hasToolsConfigChanges(state)) return true;
+
+  if (!state.modelConfigOriginal) return false;
+
+  const currentJson = JSON.stringify({
+    providers: state.modelConfigProviders,
+    agentDefaults: state.modelConfigAgentDefaults,
+    gateway: state.modelConfigGateway,
+    channels: state.modelConfigChannelsConfig,
+  });
+
+  const originalJson = JSON.stringify(state.modelConfigOriginal);
+
+  return currentJson !== originalJson;
+}
+
+/**
+ * 加载模型配置
+ */
+export async function loadModelConfig(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.modelConfigLoading = true;
+  state.lastError = null;
+
+  try {
+    const res = (await state.client.request("config.get", {})) as {
+      config?: Record<string, unknown>;
+      hash?: string;
+    };
+
+    const config = res.config ?? {};
+
+    // 保存完整配置快照和 hash（用于保存时）
+    state.modelConfigFullSnapshot = JSON.parse(JSON.stringify(config));
+    state.modelConfigHash = res.hash ?? null;
+
+    state.modelConfigProviders = extractProviders(config);
+    state.modelConfigAgentDefaults = extractAgentDefaults(config);
+    state.modelConfigGateway = extractGatewayConfig(config);
+    state.modelConfigChannelsConfig = extractChannelsConfig(config);
+
+    // 提取工具配置
+    state.toolsConfig = extractToolsConfig(config);
+    state.toolsConfigOriginal = JSON.parse(JSON.stringify(state.toolsConfig));
+    state.agentToolsConfigs = extractAgentToolsConfigs(config);
+    state.agentToolsConfigsOriginal = JSON.parse(JSON.stringify(state.agentToolsConfigs));
+
+    // 提取 Agent 列表（含身份信息）
+    state.modelConfigAgentsList = extractAgentsList(config);
+    state.modelConfigAgentsListOriginal = JSON.parse(JSON.stringify(state.modelConfigAgentsList));
+
+    // 保存原始数据用于比较
+    state.modelConfigOriginal = {
+      providers: JSON.parse(JSON.stringify(state.modelConfigProviders)),
+      agentDefaults: JSON.parse(JSON.stringify(state.modelConfigAgentDefaults)),
+      gateway: JSON.parse(JSON.stringify(state.modelConfigGateway)),
+      channels: JSON.parse(JSON.stringify(state.modelConfigChannelsConfig)),
+    };
+
+    // 默认展开第一个供应商
+    const providerKeys = Object.keys(state.modelConfigProviders);
+    if (providerKeys.length > 0 && state.modelConfigExpandedProviders.size === 0) {
+      state.modelConfigExpandedProviders = new Set([providerKeys[0]]);
+    }
+  } catch (err) {
+    state.lastError = `加载配置失败: ${String(err)}`;
+  } finally {
+    state.modelConfigLoading = false;
+  }
+}
+
+/**
+ * 构建更新后的配置 raw 字符串
+ */
+function buildConfigRaw(state: ModelConfigState): string | null {
+  if (!state.modelConfigFullSnapshot) {
+    state.lastError = "配置快照缺失，请重新加载后再试";
+    return null;
+  }
+  if (!state.modelConfigHash) {
+    state.lastError = "配置 hash 缺失，请重新加载后再试";
+    return null;
+  }
+
+  // 深度复制完整配置
+  const updatedConfig = JSON.parse(JSON.stringify(state.modelConfigFullSnapshot)) as Record<string, unknown>;
+
+  // 更新 models.providers
+  if (!updatedConfig.models) {
+    updatedConfig.models = {};
+  }
+  (updatedConfig.models as Record<string, unknown>).providers = state.modelConfigProviders;
+
+  // 更新 agents.defaults
+  if (!updatedConfig.agents) {
+    updatedConfig.agents = {};
+  }
+  (updatedConfig.agents as Record<string, unknown>).defaults = state.modelConfigAgentDefaults;
+
+  // 更新 gateway（合并而不是替换）
+  if (!updatedConfig.gateway) {
+    updatedConfig.gateway = {};
+  }
+  const gatewayConfig = updatedConfig.gateway as Record<string, unknown>;
+  if (state.modelConfigGateway.port !== undefined) {
+    gatewayConfig.port = state.modelConfigGateway.port;
+  }
+  if (state.modelConfigGateway.bind !== undefined) {
+    gatewayConfig.bind = state.modelConfigGateway.bind;
+  }
+  if (state.modelConfigGateway.auth !== undefined) {
+    gatewayConfig.auth = state.modelConfigGateway.auth;
+  }
+
+  // 更新 channels（合并而不是替换）
+  if (state.modelConfigChannelsConfig) {
+    if (!updatedConfig.channels) {
+      updatedConfig.channels = {};
+    }
+    const channelsConfig = updatedConfig.channels as Record<string, unknown>;
+    for (const [channelId, channelSettings] of Object.entries(state.modelConfigChannelsConfig)) {
+      if (channelId === "defaults") {
+        channelsConfig.defaults = channelSettings;
+      } else if (channelSettings && typeof channelSettings === "object") {
+        channelsConfig[channelId] = {
+          ...(channelsConfig[channelId] as Record<string, unknown> ?? {}),
+          ...channelSettings,
+        };
+      }
+    }
+  }
+
+  // 更新 tools（全局工具配置）
+  if (state.toolsConfig) {
+    if (!updatedConfig.tools) {
+      updatedConfig.tools = {};
+    }
+    const toolsConfig = updatedConfig.tools as Record<string, unknown>;
+    if (state.toolsConfig.profile !== undefined) {
+      toolsConfig.profile = state.toolsConfig.profile;
+    } else {
+      delete toolsConfig.profile;
+    }
+    if (state.toolsConfig.allow && state.toolsConfig.allow.length > 0) {
+      toolsConfig.allow = state.toolsConfig.allow;
+    } else {
+      delete toolsConfig.allow;
+    }
+    if (state.toolsConfig.alsoAllow && state.toolsConfig.alsoAllow.length > 0) {
+      toolsConfig.alsoAllow = state.toolsConfig.alsoAllow;
+    } else {
+      delete toolsConfig.alsoAllow;
+    }
+    if (state.toolsConfig.deny && state.toolsConfig.deny.length > 0) {
+      toolsConfig.deny = state.toolsConfig.deny;
+    } else {
+      delete toolsConfig.deny;
+    }
+  }
+
+  // 更新 agents.list 中每个 agent 的 tools 配置
+  if (state.agentToolsConfigs.length > 0) {
+    if (!updatedConfig.agents) {
+      updatedConfig.agents = {};
+    }
+    const agentsConfig = updatedConfig.agents as Record<string, unknown>;
+    const list = (agentsConfig.list ?? []) as Array<Record<string, unknown>>;
+
+    for (const agentTools of state.agentToolsConfigs) {
+      const existingAgent = list.find((a) => a.id === agentTools.id);
+      if (existingAgent) {
+        // 更新现有 agent 的 tools
+        if (agentTools.tools) {
+          if (!existingAgent.tools) {
+            existingAgent.tools = {};
+          }
+          const tools = existingAgent.tools as Record<string, unknown>;
+          if (agentTools.tools.profile !== undefined) {
+            tools.profile = agentTools.tools.profile;
+          } else {
+            delete tools.profile;
+          }
+          if (agentTools.tools.allow && agentTools.tools.allow.length > 0) {
+            tools.allow = agentTools.tools.allow;
+          } else {
+            delete tools.allow;
+          }
+          if (agentTools.tools.alsoAllow && agentTools.tools.alsoAllow.length > 0) {
+            tools.alsoAllow = agentTools.tools.alsoAllow;
+          } else {
+            delete tools.alsoAllow;
+          }
+          if (agentTools.tools.deny && agentTools.tools.deny.length > 0) {
+            tools.deny = agentTools.tools.deny;
+          } else {
+            delete tools.deny;
+          }
+        }
+      }
+    }
+  }
+
+  // 更新 agents.list 中每个 agent 的 identity 配置
+  if (state.modelConfigAgentsList.length > 0) {
+    if (!updatedConfig.agents) {
+      updatedConfig.agents = {};
+    }
+    const agentsConfig = updatedConfig.agents as Record<string, unknown>;
+    const list = (agentsConfig.list ?? []) as Array<Record<string, unknown>>;
+
+    for (const agentIdentity of state.modelConfigAgentsList) {
+      const existingAgent = list.find((a) => a.id === agentIdentity.id);
+      if (existingAgent) {
+        // 更新现有 agent 的 identity
+        if (agentIdentity.identity && Object.keys(agentIdentity.identity).length > 0) {
+          existingAgent.identity = agentIdentity.identity;
+        } else {
+          delete existingAgent.identity;
+        }
+      }
+    }
+  }
+
+  return `${JSON.stringify(updatedConfig, null, 2).trimEnd()}\n`;
+}
+
+/**
+ * 检查主配置是否有更改（不包括权限配置）
+ */
+function hasMainConfigChanges(state: ModelConfigState): boolean {
+  // 检查工具配置是否有更改
+  if (hasToolsConfigChanges(state)) return true;
+
+  // 检查 Agent 身份列表是否有更改
+  if (JSON.stringify(state.modelConfigAgentsList) !== JSON.stringify(state.modelConfigAgentsListOriginal)) {
+    return true;
+  }
+
+  if (!state.modelConfigOriginal) return false;
+
+  const currentJson = JSON.stringify({
+    providers: state.modelConfigProviders,
+    agentDefaults: state.modelConfigAgentDefaults,
+    gateway: state.modelConfigGateway,
+    channels: state.modelConfigChannelsConfig,
+  });
+
+  const originalJson = JSON.stringify(state.modelConfigOriginal);
+
+  return currentJson !== originalJson;
+}
+
+/**
+ * 保存模型配置（仅保存，不重启服务）
+ */
+export async function saveModelConfig(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.modelConfigSaving = true;
+  state.lastError = null;
+
+  try {
+    // 检查主配置是否有更改
+    const mainConfigChanged = hasMainConfigChanges(state);
+
+    // 保存主配置（如果有更改）
+    if (mainConfigChanged) {
+      const raw = buildConfigRaw(state);
+      if (!raw) {
+        // 主配置保存失败，但继续尝试保存权限配置
+        console.warn("主配置保存失败，继续保存权限配置");
+      } else {
+        await state.client.request("config.set", {
+          raw,
+          baseHash: state.modelConfigHash,
+        });
+      }
+    }
+
+    // 保存权限配置（如果有更改）
+    if (state.permissionsDirty && state.execApprovalsSnapshot?.hash) {
+      const file = state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {};
+      await state.client.request("exec.approvals.set", {
+        file,
+        baseHash: state.execApprovalsSnapshot.hash,
+      });
+      state.permissionsDirty = false;
+    }
+
+    // 重新加载配置以获取最新状态
+    if (mainConfigChanged) {
+      await loadModelConfig(state);
+    }
+    // 重新加载权限配置
+    if (state.execApprovalsSnapshot) {
+      await loadPermissions(state);
+    }
+
+  } catch (err) {
+    state.lastError = `保存配置失败: ${String(err)}`;
+  } finally {
+    state.modelConfigSaving = false;
+  }
+}
+
+/**
+ * 保存并应用模型配置（保存 + 重启服务）
+ */
+export async function applyModelConfig(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.modelConfigApplying = true;
+  state.lastError = null;
+
+  try {
+    // 保存权限配置（如果有更改，需要在 apply 之前保存）
+    if (state.permissionsDirty && state.execApprovalsSnapshot?.hash) {
+      const file = state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {};
+      await state.client.request("exec.approvals.set", {
+        file,
+        baseHash: state.execApprovalsSnapshot.hash,
+      });
+      state.permissionsDirty = false;
+    }
+
+    // 检查主配置是否有更改
+    const mainConfigChanged = hasMainConfigChanges(state);
+
+    // 保存并应用主配置（如果有更改）
+    if (mainConfigChanged) {
+      const raw = buildConfigRaw(state);
+      if (!raw) {
+        // 主配置保存失败
+        console.warn("主配置保存失败");
+      } else {
+        await state.client.request("config.apply", {
+          raw,
+          baseHash: state.modelConfigHash,
+        });
+      }
+    }
+
+    // 重新加载配置以获取最新状态
+    if (mainConfigChanged) {
+      await loadModelConfig(state);
+    }
+    // 重新加载权限配置
+    if (state.execApprovalsSnapshot) {
+      await loadPermissions(state);
+    }
+
+  } catch (err) {
+    state.lastError = `应用配置失败: ${String(err)}`;
+  } finally {
+    state.modelConfigApplying = false;
+  }
+}
+
+/**
+ * 切换供应商展开状态
+ */
+export function toggleProviderExpanded(state: ModelConfigState, key: string): void {
+  const expanded = new Set(state.modelConfigExpandedProviders);
+  if (expanded.has(key)) {
+    expanded.delete(key);
+  } else {
+    expanded.add(key);
+  }
+  state.modelConfigExpandedProviders = expanded;
+}
+
+/**
+ * 添加新供应商
+ */
+export function addProvider(state: ModelConfigState): void {
+  // 生成唯一的供应商名称
+  let baseName = "new-provider";
+  let counter = 1;
+  while (state.modelConfigProviders[baseName]) {
+    baseName = `new-provider-${counter}`;
+    counter++;
+  }
+
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [baseName]: {
+      baseUrl: "",
+      apiKey: "",
+      api: "openai-completions",
+      models: [],
+    },
+  };
+
+  // 展开新添加的供应商
+  state.modelConfigExpandedProviders = new Set([
+    ...state.modelConfigExpandedProviders,
+    baseName,
+  ]);
+}
+
+/**
+ * 默认添加供应商表单
+ */
+const DEFAULT_ADD_PROVIDER_FORM: ProviderFormState = {
+  name: "",
+  baseUrl: "",
+  apiKey: "",
+  api: "openai-completions",
+  auth: "api-key",
+};
+
+/**
+ * 显示/隐藏添加供应商弹窗
+ */
+export function showAddProviderModal(state: ModelConfigState, show: boolean): void {
+  state.addProviderModalShow = show;
+  if (show) {
+    // 打开弹窗时重置表单
+    state.addProviderForm = { ...DEFAULT_ADD_PROVIDER_FORM };
+    state.addProviderError = null;
+  }
+}
+
+/**
+ * 更新添加供应商表单
+ */
+export function updateAddProviderForm(
+  state: ModelConfigState,
+  patch: Partial<ProviderFormState>,
+): void {
+  state.addProviderForm = {
+    ...state.addProviderForm,
+    ...patch,
+  };
+  // 清除之前的错误
+  state.addProviderError = null;
+}
+
+/**
+ * 确认添加供应商
+ */
+export function confirmAddProvider(state: ModelConfigState): void {
+  const form = state.addProviderForm;
+  const name = form.name.trim();
+
+  // 验证名称
+  if (!name) {
+    state.addProviderError = "请输入供应商名称";
+    return;
+  }
+
+  // 检查名称是否已存在
+  if (state.modelConfigProviders[name]) {
+    state.addProviderError = `供应商名称 "${name}" 已存在`;
+    return;
+  }
+
+  // 创建新供应商
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [name]: {
+      baseUrl: form.baseUrl,
+      apiKey: form.apiKey || undefined,
+      auth: form.auth,
+      api: form.api,
+      models: [],
+    },
+  };
+
+  // 展开新添加的供应商
+  state.modelConfigExpandedProviders = new Set([
+    ...state.modelConfigExpandedProviders,
+    name,
+  ]);
+
+  // 关闭弹窗
+  state.addProviderModalShow = false;
+  state.addProviderForm = { ...DEFAULT_ADD_PROVIDER_FORM };
+  state.addProviderError = null;
+}
+
+/**
+ * 删除供应商
+ */
+export function removeProvider(state: ModelConfigState, key: string): void {
+  const { [key]: _, ...rest } = state.modelConfigProviders;
+  state.modelConfigProviders = rest;
+
+  // 从展开列表中移除
+  const expanded = new Set(state.modelConfigExpandedProviders);
+  expanded.delete(key);
+  state.modelConfigExpandedProviders = expanded;
+}
+
+/**
+ * 重命名供应商
+ */
+export function renameProvider(
+  state: ModelConfigState,
+  oldKey: string,
+  newKey: string,
+): void {
+  // 验证新名称
+  const trimmedKey = newKey.trim();
+  if (!trimmedKey) {
+    state.lastError = "供应商名称不能为空";
+    return;
+  }
+  if (oldKey === trimmedKey) return;
+  if (state.modelConfigProviders[trimmedKey]) {
+    state.lastError = `供应商名称 "${trimmedKey}" 已存在`;
+    return;
+  }
+
+  // 获取旧配置
+  const provider = state.modelConfigProviders[oldKey];
+  if (!provider) return;
+
+  // 创建新的 providers 对象，保持顺序
+  const newProviders: Record<string, ProviderConfig> = {};
+  for (const [key, value] of Object.entries(state.modelConfigProviders)) {
+    if (key === oldKey) {
+      newProviders[trimmedKey] = value;
+    } else {
+      newProviders[key] = value;
+    }
+  }
+  state.modelConfigProviders = newProviders;
+
+  // 更新展开状态
+  const expanded = new Set(state.modelConfigExpandedProviders);
+  if (expanded.has(oldKey)) {
+    expanded.delete(oldKey);
+    expanded.add(trimmedKey);
+  }
+  state.modelConfigExpandedProviders = expanded;
+
+  // 清除可能的旧错误
+  if (state.lastError?.includes("供应商名称")) {
+    state.lastError = null;
+  }
+}
+
+/**
+ * 更新供应商字段
+ */
+export function updateProviderField(
+  state: ModelConfigState,
+  key: string,
+  field: string,
+  value: unknown,
+): void {
+  const provider = state.modelConfigProviders[key];
+  if (!provider) return;
+
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [key]: {
+      ...provider,
+      [field]: value,
+    },
+  };
+}
+
+/**
+ * 添加模型到供应商
+ */
+export function addModel(state: ModelConfigState, providerKey: string): void {
+  const provider = state.modelConfigProviders[providerKey];
+  if (!provider) return;
+
+  const newModel: ModelConfig = {
+    id: "new-model",
+    name: "New Model",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 4096,
+  };
+
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [providerKey]: {
+      ...provider,
+      models: [...provider.models, newModel],
+    },
+  };
+}
+
+/**
+ * 删除模型
+ */
+export function removeModel(
+  state: ModelConfigState,
+  providerKey: string,
+  modelIndex: number,
+): void {
+  const provider = state.modelConfigProviders[providerKey];
+  if (!provider) return;
+
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [providerKey]: {
+      ...provider,
+      models: provider.models.filter((_, idx) => idx !== modelIndex),
+    },
+  };
+}
+
+/**
+ * 更新模型字段
+ */
+export function updateModelField(
+  state: ModelConfigState,
+  providerKey: string,
+  modelIndex: number,
+  field: string,
+  value: unknown,
+): void {
+  const provider = state.modelConfigProviders[providerKey];
+  if (!provider || !provider.models[modelIndex]) return;
+
+  const updatedModels = [...provider.models];
+  updatedModels[modelIndex] = {
+    ...updatedModels[modelIndex],
+    [field]: value,
+  };
+
+  state.modelConfigProviders = {
+    ...state.modelConfigProviders,
+    [providerKey]: {
+      ...provider,
+      models: updatedModels,
+    },
+  };
+}
+
+/**
+ * 更新 Agent 默认设置
+ */
+export function updateAgentDefaults(
+  state: ModelConfigState,
+  path: string[],
+  value: unknown,
+): void {
+  const updated = { ...state.modelConfigAgentDefaults };
+
+  if (path.length === 1) {
+    (updated as Record<string, unknown>)[path[0]] = value;
+  } else if (path.length === 2) {
+    const [key, subKey] = path;
+    const current = (updated as Record<string, Record<string, unknown>>)[key] ?? {};
+    (updated as Record<string, unknown>)[key] = {
+      ...current,
+      [subKey]: value,
+    };
+  }
+
+  state.modelConfigAgentDefaults = updated;
+}
+
+/**
+ * 更新 Gateway 配置
+ */
+export function updateGatewayConfig(
+  state: ModelConfigState,
+  path: string[],
+  value: unknown,
+): void {
+  const updated = { ...state.modelConfigGateway };
+
+  if (path.length === 1) {
+    (updated as Record<string, unknown>)[path[0]] = value;
+  } else if (path.length === 2) {
+    const [key, subKey] = path;
+    const current = (updated as Record<string, Record<string, unknown>>)[key] ?? {};
+    (updated as Record<string, unknown>)[key] = {
+      ...current,
+      [subKey]: value,
+    };
+  }
+
+  state.modelConfigGateway = updated;
+}
+
+/**
+ * 选择要编辑身份的 Agent
+ */
+export function selectAgentForIdentity(
+  state: ModelConfigState,
+  agentId: string | null,
+): void {
+  state.modelConfigSelectedAgentId = agentId;
+}
+
+/**
+ * 更新 Agent 身份配置
+ */
+export function updateAgentIdentity(
+  state: ModelConfigState,
+  agentId: string,
+  field: keyof AgentIdentityConfig,
+  value: string | undefined,
+): void {
+  const list = [...state.modelConfigAgentsList];
+  const index = list.findIndex((a) => a.id === agentId);
+  if (index === -1) return;
+
+  const agent = { ...list[index] };
+  const identity = { ...agent.identity };
+
+  if (value) {
+    identity[field] = value;
+  } else {
+    delete identity[field];
+  }
+
+  // 如果 identity 全空，删除整个对象
+  if (Object.keys(identity).length === 0) {
+    delete agent.identity;
+  } else {
+    agent.identity = identity;
+  }
+
+  list[index] = agent;
+  state.modelConfigAgentsList = list;
+}
+
+/**
+ * 切换配置区块
+ */
+export function setActiveSection(
+  state: ModelConfigState,
+  sectionId: string,
+): void {
+  state.modelConfigActiveSection = sectionId as ConfigSectionId;
+
+  // 切换到权限管理时自动加载权限数据
+  if (sectionId === "permissions" && !state.execApprovalsSnapshot && !state.permissionsLoading) {
+    void loadPermissions(state);
+  }
+
+  // 切换到 Agent 设置时自动加载会话列表
+  if (sectionId === "agent" && !state.agentSessionsResult && !state.agentSessionsLoading) {
+    void loadAgentSessions(state);
+  }
+}
+
+// ============================================
+// 权限管理相关函数
+// ============================================
+
+/**
+ * 从配置中提取 Agent 列表用于权限管理
+ */
+export function getPermissionsAgents(state: ModelConfigState): AgentOption[] {
+  const config = state.modelConfigFullSnapshot;
+  const form = state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? null;
+
+  // 从配置中提取 agents
+  const agentsNode = (config?.agents ?? {}) as Record<string, unknown>;
+  const list = Array.isArray(agentsNode.list) ? agentsNode.list : [];
+  const configAgents: AgentOption[] = [];
+
+  list.forEach((entry) => {
+    if (!entry || typeof entry !== "object") return;
+    const record = entry as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id.trim() : "";
+    if (!id) return;
+    const name = typeof record.name === "string" ? record.name.trim() : undefined;
+    const isDefault = record.default === true;
+    configAgents.push({ id, name: name || undefined, isDefault });
+  });
+
+  // 从 exec approvals 中提取额外的 agents
+  const approvalsAgents = Object.keys(form?.agents ?? {}).filter((id) => id !== "*");
+  const merged = new Map<string, AgentOption>();
+  configAgents.forEach((agent) => merged.set(agent.id, agent));
+  approvalsAgents.forEach((id) => {
+    if (merged.has(id)) return;
+    merged.set(id, { id });
+  });
+
+  const agents = Array.from(merged.values());
+  if (agents.length === 0) {
+    agents.push({ id: "main", isDefault: true });
+  }
+
+  // 排序：默认 agent 在前
+  agents.sort((a, b) => {
+    if (a.isDefault && !b.isDefault) return -1;
+    if (!a.isDefault && b.isDefault) return 1;
+    const aLabel = a.name?.trim() ? a.name : a.id;
+    const bLabel = b.name?.trim() ? b.name : b.id;
+    return aLabel.localeCompare(bLabel);
+  });
+
+  // 添加通配符 Agent 到最后（如果配置中存在）
+  const hasWildcard = form?.agents?.["*"] != null;
+  if (hasWildcard) {
+    agents.push({ id: "*", name: "通配符规则" });
+  }
+
+  return agents;
+}
+
+/**
+ * Exec Approvals 目标类型
+ */
+export type ExecApprovalsTarget = "gateway" | "node";
+
+export type ExecApprovalsTargetNode = {
+  id: string;
+  label: string;
+};
+
+// 支持 Exec Approvals 的节点命令
+const EXEC_APPROVALS_COMMANDS = [
+  "system.execApprovals.get",
+  "system.execApprovals.set",
+];
+
+/**
+ * 从节点列表中筛选支持 Exec Approvals 的节点
+ */
+export function resolveExecApprovalsNodes(
+  nodes: Array<Record<string, unknown>>,
+): ExecApprovalsTargetNode[] {
+  return nodes
+    .filter((node) => {
+      const commands = Array.isArray(node.commands) ? node.commands : [];
+      return EXEC_APPROVALS_COMMANDS.some((cmd) => commands.includes(cmd));
+    })
+    .map((node) => {
+      const nodeId = String(node.nodeId ?? "");
+      const displayName = node.displayName as string | undefined;
+      const label = displayName && displayName !== nodeId
+        ? `${displayName} · ${nodeId}`
+        : nodeId;
+      return { id: nodeId, label };
+    });
+}
+
+/**
+ * 加载权限配置
+ */
+export async function loadPermissions(
+  state: ModelConfigState,
+  target?: { kind: "gateway" } | { kind: "node"; nodeId: string },
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+  if (state.permissionsLoading) return;
+
+  // 如果是 node 目标，必须有 nodeId
+  if (target?.kind === "node" && !target.nodeId) {
+    state.lastError = "请先选择一个节点";
+    return;
+  }
+
+  state.permissionsLoading = true;
+  state.lastError = null;
+
+  try {
+    const rpc = target?.kind === "node"
+      ? { method: "exec.approvals.node.get", params: { nodeId: target.nodeId } }
+      : { method: "exec.approvals.get", params: {} };
+
+    const res = (await state.client.request(rpc.method, rpc.params)) as ExecApprovalsSnapshot;
+    state.execApprovalsSnapshot = res;
+    if (!state.permissionsDirty) {
+      state.execApprovalsForm = JSON.parse(JSON.stringify(res.file ?? {}));
+    }
+  } catch (err) {
+    state.lastError = `加载权限配置失败: ${String(err)}`;
+  } finally {
+    state.permissionsLoading = false;
+  }
+}
+
+/**
+ * 添加新的 Agent 配置（包括通配符）
+ */
+export function addPermissionsAgent(
+  state: ModelConfigState,
+  agentId: string,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  if (!base.agents) {
+    base.agents = {};
+  }
+
+  // 如果已存在，不重复添加
+  if (base.agents[agentId]) {
+    return;
+  }
+
+  // 初始化空配置
+  base.agents[agentId] = {};
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+
+  // 自动选中新添加的 Agent
+  state.permissionsSelectedAgent = agentId;
+}
+
+/**
+ * 删除 Agent 配置
+ */
+export function removePermissionsAgent(
+  state: ModelConfigState,
+  agentId: string,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  if (!base.agents || !base.agents[agentId]) {
+    return;
+  }
+
+  delete base.agents[agentId];
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+
+  // 如果删除的是当前选中的，切换回默认
+  if (state.permissionsSelectedAgent === agentId) {
+    state.permissionsSelectedAgent = null;
+  }
+}
+
+/**
+ * 保存权限配置
+ */
+export async function savePermissions(
+  state: ModelConfigState,
+  target?: { kind: "gateway" } | { kind: "node"; nodeId: string },
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  // 如果是 node 目标，必须有 nodeId
+  if (target?.kind === "node" && !target.nodeId) {
+    state.lastError = "请先选择一个节点";
+    return;
+  }
+
+  state.permissionsSaving = true;
+  state.lastError = null;
+
+  try {
+    const baseHash = state.execApprovalsSnapshot?.hash;
+    if (!baseHash) {
+      state.lastError = "权限配置 hash 缺失，请重新加载后再试";
+      return;
+    }
+
+    const file = state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {};
+    const rpc = target?.kind === "node"
+      ? { method: "exec.approvals.node.set", params: { nodeId: target.nodeId, file, baseHash } }
+      : { method: "exec.approvals.set", params: { file, baseHash } };
+
+    await state.client.request(rpc.method, rpc.params);
+
+    state.permissionsDirty = false;
+    await loadPermissions(state, target);
+  } catch (err) {
+    state.lastError = `保存权限配置失败: ${String(err)}`;
+  } finally {
+    state.permissionsSaving = false;
+  }
+}
+
+/**
+ * 选择权限管理的 Agent
+ */
+export function selectPermissionsAgent(
+  state: ModelConfigState,
+  agentId: string | null,
+): void {
+  state.permissionsSelectedAgent = agentId;
+}
+
+/**
+ * 切换权限管理的标签页
+ */
+export function setPermissionsActiveTab(
+  state: ModelConfigState,
+  tab: PermissionsTabId,
+): void {
+  state.permissionsActiveTab = tab;
+}
+
+/**
+ * 更新权限配置表单值
+ */
+export function updatePermissionsFormValue(
+  state: ModelConfigState,
+  path: Array<string | number>,
+  value: unknown,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  // 设置路径值
+  let current: unknown = base;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (current == null || typeof current !== "object") break;
+    const obj = current as Record<string | number, unknown>;
+    if (obj[key] == null || typeof obj[key] !== "object") {
+      obj[key] = typeof path[i + 1] === "number" ? [] : {};
+    }
+    current = obj[key];
+  }
+
+  if (current != null && typeof current === "object") {
+    const lastKey = path[path.length - 1];
+    (current as Record<string | number, unknown>)[lastKey] = value;
+  }
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+}
+
+/**
+ * 移除权限配置表单值
+ */
+export function removePermissionsFormValue(
+  state: ModelConfigState,
+  path: Array<string | number>,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  // 移除路径值
+  let current: unknown = base;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (current == null || typeof current !== "object") return;
+    current = (current as Record<string | number, unknown>)[key];
+  }
+
+  if (current != null && typeof current === "object") {
+    const lastKey = path[path.length - 1];
+    if (Array.isArray(current) && typeof lastKey === "number") {
+      current.splice(lastKey, 1);
+    } else {
+      delete (current as Record<string | number, unknown>)[lastKey];
+    }
+  }
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+}
+
+/**
+ * 添加允许列表条目
+ */
+export function addPermissionsAllowlistEntry(
+  state: ModelConfigState,
+  agentId: string,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  if (!base.agents) {
+    base.agents = {};
+  }
+  if (!base.agents[agentId]) {
+    base.agents[agentId] = {};
+  }
+  if (!base.agents[agentId].allowlist) {
+    base.agents[agentId].allowlist = [];
+  }
+
+  base.agents[agentId].allowlist!.push({ pattern: "" });
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+}
+
+/**
+ * 移除允许列表条目
+ */
+export function removePermissionsAllowlistEntry(
+  state: ModelConfigState,
+  agentId: string,
+  index: number,
+): void {
+  const base = JSON.parse(
+    JSON.stringify(state.execApprovalsForm ?? state.execApprovalsSnapshot?.file ?? {}),
+  ) as ExecApprovalsFile;
+
+  const allowlist = base.agents?.[agentId]?.allowlist;
+  if (!allowlist || !Array.isArray(allowlist)) return;
+
+  if (allowlist.length <= 1) {
+    // 如果只剩一个条目，删除整个 allowlist
+    delete base.agents![agentId].allowlist;
+  } else {
+    allowlist.splice(index, 1);
+  }
+
+  state.execApprovalsForm = base;
+  state.permissionsDirty = true;
+}
+
+// ============================================
+// 工具权限管理相关函数
+// ============================================
+
+/**
+ * 检查工具配置是否有更改
+ */
+export function hasToolsConfigChanges(state: ModelConfigState): boolean {
+  const currentGlobal = JSON.stringify(state.toolsConfig ?? {});
+  const originalGlobal = JSON.stringify(state.toolsConfigOriginal ?? {});
+  if (currentGlobal !== originalGlobal) return true;
+
+  const currentAgents = JSON.stringify(state.agentToolsConfigs ?? []);
+  const originalAgents = JSON.stringify(state.agentToolsConfigsOriginal ?? []);
+  return currentAgents !== originalAgents;
+}
+
+/**
+ * 获取工具权限管理的 Agent 列表
+ */
+export function getToolsAgents(state: ModelConfigState): AgentOption[] {
+  const agents: AgentOption[] = state.agentToolsConfigs.map((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    isDefault: agent.default,
+  }));
+
+  // 排序：默认 agent 在前
+  agents.sort((a, b) => {
+    if (a.isDefault && !b.isDefault) return -1;
+    if (!a.isDefault && b.isDefault) return 1;
+    const aLabel = a.name?.trim() ? a.name : a.id;
+    const bLabel = b.name?.trim() ? b.name : b.id;
+    return aLabel.localeCompare(bLabel);
+  });
+
+  return agents;
+}
+
+/**
+ * 选择工具权限管理的作用域
+ */
+export function selectToolsAgent(
+  state: ModelConfigState,
+  agentId: string | null,
+): void {
+  state.toolsSelectedAgent = agentId;
+}
+
+/**
+ * 切换工具列表展开状态
+ */
+export function toggleToolsExpanded(state: ModelConfigState): void {
+  state.toolsExpanded = !state.toolsExpanded;
+}
+
+/**
+ * 更新全局工具配置
+ */
+export function updateGlobalToolsConfig(
+  state: ModelConfigState,
+  field: keyof ToolPolicyConfig,
+  value: unknown,
+): void {
+  const current = state.toolsConfig ?? {};
+  state.toolsConfig = {
+    ...current,
+    [field]: value,
+  };
+}
+
+/**
+ * 更新特定 Agent 的工具配置
+ */
+export function updateAgentToolsConfig(
+  state: ModelConfigState,
+  agentId: string,
+  field: keyof ToolPolicyConfig,
+  value: unknown,
+): void {
+  const agents = [...state.agentToolsConfigs];
+  const index = agents.findIndex((a) => a.id === agentId);
+  if (index < 0) return;
+
+  const agent = agents[index];
+  const tools = agent.tools ?? {};
+  agents[index] = {
+    ...agent,
+    tools: {
+      ...tools,
+      [field]: value,
+    },
+  };
+  state.agentToolsConfigs = agents;
+}
+
+/**
+ * 添加全局 deny 规则
+ */
+export function addGlobalToolsDenyEntry(state: ModelConfigState, entry: string): void {
+  const current = state.toolsConfig ?? {};
+  const deny = [...(current.deny ?? [])];
+  if (!deny.includes(entry)) {
+    deny.push(entry);
+  }
+  state.toolsConfig = {
+    ...current,
+    deny,
+  };
+}
+
+/**
+ * 移除全局 deny 规则
+ */
+export function removeGlobalToolsDenyEntry(state: ModelConfigState, entry: string): void {
+  const current = state.toolsConfig ?? {};
+  const deny = (current.deny ?? []).filter((d) => d !== entry);
+  state.toolsConfig = {
+    ...current,
+    deny: deny.length > 0 ? deny : undefined,
+  };
+}
+
+/**
+ * 添加 Agent deny 规则
+ */
+export function addAgentToolsDenyEntry(
+  state: ModelConfigState,
+  agentId: string,
+  entry: string,
+): void {
+  const agents = [...state.agentToolsConfigs];
+  const index = agents.findIndex((a) => a.id === agentId);
+  if (index < 0) return;
+
+  const agent = agents[index];
+  const tools = agent.tools ?? {};
+  const deny = [...(tools.deny ?? [])];
+  if (!deny.includes(entry)) {
+    deny.push(entry);
+  }
+  agents[index] = {
+    ...agent,
+    tools: {
+      ...tools,
+      deny,
+    },
+  };
+  state.agentToolsConfigs = agents;
+}
+
+/**
+ * 移除 Agent deny 规则
+ */
+export function removeAgentToolsDenyEntry(
+  state: ModelConfigState,
+  agentId: string,
+  entry: string,
+): void {
+  const agents = [...state.agentToolsConfigs];
+  const index = agents.findIndex((a) => a.id === agentId);
+  if (index < 0) return;
+
+  const agent = agents[index];
+  const tools = agent.tools ?? {};
+  const deny = (tools.deny ?? []).filter((d) => d !== entry);
+  agents[index] = {
+    ...agent,
+    tools: {
+      ...tools,
+      deny: deny.length > 0 ? deny : undefined,
+    },
+  };
+  state.agentToolsConfigs = agents;
+}
+
+// ============================================
+// 会话管理相关函数 (Agent 设置页)
+// ============================================
+
+/**
+ * 加载会话列表
+ */
+export async function loadAgentSessions(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected) return;
+  if (state.agentSessionsLoading) return;
+
+  state.agentSessionsLoading = true;
+  state.agentSessionsError = null;
+
+  try {
+    const res = (await state.client.request("sessions.list", {
+      limit: 50,
+      includeGlobal: false,
+      includeUnknown: false,
+    })) as SessionsListResult | undefined;
+
+    if (res) {
+      state.agentSessionsResult = res;
+    }
+  } catch (err) {
+    state.agentSessionsError = `加载会话列表失败: ${String(err)}`;
+  } finally {
+    state.agentSessionsLoading = false;
+  }
+}
+
+/**
+ * 更新会话模型 (per-session model override)
+ */
+export async function patchSessionModel(
+  state: ModelConfigState,
+  sessionKey: string,
+  model: string | null,
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  const params: Record<string, unknown> = { key: sessionKey };
+  // 只有当 model 不是 undefined 时才添加到参数中
+  params.model = model;
+
+  try {
+    await state.client.request("sessions.patch", params);
+    // 重新加载会话列表 / Reload session list
+    await loadAgentSessions(state);
+  } catch (err) {
+    state.agentSessionsError = `更新会话模型失败: ${String(err)}`;
+  }
+}
+
+// ============================================================
+// 工作区文件操作 / Workspace file operations
+// ============================================================
+
+/**
+ * 加载工作区文件列表
+ * Load workspace file list
+ */
+export async function loadWorkspaceFiles(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.workspaceLoading = true;
+  state.workspaceError = null;
+
+  try {
+    const res = (await state.client.request("workspace.files.list", {
+      agentId: state.workspaceAgentId || undefined,
+    })) as {
+      workspaceDir: string;
+      agentId: string;
+      files: WorkspaceFileInfo[];
+    };
+
+    state.workspaceFiles = res.files;
+    state.workspaceDir = res.workspaceDir;
+    state.workspaceAgentId = res.agentId;
+  } catch (err) {
+    state.workspaceError = `加载文件列表失败: ${String(err)}`;
+  } finally {
+    state.workspaceLoading = false;
+  }
+}
+
+/**
+ * 选择并读取工作区文件
+ * Select and read a workspace file
+ */
+export async function selectWorkspaceFile(
+  state: ModelConfigState,
+  fileName: string,
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.workspaceSelectedFile = fileName;
+  state.workspaceLoading = true;
+  state.workspaceError = null;
+
+  try {
+    const res = (await state.client.request("workspace.file.read", {
+      fileName,
+      agentId: state.workspaceAgentId || undefined,
+    })) as {
+      name: string;
+      path: string;
+      exists: boolean;
+      content: string;
+    };
+
+    state.workspaceEditorContent = res.content;
+    state.workspaceOriginalContent = res.content;
+
+    if (!res.exists) {
+      state.workspaceError = "文件不存在，编辑后保存将自动创建";
+    }
+  } catch (err) {
+    state.workspaceError = `读取文件失败: ${String(err)}`;
+  } finally {
+    state.workspaceLoading = false;
+  }
+}
+
+/**
+ * 保存当前工作区文件
+ * Save current workspace file
+ */
+export async function saveWorkspaceFile(state: ModelConfigState): Promise<void> {
+  if (!state.client || !state.connected || !state.workspaceSelectedFile) return;
+
+  state.workspaceSaving = true;
+  state.workspaceError = null;
+
+  try {
+    await state.client.request("workspace.file.write", {
+      fileName: state.workspaceSelectedFile,
+      content: state.workspaceEditorContent,
+      agentId: state.workspaceAgentId || undefined,
+    });
+
+    // 保存成功后更新原始内容 / Update original content after save
+    state.workspaceOriginalContent = state.workspaceEditorContent;
+
+    // 刷新文件列表 / Refresh file list
+    await loadWorkspaceFiles(state);
+  } catch (err) {
+    state.workspaceError = `保存文件失败: ${String(err)}`;
+  } finally {
+    state.workspaceSaving = false;
+  }
+}
+
+/**
+ * 创建新的工作区文件（设置空内容，等待用户编辑后保存）
+ * Create new workspace file (set empty content, wait for user to edit and save)
+ */
+export function createWorkspaceFile(
+  state: ModelConfigState,
+  fileName: string,
+): void {
+  state.workspaceSelectedFile = fileName;
+  state.workspaceEditorContent = "";
+  state.workspaceOriginalContent = "";
+  state.workspaceError = "文件不存在，编辑后保存将自动创建";
+}
+
+// ============================================
+// 定时任务 Cron 控制函数
+// ============================================
+
+/**
+ * 获取 CronState 适配器（将 ModelConfigState 映射到 CronState）
+ */
+function getCronStateAdapter(state: ModelConfigState): CronState {
+  return {
+    get client() { return state.client; },
+    set client(v) { state.client = v; },
+    get connected() { return state.connected; },
+    set connected(v) { state.connected = v; },
+    get cronLoading() { return state.cronLoading; },
+    set cronLoading(v) { state.cronLoading = v; },
+    get cronJobs() { return state.cronJobs; },
+    set cronJobs(v) { state.cronJobs = v; },
+    get cronStatus() { return state.cronStatus; },
+    set cronStatus(v) { state.cronStatus = v; },
+    get cronError() { return state.cronError; },
+    set cronError(v) { state.cronError = v; },
+    get cronForm() { return state.cronForm; },
+    set cronForm(v) { state.cronForm = v; },
+    get cronRunsJobId() { return state.cronRunsJobId; },
+    set cronRunsJobId(v) { state.cronRunsJobId = v; },
+    get cronRuns() { return state.cronRuns; },
+    set cronRuns(v) { state.cronRuns = v; },
+    get cronBusy() { return state.cronBusy; },
+    set cronBusy(v) { state.cronBusy = v; },
+  };
+}
+
+/**
+ * 初始化 Cron 默认状态
+ */
+export function getDefaultCronState(): Pick<
+  ModelConfigState,
+  | "cronLoading" | "cronBusy" | "cronError"
+  | "cronStatus" | "cronJobs" | "cronForm"
+  | "cronChannels" | "cronChannelLabels" | "cronChannelMeta"
+  | "cronRunsJobId" | "cronRuns"
+  | "cronExpandedJobId" | "cronDeleteConfirmJobId"
+> {
+  return {
+    cronLoading: false,
+    cronBusy: false,
+    cronError: null,
+    cronStatus: null,
+    cronJobs: [],
+    cronForm: { ...DEFAULT_CRON_FORM },
+    cronChannels: [],
+    cronChannelLabels: {},
+    cronChannelMeta: [],
+    cronRunsJobId: null,
+    cronRuns: [],
+    cronExpandedJobId: null,
+    cronDeleteConfirmJobId: null,
+  };
+}
+
+/**
+ * 加载 Cron 数据（状态 + 任务列表）
+ */
+export async function loadCronData(state: ModelConfigState): Promise<void> {
+  const adapter = getCronStateAdapter(state);
+  await Promise.all([
+    loadCronStatusBase(adapter),
+    loadCronJobsBase(adapter),
+  ]);
+}
+
+/**
+ * 添加 Cron 任务
+ */
+export async function addCronJob(state: ModelConfigState): Promise<void> {
+  await addCronJobBase(getCronStateAdapter(state));
+}
+
+/**
+ * 切换 Cron 任务启用/禁用
+ */
+export async function toggleCronJob(
+  state: ModelConfigState,
+  job: CronJob,
+  enabled: boolean,
+): Promise<void> {
+  await toggleCronJobBase(getCronStateAdapter(state), job, enabled);
+}
+
+/**
+ * 立即运行 Cron 任务
+ */
+export async function runCronJob(state: ModelConfigState, job: CronJob): Promise<void> {
+  await runCronJobBase(getCronStateAdapter(state), job);
+}
+
+/**
+ * 删除 Cron 任务
+ */
+export async function removeCronJob(state: ModelConfigState, job: CronJob): Promise<void> {
+  await removeCronJobBase(getCronStateAdapter(state), job);
+}
+
+/**
+ * 加载 Cron 任务运行记录
+ */
+export async function loadCronRuns(state: ModelConfigState, jobId: string): Promise<void> {
+  await loadCronRunsBase(getCronStateAdapter(state), jobId);
+}
+
+/**
+ * 更新 Cron 表单
+ */
+export function updateCronForm(state: ModelConfigState, patch: Partial<CronFormState>): void {
+  state.cronForm = { ...state.cronForm, ...patch };
+}
+
+/**
+ * 展开/折叠 Cron 任务详情
+ */
+export function expandCronJob(state: ModelConfigState, jobId: string | null): void {
+  state.cronExpandedJobId = jobId;
+}
+
+/**
+ * 设置/清除删除确认
+ */
+export function setCronDeleteConfirm(state: ModelConfigState, jobId: string | null): void {
+  state.cronDeleteConfirmJobId = jobId;
+}
+
+/**
+ * 更新 Cron 通道数据（从 channels snapshot 中获取）
+ */
+export function updateCronChannels(
+  state: ModelConfigState,
+  channels: string[],
+  channelLabels: Record<string, string>,
+  channelMeta: ChannelUiMetaEntry[],
+): void {
+  state.cronChannels = channels;
+  state.cronChannelLabels = channelLabels;
+  state.cronChannelMeta = channelMeta;
+}
+

--- a/ui/src/ui-zh-CN/controllers/skills-config.ts
+++ b/ui/src/ui-zh-CN/controllers/skills-config.ts
@@ -1,0 +1,1032 @@
+/**
+ * 技能配置控制器
+ * Skills config controller
+ *
+ * 处理技能管理页面的数据加载和保存
+ * Handles loading and saving of skills management page data
+ */
+import type { GatewayBrowserClient } from "../../ui/gateway";
+import type {
+  SkillStatusReport,
+  SkillsConfig,
+  SkillSourceFilter,
+  SkillStatusFilter,
+  SkillEditState,
+  SkillMessage,
+  SkillEditorState,
+  SkillCreateState,
+  SkillDeleteState,
+  EditableSkillSource,
+  SkillEditorMode,
+} from "../types/skills-config";
+
+// ─── 类型定义 / Type definitions ────────────────────────────────────────────
+
+export type SkillsConfigState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+
+  // 技能数据 (使用 skillsConfig 前缀匹配 app.ts 状态)
+  skillsConfigLoading: boolean;
+  skillsConfigSaving: boolean;
+  skillsConfigError: string | null;
+  skillsConfigReport: SkillStatusReport | null;
+  skillsConfig: SkillsConfig | null;
+  skillsConfigOriginal: SkillsConfig | null;
+  skillsConfigBaseHash: string | null;
+
+  // UI 状态
+  skillsConfigFilter: string;
+  skillsConfigSourceFilter: SkillSourceFilter;
+  skillsConfigStatusFilter: SkillStatusFilter;
+  skillsConfigExpandedGroups: Set<string>;
+  skillsConfigSelectedSkill: string | null;
+  skillsConfigBusySkill: string | null;
+  skillsConfigMessages: Record<string, SkillMessage>;
+
+  // 白名单状态
+  skillsConfigAllowlistMode: "all" | "whitelist";
+  skillsConfigAllowlistDraft: Set<string>;
+
+  // 编辑状态
+  skillsConfigEdits: Record<string, SkillEditState>;
+
+  // 编辑器/创建/删除状态 (Phase 5-6)
+  skillsConfigEditor: SkillEditorState;
+  skillsConfigCreate: SkillCreateState;
+  skillsConfigDelete: SkillDeleteState;
+};
+
+// ─── 初始状态 / Initial state ───────────────────────────────────────────────
+
+export function createInitialSkillsConfigState(): Partial<SkillsConfigState> {
+  return {
+    skillsConfigLoading: false,
+    skillsConfigSaving: false,
+    skillsConfigError: null,
+    skillsConfigReport: null,
+    skillsConfig: null,
+    skillsConfigOriginal: null,
+    skillsConfigBaseHash: null,
+    skillsConfigFilter: "",
+    skillsConfigSourceFilter: "all",
+    skillsConfigStatusFilter: "all",
+    skillsConfigExpandedGroups: new Set(["bundled"]),
+    skillsConfigSelectedSkill: null,
+    skillsConfigBusySkill: null,
+    skillsConfigMessages: {},
+    skillsConfigAllowlistMode: "all",
+    skillsConfigAllowlistDraft: new Set(),
+    skillsConfigEdits: {},
+    // 编辑器初始状态 / Editor initial state
+    skillsConfigEditor: {
+      open: false,
+      skillKey: null,
+      skillName: null,
+      source: null,
+      content: "",
+      original: "",
+      mode: "edit",
+      saving: false,
+      loading: false,
+      error: null,
+    },
+    // 创建弹窗初始状态 / Create modal initial state
+    skillsConfigCreate: {
+      open: false,
+      name: "",
+      source: "workspace",
+      template: "",
+      creating: false,
+      error: null,
+      nameError: null,
+    },
+    // 删除确认初始状态 / Delete confirmation initial state
+    skillsConfigDelete: {
+      open: false,
+      skillKey: null,
+      skillName: null,
+      source: null,
+      deleting: false,
+      error: null,
+    },
+  };
+}
+
+// ─── 辅助函数 / Helper functions ────────────────────────────────────────────
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function setSkillMessage(
+  state: SkillsConfigState,
+  key: string,
+  message?: SkillMessage,
+) {
+  if (!key.trim()) return;
+  const next = { ...state.skillsConfigMessages };
+  if (message) next[key] = message;
+  else delete next[key];
+  state.skillsConfigMessages = next;
+}
+
+/**
+ * 检测是否有未保存的更改
+ */
+export function hasSkillsConfigChanges(state: SkillsConfigState): boolean {
+  // 检查编辑状态
+  if (Object.keys(state.skillsConfigEdits).length > 0) {
+    for (const edit of Object.values(state.skillsConfigEdits)) {
+      if (edit.enabled !== undefined || edit.apiKey !== undefined || edit.inAllowlist !== undefined) {
+        return true;
+      }
+      // 检查环境变量变更
+      if (edit.env && Object.keys(edit.env).length > 0) {
+        return true;
+      }
+      // 检查自定义配置变更
+      if (edit.config && Object.keys(edit.config).length > 0) {
+        return true;
+      }
+    }
+  }
+
+  // 检查白名单草稿与原配置的差异
+  const originalAllowBundled = state.skillsConfigOriginal?.allowBundled ?? [];
+  const currentAllowBundled = Array.from(state.skillsConfigAllowlistDraft);
+
+  if (state.skillsConfigAllowlistMode === "whitelist") {
+    if (originalAllowBundled.length !== currentAllowBundled.length) return true;
+    for (const key of currentAllowBundled) {
+      if (!originalAllowBundled.includes(key)) return true;
+    }
+  }
+
+  return false;
+}
+
+// ─── 加载技能状态 / Load skills status ──────────────────────────────────────
+
+export type LoadSkillsOptions = {
+  clearMessages?: boolean;
+};
+
+export async function loadSkillsStatus(
+  state: SkillsConfigState,
+  options?: LoadSkillsOptions,
+) {
+  if (options?.clearMessages && Object.keys(state.skillsConfigMessages).length > 0) {
+    state.skillsConfigMessages = {};
+  }
+  if (!state.client || !state.connected) return;
+  if (state.skillsConfigLoading) return;
+
+  state.skillsConfigLoading = true;
+  state.skillsConfigError = null;
+
+  try {
+    const res = (await state.client.request("skills.status", {})) as
+      | SkillStatusReport
+      | undefined;
+
+    if (res) {
+      state.skillsConfigReport = res;
+
+      // 从配置中提取现有技能配置
+      // 通过 gateway 获取完整配置
+      const configRes = (await state.client.request("config.get", {})) as
+        | { config: Record<string, unknown>; hash?: string }
+        | undefined;
+
+      if (configRes?.config) {
+        const skillsConfig = extractSkillsConfig(configRes.config);
+        state.skillsConfig = skillsConfig;
+        state.skillsConfigOriginal = JSON.parse(JSON.stringify(skillsConfig));
+        state.skillsConfigBaseHash = configRes.hash ?? null;
+
+        // 初始化白名单状态
+        if (skillsConfig.allowBundled && skillsConfig.allowBundled.length > 0) {
+          state.skillsConfigAllowlistMode = "whitelist";
+          state.skillsConfigAllowlistDraft = new Set(skillsConfig.allowBundled);
+        } else {
+          state.skillsConfigAllowlistMode = "all";
+          state.skillsConfigAllowlistDraft = new Set();
+        }
+      }
+    }
+  } catch (err) {
+    state.skillsConfigError = getErrorMessage(err);
+  } finally {
+    state.skillsConfigLoading = false;
+  }
+}
+
+/**
+ * 从配置中提取技能配置
+ */
+function extractSkillsConfig(config: Record<string, unknown>): SkillsConfig {
+  const skills = config.skills as Record<string, unknown> | undefined;
+  if (!skills) return {};
+
+  return {
+    allowBundled: skills.allowBundled as string[] | undefined,
+    load: skills.load as SkillsConfig["load"],
+    install: skills.install as SkillsConfig["install"],
+    entries: skills.entries as SkillsConfig["entries"],
+  };
+}
+
+// ─── 保存技能配置 / Save skills config ──────────────────────────────────────
+
+export async function saveSkillsConfig(state: SkillsConfigState) {
+  if (!state.client || !state.connected) return;
+  if (state.skillsConfigSaving) return;
+
+  state.skillsConfigSaving = true;
+  state.skillsConfigError = null;
+
+  try {
+    // 处理所有编辑
+    for (const [skillKey, edit] of Object.entries(state.skillsConfigEdits)) {
+      if (edit.enabled !== undefined) {
+        await state.client.request("skills.update", {
+          skillKey,
+          enabled: edit.enabled,
+        });
+      }
+      if (edit.apiKey !== undefined && edit.apiKey.trim()) {
+        await state.client.request("skills.update", {
+          skillKey,
+          apiKey: edit.apiKey,
+        });
+      }
+      // 保存环境变量
+      if (edit.env && Object.keys(edit.env).length > 0) {
+        for (const [envKey, value] of Object.entries(edit.env)) {
+          if (value.trim()) {
+            await state.client.request("skills.update", {
+              skillKey,
+              env: { [envKey]: value },
+            });
+          }
+        }
+      }
+      // 保存自定义配置
+      if (edit.config && Object.keys(edit.config).length > 0) {
+        await state.client.request("skills.update", {
+          skillKey,
+          config: edit.config,
+        });
+      }
+    }
+
+    // 保存白名单配置
+    if (state.skillsConfigAllowlistMode === "whitelist") {
+      const allowBundled = Array.from(state.skillsConfigAllowlistDraft);
+      await updateSkillsConfigField(state, "allowBundled", allowBundled);
+    } else {
+      // 清空白名单（允许全部）
+      await updateSkillsConfigField(state, "allowBundled", undefined);
+    }
+
+    // 清空编辑状态
+    state.skillsConfigEdits = {};
+
+    // 重新加载状态
+    await loadSkillsStatus(state, { clearMessages: false });
+  } catch (err) {
+    state.skillsConfigError = getErrorMessage(err);
+  } finally {
+    state.skillsConfigSaving = false;
+  }
+}
+
+/**
+ * 更新技能配置字段
+ * 使用 config.patch 的 merge-patch 语义（RFC 7386）
+ */
+async function updateSkillsConfigField(
+  state: SkillsConfigState,
+  field: string,
+  value: unknown,
+) {
+  if (!state.client || !state.connected) return;
+  if (!state.skillsConfigBaseHash) {
+    state.skillsConfigError = "Config hash missing; reload and retry.";
+    return;
+  }
+
+  // merge-patch: null 表示删除，非 null 表示设置
+  const patch: Record<string, unknown> = {
+    skills: {
+      [field]: value === undefined ? null : value,
+    },
+  };
+
+  await state.client.request("config.patch", {
+    raw: JSON.stringify(patch),
+    baseHash: state.skillsConfigBaseHash,
+  });
+}
+
+// ─── 切换技能启用状态 / Toggle skill enabled ────────────────────────────────
+
+export async function updateSkillEnabled(
+  state: SkillsConfigState,
+  skillKey: string,
+  enabled: boolean,
+) {
+  if (!state.client || !state.connected) return;
+
+  state.skillsConfigBusySkill = skillKey;
+  state.skillsConfigError = null;
+
+  try {
+    await state.client.request("skills.update", { skillKey, enabled });
+    await loadSkillsStatus(state);
+    setSkillMessage(state, skillKey, {
+      kind: "success",
+      message: enabled ? "技能已启用" : "技能已禁用",
+    });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    state.skillsConfigError = message;
+    setSkillMessage(state, skillKey, { kind: "error", message });
+  } finally {
+    state.skillsConfigBusySkill = null;
+  }
+}
+
+// ─── 保存 API Key / Save API key ────────────────────────────────────────────
+
+export async function saveSkillApiKey(
+  state: SkillsConfigState,
+  skillKey: string,
+) {
+  if (!state.client || !state.connected) return;
+
+  const edit = state.skillsConfigEdits[skillKey];
+  const apiKey = edit?.apiKey ?? "";
+  if (!apiKey.trim()) return;
+
+  state.skillsConfigBusySkill = skillKey;
+  state.skillsConfigError = null;
+
+  try {
+    await state.client.request("skills.update", { skillKey, apiKey });
+    await loadSkillsStatus(state);
+
+    // 清除此技能的 apiKey 编辑
+    const edits = { ...state.skillsConfigEdits };
+    if (edits[skillKey]) {
+      delete edits[skillKey].apiKey;
+      if (Object.keys(edits[skillKey]).length === 0) {
+        delete edits[skillKey];
+      }
+    }
+    state.skillsConfigEdits = edits;
+
+    setSkillMessage(state, skillKey, {
+      kind: "success",
+      message: "API Key 已保存",
+    });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    state.skillsConfigError = message;
+    setSkillMessage(state, skillKey, { kind: "error", message });
+  } finally {
+    state.skillsConfigBusySkill = null;
+  }
+}
+
+// ─── 安装技能依赖 / Install skill dependency ────────────────────────────────
+
+export async function installSkillDependency(
+  state: SkillsConfigState,
+  skillKey: string,
+  name: string,
+  installId: string,
+) {
+  if (!state.client || !state.connected) return;
+
+  state.skillsConfigBusySkill = skillKey;
+  state.skillsConfigError = null;
+
+  try {
+    const result = (await state.client.request("skills.install", {
+      name,
+      installId,
+      timeoutMs: 120000,
+    })) as { ok?: boolean; message?: string };
+
+    await loadSkillsStatus(state);
+
+    setSkillMessage(state, skillKey, {
+      kind: "success",
+      message: result?.message ?? "安装完成",
+    });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    state.skillsConfigError = message;
+    setSkillMessage(state, skillKey, { kind: "error", message });
+  } finally {
+    state.skillsConfigBusySkill = null;
+  }
+}
+
+// ─── UI 状态更新 / UI state updates ─────────────────────────────────────────
+
+export function updateSkillsFilter(state: SkillsConfigState, filter: string) {
+  state.skillsConfigFilter = filter;
+}
+
+export function updateSkillsSourceFilter(
+  state: SkillsConfigState,
+  source: SkillSourceFilter,
+) {
+  state.skillsConfigSourceFilter = source;
+}
+
+export function updateSkillsStatusFilter(
+  state: SkillsConfigState,
+  status: SkillStatusFilter,
+) {
+  state.skillsConfigStatusFilter = status;
+}
+
+export function toggleSkillsGroup(state: SkillsConfigState, group: string) {
+  const groups = new Set(state.skillsConfigExpandedGroups);
+  if (groups.has(group)) {
+    groups.delete(group);
+  } else {
+    groups.add(group);
+  }
+  state.skillsConfigExpandedGroups = groups;
+}
+
+export function selectSkill(state: SkillsConfigState, skillKey: string | null) {
+  state.skillsConfigSelectedSkill = skillKey;
+}
+
+// ─── 编辑状态管理 / Edit state management ───────────────────────────────────
+
+export function updateSkillApiKeyEdit(
+  state: SkillsConfigState,
+  skillKey: string,
+  apiKey: string,
+) {
+  const edits = { ...state.skillsConfigEdits };
+  if (!edits[skillKey]) edits[skillKey] = {};
+  edits[skillKey].apiKey = apiKey;
+  state.skillsConfigEdits = edits;
+}
+
+export function updateSkillEnabledEdit(
+  state: SkillsConfigState,
+  skillKey: string,
+  enabled: boolean,
+) {
+  const edits = { ...state.skillsConfigEdits };
+  if (!edits[skillKey]) edits[skillKey] = {};
+  edits[skillKey].enabled = enabled;
+  state.skillsConfigEdits = edits;
+}
+
+// ─── 环境变量编辑 / Environment variable editing ─────────────────────────────
+
+export function updateSkillEnv(
+  state: SkillsConfigState,
+  skillKey: string,
+  envKey: string,
+  value: string,
+) {
+  const edits = { ...state.skillsConfigEdits };
+  if (!edits[skillKey]) edits[skillKey] = {};
+  if (!edits[skillKey].env) edits[skillKey].env = {};
+  edits[skillKey].env![envKey] = value;
+  state.skillsConfigEdits = edits;
+}
+
+export function removeSkillEnv(
+  state: SkillsConfigState,
+  skillKey: string,
+  envKey: string,
+) {
+  const edits = { ...state.skillsConfigEdits };
+  if (edits[skillKey]?.env) {
+    delete edits[skillKey].env![envKey];
+    // 如果 env 为空，清除它
+    if (Object.keys(edits[skillKey].env!).length === 0) {
+      delete edits[skillKey].env;
+    }
+    // 如果整个编辑状态为空，清除它
+    if (Object.keys(edits[skillKey]).length === 0) {
+      delete edits[skillKey];
+    }
+  }
+  state.skillsConfigEdits = edits;
+}
+
+// ─── 自定义配置编辑 / Custom config editing ──────────────────────────────────
+
+export function updateSkillConfig(
+  state: SkillsConfigState,
+  skillKey: string,
+  config: Record<string, unknown>,
+) {
+  const edits = { ...state.skillsConfigEdits };
+  if (!edits[skillKey]) edits[skillKey] = {};
+  edits[skillKey].config = config;
+  state.skillsConfigEdits = edits;
+}
+
+// ─── 额外技能目录 / Extra skill directories ──────────────────────────────────
+
+export async function updateExtraDirs(
+  state: SkillsConfigState,
+  dirs: string[],
+) {
+  if (!state.client || !state.connected) return;
+  if (!state.skillsConfigBaseHash) {
+    state.skillsConfigError = "Config hash missing; reload and retry.";
+    return;
+  }
+
+  try {
+    const patch = {
+      skills: {
+        load: {
+          extraDirs: dirs,
+        },
+      },
+    };
+    await state.client.request("config.patch", {
+      raw: JSON.stringify(patch),
+      baseHash: state.skillsConfigBaseHash,
+    });
+    await loadSkillsStatus(state);
+  } catch (err) {
+    state.skillsConfigError = getErrorMessage(err);
+  }
+}
+
+// ─── 白名单管理 / Allowlist management ──────────────────────────────────────
+
+export function setAllowlistMode(
+  state: SkillsConfigState,
+  mode: "all" | "whitelist",
+) {
+  state.skillsConfigAllowlistMode = mode;
+
+  // 如果切换到白名单模式，初始化草稿（如果为空）
+  if (mode === "whitelist" && state.skillsConfigAllowlistDraft.size === 0) {
+    // 可以选择默认添加一些技能，或保持为空让用户选择
+    state.skillsConfigAllowlistDraft = new Set();
+  }
+}
+
+export function toggleAllowlistEntry(
+  state: SkillsConfigState,
+  skillKey: string,
+  inList: boolean,
+) {
+  const draft = new Set(state.skillsConfigAllowlistDraft);
+  if (inList) {
+    draft.add(skillKey);
+  } else {
+    draft.delete(skillKey);
+  }
+  state.skillsConfigAllowlistDraft = draft;
+
+  // 也更新编辑状态
+  const edits = { ...state.skillsConfigEdits };
+  if (!edits[skillKey]) edits[skillKey] = {};
+  edits[skillKey].inAllowlist = inList;
+  state.skillsConfigEdits = edits;
+}
+
+// ─── 全局设置 / Global settings ─────────────────────────────────────────────
+
+export async function updateGlobalSetting(
+  state: SkillsConfigState,
+  field: string,
+  value: unknown,
+) {
+  if (!state.client || !state.connected) return;
+  if (!state.skillsConfigBaseHash) {
+    state.skillsConfigError = "Config hash missing; reload and retry.";
+    return;
+  }
+
+  try {
+    // 根据字段构建 merge-patch 对象
+    let patch: Record<string, unknown>;
+    switch (field) {
+      case "preferBrew":
+        patch = { skills: { install: { preferBrew: value } } };
+        break;
+      case "nodeManager":
+        patch = { skills: { install: { nodeManager: value } } };
+        break;
+      case "watch":
+        patch = { skills: { load: { watch: value } } };
+        break;
+      default:
+        return;
+    }
+
+    await state.client.request("config.patch", {
+      raw: JSON.stringify(patch),
+      baseHash: state.skillsConfigBaseHash,
+    });
+
+    await loadSkillsStatus(state);
+  } catch (err) {
+    state.skillsConfigError = getErrorMessage(err);
+  }
+}
+
+// =========================================================================
+// 技能编辑器操作 / Skills editor operations (Phase 5-6)
+// =========================================================================
+
+/**
+ * 默认技能模板
+ * Default skill template
+ */
+const DEFAULT_SKILL_TEMPLATE = `---
+name: "{{SKILL_NAME}}"
+emoji:
+description: 在此描述技能的功能
+homepage:
+requirements:
+  bins: []
+  env: []
+  config: []
+  os: []
+  anyBins: []
+install: []
+---
+
+# {{SKILL_NAME}}
+
+在此编写技能的详细说明，指导 Agent 如何使用此技能。
+
+## 用法
+
+描述典型的使用场景和命令。
+
+## 示例
+
+提供具体的示例。
+`;
+
+/**
+ * 技能名称验证正则（只允许小写字母、数字和连字符）
+ * Skill name validation regex (only lowercase letters, numbers and hyphens)
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+/**
+ * 验证技能名称
+ * Validate skill name
+ */
+function validateSkillName(name: string): string | null {
+  if (!name.trim()) {
+    return "技能名称不能为空";
+  }
+  if (name.includes("/") || name.includes("\\") || name.includes("..")) {
+    return "技能名称包含非法字符";
+  }
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    return "技能名称只能包含小写字母、数字和连字符，且不能以连字符开头或结尾";
+  }
+  return null;
+}
+
+// ─── 编辑器操作 / Editor operations ──────────────────────────────────────────
+
+/**
+ * 打开技能编辑器
+ * Open skill editor
+ */
+export async function openSkillEditor(
+  state: SkillsConfigState,
+  skillKey: string,
+  skillName: string,
+  source: EditableSkillSource,
+) {
+  if (!state.client || !state.connected) return;
+
+  // 更新编辑器状态为加载中
+  state.skillsConfigEditor = {
+    ...state.skillsConfigEditor,
+    open: true,
+    skillKey,
+    skillName,
+    source,
+    content: "",
+    original: "",
+    loading: true,
+    error: null,
+  };
+
+  try {
+    // 调用 RPC 读取技能文件
+    // 使用 skillKey（目录名）而非 skillName（显示名）
+    const result = (await state.client.request("skills.file.read", {
+      skillName: skillKey,
+      source,
+    })) as { name: string; path: string; source: string; exists: boolean; content: string };
+
+    state.skillsConfigEditor = {
+      ...state.skillsConfigEditor,
+      content: result.content,
+      original: result.content,
+      loading: false,
+    };
+  } catch (err) {
+    state.skillsConfigEditor = {
+      ...state.skillsConfigEditor,
+      loading: false,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+/**
+ * 关闭技能编辑器
+ * Close skill editor
+ */
+export function closeSkillEditor(state: SkillsConfigState) {
+  state.skillsConfigEditor = {
+    open: false,
+    skillKey: null,
+    skillName: null,
+    source: null,
+    content: "",
+    original: "",
+    mode: "edit",
+    saving: false,
+    loading: false,
+    error: null,
+  };
+}
+
+/**
+ * 更新编辑器内容
+ * Update editor content
+ */
+export function updateEditorContent(state: SkillsConfigState, content: string) {
+  state.skillsConfigEditor = {
+    ...state.skillsConfigEditor,
+    content,
+  };
+}
+
+/**
+ * 更新编辑器模式
+ * Update editor mode
+ */
+export function updateEditorMode(state: SkillsConfigState, mode: SkillEditorMode) {
+  state.skillsConfigEditor = {
+    ...state.skillsConfigEditor,
+    mode,
+  };
+}
+
+/**
+ * 保存技能文件
+ * Save skill file
+ */
+export async function saveSkillFile(state: SkillsConfigState) {
+  if (!state.client || !state.connected) return;
+
+  const { skillKey, source, content } = state.skillsConfigEditor;
+  if (!skillKey || !source) return;
+
+  state.skillsConfigEditor = {
+    ...state.skillsConfigEditor,
+    saving: true,
+    error: null,
+  };
+
+  try {
+    // 使用 skillKey（目录名）而非 skillName（显示名）
+    await state.client.request("skills.file.write", {
+      skillName: skillKey,
+      source,
+      content,
+    });
+
+    state.skillsConfigEditor = {
+      ...state.skillsConfigEditor,
+      original: content,
+      saving: false,
+    };
+
+    // 重新加载技能状态以反映更改
+    await loadSkillsStatus(state);
+  } catch (err) {
+    state.skillsConfigEditor = {
+      ...state.skillsConfigEditor,
+      saving: false,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+// ─── 创建技能操作 / Create skill operations ──────────────────────────────────
+
+/**
+ * 打开创建技能弹窗
+ * Open create skill modal
+ */
+export function openCreateSkill(state: SkillsConfigState, source?: EditableSkillSource) {
+  state.skillsConfigCreate = {
+    open: true,
+    name: "",
+    source: source ?? "workspace",
+    template: "",
+    creating: false,
+    error: null,
+    nameError: null,
+  };
+}
+
+/**
+ * 关闭创建技能弹窗
+ * Close create skill modal
+ */
+export function closeCreateSkill(state: SkillsConfigState) {
+  state.skillsConfigCreate = {
+    open: false,
+    name: "",
+    source: "workspace",
+    template: "",
+    creating: false,
+    error: null,
+    nameError: null,
+  };
+}
+
+/**
+ * 更新创建技能名称
+ * Update create skill name
+ */
+export function updateCreateSkillName(state: SkillsConfigState, name: string) {
+  const nameError = validateSkillName(name);
+  state.skillsConfigCreate = {
+    ...state.skillsConfigCreate,
+    name,
+    nameError,
+  };
+}
+
+/**
+ * 更新创建技能来源
+ * Update create skill source
+ */
+export function updateCreateSkillSource(state: SkillsConfigState, source: EditableSkillSource) {
+  state.skillsConfigCreate = {
+    ...state.skillsConfigCreate,
+    source,
+  };
+}
+
+/**
+ * 确认创建技能
+ * Confirm create skill
+ */
+export async function confirmCreateSkill(state: SkillsConfigState) {
+  if (!state.client || !state.connected) return;
+
+  const { name, source } = state.skillsConfigCreate;
+
+  // 验证名称
+  const nameError = validateSkillName(name);
+  if (nameError) {
+    state.skillsConfigCreate = {
+      ...state.skillsConfigCreate,
+      nameError,
+    };
+    return;
+  }
+
+  state.skillsConfigCreate = {
+    ...state.skillsConfigCreate,
+    creating: true,
+    error: null,
+  };
+
+  try {
+    // 调用 RPC 创建技能
+    const content = DEFAULT_SKILL_TEMPLATE.replace(/\{\{SKILL_NAME\}\}/g, name);
+    await state.client.request("skills.file.create", {
+      skillName: name,
+      source,
+      content,
+    });
+
+    // 关闭创建弹窗
+    closeCreateSkill(state);
+
+    // 重新加载技能状态
+    await loadSkillsStatus(state);
+
+    // 打开编辑器编辑新创建的技能
+    await openSkillEditor(state, name, name, source);
+  } catch (err) {
+    state.skillsConfigCreate = {
+      ...state.skillsConfigCreate,
+      creating: false,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+// ─── 删除技能操作 / Delete skill operations ──────────────────────────────────
+
+/**
+ * 打开删除确认弹窗
+ * Open delete confirmation modal
+ */
+export function openDeleteSkill(
+  state: SkillsConfigState,
+  skillKey: string,
+  skillName: string,
+  source: EditableSkillSource,
+) {
+  state.skillsConfigDelete = {
+    open: true,
+    skillKey,
+    skillName,
+    source,
+    deleting: false,
+    error: null,
+  };
+}
+
+/**
+ * 关闭删除确认弹窗
+ * Close delete confirmation modal
+ */
+export function closeDeleteSkill(state: SkillsConfigState) {
+  state.skillsConfigDelete = {
+    open: false,
+    skillKey: null,
+    skillName: null,
+    source: null,
+    deleting: false,
+    error: null,
+  };
+}
+
+/**
+ * 确认删除技能
+ * Confirm delete skill
+ */
+export async function confirmDeleteSkill(state: SkillsConfigState) {
+  if (!state.client || !state.connected) return;
+
+  const { skillKey, source } = state.skillsConfigDelete;
+  if (!skillKey || !source) return;
+
+  state.skillsConfigDelete = {
+    ...state.skillsConfigDelete,
+    deleting: true,
+    error: null,
+  };
+
+  try {
+    // 调用 RPC 删除技能
+    // 使用 skillKey（目录名）而非 skillName（显示名）
+    await state.client.request("skills.file.delete", {
+      skillName: skillKey,
+      source,
+    });
+
+    // 关闭删除弹窗
+    closeDeleteSkill(state);
+
+    // 重新加载技能状态
+    await loadSkillsStatus(state);
+  } catch (err) {
+    state.skillsConfigDelete = {
+      ...state.skillsConfigDelete,
+      deleting: false,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+/**
+ * 检测编辑器是否有未保存的更改
+ * Check if editor has unsaved changes
+ */
+export function hasEditorChanges(state: SkillsConfigState): boolean {
+  const { content, original } = state.skillsConfigEditor;
+  return content !== original;
+}

--- a/ui/src/ui-zh-CN/controllers/workspace.ts
+++ b/ui/src/ui-zh-CN/controllers/workspace.ts
@@ -1,0 +1,245 @@
+/**
+ * 工作区文件控制器
+ * Workspace file controller
+ *
+ * 管理工作区文件的加载、读取、编辑、保存逻辑
+ * Manages workspace file loading, reading, editing, and saving logic
+ */
+import type { WorkspaceFileInfo } from "../components/workspace-content";
+
+// ─── 类型定义 / Types ──────────────────────────────────────────────────────
+
+/**
+ * Gateway 客户端接口（精简）
+ * Gateway client interface (minimal)
+ */
+export type WorkspaceClient = {
+  request: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+/**
+ * 工作区状态
+ * Workspace state
+ */
+export type WorkspaceState = {
+  /** Gateway 客户端 / Gateway client */
+  client: WorkspaceClient | null;
+  /** 是否已连接 / Connected */
+  connected: boolean;
+
+  /** 文件列表 / File list */
+  workspaceFiles: WorkspaceFileInfo[];
+  /** 工作区目录 / Workspace directory */
+  workspaceDir: string;
+  /** Agent ID */
+  workspaceAgentId: string;
+  /** 当前选中的文件 / Currently selected file */
+  workspaceSelectedFile: string | null;
+  /** 编辑器内容 / Editor content */
+  workspaceEditorContent: string;
+  /** 原始内容（保存时的内容）/ Original content (content at save time) */
+  workspaceOriginalContent: string;
+  /** 是否正在加载文件列表 / Loading file list */
+  workspaceLoading: boolean;
+  /** 是否正在保存文件 / Saving file */
+  workspaceSaving: boolean;
+  /** 错误信息 / Error message */
+  workspaceError: string | null;
+  /** 编辑器模式 / Editor mode */
+  workspaceEditorMode: "edit" | "preview" | "split";
+};
+
+/**
+ * 创建工作区初始状态
+ * Create initial workspace state
+ */
+export function createWorkspaceState(): WorkspaceState {
+  return {
+    client: null,
+    connected: false,
+    workspaceFiles: [],
+    workspaceDir: "",
+    workspaceAgentId: "main",
+    workspaceSelectedFile: null,
+    workspaceEditorContent: "",
+    workspaceOriginalContent: "",
+    workspaceLoading: false,
+    workspaceSaving: false,
+    workspaceError: null,
+    workspaceEditorMode: "edit",
+  };
+}
+
+// ─── 类型守卫 / Type guards ──────────────────────────────────────────────────
+
+type FilesListResponse = {
+  workspaceDir: string;
+  agentId: string;
+  files: WorkspaceFileInfo[];
+};
+
+type FileReadResponse = {
+  name: string;
+  path: string;
+  exists: boolean;
+  content: string;
+};
+
+type FileWriteResponse = {
+  ok: boolean;
+  path: string;
+  bytesWritten: number;
+};
+
+// ─── 操作函数 / Actions ─────────────────────────────────────────────────────
+
+/**
+ * 加载工作区文件列表
+ * Load workspace file list
+ */
+export async function loadWorkspaceFiles(
+  state: WorkspaceState,
+  requestUpdate: () => void,
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.workspaceLoading = true;
+  state.workspaceError = null;
+  requestUpdate();
+
+  try {
+    const res = (await state.client.request("workspace.files.list", {
+      agentId: state.workspaceAgentId || undefined,
+    })) as FilesListResponse;
+
+    state.workspaceFiles = res.files;
+    state.workspaceDir = res.workspaceDir;
+    state.workspaceAgentId = res.agentId;
+  } catch (err) {
+    state.workspaceError = `加载文件列表失败: ${String(err)}`;
+  } finally {
+    state.workspaceLoading = false;
+    requestUpdate();
+  }
+}
+
+/**
+ * 选择并读取文件
+ * Select and read a file
+ */
+export async function selectWorkspaceFile(
+  state: WorkspaceState,
+  fileName: string,
+  requestUpdate: () => void,
+): Promise<void> {
+  if (!state.client || !state.connected) return;
+
+  state.workspaceSelectedFile = fileName;
+  state.workspaceLoading = true;
+  state.workspaceError = null;
+  requestUpdate();
+
+  try {
+    const res = (await state.client.request("workspace.file.read", {
+      fileName,
+      agentId: state.workspaceAgentId || undefined,
+    })) as FileReadResponse;
+
+    state.workspaceEditorContent = res.content;
+    state.workspaceOriginalContent = res.content;
+
+    if (!res.exists) {
+      // 文件不存在，显示提示 / File does not exist
+      state.workspaceError = "文件不存在，编辑后保存将自动创建";
+    }
+  } catch (err) {
+    state.workspaceError = `读取文件失败: ${String(err)}`;
+  } finally {
+    state.workspaceLoading = false;
+    requestUpdate();
+  }
+}
+
+/**
+ * 更新编辑器内容
+ * Update editor content
+ */
+export function updateWorkspaceContent(
+  state: WorkspaceState,
+  content: string,
+  requestUpdate: () => void,
+): void {
+  state.workspaceEditorContent = content;
+  requestUpdate();
+}
+
+/**
+ * 保存当前文件
+ * Save current file
+ */
+export async function saveWorkspaceFile(
+  state: WorkspaceState,
+  requestUpdate: () => void,
+): Promise<void> {
+  if (!state.client || !state.connected || !state.workspaceSelectedFile) return;
+
+  state.workspaceSaving = true;
+  state.workspaceError = null;
+  requestUpdate();
+
+  try {
+    (await state.client.request("workspace.file.write", {
+      fileName: state.workspaceSelectedFile,
+      content: state.workspaceEditorContent,
+      agentId: state.workspaceAgentId || undefined,
+    })) as FileWriteResponse;
+
+    // 保存成功后更新原始内容 / Update original content after successful save
+    state.workspaceOriginalContent = state.workspaceEditorContent;
+
+    // 刷新文件列表以更新大小和修改时间 / Refresh file list to update size and modification time
+    await loadWorkspaceFiles(state, requestUpdate);
+  } catch (err) {
+    state.workspaceError = `保存文件失败: ${String(err)}`;
+  } finally {
+    state.workspaceSaving = false;
+    requestUpdate();
+  }
+}
+
+/**
+ * 切换编辑器模式
+ * Toggle editor mode
+ */
+export function setWorkspaceEditorMode(
+  state: WorkspaceState,
+  mode: "edit" | "preview" | "split",
+  requestUpdate: () => void,
+): void {
+  state.workspaceEditorMode = mode;
+  requestUpdate();
+}
+
+/**
+ * 创建新文件（通过选择并保存空内容）
+ * Create new file (by selecting and saving empty content)
+ */
+export async function createWorkspaceFile(
+  state: WorkspaceState,
+  fileName: string,
+  requestUpdate: () => void,
+): Promise<void> {
+  state.workspaceSelectedFile = fileName;
+  state.workspaceEditorContent = "";
+  state.workspaceOriginalContent = "";
+  state.workspaceError = "文件不存在，编辑后保存将自动创建";
+  requestUpdate();
+}
+
+/**
+ * 检查工作区是否有未保存的变更
+ * Check if workspace has unsaved changes
+ */
+export function hasWorkspaceChanges(state: WorkspaceState): boolean {
+  return state.workspaceEditorContent !== state.workspaceOriginalContent;
+}

--- a/ui/src/ui-zh-CN/styles/model-config.css
+++ b/ui/src/ui-zh-CN/styles/model-config.css
@@ -1,0 +1,6084 @@
+/* ===========================================
+   Model Config Page - 模型配置页面
+   =========================================== */
+
+/* Layout */
+.mc-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  height: calc(100vh - 160px);
+  margin: -16px;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+
+/* Sidebar Layout - 侧边栏布局 */
+.mc-layout--sidebar {
+  flex-direction: row;
+}
+
+.mc-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ===========================================
+   Config Sidebar - 配置侧边栏
+   =========================================== */
+
+.config-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-accent);
+  border-right: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .config-sidebar {
+  background: var(--bg-hover);
+}
+
+.config-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.config-sidebar__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.config-sidebar__badge {
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--accent-subtle);
+  border: 1px solid rgba(255, 77, 77, 0.3);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.config-sidebar__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.config-sidebar__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 16px;
+  margin-bottom: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.config-sidebar__item:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.config-sidebar__item--active {
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+:root[data-theme="light"] .config-sidebar__item--active {
+  background: white;
+}
+
+.config-sidebar__item-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.config-sidebar__item--active .config-sidebar__item-icon {
+  color: var(--accent);
+}
+
+.config-sidebar__item-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.config-sidebar__item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-sidebar__item-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.config-sidebar__item-desc {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.config-sidebar__footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+}
+
+.config-sidebar__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.config-sidebar__status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--danger);
+}
+
+.config-sidebar__status-dot--ok {
+  background: var(--ok);
+}
+
+.config-sidebar__status-text {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ===========================================
+   Config Content - 配置内容区
+   =========================================== */
+
+.config-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.config-content__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .config-content__header {
+  background: var(--bg-hover);
+}
+
+.config-content__icon {
+  width: 36px;
+  height: 36px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.config-content__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.config-content__titles {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-content__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.config-content__desc {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.config-content__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Actions Bar - 操作栏 */
+.mc-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 22px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .mc-actions {
+  background: var(--bg-hover);
+}
+
+.mc-actions__left,
+.mc-actions__right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mc-changes-badge {
+  padding: 6px 14px;
+  border-radius: var(--radius-full);
+  background: var(--accent-subtle);
+  border: 1px solid rgba(255, 77, 77, 0.3);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mc-status {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Content Area - 内容区域 */
+.mc-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Section - 区块 */
+.mc-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mc-section__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .mc-section__header {
+  background: var(--bg-hover);
+}
+
+.mc-section__icon {
+  width: 32px;
+  height: 32px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.mc-section__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mc-section__titles {
+  flex: 1;
+  min-width: 0;
+}
+
+.mc-section__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.mc-section__desc {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Card - 卡片 */
+.mc-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition: border-color var(--duration-fast) ease;
+}
+
+.mc-card:hover {
+  border-color: var(--border-strong);
+}
+
+:root[data-theme="light"] .mc-card {
+  background: white;
+}
+
+.mc-card--link {
+  cursor: pointer;
+}
+
+.mc-card--link:hover {
+  border-color: var(--accent);
+}
+
+.mc-card--link:hover .mc-card__link-icon {
+  color: var(--accent);
+}
+
+.mc-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 20px 22px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .mc-card__header {
+  background: var(--bg-hover);
+}
+
+.mc-card__icon {
+  width: 32px;
+  height: 32px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.mc-card__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mc-card__titles {
+  flex: 1;
+  min-width: 0;
+}
+
+.mc-card__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.mc-card__desc {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.mc-card__link-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  transition: color var(--duration-fast) ease;
+}
+
+.mc-card__link-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mc-card__content {
+  padding: 22px;
+}
+
+/* Provider Card - 供应商卡片 */
+.mc-providers-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mc-provider-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition: border-color var(--duration-fast) ease;
+}
+
+.mc-provider-card:hover {
+  border-color: var(--border-strong);
+}
+
+:root[data-theme="light"] .mc-provider-card {
+  background: white;
+}
+
+.mc-provider-card--expanded {
+  border-color: var(--accent);
+}
+
+.mc-provider-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.mc-provider-card__header:hover {
+  background: var(--bg-hover);
+}
+
+.mc-provider-card__info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.mc-provider-card__icon {
+  width: 28px;
+  height: 28px;
+  color: var(--accent);
+}
+
+.mc-provider-card__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mc-provider-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mc-provider-card__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.mc-provider-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.mc-provider-card__protocol {
+  padding: 2px 8px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-sm);
+}
+
+.mc-provider-card__count {
+  opacity: 0.8;
+}
+
+.mc-provider-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mc-provider-card__chevron {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+
+.mc-provider-card__chevron svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mc-provider-card__chevron--open {
+  transform: rotate(180deg);
+}
+
+.mc-provider-card__content {
+  padding: 20px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .mc-provider-card__content {
+  background: var(--bg-hover);
+}
+
+/* Form Elements - 表单元素 */
+.mc-form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mc-form-row {
+  display: flex;
+  gap: 16px;
+}
+
+.mc-form-row--2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.mc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.mc-field--sm {
+  gap: 4px;
+}
+
+.mc-field__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.mc-field--sm .mc-field__label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.mc-input {
+  padding: 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 14px;
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.mc-input::placeholder {
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+.mc-input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+  background: var(--bg-hover);
+}
+
+:root[data-theme="light"] .mc-input {
+  background: white;
+}
+
+:root[data-theme="light"] .mc-input:focus {
+  background: white;
+}
+
+.mc-input--sm {
+  padding: 8px 10px;
+  font-size: 13px;
+}
+
+.mc-textarea {
+  padding: 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 14px;
+  font-family: var(--font-mono);
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+  line-height: 1.5;
+  width: 100%;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.mc-textarea::placeholder {
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+.mc-textarea:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+  background: var(--bg-hover);
+}
+
+:root[data-theme="light"] .mc-textarea {
+  background: white;
+}
+
+:root[data-theme="light"] .mc-textarea:focus {
+  background: white;
+}
+
+.mc-field__desc {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.mc-select {
+  padding: 11px 40px 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-elevated);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  font-size: 14px;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.mc-select:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+:root[data-theme="light"] .mc-select {
+  background-color: white;
+}
+
+/* Toggle - 开关 */
+.mc-toggle-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mc-toggle-field__label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.mc-toggle {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.mc-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.mc-toggle__track {
+  display: block;
+  width: 40px;
+  height: 22px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  position: relative;
+  transition:
+    background var(--duration-normal) ease,
+    border-color var(--duration-normal) ease;
+  cursor: pointer;
+}
+
+:root[data-theme="light"] .mc-toggle__track {
+  background: var(--border);
+}
+
+.mc-toggle__track::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--text);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    background var(--duration-normal) ease;
+}
+
+.mc-toggle input:checked + .mc-toggle__track {
+  background: var(--ok-subtle);
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.mc-toggle input:checked + .mc-toggle__track::after {
+  transform: translateX(18px);
+  background: var(--ok);
+}
+
+.mc-toggle input:focus + .mc-toggle__track {
+  box-shadow: var(--focus-ring);
+}
+
+/* Models Section - 模型列表 */
+.mc-models-section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+.mc-models-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.mc-models-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.mc-models-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mc-model-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+:root[data-theme="light"] .mc-model-row {
+  background: white;
+}
+
+.mc-model-row__main {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.mc-model-row__field {
+  min-width: 0;
+}
+
+.mc-model-row__field--id {
+  flex: 2;
+  min-width: 150px;
+}
+
+.mc-model-row__field--name {
+  flex: 2;
+  min-width: 150px;
+}
+
+.mc-model-row__field--context {
+  flex: 1;
+  min-width: 100px;
+}
+
+.mc-model-row__field--tokens {
+  flex: 1;
+  min-width: 100px;
+}
+
+.mc-model-row__field--input {
+  flex: 0 0 auto;
+  min-width: 120px;
+}
+
+.mc-model-row__field--reasoning {
+  flex: 0 0 auto;
+  padding-bottom: 8px;
+}
+
+.mc-model-row__remove {
+  flex-shrink: 0;
+  margin-bottom: 4px;
+}
+
+/* Checkbox Group - 复选框组 */
+.mc-checkbox-group {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.mc-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.mc-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* Model Advanced - 模型高级配置 */
+.mc-model-advanced {
+  margin-top: 8px;
+  margin-left: 12px;
+}
+
+.mc-model-advanced__details {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .mc-model-advanced__details {
+  background: var(--bg-hover);
+}
+
+.mc-model-advanced__summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  transition: color var(--duration-fast) ease;
+}
+
+.mc-model-advanced__summary:hover {
+  color: var(--text);
+}
+
+.mc-model-advanced__summary svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mc-model-advanced__content {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mc-model-advanced__section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mc-model-advanced__section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.mc-model-advanced__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 992px) {
+  .mc-model-advanced__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .mc-model-advanced__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mc-model-advanced__compat {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+/* Input with Unit - 带单位的输入框 */
+.mc-input-with-unit {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mc-input-with-unit .mc-input {
+  flex: 1;
+  min-width: 60px;
+}
+
+.mc-input-unit {
+  font-size: 10px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Compat Select - 兼容性选择器 */
+.mc-compat-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mc-compat-select__label {
+  font-size: 12px;
+  color: var(--text);
+}
+
+/* Headers Section - Headers 编辑器 */
+.mc-headers-section {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.mc-headers-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.mc-headers-section__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.mc-headers-section__hint {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+:root[data-theme="light"] .mc-headers-section__hint {
+  background: white;
+}
+
+.mc-headers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mc-header-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.mc-header-row .mc-input {
+  flex: 1;
+}
+
+.mc-icon-btn--sm {
+  width: 28px;
+  height: 28px;
+}
+
+.mc-icon-btn--sm svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Button - 按钮 */
+.mc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.mc-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.mc-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mc-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mc-btn--sm {
+  padding: 7px 12px;
+  font-size: 12px;
+}
+
+.mc-btn--sm svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mc-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.mc-btn--primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.mc-btn--danger {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: white;
+}
+
+.mc-btn--danger:hover:not(:disabled) {
+  background: #dc2626;
+  border-color: #dc2626;
+}
+
+/* Icon Button - 图标按钮 */
+.mc-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.mc-icon-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mc-icon-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.mc-icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.mc-icon-btn--danger:hover:not(:disabled) {
+  background: var(--danger-subtle);
+  color: var(--danger);
+}
+
+/* Empty State - 空状态 */
+.mc-empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+  background: var(--bg-accent);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* ===========================================
+   Mobile Responsiveness - 移动端适配
+   =========================================== */
+
+@media (max-width: 992px) {
+  /* Sidebar becomes collapsible on medium screens */
+  .config-sidebar {
+    width: 220px;
+  }
+
+  .config-sidebar__item {
+    padding: 12px 14px;
+  }
+
+  .config-sidebar__item-desc {
+    display: none;
+  }
+
+  .config-content__header {
+    padding: 16px 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  .mc-layout {
+    margin: -12px;
+    border-radius: var(--radius-lg);
+  }
+
+  /* Stack sidebar on top on mobile */
+  .mc-layout--sidebar {
+    flex-direction: column;
+  }
+
+  .config-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    max-height: none;
+  }
+
+  .config-sidebar__nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .config-sidebar__item {
+    flex: 1 1 auto;
+    min-width: 100px;
+    margin-bottom: 0;
+    padding: 10px 14px;
+    justify-content: center;
+  }
+
+  .config-sidebar__item-icon {
+    margin-top: 0;
+  }
+
+  .config-sidebar__item-content {
+    display: none;
+  }
+
+  .config-sidebar__footer {
+    display: none;
+  }
+
+  .mc-main {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .mc-actions {
+    flex-wrap: wrap;
+    padding: 12px 16px;
+  }
+
+  .mc-actions__left,
+  .mc-actions__right {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .mc-content {
+    padding: 16px;
+  }
+
+  .mc-section__header {
+    flex-wrap: wrap;
+    padding: 14px 16px;
+  }
+
+  .mc-form-row--2col {
+    grid-template-columns: 1fr;
+  }
+
+  .mc-model-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mc-model-row__main {
+    flex-direction: column;
+  }
+
+  .mc-model-row__field {
+    width: 100%;
+  }
+
+  .mc-model-row__remove {
+    align-self: flex-end;
+  }
+
+  .config-content__header {
+    flex-wrap: wrap;
+    padding: 14px 16px;
+  }
+
+  .config-content__icon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .config-content__title {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .mc-provider-card__header {
+    padding: 12px 14px;
+  }
+
+  .mc-provider-card__content {
+    padding: 14px;
+  }
+
+  .mc-card__header {
+    padding: 14px 16px;
+  }
+
+  .mc-card__content {
+    padding: 16px;
+  }
+
+  .config-sidebar__item {
+    padding: 8px 12px;
+    min-width: 80px;
+  }
+
+  .config-sidebar__item-icon {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+/* ===========================================
+   Channels Configuration - 通道配置
+   =========================================== */
+
+/* Channels Layout - 通道布局 */
+.channels-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 400px;
+}
+
+.channels-layout__sidebar {
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.channels-layout__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Channel List - 通道列表（水平滚动） */
+.channel-list {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.channel-list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.channel-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.channel-list::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 3px;
+}
+
+.channel-list::-webkit-scrollbar-thumb:hover {
+  background: var(--muted);
+}
+
+:root[data-theme="light"] .channel-list {
+  background: var(--bg-hover);
+}
+
+.channel-list__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 10px 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.channel-list__item:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.channel-list__item--active {
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+:root[data-theme="light"] .channel-list__item--active {
+  background: white;
+}
+
+.channel-list__item--disabled {
+  opacity: 0.6;
+}
+
+.channel-list__item--disabled .channel-list__icon {
+  color: var(--muted);
+}
+
+.channel-list__icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.channel-list__icon--enabled {
+  color: var(--accent);
+}
+
+.channel-list__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.channel-list__content {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.channel-list__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.channel-list__status {
+  display: none; /* 水平模式下隐藏状态文本 */
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.channel-list__indicator {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.channel-list__item--active .channel-list__indicator {
+  color: var(--ok);
+}
+
+.channel-list__item--disabled .channel-list__indicator {
+  color: var(--danger);
+}
+
+.channel-list__indicator svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Channel Detail - 通道详情 */
+.channel-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+:root[data-theme="light"] .channel-detail {
+  background: white;
+}
+
+.channel-detail__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--muted);
+  background: var(--bg-accent);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  min-height: 300px;
+}
+
+.channel-detail__empty-icon {
+  width: 48px;
+  height: 48px;
+  opacity: 0.5;
+}
+
+.channel-detail__empty-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.channel-detail__empty-text {
+  font-size: 14px;
+}
+
+.channel-detail__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.channel-detail__icon {
+  width: 40px;
+  height: 40px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.channel-detail__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.channel-detail__titles {
+  flex: 1;
+  min-width: 0;
+}
+
+.channel-detail__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.channel-detail__desc {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.channel-detail__docs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.channel-detail__docs:hover {
+  background: var(--bg-hover);
+  color: var(--accent);
+}
+
+.channel-detail__docs svg {
+  width: 18px;
+  height: 18px;
+}
+
+.channel-detail__body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.channel-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.channel-detail__section-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.channel-detail__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Channel Content Header - 通道内容头部 */
+.config-content--channels .config-content__header {
+  flex-wrap: wrap;
+}
+
+.config-content--channels .config-content__header .mc-btn {
+  margin-left: auto;
+}
+
+/* Responsive - 通道配置响应式 */
+@media (max-width: 768px) {
+  .channel-list__item {
+    padding: 8px 12px;
+  }
+
+  .channel-list__icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  .channel-detail {
+    padding: 16px;
+  }
+
+  .channel-detail__header {
+    flex-wrap: wrap;
+  }
+
+  .channel-detail__icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .channel-detail__title {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .channel-list {
+    padding: 6px 8px;
+    gap: 6px;
+  }
+
+  .channel-list__item {
+    padding: 6px 10px;
+  }
+
+  .channel-list__icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  .channel-list__indicator {
+    display: none;
+  }
+
+  .channel-detail {
+    padding: 14px;
+  }
+
+  .channel-detail__fields {
+    gap: 12px;
+  }
+}
+
+/* ===========================================
+   Permissions Configuration - 权限配置
+   =========================================== */
+
+/* Permissions Content */
+.permissions-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Permissions Main Tabs Header */
+.permissions-tabs-header {
+  display: flex;
+  gap: 8px;
+  padding: 4px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+:root[data-theme="light"] .permissions-tabs-header {
+  background: var(--bg-hover);
+}
+
+.permissions-main-tab {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  padding: 14px 20px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.permissions-main-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.permissions-main-tab--active {
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+
+:root[data-theme="light"] .permissions-main-tab--active {
+  background: white;
+}
+
+.permissions-main-tab__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.permissions-main-tab__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.permissions-main-tab--active .permissions-main-tab__icon {
+  color: var(--accent);
+}
+
+.permissions-main-tab__text {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .permissions-tabs-header {
+    flex-direction: column;
+  }
+
+  .permissions-main-tab {
+    padding: 12px 16px;
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 480px) {
+  .permissions-main-tab {
+    padding: 10px 14px;
+    gap: 8px;
+  }
+
+  .permissions-main-tab__icon {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.permissions-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.permissions-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.permissions-desc {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.permissions-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 18px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+:root[data-theme="light"] .permissions-actions {
+  background: var(--bg-hover);
+}
+
+.permissions-actions__left,
+.permissions-actions__right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.permissions-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--muted);
+  background: var(--bg-accent);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* Permissions Section */
+.permissions-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+:root[data-theme="light"] .permissions-section {
+  background: white;
+}
+
+.permissions-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.permissions-section__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.permissions-section__desc {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.permissions-section__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Permissions Tabs (Agent Selector) */
+.permissions-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.permissions-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+:root[data-theme="light"] .permissions-tab {
+  background: var(--bg-hover);
+}
+
+.permissions-tab:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.permissions-tab--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.permissions-tab--active:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.permissions-tab__badge {
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.permissions-tab--active .permissions-tab__badge {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* Permissions Policy Grid */
+.permissions-policy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.permissions-policy-item {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+:root[data-theme="light"] .permissions-policy-item {
+  background: var(--bg-hover);
+}
+
+.permissions-policy-item__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.permissions-policy-item__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.permissions-policy-item__desc {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Permissions Select */
+.permissions-select {
+  width: 100%;
+  padding: 11px 40px 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-elevated);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  font-size: 14px;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.permissions-select:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+:root[data-theme="light"] .permissions-select {
+  background-color: white;
+}
+
+/* Permissions Checkbox */
+.permissions-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.permissions-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.permissions-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* Permissions Input */
+.permissions-input {
+  width: 100%;
+  padding: 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 14px;
+  font-family: var(--font-mono);
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.permissions-input::placeholder {
+  color: var(--muted);
+  opacity: 0.7;
+  font-family: var(--font-sans);
+}
+
+.permissions-input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+  background: var(--bg-hover);
+}
+
+:root[data-theme="light"] .permissions-input {
+  background: white;
+}
+
+:root[data-theme="light"] .permissions-input:focus {
+  background: white;
+}
+
+/* Permissions Allowlist */
+.permissions-allowlist {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.permissions-allowlist__empty {
+  padding: 32px 24px;
+  text-align: center;
+  color: var(--muted);
+  background: var(--bg-accent);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+}
+
+.permissions-allowlist__empty p {
+  margin: 0;
+}
+
+.permissions-allowlist__empty p.muted {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.permissions-allowlist__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 14px 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+:root[data-theme="light"] .permissions-allowlist__item {
+  background: var(--bg-hover);
+}
+
+.permissions-allowlist__item-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.permissions-allowlist__item-pattern {
+  width: 100%;
+}
+
+.permissions-allowlist__item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.permissions-allowlist__item-meta .mono {
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+.permissions-allowlist__item-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Responsive - 权限配置响应式 */
+@media (max-width: 768px) {
+  .permissions-actions {
+    flex-wrap: wrap;
+    padding: 12px 16px;
+  }
+
+  .permissions-actions__left,
+  .permissions-actions__right {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .permissions-section {
+    padding: 16px;
+  }
+
+  .permissions-policy-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .permissions-tabs {
+    gap: 6px;
+  }
+
+  .permissions-tab {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+
+  .permissions-allowlist__item {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .permissions-allowlist__item-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 480px) {
+  .permissions-header {
+    padding-bottom: 12px;
+  }
+
+  .permissions-title {
+    font-size: 16px;
+  }
+
+  .permissions-desc {
+    font-size: 13px;
+  }
+
+  .permissions-section__title {
+    font-size: 14px;
+  }
+
+  .permissions-policy-item {
+    padding: 12px;
+  }
+}
+
+/* ===========================================
+   Permissions Target Selector - 目标选择器
+   =========================================== */
+
+.permissions-target-section {
+  border-color: var(--accent);
+  border-style: solid;
+  border-width: 1px;
+}
+
+.permissions-target {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.permissions-target__type,
+.permissions-target__node {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.permissions-target__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.permissions-target__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* Radio Button Styles */
+.permissions-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text);
+  padding: 10px 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+:root[data-theme="light"] .permissions-radio {
+  background: var(--bg-hover);
+}
+
+.permissions-radio:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.permissions-radio:has(input:checked) {
+  background: var(--accent-subtle);
+  border-color: var(--accent);
+}
+
+.permissions-radio:has(input:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.permissions-radio input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.permissions-radio__mark {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-strong);
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.permissions-radio:has(input:checked) .permissions-radio__mark {
+  border-color: var(--accent);
+}
+
+.permissions-radio__mark::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  transition: transform var(--duration-fast) ease;
+}
+
+.permissions-radio:has(input:checked) .permissions-radio__mark::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.permissions-radio__text {
+  font-weight: 500;
+}
+
+.permissions-radio__hint {
+  font-size: 12px;
+  color: var(--muted);
+  margin-left: 4px;
+}
+
+/* Info Box */
+.permissions-target__info {
+  margin-top: 8px;
+}
+
+.permissions-info-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+:root[data-theme="light"] .permissions-info-box {
+  background: var(--bg-hover);
+}
+
+.permissions-info-box__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--accent);
+  margin-top: 2px;
+}
+
+.permissions-info-box__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.permissions-info-box__text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.permissions-info-box__text strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* Wildcard Tab Style */
+.permissions-tab--wildcard {
+  background: var(--accent-subtle);
+  border-color: rgba(255, 77, 77, 0.3);
+}
+
+.permissions-tab--wildcard:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent);
+}
+
+.permissions-tab--wildcard.permissions-tab--active {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+/* Config Badge Style */
+.permissions-tab__badge--config {
+  background: rgba(34, 197, 94, 0.2);
+  color: var(--ok);
+}
+
+.permissions-tab--active .permissions-tab__badge--config {
+  background: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+/* Responsive - Target Selector */
+@media (max-width: 768px) {
+  .permissions-target__options {
+    flex-direction: column;
+  }
+
+  .permissions-radio {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .permissions-radio {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .permissions-info-box {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .permissions-info-box__icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  .permissions-info-box__text {
+    font-size: 12px;
+  }
+}
+
+/* ===========================================
+   Tools Permissions - 工具权限
+   =========================================== */
+
+/* Permissions Divider */
+.permissions-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 32px 0;
+}
+
+/* Tools List */
+.tools-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Tools Group */
+.tools-group {
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .tools-group {
+  background: var(--bg-hover);
+}
+
+.tools-group--denied {
+  opacity: 0.7;
+}
+
+.tools-group__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .tools-group__header {
+  background: white;
+}
+
+.tools-group__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tools-group__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.tools-group__desc {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.tools-group__toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tools-group__count {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.tools-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Tools Item */
+.tools-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--duration-fast) ease;
+}
+
+.tools-item:last-child {
+  border-bottom: none;
+}
+
+.tools-item:hover {
+  background: var(--bg-hover);
+}
+
+.tools-item--denied {
+  opacity: 0.5;
+}
+
+.tools-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.tools-item__name {
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+
+.tools-item--denied .tools-item__name {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+
+.tools-item__label {
+  font-size: 12px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.tools-item__desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+/* Small Toggle */
+.mc-toggle--sm .mc-toggle__track {
+  width: 32px;
+  height: 18px;
+}
+
+.mc-toggle--sm .mc-toggle__track::after {
+  width: 12px;
+  height: 12px;
+}
+
+.mc-toggle--sm input:checked + .mc-toggle__track::after {
+  transform: translateX(14px);
+}
+
+/* Responsive - Tools */
+@media (max-width: 768px) {
+  .tools-group__header {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .tools-group__info {
+    flex: 1;
+    min-width: 200px;
+  }
+
+  .tools-item {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .tools-item__info {
+    flex: 1;
+    min-width: 200px;
+  }
+}
+
+@media (max-width: 480px) {
+  .permissions-divider {
+    margin: 24px 0;
+  }
+
+  .tools-group__name {
+    font-size: 13px;
+  }
+
+  .tools-item__name {
+    font-size: 12px;
+  }
+
+  .tools-item__desc {
+    font-size: 11px;
+  }
+}
+
+/* ===========================================
+   Sessions List - 会话列表 (Agent 设置页)
+   =========================================== */
+
+.sessions-list {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .sessions-list {
+  background: white;
+}
+
+.sessions-list__header {
+  display: grid;
+  grid-template-columns: 2fr 2fr 1fr;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+:root[data-theme="light"] .sessions-list__header {
+  background: var(--bg-hover);
+}
+
+.sessions-list__col {
+  display: flex;
+  align-items: center;
+}
+
+.sessions-list__col--key {
+  min-width: 0;
+}
+
+.sessions-list__col--model {
+  min-width: 0;
+}
+
+.sessions-list__col--updated {
+  text-align: right;
+  justify-content: flex-end;
+}
+
+.sessions-list__body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Session Row */
+.session-row {
+  display: grid;
+  grid-template-columns: 2fr 2fr 1fr;
+  gap: 12px;
+  padding: 12px 16px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--duration-fast) ease;
+}
+
+.session-row:last-child {
+  border-bottom: none;
+}
+
+.session-row:hover {
+  background: var(--bg-hover);
+}
+
+.session-row__key {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.session-row__name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-row__link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-row__link:hover {
+  text-decoration: underline;
+}
+
+.session-row__kind {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.session-row__model {
+  min-width: 0;
+}
+
+.session-row__updated {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+}
+
+/* Small Select for Sessions */
+.mc-select--sm {
+  padding: 8px 32px 8px 10px;
+  font-size: 13px;
+  background-position: right 8px center;
+}
+
+/* Error Message */
+.mc-error {
+  padding: 12px 16px;
+  background: var(--danger-subtle);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-md);
+  color: var(--danger);
+  font-size: 13px;
+}
+
+/* Mobile Responsiveness for Sessions */
+@media (max-width: 768px) {
+  .sessions-list__header {
+    grid-template-columns: 1fr 1fr;
+    padding: 10px 14px;
+  }
+
+  .sessions-list__col--updated {
+    display: none;
+  }
+
+  .session-row {
+    grid-template-columns: 1fr 1fr;
+    padding: 10px 14px;
+  }
+
+  .session-row__updated {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .sessions-list__header {
+    grid-template-columns: 1fr;
+  }
+
+  .sessions-list__col--model {
+    display: none;
+  }
+
+  .session-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .session-row__model {
+    width: 100%;
+  }
+
+  .session-row__model .mc-select--sm {
+    width: 100%;
+  }
+}
+
+/* ===========================================
+   Agent Identity Section - Agent 身份设置
+   =========================================== */
+
+/* Agent 身份预览 */
+.agent-identity-preview {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 16px;
+}
+
+:root[data-theme="light"] .agent-identity-preview {
+  background: var(--bg-hover);
+}
+
+.agent-identity-preview__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+:root[data-theme="light"] .agent-identity-preview__avatar {
+  background: white;
+}
+
+.agent-identity-preview__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.agent-identity-preview__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-identity-preview__name {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.agent-identity-preview__theme {
+  font-size: 14px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+/* Avatar 输入行 */
+.agent-identity-avatar-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.agent-identity-avatar-row .mc-input {
+  flex: 1;
+}
+
+/* Help Card - 帮助说明卡片 */
+.mc-help-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 18px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-top: 4px;
+}
+
+:root[data-theme="light"] .mc-help-card {
+  background: var(--bg-hover);
+}
+
+.mc-help-card__icon {
+  font-size: 16px;
+  flex-shrink: 0;
+  line-height: 1.4;
+}
+
+.mc-help-card__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.mc-help-card__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.mc-help-card__text {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+/* Responsive - Agent 身份设置 */
+@media (max-width: 768px) {
+  .agent-identity-preview {
+    flex-direction: column;
+    text-align: center;
+    padding: 16px;
+  }
+
+  .agent-identity-preview__avatar {
+    width: 80px;
+    height: 80px;
+    font-size: 40px;
+  }
+
+  .agent-identity-preview__name {
+    font-size: 16px;
+  }
+
+  .agent-identity-avatar-row {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .agent-identity-avatar-row .mc-input {
+    width: 100%;
+  }
+
+  .agent-identity-avatar-row .mc-btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .agent-identity-preview {
+    padding: 14px;
+  }
+
+  .agent-identity-preview__avatar {
+    width: 60px;
+    height: 60px;
+    font-size: 30px;
+  }
+
+  .agent-identity-preview__name {
+    font-size: 15px;
+  }
+
+  .agent-identity-preview__theme {
+    font-size: 13px;
+  }
+}
+
+/* ===========================================
+   Workspace Editor - 工作区文件编辑器
+   =========================================== */
+
+/* 工作区布局 / Workspace layout */
+.ws-layout {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+  height: calc(100vh - 320px);
+}
+
+/* 文件列表 / File list */
+.ws-file-list {
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .ws-file-list {
+  background: white;
+}
+
+.ws-file-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .ws-file-list__header {
+  background: var(--bg-hover);
+}
+
+.ws-file-list__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ws-file-list__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.ws-file-list__footer {
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .ws-file-list__footer {
+  background: var(--bg-hover);
+}
+
+.ws-file-list__dir-label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 4px;
+}
+
+.ws-file-list__dir-path {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  word-break: break-all;
+  line-height: 1.4;
+}
+
+/* 文件项 / File item */
+.ws-file-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  margin-bottom: 4px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.ws-file-item:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.ws-file-item--active {
+  background: var(--bg-accent);
+  border-color: var(--accent);
+}
+
+.ws-file-item--missing {
+  opacity: 0.7;
+}
+
+.ws-file-item--missing:not(.ws-file-item--active) {
+  border-style: dashed;
+}
+
+.ws-file-item__icon {
+  width: 16px;
+  height: 16px;
+  color: var(--muted);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.ws-file-item--active .ws-file-item__icon {
+  color: var(--accent);
+}
+
+.ws-file-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ws-file-item__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.ws-file-item__name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.ws-file-item__badge {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.ws-file-item__badge--new {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.ws-file-item__badge--unsaved {
+  background: var(--warning-subtle);
+  color: var(--warning);
+}
+
+.ws-file-item__desc {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.ws-file-item__meta {
+  display: block;
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: 4px;
+  opacity: 0.8;
+}
+
+/* 编辑器 / Editor */
+.ws-editor {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  min-width: 0;
+}
+
+:root[data-theme="light"] .ws-editor {
+  background: white;
+}
+
+.ws-editor__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .ws-editor__toolbar {
+  background: var(--bg-hover);
+}
+
+.ws-editor__toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ws-editor__toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ws-editor__filename {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ws-editor__unsaved-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--warning);
+}
+
+/* 模式切换按钮组 / Mode toggle group */
+.ws-editor__mode-group {
+  display: flex;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.ws-editor__mode-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.ws-editor__mode-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.ws-editor__mode-btn--active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.ws-editor__mode-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* 编辑器面板 / Editor panels */
+.ws-editor__panels {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.ws-editor__panels--split {
+  gap: 1px;
+  background: var(--border);
+}
+
+.ws-editor__edit-panel,
+.ws-editor__preview-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-elevated);
+}
+
+:root[data-theme="light"] .ws-editor__edit-panel,
+:root[data-theme="light"] .ws-editor__preview-panel {
+  background: white;
+}
+
+.ws-editor__textarea {
+  flex: 1;
+  width: 100%;
+  padding: 16px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+}
+
+.ws-editor__textarea::placeholder {
+  color: var(--muted);
+  opacity: 0.6;
+}
+
+/* 预览面板 / Preview panel */
+.ws-preview {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ws-preview__iframe {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: transparent;
+}
+
+/* 空状态 / Empty state */
+.ws-editor__empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px;
+  color: var(--muted);
+}
+
+.ws-editor__empty-icon {
+  width: 48px;
+  height: 48px;
+  opacity: 0.5;
+}
+
+.ws-editor__empty-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ws-editor__empty-text {
+  font-size: 14px;
+}
+
+/* 加载状态 / Loading state */
+.ws-editor__loading {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+/* 移动端适配 / Mobile responsiveness */
+@media (max-width: 992px) {
+  .ws-layout {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .ws-file-list {
+    width: 100%;
+    max-height: 200px;
+  }
+
+  .ws-editor {
+    min-height: 400px;
+  }
+}
+
+@media (max-width: 768px) {
+  .ws-editor__panels--split {
+    flex-direction: column;
+  }
+
+  .ws-file-list__body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .ws-file-item {
+    flex: 1 1 calc(50% - 4px);
+    min-width: 140px;
+    margin-bottom: 0;
+  }
+
+  .ws-file-item__desc {
+    display: none;
+  }
+
+  .ws-file-item__meta {
+    display: none;
+  }
+}
+
+/* ===========================================
+   Folder Items - 文件夹项
+   =========================================== */
+
+/* 文件夹项 / Folder item */
+.ws-folder-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px 12px;
+  margin-bottom: 4px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+:root[data-theme="light"] .ws-folder-item {
+  background: var(--bg-hover);
+}
+
+.ws-folder-item:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.ws-folder-item--has-active {
+  border-color: var(--accent);
+  border-style: dashed;
+}
+
+.ws-folder-item__chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) ease;
+}
+
+.ws-folder-item__chevron svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ws-folder-item__icon {
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.ws-folder-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ws-folder-item__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.ws-folder-item__name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ws-folder-item__count {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.ws-folder-item__desc {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+/* 缩进的文件项 / Indented file items */
+.ws-file-item--indent {
+  margin-left: 20px;
+  width: calc(100% - 20px);
+}
+
+/* 移动端适配 / Mobile responsiveness */
+@media (max-width: 768px) {
+  .ws-folder-item__desc {
+    display: none;
+  }
+
+  .ws-file-item--indent {
+    margin-left: 12px;
+    width: calc(100% - 12px);
+  }
+}
+
+/* ===========================================
+   Skills Management - 技能管理
+   =========================================== */
+
+.skills-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Skills Header */
+.skills-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.skills-header__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.skills-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.skills-desc {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.skills-header__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Skills Section */
+.skills-section {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.skills-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-section__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Skills Global Settings */
+.skills-global-settings {
+  padding: 16px 20px;
+}
+
+.skills-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.skills-setting-item {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.skills-setting-item__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.skills-setting-item__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-setting-item__desc {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Skills Radio Group */
+.skills-radio-group {
+  display: flex;
+  gap: 16px;
+}
+
+.skills-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.skills-radio input[type="radio"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.skills-radio__mark {
+  display: none;
+}
+
+.skills-radio__text {
+  font-size: 13px;
+}
+
+/* Skills Select */
+.skills-select {
+  padding: 10px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.skills-select:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+/* Skills Filter Bar */
+.skills-filter {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  flex-wrap: wrap;
+}
+
+:root[data-theme="light"] .skills-filter {
+  background: var(--bg-hover);
+}
+
+.skills-filter__search {
+  flex: 1;
+  min-width: 200px;
+}
+
+.skills-filter__input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.skills-filter__input::placeholder {
+  color: var(--muted);
+}
+
+.skills-filter__input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.skills-filter__selects {
+  display: flex;
+  gap: 8px;
+}
+
+.skills-filter__select {
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+
+.skills-filter__count {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Skills Group */
+.skills-group {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.skills-group__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.skills-group__header:hover {
+  background: var(--bg-hover);
+}
+
+.skills-group__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  transition: transform var(--duration-fast) ease;
+}
+
+.skills-group__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.skills-group--expanded .skills-group__icon {
+  transform: rotate(0deg);
+}
+
+.skills-group__label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-group__body {
+  border-top: 1px solid var(--border);
+  padding: 8px;
+}
+
+/* Skills Item */
+.skills-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  margin-bottom: 4px;
+  transition: background var(--duration-fast) ease;
+}
+
+.skills-item:hover {
+  background: var(--bg-hover);
+}
+
+.skills-item:last-child {
+  margin-bottom: 0;
+}
+
+.skills-item--disabled {
+  opacity: 0.6;
+}
+
+.skills-item__main {
+  flex: 1;
+  min-width: 0;
+}
+
+.skills-item__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.skills-item__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-item__desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+  margin-bottom: 8px;
+}
+
+.skills-item__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.skills-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-accent);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.skills-chip--ok {
+  background: var(--success-subtle, rgba(16, 185, 129, 0.1));
+  color: var(--success, #10b981);
+}
+
+.skills-chip--warn {
+  background: var(--warning-subtle, rgba(245, 158, 11, 0.1));
+  color: var(--warning, #f59e0b);
+}
+
+.skills-item__missing,
+.skills-item__reasons {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.skills-item__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Skills Allowlist Toggle */
+.skills-allowlist-toggle {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.skills-allowlist-toggle input[type="checkbox"] {
+  display: none;
+}
+
+.skills-allowlist-toggle__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  font-size: 12px;
+  color: var(--accent);
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.skills-allowlist-toggle input:checked + .skills-allowlist-toggle__icon {
+  background: var(--accent-subtle);
+  border-color: var(--accent);
+}
+
+/* Skills Message */
+.skills-message {
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.skills-message--success {
+  background: var(--success-subtle, rgba(16, 185, 129, 0.1));
+  color: var(--success, #10b981);
+}
+
+.skills-message--error {
+  background: var(--danger-subtle, rgba(239, 68, 68, 0.1));
+  color: var(--danger, #ef4444);
+}
+
+/* Skills API Key */
+.skills-apikey {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  max-width: 280px;
+}
+
+.skills-apikey__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.skills-apikey__row {
+  display: flex;
+  gap: 8px;
+}
+
+.skills-apikey__input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.skills-apikey__input::placeholder {
+  color: var(--muted);
+  font-family: var(--font-sans);
+}
+
+.skills-apikey__input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+/* Skills Loading / Empty / Error states */
+.skills-loading,
+.skills-empty,
+.skills-error {
+  padding: 40px 20px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.skills-error {
+  color: var(--danger);
+  background: var(--danger-subtle);
+  border-radius: var(--radius-lg);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .skills-header {
+    flex-direction: column;
+  }
+
+  .skills-header__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .skills-filter {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .skills-filter__search {
+    min-width: 0;
+  }
+
+  .skills-filter__selects {
+    flex-wrap: wrap;
+  }
+
+  .skills-filter__count {
+    text-align: right;
+  }
+
+  .skills-item {
+    flex-direction: column;
+  }
+
+  .skills-item__actions {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .skills-apikey {
+    max-width: none;
+  }
+}
+
+/* ===========================================
+   Skills Item Expanded - 技能展开详情
+   =========================================== */
+
+.skills-item--expanded {
+  flex-direction: column;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0;
+}
+
+:root[data-theme="light"] .skills-item--expanded {
+  background: var(--bg-hover);
+}
+
+.skills-item--expanded .skills-item__main {
+  padding: 14px 16px;
+}
+
+.skills-item--expanded .skills-item__actions {
+  padding: 0 16px 14px;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.skills-item__expand-btn {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.skills-item__expand-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Skills Item Details */
+.skills-item__details {
+  border-top: 1px solid var(--border);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: var(--bg-elevated);
+}
+
+:root[data-theme="light"] .skills-item__details {
+  background: white;
+}
+
+/* Skills Detail Section */
+.skills-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skills-detail-section__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skills-detail-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.skills-detail-label {
+  flex-shrink: 0;
+  color: var(--muted);
+  min-width: 60px;
+}
+
+.skills-detail-value {
+  color: var(--text);
+  word-break: break-all;
+}
+
+.skills-detail-value.mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.skills-detail-link {
+  color: var(--accent);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.skills-detail-link:hover {
+  text-decoration: underline;
+}
+
+/* ===========================================
+   Skills Environment Editor - 环境变量编辑器
+   =========================================== */
+
+.skills-env-editor {
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .skills-env-editor {
+  background: var(--bg-hover);
+}
+
+.skills-env-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-env-editor__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-env-editor__list {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.skills-env-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+:root[data-theme="light"] .skills-env-row {
+  background: white;
+}
+
+.skills-env-row--missing {
+  border-color: var(--warning);
+  border-style: dashed;
+}
+
+.skills-env-row__key {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.skills-env-row__label {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.skills-env-row__badge {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.skills-env-row__value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.skills-env-row__input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.skills-env-row__input::placeholder {
+  color: var(--muted);
+  font-family: var(--font-sans);
+}
+
+.skills-env-row__input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+/* ===========================================
+   Skills Config Editor - 自定义配置编辑器
+   =========================================== */
+
+.skills-config-editor {
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .skills-config-editor {
+  background: var(--bg-hover);
+}
+
+.skills-config-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-config-editor__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-config-editor__hint {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.skills-config-editor__textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 12px 14px;
+  border: none;
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+
+.skills-config-editor__textarea::placeholder {
+  color: var(--muted);
+}
+
+.skills-config-editor__textarea:focus {
+  background: var(--bg-hover);
+}
+
+:root[data-theme="light"] .skills-config-editor__textarea {
+  background: white;
+}
+
+:root[data-theme="light"] .skills-config-editor__textarea:focus {
+  background: white;
+}
+
+/* ===========================================
+   Skills Extra Dirs - 额外目录配置
+   =========================================== */
+
+.skills-extra-dirs {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+.skills-extra-dirs__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.skills-extra-dirs__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-extra-dirs__desc {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.skills-extra-dirs__textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.skills-extra-dirs__textarea::placeholder {
+  color: var(--muted);
+  font-family: var(--font-sans);
+}
+
+.skills-extra-dirs__textarea:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+:root[data-theme="light"] .skills-extra-dirs__textarea {
+  background: white;
+}
+
+/* ===========================================
+   Skills Checkbox - 技能复选框
+   =========================================== */
+
+.skills-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.skills-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.skills-checkbox__text {
+  font-size: 13px;
+}
+
+/* Mobile responsiveness for Phase 3 components */
+@media (max-width: 768px) {
+  .skills-item--expanded .skills-item__actions {
+    padding: 14px 16px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-elevated);
+  }
+
+  .skills-item__details {
+    padding: 14px;
+    gap: 16px;
+  }
+
+  .skills-detail-row {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .skills-detail-label {
+    min-width: 0;
+  }
+
+  .skills-env-row__value {
+    flex-wrap: wrap;
+  }
+
+  .skills-env-row__input {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .skills-settings-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .skills-radio-group {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .skills-item__expand-btn {
+    width: 24px;
+    height: 24px;
+  }
+
+  .skills-env-editor__list {
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .skills-env-row {
+    padding: 10px;
+  }
+}
+
+/* ===========================================
+   Phase 4: Skills Statistics Bar - 技能统计栏
+   =========================================== */
+
+.skills-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 18px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  flex-wrap: wrap;
+}
+
+:root[data-theme="light"] .skills-stats {
+  background: white;
+}
+
+.skills-stats__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  min-width: 60px;
+}
+
+.skills-stats__item--ok {
+  background: var(--success-subtle, rgba(16, 185, 129, 0.1));
+}
+
+.skills-stats__item--warn {
+  background: var(--warning-subtle, rgba(245, 158, 11, 0.1));
+}
+
+.skills-stats__item--disabled {
+  background: var(--bg-accent);
+}
+
+.skills-stats__value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.skills-stats__item--ok .skills-stats__value {
+  color: var(--success, #10b981);
+}
+
+.skills-stats__item--warn .skills-stats__value {
+  color: var(--warning, #f59e0b);
+}
+
+.skills-stats__item--disabled .skills-stats__value {
+  color: var(--muted);
+}
+
+.skills-stats__label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.skills-stats__divider {
+  width: 1px;
+  height: 36px;
+  background: var(--border);
+  margin: 0 8px;
+}
+
+/* Phase 4: Search Highlighting - 搜索高亮 */
+
+.skills-highlight {
+  background: var(--accent-subtle);
+  color: var(--accent);
+  padding: 1px 3px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+/* Phase 4: Installation Progress - 安装进度 */
+
+.skills-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-top: 8px;
+}
+
+:root[data-theme="light"] .skills-progress {
+  background: var(--bg-hover);
+}
+
+.skills-progress__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.skills-progress__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-progress__status {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.skills-progress__bar {
+  height: 6px;
+  background: var(--border);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.skills-progress__fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: var(--radius-full);
+  transition: width var(--duration-normal) ease;
+}
+
+.skills-progress__fill--indeterminate {
+  width: 30%;
+  animation: skills-progress-indeterminate 1.5s ease-in-out infinite;
+}
+
+@keyframes skills-progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.skills-progress__message {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.skills-progress__message--success {
+  color: var(--success, #10b981);
+}
+
+.skills-progress__message--error {
+  color: var(--danger);
+}
+
+/* Phase 4: SKILL.md Preview - 技能文档预览 */
+
+.skills-docs-preview {
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .skills-docs-preview {
+  background: var(--bg-hover);
+}
+
+.skills-docs-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-docs-preview__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-docs-preview__icon {
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
+}
+
+.skills-docs-preview__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.skills-docs-preview__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.skills-docs-preview__content {
+  padding: 16px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.skills-docs-preview__content pre {
+  margin: 0;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+:root[data-theme="light"] .skills-docs-preview__content pre {
+  background: white;
+}
+
+.skills-docs-preview__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.skills-docs-preview__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--accent);
+  font-size: 12px;
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+:root[data-theme="light"] .skills-docs-preview__link {
+  background: white;
+}
+
+.skills-docs-preview__link:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.skills-docs-preview__link svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Mobile responsiveness for Phase 4 */
+@media (max-width: 768px) {
+  .skills-stats {
+    padding: 12px;
+    gap: 6px;
+  }
+
+  .skills-stats__item {
+    padding: 6px 10px;
+    min-width: 50px;
+  }
+
+  .skills-stats__value {
+    font-size: 16px;
+  }
+
+  .skills-stats__label {
+    font-size: 10px;
+  }
+
+  .skills-stats__divider {
+    height: 28px;
+    margin: 0 4px;
+  }
+
+  .skills-docs-preview__content {
+    max-height: 200px;
+  }
+}
+
+@media (max-width: 480px) {
+  .skills-stats {
+    justify-content: center;
+  }
+
+  .skills-stats__divider {
+    display: none;
+  }
+
+  .skills-stats__item {
+    flex: 1 1 calc(33% - 6px);
+    min-width: 0;
+  }
+
+  .skills-progress {
+    padding: 10px 12px;
+  }
+}
+
+/* ===========================================
+   Skills Editor & Modals - 技能编辑器和弹窗 (Phase 5-6)
+   =========================================== */
+
+/* 弹窗遮罩 / Modal overlay */
+.skills-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+/* 弹窗容器 / Modal container */
+.skills-modal {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 48px);
+  width: 100%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+}
+
+/* 编辑器弹窗（较大）/ Editor modal (larger) */
+.skills-editor-modal {
+  max-width: 900px;
+  height: calc(100vh - 80px);
+}
+
+/* 创建弹窗（中等）/ Create modal (medium) */
+.skills-create-modal {
+  max-width: 500px;
+}
+
+/* 删除弹窗（小）/ Delete modal (small) */
+.skills-delete-modal {
+  max-width: 440px;
+}
+
+/* 弹窗头部 / Modal header */
+.skills-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.skills-modal__header--danger {
+  border-bottom-color: var(--color-error, #ef4444);
+}
+
+.skills-modal__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.skills-modal__icon {
+  display: flex;
+  align-items: center;
+}
+
+.skills-modal__icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.skills-modal__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background 0.15s, color 0.15s;
+}
+
+.skills-modal__close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.skills-modal__close svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* 弹窗内容 / Modal body */
+.skills-modal__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  min-height: 0;
+}
+
+/* 弹窗底部 / Modal footer */
+.skills-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ===========================================
+   Skills Editor - 技能编辑器
+   =========================================== */
+
+/* 编辑器工具栏 / Editor toolbar */
+.skills-editor__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.skills-editor__mode-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-accent);
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.skills-editor__mode-tab {
+  padding: 4px 12px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.skills-editor__mode-tab:hover {
+  color: var(--text-primary);
+}
+
+.skills-editor__mode-tab.active {
+  background: var(--panel);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.skills-editor__info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.skills-editor__source {
+  color: var(--text-tertiary);
+  padding: 2px 6px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-sm);
+}
+
+.skills-editor__dirty {
+  color: var(--color-warning, #f59e0b);
+  font-weight: 500;
+}
+
+/* 编辑器内容区 / Editor content area */
+.skills-editor__body {
+  padding: 0 !important;
+  display: flex;
+  flex-direction: column;
+}
+
+.skills-editor__loading,
+.skills-editor__error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.skills-editor__error {
+  color: var(--color-error, #ef4444);
+}
+
+/* 编辑器面板 / Editor pane */
+.skills-editor__pane {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.skills-editor__pane--full {
+  height: 100%;
+}
+
+/* 编辑器文本区 / Editor textarea */
+.skills-editor__textarea {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: "SF Mono", "Consolas", "Monaco", monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 16px 20px;
+  resize: none;
+  outline: none;
+  tab-size: 2;
+}
+
+.skills-editor__textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* 分屏模式 / Split mode */
+.skills-editor__split {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.skills-editor__divider {
+  width: 1px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+/* 预览区域 / Preview area */
+.skills-editor__preview {
+  overflow-y: auto;
+  padding: 16px 20px;
+  background: var(--bg);
+}
+
+/* Markdown 预览样式 / Markdown preview styles */
+.skills-preview__content {
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.skills-preview__h2 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 16px 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skills-preview__h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+
+.skills-preview__h4 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 10px 0 4px;
+}
+
+.skills-preview__p {
+  margin: 4px 0;
+  font-size: 13px;
+}
+
+.skills-preview__li {
+  margin: 2px 0 2px 20px;
+  font-size: 13px;
+}
+
+.skills-preview__code {
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  margin: 8px 0;
+  font-family: "SF Mono", "Consolas", "Monaco", monospace;
+  font-size: 12px;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.skills-preview__hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 12px 0;
+}
+
+/* ===========================================
+   Skills Create Modal - 创建技能弹窗
+   =========================================== */
+
+.skills-create__error {
+  background: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  color: var(--color-error, #ef4444);
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.skills-create__field {
+  margin-bottom: 16px;
+}
+
+.skills-create__label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.skills-create__input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: "SF Mono", "Consolas", "Monaco", monospace;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.skills-create__input:focus {
+  border-color: var(--color-primary, #3b82f6);
+}
+
+.skills-create__input.error {
+  border-color: var(--color-error, #ef4444);
+}
+
+.skills-create__hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}
+
+.skills-create__field-error {
+  font-size: 11px;
+  color: var(--color-error, #ef4444);
+  margin-top: 4px;
+}
+
+/* 创建来源选择 / Create source selection */
+.skills-create__radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skills-create__radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.skills-create__radio:hover {
+  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-hover);
+}
+
+.skills-create__radio input[type="radio"] {
+  margin-top: 2px;
+  accent-color: var(--color-primary, #3b82f6);
+}
+
+.skills-create__radio-mark {
+  display: none;
+}
+
+.skills-create__radio-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.skills-create__radio-text strong {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.skills-create__radio-text small {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+/* ===========================================
+   Skills Delete Modal - 删除技能弹窗
+   =========================================== */
+
+.skills-delete__error {
+  background: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  color: var(--color-error, #ef4444);
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.skills-delete__warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
+  color: var(--color-warning, #f59e0b);
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 16px;
+}
+
+.skills-delete__warning svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.skills-delete__message {
+  font-size: 14px;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.skills-delete__info {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* 危险按钮 / Danger button */
+.mc-btn--danger {
+  background: var(--color-error, #ef4444);
+  color: white;
+  border-color: var(--color-error, #ef4444);
+}
+
+.mc-btn--danger:hover {
+  background: var(--color-error-hover, #dc2626);
+  border-color: var(--color-error-hover, #dc2626);
+}
+
+.mc-btn--danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===========================================
+   Skills Editor Responsive - 编辑器响应式
+   =========================================== */
+
+@media (max-width: 768px) {
+  .skills-modal-overlay {
+    padding: 12px;
+  }
+
+  .skills-editor-modal {
+    height: calc(100vh - 24px);
+  }
+
+  .skills-editor__split {
+    flex-direction: column;
+  }
+
+  .skills-editor__divider {
+    width: auto;
+    height: 1px;
+  }
+
+  .skills-editor__toolbar {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}
+
+/* ===========================================
+   Skills Priority Info - 技能优先级说明
+   =========================================== */
+
+.skills-priority-info {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .skills-priority-info {
+  background: white;
+}
+
+.skills-priority-info__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .skills-priority-info__header {
+  background: var(--bg-hover);
+}
+
+.skills-priority-info__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--accent);
+}
+
+.skills-priority-info__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.skills-priority-info__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-priority-info__content {
+  padding: 16px 18px;
+}
+
+.skills-priority-info__desc {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.skills-priority-info__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skills-priority-info__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+}
+
+:root[data-theme="light"] .skills-priority-info__list li {
+  background: var(--bg-hover);
+}
+
+.skills-priority-info__source {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skills-priority-info__priority {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  padding: 2px 8px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+}
+
+:root[data-theme="light"] .skills-priority-info__priority {
+  background: white;
+}
+
+.skills-priority-info__priority--high {
+  background: var(--success-subtle, rgba(16, 185, 129, 0.1));
+  color: var(--success, #10b981);
+  font-weight: 600;
+}
+
+.skills-priority-info__note {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-md);
+  line-height: 1.5;
+}
+
+:root[data-theme="light"] .skills-priority-info__note {
+  background: var(--bg-hover);
+}
+
+/* Mobile responsiveness for priority info */
+@media (max-width: 768px) {
+  .skills-priority-info__content {
+    padding: 14px;
+  }
+
+  .skills-priority-info__list li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 10px 12px;
+  }
+
+  .skills-priority-info__priority {
+    margin-top: 2px;
+  }
+}
+
+@media (max-width: 480px) {
+  .skills-priority-info__header {
+    padding: 12px 14px;
+  }
+
+  .skills-priority-info__title {
+    font-size: 13px;
+  }
+
+  .skills-priority-info__desc {
+    font-size: 12px;
+  }
+
+  .skills-priority-info__list li {
+    padding: 8px 10px;
+    font-size: 12px;
+  }
+}
+
+/* ============================================
+   定时任务 Cron 模块样式
+   ============================================ */
+
+/* 调度器状态卡片 */
+.cron-status-card {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  padding: 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 20px;
+}
+
+.cron-status-card__item {
+  text-align: center;
+}
+
+.cron-status-card__label {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cron-status-card__value {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text);
+  margin-top: 4px;
+}
+
+.cron-status-card__value--ok {
+  color: var(--ok);
+}
+
+.cron-status-card__value--error {
+  color: var(--danger);
+}
+
+/* 提示卡片 */
+.cron-tip-card {
+  padding: 14px 18px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  border-radius: var(--radius-lg);
+  margin-bottom: 20px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.cron-tip-card__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 12px;
+  color: var(--accent);
+}
+
+.cron-tip-card__title svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+/* 可折叠提示卡片 */
+.cron-tip-card--collapsible {
+  padding: 0;
+}
+
+.cron-tip-card--collapsible > summary {
+  padding: 14px 18px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  margin-bottom: 0;
+}
+
+.cron-tip-card--collapsible > summary::-webkit-details-marker {
+  display: none;
+}
+
+.cron-tip-card--collapsible > summary svg:last-child {
+  margin-left: auto;
+  transition: transform var(--duration-normal) ease;
+}
+
+.cron-tip-card--collapsible[open] > summary svg:last-child {
+  transform: rotate(180deg);
+}
+
+.cron-tip-card--collapsible > summary:hover {
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elevated));
+  border-radius: var(--radius-lg);
+}
+
+.cron-tip-card--collapsible[open] > summary {
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  margin-bottom: 0;
+}
+
+.cron-tip-card--collapsible .cron-tip-card__table {
+  padding: 0;
+}
+
+.cron-tip-card__content {
+  padding: 12px 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cron-tip-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cron-tip-card__section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  margin-bottom: 4px;
+}
+
+.cron-tip-card__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.cron-tip-card__table tr {
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+}
+
+.cron-tip-card__table tr:last-child {
+  border-bottom: none;
+}
+
+.cron-tip-card__term {
+  width: 100px;
+  padding: 6px 12px 6px 0;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  vertical-align: top;
+}
+
+.cron-tip-card__def {
+  padding: 6px 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.cron-tip-card__def b {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* 表单区块 */
+.cron-form-section {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.cron-form-section__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cron-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+/* 调度类型切换 Tab */
+.cron-schedule-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+}
+
+.cron-schedule-tab {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+  text-align: center;
+}
+
+.cron-schedule-tab:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+.cron-schedule-tab--active {
+  background: var(--bg-elevated);
+  color: var(--text);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+/* 任务卡片 */
+.cron-job-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  margin-bottom: 12px;
+  overflow: hidden;
+  transition: border-color var(--duration-fast) ease, box-shadow var(--duration-fast) ease;
+}
+
+.cron-job-card:hover {
+  border-color: var(--border-strong);
+}
+
+.cron-job-card--selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.cron-job-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.cron-job-card__header:hover {
+  background: var(--bg-hover);
+}
+
+.cron-job-card__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cron-job-card__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cron-job-card__schedule {
+  font-size: 13px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+.cron-job-card__payload {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 400px;
+}
+
+.cron-job-card__status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.cron-job-card__chevron {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+}
+
+/* 状态徽章 */
+.cron-job-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.cron-job-card__badge--enabled {
+  background: var(--ok-subtle);
+  color: var(--ok);
+}
+
+.cron-job-card__badge--disabled {
+  background: var(--bg-accent);
+  color: var(--muted);
+}
+
+.cron-job-card__badge--running {
+  background: var(--accent-subtle);
+  color: var(--accent);
+  animation: cron-pulse 2s infinite;
+}
+
+@keyframes cron-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* 任务详情展开 */
+.cron-job-card__details {
+  padding: 0 20px 20px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+.cron-job-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.cron-job-card__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cron-job-card__meta-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cron-job-card__meta-value {
+  font-size: 13px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+/* 操作按钮组 */
+.cron-job-card__actions {
+  display: flex;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+/* 运行历史 */
+.cron-runs-list {
+  max-height: 360px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.cron-run-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--duration-fast) ease;
+}
+
+.cron-run-item:last-child {
+  border-bottom: none;
+}
+
+.cron-run-item:hover {
+  background: var(--bg-hover);
+}
+
+.cron-run-item__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cron-run-item__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.cron-run-item__dot--ok {
+  background: var(--ok);
+}
+
+.cron-run-item__dot--error {
+  background: var(--danger);
+}
+
+.cron-run-item__dot--skipped {
+  background: var(--warning);
+}
+
+/* 错误横幅 */
+.cron-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--danger-subtle);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-md);
+  color: var(--danger);
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+/* 空状态 */
+.cron-empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--muted);
+}
+
+.cron-empty__icon {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 16px;
+  opacity: 0.4;
+  color: var(--muted);
+}
+
+.cron-empty__text {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+
+/* 确认弹窗 */
+.cron-confirm-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: cron-modal-in 0.15s ease-out;
+}
+
+@keyframes cron-modal-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.cron-confirm-modal__content {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 24px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+  animation: cron-modal-content-in 0.2s ease-out;
+}
+
+@keyframes cron-modal-content-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.cron-confirm-modal__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+
+.cron-confirm-modal__desc {
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.cron-confirm-modal__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+/* 新建任务弹窗 */
+.cron-create-modal__content {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  max-width: 600px;
+  width: 90%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+  animation: cron-modal-content-in 0.2s ease-out;
+}
+
+.cron-create-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.cron-create-modal__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cron-create-modal__title svg {
+  width: 20px;
+  height: 20px;
+  color: var(--accent);
+}
+
+.cron-create-modal__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.cron-create-modal__close:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.cron-create-modal__body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.cron-create-modal__footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* 任务列表容器 */
+.cron-jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* 响应式适配 */
+@media (max-width: 768px) {
+  .cron-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cron-status-card {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .cron-status-card__value {
+    font-size: 20px;
+  }
+
+  .cron-job-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .cron-job-card__status {
+    align-self: flex-end;
+  }
+
+  .cron-job-card__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .cron-job-card__actions {
+    flex-direction: column;
+  }
+
+  .cron-job-card__actions .mc-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .cron-schedule-tabs {
+    flex-direction: column;
+  }
+}
+
+/* 亮色主题适配 */
+:root[data-theme="light"] .cron-status-card {
+  background: white;
+}
+
+:root[data-theme="light"] .cron-form-section {
+  background: white;
+}
+
+:root[data-theme="light"] .cron-job-card {
+  background: white;
+}
+
+:root[data-theme="light"] .cron-confirm-modal__content {
+  background: white;
+}
+
+:root[data-theme="light"] .cron-create-modal__content {
+  background: white;
+}

--- a/ui/src/ui-zh-CN/types/channel-config.ts
+++ b/ui/src/ui-zh-CN/types/channel-config.ts
@@ -1,0 +1,242 @@
+/**
+ * 通道配置类型定义
+ */
+
+// DM 访问策略
+export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+
+// 群组访问策略
+export type GroupPolicy = "open" | "disabled" | "allowlist";
+
+// 通道基础配置
+export type BaseChannelConfig = {
+  enabled?: boolean;
+  name?: string;
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string | number>;
+  groupPolicy?: GroupPolicy;
+  groupAllowFrom?: Array<string | number>;
+  textChunkLimit?: number;
+  historyLimit?: number;
+  dmHistoryLimit?: number;
+  mediaMaxMb?: number;
+};
+
+// Telegram 配置
+export type TelegramChannelConfig = BaseChannelConfig & {
+  botToken?: string;
+  tokenFile?: string;
+  streamMode?: "off" | "partial" | "block";
+  chunkMode?: "length" | "newline";
+  reactionNotifications?: "off" | "own" | "all" | "allowlist";
+};
+
+// Discord 配置
+export type DiscordChannelConfig = BaseChannelConfig & {
+  token?: string;
+  intents?: {
+    presence?: boolean;
+    guildMembers?: boolean;
+  };
+  reactionNotifications?: "off" | "own" | "all" | "allowlist";
+};
+
+// Slack 配置
+export type SlackChannelConfig = BaseChannelConfig & {
+  mode?: "socket" | "http";
+  botToken?: string;
+  appToken?: string;
+  userToken?: string;
+  requireMention?: boolean;
+  slashCommand?: string;
+};
+
+// WhatsApp 配置
+export type WhatsAppChannelConfig = BaseChannelConfig & {
+  authDir?: string;
+  sendReadReceipts?: boolean;
+  selfChatMode?: "off" | "forward" | "local";
+  debounceMs?: number;
+  ackReaction?: string;
+};
+
+// Signal 配置
+export type SignalChannelConfig = BaseChannelConfig & {
+  account?: string;
+  httpUrl?: string;
+  httpHost?: string;
+  httpPort?: number;
+  cliPath?: string;
+  autoStart?: boolean;
+  sendReadReceipts?: boolean;
+};
+
+// Google Chat 配置
+export type GoogleChatChannelConfig = BaseChannelConfig & {
+  serviceAccount?: string | object;
+  serviceAccountFile?: string;
+  webhookPath?: string;
+  webhookUrl?: string;
+  typingIndicator?: "none" | "message" | "reaction";
+};
+
+// iMessage 配置
+export type IMessageChannelConfig = BaseChannelConfig & {
+  cliPath?: string;
+  dbPath?: string;
+  remoteHost?: string;
+  service?: "imessage" | "sms" | "auto";
+  region?: string;
+  includeAttachments?: boolean;
+};
+
+// MS Teams 配置
+export type MSTeamsChannelConfig = BaseChannelConfig & {
+  appId?: string;
+  appPassword?: string;
+  tenantId?: string;
+  webhook?: {
+    port?: number;
+    path?: string;
+  };
+  replyStyle?: "thread" | "top-level";
+};
+
+// WeChat 配置
+export type WeChatPollingConfig = {
+  pollingIntervalMs?: number;
+  pollContactIds?: string[];
+  pollAllContacts?: boolean;
+  maxPollContacts?: number;
+};
+
+export type WeChatChannelConfig = BaseChannelConfig & {
+  name?: string;
+  baseUrl?: string;
+  apiToken?: string;
+  tokenFile?: string;
+  robotId?: number;
+  defaultAccount?: string;
+  requireMention?: boolean;
+  polling?: WeChatPollingConfig;
+  accounts?: Record<string, WeChatChannelConfig>;
+};
+
+// Matrix 配置
+export type MatrixChannelConfig = BaseChannelConfig & {
+  homeserver?: string;
+  userId?: string;
+  accessToken?: string;
+  password?: string;
+  encryption?: boolean;
+  autoJoin?: "always" | "allowlist" | "off";
+};
+
+// Mattermost 配置
+export type MattermostChannelConfig = BaseChannelConfig & {
+  baseUrl?: string;
+  botToken?: string;
+  requireMention?: boolean;
+};
+
+// Nostr 配置
+export type NostrChannelConfig = BaseChannelConfig & {
+  privateKey?: string;
+};
+
+// LINE 配置
+export type LineChannelConfig = BaseChannelConfig & {
+  channelAccessToken?: string;
+  channelSecret?: string;
+};
+
+// Twitch 配置
+export type TwitchChannelConfig = BaseChannelConfig & {
+  username?: string;
+  accessToken?: string;
+  clientId?: string;
+  channel?: string;
+  requireMention?: boolean;
+};
+
+// BlueBubbles 配置
+export type BlueBubblesChannelConfig = BaseChannelConfig & {
+  serverUrl?: string;
+  password?: string;
+  webhookPath?: string;
+  sendReadReceipts?: boolean;
+};
+
+// Zalo 配置
+export type ZaloChannelConfig = BaseChannelConfig & {
+  botToken?: string;
+  tokenFile?: string;
+  webhookUrl?: string;
+  webhookSecret?: string;
+};
+
+// Nextcloud Talk 配置
+export type NextcloudTalkChannelConfig = BaseChannelConfig & {
+  baseUrl?: string;
+  botSecret?: string;
+  apiUser?: string;
+  apiPassword?: string;
+};
+
+// Tlon (Urbit) 配置
+export type TlonChannelConfig = BaseChannelConfig & {
+  ship?: string;
+  url?: string;
+  code?: string;
+  autoDiscoverChannels?: boolean;
+};
+
+// 通道元数据
+export type ChannelMeta = {
+  id: string;
+  label: string;
+  icon: string;
+  description: string;
+  docsUrl?: string;
+  configFields: ChannelConfigField[];
+};
+
+// 配置字段定义
+export type ChannelConfigField = {
+  key: string;
+  label: string;
+  type: "text" | "password" | "number" | "select" | "toggle" | "array";
+  placeholder?: string;
+  description?: string;
+  options?: Array<{ value: string; label: string }>;
+  required?: boolean;
+  section?: string;
+};
+
+// 所有通道配置
+export type ChannelsConfigData = {
+  defaults?: {
+    groupPolicy?: GroupPolicy;
+  };
+  // 内置通道
+  telegram?: TelegramChannelConfig;
+  discord?: DiscordChannelConfig;
+  slack?: SlackChannelConfig;
+  whatsapp?: WhatsAppChannelConfig;
+  signal?: SignalChannelConfig;
+  googlechat?: GoogleChatChannelConfig;
+  imessage?: IMessageChannelConfig;
+  msteams?: MSTeamsChannelConfig;
+  // 扩展通道
+  wechat?: WeChatChannelConfig;
+  matrix?: MatrixChannelConfig;
+  mattermost?: MattermostChannelConfig;
+  nostr?: NostrChannelConfig;
+  line?: LineChannelConfig;
+  twitch?: TwitchChannelConfig;
+  bluebubbles?: BlueBubblesChannelConfig;
+  zalo?: ZaloChannelConfig;
+  "nextcloud-talk"?: NextcloudTalkChannelConfig;
+  tlon?: TlonChannelConfig;
+  [key: string]: unknown;
+};

--- a/ui/src/ui-zh-CN/types/config-sections.ts
+++ b/ui/src/ui-zh-CN/types/config-sections.ts
@@ -1,0 +1,18 @@
+/**
+ * 配置区块类型定义
+ * Config section type definitions
+ */
+
+export type ConfigSection = {
+  id: string;
+  label: string;
+  icon: string;
+  description: string;
+};
+
+/**
+ * 配置区块 ID
+ * workspace - 工作区文件管理（SOUL.md, IDENTITY.md 等）
+ * skills - 技能配置管理
+ */
+export type ConfigSectionId = "providers" | "agent" | "gateway" | "channels" | "permissions" | "workspace" | "skills" | "cron";

--- a/ui/src/ui-zh-CN/types/cron-config.ts
+++ b/ui/src/ui-zh-CN/types/cron-config.ts
@@ -1,0 +1,60 @@
+/**
+ * Cron 定时任务配置类型
+ * Cron scheduled task configuration types
+ */
+import type { CronJob, CronStatus, CronRunLogEntry, ChannelUiMetaEntry, GatewayAgentRow } from "../../ui/types";
+import type { CronFormState } from "../../ui/ui-types";
+
+/**
+ * Cron 内容组件 Props
+ */
+export type CronContentProps = {
+  // 加载状态 / Loading states
+  loading: boolean;
+  busy: boolean;
+  error: string | null;
+
+  // 数据 / Data
+  status: CronStatus | null;
+  jobs: CronJob[];
+  form: CronFormState;
+
+  // Agent 列表 / Agent list
+  agents: GatewayAgentRow[];
+  defaultAgentId: string;
+
+  // 通道关联 / Channel association
+  channels: string[];
+  channelLabels?: Record<string, string>;
+  channelMeta?: ChannelUiMetaEntry[];
+
+  // 运行历史 / Run history
+  runsJobId: string | null;
+  runs: CronRunLogEntry[];
+
+  // 展开状态 / Expansion state
+  expandedJobId: string | null;
+
+  // 删除确认 / Delete confirmation
+  deleteConfirmJobId: string | null;
+
+  // 新建弹窗状态 / Create modal state
+  showCreateModal: boolean;
+
+  // 编辑任务ID / Edit job ID
+  editJobId: string | null;
+
+  // 回调函数 / Callbacks
+  onFormChange: (patch: Partial<CronFormState>) => void;
+  onRefresh: () => void;
+  onAdd: () => void;
+  onUpdate: () => void;
+  onToggle: (job: CronJob, enabled: boolean) => void;
+  onRun: (job: CronJob) => void;
+  onRemove: (job: CronJob) => void;
+  onLoadRuns: (jobId: string) => void;
+  onExpandJob: (jobId: string | null) => void;
+  onDeleteConfirm: (jobId: string | null) => void;
+  onShowCreateModal: (show: boolean) => void;
+  onEdit: (job: CronJob) => void;
+};

--- a/ui/src/ui-zh-CN/types/skills-config.ts
+++ b/ui/src/ui-zh-CN/types/skills-config.ts
@@ -1,0 +1,284 @@
+/**
+ * Skills 配置类型定义
+ * Skills configuration type definitions
+ */
+
+// ─── 技能安装选项 / Skill install option ──────────────────────────────────────
+
+export type SkillInstallOption = {
+  id: string;
+  kind: "brew" | "node" | "go" | "uv" | "download";
+  label: string;
+  bins: string[];
+};
+
+// ─── 技能状态条目 / Skill status entry ────────────────────────────────────────
+
+export type SkillStatusEntry = {
+  name: string;
+  description: string;
+  source: string;
+  filePath: string;
+  baseDir: string;
+  skillKey: string;
+  primaryEnv?: string;
+  emoji?: string;
+  homepage?: string;
+  always: boolean;
+  disabled: boolean;
+  blockedByAllowlist: boolean;
+  eligible: boolean;
+  requirements: {
+    bins: string[];
+    anyBins: string[];
+    env: string[];
+    config: string[];
+    os: string[];
+  };
+  missing: {
+    bins: string[];
+    anyBins: string[];
+    env: string[];
+    config: string[];
+    os: string[];
+  };
+  configChecks: Array<{
+    path: string;
+    value: unknown;
+    satisfied: boolean;
+  }>;
+  install: SkillInstallOption[];
+};
+
+// ─── 技能状态报告 / Skill status report ───────────────────────────────────────
+
+export type SkillStatusReport = {
+  workspaceDir: string;
+  managedSkillsDir: string;
+  skills: SkillStatusEntry[];
+};
+
+// ─── 单个技能配置 / Single skill config ───────────────────────────────────────
+
+export type SkillEntryConfig = {
+  enabled?: boolean;
+  apiKey?: string;
+  env?: Record<string, string>;
+  config?: Record<string, unknown>;
+};
+
+// ─── 技能加载配置 / Skills load config ────────────────────────────────────────
+
+export type SkillsLoadConfig = {
+  extraDirs?: string[];
+  watch?: boolean;
+  watchDebounceMs?: number;
+};
+
+// ─── 技能安装配置 / Skills install config ─────────────────────────────────────
+
+export type SkillsInstallConfig = {
+  preferBrew?: boolean;
+  nodeManager?: "npm" | "pnpm" | "yarn" | "bun";
+};
+
+// ─── 完整技能配置 / Full skills config ────────────────────────────────────────
+
+export type SkillsConfig = {
+  allowBundled?: string[];
+  load?: SkillsLoadConfig;
+  install?: SkillsInstallConfig;
+  entries?: Record<string, SkillEntryConfig>;
+};
+
+// ─── 技能编辑状态 / Skill edit state ──────────────────────────────────────────
+
+export type SkillEditState = {
+  enabled?: boolean;
+  apiKey?: string;
+  env?: Record<string, string>;
+  config?: Record<string, unknown>;
+  inAllowlist?: boolean;
+};
+
+// ─── 技能消息 / Skill message ─────────────────────────────────────────────────
+
+export type SkillMessage = {
+  kind: "success" | "error";
+  message: string;
+};
+
+// ─── 筛选类型 / Filter types ──────────────────────────────────────────────────
+
+export type SkillSourceFilter = "all" | "bundled" | "managed" | "workspace";
+export type SkillStatusFilter = "all" | "eligible" | "blocked" | "disabled";
+
+// ─── 技能分组 / Skill group ───────────────────────────────────────────────────
+
+export type SkillGroup = {
+  id: string;
+  label: string;
+  skills: SkillStatusEntry[];
+};
+
+// ─── 技能文件来源 / Skill file source ─────────────────────────────────────────
+
+/**
+ * 可编辑的技能来源（仅 managed 和 workspace 可编辑）
+ * Editable skill sources (only managed and workspace are editable)
+ */
+export type EditableSkillSource = "managed" | "workspace";
+
+// ─── 技能文件信息 / Skill file info ───────────────────────────────────────────
+
+/**
+ * 技能文件信息（来自 skills.files.list RPC）
+ * Skill file information (from skills.files.list RPC)
+ */
+export type SkillFileInfo = {
+  name: string;              // 技能名称 / Skill name
+  path: string;              // SKILL.md 完整路径 / Full path to SKILL.md
+  source: EditableSkillSource; // 来源 / Source
+  exists: boolean;           // 是否存在 / Whether file exists
+  size: number;              // 文件大小（字节）/ File size in bytes
+  modifiedAt: number | null; // 最后修改时间戳 / Last modified timestamp
+};
+
+/**
+ * 列出技能文件的结果
+ * Result of listing skill files
+ */
+export type SkillFilesListResult = {
+  managedDir: string;        // managed 技能目录 / Managed skills directory
+  workspaceDir: string;      // workspace 技能目录 / Workspace skills directory
+  skills: SkillFileInfo[];   // 技能列表 / Skill list
+};
+
+// ─── 编辑器视图模式 / Editor view mode ────────────────────────────────────────
+
+/**
+ * 编辑器视图模式
+ * Editor view mode
+ */
+export type SkillEditorMode = "edit" | "preview" | "split";
+
+// ─── 编辑器状态 / Editor state ────────────────────────────────────────────────
+
+/**
+ * 技能编辑器状态
+ * Skill editor state
+ */
+export type SkillEditorState = {
+  open: boolean;                    // 编辑器是否打开 / Whether editor is open
+  skillKey: string | null;          // 当前编辑的技能键 / Current editing skill key
+  skillName: string | null;         // 当前编辑的技能名称 / Current editing skill name
+  source: EditableSkillSource | null; // 技能来源 / Skill source
+  content: string;                  // 编辑器内容 / Editor content
+  original: string;                 // 原始内容（用于脏检查）/ Original content (for dirty check)
+  mode: SkillEditorMode;            // 编辑模式 / Edit mode
+  saving: boolean;                  // 保存中 / Saving
+  loading: boolean;                 // 加载中 / Loading
+  error: string | null;             // 错误信息 / Error message
+};
+
+/**
+ * 创建技能弹窗状态
+ * Create skill modal state
+ */
+export type SkillCreateState = {
+  open: boolean;                    // 弹窗是否打开 / Whether modal is open
+  name: string;                     // 新技能名称 / New skill name
+  source: EditableSkillSource;      // 创建位置 / Create location
+  template: string;                 // 模板内容 / Template content
+  creating: boolean;                // 创建中 / Creating
+  error: string | null;             // 错误信息 / Error message
+  nameError: string | null;         // 名称验证错误 / Name validation error
+};
+
+/**
+ * 删除技能确认状态
+ * Delete skill confirmation state
+ */
+export type SkillDeleteState = {
+  open: boolean;                    // 确认弹窗是否打开 / Whether confirmation is open
+  skillKey: string | null;          // 待删除的技能键 / Skill key to delete
+  skillName: string | null;         // 待删除的技能名称 / Skill name to delete
+  source: EditableSkillSource | null; // 技能来源 / Skill source
+  deleting: boolean;                // 删除中 / Deleting
+  error: string | null;             // 错误信息 / Error message
+};
+
+// ─── 组件属性 / Component props ───────────────────────────────────────────────
+
+export type SkillsContentProps = {
+  // 加载状态 / Loading state
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+
+  // 数据 / Data
+  report: SkillStatusReport | null;
+  config: SkillsConfig | null;
+  hasChanges: boolean;
+
+  // UI 状态 / UI state
+  filter: string;
+  sourceFilter: SkillSourceFilter;
+  statusFilter: SkillStatusFilter;
+  expandedGroups: Set<string>;
+  selectedSkill: string | null;
+  busySkill: string | null;
+  messages: Record<string, SkillMessage>;
+
+  // 白名单 / Allowlist
+  allowlistMode: "all" | "whitelist";
+  allowlistDraft: Set<string>;
+
+  // 编辑状态 / Edit state
+  edits: Record<string, SkillEditState>;
+
+  // 回调 / Callbacks
+  onRefresh: () => void;
+  onSave: () => void;
+  onFilterChange: (filter: string) => void;
+  onSourceFilterChange: (source: SkillSourceFilter) => void;
+  onStatusFilterChange: (status: SkillStatusFilter) => void;
+  onGroupToggle: (group: string) => void;
+  onSkillSelect: (skillKey: string | null) => void;
+  onSkillToggle: (skillKey: string, enabled: boolean) => void;
+  onSkillApiKeyChange: (skillKey: string, apiKey: string) => void;
+  onSkillApiKeySave: (skillKey: string) => void;
+  onAllowlistModeChange: (mode: "all" | "whitelist") => void;
+  onAllowlistToggle: (skillKey: string, inList: boolean) => void;
+  onInstall: (skillKey: string, name: string, installId: string) => void;
+  onGlobalSettingChange: (field: string, value: unknown) => void;
+  // Phase 3: 环境变量和配置编辑 / Env and config editing
+  onSkillEnvChange: (skillKey: string, envKey: string, value: string) => void;
+  onSkillEnvRemove: (skillKey: string, envKey: string) => void;
+  onSkillConfigChange: (skillKey: string, config: Record<string, unknown>) => void;
+  onExtraDirsChange: (dirs: string[]) => void;
+
+  // Phase 5-6: 编辑器相关 / Editor related
+  editorState: SkillEditorState;
+  createState: SkillCreateState;
+  deleteState: SkillDeleteState;
+
+  // 编辑器回调 / Editor callbacks
+  onEditorOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => void;
+  onEditorClose: () => void;
+  onEditorContentChange: (content: string) => void;
+  onEditorModeChange: (mode: SkillEditorMode) => void;
+  onEditorSave: () => void;
+
+  // 创建技能回调 / Create skill callbacks
+  onCreateOpen: (source?: EditableSkillSource) => void;
+  onCreateClose: () => void;
+  onCreateNameChange: (name: string) => void;
+  onCreateSourceChange: (source: EditableSkillSource) => void;
+  onCreateConfirm: () => void;
+
+  // 删除技能回调 / Delete skill callbacks
+  onDeleteOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => void;
+  onDeleteClose: () => void;
+  onDeleteConfirm: () => void;
+};

--- a/ui/src/ui-zh-CN/views/model-config.ts
+++ b/ui/src/ui-zh-CN/views/model-config.ts
@@ -1,0 +1,648 @@
+/**
+ * 模型配置页面视图
+ * 左侧侧边栏 + 右侧配置内容的布局
+ */
+import { html, nothing } from "lit";
+import { renderConfigSidebar } from "../components/config-sidebar";
+import { renderProvidersContent } from "../components/providers-content";
+import { renderAgentContent } from "../components/agent-content";
+import { renderGatewayContent } from "../components/gateway-content";
+import { renderChannelsContent } from "../components/channels-content";
+import {
+  renderWorkspaceContent,
+  type WorkspaceFileInfo,
+  type WorkspaceAgentOption,
+} from "../components/workspace-content";
+import {
+  renderPermissionsContent,
+  type ExecApprovalsSnapshot,
+  type ExecApprovalsFile,
+  type AgentOption,
+} from "../components/permissions-content";
+import { renderSkillsContent } from "../components/skills-content";
+import { renderCronContent } from "../components/cron-content";
+import type {
+  SkillStatusReport,
+  SkillsConfig,
+  SkillSourceFilter,
+  SkillStatusFilter,
+  SkillEditState,
+  SkillMessage,
+  SkillEditorState,
+  SkillCreateState,
+  SkillDeleteState,
+  EditableSkillSource,
+  SkillEditorMode,
+} from "../types/skills-config";
+import type {
+  ExecApprovalsTarget,
+  ExecApprovalsTargetNode,
+} from "../controllers/model-config";
+import type { ChannelsConfigData } from "../types/channel-config";
+import type { CronJob, CronStatus, CronRunLogEntry, ChannelUiMetaEntry, GatewayAgentRow } from "../../ui/types";
+import type { CronFormState } from "../../ui/ui-types";
+import type {
+  ToolPolicyConfig,
+  ToolsConfig,
+  AgentWithTools,
+  PermissionsTabId,
+  SessionsListResult,
+} from "../controllers/model-config";
+
+// 中文标签
+const LABELS = {
+  save: "保存配置",
+  apply: "保存并应用",
+  reload: "重新加载",
+  saving: "保存中...",
+  applying: "应用中...",
+  loading: "加载中...",
+};
+
+// 类型定义
+export type ModelApi =
+  | "openai-completions"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-generative-ai"
+  | "github-copilot"
+  | "bedrock-converse-stream";
+
+export type AuthMode = "api-key" | "aws-sdk" | "oauth" | "token";
+
+export type ProviderConfig = {
+  baseUrl: string;
+  apiKey?: string;
+  auth?: AuthMode;
+  api: ModelApi;
+  headers?: Record<string, string>;
+  models: ModelConfig[];
+};
+
+export type ModelCost = {
+  input: number;
+  output: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+};
+
+export type ModelCompat = {
+  supportsStore?: boolean;
+  supportsDeveloperRole?: boolean;
+  supportsReasoningEffort?: boolean;
+  maxTokensField?: "max_completion_tokens" | "max_tokens";
+};
+
+export type ModelConfig = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  contextWindow: number;
+  maxTokens: number;
+  cost?: ModelCost;
+  compat?: ModelCompat;
+};
+
+export type AgentDefaults = {
+  maxConcurrent?: number;
+  subagents?: {
+    maxConcurrent?: number;
+  };
+  workspace?: string;
+  model?: {
+    primary?: string;
+  };
+  contextPruning?: {
+    mode?: string;
+    ttl?: string;
+  };
+  compaction?: {
+    mode?: string;
+  };
+};
+
+export type GatewayConfig = {
+  port?: number;
+  bind?: string;
+  auth?: {
+    mode?: string;
+    token?: string;
+  };
+};
+
+export type ModelConfigProps = {
+  loading: boolean;
+  saving: boolean;
+  applying: boolean;
+  connected: boolean;
+  hasChanges: boolean;
+
+  // 模型供应商数据
+  providers: Record<string, ProviderConfig>;
+  // Agent 默认设置
+  agentDefaults: AgentDefaults;
+  // Gateway 配置
+  gatewayConfig: GatewayConfig;
+  // 可用模型列表（用于下拉选择）
+  availableModels: Array<{ id: string; name: string; provider: string }>;
+
+  // 通道配置
+  channelsConfig: ChannelsConfigData;
+  selectedChannel: string | null;
+
+  // 展开状态
+  expandedProviders: Set<string>;
+
+  // 添加供应商弹窗状态
+  showAddProviderModal?: boolean;
+  addProviderForm?: import("../components/providers-content").ProviderFormState;
+  addProviderError?: string | null;
+  onShowAddProviderModal?: (show: boolean) => void;
+  onAddProviderFormChange?: (patch: Partial<import("../components/providers-content").ProviderFormState>) => void;
+  onAddProviderConfirm?: () => void;
+
+  // 当前选中的配置区块
+  activeSection?: string;
+
+  // 会话管理相关 (用于 Agent 设置页)
+  agentSessionsLoading: boolean;
+  agentSessionsResult: SessionsListResult | null;
+  agentSessionsError: string | null;
+  onAgentSessionsRefresh: () => void;
+  onAgentSessionModelChange: (sessionKey: string, model: string | null) => void;
+  onAgentSessionNavigate: (sessionKey: string) => void;
+
+  // 工作区文件相关 / Workspace file props
+  workspaceFiles: WorkspaceFileInfo[];
+  workspaceDir: string;
+  workspaceAgentId: string;
+  workspaceAgents: WorkspaceAgentOption[];
+  workspaceSelectedFile: string | null;
+  workspaceEditorContent: string;
+  workspaceOriginalContent: string;
+  workspaceLoading: boolean;
+  workspaceSaving: boolean;
+  workspaceError: string | null;
+  workspaceEditorMode: "edit" | "preview" | "split";
+  expandedFolders?: Set<string>;
+  onWorkspaceFileSelect: (fileName: string) => void;
+  onWorkspaceContentChange: (content: string) => void;
+  onWorkspaceFileSave: () => void;
+  onWorkspaceRefresh: () => void;
+  onWorkspaceModeChange: (mode: "edit" | "preview" | "split") => void;
+  onWorkspaceFileCreate: (fileName: string) => void;
+  onFolderToggle?: (folderName: string) => void;
+  onWorkspaceAgentChange?: (agentId: string) => void;
+
+  // 权限管理相关 / Permissions props
+  permissionsLoading: boolean;
+  permissionsSaving: boolean;
+  permissionsDirty: boolean;
+  execApprovalsSnapshot: ExecApprovalsSnapshot | null;
+  execApprovalsForm: ExecApprovalsFile | null;
+  permissionsSelectedAgent: string | null;
+  permissionsAgents: AgentOption[];
+
+  // Exec Approvals 目标选择
+  execTarget: ExecApprovalsTarget;
+  execTargetNodeId: string | null;
+  execTargetNodes: ExecApprovalsTargetNode[];
+  onExecTargetChange: (target: ExecApprovalsTarget, nodeId: string | null) => void;
+
+  // 工具权限相关
+  toolsConfig: ToolsConfig | null;
+  agentToolsConfigs: AgentWithTools[];
+  toolsAgents: AgentOption[];
+  toolsSelectedAgent: string | null;
+  toolsExpanded: boolean;
+
+  // 回调函数
+  onReload: () => void;
+  onSave: () => void;
+  onApply: () => void;
+  onSectionChange?: (sectionId: string) => void;
+  onProviderToggle: (key: string) => void;
+  onProviderAdd: () => void;
+  onProviderRemove: (key: string) => void;
+  onProviderRename: (oldKey: string, newKey: string) => void;
+  onProviderUpdate: (key: string, field: string, value: unknown) => void;
+  onModelAdd: (providerKey: string) => void;
+  onModelRemove: (providerKey: string, modelIndex: number) => void;
+  onModelUpdate: (providerKey: string, modelIndex: number, field: string, value: unknown) => void;
+  onAgentDefaultsUpdate: (path: string[], value: unknown) => void;
+  onGatewayUpdate: (path: string[], value: unknown) => void;
+  onNavigateToChannels: () => void;
+  onChannelSelect: (channelId: string) => void;
+  onChannelConfigUpdate: (channelId: string, field: string, value: unknown) => void;
+  // 权限管理回调
+  permissionsActiveTab: PermissionsTabId;
+  onPermissionsTabChange: (tab: PermissionsTabId) => void;
+  onPermissionsLoad: () => void;
+  onPermissionsSave: () => void;
+  onPermissionsSelectAgent: (agentId: string | null) => void;
+  onPermissionsAddAgent: (agentId: string) => void;
+  onPermissionsRemoveAgent: (agentId: string) => void;
+  onPermissionsPatch: (path: Array<string | number>, value: unknown) => void;
+  onPermissionsRemove: (path: Array<string | number>) => void;
+  onPermissionsAddAllowlistEntry: (agentId: string) => void;
+  onPermissionsRemoveAllowlistEntry: (agentId: string, index: number) => void;
+  // 工具权限回调
+  onToolsSelectAgent: (agentId: string | null) => void;
+  onToolsToggleExpanded: () => void;
+  onToolsUpdateGlobal: (field: keyof ToolPolicyConfig, value: unknown) => void;
+  onToolsUpdateAgent: (agentId: string, field: keyof ToolPolicyConfig, value: unknown) => void;
+  onToolsAddGlobalDeny: (entry: string) => void;
+  onToolsRemoveGlobalDeny: (entry: string) => void;
+  onToolsAddAgentDeny: (agentId: string, entry: string) => void;
+  onToolsRemoveAgentDeny: (agentId: string, entry: string) => void;
+  onToolsToggleDeny: (tool: string, denied: boolean) => void;
+
+  // 技能管理相关 / Skills management props
+  skillsLoading: boolean;
+  skillsSaving: boolean;
+  skillsError: string | null;
+  skillsReport: SkillStatusReport | null;
+  skillsConfig: SkillsConfig | null;
+  skillsHasChanges: boolean;
+  skillsFilter: string;
+  skillsSourceFilter: SkillSourceFilter;
+  skillsStatusFilter: SkillStatusFilter;
+  skillsExpandedGroups: Set<string>;
+  skillsSelectedSkill: string | null;
+  skillsBusySkill: string | null;
+  skillsMessages: Record<string, SkillMessage>;
+  skillsAllowlistMode: "all" | "whitelist";
+  skillsAllowlistDraft: Set<string>;
+  skillsEdits: Record<string, SkillEditState>;
+  // 技能管理回调
+  onSkillsRefresh: () => void;
+  onSkillsSave: () => void;
+  onSkillsFilterChange: (filter: string) => void;
+  onSkillsSourceFilterChange: (source: SkillSourceFilter) => void;
+  onSkillsStatusFilterChange: (status: SkillStatusFilter) => void;
+  onSkillsGroupToggle: (group: string) => void;
+  onSkillsSkillSelect: (skillKey: string | null) => void;
+  onSkillsSkillToggle: (skillKey: string, enabled: boolean) => void;
+  onSkillsApiKeyChange: (skillKey: string, apiKey: string) => void;
+  onSkillsApiKeySave: (skillKey: string) => void;
+  onSkillsAllowlistModeChange: (mode: "all" | "whitelist") => void;
+  onSkillsAllowlistToggle: (skillKey: string, inList: boolean) => void;
+  onSkillsInstall: (skillKey: string, name: string, installId: string) => void;
+  onSkillsGlobalSettingChange: (field: string, value: unknown) => void;
+  // Phase 3: 环境变量和配置编辑回调
+  onSkillsEnvChange?: (skillKey: string, envKey: string, value: string) => void;
+  onSkillsEnvRemove?: (skillKey: string, envKey: string) => void;
+  onSkillsConfigChange?: (skillKey: string, config: Record<string, unknown>) => void;
+  onSkillsExtraDirsChange?: (dirs: string[]) => void;
+
+  // Phase 5-6: 编辑器相关状态 / Editor related state
+  skillsEditorState: SkillEditorState;
+  skillsCreateState: SkillCreateState;
+  skillsDeleteState: SkillDeleteState;
+  // Phase 5-6: 编辑器相关回调 / Editor related callbacks
+  onSkillsEditorOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => void;
+  onSkillsEditorClose: () => void;
+  onSkillsEditorContentChange: (content: string) => void;
+  onSkillsEditorModeChange: (mode: SkillEditorMode) => void;
+  onSkillsEditorSave: () => void;
+  onSkillsCreateOpen: (source?: EditableSkillSource) => void;
+  onSkillsCreateClose: () => void;
+  onSkillsCreateNameChange: (name: string) => void;
+  onSkillsCreateSourceChange: (source: EditableSkillSource) => void;
+  onSkillsCreateConfirm: () => void;
+  onSkillsDeleteOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => void;
+  onSkillsDeleteClose: () => void;
+  onSkillsDeleteConfirm: () => void;
+
+  // 定时任务相关 / Cron management props
+  cronLoading: boolean;
+  cronBusy: boolean;
+  cronError: string | null;
+  cronStatus: CronStatus | null;
+  cronJobs: CronJob[];
+  cronForm: CronFormState;
+  cronAgents: GatewayAgentRow[];
+  cronDefaultAgentId: string;
+  cronChannels: string[];
+  cronChannelLabels?: Record<string, string>;
+  cronChannelMeta?: ChannelUiMetaEntry[];
+  cronRunsJobId: string | null;
+  cronRuns: CronRunLogEntry[];
+  cronExpandedJobId: string | null;
+  cronDeleteConfirmJobId: string | null;
+  cronShowCreateModal: boolean;
+  cronEditJobId: string | null;
+  // 定时任务回调
+  onCronFormChange: (patch: Partial<CronFormState>) => void;
+  onCronRefresh: () => void;
+  onCronAdd: () => void;
+  onCronUpdate: () => void;
+  onCronToggle: (job: CronJob, enabled: boolean) => void;
+  onCronRun: (job: CronJob) => void;
+  onCronRemove: (job: CronJob) => void;
+  onCronLoadRuns: (jobId: string) => void;
+  onCronExpandJob: (jobId: string | null) => void;
+  onCronDeleteConfirm: (jobId: string | null) => void;
+  onCronShowCreateModal: (show: boolean) => void;
+  onCronEdit: (job: CronJob) => void;
+};
+
+/**
+ * 渲染右侧配置内容
+ */
+function renderContentSection(props: ModelConfigProps, section: string) {
+  switch (section) {
+    case "providers":
+      return renderProvidersContent({
+        providers: props.providers,
+        expandedProviders: props.expandedProviders,
+        // 添加供应商弹窗
+        showAddModal: props.showAddProviderModal,
+        addForm: props.addProviderForm,
+        addError: props.addProviderError,
+        onShowAddModal: props.onShowAddProviderModal,
+        onAddFormChange: props.onAddProviderFormChange,
+        onAddConfirm: props.onAddProviderConfirm,
+        // 回调
+        onProviderToggle: props.onProviderToggle,
+        onProviderAdd: props.onProviderAdd,
+        onProviderRemove: props.onProviderRemove,
+        onProviderRename: props.onProviderRename,
+        onProviderUpdate: props.onProviderUpdate,
+        onModelAdd: props.onModelAdd,
+        onModelRemove: props.onModelRemove,
+        onModelUpdate: props.onModelUpdate,
+      });
+
+    case "agent":
+      return renderAgentContent({
+        // Agent 默认设置
+        agentDefaults: props.agentDefaults,
+        availableModels: props.availableModels,
+        onAgentDefaultsUpdate: props.onAgentDefaultsUpdate,
+        // 会话管理
+        sessionsLoading: props.agentSessionsLoading,
+        sessionsResult: props.agentSessionsResult,
+        sessionsError: props.agentSessionsError,
+        onSessionsRefresh: props.onAgentSessionsRefresh,
+        onSessionModelChange: props.onAgentSessionModelChange,
+        onSessionNavigate: props.onAgentSessionNavigate,
+      });
+
+    case "gateway":
+      return renderGatewayContent({
+        gatewayConfig: props.gatewayConfig,
+        onGatewayUpdate: props.onGatewayUpdate,
+      });
+
+    case "channels":
+      return renderChannelsContent({
+        channelsConfig: props.channelsConfig,
+        selectedChannel: props.selectedChannel,
+        onChannelSelect: props.onChannelSelect,
+        onChannelConfigUpdate: props.onChannelConfigUpdate,
+        onNavigateToChannels: props.onNavigateToChannels,
+      });
+
+    case "workspace":
+      // 工作区文件管理 / Workspace file management
+      return renderWorkspaceContent({
+        files: props.workspaceFiles,
+        workspaceDir: props.workspaceDir,
+        agentId: props.workspaceAgentId,
+        agents: props.workspaceAgents,
+        selectedFile: props.workspaceSelectedFile,
+        editorContent: props.workspaceEditorContent,
+        originalContent: props.workspaceOriginalContent,
+        loading: props.workspaceLoading,
+        saving: props.workspaceSaving,
+        error: props.workspaceError,
+        editorMode: props.workspaceEditorMode,
+        expandedFolders: props.expandedFolders,
+        onFileSelect: props.onWorkspaceFileSelect,
+        onContentChange: props.onWorkspaceContentChange,
+        onFileSave: props.onWorkspaceFileSave,
+        onRefresh: props.onWorkspaceRefresh,
+        onModeChange: props.onWorkspaceModeChange,
+        onFileCreate: props.onWorkspaceFileCreate,
+        onFolderToggle: props.onFolderToggle,
+        onAgentChange: props.onWorkspaceAgentChange,
+      });
+
+    case "permissions":
+      return renderPermissionsContent({
+        loading: props.permissionsLoading,
+        saving: props.permissionsSaving,
+        dirty: props.permissionsDirty,
+        connected: props.connected,
+        activeTab: props.permissionsActiveTab,
+        onTabChange: props.onPermissionsTabChange,
+        // Exec Approvals 目标选择
+        execTarget: props.execTarget,
+        execTargetNodeId: props.execTargetNodeId,
+        execTargetNodes: props.execTargetNodes,
+        onExecTargetChange: props.onExecTargetChange,
+        // Exec Approvals 数据
+        execApprovalsSnapshot: props.execApprovalsSnapshot,
+        execApprovalsForm: props.execApprovalsForm,
+        selectedAgent: props.permissionsSelectedAgent,
+        agents: props.permissionsAgents,
+        onLoad: props.onPermissionsLoad,
+        onSave: props.onPermissionsSave,
+        onSelectAgent: props.onPermissionsSelectAgent,
+        onAddAgent: props.onPermissionsAddAgent,
+        onRemoveAgent: props.onPermissionsRemoveAgent,
+        onPatch: props.onPermissionsPatch,
+        onRemove: props.onPermissionsRemove,
+        onAddAllowlistEntry: props.onPermissionsAddAllowlistEntry,
+        onRemoveAllowlistEntry: props.onPermissionsRemoveAllowlistEntry,
+        // 工具权限
+        toolsConfig: props.toolsConfig,
+        agentToolsConfigs: props.agentToolsConfigs,
+        toolsAgents: props.toolsAgents,
+        toolsSelectedAgent: props.toolsSelectedAgent,
+        toolsExpanded: props.toolsExpanded,
+        onToolsSelectAgent: props.onToolsSelectAgent,
+        onToolsToggleExpanded: props.onToolsToggleExpanded,
+        onToolsUpdateGlobal: props.onToolsUpdateGlobal,
+        onToolsUpdateAgent: props.onToolsUpdateAgent,
+        onToolsAddGlobalDeny: props.onToolsAddGlobalDeny,
+        onToolsRemoveGlobalDeny: props.onToolsRemoveGlobalDeny,
+        onToolsAddAgentDeny: props.onToolsAddAgentDeny,
+        onToolsRemoveAgentDeny: props.onToolsRemoveAgentDeny,
+        onToolsToggleDeny: props.onToolsToggleDeny,
+      });
+
+    case "skills":
+      return renderSkillsContent({
+        loading: props.skillsLoading,
+        saving: props.skillsSaving,
+        error: props.skillsError,
+        report: props.skillsReport,
+        config: props.skillsConfig,
+        hasChanges: props.skillsHasChanges,
+        filter: props.skillsFilter,
+        sourceFilter: props.skillsSourceFilter,
+        statusFilter: props.skillsStatusFilter,
+        expandedGroups: props.skillsExpandedGroups,
+        selectedSkill: props.skillsSelectedSkill,
+        busySkill: props.skillsBusySkill,
+        messages: props.skillsMessages,
+        allowlistMode: props.skillsAllowlistMode,
+        allowlistDraft: props.skillsAllowlistDraft,
+        edits: props.skillsEdits,
+        onRefresh: props.onSkillsRefresh,
+        onSave: props.onSkillsSave,
+        onFilterChange: props.onSkillsFilterChange,
+        onSourceFilterChange: props.onSkillsSourceFilterChange,
+        onStatusFilterChange: props.onSkillsStatusFilterChange,
+        onGroupToggle: props.onSkillsGroupToggle,
+        onSkillSelect: props.onSkillsSkillSelect,
+        onSkillToggle: props.onSkillsSkillToggle,
+        onSkillApiKeyChange: props.onSkillsApiKeyChange,
+        onSkillApiKeySave: props.onSkillsApiKeySave,
+        onAllowlistModeChange: props.onSkillsAllowlistModeChange,
+        onAllowlistToggle: props.onSkillsAllowlistToggle,
+        onInstall: props.onSkillsInstall,
+        onGlobalSettingChange: props.onSkillsGlobalSettingChange,
+        // Phase 3: 环境变量和配置编辑
+        onSkillEnvChange: props.onSkillsEnvChange ?? (() => {}),
+        onSkillEnvRemove: props.onSkillsEnvRemove ?? (() => {}),
+        onSkillConfigChange: props.onSkillsConfigChange ?? (() => {}),
+        onExtraDirsChange: props.onSkillsExtraDirsChange ?? (() => {}),
+        // Phase 5-6: 编辑器状态和回调
+        editorState: props.skillsEditorState,
+        createState: props.skillsCreateState,
+        deleteState: props.skillsDeleteState,
+        onEditorOpen: props.onSkillsEditorOpen,
+        onEditorClose: props.onSkillsEditorClose,
+        onEditorContentChange: props.onSkillsEditorContentChange,
+        onEditorModeChange: props.onSkillsEditorModeChange,
+        onEditorSave: props.onSkillsEditorSave,
+        onCreateOpen: props.onSkillsCreateOpen,
+        onCreateClose: props.onSkillsCreateClose,
+        onCreateNameChange: props.onSkillsCreateNameChange,
+        onCreateSourceChange: props.onSkillsCreateSourceChange,
+        onCreateConfirm: props.onSkillsCreateConfirm,
+        onDeleteOpen: props.onSkillsDeleteOpen,
+        onDeleteClose: props.onSkillsDeleteClose,
+        onDeleteConfirm: props.onSkillsDeleteConfirm,
+      });
+
+    case "cron":
+      return renderCronContent({
+        loading: props.cronLoading,
+        busy: props.cronBusy,
+        error: props.cronError,
+        status: props.cronStatus,
+        jobs: props.cronJobs,
+        form: props.cronForm,
+        agents: props.cronAgents,
+        defaultAgentId: props.cronDefaultAgentId,
+        channels: props.cronChannels,
+        channelLabels: props.cronChannelLabels,
+        channelMeta: props.cronChannelMeta,
+        runsJobId: props.cronRunsJobId,
+        runs: props.cronRuns,
+        expandedJobId: props.cronExpandedJobId,
+        deleteConfirmJobId: props.cronDeleteConfirmJobId,
+        showCreateModal: props.cronShowCreateModal,
+        editJobId: props.cronEditJobId,
+        onFormChange: props.onCronFormChange,
+        onRefresh: props.onCronRefresh,
+        onAdd: props.onCronAdd,
+        onUpdate: props.onCronUpdate,
+        onToggle: props.onCronToggle,
+        onRun: props.onCronRun,
+        onRemove: props.onCronRemove,
+        onLoadRuns: props.onCronLoadRuns,
+        onExpandJob: props.onCronExpandJob,
+        onDeleteConfirm: props.onCronDeleteConfirm,
+        onShowCreateModal: props.onCronShowCreateModal,
+        onEdit: props.onCronEdit,
+      });
+
+    default:
+      return renderProvidersContent({
+        providers: props.providers,
+        expandedProviders: props.expandedProviders,
+        // 添加供应商弹窗
+        showAddModal: props.showAddProviderModal,
+        addForm: props.addProviderForm,
+        addError: props.addProviderError,
+        onShowAddModal: props.onShowAddProviderModal,
+        onAddFormChange: props.onAddProviderFormChange,
+        onAddConfirm: props.onAddProviderConfirm,
+        // 回调
+        onProviderToggle: props.onProviderToggle,
+        onProviderAdd: props.onProviderAdd,
+        onProviderRemove: props.onProviderRemove,
+        onProviderRename: props.onProviderRename,
+        onProviderUpdate: props.onProviderUpdate,
+        onModelAdd: props.onModelAdd,
+        onModelRemove: props.onModelRemove,
+        onModelUpdate: props.onModelUpdate,
+      });
+  }
+}
+
+/**
+ * 主渲染函数 - 带侧边栏布局
+ */
+export function renderModelConfig(props: ModelConfigProps) {
+  const activeSection = props.activeSection ?? "providers";
+
+  return html`
+    <div class="mc-layout mc-layout--sidebar">
+      <!-- 左侧侧边栏 -->
+      ${renderConfigSidebar({
+        activeSection,
+        onSectionChange: props.onSectionChange ?? (() => {}),
+        hasChanges: props.hasChanges,
+        connected: props.connected,
+      })}
+
+      <!-- 右侧主内容区 -->
+      <div class="mc-main">
+        <!-- 操作栏 -->
+        <div class="mc-actions">
+          <div class="mc-actions__left">
+            ${props.hasChanges
+              ? html`<span class="mc-changes-badge">有未保存的更改</span>`
+              : html`<span class="mc-status">配置已同步</span>`}
+          </div>
+          <div class="mc-actions__right">
+            <button
+              class="btn btn--sm"
+              ?disabled=${props.loading}
+              @click=${props.onReload}
+            >
+              ${props.loading ? LABELS.loading : LABELS.reload}
+            </button>
+            <button
+              class="btn btn--sm"
+              ?disabled=${!props.hasChanges || props.saving || props.applying || !props.connected}
+              @click=${props.onSave}
+            >
+              ${props.saving ? LABELS.saving : LABELS.save}
+            </button>
+            <button
+              class="btn btn--sm primary"
+              ?disabled=${!props.hasChanges || props.saving || props.applying || !props.connected}
+              @click=${props.onApply}
+              title="保存配置并重启相关服务"
+            >
+              ${props.applying ? LABELS.applying : LABELS.apply}
+            </button>
+          </div>
+        </div>
+
+        <!-- 配置内容 -->
+        <div class="mc-content">
+          ${renderContentSection(props, activeSection)}
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -51,6 +51,7 @@ import {
   rotateDeviceToken,
 } from "./controllers/devices";
 import { renderSkills } from "./views/skills";
+import { renderModelConfigTab } from "./ui-zh-CN-adapter";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers";
 import { loadChannels } from "./controllers/channels";
 import { loadPresence } from "./controllers/presence";
@@ -79,13 +80,7 @@ import {
   saveExecApprovals,
   updateExecApprovalsFormValue,
 } from "./controllers/exec-approvals";
-import {
-  loadCronRuns,
-  toggleCronJob,
-  runCronJob,
-  removeCronJob,
-  addCronJob,
-} from "./controllers/cron";
+import { loadCronRuns, toggleCronJob, runCronJob, removeCronJob, addCronJob } from "./controllers/cron";
 import { loadDebug, callDebugMethod } from "./controllers/debug";
 import { loadLogs } from "./controllers/logs";
 
@@ -515,7 +510,7 @@ export function renderApp(state: AppViewState) {
               })
             : nothing
         }
-
+          ${state.tab === "model-config" ? renderModelConfigTab(state) : nothing}
         ${
           state.tab === "config"
             ? renderConfig({

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -9,6 +9,7 @@ import { loadExecApprovals } from "./controllers/exec-approvals";
 import { loadPresence } from "./controllers/presence";
 import { loadSessions } from "./controllers/sessions";
 import { loadSkills } from "./controllers/skills";
+import { loadModelConfig, loadAgentSessions } from "./ui-zh-CN-adapter";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -172,6 +173,9 @@ export async function refreshActiveTab(host: SettingsHost) {
   if (host.tab === "config") {
     await loadConfigSchema(host as unknown as OpenClawApp);
     await loadConfig(host as unknown as OpenClawApp);
+  }
+  if (host.tab === "model-config") {
+    await loadModelConfig(host as unknown as MoltbotApp);
   }
   if (host.tab === "debug") {
     await loadDebug(host as unknown as OpenClawApp);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -26,6 +26,30 @@ import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exe
 import type { DevicePairingList } from "./controllers/devices";
 import type { ExecApprovalRequest } from "./controllers/exec-approval";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form";
+import type {
+  ProviderConfig,
+  AgentDefaults,
+  GatewayConfig,
+  ToolsConfig,
+  AgentWithTools,
+  PermissionsTabId,
+  AgentSessionsListResult,
+  AgentIdentityEntry,
+  WorkspaceFileInfo,
+  ProviderFormState,
+  ConfigSectionId,
+  ChannelsConfigData,
+  SkillsConfig,
+  SkillSourceFilter,
+  SkillStatusFilter,
+  SkillEditState,
+  SkillConfigMessage,
+  SkillEditorState,
+  SkillCreateState,
+  SkillDeleteState,
+  EditableSkillSource,
+  SkillEditorMode,
+} from "./ui-zh-CN-adapter";
 
 export type AppViewState = {
   settings: UiSettings;
@@ -119,6 +143,10 @@ export type AppViewState = {
   cronRunsJobId: string | null;
   cronRuns: CronRunLogEntry[];
   cronBusy: boolean;
+  cronExpandedJobId: string | null;
+  cronDeleteConfirmJobId: string | null;
+  cronShowCreateModal: boolean;
+  cronEditJobId: string | null;
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;
   skillsError: string | null;
@@ -143,6 +171,86 @@ export type AppViewState = {
   logsLevelFilters: Record<LogLevel, boolean>;
   logsAutoFollow: boolean;
   logsTruncated: boolean;
+  // 模型配置状态
+  modelConfigLoading: boolean;
+  modelConfigSaving: boolean;
+  modelConfigApplying: boolean;
+  modelConfigProviders: Record<string, ProviderConfig>;
+  modelConfigAgentDefaults: AgentDefaults;
+  modelConfigGateway: GatewayConfig;
+  modelConfigExpandedProviders: Set<string>;
+  modelConfigOriginal: {
+    providers: Record<string, ProviderConfig>;
+    agentDefaults: AgentDefaults;
+    gateway: GatewayConfig;
+    channels: ChannelsConfigData | null;
+  } | null;
+  // 完整配置快照（用于保存）
+  modelConfigFullSnapshot: Record<string, unknown> | null;
+  modelConfigHash: string | null;
+  // 当前选中的配置区块
+  modelConfigActiveSection: ConfigSectionId;
+  // 通道配置
+  modelConfigChannelsConfig: ChannelsConfigData | null;
+  modelConfigSelectedChannel: string | null;
+  // 权限管理状态（模型配置页面）
+  permissionsLoading: boolean;
+  permissionsSaving: boolean;
+  permissionsDirty: boolean;
+  permissionsSelectedAgent: string | null;
+  permissionsActiveTab: PermissionsTabId;
+  // 工具权限状态
+  toolsConfig: ToolsConfig | null;
+  toolsConfigOriginal: ToolsConfig | null;
+  agentToolsConfigs: AgentWithTools[];
+  agentToolsConfigsOriginal: AgentWithTools[];
+  toolsSelectedAgent: string | null;
+  toolsExpanded: boolean;
+  // 会话管理状态 (Agent 设置页)
+  agentSessionsLoading: boolean;
+  agentSessionsResult: AgentSessionsListResult | null;
+  agentSessionsError: string | null;
+  // Agent 身份配置状态 / Agent identity config state
+  modelConfigAgentsList: AgentIdentityEntry[];
+  modelConfigAgentsListOriginal: AgentIdentityEntry[];
+  modelConfigSelectedAgentId: string | null;
+  // 工作区文件状态 / Workspace file state
+  workspaceFiles: WorkspaceFileInfo[];
+  workspaceDir: string;
+  workspaceAgentId: string;
+  workspaceSelectedFile: string | null;
+  workspaceEditorContent: string;
+  workspaceOriginalContent: string;
+  workspaceLoading: boolean;
+  workspaceSaving: boolean;
+  workspaceError: string | null;
+  workspaceEditorMode: "edit" | "preview" | "split";
+  workspaceExpandedFolders: Set<string>;
+  // 添加供应商弹窗状态 / Add provider modal state
+  addProviderModalShow: boolean;
+  addProviderForm: ProviderFormState;
+  addProviderError: string | null;
+  // 技能管理状态 (Skills management state for changeoradd)
+  skillsConfigLoading: boolean;
+  skillsConfigSaving: boolean;
+  skillsConfigError: string | null;
+  skillsConfigReport: SkillStatusReport | null;
+  skillsConfig: SkillsConfig | null;
+  skillsConfigOriginal: SkillsConfig | null;
+  skillsConfigFilter: string;
+  skillsConfigSourceFilter: SkillSourceFilter;
+  skillsConfigStatusFilter: SkillStatusFilter;
+  skillsConfigExpandedGroups: Set<string>;
+  skillsConfigSelectedSkill: string | null;
+  skillsConfigBusySkill: string | null;
+  skillsConfigMessages: Record<string, SkillConfigMessage>;
+  skillsConfigAllowlistMode: "all" | "whitelist";
+  skillsConfigAllowlistDraft: Set<string>;
+  skillsConfigEdits: Record<string, SkillEditState>;
+  // 技能编辑器状态 / Skills editor state (Phase 5-6)
+  skillsConfigEditor: SkillEditorState;
+  skillsConfigCreate: SkillCreateState;
+  skillsConfigDelete: SkillDeleteState;
   client: GatewayBrowserClient | null;
   connect: () => void;
   setTab: (tab: Tab) => void;
@@ -203,4 +311,18 @@ export type AppViewState = {
   handleLogsLevelFilterToggle: (level: LogLevel) => void;
   handleLogsAutoFollowToggle: (next: boolean) => void;
   handleCallDebugMethod: (method: string, params: string) => Promise<void>;
+  // 技能编辑器处理函数 / Skills editor handlers (Phase 5-6)
+  handleSkillEditorOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => Promise<void>;
+  handleSkillEditorClose: () => void;
+  handleSkillEditorContentChange: (content: string) => void;
+  handleSkillEditorModeChange: (mode: SkillEditorMode) => void;
+  handleSkillEditorSave: () => Promise<void>;
+  handleSkillCreateOpen: (source?: EditableSkillSource) => void;
+  handleSkillCreateClose: () => void;
+  handleSkillCreateNameChange: (name: string) => void;
+  handleSkillCreateSourceChange: (source: EditableSkillSource) => void;
+  handleSkillCreateConfirm: () => Promise<void>;
+  handleSkillDeleteOpen: (skillKey: string, skillName: string, source: EditableSkillSource) => void;
+  handleSkillDeleteClose: () => void;
+  handleSkillDeleteConfirm: () => Promise<void>;
 };

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -7,7 +7,7 @@ export const TAB_GROUPS = [
     tabs: ["overview", "channels", "instances", "sessions", "cron"],
   },
   { label: "Agent", tabs: ["skills", "nodes"] },
-  { label: "Settings", tabs: ["config", "debug", "logs"] },
+  { label: "Settings", tabs: ["model-config", "config", "debug", "logs"] },
 ] as const;
 
 export type Tab =
@@ -19,6 +19,7 @@ export type Tab =
   | "skills"
   | "nodes"
   | "chat"
+  | "model-config"
   | "config"
   | "debug"
   | "logs";
@@ -32,6 +33,7 @@ const TAB_PATHS: Record<Tab, string> = {
   skills: "/skills",
   nodes: "/nodes",
   chat: "/chat",
+  "model-config": "/model-config",
   config: "/config",
   debug: "/debug",
   logs: "/logs",
@@ -116,6 +118,8 @@ export function iconForTab(tab: Tab): IconName {
       return "zap";
     case "nodes":
       return "monitor";
+    case "model-config":
+      return "brain";
     case "config":
       return "settings";
     case "debug":
@@ -145,6 +149,8 @@ export function titleForTab(tab: Tab) {
       return "Nodes";
     case "chat":
       return "Chat";
+    case "model-config":
+      return "可视化配置";
     case "config":
       return "Config";
     case "debug":
@@ -174,6 +180,8 @@ export function subtitleForTab(tab: Tab) {
       return "Paired devices, capabilities, and command exposure.";
     case "chat":
       return "Direct gateway chat session for quick interventions.";
+    case "model-config":
+      return "可视化管理模型供应商、Agent 默认设置和网关配置";
     case "config":
       return "Edit ~/.openclaw/openclaw.json safely.";
     case "debug":

--- a/ui/src/ui/ui-zh-CN-adapter.ts
+++ b/ui/src/ui/ui-zh-CN-adapter.ts
@@ -1,0 +1,693 @@
+/**
+ * ui-zh-CN 适配层
+ * 将所有 ui-zh-CN 引用集中到此文件，减少主 UI 文件的耦合
+ *
+ * Adapter layer for ui-zh-CN module
+ * Centralizes all ui-zh-CN references to reduce coupling in main UI files
+ */
+import { html, nothing } from "lit";
+
+import type { AppViewState } from "./app-view-state";
+import type { CronJob } from "./types";
+import type { CronFormState } from "./ui-types";
+import { DEFAULT_CRON_FORM } from "./app-defaults";
+
+// ============================================
+// 类型重导出 / Type re-exports
+// ============================================
+
+// 从 views/model-config
+export type {
+  ProviderConfig,
+  AgentDefaults,
+  GatewayConfig,
+  ModelConfig,
+  ModelApi,
+  AuthMode,
+  ModelCost,
+  ModelCompat,
+  ModelConfigProps,
+} from "../ui-zh-CN/views/model-config";
+
+// 从 controllers/model-config
+export type {
+  ExecApprovalsSnapshot,
+  ExecApprovalsFile,
+  ExecApprovalsAllowlistEntry,
+  AgentOption,
+  WorkspaceFileInfo,
+  SessionRow,
+  SessionsListResult as AgentSessionsListResult,
+  ToolProfileId,
+  ToolPolicyConfig,
+  ToolsConfig,
+  AgentToolsConfig,
+  AgentWithTools,
+  PermissionsTabId,
+  AgentIdentityEntry,
+  ExecApprovalsTarget,
+  ExecApprovalsTargetNode,
+} from "../ui-zh-CN/controllers/model-config";
+
+// 从 components/providers-content
+export type { ProviderFormState } from "../ui-zh-CN/components/providers-content";
+
+// 从 components/workspace-content
+export type { WorkspaceAgentOption } from "../ui-zh-CN/components/workspace-content";
+
+// 从 types/config-sections
+export type { ConfigSectionId, ConfigSection } from "../ui-zh-CN/types/config-sections";
+
+// 从 types/channel-config
+export type { ChannelsConfigData } from "../ui-zh-CN/types/channel-config";
+
+// 从 types/skills-config
+export type {
+  SkillsConfig,
+  SkillSourceFilter,
+  SkillStatusFilter,
+  SkillEditState,
+  SkillMessage as SkillConfigMessage,
+  SkillEditorState,
+  SkillCreateState,
+  SkillDeleteState,
+  EditableSkillSource,
+  SkillEditorMode,
+  SkillInstallOption,
+  SkillStatusEntry,
+  SkillEntryConfig,
+  SkillsLoadConfig,
+  SkillsInstallConfig,
+  SkillGroup,
+  SkillFileInfo,
+  SkillFilesListResult,
+} from "../ui-zh-CN/types/skills-config";
+
+// ============================================
+// 控制器函数重导出 / Controller function re-exports
+// ============================================
+
+// model-config 控制器
+export {
+  loadModelConfig,
+  saveModelConfig,
+  applyModelConfig,
+  toggleProviderExpanded,
+  addProvider,
+  removeProvider,
+  renameProvider,
+  updateProviderField,
+  addModel,
+  removeModel,
+  updateModelField,
+  updateAgentDefaults,
+  updateGatewayConfig,
+  getAvailableModels,
+  hasModelConfigChanges,
+  setActiveSection,
+  getPermissionsAgents,
+  loadPermissions,
+  savePermissions,
+  selectPermissionsAgent,
+  updatePermissionsFormValue,
+  removePermissionsFormValue,
+  addPermissionsAllowlistEntry,
+  removePermissionsAllowlistEntry,
+  addPermissionsAgent,
+  removePermissionsAgent,
+  setPermissionsActiveTab,
+  resolveExecApprovalsNodes,
+  getToolsAgents,
+  selectToolsAgent,
+  toggleToolsExpanded,
+  updateGlobalToolsConfig,
+  updateAgentToolsConfig,
+  addGlobalToolsDenyEntry,
+  removeGlobalToolsDenyEntry,
+  addAgentToolsDenyEntry,
+  removeAgentToolsDenyEntry,
+  loadAgentSessions,
+  patchSessionModel,
+  loadWorkspaceFiles,
+  selectWorkspaceFile,
+  saveWorkspaceFile,
+  createWorkspaceFile,
+  showAddProviderModal,
+  updateAddProviderForm,
+  confirmAddProvider,
+} from "../ui-zh-CN/controllers/model-config";
+
+// skills-config 控制器
+export {
+  loadSkillsStatus as loadSkillsConfig,
+  saveSkillsConfig,
+  updateSkillEnabled as updateSkillEnabledConfig,
+  saveSkillApiKey as saveSkillApiKeyConfig,
+  installSkillDependency,
+  updateSkillsFilter,
+  updateSkillsSourceFilter,
+  updateSkillsStatusFilter,
+  toggleSkillsGroup,
+  selectSkill,
+  updateSkillApiKeyEdit as updateSkillApiKeyEditConfig,
+  setAllowlistMode,
+  toggleAllowlistEntry,
+  updateGlobalSetting,
+  hasSkillsConfigChanges,
+  updateSkillEnv as updateSkillEnvConfig,
+  removeSkillEnv as removeSkillEnvConfig,
+  updateSkillConfig as updateSkillConfigConfig,
+  updateExtraDirs as updateExtraDirsConfig,
+  openSkillEditor,
+  closeSkillEditor,
+  updateEditorContent,
+  updateEditorMode,
+  saveSkillFile,
+  openCreateSkill,
+  closeCreateSkill,
+  updateCreateSkillName,
+  updateCreateSkillSource,
+  confirmCreateSkill,
+  openDeleteSkill,
+  closeDeleteSkill,
+  confirmDeleteSkill,
+} from "../ui-zh-CN/controllers/skills-config";
+
+// 视图渲染
+import { renderModelConfig } from "../ui-zh-CN/views/model-config";
+import {
+  loadModelConfig as loadModelConfigInternal,
+  saveModelConfig as saveModelConfigInternal,
+  applyModelConfig as applyModelConfigInternal,
+  toggleProviderExpanded as toggleProviderExpandedInternal,
+  addProvider as addProviderInternal,
+  removeProvider as removeProviderInternal,
+  renameProvider as renameProviderInternal,
+  updateProviderField as updateProviderFieldInternal,
+  addModel as addModelInternal,
+  removeModel as removeModelInternal,
+  updateModelField as updateModelFieldInternal,
+  updateAgentDefaults as updateAgentDefaultsInternal,
+  updateGatewayConfig as updateGatewayConfigInternal,
+  getAvailableModels as getAvailableModelsInternal,
+  hasModelConfigChanges as hasModelConfigChangesInternal,
+  setActiveSection as setActiveSectionInternal,
+  getPermissionsAgents as getPermissionsAgentsInternal,
+  loadPermissions as loadPermissionsInternal,
+  savePermissions as savePermissionsInternal,
+  selectPermissionsAgent as selectPermissionsAgentInternal,
+  updatePermissionsFormValue as updatePermissionsFormValueInternal,
+  removePermissionsFormValue as removePermissionsFormValueInternal,
+  addPermissionsAllowlistEntry as addPermissionsAllowlistEntryInternal,
+  removePermissionsAllowlistEntry as removePermissionsAllowlistEntryInternal,
+  addPermissionsAgent as addPermissionsAgentInternal,
+  removePermissionsAgent as removePermissionsAgentInternal,
+  resolveExecApprovalsNodes as resolveExecApprovalsNodesInternal,
+  getToolsAgents as getToolsAgentsInternal,
+  selectToolsAgent as selectToolsAgentInternal,
+  toggleToolsExpanded as toggleToolsExpandedInternal,
+  updateGlobalToolsConfig as updateGlobalToolsConfigInternal,
+  updateAgentToolsConfig as updateAgentToolsConfigInternal,
+  addGlobalToolsDenyEntry as addGlobalToolsDenyEntryInternal,
+  removeGlobalToolsDenyEntry as removeGlobalToolsDenyEntryInternal,
+  addAgentToolsDenyEntry as addAgentToolsDenyEntryInternal,
+  removeAgentToolsDenyEntry as removeAgentToolsDenyEntryInternal,
+  loadAgentSessions as loadAgentSessionsInternal,
+  patchSessionModel as patchSessionModelInternal,
+  loadWorkspaceFiles as loadWorkspaceFilesInternal,
+  selectWorkspaceFile as selectWorkspaceFileInternal,
+  saveWorkspaceFile as saveWorkspaceFileInternal,
+  createWorkspaceFile as createWorkspaceFileInternal,
+  showAddProviderModal as showAddProviderModalInternal,
+  updateAddProviderForm as updateAddProviderFormInternal,
+  confirmAddProvider as confirmAddProviderInternal,
+} from "../ui-zh-CN/controllers/model-config";
+
+import {
+  loadSkillsStatus as loadSkillsConfigInternal,
+  saveSkillsConfig as saveSkillsConfigInternal,
+  updateSkillEnabled as updateSkillEnabledConfigInternal,
+  saveSkillApiKey as saveSkillApiKeyConfigInternal,
+  installSkillDependency as installSkillDependencyInternal,
+  toggleSkillsGroup as toggleSkillsGroupInternal,
+  setAllowlistMode as setAllowlistModeInternal,
+  toggleAllowlistEntry as toggleAllowlistEntryInternal,
+  updateGlobalSetting as updateGlobalSettingInternal,
+  hasSkillsConfigChanges as hasSkillsConfigChangesInternal,
+  updateSkillEnv as updateSkillEnvConfigInternal,
+  removeSkillEnv as removeSkillEnvConfigInternal,
+  updateSkillConfig as updateSkillConfigConfigInternal,
+  updateExtraDirs as updateExtraDirsConfigInternal,
+  openSkillEditor as openSkillEditorInternal,
+  closeSkillEditor as closeSkillEditorInternal,
+  updateEditorContent as updateEditorContentInternal,
+  updateEditorMode as updateEditorModeInternal,
+  saveSkillFile as saveSkillFileInternal,
+  openCreateSkill as openCreateSkillInternal,
+  closeCreateSkill as closeCreateSkillInternal,
+  updateCreateSkillName as updateCreateSkillNameInternal,
+  updateCreateSkillSource as updateCreateSkillSourceInternal,
+  confirmCreateSkill as confirmCreateSkillInternal,
+  openDeleteSkill as openDeleteSkillInternal,
+  closeDeleteSkill as closeDeleteSkillInternal,
+  confirmDeleteSkill as confirmDeleteSkillInternal,
+  updateSkillApiKeyEdit as updateSkillApiKeyEditConfigInternal,
+} from "../ui-zh-CN/controllers/skills-config";
+
+import { loadCronRuns, toggleCronJob, runCronJob, removeCronJob, addCronJob, updateCronJob } from "./controllers/cron";
+import type { GatewayAgentRow } from "./types";
+
+// ============================================
+// 辅助函数 / Helper functions
+// ============================================
+
+/**
+ * 将 CronJob 转换为 CronFormState（用于编辑）
+ */
+function jobToFormState(job: CronJob): CronFormState {
+  const schedule = job.schedule;
+  let scheduleKind: "at" | "every" | "cron" = "every";
+  let scheduleAt = "";
+  let everyAmount = "30";
+  let everyUnit: "minutes" | "hours" | "days" = "minutes";
+  let cronExpr = "0 7 * * *";
+  let cronTz = "";
+
+  if (schedule.kind === "at") {
+    scheduleKind = "at";
+    scheduleAt = new Date(schedule.atMs).toISOString().slice(0, 16);
+  } else if (schedule.kind === "every") {
+    scheduleKind = "every";
+    const ms = schedule.everyMs;
+    if (ms % 86400000 === 0) {
+      everyAmount = String(ms / 86400000);
+      everyUnit = "days";
+    } else if (ms % 3600000 === 0) {
+      everyAmount = String(ms / 3600000);
+      everyUnit = "hours";
+    } else {
+      everyAmount = String(ms / 60000);
+      everyUnit = "minutes";
+    }
+  } else if (schedule.kind === "cron") {
+    scheduleKind = "cron";
+    cronExpr = schedule.expr;
+    cronTz = schedule.tz ?? "";
+  }
+
+  const payload = job.payload;
+  const payloadKind = payload.kind;
+  const payloadText = payload.kind === "systemEvent" ? payload.text : payload.message;
+
+  return {
+    name: job.name,
+    description: job.description ?? "",
+    agentId: job.agentId ?? "",
+    enabled: job.enabled,
+    scheduleKind,
+    scheduleAt,
+    everyAmount,
+    everyUnit,
+    cronExpr,
+    cronTz,
+    sessionTarget: job.sessionTarget,
+    wakeMode: job.wakeMode,
+    payloadKind,
+    payloadText,
+    deliver: payload.kind === "agentTurn" ? (payload.deliver ?? false) : false,
+    channel: payload.kind === "agentTurn" ? (payload.provider ?? "last") : "last",
+    to: payload.kind === "agentTurn" ? (payload.to ?? "") : "",
+    timeoutSeconds: payload.kind === "agentTurn" ? String(payload.timeoutSeconds ?? "") : "",
+    postToMainPrefix: job.isolation?.postToMainPrefix ?? "",
+  };
+}
+
+/**
+ * 处理工作区文件选择
+ */
+function handleWorkspaceFileSelect(state: AppViewState, fileName: string): void {
+  void selectWorkspaceFileInternal(state as Parameters<typeof selectWorkspaceFileInternal>[0], fileName);
+}
+
+/**
+ * 处理工作区文件保存
+ */
+function handleWorkspaceFileSave(state: AppViewState): void {
+  void saveWorkspaceFileInternal(state as Parameters<typeof saveWorkspaceFileInternal>[0]);
+}
+
+/**
+ * 处理工作区文件刷新
+ */
+function handleWorkspaceRefresh(state: AppViewState): void {
+  void loadWorkspaceFilesInternal(state as Parameters<typeof loadWorkspaceFilesInternal>[0]);
+}
+
+/**
+ * 处理工作区 Agent 切换
+ */
+function handleWorkspaceAgentChange(state: AppViewState, agentId: string): void {
+  state.workspaceAgentId = agentId;
+  state.workspaceSelectedFile = null;
+  state.workspaceEditorContent = "";
+  state.workspaceOriginalContent = "";
+  void loadWorkspaceFilesInternal(state as Parameters<typeof loadWorkspaceFilesInternal>[0]);
+}
+
+/**
+ * 获取工作区可用的 Agent 列表
+ */
+function getWorkspaceAgents(state: AppViewState): Array<{ id: string; name?: string; default?: boolean }> {
+  const agents = state.modelConfigAgentsList ?? [];
+  if (agents.length === 0) {
+    return [{ id: "main", name: "Main Agent", default: true }];
+  }
+  return agents.map((agent) => ({
+    id: agent.id,
+    name: agent.name ?? agent.identity?.name,
+    default: agent.default,
+  }));
+}
+
+/**
+ * 处理工作区文件创建
+ */
+function handleWorkspaceFileCreate(state: AppViewState, fileName: string): void {
+  createWorkspaceFileInternal(state as Parameters<typeof createWorkspaceFileInternal>[0], fileName);
+}
+
+// ============================================
+// 主渲染函数 / Main render function
+// ============================================
+
+/**
+ * 渲染 model-config Tab
+ * Render the model-config tab with all props mapped from AppViewState
+ */
+export function renderModelConfigTab(state: AppViewState) {
+  return renderModelConfig({
+    loading: state.modelConfigLoading,
+    saving: state.modelConfigSaving,
+    applying: state.modelConfigApplying,
+    connected: state.connected,
+    hasChanges: hasModelConfigChangesInternal(state),
+    providers: state.modelConfigProviders,
+    agentDefaults: state.modelConfigAgentDefaults,
+    gatewayConfig: state.modelConfigGateway,
+    availableModels: getAvailableModelsInternal(state.modelConfigProviders),
+    channelsConfig: state.modelConfigChannelsConfig ?? {},
+    selectedChannel: state.modelConfigSelectedChannel,
+    expandedProviders: state.modelConfigExpandedProviders,
+    activeSection: state.modelConfigActiveSection,
+    // 会话管理相关状态
+    agentSessionsLoading: state.agentSessionsLoading,
+    agentSessionsResult: state.agentSessionsResult,
+    agentSessionsError: state.agentSessionsError,
+    onAgentSessionsRefresh: () => loadAgentSessionsInternal(state),
+    onAgentSessionModelChange: (sessionKey, model) => patchSessionModelInternal(state, sessionKey, model),
+    onAgentSessionNavigate: (sessionKey) => {
+      state.sessionKey = sessionKey;
+      state.chatMessage = "";
+      state.resetToolStream();
+      state.applySettings({
+        ...state.settings,
+        sessionKey,
+        lastActiveSessionKey: sessionKey,
+      });
+      void state.loadAssistantIdentity();
+      state.setTab("chat");
+    },
+    // 工作区文件相关 / Workspace file props
+    workspaceFiles: state.workspaceFiles,
+    workspaceDir: state.workspaceDir,
+    workspaceAgentId: state.workspaceAgentId,
+    workspaceAgents: getWorkspaceAgents(state),
+    workspaceSelectedFile: state.workspaceSelectedFile,
+    workspaceEditorContent: state.workspaceEditorContent,
+    workspaceOriginalContent: state.workspaceOriginalContent,
+    workspaceLoading: state.workspaceLoading,
+    workspaceSaving: state.workspaceSaving,
+    workspaceError: state.workspaceError,
+    workspaceEditorMode: state.workspaceEditorMode,
+    onWorkspaceFileSelect: (fileName) => handleWorkspaceFileSelect(state, fileName),
+    onWorkspaceContentChange: (content) => { state.workspaceEditorContent = content; },
+    onWorkspaceFileSave: () => handleWorkspaceFileSave(state),
+    onWorkspaceRefresh: () => handleWorkspaceRefresh(state),
+    onWorkspaceModeChange: (mode) => { state.workspaceEditorMode = mode; },
+    onWorkspaceFileCreate: (fileName) => handleWorkspaceFileCreate(state, fileName),
+    onWorkspaceAgentChange: (agentId) => handleWorkspaceAgentChange(state, agentId),
+    expandedFolders: state.workspaceExpandedFolders,
+    onFolderToggle: (folderName) => {
+      const next = new Set(state.workspaceExpandedFolders);
+      if (next.has(folderName)) {
+        next.delete(folderName);
+      } else {
+        next.add(folderName);
+      }
+      state.workspaceExpandedFolders = next;
+    },
+    // 权限管理相关状态 / Permissions state
+    permissionsLoading: state.permissionsLoading,
+    permissionsSaving: state.permissionsSaving,
+    permissionsDirty: state.permissionsDirty,
+    execApprovalsSnapshot: state.execApprovalsSnapshot,
+    execApprovalsForm: state.execApprovalsForm,
+    permissionsSelectedAgent: state.permissionsSelectedAgent,
+    permissionsAgents: getPermissionsAgentsInternal(state),
+    // Exec Approvals 目标选择
+    execTarget: state.execApprovalsTarget ?? "gateway",
+    execTargetNodeId: state.execApprovalsTargetNodeId ?? null,
+    execTargetNodes: resolveExecApprovalsNodesInternal(state.nodes ?? []),
+    onExecTargetChange: (target, nodeId) => {
+      state.execApprovalsTarget = target;
+      state.execApprovalsTargetNodeId = nodeId;
+      state.execApprovalsSnapshot = null;
+      state.execApprovalsForm = null;
+      state.permissionsDirty = false;
+      state.permissionsSelectedAgent = null;
+      // 自动加载新目标的权限配置
+      const loadTarget = target === "node" && nodeId
+        ? { kind: "node" as const, nodeId }
+        : { kind: "gateway" as const };
+      void loadPermissionsInternal(state, loadTarget);
+    },
+    onReload: () => loadModelConfigInternal(state),
+    onSave: () => saveModelConfigInternal(state),
+    onApply: () => applyModelConfigInternal(state),
+    onSectionChange: (sectionId) => {
+      setActiveSectionInternal(state, sectionId);
+      // 自动加载工作区文件 / Auto-load workspace files
+      if (sectionId === "workspace" && state.workspaceFiles.length === 0) {
+        void loadWorkspaceFilesInternal(state as Parameters<typeof loadWorkspaceFilesInternal>[0]);
+      }
+      // 自动加载技能数据 / Auto-load skills data
+      if (sectionId === "skills" && !state.skillsConfigReport) {
+        void loadSkillsConfigInternal(state as Parameters<typeof loadSkillsConfigInternal>[0]);
+      }
+      // 自动加载定时任务数据 / Auto-load cron data
+      if (sectionId === "cron" && state.cronJobs.length === 0 && !state.cronLoading) {
+        void state.loadCron();
+      }
+    },
+    onProviderToggle: (key) => toggleProviderExpandedInternal(state, key),
+    onProviderAdd: () => addProviderInternal(state),
+    // 添加供应商弹窗 / Add provider modal
+    showAddProviderModal: state.addProviderModalShow,
+    addProviderForm: state.addProviderForm,
+    addProviderError: state.addProviderError,
+    onShowAddProviderModal: (show) => showAddProviderModalInternal(state, show),
+    onAddProviderFormChange: (patch) => updateAddProviderFormInternal(state, patch),
+    onAddProviderConfirm: () => confirmAddProviderInternal(state),
+    onProviderRemove: (key) => removeProviderInternal(state, key),
+    onProviderRename: (oldKey, newKey) => renameProviderInternal(state, oldKey, newKey),
+    onProviderUpdate: (key, field, value) =>
+      updateProviderFieldInternal(state, key, field, value),
+    onModelAdd: (providerKey) => addModelInternal(state, providerKey),
+    onModelRemove: (providerKey, modelIndex) =>
+      removeModelInternal(state, providerKey, modelIndex),
+    onModelUpdate: (providerKey, modelIndex, field, value) =>
+      updateModelFieldInternal(state, providerKey, modelIndex, field, value),
+    onAgentDefaultsUpdate: (path, value) =>
+      updateAgentDefaultsInternal(state, path, value),
+    onGatewayUpdate: (path, value) =>
+      updateGatewayConfigInternal(state, path, value),
+    onNavigateToChannels: () => state.setTab("channels"),
+    onChannelSelect: (channelId) => {
+      state.modelConfigSelectedChannel = channelId;
+    },
+    onChannelConfigUpdate: (channelId, field, value) => {
+      const current = state.modelConfigChannelsConfig ?? {};
+      const channelConfig = JSON.parse(JSON.stringify(current[channelId] ?? {})) as Record<string, unknown>;
+
+      // 支持嵌套路径，如 "polling.pollingIntervalMs"
+      const parts = field.split(".");
+      if (parts.length === 1) {
+        channelConfig[field] = value;
+      } else {
+        let target = channelConfig;
+        for (let i = 0; i < parts.length - 1; i++) {
+          const part = parts[i];
+          if (!target[part] || typeof target[part] !== "object") {
+            target[part] = {};
+          }
+          target = target[part] as Record<string, unknown>;
+        }
+        target[parts[parts.length - 1]] = value;
+      }
+
+      state.modelConfigChannelsConfig = {
+        ...current,
+        [channelId]: channelConfig,
+      };
+    },
+    // 权限管理回调
+    permissionsActiveTab: state.permissionsActiveTab ?? "exec",
+    onPermissionsTabChange: (tab) => { state.permissionsActiveTab = tab; },
+    onPermissionsLoad: () => {
+      const target = state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+        : { kind: "gateway" as const };
+      return loadPermissionsInternal(state, target);
+    },
+    onPermissionsSave: () => {
+      const target = state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+        : { kind: "gateway" as const };
+      return savePermissionsInternal(state, target);
+    },
+    onPermissionsSelectAgent: (agentId) => selectPermissionsAgentInternal(state, agentId),
+    onPermissionsPatch: (path, value) => updatePermissionsFormValueInternal(state, path, value),
+    onPermissionsRemove: (path) => removePermissionsFormValueInternal(state, path),
+    onPermissionsAddAllowlistEntry: (agentId) => addPermissionsAllowlistEntryInternal(state, agentId),
+    onPermissionsRemoveAllowlistEntry: (agentId, index) => removePermissionsAllowlistEntryInternal(state, agentId, index),
+    onPermissionsAddAgent: (agentId) => addPermissionsAgentInternal(state, agentId),
+    onPermissionsRemoveAgent: (agentId) => removePermissionsAgentInternal(state, agentId),
+    // 工具权限相关状态
+    toolsConfig: state.toolsConfig,
+    agentToolsConfigs: state.agentToolsConfigs,
+    toolsAgents: getToolsAgentsInternal(state),
+    toolsSelectedAgent: state.toolsSelectedAgent,
+    toolsExpanded: state.toolsExpanded,
+    // 工具权限回调
+    onToolsSelectAgent: (agentId) => selectToolsAgentInternal(state, agentId),
+    onToolsToggleExpanded: () => toggleToolsExpandedInternal(state),
+    onToolsUpdateGlobal: (field, value) => updateGlobalToolsConfigInternal(state, field, value),
+    onToolsUpdateAgent: (agentId, field, value) => updateAgentToolsConfigInternal(state, agentId, field, value),
+    onToolsAddGlobalDeny: (entry) => addGlobalToolsDenyEntryInternal(state, entry),
+    onToolsRemoveGlobalDeny: (entry) => removeGlobalToolsDenyEntryInternal(state, entry),
+    onToolsAddAgentDeny: (agentId, entry) => addAgentToolsDenyEntryInternal(state, agentId, entry),
+    onToolsRemoveAgentDeny: (agentId, entry) => removeAgentToolsDenyEntryInternal(state, agentId, entry),
+    onToolsToggleDeny: (tool, denied) => {
+      if (denied) {
+        addGlobalToolsDenyEntryInternal(state, tool);
+      } else {
+        removeGlobalToolsDenyEntryInternal(state, tool);
+      }
+    },
+    // 技能管理相关状态 / Skills management props
+    skillsLoading: state.skillsConfigLoading,
+    skillsSaving: state.skillsConfigSaving,
+    skillsError: state.skillsConfigError,
+    skillsReport: state.skillsConfigReport,
+    skillsConfig: state.skillsConfig,
+    skillsHasChanges: hasSkillsConfigChangesInternal(state as Parameters<typeof hasSkillsConfigChangesInternal>[0]),
+    skillsFilter: state.skillsConfigFilter,
+    skillsSourceFilter: state.skillsConfigSourceFilter,
+    skillsStatusFilter: state.skillsConfigStatusFilter,
+    skillsExpandedGroups: state.skillsConfigExpandedGroups,
+    skillsSelectedSkill: state.skillsConfigSelectedSkill,
+    skillsBusySkill: state.skillsConfigBusySkill,
+    skillsMessages: state.skillsConfigMessages,
+    skillsAllowlistMode: state.skillsConfigAllowlistMode,
+    skillsAllowlistDraft: state.skillsConfigAllowlistDraft,
+    skillsEdits: state.skillsConfigEdits,
+    // 技能管理回调 / Skills management callbacks
+    onSkillsRefresh: () => loadSkillsConfigInternal(state as Parameters<typeof loadSkillsConfigInternal>[0]),
+    onSkillsSave: () => saveSkillsConfigInternal(state as Parameters<typeof saveSkillsConfigInternal>[0]),
+    onSkillsFilterChange: (filter) => { state.skillsConfigFilter = filter; },
+    onSkillsSourceFilterChange: (source) => { state.skillsConfigSourceFilter = source; },
+    onSkillsStatusFilterChange: (status) => { state.skillsConfigStatusFilter = status; },
+    onSkillsGroupToggle: (group) => toggleSkillsGroupInternal(state as Parameters<typeof toggleSkillsGroupInternal>[0], group),
+    onSkillsSkillSelect: (skillKey) => { state.skillsConfigSelectedSkill = skillKey; },
+    onSkillsSkillToggle: (skillKey, enabled) => updateSkillEnabledConfigInternal(state as Parameters<typeof updateSkillEnabledConfigInternal>[0], skillKey, enabled),
+    onSkillsApiKeyChange: (skillKey, apiKey) => updateSkillApiKeyEditConfigInternal(state as Parameters<typeof updateSkillApiKeyEditConfigInternal>[0], skillKey, apiKey),
+    onSkillsApiKeySave: (skillKey) => saveSkillApiKeyConfigInternal(state as Parameters<typeof saveSkillApiKeyConfigInternal>[0], skillKey),
+    onSkillsAllowlistModeChange: (mode) => setAllowlistModeInternal(state as Parameters<typeof setAllowlistModeInternal>[0], mode),
+    onSkillsAllowlistToggle: (skillKey, inList) => toggleAllowlistEntryInternal(state as Parameters<typeof toggleAllowlistEntryInternal>[0], skillKey, inList),
+    onSkillsInstall: (skillKey, name, installId) => installSkillDependencyInternal(state as Parameters<typeof installSkillDependencyInternal>[0], skillKey, name, installId),
+    onSkillsGlobalSettingChange: (field, value) => updateGlobalSettingInternal(state as Parameters<typeof updateGlobalSettingInternal>[0], field, value),
+    // Phase 3: 环境变量和配置编辑
+    onSkillsEnvChange: (skillKey, envKey, value) => updateSkillEnvConfigInternal(state as Parameters<typeof updateSkillEnvConfigInternal>[0], skillKey, envKey, value),
+    onSkillsEnvRemove: (skillKey, envKey) => removeSkillEnvConfigInternal(state as Parameters<typeof removeSkillEnvConfigInternal>[0], skillKey, envKey),
+    onSkillsConfigChange: (skillKey, config) => updateSkillConfigConfigInternal(state as Parameters<typeof updateSkillConfigConfigInternal>[0], skillKey, config),
+    onSkillsExtraDirsChange: (dirs) => updateExtraDirsConfigInternal(state as Parameters<typeof updateExtraDirsConfigInternal>[0], dirs),
+    // Phase 5-6: 编辑器状态和回调
+    skillsEditorState: state.skillsConfigEditor,
+    skillsCreateState: state.skillsConfigCreate,
+    skillsDeleteState: state.skillsConfigDelete,
+    onSkillsEditorOpen: (skillKey, skillName, source) => openSkillEditorInternal(state as Parameters<typeof openSkillEditorInternal>[0], skillKey, skillName, source),
+    onSkillsEditorClose: () => closeSkillEditorInternal(state as Parameters<typeof closeSkillEditorInternal>[0]),
+    onSkillsEditorContentChange: (content) => updateEditorContentInternal(state as Parameters<typeof updateEditorContentInternal>[0], content),
+    onSkillsEditorModeChange: (mode) => updateEditorModeInternal(state as Parameters<typeof updateEditorModeInternal>[0], mode),
+    onSkillsEditorSave: () => saveSkillFileInternal(state as Parameters<typeof saveSkillFileInternal>[0]),
+    onSkillsCreateOpen: (source) => openCreateSkillInternal(state as Parameters<typeof openCreateSkillInternal>[0], source),
+    onSkillsCreateClose: () => closeCreateSkillInternal(state as Parameters<typeof closeCreateSkillInternal>[0]),
+    onSkillsCreateNameChange: (name) => updateCreateSkillNameInternal(state as Parameters<typeof updateCreateSkillNameInternal>[0], name),
+    onSkillsCreateSourceChange: (source) => updateCreateSkillSourceInternal(state as Parameters<typeof updateCreateSkillSourceInternal>[0], source),
+    onSkillsCreateConfirm: () => confirmCreateSkillInternal(state as Parameters<typeof confirmCreateSkillInternal>[0]),
+    onSkillsDeleteOpen: (skillKey, skillName, source) => openDeleteSkillInternal(state as Parameters<typeof openDeleteSkillInternal>[0], skillKey, skillName, source),
+    onSkillsDeleteClose: () => closeDeleteSkillInternal(state as Parameters<typeof closeDeleteSkillInternal>[0]),
+    onSkillsDeleteConfirm: () => confirmDeleteSkillInternal(state as Parameters<typeof confirmDeleteSkillInternal>[0]),
+    // 定时任务状态 / Cron state props
+    cronLoading: state.cronLoading,
+    cronBusy: state.cronBusy,
+    cronError: state.cronError,
+    cronStatus: state.cronStatus,
+    cronJobs: state.cronJobs,
+    cronForm: state.cronForm,
+    cronAgents: (state.agentsList?.agents ?? []) as GatewayAgentRow[],
+    cronDefaultAgentId: state.agentsList?.defaultId ?? "",
+    cronChannels: state.channelsSnapshot?.channelMeta?.length
+      ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+      : state.channelsSnapshot?.channelOrder ?? [],
+    cronChannelLabels: state.channelsSnapshot?.channelLabels ?? {},
+    cronChannelMeta: state.channelsSnapshot?.channelMeta ?? [],
+    cronRunsJobId: state.cronRunsJobId,
+    cronRuns: state.cronRuns,
+    cronExpandedJobId: state.cronExpandedJobId,
+    cronDeleteConfirmJobId: state.cronDeleteConfirmJobId,
+    cronShowCreateModal: state.cronShowCreateModal,
+    cronEditJobId: state.cronEditJobId,
+    // 定时任务回调 / Cron callbacks
+    onCronFormChange: (patch) => { state.cronForm = { ...state.cronForm, ...patch }; },
+    onCronRefresh: () => state.loadCron(),
+    onCronAdd: () => addCronJob(state),
+    onCronUpdate: () => {
+      if (state.cronEditJobId) {
+        void updateCronJob(state, state.cronEditJobId);
+      }
+    },
+    onCronToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+    onCronRun: (job) => runCronJob(state, job),
+    onCronRemove: (job) => removeCronJob(state, job),
+    onCronLoadRuns: (jobId) => loadCronRuns(state, jobId),
+    onCronExpandJob: (jobId) => { state.cronExpandedJobId = jobId; },
+    onCronDeleteConfirm: (jobId) => { state.cronDeleteConfirmJobId = jobId; },
+    onCronShowCreateModal: (show) => {
+      state.cronShowCreateModal = show;
+      if (show) {
+        // 打开新建模式时，重置表单和编辑状态
+        state.cronEditJobId = null;
+        state.cronForm = { ...DEFAULT_CRON_FORM };
+      } else {
+        state.cronEditJobId = null;
+      }
+    },
+    onCronEdit: (job) => {
+      // 填充表单数据
+      state.cronForm = jobToFormState(job);
+      state.cronEditJobId = job.id;
+      state.cronShowCreateModal = true;
+    },
+  });
+}


### PR DESCRIPTION
… extension

Add a comprehensive Chinese visual configuration interface. 添加中文可视化配置界面。

Features / 功能：
- Provider configuration (models, API keys) / 服务商配置（模型、API 密钥）
- Agent defaults settings / Agent 默认设置
- Gateway configuration / 网关配置
- Channel configuration / 通道配置
- Permissions management (exec, tools, agents) / 权限管理（执行、工具、Agent）
- Workspace file management / 工作区文件管理
- Skills configuration with editor / 技能配置与编辑器
- Cron job management / 定时任务管理

UI Components / UI 组件：
- config-sidebar: navigation sidebar / 导航侧边栏
- providers-content: provider settings / 服务商设置
- agent-content: agent defaults / Agent 默认设置
- gateway-content: gateway settings / 网关设置
- channels-content: channel configuration / 通道配置
- permissions-content: permissions management / 权限管理
- workspace-content: workspace files / 工作区文件
- skills-content: skills configuration / 技能配置
- cron-content: cron jobs / 定时任务

Extension / 扩展插件：
- workspace-editor: workspace and skills file management plugin / 工作区与技能文件管理插件

 
<img width="1778" height="845" alt="image" src="https://github.com/user-attachments/assets/7f3d1823-9d76-45ec-8498-114e7c7a06b2" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a large Chinese-language “model-config” settings tab (`ui/src/ui-zh-CN/**`) with a visual configuration interface for providers/models, agent defaults, gateway settings, channel configuration, permissions, workspace file editing, skills editing, and cron management. It also introduces a new `workspace-editor` extension that exposes Gateway RPC methods for listing/reading/writing a whitelisted set of workspace bootstrap files and managing skill `SKILL.md` files.

The main UI is integrated via a new `model-config` tab in `ui/src/ui/navigation.ts`, `ui/src/ui/app-render.ts`, and a central adapter (`ui/src/ui/ui-zh-CN-adapter.ts`) that maps `AppViewState` to the new view’s props and re-exports controller functions.

Key issues found are mostly around small correctness/tooling problems (missing trailing newlines) and a runtime safety bug in the new cron update helper, plus an integration gap where sessions data for the model-config tab isn’t loaded automatically on tab refresh.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge but has a few correctness and integration issues that should be addressed first.
- The changes are large and touch core UI state/rendering and introduce a new extension; most logic appears straightforward, but there is at least one concrete runtime crash risk (cron update using `.trim()` on possibly undefined) and some integration gaps (model-config sessions not auto-loaded) plus minor tooling nuisances (missing trailing newline).
- ui/src/ui/controllers/cron.ts, ui/src/ui/app-settings.ts, ui/src/styles.css

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->