### PR TITLE
Fix #5488: Add startup delay to sessions_spawn

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -204,6 +204,8 @@ export type AgentDefaultsConfig = {
     archiveAfterMinutes?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /** Startup delay (ms) before subagent makes first API call (default: 500). */
+    startupDelayMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -344,6 +344,14 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
+    // Apply startup delay for subagent spawns to avoid auth race conditions (#5488).
+    const subagentStartupDelayMs = spawnedByValue
+      ? (cfg.agents?.defaults?.subagents?.startupDelayMs ?? 500)
+      : 0;
+    if (subagentStartupDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, subagentStartupDelayMs));
+    }
+
     void agentCommand(
       {
         message,


### PR DESCRIPTION
## Summary
- Adds a configurable `startupDelayMs` option to `agents.defaults.subagents` config (default: 500ms)
- Applies startup delay in the gateway agent handler before calling `agentCommand` when `spawnedBy` is present
- Fixes auth race condition where the first API call from a spawned subagent gets 401 because the token isn't ready yet

Fixes #5488

## Test plan
- [ ] Verify subagent spawns no longer get 401 on first API call
- [ ] Verify delay can be configured via `agents.defaults.subagents.startupDelayMs`
- [ ] Verify setting delay to 0 disables the delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a configurable `agents.defaults.subagents.startupDelayMs` (defaulting to 500ms) and applies it in the gateway `agent` handler when the request indicates it was spawned (`spawnedBy` is present). The intent is to mitigate an auth race where the first API call from a spawned subagent can see a 401 before its token is ready.

The change fits into the existing gateway flow by delaying the `agentCommand(...)` invocation after the initial “accepted” response is sent and after delivery plan resolution is computed.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and localized but have a couple configuration-consistency edge cases.
- The core behavior is a simple gated delay before `agentCommand` for spawned subagents, which should reduce the reported race. Main risk is subtle config resolution inconsistency (using `cfg` rather than `cfgForAgent`) and lack of normalization for unusual config values.
- src/gateway/server-methods/agent.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->