### PR TITLE
fix(session): strip malformed tool_use blocks to prevent session corruption

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import {
+  repairToolUseResultPairing,
+  sanitizeToolUseResultPairing,
+} from "./session-transcript-repair.js";
 
 describe("sanitizeToolUseResultPairing", () => {
   it("moves tool results directly after tool calls and inserts missing results", () => {
@@ -108,5 +111,195 @@ describe("sanitizeToolUseResultPairing", () => {
     const out = sanitizeToolUseResultPairing(input);
     expect(out.some((m) => m.role === "toolResult")).toBe(false);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+});
+
+describe("repairToolUseResultPairing malformed tool_use stripping", () => {
+  // Reproduces the root cause of issues #5497, #5481, #5430, #5518:
+  // Malformed tool_use blocks (from interrupted tool calls) cause API rejections:
+  // - "unexpected tool_use_id found in tool_result blocks"
+  // - "tool result's tool id not found (2013)"
+  // The fix: strip malformed blocks before pairing repair runs.
+
+  it("strips tool_use blocks with missing id", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", name: "read", arguments: {} },
+          { type: "text", text: "hello" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+    expect((assistantContent![0] as { type: string }).type).toBe("text");
+  });
+
+  it("strips tool_use blocks with empty string id", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "", name: "read", arguments: {} },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+  });
+
+  it("strips tool_use blocks with partialJson field", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "read", arguments: {}, partialJson: '{"foo":' },
+          { type: "text", text: "done" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+    expect((assistantContent![0] as { type: string }).type).toBe("text");
+  });
+
+  it("strips tool_use blocks with missing name", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", arguments: {} },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+  });
+
+  it("keeps valid blocks while stripping malformed ones", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_valid", name: "read", arguments: {} },
+          { type: "toolCall", id: "", name: "write", arguments: {} }, // malformed: empty id
+          { type: "text", text: "text block" },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_valid",
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(2); // valid toolCall + text
+    expect((assistantContent![0] as { id?: string }).id).toBe("call_valid");
+    // Should not create synthetic result for the stripped malformed block
+    expect(report.added).toHaveLength(0);
+  });
+
+  it("preserves error assistant messages after stripping all tool blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: {} }], // missing id
+        stopReason: "error",
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    expect(report.messages).toHaveLength(1);
+    expect((report.messages[0] as { stopReason?: string }).stopReason).toBe("error");
+    expect((report.messages[0] as { content?: unknown[] }).content).toHaveLength(0);
+  });
+
+  it("does not create synthetic results for stripped malformed blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", name: "read", arguments: {} }, // malformed: no id
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    expect(report.added).toHaveLength(0);
+  });
+
+  it("report includes droppedMalformedToolUseCount", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report).toHaveProperty("droppedMalformedToolUseCount");
+    expect(report.droppedMalformedToolUseCount).toBe(0);
+  });
+
+  it("recovers from interrupted tool call (session corruption scenario)", () => {
+    // This simulates the exact scenario from issues #5497, #5481, #5430, #5518:
+    // A tool call is interrupted mid-stream (error, timeout, content filtering, or process death).
+    // The session file contains a malformed tool_use block with no id.
+    // Without the fix, every subsequent API request fails because the API expects
+    // a matching tool_result for every tool_use, but we can't provide one for an id-less block.
+    const corruptedSession = [
+      { role: "user", content: "read file.txt" },
+      {
+        role: "assistant",
+        content: [
+          // Interrupted tool call - no id assigned before the stream was cut
+          { type: "toolCall", name: "read", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      // User tries again after the error
+      { role: "user", content: "try again" },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(corruptedSession);
+
+    // The malformed tool_use block should be stripped
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    // No synthetic results should be created for the stripped block
+    expect(report.added).toHaveLength(0);
+    // Session should be usable again: user, (empty) assistant with error, user
+    expect(report.messages).toHaveLength(3);
+    expect(report.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    // The error assistant message is preserved (with empty content) for debugging
+    const errorAssistant = report.messages[1] as { stopReason?: string; content?: unknown[] };
+    expect(errorAssistant.stopReason).toBe("error");
+    expect(errorAssistant.content).toHaveLength(0);
   });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -5,6 +5,92 @@ type ToolCallLike = {
   name?: string;
 };
 
+/**
+ * Check if a content block is a valid tool_use/toolCall/functionCall block.
+ * Returns true for non-tool blocks (they pass through) and valid tool blocks.
+ * Returns false for malformed tool blocks that should be stripped.
+ */
+function isValidToolUseBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return true; // Non-objects pass through
+  }
+  const rec = block as {
+    type?: unknown;
+    id?: unknown;
+    name?: unknown;
+    partialJson?: unknown;
+  };
+  // Only validate tool-related types
+  if (rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall") {
+    return true;
+  }
+  // Malformed: missing/invalid id, missing name, or has partialJson (indicates interrupted serialization)
+  if (typeof rec.id !== "string" || !rec.id) {
+    return false;
+  }
+  if (typeof rec.name !== "string") {
+    return false;
+  }
+  if (rec.partialJson !== undefined) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Strip malformed tool_use blocks from assistant messages.
+ * This must run BEFORE pairing repair to prevent creating synthetic results for invalid blocks.
+ */
+function stripMalformedToolUseBlocks(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  droppedMalformedCount: number;
+} {
+  let droppedMalformedCount = 0;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      out.push(msg);
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    const content = assistant.content;
+    if (!Array.isArray(content)) {
+      out.push(msg);
+      continue;
+    }
+
+    const validContent = content.filter((block) => {
+      const valid = isValidToolUseBlock(block);
+      if (!valid) {
+        droppedMalformedCount += 1;
+      }
+      return valid;
+    });
+
+    if (validContent.length === content.length) {
+      out.push(msg);
+    } else if (validContent.length === 0) {
+      // Keep empty assistant with stopReason: "error" for error tracking
+      const stopReason = (assistant as { stopReason?: unknown }).stopReason;
+      if (stopReason === "error") {
+        out.push({ ...assistant, content: [] } as typeof assistant);
+      }
+      // Otherwise drop the empty assistant message entirely
+    } else {
+      out.push({ ...assistant, content: validContent } as typeof assistant);
+    }
+  }
+
+  return { messages: droppedMalformedCount > 0 ? out : messages, droppedMalformedCount };
+}
+
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
@@ -75,10 +161,15 @@ export type ToolUseRepairReport = {
   added: Array<Extract<AgentMessage, { role: "toolResult" }>>;
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
+  droppedMalformedToolUseCount: number;
   moved: boolean;
 };
 
 export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRepairReport {
+  // Strip malformed tool_use blocks first to prevent creating synthetic results for invalid blocks
+  const { messages: cleanedMessages, droppedMalformedCount } =
+    stripMalformedToolUseBlocks(messages);
+
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
   // displaced (e.g. after user turns) or duplicated. Repair by:
@@ -91,7 +182,7 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
   let droppedDuplicateCount = 0;
   let droppedOrphanCount = 0;
   let moved = false;
-  let changed = false;
+  let changed = droppedMalformedCount > 0;
 
   const pushToolResult = (msg: Extract<AgentMessage, { role: "toolResult" }>) => {
     const id = extractToolResultId(msg);
@@ -106,8 +197,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     out.push(msg);
   };
 
-  for (let i = 0; i < messages.length; i += 1) {
-    const msg = messages[i];
+  for (let i = 0; i < cleanedMessages.length; i += 1) {
+    const msg = cleanedMessages[i];
     if (!msg || typeof msg !== "object") {
       out.push(msg);
       continue;
@@ -140,8 +231,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     const remainder: AgentMessage[] = [];
 
     let j = i + 1;
-    for (; j < messages.length; j += 1) {
-      const next = messages[j];
+    for (; j < cleanedMessages.length; j += 1) {
+      const next = cleanedMessages[j];
       if (!next || typeof next !== "object") {
         remainder.push(next);
         continue;
@@ -211,10 +302,11 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
   const changedOrMoved = changed || moved;
   return {
-    messages: changedOrMoved ? out : messages,
+    messages: changedOrMoved ? out : cleanedMessages,
     added,
     droppedDuplicateCount,
     droppedOrphanCount,
+    droppedMalformedToolUseCount: droppedMalformedCount,
     moved: changedOrMoved,
   };
 }


### PR DESCRIPTION
## Summary

- Strip malformed tool_use blocks from assistant messages during transcript repair to fix permanent session corruption
- Malformed blocks (missing id, missing name, or with `partialJson` field) are now detected and removed before pairing repair runs
- Sessions that would previously require manual JSONL surgery now auto-recover
- Added logging when malformed blocks are stripped for observability

## Problem

When tool calls are interrupted (by error, timeout, content filtering, or process termination), sessions become **permanently corrupted**. Every subsequent API request fails with:
- `unexpected tool_use_id found in tool_result blocks`
- `tool result's tool id not found (2013)`

**Root cause:** `extractToolCallsFromAssistant()` skips malformed tool_use blocks (lines 22-23 in the old code) but **leaves them in the message content**. The blocks remain in the transcript causing API rejections.

## Solution

1. Add `isValidToolUseBlock()` to detect malformed blocks
2. Add `stripMalformedToolUseBlocks()` to remove them from assistant messages
3. Call the strip function **before** pairing repair to prevent creating synthetic results for invalid blocks
4. Track `droppedMalformedToolUseCount` in the repair report for observability
5. Log a warning when malformed blocks are stripped

## Test plan

- [x] All 13 unit tests pass (4 existing + 9 new)
- [x] New test "recovers from interrupted tool call (session corruption scenario)" reproduces the exact failure mode
- [x] Lint passes
- [x] Build succeeds

## Future suggestions

These are not blockers but could improve robustness:

1. **Consolidate validation logic** - `extractToolCallsFromAssistant()` has similar but not identical validation. Could extract shared validation to reduce duplication.

2. **Provider-specific partial data fields** - Currently only checks for `partialJson`. Other providers might use different field names for partial/streaming data.

3. **Consider logging in `stripMalformedToolUseBlocks` directly** - Currently only logs in google.ts. Other call sites via `sanitizeToolUseResultPairing()` don't get the warning.

Fixes #5497, #5481, #5430, #5518

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves session transcript repair by stripping malformed assistant `toolCall` blocks (e.g., missing/empty `id` or containing `partialJson`) before attempting to re-pair `toolResult` messages. The repair report now exposes `droppedMalformedToolUseCount`, and the Google embedded runner logs a warning when malformed tool blocks are removed. A new test suite reproduces the “interrupted tool call causes permanent session corruption” scenario and validates the new behavior.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and should improve recovery from corrupted transcripts, with low behavioral risk outside transcript sanitization.
- Changes are localized to transcript-repair logic and the Google runner’s sanitization pipeline, with comprehensive new unit tests covering key malformed-block scenarios. Minor edge-case risk remains around provider-specific malformed tool-call shapes not covered (beyond `partialJson`/missing `id`).
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->