### PR TITLE
Add plugin hook to resolve canonical RoomKey for session identity and FIFO routing

### DIFF
--- a/PR_ROOMKEY_HOOK.md
+++ b/PR_ROOMKEY_HOOK.md
@@ -1,0 +1,106 @@
+## Summary
+
+This PR introduces a small, backward-compatible core hook that allows plugins to deterministically influence the canonical conversation identity ("RoomKey") used by OpenClaw for:
+
+- session/transcript selection
+- FIFO queue lane selection (ordering)
+
+By default, behavior is unchanged.
+
+## Motivation
+
+OpenClaw’s pipeline already relies on a stable concept of "room/session identity" that drives both history selection and per-session serialization. Today, there is no first-class extension point for plugins to participate in that identity derivation, which forces plugins that need deterministic isolation to either patch channel internals (fragile) or rely on prompt-only scoping (best-effort).
+
+This PR adds the minimal missing abstraction: a hook that lets plugins resolve a canonical RoomKey early in inbound context construction, before any session lookup or queueing occurs.
+
+## Design goals
+
+- Minimal surface area: one hook, one return value
+- Backward compatible: default path unchanged
+- One invariant: the same key is used for transcript identity and FIFO lane ordering
+- Channel-agnostic core API (no "projects" concept in core)
+
+## Proposed API
+
+New hook: `resolve_room_key`
+
+- Called after core computes the default session/room key.
+- Plugins may return `{ roomKey }` to override the canonical key; returning `undefined` means no change.
+
+Invariant:
+- The returned `roomKey` is used as both the session identity key and the FIFO lane key.
+
+## Implementation notes
+
+- Adds helper: `resolveCanonicalRoomKey()` in `src/routing/room-key.ts` which calls the global hook runner if hooks are registered.
+- Telegram inbound context builder calls `resolveCanonicalRoomKey()` after computing the base key.
+- Plugin command context includes optional message metadata (`messageId`, `threadId`, `chatId`) to support deterministic semantics tied to monotonic message ids.
+
+## Tests
+
+- Unit test asserts:
+  - no hook => roomKey unchanged
+  - hook override => roomKey changes and the derived session lane uses the same key
+
+## Non-goals
+
+- No new user-facing features
+- No Telegram-specific behavior beyond supplying normalized metadata into the hook
+- No changes to default session semantics
+
+---
+
+## Behavioral Contract (normative)
+
+This PR intentionally specifies behavior as **invariants**, not implementation details.
+
+### RoomKey resolution
+
+- **Single canonical key:** For every inbound message, OpenClaw computes exactly one *canonical* `roomKey`.
+- **Deterministic:** Given the same inbound message metadata and plugin configuration, the canonical `roomKey` must resolve deterministically.
+- **Early binding:** The canonical `roomKey` is finalized **before** any transcript/session lookup or FIFO lane selection.
+- **Opt-in override:** If no plugin returns an override from `resolve_room_key`, behavior is unchanged from today.
+
+### Queue + transcript alignment
+
+- **No split-brain:** The canonical `roomKey` is used for **both**:
+  - transcript/session identity selection, and
+  - FIFO queue lane ordering.
+- Therefore, it must be impossible for an inbound message to be queued under one key but persisted/read under another.
+
+### Isolation properties (enabled by plugins)
+
+- Core remains channel-agnostic, but by allowing plugins to override `roomKey`, the system can provide **true isolation boundaries** (e.g., per-project transcripts and ordering) without patching channel internals.
+
+---
+
+## 3-layer model: Transcript / Project Memory / Global Memory (normative)
+
+This PR enables a clean separation of concerns for higher-level UX features (e.g., a Projects mode plugin). The intended model is:
+
+1. **Transcript** (per canonical `roomKey`)
+   - The conversation history used for immediate continuity.
+   - Must be isolated by design when `roomKey` is isolated.
+
+2. **Project Memory** (durable, project-scoped)
+   - Long-lived notes/state associated with a project.
+   - Must not be written to/read from other projects.
+
+3. **Global Memory** (durable, explicitly accessed)
+   - A separate global store that is **not** implicitly consulted by natural-language recall.
+   - Access is explicit (e.g., a dedicated command / route), so reviewers and users can reason about scope.
+
+### Explicitly deferred (out of scope)
+
+- Whether **natural-language recall** should ever *fall back* to global memory is intentionally **not** decided in this PR.
+
+---
+
+## Condensed verification checklist (reasoning about correctness)
+
+- **Deterministic routing:** A stable rule exists to derive a canonical `roomKey` (including any plugin override).
+- **One key everywhere:** Transcript identity and FIFO queue lane use the same canonical `roomKey`.
+- **True isolation:** Switching scope (e.g., project A → project B) results in different `roomKey`s, hence different transcripts and ordering lanes.
+- **No silent miswrites:** There is no path that can write/read history under a key different from the one used for ordering.
+- **Escape hatch works:** Disabling the feature (or bypassing the override) immediately returns to classic behavior.
+- **Debug visibility matches reality:** Any debug/telemetry surface reflects the canonical `roomKey` actually used.

