### PR TITLE
fix(config): add missing customBindHost to gateway Zod schema [AI-assisted]

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/src/config/config.gateway-custom-bind-host.test.ts
+++ b/src/config/config.gateway-custom-bind-host.test.ts
@@ -13,11 +13,14 @@ describe("gateway.customBindHost", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("accepts customBindHost without bind mode", async () => {
+  it("accepts customBindHost with lan bind mode", async () => {
+    // customBindHost is documented for bind="custom", but Zod validates
+    // schema shape only - runtime handles semantic validation.
     vi.resetModules();
     const { validateConfigObject } = await import("./config.js");
     const res = validateConfigObject({
       gateway: {
+        bind: "lan",
         customBindHost: "10.0.0.5",
       },
     });

--- a/src/config/config.gateway-custom-bind-host.test.ts
+++ b/src/config/config.gateway-custom-bind-host.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("gateway.customBindHost", () => {
+  it("accepts custom bind mode with customBindHost", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "192.168.1.100",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts customBindHost without bind mode", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        customBindHost: "10.0.0.5",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts customBindHost with 0.0.0.0", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "0.0.0.0",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -314,6 +314,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        customBindHost: z.string().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds the missing `customBindHost` field to the gateway Zod validation schema.

## Problem

The TypeScript type `GatewayConfig` in `types.gateway.ts` includes `customBindHost`, but the Zod validation schema in `zod-schema.ts` was missing it. This caused config validation to fail with "Unrecognized key: customBindHost" when users set `bind: "custom"` with a custom IP address.

## Changes

- Added `customBindHost: z.string().optional()` to the gateway schema (after `bind` field)
- Added test coverage for `customBindHost` validation

## Test plan

- [x] New test file `config.gateway-custom-bind-host.test.ts` with 3 test cases
- [x] All tests pass (`pnpm exec vitest run src/config/config.gateway-custom-bind-host.test.ts`)
- [x] Lint clean on changed files

Fixes #5435

## AI Assistance

- [x] This PR was created with Claude Code
- **Testing level:** Fully tested (3 dedicated test cases, lint verified)
- **Understanding:** The fix adds a single line (`customBindHost: z.string().optional()`) to the Zod schema to match the existing TypeScript type definition. This allows the config validator to accept the `customBindHost` field when users configure `gateway.bind: "custom"` with a custom IP address.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the main config Zod schema (`src/config/zod-schema.ts`) to include the missing `gateway.customBindHost` field, aligning runtime validation with the existing `GatewayConfig` type. It also adds a small Vitest file (`src/config/config.gateway-custom-bind-host.test.ts`) to ensure configs containing `customBindHost` now validate successfully.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small schema alignment plus a targeted test, with one potential contract ambiguity around when `customBindHost` should be accepted.
- The core change (adding an optional schema key) is straightforward and matches the existing TypeScript type. The only notable risk is that the added test may lock in behavior (accepting `customBindHost` without `bind: "custom"`) that conflicts with the documented intent, depending on how strictly config validity should be enforced.
- src/config/config.gateway-custom-bind-host.test.ts; src/config/zod-schema.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->