### PR TITLE
feat(logging): add server-side logging for API errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -360,6 +360,7 @@ export async function runEmbeddedPiAgent(
 
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
+            log.error(`API error [${provider}/${modelId}]: ${errorText}`);
             if (isContextOverflowError(errorText)) {
               const isCompactionFailure = isCompactionFailureError(errorText);
               // Attempt auto-compaction on context overflow (not compaction_failure)
@@ -527,6 +528,9 @@ export async function runEmbeddedPiAgent(
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
+          if (lastAssistant?.errorMessage) {
+            log.error(`API error [${provider}/${modelId}]: ${lastAssistant.errorMessage}`);
+          }
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
 


### PR DESCRIPTION
## Summary
- Added  calls to capture API errors server-side
- Errors like 403/401/rate-limits now appear in gateway logs
- Helps operators diagnose API issues without client access

## Problem
API errors (403, 401, rate limits, etc.) were only sent to clients but not logged server-side. This made debugging authentication issues and API failures difficult.

## Solution
Added logging in two locations in :
1. When  occurs during API calls
2. When  contains an error response

Now errors appear in logs as:


## Test plan
- [x] Tested with revoked OAuth token - error now appears in 
- [x] Verified logging format includes provider, model, and full error message

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds server-side logging for provider/model API errors in the embedded PI runner (`runEmbeddedPiAgent`), capturing both prompt submission failures (`promptError`) and assistant error responses (`lastAssistant.errorMessage`). The intent is to surface auth/rate-limit/403-style failures in gateway logs to improve operator debugging without client access.

Most of the change is localized to `src/agents/pi-embedded-runner/run.ts` and integrates with the existing per-run provider/model context already used by other log lines.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and localized to logging paths.
- The diff only adds two `log.error` statements without altering control flow, so functional behavior should remain unchanged. The main remaining concerns are operational (log noise/duplication and losing structured error metadata when stringifying).
- src/agents/pi-embedded-runner/run.ts (logging volume/format)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->