### PR TITLE
feat(telegram): add media index for reply-to media lookup

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -131,7 +131,13 @@ export const registerTelegramHandlers = ({
         stickerMetadata?: { emoji?: string; setName?: string; fileId?: string };
       }> = [];
       for (const { ctx } of entry.messages) {
-        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const msg = ctx.message;
+        const mediaMeta = {
+          channel: "telegram",
+          chatId: msg.chat.id,
+          messageId: msg.message_id,
+        };
+        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, mediaMeta);
         if (media) {
           allMedia.push({
             path: media.path,
@@ -673,7 +679,12 @@ export const registerTelegramHandlers = ({
 
       let media: Awaited<ReturnType<typeof resolveMedia>> = null;
       try {
-        media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const mediaMeta = {
+          channel: "telegram",
+          chatId: msg.chat.id,
+          messageId: msg.message_id,
+        };
+        media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, mediaMeta);
       } catch (mediaErr) {
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -494,7 +494,7 @@ export const buildTelegramMessageContext = async ({
         )
       : null;
 
-  const replyTarget = describeReplyTarget(msg);
+  const replyTarget = await describeReplyTarget(msg, chatId);
   const forwardOrigin = normalizeForwardedContext(msg);
   const replySuffix = replyTarget
     ? replyTarget.kind === "quote"
@@ -587,6 +587,8 @@ export const buildTelegramMessageContext = async ({
     ReplyToBody: replyTarget?.body,
     ReplyToSender: replyTarget?.sender,
     ReplyToIsQuote: replyTarget?.kind === "quote" ? true : undefined,
+    ReplyToMediaPath: replyTarget?.mediaPath,
+    ReplyToMediaType: replyTarget?.mediaType,
     ForwardedFrom: forwardOrigin?.from,
     ForwardedFromType: forwardOrigin?.fromType,
     ForwardedFromId: forwardOrigin?.fromId,

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -15,7 +15,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
-import { saveMediaBuffer } from "../../media/store.js";
+import { saveMediaBuffer, type MediaMeta } from "../../media/store.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { loadWebMedia } from "../../web/media.js";
 import { buildInlineKeyboard } from "../send.js";
@@ -292,6 +292,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  mediaMeta?: MediaMeta,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -336,6 +337,7 @@ export async function resolveMedia(
         "inbound",
         maxBytes,
         originalName,
+        mediaMeta,
       );
 
       // Check sticker cache for existing description
@@ -417,6 +419,7 @@ export async function resolveMedia(
     "inbound",
     maxBytes,
     originalName,
+    mediaMeta,
   );
   let placeholder = "<media:document>";
   if (msg.photo) {


### PR DESCRIPTION
## Summary

Implements a media index that maps `channel:chatId:messageId` to cached media file paths. When users reply to messages containing media (images, videos, audio), the agent can now access the original media file for re-processing.

## Problem

When replying to a message with media, Telegram's `reply_to_message` only includes metadata, not the actual file. Currently OpenClaw shows placeholders like `<media:audio>` without access to the original content. This breaks conversation continuity for use cases like:
- Re-transcribing audio from a replied-to voice message  
- Re-analyzing an image someone is asking about
- Any context where users reference previous media

## Solution

1. **Media Index** (`media/store.ts`): New JSON index at `~/.openclaw/media/inbound/index.json` mapping message IDs to file paths
2. **Automatic Indexing**: When media is saved, it's indexed by `channel:chatId:messageId`
3. **Lookup on Reply**: `describeReplyTarget()` now looks up cached media and exposes `mediaPath`/`mediaType`
4. **Context Fields**: New `ReplyToMediaPath` and `ReplyToMediaType` fields in message context

## Changes

| File | Description |
|------|-------------|
| `src/media/store.ts` | Add `MediaMeta` interface, index functions, `lookupMediaByMessageId()` |
| `src/telegram/bot/delivery.ts` | Accept `mediaMeta` param in `resolveMedia()` |
| `src/telegram/bot-handlers.ts` | Build and pass `mediaMeta` when processing messages |
| `src/telegram/bot/helpers.ts` | Make `describeReplyTarget()` async, lookup cached media |
| `src/telegram/bot-message-context.ts` | Expose `ReplyToMediaPath`/`ReplyToMediaType` |

## Testing

- [x] Media saved with message metadata gets indexed
- [x] Reply to media message includes cached file path
- [x] Graceful fallback when media not in index (cleaned up)

Fixes #1769

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a persistent “media index” to improve Telegram reply-to-media handling:
- `src/media/store.ts` extends `saveMediaBuffer()` with optional `MediaMeta` and writes a JSON index (`channel:chatId:messageId -> {path, contentType, ts}`) plus a lookup helper.
- Telegram ingestion (`src/telegram/bot-handlers.ts`, `src/telegram/bot/delivery.ts`) now passes message metadata into media saving so inbound media gets indexed.
- Reply context building (`src/telegram/bot/helpers.ts`, `src/telegram/bot-message-context.ts`) becomes async and attempts to resolve replied-to media from the cache, exposing `ReplyToMediaPath`/`ReplyToMediaType` in the inbound message context.

Net effect: replying to an earlier media message can re-surface the original cached media file for downstream processing, rather than only a `<media:...>` placeholder.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple of functional edge cases around index file creation and cache cleanup that can cause runtime errors or unbounded disk growth.
- Core wiring (passing MediaMeta, async reply target lookup, context fields) is straightforward, but `writeMediaIndex()` doesn’t ensure its parent directory exists and the existing media cleanup logic appears not to apply to the new `inbound/` storage location. Those issues can break indexing or lead to persistent disk usage.
- src/media/store.ts (index write path creation; cleanup/pruning semantics), src/telegram/bot/helpers.ts (quote vs reply sender handling)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->