### PR TITLE
fix(config): clamp maxTokens to contextWindow to prevent invalid configurations

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -215,7 +215,9 @@ export function applyModelDefaults(cfg: OpenClawConfig): OpenClawConfig {
         }
 
         const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
-        const maxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
+        // Clamp maxTokens to contextWindow to prevent invalid configurations
+        const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
+        const maxTokens = Math.min(rawMaxTokens, contextWindow);
         if (raw.maxTokens !== maxTokens) {
           modelMutated = true;
         }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -215,7 +215,6 @@ export function applyModelDefaults(cfg: OpenClawConfig): OpenClawConfig {
         }
 
         const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
-        // Clamp maxTokens to contextWindow to prevent invalid configurations
         const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
         const maxTokens = Math.min(rawMaxTokens, contextWindow);
         if (raw.maxTokens !== maxTokens) {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -80,4 +80,23 @@ describe("applyModelDefaults", () => {
     expect(model?.contextWindow).toBe(DEFAULT_CONTEXT_TOKENS);
     expect(model?.maxTokens).toBe(8192);
   });
+
+  it("clamps maxTokens to contextWindow", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            api: "openai-completions",
+            models: [{ id: "gpt-5.2", name: "GPT-5.2", contextWindow: 32768, maxTokens: 40960 }],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(32768);
+    expect(model?.maxTokens).toBe(32768);
+  });
 });


### PR DESCRIPTION
## Summary

Clamp `maxTokens` to `contextWindow` to prevent invalid configurations where `maxTokens > contextWindow`.

## Problem

When users configure `maxTokens` larger than `contextWindow` (e.g., `maxTokens: 40960` with `contextWindow: 32768`), the model may fail silently or produce unexpected behavior.

Example from Issue #5308:
```json
{
  "id": "deepseek-r1:14b",
  "contextWindow": 32768,
  "maxTokens": 40960  // Invalid: larger than contextWindow
}
```

## Solution

Clamp `maxTokens` to be at most `contextWindow`:
```typescript
const maxTokens = Math.min(rawMaxTokens, contextWindow);
```

## Testing

- All 4907 tests pass

Closes #5308

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates model defaulting logic in `src/config/defaults.ts` to prevent invalid model configurations where `maxTokens` exceeds `contextWindow`. Specifically, after determining a `defaultMaxTokens` (bounded by both `DEFAULT_MODEL_MAX_TOKENS` and `contextWindow`), it now computes a `rawMaxTokens` from user input (or the default) and then clamps the final `maxTokens` to `Math.min(rawMaxTokens, contextWindow)`. This ensures downstream model calls don’t receive an output-token limit larger than the model’s context window, which can otherwise lead to provider failures or confusing behavior.

The change is localized to `applyModelDefaults`, which already normalizes other model fields (`reasoning`, `input`, `cost`, `contextWindow`). The new clamping fits that pattern by continuing to “sanitize” model definitions into a consistent `ModelDefinitionConfig` before the rest of the application consumes it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, self-contained adjustment to config normalization: it adds a straightforward clamp of `maxTokens` to `contextWindow` while preserving existing defaulting behavior. It does not alter external interfaces, and it reduces the chance of invalid provider requests rather than introducing new behavior paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->