### PR TITLE
fix: restore telegram draft streaming partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: restore draft streaming partials. (#5543) Thanks @obviyus.
+
 ## 2026.1.30
 
 ### Changes

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -385,6 +385,7 @@ openclaw cron add \
 ```
 
 Agent selection (multi-agent setups):
+
 ```bash
 # Pin a job to agent "ops" (falls back to default if that agent is missing)
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
@@ -395,6 +396,7 @@ openclaw cron edit <jobId> --clear-agent
 ```
 
 Manual run (debug):
+
 ```bash
 openclaw cron run <jobId> --force
 ```

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -109,6 +109,18 @@ group messages, so use admin if you need full visibility.
 - Long-polling uses grammY runner with per-chat sequencing; overall concurrency is capped by `agents.defaults.maxConcurrent`.
 - Telegram Bot API does not support read receipts; there is no `sendReadReceipts` option.
 
+## Draft streaming
+
+OpenClaw can stream partial replies in Telegram DMs using `sendMessageDraft`.
+
+Requirements:
+
+- Threaded Mode enabled for the bot in @BotFather (forum topic mode).
+- Private chat threads only (Telegram includes `message_thread_id` on inbound messages).
+- `channels.telegram.streamMode` not set to `"off"` (default: `"partial"`, `"block"` enables chunked draft updates).
+
+Draft streaming is DM-only; Telegram does not support it in groups or channels.
+
 ## Formatting (Telegram HTML)
 
 - Outbound Telegram text uses `parse_mode: "HTML"` (Telegram’s supported tag subset).

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -302,4 +302,5 @@ export function handleMessageEnd(
   ctx.state.blockState.final = false;
   ctx.state.blockState.inlineCode = createInlineCodeState();
   ctx.state.lastStreamedAssistant = undefined;
+  ctx.state.lastStreamedAssistantCleaned = undefined;
 }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -38,6 +38,7 @@ export type EmbeddedPiSubscribeState = {
   blockBuffer: string;
   blockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
   lastStreamedAssistant?: string;
+  lastStreamedAssistantCleaned?: string;
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   assistantMessageIndex: number;
@@ -79,6 +80,10 @@ export type EmbeddedPiSubscribeContext = {
   flushBlockReplyBuffer: () => void;
   emitReasoningStream: (text: string) => void;
   consumeReplyDirectives: (
+    text: string,
+    options?: { final?: boolean },
+  ) => ReplyDirectiveParseResult | null;
+  consumePartialReplyDirectives: (
     text: string,
     options?: { final?: boolean },
   ) => ReplyDirectiveParseResult | null;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -37,6 +37,7 @@ export type EmbeddedPiSubscribeState = {
   deltaBuffer: string;
   blockBuffer: string;
   blockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
+  partialBlockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
   lastStreamedAssistant?: string;
   lastStreamedAssistantCleaned?: string;
   lastStreamedReasoning?: string;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -46,6 +46,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
     blockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
+    partialBlockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
     lastStreamedAssistant: undefined,
     lastStreamedAssistantCleaned: undefined,
     lastStreamedReasoning: undefined,
@@ -89,6 +90,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.blockState.thinking = false;
     state.blockState.final = false;
     state.blockState.inlineCode = createInlineCodeState();
+    state.partialBlockState.thinking = false;
+    state.partialBlockState.final = false;
+    state.partialBlockState.inlineCode = createInlineCodeState();
     state.lastStreamedAssistant = undefined;
     state.lastStreamedAssistantCleaned = undefined;
     state.lastBlockReplyText = undefined;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -47,6 +47,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
     blockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
     lastStreamedAssistant: undefined,
+    lastStreamedAssistantCleaned: undefined,
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     assistantMessageIndex: 0,
@@ -77,16 +78,19 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const pendingMessagingTexts = state.pendingMessagingTexts;
   const pendingMessagingTargets = state.pendingMessagingTargets;
   const replyDirectiveAccumulator = createStreamingDirectiveAccumulator();
+  const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
     state.deltaBuffer = "";
     state.blockBuffer = "";
     blockChunker?.reset();
     replyDirectiveAccumulator.reset();
+    partialReplyDirectiveAccumulator.reset();
     state.blockState.thinking = false;
     state.blockState.final = false;
     state.blockState.inlineCode = createInlineCodeState();
     state.lastStreamedAssistant = undefined;
+    state.lastStreamedAssistantCleaned = undefined;
     state.lastBlockReplyText = undefined;
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
@@ -447,6 +451,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
     replyDirectiveAccumulator.consume(text, options);
+  const consumePartialReplyDirectives = (text: string, options?: { final?: boolean }) =>
+    partialReplyDirectiveAccumulator.consume(text, options);
 
   const flushBlockReplyBuffer = () => {
     if (!params.onBlockReply) {
@@ -509,6 +515,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     flushBlockReplyBuffer,
     emitReasoningStream,
     consumeReplyDirectives,
+    consumePartialReplyDirectives,
     resetAssistantMessageState,
     resetForCompactionRetry,
     finalizeAssistantTexts,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -163,6 +163,7 @@ export const buildTelegramMessageContext = async ({
     isForum,
     messageThreadId,
   });
+  const replyThreadId = isGroup ? resolvedThreadId : messageThreadId;
   const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, resolvedThreadId);
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const route = resolveAgentRoute({
@@ -205,7 +206,7 @@ export const buildTelegramMessageContext = async ({
   const sendTyping = async () => {
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
-      fn: () => bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(resolvedThreadId)),
+      fn: () => bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(replyThreadId)),
     });
   };
 
@@ -214,7 +215,7 @@ export const buildTelegramMessageContext = async ({
       await withTelegramApiErrorLogging({
         operation: "sendChatAction",
         fn: () =>
-          bot.api.sendChatAction(chatId, "record_voice", buildTypingThreadParams(resolvedThreadId)),
+          bot.api.sendChatAction(chatId, "record_voice", buildTypingThreadParams(replyThreadId)),
       });
     } catch (err) {
       logVerbose(`telegram record_voice cue failed for chat ${chatId}: ${String(err)}`);
@@ -672,6 +673,7 @@ export const buildTelegramMessageContext = async ({
     chatId,
     isGroup,
     resolvedThreadId,
+    replyThreadId,
     isForum,
     historyKey,
     historyLimit,

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createTelegramDraftStream = vi.hoisted(() => vi.fn());
+const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
+const deliverReplies = vi.hoisted(() => vi.fn());
+
+vi.mock("./draft-stream.js", () => ({
+  createTelegramDraftStream,
+}));
+
+vi.mock("../auto-reply/reply/provider-dispatcher.js", () => ({
+  dispatchReplyWithBufferedBlockDispatcher,
+}));
+
+vi.mock("./bot/delivery.js", () => ({
+  deliverReplies,
+}));
+
+vi.mock("./sticker-cache.js", () => ({
+  cacheSticker: vi.fn(),
+  describeStickerImage: vi.fn(),
+}));
+
+import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+
+describe("dispatchTelegramMessage draft streaming", () => {
+  beforeEach(() => {
+    createTelegramDraftStream.mockReset();
+    dispatchReplyWithBufferedBlockDispatcher.mockReset();
+    deliverReplies.mockReset();
+  });
+
+  it("streams drafts in private threads and forwards thread id", async () => {
+    const draftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+    };
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hello" });
+        await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const resolveBotTopicsEnabled = vi.fn().mockResolvedValue(true);
+    const context = {
+      ctxPayload: {},
+      primaryCtx: { message: { chat: { id: 123, type: "private" } } },
+      msg: {
+        chat: { id: 123, type: "private" },
+        message_id: 456,
+        message_thread_id: 777,
+      },
+      chatId: 123,
+      isGroup: false,
+      resolvedThreadId: undefined,
+      replyThreadId: 777,
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: { agentId: "default", accountId: "default" },
+      skillFilter: undefined,
+      sendTyping: vi.fn(),
+      sendRecordVoice: vi.fn(),
+      ackReactionPromise: null,
+      reactionApi: null,
+      removeAckAfterReply: false,
+    };
+
+    await dispatchTelegramMessage({
+      context,
+      bot: { api: {} },
+      cfg: {},
+      runtime: {},
+      replyToMode: "first",
+      streamMode: "partial",
+      textLimit: 4096,
+      telegramCfg: {},
+      opts: {},
+      resolveBotTopicsEnabled,
+    });
+
+    expect(resolveBotTopicsEnabled).toHaveBeenCalledWith(context.primaryCtx);
+    expect(createTelegramDraftStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 123,
+        messageThreadId: 777,
+      }),
+    );
+    expect(draftStream.update).toHaveBeenCalledWith("Hello");
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageThreadId: 777,
+      }),
+    );
+  });
+});

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -70,11 +70,12 @@ export const dispatchTelegramMessage = async ({
 
   const isPrivateChat = msg.chat.type === "private";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+  const draftThreadId = replyThreadId ?? messageThreadId;
   const draftMaxChars = Math.min(textLimit, 4096);
   const canStreamDraft =
     streamMode !== "off" &&
     isPrivateChat &&
-    typeof messageThreadId === "number" &&
+    typeof draftThreadId === "number" &&
     (await resolveBotTopicsEnabled(primaryCtx));
   const draftStream = canStreamDraft
     ? createTelegramDraftStream({
@@ -82,7 +83,7 @@ export const dispatchTelegramMessage = async ({
         chatId,
         draftId: msg.message_id || Date.now(),
         maxChars: draftMaxChars,
-        messageThreadId: replyThreadId,
+        messageThreadId: draftThreadId,
         log: logVerbose,
         warn: logVerbose,
       })

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -1,5 +1,4 @@
 import { formatLocationText, type NormalizedLocation } from "../../channels/location.js";
-import type { TelegramAccountConfig } from "../../config/types.telegram.js";
 import type {
   TelegramForwardChat,
   TelegramForwardOrigin,
@@ -61,9 +60,9 @@ export function buildTypingThreadParams(messageThreadId?: number) {
   return { message_thread_id: Math.trunc(messageThreadId) };
 }
 
-export function resolveTelegramStreamMode(
-  telegramCfg: Pick<TelegramAccountConfig, "streamMode"> | undefined,
-): TelegramStreamMode {
+export function resolveTelegramStreamMode(telegramCfg?: {
+  streamMode?: TelegramStreamMode;
+}): TelegramStreamMode {
   const raw = telegramCfg?.streamMode?.trim().toLowerCase();
   if (raw === "off" || raw === "partial" || raw === "block") {
     return raw;

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTelegramDraftStream } from "./draft-stream.js";
+
+describe("createTelegramDraftStream", () => {
+  it("passes message_thread_id when provided", () => {
+    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+    const stream = createTelegramDraftStream({
+      api: api as any,
+      chatId: 123,
+      draftId: 42,
+      messageThreadId: 99,
+    });
+
+    stream.update("Hello");
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
+      message_thread_id: 99,
+    });
+  });
+
+  it("omits message_thread_id for general topic id", () => {
+    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+    const stream = createTelegramDraftStream({
+      api: api as any,
+      chatId: 123,
+      draftId: 42,
+      messageThreadId: 1,
+    });
+
+    stream.update("Hello");
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
+  });
+});

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -74,13 +74,17 @@ export function createTelegramDraftStream(params: {
       return;
     }
     const text = pendingText;
-    pendingText = "";
-    if (!text.trim()) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      if (pendingText === text) {
+        pendingText = "";
+      }
       if (pendingText) {
         schedule();
       }
       return;
     }
+    pendingText = "";
     inFlight = true;
     try {
       await sendDraft(text);

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { buildTelegramThreadParams } from "./bot/helpers.js";
 
 const TELEGRAM_DRAFT_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 300;
@@ -24,10 +25,7 @@ export function createTelegramDraftStream(params: {
   const rawDraftId = Number.isFinite(params.draftId) ? Math.trunc(params.draftId) : 1;
   const draftId = rawDraftId === 0 ? 1 : Math.abs(rawDraftId);
   const chatId = params.chatId;
-  const threadParams =
-    typeof params.messageThreadId === "number"
-      ? { message_thread_id: Math.trunc(params.messageThreadId) }
-      : undefined;
+  const threadParams = buildTelegramThreadParams(params.messageThreadId);
 
   let lastSentText = "";
   let lastSentAt = 0;


### PR DESCRIPTION
## Summary
- fix Telegram draft streaming to keep partial updates flowing across split reply tags
- route DM thread ids into draft streaming + reply sends
- add regression coverage for draft streaming and reply tag partials

## Testing
- pnpm test src/telegram/draft-stream.test.ts src/telegram/bot-message-dispatch.test.ts src/agents/pi-embedded-subscribe.reply-tags.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR restores Telegram DM draft streaming and fixes partial streaming behavior when reply directives (e.g. `[[reply_to:...]]`) are split across streaming chunks. It does this by introducing a separate streaming directive accumulator for partial updates in the embedded PI subscriber, routing DM `message_thread_id` through message context into draft streaming + reply delivery, and adding regression tests around draft streaming and reply-tag handling.

Key integration points are in `buildTelegramMessageContext` (computing `replyThreadId` for DMs vs forum topics) and `dispatchTelegramMessage` (creating a draft stream only when private topic threads are present and topics are enabled).

<h3>Confidence Score: 3/5</h3>

- This PR looks reasonably safe to merge, but has a couple of edge-case state and scheduling issues worth fixing first.
- Core changes align with the stated intent and are covered by new tests, but there are two logic-level edge cases: (1) the draft-stream `flush()` branch that can never reschedule due to clearing `pendingText` before checking it, and (2) partial streaming state (`lastStreamedAssistantCleaned`) not being reset in the message-end path, which could misbehave under late/duplicate events (a scenario the code already calls out).
- src/telegram/draft-stream.ts, src/agents/pi-embedded-subscribe.handlers.messages.ts, src/telegram/bot-message-dispatch.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->