### PR TITLE
perf(workspace): optimize template loading for better performance

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -166,22 +166,30 @@ export async function ensureAgentWorkspace(params?: {
     return existing.every((v) => !v);
   })();
 
-  const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
-  const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
-  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
-  const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
-  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
-  const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
+  // Check if workspace is incomplete and copy missing files
+  const filesToEnsure = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+  const templates = [
+    DEFAULT_AGENTS_FILENAME,
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_TOOLS_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+  ];
 
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  for (let i = 0; i < filesToEnsure.length; i++) {
+    try {
+      await fs.access(filesToEnsure[i]);
+    } catch {
+      await writeFileIfMissing(filesToEnsure[i], await loadTemplate(templates[i]));
+    }
+  }
   if (isBrandNewWorkspace) {
-    await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
+    try {
+      await fs.access(bootstrapPath);
+    } catch {
+      await writeFileIfMissing(bootstrapPath, await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME));
+    }
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
 


### PR DESCRIPTION
- Only load templates for missing files instead of always loading all templates
- Performance improvement: skip I/O operations for existing workspace files

## Testing
- Fresh workspace creation: ✅ All templates copied correctly
- Incomplete workspace: ✅ Only missing files get templates loaded
- Linter passed: ✅ pnpm lint (0 warnings, 0 errors)

## AI-Assisted
- Built with Claude Code assistance
- Fully tested locally with multiple scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR optimizes `ensureAgentWorkspace` by avoiding eagerly reading all workspace bootstrap templates on every run. Instead, it checks for the presence of each expected workspace file (AGENTS/SOUL/TOOLS/IDENTITY/USER/HEARTBEAT, plus BOOTSTRAP on brand-new workspaces) and only loads/copies the template for files that are missing, reducing unnecessary I/O when a workspace already exists.

<h3>Confidence Score: 4/5</h3>

- Likely safe to merge; change is localized and behavior-preserving in common cases.
- The change is limited to workspace bootstrap logic and primarily reorders I/O to be conditional. Main remaining concern is subtle behavioral drift in edge cases (e.g., permission errors or non-regular files) due to added `fs.access` checks that may mask underlying errors by falling back to template loading/writing.
- src/agents/workspace.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->