### PR TITLE
feat(ui): add Usage Analytics tab with cost tracking and provider quotas

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1,5 +1,9 @@
 import { loadConfig } from "../../config/config.js";
-import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
+import type {
+  CostUsageDailyEntry,
+  CostUsageSummary,
+  CostUsageTotals,
+} from "../../infra/session-cost-usage.js";
 import { loadCostUsageSummary } from "../../infra/session-cost-usage.js";
 import { loadProviderUsageSummary } from "../../infra/provider-usage.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -12,7 +16,7 @@ type CostUsageCacheEntry = {
   inFlight?: Promise<CostUsageSummary>;
 };
 
-const costUsageCache = new Map<number, CostUsageCacheEntry>();
+const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
 const parseDays = (raw: unknown): number => {
   if (typeof raw === "number" && Number.isFinite(raw)) {
@@ -27,13 +31,65 @@ const parseDays = (raw: unknown): number => {
   return 30;
 };
 
+const emptyTotals = (): CostUsageTotals => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  missingCostEntries: 0,
+});
+
+const addTotals = (target: CostUsageTotals, source: CostUsageTotals) => {
+  target.input += source.input;
+  target.output += source.output;
+  target.cacheRead += source.cacheRead;
+  target.cacheWrite += source.cacheWrite;
+  target.totalTokens += source.totalTokens;
+  target.totalCost += source.totalCost;
+  target.missingCostEntries += source.missingCostEntries;
+};
+
+/**
+ * Merge summaries from multiple agents into a single aggregate.
+ */
+function mergeCostUsageSummaries(summaries: CostUsageSummary[], days: number): CostUsageSummary {
+  const totals = emptyTotals();
+  const dailyMap = new Map<string, CostUsageTotals>();
+
+  for (const summary of summaries) {
+    addTotals(totals, summary.totals);
+    for (const entry of summary.daily) {
+      const existing = dailyMap.get(entry.date) ?? emptyTotals();
+      addTotals(existing, entry);
+      dailyMap.set(entry.date, existing);
+    }
+  }
+
+  const daily: CostUsageDailyEntry[] = Array.from(dailyMap.entries())
+    .map(([date, bucket]) => Object.assign({ date }, bucket))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
+
+  return { updatedAt: Date.now(), days, daily, totals };
+}
+
+function resolveAgentIds(config: ReturnType<typeof loadConfig>): string[] {
+  const agents = config?.agents?.list;
+  if (!Array.isArray(agents) || agents.length === 0) {
+    return []; // falls back to default in loadCostUsageSummary
+  }
+  return agents.map((a: { id?: string }) => a.id?.trim()).filter((id): id is string => Boolean(id));
+}
+
 async function loadCostUsageSummaryCached(params: {
   days: number;
   config: ReturnType<typeof loadConfig>;
 }): Promise<CostUsageSummary> {
   const days = Math.max(1, params.days);
+  const cacheKey = `all:${days}`;
   const now = Date.now();
-  const cached = costUsageCache.get(days);
+  const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
     return cached.summary;
   }
