### PR TITLE
fix(android): re-check microphone permission when activity resumes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
@@ -67,6 +67,7 @@ class MainActivity : ComponentActivity() {
   override fun onResume() {
     super.onResume()
     applyImmersiveMode()
+    viewModel.recheckPermissions()
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -68,6 +68,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setForeground(value)
   }
 
+  fun recheckPermissions() {
+    runtime.recheckPermissions()
+  }
+
   fun setDisplayName(value: String) {
     runtime.setDisplayName(value)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
@@ -177,4 +177,4 @@ class NodeForegroundService : Service() {
   }
 }
 
-private data class Quint<A, B, C, D, E>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E)
+internal data class Quint<A, B, C, D, E>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E)


### PR DESCRIPTION
## Problem

Voice wake checks `hasRecordAudioPermission()` inside a `combine` flow over `voiceWakeMode`, `isForeground`, `externalAudioCaptureActive`, and `wakeWords`. When the user grants microphone permission externally (e.g. via Android Settings → App Permissions), **none of these flows emit a new value**, so the permission is never re-checked. Voice wake stays permanently stuck displaying:

> Microphone permission required

…even though the permission is now granted. The only workaround is toggling Voice Wake off and on, or restarting the app.

## Fix

Add a `permissionEpoch` counter to the combine flow and bump it in `onResume()`. This forces the flow to re-collect and re-evaluate the runtime permission state whenever the activity returns to foreground — including after the user navigates back from Android Settings.

## Changes

| File | Change |
|------|--------|
| `NodeRuntime.kt` | Add `permissionEpoch` StateFlow, include in voice wake combine (5-flow), add `recheckPermissions()` |
| `MainViewModel.kt` | Forward `recheckPermissions()` |
| `MainActivity.kt` | Call `recheckPermissions()` in `onResume()` |
| `NodeForegroundService.kt` | Make `Quint` data class `internal` (shared with NodeRuntime) |

## Testing

- Verified on Pixel 9 Pro Fold: grant mic in Settings → return to app → voice wake starts automatically without needing to toggle settings

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an Android voice-wake UX bug where microphone permission changes made outside the app (e.g. Settings → App Permissions) were never re-evaluated because the `combine` driving voice wake only depended on flows that didn’t emit on permission changes.

Changes add a `permissionEpoch` `StateFlow` to `NodeRuntime` and include it in the voice wake `combine`, plus a `recheckPermissions()` method that bumps the epoch. `MainActivity.onResume()` now calls through `MainViewModel` to trigger rechecking when returning to foreground. Additionally, `Quint` is made `internal` so it can be shared with `NodeRuntime`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of correctness/maintainability concerns worth addressing first.
- The core fix (bumping an epoch on `onResume()` to force a permission re-check) is straightforward and aligns with Android lifecycle behavior. Main concerns are (1) the `requiresMic` logic in the foreground service notification path appears inverted/incorrect for microphone foreground service typing, and (2) the new vararg `combine` with unchecked casts is brittle and can cause runtime failures if reordered.
- apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt, apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->