### PR TITLE
feat(skills): add pomodoro timer skill

### DIFF
--- a/skills/pomodoro/SKILL.md
+++ b/skills/pomodoro/SKILL.md
@@ -10,54 +10,76 @@ Time management using the Pomodoro Technique.
 
 ## Quick Start
 
-Start a focus session:
+### macOS
 
 ```bash
-# macOS: 25-minute focus timer with notification
+# 25-minute focus timer with notification
 ( sleep 1500 && osascript -e 'display notification "Focus session complete! Time for a break." with title "🍅 Pomodoro"' ) &
 echo "Started 25-minute pomodoro. Focus!"
+```
 
-# Linux: same with notify-send
+### Linux
+
+```bash
+# 25-minute focus timer with notification
 ( sleep 1500 && notify-send "🍅 Pomodoro" "Focus session complete! Time for a break." ) &
 echo "Started 25-minute pomodoro. Focus!"
 ```
 
 ## Commands
 
-### Focus Session (25 min default)
+### Focus Session (customizable duration)
+
+#### macOS
 
 ```bash
-# macOS
-MINUTES=${1:-25}
-( sleep $((MINUTES * 60)) && osascript -e "display notification \"$MINUTES-minute session complete!\" with title \"🍅 Pomodoro\"" ) &
+# Set duration (default 25 minutes)
+MINUTES=25
+# Validate: ensure MINUTES is a positive integer
+[[ "$MINUTES" =~ ^[0-9]+$ ]] || MINUTES=25
+( sleep $((MINUTES * 60)) && osascript -e 'display notification "Focus session complete!" with title "🍅 Pomodoro"' ) &
 echo "Started $MINUTES-minute focus session."
+```
 
-# Linux
-MINUTES=${1:-25}
-( sleep $((MINUTES * 60)) && notify-send "🍅 Pomodoro" "$MINUTES-minute session complete!" ) &
+#### Linux
+
+```bash
+# Set duration (default 25 minutes)
+MINUTES=25
+# Validate: ensure MINUTES is a positive integer
+[[ "$MINUTES" =~ ^[0-9]+$ ]] || MINUTES=25
+( sleep $((MINUTES * 60)) && notify-send "🍅 Pomodoro" "Focus session complete!" ) &
 echo "Started $MINUTES-minute focus session."
 ```
 
 ### Short Break (5 min)
 
+#### macOS
+
 ```bash
-# macOS
 ( sleep 300 && osascript -e 'display notification "Break over! Ready to focus?" with title "☕ Break Complete"' ) &
 echo "Short break started. Relax for 5 minutes."
+```
 
-# Linux
+#### Linux
+
+```bash
 ( sleep 300 && notify-send "☕ Break Complete" "Break over! Ready to focus?" ) &
 echo "Short break started. Relax for 5 minutes."
 ```
 
 ### Long Break (15-30 min)
 
+#### macOS
+
 ```bash
-# macOS (15 min)
 ( sleep 900 && osascript -e 'display notification "Long break over! Start a new cycle?" with title "🌴 Long Break"' ) &
 echo "Long break started. Enjoy 15 minutes of rest."
+```
 
-# Linux (15 min)
+#### Linux
+
+```bash
 ( sleep 900 && notify-send "🌴 Long Break" "Long break over! Start a new cycle?" ) &
 echo "Long break started. Enjoy 15 minutes of rest."
 ```
@@ -81,7 +103,7 @@ echo "Long break started. Enjoy 15 minutes of rest."
 
 For recurring reminders, use OpenClaw's cron:
 
