### PR TITLE
fix(voice-call): hang up rejected inbound calls

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -312,6 +312,9 @@ export const VoiceCallConfigSchema = z
     /** Greeting message for inbound calls */
     inboundGreeting: z.string().optional(),
 
+    /** Hang up rejected inbound calls immediately (default: false, let carrier timeout) */
+    rejectHangup: z.boolean().default(false),
+
     /** Outbound call configuration */
     outbound: OutboundConfigSchema,
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -552,7 +552,13 @@ export class CallManager {
     if (!call && event.direction === "inbound" && event.providerCallId) {
       // Check if we should accept this inbound call
       if (!this.shouldAcceptInbound(event.from)) {
-        // TODO: Could hang up the call here
+        if (this.config.rejectHangup && this.provider) {
+          this.provider
+            .hangupCall({ providerCallId: event.providerCallId, reason: "hangup-bot" })
+            .catch((err) => {
+              console.warn("[voice-call] Failed to hang up rejected inbound call:", err);
+            });
+        }
         return;
       }
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -93,7 +93,13 @@ export function processEvent(ctx: CallManagerContext, event: NormalizedEvent): v
 
   if (!call && event.direction === "inbound" && event.providerCallId) {
     if (!shouldAcceptInbound(ctx.config, event.from)) {
-      // TODO: Could hang up the call here.
+      if (ctx.config.rejectHangup && ctx.provider) {
+        ctx.provider
+          .hangupCall({ providerCallId: event.providerCallId, reason: "hangup-bot" })
+          .catch((err) => {
+            console.warn("[voice-call] Failed to hang up rejected inbound call:", err);
+          });
+      }
       return;
     }
 

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -210,7 +210,8 @@ export type InitiateCallResult = {
 };
 
 export type HangupCallInput = {
-  callId: CallId;
+  /** Internal call ID (optional for provider-only hangups like rejected inbound) */
+  callId?: CallId;
   providerCallId: ProviderCallId;
   reason: EndReason;
 };


### PR DESCRIPTION
## Summary

Adds an optional `rejectHangup` config setting for the voice-call plugin. When enabled, rejected inbound calls are actively terminated via `hangupCall()` instead of silently returning (letting the carrier timeout).

**Default behavior unchanged** - `rejectHangup: false` preserves the current silent-return behavior.

## Changes

- Add `voiceCall.rejectHangup` config option (default: `false`)
- Make `HangupCallInput.callId` optional for provider-only hangups
- Only call `hangupCall()` when `rejectHangup` is enabled

## Why `callId` can be optional

Verified that no provider implementation uses `callId` in `hangupCall()`:

| Provider | Uses `callId`? | What it uses |
|----------|---------------|--------------|
| Twilio | No | `providerCallId` only |
| Telnyx | No | `providerCallId` only |
| Plivo | No | `providerCallId` only |
| Mock | No | No-op |

All providers only need `providerCallId` to make the hangup API call.

## Config example

```yaml
voiceCall:
  rejectHangup: true  # Actively hang up rejected calls
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Voice-call tests pass (26 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)