### PR TITLE
Fix: Windows path separators stripped in Gateway scheduled task

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -168,17 +168,51 @@ describe("readScheduledTaskCommand", () => {
     try {
       const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
       await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      // Use forward slashes which work in Windows cmd and avoid escape parsing issues
       await fs.writeFile(
         scriptPath,
-        ["@echo off", '"C:/Program Files/Node/node.exe" gateway.js'].join("\r\n"),
+        ["@echo off", '"C:\\Program Files\\Node\\node.exe" gateway.js'].join("\r\n"),
         "utf8",
       );
 
       const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
       const result = await readScheduledTaskCommand(env);
       expect(result).toEqual({
-        programArguments: ["C:/Program Files/Node/node.exe", "gateway.js"],
+        programArguments: ["C:\\Program Files\\Node\\node.exe", "gateway.js"],
+      });
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves backslashes in Windows paths", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
+    try {
+      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(
+        scriptPath,
+        [
+          "@echo off",
+          "rem OpenClaw Gateway (v2026.1.29)",
+          "set OPENCLAW_GATEWAY_PORT=18789",
+          '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\test\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openclaw\\dist\\index.js gateway --port 18789',
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+      const result = await readScheduledTaskCommand(env);
+      expect(result).toEqual({
+        programArguments: [
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\test\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openclaw\\dist\\index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ],
+        environment: {
+          OPENCLAW_GATEWAY_PORT: "18789",
+        },
       });
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -57,21 +57,14 @@ function resolveTaskUser(env: Record<string, string | undefined>): string | null
 }
 
 function parseCommandLine(value: string): string[] {
+  // This parses a Windows cmd.exe command line where backslash is a path
+  // separator, not an escape character.  Only double-quote toggling and
+  // whitespace splitting are needed.
   const args: string[] = [];
   let current = "";
   let inQuotes = false;
-  let escapeNext = false;
 
   for (const char of value) {
-    if (escapeNext) {
-      current += char;
-      escapeNext = false;
-      continue;
-    }
-    if (char === "\\") {
-      escapeNext = true;
-      continue;
-    }
     if (char === '"') {
       inQuotes = !inQuotes;
       continue;


### PR DESCRIPTION
## Summary
The parseCommandLine function in src/daemon/schtasks.ts was applying Unix-style escape logic (\ as escape character) to Windows cmd.exe command lines. This caused every backslash in file paths to be silently stripped when reading back gateway.cmd, so the gateway entrypoint path was always corrupted.

As a result, openclaw doctor permanently reported "Gateway service entrypoint does not match the current install" on Windows, and --fix could never resolve it.

## Changes
- **src/daemon/schtasks.ts**: Removed the scapeNext / backslash-escape logic from parseCommandLine. In cmd.exe, \ is a path separator, not an escape character.
- **src/daemon/schtasks.test.ts**: Updated existing quoted-path test to use backslash paths. Added a new regression test (preserves backslashes in Windows paths).

## Test plan
- [x] pnpm vitest run src/daemon/schtasks.test.ts — all 18 tests pass
- [x] Verified on a real Windows 10 machine: openclaw doctor no longer reports the gateway entrypoint mismatch after this fix.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Windows scheduled task command parsing by removing Unix-style backslash escaping from `parseCommandLine` in `src/daemon/schtasks.ts`, which was stripping path separators when reading `gateway.cmd`. Tests in `src/daemon/schtasks.test.ts` were updated to use realistic backslash paths and a new regression test was added to ensure backslashes are preserved when parsing a typical gateway script that includes `set` env vars and a quoted Node executable path.

Overall this aligns the parser with cmd.exe semantics for backslashes and should unblock `openclaw doctor --fix` from repeatedly reporting a gateway entrypoint mismatch on Windows.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and appears to fix the reported Windows path corruption.
- Change is narrow (removes backslash-escape handling) and is covered by updated/added unit tests; main remaining risk is that cmd.exe quoting/escaping rules are more complex than simple quote toggling, so unusual arguments containing literal quotes could still parse incorrectly.
- src/daemon/schtasks.ts (cmd.exe quoting/escaping edge cases)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->