-```
+```bash
 /cron set pomodoro-reminder "0 9 * * 1-5" "Remind me to start a pomodoro session"
 ```
 

--- a/skills/pomodoro/SKILL.md
+++ b/skills/pomodoro/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: pomodoro
+description: Pomodoro technique timers for focused work sessions.
+metadata: { "openclaw": { "emoji": "🍅" } }
+---
+
+# Pomodoro Timer
+
+Time management using the Pomodoro Technique.
+
+## Quick Start
+
+Start a focus session:
+
+```bash
+# macOS: 25-minute focus timer with notification
+( sleep 1500 && osascript -e 'display notification "Focus session complete! Time for a break." with title "🍅 Pomodoro"' ) &
+echo "Started 25-minute pomodoro. Focus!"
+
+# Linux: same with notify-send
+( sleep 1500 && notify-send "🍅 Pomodoro" "Focus session complete! Time for a break." ) &
+echo "Started 25-minute pomodoro. Focus!"
+```
+
+## Commands
+
+### Focus Session (25 min default)
+
+```bash
+# macOS
+MINUTES=${1:-25}
+( sleep $((MINUTES * 60)) && osascript -e "display notification \"$MINUTES-minute session complete!\" with title \"🍅 Pomodoro\"" ) &
+echo "Started $MINUTES-minute focus session."
+
+# Linux
+MINUTES=${1:-25}
+( sleep $((MINUTES * 60)) && notify-send "🍅 Pomodoro" "$MINUTES-minute session complete!" ) &
+echo "Started $MINUTES-minute focus session."
+```
+
+### Short Break (5 min)
+
+```bash
+# macOS
+( sleep 300 && osascript -e 'display notification "Break over! Ready to focus?" with title "☕ Break Complete"' ) &
+echo "Short break started. Relax for 5 minutes."
+
+# Linux
+( sleep 300 && notify-send "☕ Break Complete" "Break over! Ready to focus?" ) &
+echo "Short break started. Relax for 5 minutes."
+```
+
+### Long Break (15-30 min)
+
+```bash
+# macOS (15 min)
+( sleep 900 && osascript -e 'display notification "Long break over! Start a new cycle?" with title "🌴 Long Break"' ) &
+echo "Long break started. Enjoy 15 minutes of rest."
+
+# Linux (15 min)
+( sleep 900 && notify-send "🌴 Long Break" "Long break over! Start a new cycle?" ) &
+echo "Long break started. Enjoy 15 minutes of rest."
+```
+
+## The Pomodoro Cycle
+
+1. 🍅 **Focus**: Work for 25 minutes
+2. ☕ **Short Break**: Rest for 5 minutes
+3. Repeat steps 1-2 four times
+4. 🌴 **Long Break**: Rest for 15-30 minutes
+5. Start a new cycle
+
+## Tips
+
+- Remove distractions during focus sessions
+- Use breaks to stretch, hydrate, or rest your eyes
+- Track completed pomodoros to measure productivity
+- Adjust times to fit your rhythm (some prefer 50/10 or 90/20)
+
+## Advanced: Using cron
+
+For recurring reminders, use OpenClaw's cron:
+
+```
+/cron set pomodoro-reminder "0 9 * * 1-5" "Remind me to start a pomodoro session"
+```
+
+## Notes
+
+- Notifications work on macOS (osascript) and Linux (notify-send)
+- Background processes (`&`) allow the timer to run while you work
+- For Windows, use `powershell` with `New-BurntToastNotification` or similar


### PR DESCRIPTION
## Summary

Add a new skill for Pomodoro technique time management.

## Features

- 🍅 Focus session timers (25 min default, customizable)
- ☕ Short break timers (5 min)
- 🌴 Long break timers (15-30 min)
- Cross-platform support (macOS/Linux notifications)
- Tips and the standard Pomodoro cycle explanation

## Why?

Simple productivity tool that helps with time management. No external dependencies required - uses native OS notification systems.

## Testing

- [x] Tested timer commands on macOS
- [x] Verified notification display
- [x] Checked SKILL.md format matches existing skills

## AI Disclosure

- [x] AI-assisted (Claude)
- [x] Lightly tested
- [x] Understand what the code does

---

First contribution! 🦞

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `pomodoro` skill documentation file (`skills/pomodoro/SKILL.md`) describing focus/break timers using background `sleep` plus native notifications (`osascript` on macOS, `notify-send` on Linux), along with a brief Pomodoro cycle explanation and a cron reminder example.

Main things to double-check are that the shell snippets are safe to copy/paste (especially around user-supplied `MINUTES` and quoting) and that the Quick Start doesn’t inadvertently run commands meant for the other OS.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but the doc’s shell snippet with `MINUTES` should be adjusted to avoid copy/paste injection and quoting breakage.
- Only a documentation file is added, so runtime impact is low; however, the provided shell commands encourage running background processes and interpolate an unvalidated user parameter into command strings, which is likely to be copied verbatim by users and can lead to command injection or confusing failures.
- skills/pomodoro/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->