### PR TITLE
fix(node): use correct systemd service name for node install (#2855)

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -245,7 +245,7 @@ export async function installSystemdService({
   });
   await fs.writeFile(unitPath, unit, "utf8");
 
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   const reload = await execSystemctl(["--user", "daemon-reload"]);
   if (reload.code !== 0) {
@@ -276,7 +276,7 @@ export async function uninstallSystemdService({
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSystemdAvailable();
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   await execSystemctl(["--user", "disable", "--now", unitName]);
 


### PR DESCRIPTION
Fixes #2855

## Problem
`openclaw node install` fails on Linux with:
```
systemctl enable failed: Failed to enable unit: Unit file openclaw-gateway.service does not exist.
```

## Root Cause
`installSystemdService()` and `uninstallSystemdService()` used `resolveGatewaySystemdServiceName()` which always returns the gateway service name, ignoring the `OPENCLAW_SYSTEMD_UNIT` override set by the node service.

## Fix
Changed both functions to use `resolveSystemdServiceName(env)` which respects the `OPENCLAW_SYSTEMD_UNIT` environment variable override.

## Verification
- Node install now correctly enables `openclaw-node.service`
- Gateway install continues to work (falls back when no override is set)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `installSystemdService()` and `uninstallSystemdService()` in `src/daemon/systemd.ts` to derive the unit name via `resolveSystemdServiceName(env)` (which honors the `OPENCLAW_SYSTEMD_UNIT` override) rather than always using the gateway’s `resolveGatewaySystemdServiceName()`. This aligns node installs with their intended systemd unit (`openclaw-node.service`) while keeping the default gateway naming behavior when no override is provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped: it only switches the unit name resolution in install/uninstall to a helper already used elsewhere in this module, matching the documented environment override behavior. No new external dependencies or behavioral changes outside systemd unit naming are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->