### PR TITLE
Docs: add memory flush setup guide

### DIFF
--- a/docs/guides/memory-flush-setup.md
+++ b/docs/guides/memory-flush-setup.md
@@ -1,0 +1,140 @@
+# Memory Flush Setup Guide
+
+**Datum:** 2026-01-31  
+**Zweck:** Proaktive Speicherung vor Gateway-Komprimierung verhindern Informationsverlust
+
+---
+
+## Problem
+
+OpenClaw komprimiert automatisch Session-History wenn das Token-Limit erreicht wird. Dabei gehen ältere Nachrichten **unwiderruflich** verloren. Der Agent "vergisst" wichtige Informationen.
+
+**Symptome:**
+- Agent behauptet, Fähigkeiten nicht zu haben (obwohl vorher besprochen)
+- Projektkontexte gehen verloren
+- Entscheidungen müssen wiederholt werden
+
+---
+
+## Lösung: Memory Flush
+
+OpenClaw hat ein **eingebautes Feature** namens "Memory Flush":
+- Vor Komprimierung bekommt der Agent einen **silent turn**
+- Prompt fordert zum Speichern wichtiger Infos auf
+- Agent schreibt in `memory/YYYY-MM-DD.md` und `MEMORY.md`
+
+**Das Feature ist standardmäßig aktiv**, aber der Default-Prompt ist zu passiv ("NO_REPLY is usually correct").
+
+---
+
+## Konfiguration
+
+### 1. openclaw.json anpassen
+
+Pfad: `~/.openclaw/openclaw.json`
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "mode": "safeguard",
+        "memoryFlush": {
+          "enabled": true,
+          "softThresholdTokens": 6000,
+          "prompt": "KRITISCH: Session nähert sich Komprimierung. Speichere JETZT alles Wichtige in memory/YYYY-MM-DD.md (erstelle memory/ falls nötig).\n\nDokumetiere:\n- Konkrete Dateipfade und Projekte\n- Getroffene Entscheidungen\n- Offene Tasks\n- Neue Erkenntnisse/Tools\n\nNICHT mit NO_REPLY antworten wenn heute substanzielle Arbeit passiert ist!",
+          "systemPrompt": "Pre-Compaction Memory Flush. Nach diesem Turn wird der Kontext komprimiert — ältere Nachrichten gehen UNWIDERRUFLICH verloren. Speichere ALLE wichtigen Informationen in Memory-Dateien. Sei detailliert. Bei Unsicherheit: lieber zu viel speichern als zu wenig."
+        }
+      }
+    }
+  }
+}
+```
+
+**Parameter erklärt:**
+- `softThresholdTokens: 6000` — Flush triggert 6000 Tokens vor Komprimierung (früher = mehr Zeit)
+- `prompt` — User-Prompt für den Flush-Turn (aggressiv formuliert)
+- `systemPrompt` — System-Kontext der die Dringlichkeit betont
+
+### 2. Config anwenden
+
+```bash
+openclaw gateway restart
+```
+
+Oder via Tool: `gateway.config.patch` mit dem JSON-Patch.
+
+---
+
+## AGENTS.md Ergänzung
+
+Füge diesen Block nach "Write It Down" ein:
+
+```markdown
+### 🚨 Konkret dokumentieren — nicht oberflächlich!
+Oberflächliche Notizen wie "Konzept erhalten" sind wertlos nach Komprimierung.
+
+**Sofort dokumentieren:**
+- Konkrete Pfade: `/home/demo/projects/pact-core/` statt "PACT-Projekt"
+- Was genau gebaut wurde: "Setup-Wizard, 450 Zeilen, Templates" statt "Prototyp"
+- Entscheidungen mit Begründung
+
+**MEMORY.md aktiv pflegen:**
+- Status-Updates direkt reinschreiben, nicht nur in Tagesnotizen
+- Bei wichtiger Arbeit: MEMORY.md sofort aktualisieren, nicht "später"
+
+**Git nutzen:**
+- `git log --oneline -10` zeigt was passiert ist
+- Commits sind Beweis — nicht ignorieren!
+
+**Vor Session-Ende / bei langer Session:**
+Quick-Check: "Was haben wir gemacht? Steht das drin?"
+- [ ] Neue Pfade in MEMORY.md?
+- [ ] Neue Tools/Fähigkeiten dokumentiert?
+- [ ] Offene Tasks notiert?
+```
+
+---
+
+## Verzeichnisstruktur
+
+```
+~/.openclaw/workspace/
+├── MEMORY.md              # Langzeit-Gedächtnis (kuratiert)
+├── AGENTS.md              # Verhaltensregeln
+├── memory/
+│   ├── 2026-01-31.md      # Tagesnotizen
+│   └── ...
+```
+
+**memory/ erstellen falls nicht vorhanden:**
+```bash
+mkdir -p ~/.openclaw/workspace/memory
+```
+
+---
+
+## Relevante Dokumentation
+
+- OpenClaw Memory Docs: `/usr/lib/node_modules/openclaw/docs/concepts/memory.md`
+- Compaction Docs: `/usr/lib/node_modules/openclaw/docs/concepts/compaction.md`
+- Memory Flush Code: `/usr/lib/node_modules/openclaw/dist/auto-reply/reply/memory-flush.js`
+
+---
+
+## Validierung
+
+Prüfen ob Config aktiv:
+```bash
+openclaw config get agents.defaults.compaction
+```
+
+Sollte `memoryFlush.enabled: true` zeigen.
+
+---
+
+## Changelog
+
+| Datum | Änderung |
+|-------|----------|
+| 2026-01-31 | Initiale Dokumentation, Config angepasst, AGENTS.md ergänzt |

--- a/sessions/2026-01-31/README.md
+++ b/sessions/2026-01-31/README.md
@@ -1,0 +1,52 @@
+# Session: Memory Flush Configuration
+
+**Datum:** 2026-01-31  
+**Session ID:** 84708ef7-f377-4195-bf05-902b6947ef85  
+**Teilnehmer:** Daniel (User), BERT (Agent)
+
+## Zusammenfassung
+
+Diese Session dokumentiert die Entdeckung und Konfiguration des OpenClaw Memory Flush Features.
+
+### Problem
+Nach einer Kontext-Komprimierung hatte der Agent wichtige Informationen verloren (z.B. dass `faster-whisper` installiert ist). Die automatische Zusammenfassung war "unavailable due to context limits".
+
+### Erkenntnisse
+
+1. **Memory Flush existiert bereits** in OpenClaw
+   - Dokumentiert in `/docs/concepts/memory.md`
+   - Code in `/dist/auto-reply/reply/memory-flush.js`
+   - Standardmäßig **aktiv** (`enabled: true`)
+
+2. **Das Problem:** Der Default-Prompt ist zu passiv
+   - Sagt "NO_REPLY is usually correct"
+   - Agent speichert nichts, obwohl wichtige Arbeit passiert ist
+
+3. **Die Lösung:** Aggressiverer Prompt
+   - `softThresholdTokens: 6000` (früher triggern)
+   - Deutscher Prompt: "KRITISCH: Session nähert sich Komprimierung..."
+   - Explizit: "NICHT mit NO_REPLY antworten wenn substanzielle Arbeit passiert ist"
+
+### Ergebnisse
+
+- Config in `openclaw.json` angepasst
+- AGENTS.md mit Dokumentations-Regeln ergänzt
+- Setup-Guide erstellt: `docs/guides/memory-flush-setup.md`
+- PR eingereicht: https://github.com/openclaw/openclaw/pull/5528
+
+## Dateien
+
+- `memory-flush-session.jsonl` — Vollständige Session-History (JSONL-Format)
+
+## Wie man die Session liest
+
+```bash
+# Alle User-Nachrichten extrahieren
+cat memory-flush-session.jsonl | jq 'select(.type == "human") | .message.content'
+
+# Alle Assistant-Antworten
+cat memory-flush-session.jsonl | jq 'select(.type == "assistant") | .message.content'
+
+# Tool-Calls anzeigen
+cat memory-flush-session.jsonl | jq 'select(.type == "tool_use") | {tool: .name, input: .input}'
+```


### PR DESCRIPTION
Practical guide for configuring proactive memory summaries before gateway compression.

## What this adds

- Step-by-step setup instructions
- JSON config with aggressive German prompts
- AGENTS.md additions for better documentation habits
- Validation commands
- Links to relevant source files

## Context

Based on session 2026-01-31 where we discovered the default memory flush prompts are too passive, leading to information loss after compaction.

Related: #1

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new documentation guide (`docs/guides/memory-flush-setup.md`) describing how to configure more proactive “memory flush” prompts to reduce information loss before compaction/gateway compression.

The guide includes an `openclaw.json` example, suggested `AGENTS.md` additions to encourage concrete note-taking, a recommended workspace/memory directory layout, and basic validation steps for confirming the configuration is active.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge since it only adds documentation, with a few correctness/maintainability nits worth addressing.
- Changes are confined to a single new markdown file; the main concerns are doc usability (language consistency), a small typo in the JSON example text, and hard-coded filesystem paths that may not work for most installations.
- docs/guides/memory-flush-setup.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->