### PR TITLE
fix: skip audio/video from text extraction in extractFileBlocks

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -257,7 +257,11 @@ async function extractFileBlocks(params: {
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
     const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
-    if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
+    // Always skip audio/video from text extraction — they're handled by the
+    // transcription/description pipeline in runCapability. The old `!textLike`
+    // guard was fooled by resolveUtf16Charset detecting binary null bytes as
+    // UTF-16, causing raw binary to be dumped as a <file> block.
+    if (!forcedTextMimeResolved && (kind === "audio" || kind === "video")) {
       continue;
     }
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;


### PR DESCRIPTION
## Summary

Always skip audio/video from text extraction in `extractFileBlocks` — they are handled by the transcription/description pipeline in `runCapability`.

## Problem

The old `!textLike` guard was bypassed by `resolveUtf16Charset` detecting binary null bytes in OGG/audio data as UTF-16, causing raw binary content to be dumped as a `<file>` block in the conversation.

## Fix

Replace the `kind === "audio" && !textLike` condition with `kind === "audio" || kind === "video"` to unconditionally skip both audio and video files from text extraction, since they have their own dedicated processing pipeline.

Fixes #5209

---

*Split from #5236 as requested by @sfo2001.*