### PR TITLE
feat: allow list removes tools from default subagent deny

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -1,6 +1,11 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { filterToolsByPolicy, isToolAllowedByPolicyName } from "./pi-tools.policy.js";
+import {
+  filterToolsByPolicy,
+  isToolAllowedByPolicyName,
+  resolveSubagentToolPolicy,
+} from "./pi-tools.policy.js";
+import type { OpenClawConfig } from "../config/config.js";
 
 function createStubTool(name: string): AgentTool<unknown, unknown> {
   return {
@@ -32,5 +37,48 @@ describe("pi-tools.policy", () => {
 
   it("keeps apply_patch when exec is allowlisted", () => {
     expect(isToolAllowedByPolicyName("apply_patch", { allow: ["exec"] })).toBe(true);
+  });
+});
+
+describe("resolveSubagentToolPolicy", () => {
+  it("denies memory_search by default", () => {
+    const policy = resolveSubagentToolPolicy(undefined);
+    expect(policy.deny).toContain("memory_search");
+    expect(policy.deny).toContain("memory_get");
+  });
+
+  it("removes tool from default deny when explicitly allowed", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        subagents: {
+          tools: {
+            allow: ["memory_search", "memory_get"],
+          },
+        },
+      },
+    };
+    const policy = resolveSubagentToolPolicy(cfg);
+    expect(policy.deny).not.toContain("memory_search");
+    expect(policy.deny).not.toContain("memory_get");
+    expect(policy.allow).toContain("memory_search");
+    expect(policy.allow).toContain("memory_get");
+    // Other defaults should still be denied
+    expect(policy.deny).toContain("cron");
+    expect(policy.deny).toContain("gateway");
+  });
+
+  it("preserves custom deny even when tool is allowed", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        subagents: {
+          tools: {
+            allow: ["exec"],
+            deny: ["exec"], // explicit deny takes precedence
+          },
+        },
+      },
+    };
+    const policy = resolveSubagentToolPolicy(cfg);
+    expect(policy.deny).toContain("exec");
   });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -97,12 +97,16 @@ const DEFAULT_SUBAGENT_TOOL_DENY = [
 
 export function resolveSubagentToolPolicy(cfg?: OpenClawConfig): SandboxToolPolicy {
   const configured = cfg?.tools?.subagents?.tools;
+  const allow = Array.isArray(configured?.allow) ? configured.allow : [];
+  const allowSet = new Set(allow);
+
+  // If a tool is explicitly allowed, remove it from default deny
   const deny = [
-    ...DEFAULT_SUBAGENT_TOOL_DENY,
+    ...DEFAULT_SUBAGENT_TOOL_DENY.filter((tool) => !allowSet.has(tool)),
     ...(Array.isArray(configured?.deny) ? configured.deny : []),
   ];
-  const allow = Array.isArray(configured?.allow) ? configured.allow : undefined;
-  return { allow, deny };
+
+  return { allow: allow.length ? allow : undefined, deny };
 }
 
 export function isToolAllowedByPolicyName(name: string, policy?: SandboxToolPolicy): boolean {


### PR DESCRIPTION
🤖 **AI-Assisted PR** (Claude via OpenClaw)

When a tool is explicitly added to the subagent allow list, it is now automatically removed from the default deny list. This provides an intuitive way to enable specific tools for sub-agents.

## Problem

Currently, if you want to allow `memory_search` for sub-agents, setting `tools.subagents.tools.allow: [memory_search]` does not work because `memory_search` is in the hardcoded `DEFAULT_SUBAGENT_TOOL_DENY` list. Users need a separate mechanism to clear defaults.

## Solution

If a tool is explicitly in the `allow` list, automatically remove it from the default deny list. This is intuitive: "I am allowing this" naturally means "do not deny it."

## Usage

```yaml
tools:
  subagents:
    tools:
      allow:
        - memory_search
        - memory_get
```

## AI Contribution Checklist

- [x] **AI-assisted**: Built with Claude (Opus) via OpenClaw
- [x] **Testing**: Fully tested - typecheck passes, 7 unit tests pass (3 new tests added)
- [x] **Understanding confirmed**: The change filters `DEFAULT_SUBAGENT_TOOL_DENY` to exclude any tools present in the configured `allow` list before merging with user `deny`. This preserves security (custom deny still wins) while making the allow list intuitive.

## Notes

- Custom `deny` entries still take precedence over `allow`
- Only affects default deny list, not user-configured deny
- Minimal change: 2 files, ~50 lines including tests