### PR TITLE
Slack: fix threadId ignored on read + thread_broadcast dropped

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -363,6 +363,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -110,7 +110,6 @@ export function registerSlackMessageEvents(params: {
           sessionKey,
           contextKey: `slack:thread:broadcast:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
         });
-        return;
       }
 
       await handleSlackMessage(message, { source: "message" });


### PR DESCRIPTION
## Summary

- **Bug 1 (#2454):** The Slack extension's `action=read` handler was not passing `threadId` through to `handleSlackAction`. Added the missing `threadId` param in `extensions/slack/src/channel.ts`.
- **Bug 2 (#4351):** Messages with `subtype === "thread_broadcast"` (thread replies sent with "Also send to channel") were dropped because the handler returned early after logging a system event. Removed the early `return` in `src/slack/monitor/events/messages.ts` so these messages fall through to `handleSlackMessage`.

Closes #2454, Closes #4351

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm vitest run src/slack/ extensions/slack/` — all 126 tests pass
- [ ] Manual: send a thread broadcast in Slack and verify it's processed
- [ ] Manual: read messages with a `threadId` param via the extension and verify thread messages are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes two Slack message handling regressions:

- In the Slack extension channel plugin, the `action=read` handler now forwards `threadId` into the `readMessages` tool payload so threaded reads can be scoped correctly.
- In the core Slack monitor message event handler, `thread_broadcast` messages no longer return early after logging a system event; they now continue through the shared `handleSlackMessage(...)` path, preventing these user-visible messages from being dropped.

Both changes are small and localized, and they align the extension adapter behavior with the existing core Slack actions adapter implementation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped (one added param passthrough and one removed early return) and they restore intended Slack behavior without altering interfaces or control flow beyond the specific bug conditions; the extension change matches existing core adapter behavior and there are no new edge cases apparent in the touched code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->