### PR TITLE
fix(discord): Add thread archive/lock support to channel-edit action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Agents: prevent file descriptor leaks in child process cleanup. (#13565) Thanks @KyleChen26.
 - Agents: prevent double compaction caused by cache TTL bypassing guard. (#13514) Thanks @taw0002.
 - Agents: use last API call's cache tokens for context display instead of accumulated sum. (#13805) Thanks @akari-musubi.
+- Discord: allow channel-edit to archive/lock threads and set auto-archive duration. (#5542) Thanks @stumct.
 - Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.
 - Tests: update thread ID handling in Slack message collection tests. (#14108) Thanks @swizzmagik.
 

--- a/src/channels/plugins/actions/discord/handle-action.test.ts
+++ b/src/channels/plugins/actions/discord/handle-action.test.ts
@@ -32,4 +32,27 @@ describe("handleDiscordMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("forwards thread edit fields for channel-edit", async () => {
+    await handleDiscordMessageAction({
+      action: "channel-edit",
+      params: {
+        channelId: "123456789",
+        archived: true,
+        locked: false,
+        autoArchiveDuration: 1440,
+      },
+      cfg: {},
+    });
+    expect(handleDiscordAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "channelEdit",
+        channelId: "123456789",
+        archived: true,
+        locked: false,
+        autoArchiveDuration: 1440,
+      }),
+      expect.any(Object),
+    );
+  });
 });


### PR DESCRIPTION
## Problem

The `channel-edit` action was silently failing to archive Discord threads even when the bot had `ManageThreads` permission. The action was missing support for thread-specific parameters.

## Root Cause

The `DiscordChannelEdit` type and `editChannelDiscord` function only supported channel properties (name, topic, position, etc.) but not thread-specific properties required by Discord's API:
- `archived` (boolean) - Archive/unarchive a thread
- `locked` (boolean) - Lock/unlock a thread
- `auto_archive_duration` (number) - Set auto-archive duration

## Solution

Added support for thread management parameters:
1. Updated `DiscordChannelEdit` type to include `archived`, `locked`, and `autoArchiveDuration`
2. Modified `editChannelDiscord()` to send these fields to Discord's API
3. Updated action handlers to read and pass these parameters through the call chain

## Testing

Verified that:
- Bots with `ManageThreads` permission can now archive threads via `message channel-edit --archived true`
- Thread locking works via `--locked true`
- Existing channel-edit functionality (name, topic, etc.) remains unchanged

## Files Changed

- `src/discord/send.types.ts` - Added thread params to type
- `src/discord/send.channels.ts` - Added params to API request body
- `src/agents/tools/discord-actions-guild.ts` - Read and pass params
- `src/channels/plugins/actions/discord/handle-action.guild-admin.ts` - Read params from tool args

Fixes issue where Discord thread archiving was silently failing despite correct permissions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the Discord `channelEdit` action to support thread-specific edit fields (`archived`, `locked`, `autoArchiveDuration`) by threading them through the action handlers (`handle-action.guild-admin.ts` and `discord-actions-guild.ts`), widening `DiscordChannelEdit`, and adding the corresponding REST payload fields (`archived`, `locked`, `auto_archive_duration`) in `editChannelDiscord`.

Overall this is a straightforward pass-through change consistent with existing patterns (only include fields when defined), and it should address the previous inability to archive/lock threads via the action surface.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one input-parsing issue that can cause runtime API errors in some invocation paths.
- The change is small and localized and mainly adds optional fields to an existing REST patch payload. The main concern is inconsistent boolean parsing: one call path type-checks booleans, while another uses unchecked casts that can pass non-boolean values to Discord and trigger 400 responses.
- src/agents/tools/discord-actions-guild.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->