### PR TITLE
Fix TUI crash when terminal window is too narrow

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -242,7 +242,11 @@ Recurring, isolated job with delivery:
 ```json
 {
   "name": "Morning brief",
-  "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
+  "schedule": {
+    "kind": "cron",
+    "expr": "0 7 * * *",
+    "tz": "America/Los_Angeles"
+  },
   "sessionTarget": "isolated",
   "wakeMode": "next-heartbeat",
   "payload": {
@@ -385,6 +389,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +400,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -227,7 +227,7 @@ describe("SearchableSelectList", () => {
       description: (t) => t,
       scrollInfo: (t) => t,
       noMatch: (t) => t,
-      searchPrompt: (t) => `search: `,
+      searchPrompt: (_) => `search: `,
       searchInput: (t) => t,
       matchHighlight: (t) => t,
     };

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
 import { describe, expect, it } from "vitest";
 import { SearchableSelectList, type SearchableSelectListTheme } from "./searchable-select-list.js";
 
@@ -215,5 +216,65 @@ describe("SearchableSelectList", () => {
     list.handleInput("\x1b");
 
     expect(cancelled).toBe(true);
+  });
+
+  describe("SearchableSelectList - Width Constraints", () => {
+    // Mock theme that passes text through without adding extra characters,
+    // to isolate layout width logic from theme decorations.
+    const strictMockTheme: SearchableSelectListTheme = {
+      selectedPrefix: (t) => t,
+      selectedText: (t) => t,
+      description: (t) => t,
+      scrollInfo: (t) => t,
+      noMatch: (t) => t,
+      searchPrompt: (t) => `search: `,
+      searchInput: (t) => t,
+      matchHighlight: (t) => t,
+    };
+
+    it("truncates content to fit within terminal width", () => {
+      const longLabel = "a".repeat(300);
+      const longDesc = "b".repeat(300);
+      const items = [
+        {
+          value: "long-item",
+          label: longLabel,
+          description: longDesc,
+        },
+      ];
+      const list = new SearchableSelectList(items, 5, strictMockTheme);
+      const terminalWidth = 100;
+
+      // Render with constrained width
+      const output = list.render(terminalWidth);
+
+      // Check that no line exceeds the terminal width
+      for (const line of output) {
+        // We strip ANSI codes (though mock theme adds none) and check width
+        const width = visibleWidth(line);
+        expect(width).toBeLessThanOrEqual(terminalWidth);
+      }
+    });
+
+    it("truncates wide characters safely", () => {
+      // "你好" is 2 chars length, but 4 visual width
+      const wideLabel = "你好".repeat(50);
+      const items = [
+        {
+          value: "wide-item",
+          label: wideLabel,
+          description: "desc",
+        },
+      ];
+      const list = new SearchableSelectList(items, 5, strictMockTheme);
+      const terminalWidth = 60;
+
+      const output = list.render(terminalWidth);
+
+      for (const line of output) {
+        const width = visibleWidth(line);
+        expect(width).toBeLessThanOrEqual(terminalWidth);
+      }
+    });
   });
 });

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -215,7 +215,7 @@ export class SearchableSelectList implements Component {
     query: string,
   ): string {
     const prefix = isSelected ? "→ " : "  ";
-    const prefixWidth = prefix.length;
+    const prefixWidth = visibleWidth(prefix);
     const displayValue = this.getItemLabel(item);
 
     if (item.description && width > 40) {
@@ -236,7 +236,7 @@ export class SearchableSelectList implements Component {
       }
     }
 
-    const maxWidth = width - prefixWidth - 2;
+    const maxWidth = Math.max(0, width - prefixWidth - 2);
     const truncatedValue = truncateToWidth(displayValue, maxWidth, "");
     const valueText = this.highlightMatch(truncatedValue, query);
     const line = `${prefix}${valueText}`;

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -7,8 +7,8 @@ import {
   type SelectItem,
   type SelectListTheme,
   truncateToWidth,
+  visibleWidth,
 } from "@mariozechner/pi-tui";
-import { visibleWidth } from "../../terminal/ansi.js";
 import { findWordBoundaryIndex, fuzzyFilterLower, prepareSearchItems } from "./fuzzy-filter.js";
 
 export interface SearchableSelectListTheme extends SelectListTheme {


### PR DESCRIPTION
Fixes #5490. Uses visibleWidth from @mariozechner/pi-tui to correctly calculate string width.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `SearchableSelectList` TUI component to compute prompt/input/layout widths using `visibleWidth` from `@mariozechner/pi-tui` instead of a local ANSI-stripping width function, addressing crashes and rendering issues when the terminal is very narrow and when strings include wide characters. It also adds focused tests asserting that rendered lines don’t exceed a specified terminal width, including a wide-character case.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but edge cases with extremely small widths could still crash due to negative widths passed into truncation.
- Change is localized and conceptually correct (use a more accurate width calculator), and tests were added. However, there are still paths where calculated widths can go negative when the terminal width is extremely small, which is directly related to the original crash class. Also, some width calculations still rely on `.length` rather than `visibleWidth`, which could reintroduce mis-measurements with styled prefixes.
- src/tui/components/searchable-select-list.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->