### PR TITLE
fix(voice-call): wait for session creation before sending config update

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,4 +1,4 @@
-import { getOAuthApiKey, type OAuthCredentials } from "@mariozechner/pi-ai";
+import { getOAuthApiKey, type OAuthCredentials, type OAuthProvider } from "@mariozechner/pi-ai";
 import lockfile from "proper-lockfile";
 
 import type { OpenClawConfig } from "../../config/config.js";
@@ -64,7 +64,7 @@ async function refreshOAuthTokenWithLock(params: {
               const newCredentials = await refreshQwenPortalCredentials(cred);
               return { apiKey: newCredentials.access, newCredentials };
             })()
-          : await getOAuthApiKey(cred.provider, oauthCreds);
+          : await getOAuthApiKey(cred.provider as OAuthProvider, oauthCreds);
     if (!result) {
       return null;
     }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 
 import {
   createAgentSession,
-  DefaultResourceLoader,
   estimateTokens,
   SessionManager,
   SettingsManager,
@@ -386,17 +385,6 @@ export async function compactEmbeddedPiSessionDirect(
         sandboxEnabled: !!sandbox?.enabled,
       });
 
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
-        additionalExtensionPaths,
-        noSkills: true,
-        systemPromptOverride: systemPrompt,
-        agentsFilesOverride: () => ({ agentsFiles: [] }),
-      });
-      await resourceLoader.reload();
-
       const { session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -408,7 +396,8 @@ export async function compactEmbeddedPiSessionDirect(
         customTools,
         sessionManager,
         settingsManager,
-        resourceLoader,
+        additionalExtensionPaths,
+        systemPrompt,
       });
 
       try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4,12 +4,7 @@ import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  SessionManager,
-  SettingsManager,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
 
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import {
@@ -458,17 +453,6 @@ export async function runEmbeddedAttempt(
 
       const allCustomTools = [...customTools, ...clientToolDefs];
 
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
-        additionalExtensionPaths,
-        noSkills: true,
-        systemPromptOverride: systemPrompt,
-        agentsFilesOverride: () => ({ agentsFiles: [] }),
-      });
-      await resourceLoader.reload();
-
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -480,7 +464,8 @@ export async function runEmbeddedAttempt(
         customTools: allCustomTools,
         sessionManager,
         settingsManager,
-        resourceLoader,
+        additionalExtensionPaths,
+        systemPrompt,
       }));
       if (!session) {
         throw new Error("Embedded agent session missing");


### PR DESCRIPTION
Closes #5243

The OpenAI Realtime API requires waiting for the transcription_session.created event before sending transcription_session.update. Previously, the update was sent immediately on WebSocket open, causing 'Missing required parameter: session' errors.

Changes:
- Wait for transcription_session.created before sending session config
- Track sessionReady state to prevent sending audio before session is configured
- Add pendingSessionConfig flag to handle the initialization sequence
- Remove DefaultResourceLoader usage (no longer exported from pi-coding-agent)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the OpenAI Realtime STT provider to follow the Realtime API’s init handshake by deferring `transcription_session.update` until after `transcription_session.created`, and gates audio sends until the session is configured. It also updates the embedded runner codepaths to stop constructing a `DefaultResourceLoader` (no longer exported) and instead pass `additionalExtensionPaths` and the computed `systemPrompt` directly into `createAgentSession`.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge; main remaining risk is an edge-case where the session may never become ready and audio is silently dropped.
- The changes are localized and align with the Realtime API’s required event ordering, and the embedded runner refactor matches the local type augmentation for `additionalExtensionPaths`. The primary concern is that readiness is now contingent on receiving `transcription_session.updated`; if that event is missed or fails, the session stays non-ready and audio is dropped without surfacing an error.
- extensions/voice-call/src/providers/stt-openai-realtime.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->