### PR TITLE
feat(hooks): Add message:received internal hook event

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3,6 +3,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { createMessageReceivedEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import {
   logMessageProcessed,
   logMessageQueued,
@@ -181,6 +182,37 @@ export async function dispatchReplyFromConfig(params: {
       .catch((err) => {
         logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);
       });
+  }
+
+  // Trigger internal hook for workspace/bundled hooks (message:received)
+  {
+    const sessionKey = ctx.SessionKey ?? "";
+    const messageText =
+      typeof ctx.BodyForCommands === "string"
+        ? ctx.BodyForCommands
+        : typeof ctx.RawBody === "string"
+          ? ctx.RawBody
+          : typeof ctx.Body === "string"
+            ? ctx.Body
+            : "";
+    const channel = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+    const messageId =
+      ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+
+    const internalHookEvent = createMessageReceivedEvent(sessionKey, {
+      messageText,
+      senderId: ctx.SenderId ?? ctx.From,
+      channel,
+      messageId,
+      replyTo: ctx.QuotedMessageId,
+      isGroup: ctx.IsGroup,
+      groupId: ctx.GroupId ?? ctx.To,
+      cfg,
+    });
+
+    void triggerInternalHook(internalHookEvent).catch((err) => {
+      logVerbose(`dispatch-from-config: internal message:received hook failed: ${String(err)}`);
+    });
   }
 
   // Check if we should route replies to originating channel instead of dispatcher.

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { MoltbotConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -23,6 +23,56 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   type: "agent";
   action: "bootstrap";
   context: AgentBootstrapHookContext;
+};
+
+/**
+ * Context for message:received hook events
+ */
+export type MessageReceivedHookContext = {
+  /** The raw message text from the user */
+  messageText: string;
+  /** Who sent the message (user ID, phone number, etc.) */
+  senderId?: string;
+  /** The channel this message came from (signal, telegram, slack, etc.) */
+  channel?: string;
+  /** Platform-specific message ID */
+  messageId?: string;
+  /** If this is a reply, the ID of the message being replied to */
+  replyTo?: string;
+  /** Whether this is a group chat */
+  isGroup?: boolean;
+  /** Group ID if applicable */
+  groupId?: string;
+  /** The config object */
+  cfg?: MoltbotConfig;
+};
+
+export type MessageReceivedHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "received";
+  context: MessageReceivedHookContext;
+};
+
+/**
+ * Context for message:sent hook events
+ */
+export type MessageSentHookContext = {
+  /** The response text from the agent */
+  responseText: string;
+  /** Tool calls made during this response (JSON stringified) */
+  toolCalls?: string;
+  /** The original message that triggered this response */
+  originalMessage?: string;
+  /** The channel this response is being sent to */
+  channel?: string;
+  /** The config object */
+  cfg?: MoltbotConfig;
+};
+
+export type MessageSentHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "sent";
+  context: MessageSentHookContext;
 };
 
 export interface InternalHookEvent {
@@ -172,4 +222,60 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
   if (!context || typeof context !== "object") return false;
   if (typeof context.workspaceDir !== "string") return false;
   return Array.isArray(context.bootstrapFiles);
+}
+
+/**
+ * Type guard for message:received events
+ */
+export function isMessageReceivedEvent(
+  event: InternalHookEvent,
+): event is MessageReceivedHookEvent {
+  if (event.type !== "message" || event.action !== "received") return false;
+  const context = event.context as Partial<MessageReceivedHookContext> | null;
+  if (!context || typeof context !== "object") return false;
+  return typeof context.messageText === "string";
+}
+
+/**
+ * Type guard for message:sent events
+ */
+export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
+  if (event.type !== "message" || event.action !== "sent") return false;
+  const context = event.context as Partial<MessageSentHookContext> | null;
+  if (!context || typeof context !== "object") return false;
+  return typeof context.responseText === "string";
+}
+
+/**
+ * Create a message:received hook event
+ */
+export function createMessageReceivedEvent(
+  sessionKey: string,
+  context: MessageReceivedHookContext,
+): MessageReceivedHookEvent {
+  return {
+    type: "message",
+    action: "received",
+    sessionKey,
+    context,
+    timestamp: new Date(),
+    messages: [],
+  };
+}
+
+/**
+ * Create a message:sent hook event
+ */
+export function createMessageSentEvent(
+  sessionKey: string,
+  context: MessageSentHookContext,
+): MessageSentHookEvent {
+  return {
+    type: "message",
+    action: "sent",
+    sessionKey,
+    context,
+    timestamp: new Date(),
+    messages: [],
+  };
 }


### PR DESCRIPTION
## Summary

Adds the `message:received` event to the internal hooks system, allowing workspace hooks (HOOK.md files) to listen for incoming messages.

## Motivation

Closes #5053 (partially)

The plugin hooks system already has `message_received` for npm plugins, but this wasn't exposed to workspace/bundled hooks (the HOOK.md-based system used by bundled hooks like `session-memory`).

This enables use cases like:
- Automatic memory extraction from user messages
- Message logging and auditing
- Custom preprocessing pipelines
- Integration with external systems

## Changes

### `src/hooks/internal-hooks.ts`
- Add `'message'` to `InternalHookEventType`
- Add `MessageReceivedHookContext` and `MessageReceivedHookEvent` types
- Add `MessageSentHookContext` and `MessageSentHookEvent` types (for future use)
- Add `isMessageReceivedEvent()` and `isMessageSentEvent()` type guards
- Add `createMessageReceivedEvent()` and `createMessageSentEvent()` factory functions

### `src/auto-reply/reply/dispatch-from-config.ts`
- Trigger `message:received` internal hook alongside the existing plugin hook

## Usage

Workspace hooks can now listen to message events:

```markdown
---
name: my-message-hook
description: Process incoming messages
metadata:
  openclaw:
    events: ["message:received"]
---
```

The event context includes:
- `messageText`: The message content
- `senderId`: Who sent it
- `channel`: Which channel (telegram, slack, etc.)
- `messageId`: Platform message ID
- `isGroup`: Whether it's a group chat
- `groupId`: Group ID if applicable
- `cfg`: The config object

## Not Included

`message:sent` is defined but not yet triggered. Implementing it requires adding hooks to multiple channel output paths. This can be done in a follow-up PR.

## Testing

- [ ] Type checks pass
- [ ] Existing tests pass
- [ ] Tested manually with a workspace hook

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the internal HOOK.md-based hook system with a new `message` event type and corresponding `message:received`/`message:sent` event shapes, plus type guards and factory helpers in `src/hooks/internal-hooks.ts`. It also wires `message:received` into the reply dispatch flow (`src/auto-reply/reply/dispatch-from-config.ts`) so workspace/bundled hooks can react to incoming messages, parallel to the existing plugin hook runner’s `message_received` event.

One small maintainability concern: the new dispatch block reuses local variable names (`sessionKey`, `channel`, `messageId`) that are already defined earlier in the function, which can cause confusion during future edits (even though it doesn’t change runtime behavior today).

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; changes are additive and localized.
- The PR adds new event types/helpers and triggers an additional internal hook without altering the existing plugin hook flow. I didn’t spot logic that would break dispatching, but the new block does introduce some naming/shadowing that could lead to mistakes in future maintenance.
- src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->