@@ -45,10 +101,21 @@ async function loadCostUsageSummaryCached(params: {
     return await cached.inFlight;
   }
 
+  const agentIds = resolveAgentIds(params.config);
+
   const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = loadCostUsageSummary({ days, config: params.config })
+  const inFlight = (async () => {
+    if (agentIds.length === 0) {
+      // No agents configured — use default path
+      return loadCostUsageSummary({ days, config: params.config });
+    }
+    const summaries = await Promise.all(
+      agentIds.map((agentId) => loadCostUsageSummary({ days, config: params.config, agentId })),
+    );
+    return mergeCostUsageSummaries(summaries, days);
+  })()
     .then((summary) => {
-      costUsageCache.set(days, { summary, updatedAt: Date.now() });
+      costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
       return summary;
     })
     .catch((err) => {
@@ -58,15 +125,15 @@ async function loadCostUsageSummaryCached(params: {
       throw err;
     })
     .finally(() => {
-      const current = costUsageCache.get(days);
+      const current = costUsageCache.get(cacheKey);
       if (current?.inFlight === inFlight) {
         current.inFlight = undefined;
-        costUsageCache.set(days, current);
+        costUsageCache.set(cacheKey, current);
       }
     });
 
   entry.inFlight = inFlight;
-  costUsageCache.set(days, entry);
+  costUsageCache.set(cacheKey, entry);
 
   if (entry.summary) {
     return entry.summary;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -35,6 +35,7 @@ import { renderChat } from "./views/chat";
 import { renderConfig } from "./views/config";
 import { renderChannels } from "./views/channels";
 import { renderCron } from "./views/cron";
+import { renderUsage } from "./views/usage";
 import { renderDebug } from "./views/debug";
 import { renderInstances } from "./views/instances";
 import { renderLogs } from "./views/logs";
@@ -337,6 +338,23 @@ export function renderApp(state: AppViewState) {
                 onRun: (job) => runCronJob(state, job),
                 onRemove: (job) => removeCronJob(state, job),
                 onLoadRuns: (jobId) => loadCronRuns(state, jobId),
+              })
+            : nothing
+        }
+
+        ${
+          state.tab === "usage"
+            ? renderUsage({
+                loading: state.usageLoading,
+                error: state.usageError,
+                costSummary: state.usageCostSummary,
+                providerSummary: state.usageProviderSummary,
+                days: state.usageDays,
+                onDaysChange: (days) => {
+                  state.usageDays = days;
+                  state.loadUsage();
+                },
+                onRefresh: () => state.loadUsage(),
               })
             : nothing
         }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -155,6 +155,7 @@ export async function refreshActiveTab(host: SettingsHost) {
   if (host.tab === "instances") await loadPresence(host as unknown as OpenClawApp);
   if (host.tab === "sessions") await loadSessions(host as unknown as OpenClawApp);
   if (host.tab === "cron") await loadCron(host);
+  if (host.tab === "usage") await (host as unknown as OpenClawApp).loadUsage();
   if (host.tab === "skills") await loadSkills(host as unknown as OpenClawApp);
   if (host.tab === "nodes") {
     await loadNodes(host as unknown as OpenClawApp);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -26,6 +26,7 @@ import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exe
 import type { DevicePairingList } from "./controllers/devices";
 import type { ExecApprovalRequest } from "./controllers/exec-approval";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form";
+import type { CostUsageSummary, UsageProviderSummary } from "./controllers/usage";
 
 export type AppViewState = {
   settings: UiSettings;
@@ -119,6 +120,11 @@ export type AppViewState = {
   cronRunsJobId: string | null;
   cronRuns: CronRunLogEntry[];
   cronBusy: boolean;
+  usageLoading: boolean;
+  usageError: string | null;
+  usageCostSummary: CostUsageSummary | null;
+  usageProviderSummary: UsageProviderSummary | null;
+  usageDays: number;
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;
   skillsError: string | null;
@@ -151,6 +157,7 @@ export type AppViewState = {
   loadOverview: () => Promise<void>;
   loadAssistantIdentity: () => Promise<void>;
   loadCron: () => Promise<void>;
+  loadUsage: () => Promise<void>;
   handleWhatsAppStart: (force: boolean) => Promise<void>;
   handleWhatsAppWait: () => Promise<void>;
   handleWhatsAppLogout: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -75,6 +75,7 @@ import {
 } from "./app-channels";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity";
+import { loadUsage as loadUsageInternal } from "./controllers/usage";
 
 declare global {
   interface Window {
@@ -210,6 +211,12 @@ export class OpenClawApp extends LitElement {
   @state() cronRuns: CronRunLogEntry[] = [];
   @state() cronBusy = false;
 
+  @state() usageLoading = false;
+  @state() usageError: string | null = null;
+  @state() usageCostSummary: import("./controllers/usage").CostUsageSummary | null = null;
+  @state() usageProviderSummary: import("./controllers/usage").UsageProviderSummary | null = null;
+  @state() usageDays = 30;
+
   @state() skillsLoading = false;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
@@ -337,6 +344,10 @@ export class OpenClawApp extends LitElement {
 
   async loadCron() {
     await loadCronInternal(this as unknown as Parameters<typeof loadCronInternal>[0]);
+  }
+
+  async loadUsage() {
+    await loadUsageInternal(this);
   }
 
   async handleAbortChat() {

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -1,0 +1,78 @@
+import type { GatewayBrowserClient } from "../gateway";
+
+// ── Types matching server-side shapes ────────────────────────
+
+export type CostUsageTotals = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  totalCost: number;
+  missingCostEntries: number;
+};
+
+export type CostUsageDailyEntry = CostUsageTotals & {
+  date: string;
+};
+
+export type CostUsageSummary = {
+  updatedAt: number;
+  days: number;
+  daily: CostUsageDailyEntry[];
+  totals: CostUsageTotals;
+};
+
+export type UsageWindow = {
+  label: string;
+  usedPercent: number;
+  resetAt?: number;
+};
+
+export type ProviderUsageSnapshot = {
+  provider: string;
+  displayName: string;
+  windows: UsageWindow[];
+  plan?: string;
+  error?: string;
+};
+
+export type UsageProviderSummary = {
+  updatedAt: number;
+  providers: ProviderUsageSnapshot[];
+};
+
+// ── Controller state ─────────────────────────────────────────
+
+export type UsageState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  usageLoading: boolean;
+  usageError: string | null;
+  usageCostSummary: CostUsageSummary | null;
+  usageProviderSummary: UsageProviderSummary | null;
+  usageDays: number;
+};
+
+// ── Loaders ──────────────────────────────────────────────────
+
+export async function loadUsage(state: UsageState) {
+  if (!state.client || !state.connected) return;
+  if (state.usageLoading) return;
+  state.usageLoading = true;
+  state.usageError = null;
+  try {
+    const [costRes, statusRes] = await Promise.all([
+      state.client.request<CostUsageSummary>("usage.cost", {
+        days: state.usageDays,
+      }),
+      state.client.request<UsageProviderSummary>("usage.status", {}),
+    ]);
+    state.usageCostSummary = costRes;
+    state.usageProviderSummary = statusRes;
+  } catch (err) {
+    state.usageError = String(err);
+  } finally {
+    state.usageLoading = false;
+  }
+}

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -215,6 +215,12 @@ export const icons = {
   circle: html`
     <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /></svg>
   `,
+  dollarSign: html`
+    <svg viewBox="0 0 24 24">
+      <line x1="12" x2="12" y1="2" y2="22" />
+      <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+    </svg>
+  `,
   puzzle: html`
     <svg viewBox="0 0 24 24">
       <path

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -4,7 +4,7 @@ export const TAB_GROUPS = [
   { label: "Chat", tabs: ["chat"] },
   {
     label: "Control",
-    tabs: ["overview", "channels", "instances", "sessions", "cron"],
+    tabs: ["overview", "channels", "instances", "sessions", "cron", "usage"],
   },
   { label: "Agent", tabs: ["skills", "nodes"] },
   { label: "Settings", tabs: ["config", "debug", "logs"] },
@@ -16,6 +16,7 @@ export type Tab =
   | "instances"
   | "sessions"
   | "cron"
+  | "usage"
   | "skills"
   | "nodes"
   | "chat"
@@ -29,6 +30,7 @@ const TAB_PATHS: Record<Tab, string> = {
   instances: "/instances",
   sessions: "/sessions",
   cron: "/cron",
+  usage: "/usage",
   skills: "/skills",
   nodes: "/nodes",
   chat: "/chat",
@@ -112,6 +114,8 @@ export function iconForTab(tab: Tab): IconName {
       return "fileText";
     case "cron":
       return "loader";
+    case "usage":
+      return "dollarSign";
     case "skills":
       return "zap";
     case "nodes":
@@ -139,6 +143,8 @@ export function titleForTab(tab: Tab) {
       return "Sessions";
     case "cron":
       return "Cron Jobs";
+    case "usage":
+      return "Usage";
     case "skills":
       return "Skills";
     case "nodes":
@@ -168,6 +174,8 @@ export function subtitleForTab(tab: Tab) {
       return "Inspect active sessions and adjust per-session defaults.";
     case "cron":
       return "Schedule wakeups and recurring agent runs.";
+    case "usage":
+      return "Provider quotas, token usage, and cost analytics.";
     case "skills":
       return "Manage skill availability and API key injection.";
     case "nodes":

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -1,0 +1,499 @@
+import { html, nothing } from "lit";
+
+import { formatAgo } from "../format";
+import type {
+  CostUsageDailyEntry,
+  CostUsageSummary,
+  CostUsageTotals,
+  ProviderUsageSnapshot,
+  UsageProviderSummary,
+} from "../controllers/usage";
+
+// ── Props ────────────────────────────────────────────────────
+
+export type UsageProps = {
+  loading: boolean;
+  error: string | null;
+  costSummary: CostUsageSummary | null;
+  providerSummary: UsageProviderSummary | null;
+  days: number;
+  onDaysChange: (days: number) => void;
+  onRefresh: () => void;
+};
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const PERIOD_OPTIONS = [7, 14, 30, 90] as const;
+
+function formatCost(value: number): string {
+  if (value === 0) return "$0.00";
+  if (value < 0) return `-${formatCost(Math.abs(value))}`;
+  if (value < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatTokens(value: number): string {
+  if (value === 0) return "0";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(value);
+}
+
+function formatResetAt(ms?: number): string {
+  if (!ms) return "";
+  const diff = ms - Date.now();
+  if (diff <= 0) return "reset due";
+  const hours = Math.floor(diff / 3_600_000);
+  const minutes = Math.floor((diff % 3_600_000) / 60_000);
+  if (hours > 0) return `resets in ${hours}h ${minutes}m`;
+  return `resets in ${minutes}m`;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+}
+
+function barColor(percent: number): string {
+  if (percent >= 90) return "var(--color-danger, #ef4444)";
+  if (percent >= 70) return "var(--color-warning, #f59e0b)";
+  return "var(--color-accent, #3b82f6)";
+}
+
+function costBarColor(index: number): string {
+  const palette = [
+    "var(--color-accent, #3b82f6)",
+    "var(--color-info, #06b6d4)",
+    "var(--color-success, #22c55e)",
+    "var(--color-warning, #f59e0b)",
+  ];
+  return palette[index % palette.length];
+}
+
+// ── Provider quota section ───────────────────────────────────
+
+function renderProviderCard(provider: ProviderUsageSnapshot) {
+  if (provider.error) {
+    return html`
+      <div class="card" style="margin-bottom: 12px;">
+        <div class="row" style="justify-content: space-between; align-items: center;">
+          <div>
+            <strong>${provider.displayName}</strong>
+            ${
+              provider.plan
+                ? html`<span class="muted" style="margin-left: 8px;">${provider.plan}</span>`
+                : nothing
+            }
+          </div>
+          <span class="muted">${provider.error}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!provider.windows.length) {
+    return html`
+      <div class="card" style="margin-bottom: 12px;">
+        <div class="row" style="justify-content: space-between; align-items: center;">
+          <div>
+            <strong>${provider.displayName}</strong>
+            ${
+              provider.plan
+                ? html`<span class="muted" style="margin-left: 8px;">${provider.plan}</span>`
+                : nothing
+            }
+          </div>
+          <span class="muted">No usage windows</span>
+        </div>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="card" style="margin-bottom: 12px;">
+      <div style="margin-bottom: 8px;">
+        <strong>${provider.displayName}</strong>
+        ${
+          provider.plan
+            ? html`<span class="muted" style="margin-left: 8px;">${provider.plan}</span>`
+            : nothing
+        }
+      </div>
+      ${provider.windows.map((w) => {
+        const pct = clampPercent(w.usedPercent);
+        return html`
+          <div style="margin-bottom: 8px;">
+            <div class="row" style="justify-content: space-between; font-size: 0.85em; margin-bottom: 4px;">
+              <span>${w.label}</span>
+              <span>
+                <strong>${pct.toFixed(0)}%</strong>
+                ${
+                  w.resetAt
+                    ? html`<span class="muted" style="margin-left: 6px;">${formatResetAt(w.resetAt)}</span>`
+                    : nothing
+                }
+              </span>
+            </div>
+            <div
+              role="progressbar"
+              aria-valuenow=${pct}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-label="${w.label} usage"
+              style="
+                height: 8px;
+                background: var(--color-surface-alt, #1e293b);
+                border-radius: 4px;
+                overflow: hidden;
+            ">
+              <div style="
+                height: 100%;
+                width: ${pct}%;
+                background: ${barColor(pct)};
+                border-radius: 4px;
+                transition: width 0.3s ease;
+              "></div>
+            </div>
+          </div>
+        `;
+      })}
+    </div>
+  `;
+}
+
+function renderProviderQuotas(summary: UsageProviderSummary | null) {
+  if (!summary || !summary.providers.length) {
+    return html`
+      <div class="card">
+        <div class="card-title">Provider Quotas</div>
+        <div class="card-sub">No provider usage data available.</div>
+        <div class="muted" style="margin-top: 12px; font-size: 0.85em">
+          Using Claude Code OAuth? Plan quota is not available programmatically.
+          <a
+            href="https://claude.ai/settings/usage"
+            target="_blank"
+            rel="noopener"
+            style="color: var(--color-accent, #3b82f6)"
+          >
+            Check your usage at claude.ai →
+          </a>
+        </div>
+      </div>
+    `;
+  }
+
+  const active = summary.providers.filter((p) => !p.error);
+  const errored = summary.providers.filter((p) => p.error);
+
+  return html`
+    <div class="card">
+      <div class="card-title">Provider Quotas</div>
+      <div class="card-sub">Current usage windows across configured providers.</div>
+      <div style="margin-top: 16px;">
+        ${active.map((p) => renderProviderCard(p))}
+        ${
+          errored.length
+            ? html`
+              <details style="margin-top: 8px;">
+                <summary class="muted" style="cursor: pointer; font-size: 0.85em;">
+                  ${errored.length} unavailable provider${errored.length > 1 ? "s" : ""}
+                </summary>
+                <div style="margin-top: 8px;">
+                  ${errored.map((p) => renderProviderCard(p))}
+                </div>
+              </details>
+            `
+            : nothing
+        }
+      </div>
+    </div>
+  `;
+}
+
+// ── Cost totals section ──────────────────────────────────────
+
+function renderTotals(totals: CostUsageTotals, days: number) {
+  return html`
+    <div class="card">
+      <div class="card-title">Cost Summary</div>
+      <div class="card-sub">Aggregate token usage and estimated cost over the last ${days} days.</div>
+      <div class="stat-grid" style="margin-top: 16px;">
+        <div class="stat">
+          <div class="stat-label">Total Cost</div>
+          <div class="stat-value">${formatCost(totals.totalCost)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Total Tokens</div>
+          <div class="stat-value">${formatTokens(totals.totalTokens)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Input</div>
+          <div class="stat-value">${formatTokens(totals.input)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Output</div>
+          <div class="stat-value">${formatTokens(totals.output)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Cache Read</div>
+          <div class="stat-value">${formatTokens(totals.cacheRead)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Cache Write</div>
+          <div class="stat-value">${formatTokens(totals.cacheWrite)}</div>
+        </div>
+      </div>
+      ${
+        totals.missingCostEntries > 0
+          ? html`
+            <div class="muted" style="margin-top: 12px; font-size: 0.85em;">
+              ⚠ ${totals.missingCostEntries} entries missing cost data — totals are estimates.
+            </div>
+          `
+          : nothing
+      }
+    </div>
+  `;
+}
+
+// ── Daily cost bar chart ─────────────────────────────────────
+
+function renderDailyChart(daily: CostUsageDailyEntry[]) {
+  if (!daily.length) {
+    return html`
+      <div class="card">
+        <div class="card-title">Daily Cost</div>
+        <div class="card-sub">No daily cost data for this period.</div>
+      </div>
+    `;
+  }
+
+  const maxCost = Math.max(...daily.map((d) => d.totalCost), 0.01);
+  const labelStride = Math.ceil(daily.length / 12);
+
+  return html`
+    <div class="card">
+      <div class="card-title">Daily Cost</div>
+      <div class="card-sub">Estimated cost per day.</div>
+      <div style="
+        margin-top: 16px;
+        display: flex;
+        align-items: flex-end;
+        gap: 2px;
+        height: 160px;
+        padding-bottom: 24px;
+        position: relative;
+      ">
+        ${daily.map((d, i) => {
+          const pct = (d.totalCost / maxCost) * 100;
+          const barHeight = Math.max(pct, 1);
+          const label = d.date.slice(5); /* MM-DD */
+          return html`
+            <div style="
+              flex: 1;
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              height: 100%;
+              justify-content: flex-end;
+              position: relative;
+            " title="${d.date}: ${formatCost(d.totalCost)} — ${formatTokens(d.totalTokens)} tokens">
+              <div style="
+                width: 100%;
+                max-width: 32px;
+                height: ${barHeight}%;
+                min-height: 2px;
+                background: ${costBarColor(i)};
+                border-radius: 3px 3px 0 0;
+                transition: height 0.3s ease;
+              "></div>
+              <div style="
+                position: absolute;
+                bottom: -20px;
+                font-size: 0.65em;
+                color: var(--color-muted, #94a3b8);
+                white-space: nowrap;
+                transform: rotate(-45deg);
+                transform-origin: top left;
+              ">${i % labelStride === 0 ? label : ""}</div>
+            </div>
+          `;
+        })}
+      </div>
+      <div class="row" style="justify-content: space-between; margin-top: 8px; font-size: 0.8em;">
+        <span class="muted">${daily[0]?.date ?? ""}</span>
+        <span class="muted">max: ${formatCost(maxCost)}</span>
+        <span class="muted">${daily[daily.length - 1]?.date ?? ""}</span>
+      </div>
+    </div>
+  `;
+}
+
+// ── Daily token breakdown chart ──────────────────────────────
+
+function renderTokenBreakdown(daily: CostUsageDailyEntry[]) {
+  if (!daily.length) return nothing;
+
+  const maxTokens = Math.max(...daily.map((d) => d.totalTokens), 1);
+  const tokenLabelStride = Math.ceil(daily.length / 12);
+
+  return html`
+    <div class="card">
+      <div class="card-title">Daily Tokens</div>
+      <div class="card-sub">Token volume per day — input, output, and cache.</div>
+      <div style="
+        margin-top: 16px;
+        display: flex;
+        align-items: flex-end;
+        gap: 2px;
+        height: 120px;
+        padding-bottom: 24px;
+        position: relative;
+      ">
+        ${daily.map((d, i) => {
+          const totalPct = (d.totalTokens / maxTokens) * 100;
+          const inputPct = d.totalTokens > 0 ? (d.input / d.totalTokens) * totalPct : 0;
+          const outputPct = d.totalTokens > 0 ? (d.output / d.totalTokens) * totalPct : 0;
+          const cachePct = Math.max(totalPct - inputPct - outputPct, 0);
+          const label = d.date.slice(5);
+          return html`
+            <div style="
+              flex: 1;
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              height: 100%;
+              justify-content: flex-end;
+              position: relative;
+            " title="${d.date}: ${formatTokens(d.totalTokens)} tokens (in: ${formatTokens(d.input)}, out: ${formatTokens(d.output)})">
+              <div style="
+                width: 100%;
+                max-width: 32px;
+                display: flex;
+                flex-direction: column;
+                justify-content: flex-end;
+                height: ${Math.max(totalPct, 1)}%;
+                min-height: 2px;
+                border-radius: 3px 3px 0 0;
+                overflow: hidden;
+              ">
+                <div style="height: ${cachePct}%; background: var(--color-success, #22c55e); min-height: 0;"></div>
+                <div style="height: ${outputPct}%; background: var(--color-warning, #f59e0b); min-height: 0;"></div>
+                <div style="height: ${inputPct}%; background: var(--color-accent, #3b82f6); min-height: 0;"></div>
+              </div>
+              <div style="
+                position: absolute;
+                bottom: -20px;
+                font-size: 0.65em;
+                color: var(--color-muted, #94a3b8);
+                white-space: nowrap;
+                transform: rotate(-45deg);
+                transform-origin: top left;
+              ">${i % tokenLabelStride === 0 ? label : ""}</div>
+            </div>
+          `;
+        })}
+      </div>
+      <div class="row" style="gap: 16px; margin-top: 8px; font-size: 0.8em;">
+        <span style="display: flex; align-items: center; gap: 4px;">
+          <span style="width: 10px; height: 10px; border-radius: 2px; background: var(--color-accent, #3b82f6);"></span>
+          Input
+        </span>
+        <span style="display: flex; align-items: center; gap: 4px;">
+          <span style="width: 10px; height: 10px; border-radius: 2px; background: var(--color-warning, #f59e0b);"></span>
+          Output
+        </span>
+        <span style="display: flex; align-items: center; gap: 4px;">
+          <span style="width: 10px; height: 10px; border-radius: 2px; background: var(--color-success, #22c55e);"></span>
+          Cache
+        </span>
+      </div>
+    </div>
+  `;
+}
+
+// ── Main render ──────────────────────────────────────────────
+
+export function renderUsage(props: UsageProps) {
+  return html`
+    <section>
+      <!-- Toolbar -->
+      <div class="card" style="margin-bottom: 16px;">
+        <div class="row" style="justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+          <div class="row" style="gap: 8px; align-items: center;">
+            <span style="font-weight: 500;">Period:</span>
+            ${PERIOD_OPTIONS.map(
+              (d) => html`
+                <button
+                  class="btn ${props.days === d ? "primary" : ""}"
+                  aria-pressed=${props.days === d}
+                  @click=${() => props.onDaysChange(d)}
+                >${d}d</button>
+              `,
+            )}
+          </div>
+          <div class="row" style="gap: 8px; align-items: center;">
+            ${
+              props.costSummary || props.providerSummary
+                ? html`<span class="muted" style="font-size: 0.85em;">
+                  Updated ${formatAgo(
+                    Math.max(
+                      props.costSummary?.updatedAt ?? 0,
+                      props.providerSummary?.updatedAt ?? 0,
+                    ),
+                  )}
+                </span>`
+                : nothing
+            }
+            <button
+              class="btn"
+              @click=${props.onRefresh}
+              ?disabled=${props.loading}
+            >${props.loading ? "Loading…" : "Refresh"}</button>
+          </div>
+        </div>
+      </div>
+
+      ${
+        props.error
+          ? html`<div class="card" style="margin-bottom: 16px;">
+            <div class="pill danger">${props.error}</div>
+          </div>`
+          : nothing
+      }
+
+      ${
+        props.loading && !props.costSummary && !props.providerSummary
+          ? html`
+              <div class="card"><div class="muted">Loading usage data…</div></div>
+            `
+          : nothing
+      }
+
+      <!-- Provider Quotas -->
+      ${renderProviderQuotas(props.providerSummary)}
+
+      <!-- Cost Summary -->
+      ${
+        props.costSummary
+          ? html`
+            <div style="margin-top: 16px;">
+              ${renderTotals(props.costSummary.totals, props.costSummary.days)}
+            </div>
+          `
+          : nothing
+      }
+
+      <!-- Daily Cost Chart -->
+      ${
+        props.costSummary
+          ? html`
+            <div class="grid grid-cols-2" style="margin-top: 16px;">
+              ${renderDailyChart(props.costSummary.daily)}
+              ${renderTokenBreakdown(props.costSummary.daily)}
+            </div>
+          `
+          : nothing
+      }
+    </section>
+  `;
+}


### PR DESCRIPTION
## What

Adds a Usage tab to the Control UI under the Control nav group. The existing `usage.cost` and `usage.status` gateway RPC methods had no frontend — this wires them up.

The tab shows provider quota progress bars (with reset countdowns), a cost/token summary, daily cost bars, and a stacked daily token chart. Period is selectable (7/14/30/90 days). Everything uses existing Lit patterns and CSS variables, no new dependencies.

Also includes a fix to the `usage.cost` server handler — it was only scanning the default `"main"` agent transcript directory, which is empty when you configure named agents. Now reads `agents.list` from config and aggregates across all of them.

Previous attempt: #2028 (closed due to merge conflicts).

Closes #3882

## AI Disclosure

- [x] Mark as AI-assisted: Built with Claude (Anthropic) via [Clawdbot](https://github.com/clawdbot/clawdbot)
- [x] Testing level: Tested against live gateway — provider quotas render with real data, cost charts confirmed structurally
- [x] Understand the code: Yes, reviewed manually