--- a/PR_ROOMKEY_HOOK.md
+++ b/PR_ROOMKEY_HOOK.md
@@ -1,5 +1,7 @@
 ## Summary
 
+Compatibility note: Verified against **OpenClaw v2026.1.30**, including recent Telegram threading/HTML and routing changes. The `resolve_room_key` hook remains stable because it operates above channel-specific routing details.
+
 This PR introduces a small, backward-compatible core hook that allows plugins to deterministically influence the canonical conversation identity ("RoomKey") used by OpenClaw for:
 
 - session/transcript selection

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -80,6 +80,7 @@ See [Hooks](/hooks) for setup and examples.
 
 These run inside the agent loop or gateway pipeline:
 
+- **`resolve_room_key`**: refine the canonical RoomKey used for *both* session identity (transcripts/history) and FIFO lane ordering. The returned key is treated as untrusted: it is sanitized (control characters removed), clamped to a fixed max length with a deterministic hash suffix, and ignored if empty/whitespace.
 - **`before_agent_start`**: inject context or override system prompt before the run starts.
 - **`agent_end`**: inspect the final message list and run metadata after completion.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -232,8 +232,22 @@ export async function executePluginCommand(params: {
   isAuthorizedSender: boolean;
   commandBody: string;
   config: OpenClawConfig;
+  messageId?: number;
+  threadId?: number;
+  chatId?: string | number;
 }): Promise<PluginCommandResult> {
-  const { command, args, senderId, channel, isAuthorizedSender, commandBody, config } = params;
+  const {
+    command,
+    args,
+    senderId,
+    channel,
+    isAuthorizedSender,
+    commandBody,
+    config,
+    messageId,
+    threadId,
+    chatId,
+  } = params;
 
   // Check authorization
   const requireAuth = command.requireAuth !== false; // Default to true
@@ -254,6 +268,9 @@ export async function executePluginCommand(params: {
     args: sanitizedArgs,
     commandBody,
     config,
+    messageId,
+    threadId,
+    chatId,
   };
 
   // Lock registry during execution to prevent concurrent modifications

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -150,6 +150,12 @@ export type PluginCommandContext = {
   commandBody: string;
   /** Current OpenClaw configuration */
   config: OpenClawConfig;
+
+  // Optional message metadata (channel-specific).
+  // Useful for deterministic semantics tied to monotonic message ids.
+  messageId?: number;
+  threadId?: number;
+  chatId?: string | number;
 };
 
 /**
@@ -288,6 +294,7 @@ export type PluginDiagnostic = {
 
 export type PluginHookName =
   | "before_agent_start"
+  | "resolve_room_key"
   | "agent_end"
   | "before_compaction"
   | "after_compaction"
@@ -319,6 +326,34 @@ export type PluginHookBeforeAgentStartEvent = {
 export type PluginHookBeforeAgentStartResult = {
   systemPrompt?: string;
   prependContext?: string;
+};
+
+// resolve_room_key hook
+export type PluginHookResolveRoomKeyPeer = {
+  kind: string;
+  id: string;
+};
+
+export type PluginHookResolveRoomKeyEvent = {
+  /** Current canonical room key (defaults to the route/session key). */
+  roomKey: string;
+  /** Base room key before any thread suffixes or overrides. */
+  baseRoomKey: string;
+  agentId?: string;
+  channel: string;
+  accountId?: string;
+  peer: PluginHookResolveRoomKeyPeer;
+  messageId?: number;
+  threadId?: number;
+};
+
+export type PluginHookResolveRoomKeyResult = {
+  roomKey: string;
+};
+
+export type PluginHookResolveRoomKeyContext = {
+  channelId: string;
+  sessionKey?: string;
 };
 
 // agent_end hook
@@ -468,6 +503,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
+  resolve_room_key: (
+    event: PluginHookResolveRoomKeyEvent,
+    ctx: PluginHookResolveRoomKeyContext,
+  ) => Promise<PluginHookResolveRoomKeyResult | void> | PluginHookResolveRoomKeyResult | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,

--- a/src/routing/room-key.test.ts
+++ b/src/routing/room-key.test.ts
@@ -20,7 +20,6 @@ describe("resolve_room_key hook", () => {
     initializeGlobalHookRunner(makeRegistry([]));
 
     const roomKey = await resolveCanonicalRoomKey({
-      cfg: {},
       roomKey: "agent:main:telegram:dm:123",
       baseRoomKey: "agent:main:telegram:dm:123",
       event: {
@@ -52,7 +51,6 @@ describe("resolve_room_key hook", () => {
     initializeGlobalHookRunner(makeRegistry(hooks));
 
     const roomKey = await resolveCanonicalRoomKey({
-      cfg: {},
       roomKey: "agent:main:telegram:dm:123",
       baseRoomKey: "agent:main:telegram:dm:123",
       event: {
@@ -66,5 +64,67 @@ describe("resolve_room_key hook", () => {
 
     expect(roomKey).toBe("agent:main:telegram:dm:123:proj:proj-abc");
     expect(resolveSessionLane(roomKey)).toBe("session:agent:main:telegram:dm:123:proj:proj-abc");
+  });
+
+  it("falls back to computed key when hook returns empty/whitespace", async () => {
+    const hooks = [
+      {
+        hookName: "resolve_room_key",
+        pluginId: "test",
+        priority: 0,
+        handler: async () => ({ roomKey: "   " }),
+      },
+    ];
+
+    resetGlobalHookRunner();
+    initializeGlobalHookRunner(makeRegistry(hooks));
+
+    const roomKey = await resolveCanonicalRoomKey({
+      roomKey: "agent:main:telegram:dm:123",
+      baseRoomKey: "agent:main:telegram:dm:123",
+      event: {
+        agentId: "main",
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "dm", id: "123" },
+        messageId: 3,
+      },
+    });
+
+    expect(roomKey).toBe("agent:main:telegram:dm:123");
+  });
+
+  it("uses first valid answer in priority order", async () => {
+    const hooks = [
+      {
+        hookName: "resolve_room_key",
+        pluginId: "high",
+        priority: 10,
+        handler: async () => ({ roomKey: "agent:main:telegram:dm:123:hi" }),
+      },
+      {
+        hookName: "resolve_room_key",
+        pluginId: "low",
+        priority: 0,
+        handler: async () => ({ roomKey: "agent:main:telegram:dm:123:lo" }),
+      },
+    ];
+
+    resetGlobalHookRunner();
+    initializeGlobalHookRunner(makeRegistry(hooks));
+
+    const roomKey = await resolveCanonicalRoomKey({
+      roomKey: "agent:main:telegram:dm:123",
+      baseRoomKey: "agent:main:telegram:dm:123",
+      event: {
+        agentId: "main",
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "dm", id: "123" },
+        messageId: 4,
+      },
+    });
+
+    expect(roomKey).toBe("agent:main:telegram:dm:123:hi");
   });
 });

--- a/src/routing/room-key.test.ts
+++ b/src/routing/room-key.test.ts
@@ -127,4 +127,38 @@ describe("resolve_room_key hook", () => {
 
     expect(roomKey).toBe("agent:main:telegram:dm:123:hi");
   });
+
+  it("uses pluginId as a deterministic tie-breaker when priorities match", async () => {
+    const hooks = [
+      {
+        hookName: "resolve_room_key",
+        pluginId: "b",
+        priority: 0,
+        handler: async () => ({ roomKey: "agent:main:telegram:dm:123:b" }),
+      },
+      {
+        hookName: "resolve_room_key",
+        pluginId: "a",
+        priority: 0,
+        handler: async () => ({ roomKey: "agent:main:telegram:dm:123:a" }),
+      },
+    ];
+
+    resetGlobalHookRunner();
+    initializeGlobalHookRunner(makeRegistry(hooks));
+
+    const roomKey = await resolveCanonicalRoomKey({
+      roomKey: "agent:main:telegram:dm:123",
+      baseRoomKey: "agent:main:telegram:dm:123",
+      event: {
+        agentId: "main",
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "dm", id: "123" },
+        messageId: 5,
+      },
+    });
+
+    expect(roomKey).toBe("agent:main:telegram:dm:123:a");
+  });
 });

--- a/src/routing/room-key.test.ts
+++ b/src/routing/room-key.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { resolveCanonicalRoomKey } from "./room-key.js";
+import { resolveSessionLane } from "../agents/pi-embedded-runner/lanes.js";
+
+function makeRegistry(hooks: any[]) {
+  return {
+    hooks: [],
+    typedHooks: hooks,
+  } as any;
+}
+
+describe("resolve_room_key hook", () => {
+  it("leaves roomKey unchanged when no hooks are registered", async () => {
+    resetGlobalHookRunner();
+    initializeGlobalHookRunner(makeRegistry([]));
+
+    const roomKey = await resolveCanonicalRoomKey({
+      cfg: {},
+      roomKey: "agent:main:telegram:dm:123",
+      baseRoomKey: "agent:main:telegram:dm:123",
+      event: {
+        agentId: "main",
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "dm", id: "123" },
+        messageId: 1,
+      },
+    });
+
+    expect(roomKey).toBe("agent:main:telegram:dm:123");
+    expect(resolveSessionLane(roomKey)).toBe("session:agent:main:telegram:dm:123");
+  });
+
+  it("uses returned roomKey as canonical key (session identity + FIFO lane)", async () => {
+    const hooks = [
+      {
+        hookName: "resolve_room_key",
+        pluginId: "test",
+        priority: 0,
+        handler: async (event: any) => {
+          return { roomKey: `${event.roomKey}:proj:proj-abc` };
+        },
+      },
+    ];
+
+    resetGlobalHookRunner();
+    initializeGlobalHookRunner(makeRegistry(hooks));
+
+    const roomKey = await resolveCanonicalRoomKey({
+      cfg: {},
+      roomKey: "agent:main:telegram:dm:123",
+      baseRoomKey: "agent:main:telegram:dm:123",
+      event: {
+        agentId: "main",
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "dm", id: "123" },
+        messageId: 2,
+      },
+    });
+
+    expect(roomKey).toBe("agent:main:telegram:dm:123:proj:proj-abc");
+    expect(resolveSessionLane(roomKey)).toBe("session:agent:main:telegram:dm:123:proj:proj-abc");
+  });
+});

--- a/src/routing/room-key.ts
+++ b/src/routing/room-key.ts
@@ -1,5 +1,25 @@
+import crypto from "node:crypto";
+
 import type { PluginHookResolveRoomKeyEvent } from "../plugins/types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+const MAX_CANONICAL_ROOM_KEY_CHARS = 512;
+
+function sanitizeRoomKey(key: string): string {
+  // Treat plugin output as untrusted. Keep it mostly opaque, but remove control chars
+  // that can break logs/serialization.
+  return key.trim().replace(/[\u0000-\u001F\u007F]/g, "");
+}
+
+function clampRoomKey(key: string, maxChars = MAX_CANONICAL_ROOM_KEY_CHARS): string {
+  if (key.length <= maxChars) return key;
+
+  // Deterministic clamping: keep a readable prefix, append a stable hash suffix.
+  const hash = crypto.createHash("sha256").update(key).digest("hex").slice(0, 16);
+  const suffix = `~${hash}`;
+  const keep = Math.max(0, maxChars - suffix.length);
+  return `${key.slice(0, keep)}${suffix}`;
+}
 
 export async function resolveCanonicalRoomKey(params: {
   roomKey: string;
@@ -8,8 +28,9 @@ export async function resolveCanonicalRoomKey(params: {
 }): Promise<string> {
   // Core invariant: canonical room keys must never be empty.
   // If the computed key is somehow invalid, fall back to baseRoomKey.
-  const computed = params.roomKey.trim();
-  const fallback = computed || params.baseRoomKey.trim() || params.roomKey;
+  const computed = sanitizeRoomKey(params.roomKey);
+  const base = sanitizeRoomKey(params.baseRoomKey);
+  const fallback = clampRoomKey(computed || base || params.roomKey);
 
   const runner = getGlobalHookRunner();
   if (!runner?.hasHooks?.("resolve_room_key")) {
@@ -28,6 +49,7 @@ export async function resolveCanonicalRoomKey(params: {
     },
   );
 
-  const proposed = typeof out?.roomKey === "string" ? out.roomKey.trim() : "";
+  const proposedRaw = typeof out?.roomKey === "string" ? out.roomKey : "";
+  const proposed = clampRoomKey(sanitizeRoomKey(proposedRaw));
   return proposed ? proposed : fallback;
 }

--- a/src/routing/room-key.ts
+++ b/src/routing/room-key.ts
@@ -1,0 +1,31 @@
+import type { PluginHookResolveRoomKeyEvent } from "../plugins/types.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+export async function resolveCanonicalRoomKey(params: {
+  cfg: unknown;
+  roomKey: string;
+  baseRoomKey: string;
+  event: Omit<PluginHookResolveRoomKeyEvent, "roomKey" | "baseRoomKey">;
+}): Promise<string> {
+  const roomKey = params.roomKey.trim();
+  if (!roomKey) return roomKey;
+
+  const runner = getGlobalHookRunner();
+  if (!runner?.hasHooks?.("resolve_room_key")) {
+    return roomKey;
+  }
+
+  const out = await runner.runResolveRoomKey(
+    {
+      ...params.event,
+      roomKey,
+      baseRoomKey: params.baseRoomKey,
+    },
+    {
+      channelId: params.event.channel,
+      sessionKey: roomKey,
+    },
+  );
+
+  return typeof out?.roomKey === "string" && out.roomKey.trim() ? out.roomKey.trim() : roomKey;
+}

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -187,7 +187,6 @@ export const buildTelegramMessageContext = async ({
   // Allow plugins to deterministically refine the canonical room key used for both
   // transcript identity and FIFO lane ordering.
   sessionKey = await resolveCanonicalRoomKey({
-    cfg,
     roomKey: sessionKey,
     baseRoomKey: baseSessionKey,
     event: {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -27,6 +27,7 @@ import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import { resolveCanonicalRoomKey } from "../routing/room-key.js";
 import { shouldAckReaction as shouldAckReactionGate } from "../channels/ack-reactions.js";
 import { resolveMentionGatingWithBypass } from "../channels/mention-gating.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
@@ -181,7 +182,23 @@ export const buildTelegramMessageContext = async ({
     dmThreadId != null
       ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(dmThreadId) })
       : null;
-  const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+  let sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+
+  // Allow plugins to deterministically refine the canonical room key used for both
+  // transcript identity and FIFO lane ordering.
+  sessionKey = await resolveCanonicalRoomKey({
+    cfg,
+    roomKey: sessionKey,
+    baseRoomKey: baseSessionKey,
+    event: {
+      agentId: route.agentId,
+      channel: "telegram",
+      accountId: account.accountId,
+      peer: { kind: isGroup ? "group" : "dm", id: peerId },
+      messageId: msg.message_id,
+      threadId: messageThreadId,
+    },
+  });
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
   const effectiveDmAllow = normalizeAllowFromWithStore({ allowFrom, storeAllowFrom });
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -607,6 +607,9 @@ export const registerTelegramNativeCommands = ({
             isAuthorizedSender: commandAuthorized,
             commandBody,
             config: cfg,
+            messageId: msg.message_id,
+            threadId: messageThreadId,
+            chatId: chatId,
           });
           const tableMode = resolveMarkdownTableMode({
             cfg,


### PR DESCRIPTION
## Summary

This PR introduces a small, backward-compatible core hook that allows plugins to deterministically influence the canonical conversation identity ("RoomKey") used by OpenClaw for:

- session/transcript selection
- FIFO queue lane selection (ordering)

By default, behavior is unchanged.

## Motivation

OpenClaw’s pipeline already relies on a stable concept of "room/session identity" that drives both history selection and per-session serialization. Today, there is no first-class extension point for plugins to participate in that identity derivation, which forces plugins that need deterministic isolation to either patch channel internals (fragile) or rely on prompt-only scoping (best-effort).

This PR adds the minimal missing abstraction: a hook that lets plugins resolve a canonical RoomKey early in inbound context construction, before any session lookup or queueing occurs.

## Design goals

- Minimal surface area: one hook, one return value
- Backward compatible: default path unchanged
- One invariant: the same key is used for transcript identity and FIFO lane ordering
- Channel-agnostic core API (no "projects" concept in core)

## Proposed API

New hook: `resolve_room_key`

- Called after core computes the default session/room key.
- Plugins may return `{ roomKey }` to override the canonical key; returning `undefined` means no change.

Invariant:
- The returned `roomKey` is used as both the session identity key and the FIFO lane key.

## Implementation notes

- Adds helper: `resolveCanonicalRoomKey()` in `src/routing/room-key.ts` which calls the global hook runner if hooks are registered.
- Telegram inbound context builder calls `resolveCanonicalRoomKey()` after computing the base key.
- Plugin command context includes optional message metadata (`messageId`, `threadId`, `chatId`) to support deterministic semantics tied to monotonic message ids.

## Tests

- Unit test asserts:
  - no hook => roomKey unchanged
  - hook override => roomKey changes and the derived session lane uses the same key

## Non-goals

- No new user-facing features
- No Telegram-specific behavior beyond supplying normalized metadata into the hook
- No changes to default session semantics

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new plugin hook (`resolve_room_key`) plus a helper (`resolveCanonicalRoomKey`) to allow plugins to deterministically override the canonical “room key” used for session/transcript identity and FIFO lane ordering. Telegram inbound context now calls this helper after computing the base + thread session key, and plugin command execution gets optional message metadata (messageId/threadId/chatId) to support deterministic per-message semantics. A small unit test covers the default (no hook) and override paths.

Key risk areas are around conflict resolution when multiple plugins register the hook (priority semantics) and ensuring empty/whitespace keys can’t accidentally collapse session identity.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but has a couple of edge-case correctness concerns around room-key resolution semantics.
- Changes are small and mostly additive, with a clear test for the hook override path. Main concerns are (1) `resolve_room_key` merge semantics currently allow lower-priority hooks to override higher-priority ones when multiple plugins return different values, and (2) the helper’s empty/whitespace handling could collapse the canonical key if bad input slips through.
- src/plugins/hooks.ts, src/routing/room-key.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->