### PR TITLE
feat(config): add duplicate key detection for JSON5 config files

### DIFF
--- a/src/config/io.duplicate-keys.test.ts
+++ b/src/config/io.duplicate-keys.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { detectDuplicateKeys } from "./io.js";
+
+describe("detectDuplicateKeys", () => {
+  it("detects duplicate keys in top-level object", () => {
+    const raw = `{ key: "first", key: "second" }`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("key");
+  });
+
+  it("detects duplicate keys in nested object", () => {
+    const raw = `{ outer: { inner: 1, inner: 2 } }`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("outer.inner");
+  });
+
+  it("returns empty array when no duplicates", () => {
+    const raw = `{ a: 1, b: 2, c: 3 }`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("detects duplicates in top-level array with nested objects", () => {
+    const raw = `[{ key: "first", key: "duplicate" }]`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("key");
+  });
+
+  it("detects duplicates in multiple nested objects within array", () => {
+    const raw = `[
+      { a: 1 },
+      { b: 1, b: 2 },
+      { c: { d: 1, d: 2 } }
+    ]`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("handles empty array", () => {
+    const raw = `[]`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("handles empty object", () => {
+    const raw = `{}`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/config/io.duplicate-keys.test.ts
+++ b/src/config/io.duplicate-keys.test.ts
@@ -51,4 +51,33 @@ describe("detectDuplicateKeys", () => {
     const warnings = detectDuplicateKeys(raw);
     expect(warnings).toHaveLength(0);
   });
+
+  it("handles unterminated block comment at EOF", () => {
+    const raw = `{ a: 1 /* unterminated`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0); // should not crash
+  });
+
+  it("handles unterminated string at EOF", () => {
+    const raw = `{ a: "unterminated`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0); // should not crash
+  });
+
+  it("handles trailing slash at EOF", () => {
+    const raw = `{ a: 1 } /`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(0); // should not crash
+  });
+
+  it("detects duplicates after comments", () => {
+    const raw = `{
+      // comment
+      key: 1,
+      /* block */ key: 2
+    }`;
+    const warnings = detectDuplicateKeys(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("key");
+  });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -199,7 +199,6 @@ export type DuplicateKeyWarning = { path: string; message: string };
  */
 export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
   const warnings: DuplicateKeyWarning[] = [];
-  const keyStack: Map<string, boolean>[] = [];
   const pathStack: string[] = [];
   let i = 0;
 
@@ -290,13 +289,11 @@ export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
 
   const parseObj = (): void => {
     i++;
-    const keys = new Map<string, boolean>();
-    keyStack.push(keys);
+    const keys = new Set<string>();
     while (i < raw.length) {
       skipWs();
       if (raw[i] === "}") {
         i++;
-        keyStack.pop();
         return;
       }
       const key = raw[i] === '"' || raw[i] === "'" ? readString() : readUnquoted();
@@ -308,7 +305,7 @@ export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
         const path = [...pathStack, key].join(".");
         warnings.push({ path, message: `Duplicate key "${key}"` });
       } else {
-        keys.set(key, true);
+        keys.add(key);
       }
       skipWs();
       if (raw[i] === ":") {
@@ -322,7 +319,6 @@ export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
         i++;
       }
     }
-    keyStack.pop();
   };
 
   skipWs();

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -300,6 +300,7 @@ export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
 
   skipWs();
   if (raw[i] === "{") parseObj();
+  else if (raw[i] === "[") parseArr();
   return warnings;
 }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -191,6 +191,118 @@ function normalizeDeps(overrides: ConfigIoDeps = {}): Required<ConfigIoDeps> {
   };
 }
 
+export type DuplicateKeyWarning = { path: string; message: string };
+
+/**
+ * Detects duplicate keys in JSON/JSON5 text using a simple state machine.
+ * Returns warnings for each duplicate key found.
+ */
+export function detectDuplicateKeys(raw: string): DuplicateKeyWarning[] {
+  const warnings: DuplicateKeyWarning[] = [];
+  const keyStack: Map<string, boolean>[] = [];
+  const pathStack: string[] = [];
+  let i = 0;
+
+  const skipWs = () => {
+    while (i < raw.length) {
+      const c = raw[i];
+      if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+        i++;
+      } else if (c === "/" && raw[i + 1] === "/") {
+        while (i < raw.length && raw[i] !== "\n") i++;
+      } else if (c === "/" && raw[i + 1] === "*") {
+        i += 2;
+        while (i < raw.length && !(raw[i] === "*" && raw[i + 1] === "/")) i++;
+        i += 2;
+      } else {
+        break;
+      }
+    }
+  };
+
+  const readString = (): string | null => {
+    const q = raw[i];
+    if (q !== '"' && q !== "'") return null;
+    i++;
+    let s = "";
+    while (i < raw.length && raw[i] !== q) {
+      if (raw[i] === "\\") {
+        i++;
+        if (i < raw.length) s += raw[i++];
+      } else {
+        s += raw[i++];
+      }
+    }
+    i++;
+    return s;
+  };
+
+  const readUnquoted = (): string | null => {
+    const start = i;
+    while (i < raw.length && /[a-zA-Z0-9_$]/.test(raw[i])) i++;
+    return i > start ? raw.slice(start, i) : null;
+  };
+
+  const skipValue = (): void => {
+    skipWs();
+    if (raw[i] === "{") parseObj();
+    else if (raw[i] === "[") parseArr();
+    else if (raw[i] === '"' || raw[i] === "'") readString();
+    else while (i < raw.length && !/[,}\]\s]/.test(raw[i])) i++;
+  };
+
+  const parseArr = (): void => {
+    i++;
+    while (i < raw.length) {
+      skipWs();
+      if (raw[i] === "]") {
+        i++;
+        return;
+      }
+      skipValue();
+      skipWs();
+      if (raw[i] === ",") i++;
+    }
+  };
+
+  const parseObj = (): void => {
+    i++;
+    const keys = new Map<string, boolean>();
+    keyStack.push(keys);
+    while (i < raw.length) {
+      skipWs();
+      if (raw[i] === "}") {
+        i++;
+        keyStack.pop();
+        return;
+      }
+      const key = raw[i] === '"' || raw[i] === "'" ? readString() : readUnquoted();
+      if (!key) {
+        i++;
+        continue;
+      }
+      if (keys.has(key)) {
+        const path = [...pathStack, key].join(".");
+        warnings.push({ path, message: `Duplicate key "${key}"` });
+      } else {
+        keys.set(key, true);
+      }
+      skipWs();
+      if (raw[i] === ":") i++;
+      pathStack.push(key);
+      skipValue();
+      pathStack.pop();
+      skipWs();
+      if (raw[i] === ",") i++;
+    }
+    keyStack.pop();
+  };
+
+  skipWs();
+  if (raw[i] === "{") parseObj();
+  return warnings;
+}
+
 export function parseConfigJson5(
   raw: string,
   json5: { parse: (value: string) => unknown } = JSON5,
@@ -353,6 +465,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     try {
       const raw = deps.fs.readFileSync(configPath, "utf-8");
       const hash = hashConfigRaw(raw);
+
+      // Detect duplicate keys before parsing
+      const duplicateKeyWarnings = detectDuplicateKeys(raw);
+
       const parsedRes = parseConfigJson5(raw, deps.json5);
       if (!parsedRes.ok) {
         return {
@@ -364,7 +480,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: {},
           hash,
           issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
-          warnings: [],
+          warnings: duplicateKeyWarnings,
           legacyIssues: [],
         };
       }
@@ -390,7 +506,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: coerceConfig(parsedRes.parsed),
           hash,
           issues: [{ path: "", message }],
-          warnings: [],
+          warnings: duplicateKeyWarnings,
           legacyIssues: [],
         };
       }
@@ -418,7 +534,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: coerceConfig(resolved),
           hash,
           issues: [{ path: "", message }],
-          warnings: [],
+          warnings: duplicateKeyWarnings,
           legacyIssues: [],
         };
       }
@@ -437,7 +553,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: coerceConfig(resolvedConfigRaw),
           hash,
           issues: validated.issues,
-          warnings: validated.warnings,
+          warnings: [...duplicateKeyWarnings, ...validated.warnings],
           legacyIssues,
         };
       }
@@ -460,7 +576,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         ),
         hash,
         issues: [],
-        warnings: validated.warnings,
+        warnings: [...duplicateKeyWarnings, ...validated.warnings],
         legacyIssues,
       };
     } catch (err) {


### PR DESCRIPTION
## Summary

Adds duplicate key detection for JSON5 config files. This is a feature migration from OpenCode (see opencode#11130).

## Problem

When users have duplicate keys in their config, JSON5.parse() silently overwrites the first value with the second. Users have no way to know their config has an error.

```json5
{
  model: "gpt-4",
  model: "claude-3",  // silently overwrites, user doesn't know
}
```

## Solution

Added a simple state machine parser `detectDuplicateKeys()` that scans JSON5 text and detects duplicate keys at each object level. Duplicate keys are reported as warnings in the config snapshot.

## Implementation

- ~90 lines of code in `src/config/io.ts`
- No new dependencies
- Supports JSON5 features: comments, unquoted keys, single-quoted strings
- Supports top-level arrays (fixed in follow-up commit)
- Warnings are merged with existing validation warnings

## Testing

- Unit tests for duplicate key detection
- Tests for top-level objects and arrays
- Tests for nested objects