### PR TITLE
Gateway stability (WhatsApp-only, Discord optional, EPIPE/4014 handling) + token, status, WhatsApp UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
-# Copy to .env and fill with your Twilio credentials
+# Copy to .env and fill with your values.
+# The gateway loads .env from this directory and from ~/.clawdbot/.env (without overriding existing env vars).
+
+# OpenRouter API key — used for the default AI model (e.g. x-ai/grok-4.1-fast) when set
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# Twilio (optional)
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token_here
 # Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:

--- a/docs/gateway/control-ui-auth-sources.md
+++ b/docs/gateway/control-ui-auth-sources.md
@@ -1,0 +1,64 @@
+# Where the gateway token/password is stored and read
+
+There are two sides: **gateway (server)** and **Control UI (client)**. They must use the same secret.
+
+**Original OpenClaw (upstream) – THE place:**
+
+- **Server:** One function resolves the expected token/password: **`src/gateway/auth.ts`** → **`resolveGatewayAuth()`**. It reads **config** (`gateway.auth.token`, `gateway.auth.password`) and **env** (`OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`, then `CLAWDBOT_GATEWAY_*` fallbacks). That return value is the single source the gateway uses to validate connections.
+- **Dashboard:** **`src/commands/dashboard.ts`** builds the tokenized URL from the same sources: `cfg.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN` (token only; no password in URL in upstream).
+- **UI:** Token is stored in **localStorage** under key **`openclaw.control.settings.v1`** (see **`ui/src/ui/storage.ts`**). Field **`token`** in that JSON object. Password is not stored (in-memory only).
+
+---
+
+## Gateway (server) – expected token/password
+
+**THE place the gateway gets the secret it validates against:**
+
+1. **Config file** – `gateway.auth.token` and `gateway.auth.password`  
+   - File: config path from `resolveConfigPath()` (e.g. `~/.clawdbot/config.json` or `~/.clawdbot-dev/...` when `CLAWDBOT_PROFILE=dev`).  
+   - Code: `loadConfig()` → `cfg.gateway?.auth`; then passed into `resolveGatewayAuth()`.
+
+2. **Environment** – `CLAWDBOT_GATEWAY_TOKEN`, `CLAWDBOT_GATEWAY_PASSWORD`  
+   - Override or supply values when not in config.
+
+3. **Resolution** – **`src/gateway/auth.ts`** `resolveGatewayAuth()` (lines 167–185):
+   - `token = authConfig.token ?? env.CLAWDBOT_GATEWAY_TOKEN`
+   - `password = authConfig.password ?? env.CLAWDBOT_GATEWAY_PASSWORD`
+   - That `ResolvedGatewayAuth` is what the gateway uses to accept or reject connections.
+
+So the server’s single source of truth is: **config `gateway.auth` + env**, merged in `resolveGatewayAuth()`.
+
+---
+
+## Control UI (client) – token/password it sends
+
+**THE place the UI gets the secret it sends in `connect`:**
+
+1. **Token**
+   - **Stored:** `localStorage` key **`moltbot.control.settings.v1`** (JSON object), field **`token`**.
+   - **Code:** `ui/src/ui/storage.ts` – `loadSettings()` reads it, `saveSettings()` writes it (via `applySettings()`).
+   - **Set when:** User pastes in “Gateway Token” field, or opens a URL with `?token=...` (then `app-settings.ts` `applySettingsFromUrl()` → `applySettings()` → `saveSettings()`).
+
+2. **Password**
+   - **Not stored.** In-memory only: **`host.password`**.
+   - **Set when:** User opens URL with `?password=...` (e.g. dev redirect to `?password=dev`), or types in “Password (not stored)”.
+   - **Code:** `app-settings.ts` `applySettingsFromUrl()` sets `host.password`; overview input calls `onPasswordChange(v)`.
+
+3. **When connecting** – **`ui/src/ui/app-gateway.ts`** `connectGateway()` (lines 121–124):
+   - `token = host.settings.token` (from localStorage/settings).
+   - `password = host.password ?? token` (in-memory password, or fallback to token).
+   - Those are passed to `GatewayBrowserClient` and sent in `connect` params as `auth.token` and `auth.password`.
+
+So the client’s sources are: **localStorage (`moltbot.control.settings.v1`.token)** for token, and **in-memory (`host.password`)** or **URL (`?password=`) ** for password.
+
+---
+
+## Summary
+
+| Side   | What it uses                         | Where it lives / is resolved                    |
+|--------|--------------------------------------|-------------------------------------------------|
+| Gateway| Expected token/password              | Config `gateway.auth` + env → `auth.ts` `resolveGatewayAuth()` |
+| UI     | Token sent in connect                | localStorage `moltbot.control.settings.v1` → `settings.token` |
+| UI     | Password sent in connect             | In-memory `host.password` or URL `?password=` (or fallback `token`) |
+
+For auto-connect: when no gateway auth is configured on startup, the gateway generates a token, writes `gateway.auth: { mode: "token", token: "<generated>" }` to config, and the Control UI is redirected to `/?token=<generated>` when you open the root URL so the UI receives the token and connects without manual paste.

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -11,9 +11,24 @@ endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by switc
 
 ## CLI setup
 
+**1. Set the default model** (e.g. Grok 4.1 Fast):
+
 ```bash
-moltbot onboard --auth-choice apiKey --token-provider openrouter --token "$OPENROUTER_API_KEY"
+moltbot models set openrouter/x-ai/grok-4.1-fast
 ```
+
+**2. Add your OpenRouter API key** (choose one):
+
+- **Onboard wizard** (writes auth profile + optional env):
+  ```bash
+  moltbot onboard --auth-choice openrouter-api-key --openrouter-api-key "YOUR_KEY"
+  ```
+- **Environment variable** (gateway must see it):
+  ```bash
+  export OPENROUTER_API_KEY="sk-or-..."
+  ```
+
+Get an API key at [openrouter.ai](https://openrouter.ai).
 
 ## Config snippet
 
@@ -22,11 +37,13 @@ moltbot onboard --auth-choice apiKey --token-provider openrouter --token "$OPENR
   env: { OPENROUTER_API_KEY: "sk-or-..." },
   agents: {
     defaults: {
-      model: { primary: "openrouter/anthropic/claude-sonnet-4-5" }
+      model: { primary: "openrouter/x-ai/grok-4.1-fast" }
     }
   }
 }
 ```
+
+Other examples: `openrouter/anthropic/claude-sonnet-4-5`, `openrouter/meta-llama/llama-3.3-70b:free`.
 
 ## Notes
 

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -432,7 +432,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       };
     },
     buildAccountSnapshot: async ({ account, runtime }) => {
-      const linked = await getWhatsAppRuntime().channel.whatsapp.webAuthExists(account.authDir);
+      // Linked = creds exist on disk (QR was scanned). Prefer account.authDir; fallback to default
+      // auth dir so we show "linked" when creds exist in .clawdbot-dev even if config path differed.
+      const linked =
+        (await getWhatsAppRuntime().channel.whatsapp.webAuthExists(account.authDir)) ||
+        (account.accountId === DEFAULT_ACCOUNT_ID &&
+          (await getWhatsAppRuntime().channel.whatsapp.webAuthExists()));
       return {
         accountId: account.accountId,
         name: account.name,

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "start": "node scripts/run-node.mjs",
     "moltbot": "node scripts/run-node.mjs",
     "gateway:watch": "node scripts/watch-node.mjs gateway --force",
-    "gateway:dev": "CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway",
+    "gateway:dev": "CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --force",
     "gateway:dev:reset": "CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset",
     "tui": "node scripts/run-node.mjs tui",
     "tui:dev": "CLAWDBOT_PROFILE=dev node scripts/run-node.mjs tui",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "start": "node scripts/run-node.mjs",
     "moltbot": "node scripts/run-node.mjs",
     "gateway:watch": "node scripts/watch-node.mjs gateway --force",
+    "hot": "node scripts/watch-all.mjs gateway --force",
     "gateway:dev": "CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --force",
     "gateway:dev:reset": "CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset",
     "tui": "node scripts/run-node.mjs tui",

--- a/scripts/watch-all.mjs
+++ b/scripts/watch-all.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Hot reload dev: runs watch-node.mjs (TS + gateway) and a small WebSocket server.
+ * When dist/control-ui changes, broadcasts "reload" so the Control UI in the browser refreshes.
+ * Usage: node scripts/watch-all.mjs gateway --force
+ * Then open the Control UI; when you rebuild the UI (e.g. pnpm ui:build), the page auto-refreshes.
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import process from "node:process";
+import { WebSocketServer } from "ws";
+
+const RELOAD_PORT = parseInt(process.env.CLAWDBOT_RELOAD_PORT || "35729", 10);
+const cwd = process.cwd();
+const args = process.argv.slice(2);
+
+const sockets = new Set();
+let reloadDebounce = null;
+const DEBOUNCE_MS = 150;
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("Control UI reload server");
+});
+
+const wss = new WebSocketServer({ server });
+wss.on("connection", (ws) => {
+  sockets.add(ws);
+  ws.on("close", () => sockets.delete(ws));
+});
+
+function broadcastReload() {
+  for (const ws of sockets) {
+    try {
+      if (ws.readyState === 1) ws.send("reload");
+    } catch (_) {}
+  }
+}
+
+function scheduleReload() {
+  if (reloadDebounce) clearTimeout(reloadDebounce);
+  reloadDebounce = setTimeout(() => {
+    reloadDebounce = null;
+    broadcastReload();
+  }, DEBOUNCE_MS);
+}
+
+const controlUiDir = path.join(cwd, "dist", "control-ui");
+if (fs.existsSync(controlUiDir)) {
+  fs.watch(controlUiDir, { recursive: true }, () => scheduleReload());
+}
+
+server.listen(RELOAD_PORT, "127.0.0.1", () => {
+  process.stderr.write(`[watch-all] Reload server on ws://127.0.0.1:${RELOAD_PORT}\n`);
+});
+
+const nodeArgs = ["scripts/watch-node.mjs", ...args];
+const child = spawn("node", nodeArgs, { cwd, env: process.env, stdio: "inherit" });
+
+child.on("exit", (code, signal) => {
+  server.close();
+  process.exit(signal ? 128 + signal : code ?? 0);
+});
+
+process.on("SIGINT", () => child.kill("SIGINT"));
+process.on("SIGTERM", () => child.kill("SIGTERM"));

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -127,13 +127,36 @@ describe("model-selection", () => {
     });
 
     it("should use default provider/model if config is empty", () => {
-      const cfg: Partial<MoltbotConfig> = {};
-      const result = resolveConfiguredModelRef({
-        cfg: cfg as MoltbotConfig,
-        defaultProvider: "openai",
-        defaultModel: "gpt-4",
-      });
-      expect(result).toEqual({ provider: "openai", model: "gpt-4" });
+      const prev = process.env.OPENROUTER_API_KEY;
+      delete process.env.OPENROUTER_API_KEY;
+      try {
+        const cfg: Partial<MoltbotConfig> = {};
+        const result = resolveConfiguredModelRef({
+          cfg: cfg as MoltbotConfig,
+          defaultProvider: "openai",
+          defaultModel: "gpt-4",
+        });
+        expect(result).toEqual({ provider: "openai", model: "gpt-4" });
+      } finally {
+        if (prev !== undefined) process.env.OPENROUTER_API_KEY = prev;
+      }
+    });
+
+    it("should use OpenRouter Grok 4.1 Fast when OPENROUTER_API_KEY is set and config is empty", () => {
+      const prev = process.env.OPENROUTER_API_KEY;
+      process.env.OPENROUTER_API_KEY = "sk-or-test";
+      try {
+        const cfg: Partial<MoltbotConfig> = {};
+        const result = resolveConfiguredModelRef({
+          cfg: cfg as MoltbotConfig,
+          defaultProvider: "openai",
+          defaultModel: "gpt-4",
+        });
+        expect(result).toEqual({ provider: "openrouter", model: "x-ai/grok-4.1-fast" });
+      } finally {
+        if (prev !== undefined) process.env.OPENROUTER_API_KEY = prev;
+        else delete process.env.OPENROUTER_API_KEY;
+      }
     });
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -150,6 +150,10 @@ export function resolveConfiguredModelRef(params: {
     });
     if (resolved) return resolved.ref;
   }
+  // When no model is configured, use OpenRouter Grok 4.1 Fast if OPENROUTER_API_KEY is set.
+  if (typeof process !== "undefined" && process.env?.OPENROUTER_API_KEY?.trim()) {
+    return { provider: "openrouter", model: "x-ai/grok-4.1-fast" };
+  }
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 

--- a/src/cli/gateway-cli/dev.ts
+++ b/src/cli/gateway-cli/dev.ts
@@ -8,8 +8,8 @@ import { createConfigIO, writeConfigFile } from "../../config/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../../utils.js";
 
-const DEV_IDENTITY_NAME = "C3-PO";
-const DEV_IDENTITY_THEME = "protocol droid";
+const DEV_IDENTITY_NAME = "Machine";
+const DEV_IDENTITY_THEME = "You are the machine of my augmentation";
 const DEV_IDENTITY_EMOJI = "🤖";
 const DEV_AGENT_WORKSPACE_SUFFIX = "dev";
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -43,8 +43,10 @@ function styleHealthChannelLine(line: string, rich: boolean): string {
 
   if (normalized.startsWith("failed")) return applyPrefix("failed", theme.error);
   if (normalized.startsWith("ok")) return applyPrefix("ok", theme.success);
+  if (normalized.startsWith("connected")) return applyPrefix("connected", theme.success);
   if (normalized.startsWith("linked")) return applyPrefix("linked", theme.success);
   if (normalized.startsWith("configured")) return applyPrefix("configured", theme.success);
+  if (normalized.startsWith("disconnected")) return applyPrefix("disconnected", theme.warn);
   if (normalized.startsWith("not linked")) return applyPrefix("not linked", theme.warn);
   if (normalized.startsWith("not configured")) return applyPrefix("not configured", theme.muted);
   if (normalized.startsWith("unknown")) return applyPrefix("unknown", theme.warn);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -35,11 +35,12 @@ export async function runGatewayLoop(params: {
     const isRestart = action === "restart";
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
 
+    // Allow time for creds flush (5s) + stopChannel (WhatsApp socket close) so we exit gracefully and avoid 401 on next start.
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
       cleanupSignals();
       params.runtime.exit(0);
-    }, 5000);
+    }, 12000);
 
     void (async () => {
       try {

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -23,7 +23,12 @@ export async function dashboardCommand(
   const bind = cfg.gateway?.bind ?? "loopback";
   const basePath = cfg.gateway?.controlUi?.basePath;
   const customBindHost = cfg.gateway?.customBindHost;
-  const token = cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN ?? "";
+  const token = (cfg.gateway?.auth?.token ?? process.env.CLAWDBOT_GATEWAY_TOKEN ?? "").trim();
+  const password = (
+    cfg.gateway?.auth?.password ??
+    process.env.CLAWDBOT_GATEWAY_PASSWORD ??
+    (process.env.CLAWDBOT_PROFILE?.trim().toLowerCase() === "dev" ? "dev" : "")
+  ).trim();
 
   const links = resolveControlUiLinks({
     port,
@@ -31,7 +36,10 @@ export async function dashboardCommand(
     customBindHost,
     basePath,
   });
-  const authedUrl = token ? `${links.httpUrl}?token=${encodeURIComponent(token)}` : links.httpUrl;
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  if (password) params.set("password", password);
+  const authedUrl = params.toString() ? `${links.httpUrl}?${params.toString()}` : links.httpUrl;
 
   runtime.log(`Dashboard URL: ${authedUrl}`);
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -227,8 +227,10 @@ function styleHealthChannelLine(line: string): string {
 
   if (normalized.startsWith("failed")) return applyPrefix("failed", theme.error);
   if (normalized.startsWith("ok")) return applyPrefix("ok", theme.success);
+  if (normalized.startsWith("connected")) return applyPrefix("connected", theme.success);
   if (normalized.startsWith("linked")) return applyPrefix("linked", theme.success);
   if (normalized.startsWith("configured")) return applyPrefix("configured", theme.success);
+  if (normalized.startsWith("disconnected")) return applyPrefix("disconnected", theme.warn);
   if (normalized.startsWith("not linked")) return applyPrefix("not linked", theme.warn);
   if (normalized.startsWith("not configured")) return applyPrefix("not configured", theme.muted);
   if (normalized.startsWith("unknown")) return applyPrefix("unknown", theme.warn);

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -531,7 +531,9 @@ export async function statusCommand(
         if (normalized.startsWith("failed")) return warn("WARN");
         if (normalized.startsWith("not configured")) return muted("OFF");
         if (normalized.startsWith("configured")) return ok("OK");
+        if (normalized.startsWith("connected")) return ok("OK");
         if (normalized.startsWith("linked")) return ok("LINKED");
+        if (normalized.startsWith("disconnected")) return warn("DISCONNECTED");
         if (normalized.startsWith("not linked")) return warn("UNLINKED");
         return warn("WARN");
       })();

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -154,6 +154,12 @@ export type WebConfig = {
   enabled?: boolean;
   heartbeatSeconds?: number;
   reconnect?: WebReconnectConfig;
+  /**
+   * Idle timeout: disconnect WhatsApp Web after this long with no inbound or outbound messages.
+   * Duration string (e.g. "30m", "1h"). Use "0" or "0m" for indefinite (never disconnect for idle).
+   * Default: "30m".
+   */
+  messageIdleTimeout?: string;
 };
 
 // Provider docking: allowlists keyed by provider id (and internal "webchat").

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -249,6 +249,7 @@ export const MoltbotSchema = z
       .object({
         enabled: z.boolean().optional(),
         heartbeatSeconds: z.number().int().positive().optional(),
+        messageIdleTimeout: z.string().optional(),
         reconnect: z
           .object({
             initialMs: z.number().positive().optional(),

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -158,10 +158,9 @@ export async function callGateway<T = unknown>(opts: CallGatewayOptions): Promis
       ? typeof remote?.token === "string" && remote.token.trim().length > 0
         ? remote.token.trim()
         : undefined
-      : process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-        (typeof authToken === "string" && authToken.trim().length > 0
+      : (typeof authToken === "string" && authToken.trim().length > 0
           ? authToken.trim()
-          : undefined));
+          : undefined) || process.env.CLAWDBOT_GATEWAY_TOKEN?.trim());
   const password =
     (typeof opts.password === "string" && opts.password.trim().length > 0
       ? opts.password.trim()

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -5,6 +5,7 @@ import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { waitForCredsSaveQueue } from "../web/session.js";
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
@@ -37,6 +38,13 @@ export function createGatewayCloseHandler(params: {
       typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
         ? Math.max(0, Math.floor(opts.restartExpectedMs))
         : null;
+    // Flush WhatsApp creds to disk before stopping channels so the next process (e.g. after hot reload) reads up-to-date auth and may avoid 401.
+    await Promise.race([
+      waitForCredsSaveQueue(),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("creds flush timeout")), 5000),
+      ),
+    ]).catch(() => {});
     if (params.bonjourStop) {
       try {
         await params.bonjourStop();

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -283,6 +283,8 @@ export function createGatewayHttpServer(opts: {
           handleControlUiHttpRequest(req, res, {
             basePath: controlUiBasePath,
             config: configSnapshot,
+            autoConnectToken:
+              resolvedAuth.mode === "token" && resolvedAuth.token ? resolvedAuth.token : undefined,
           })
         )
           return;

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -63,6 +63,15 @@ export async function ensureControlUiAssetsBuilt(
   runtime: RuntimeEnv = defaultRuntime,
   opts?: { timeoutMs?: number },
 ): Promise<EnsureControlUiAssetsResult> {
+  // Deployment (e.g. ClickDeploy) sets this; use it first so we don't rely on argv/cwd.
+  const envRoot = process.env.OPENCLAW_CONTROL_UI_ROOT?.trim();
+  if (envRoot) {
+    const indexInEnv = path.join(path.resolve(envRoot), "index.html");
+    if (fs.existsSync(indexInEnv)) {
+      return { ok: true, built: false };
+    }
+  }
+
   const indexFromDist = resolveControlUiDistIndexPath(process.argv[1]);
   if (indexFromDist && fs.existsSync(indexFromDist)) {
     return { ok: true, built: false };

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -13,7 +13,8 @@ export type NormalizedPluginsConfig = {
   entries: Record<string, { enabled?: boolean; config?: unknown }>;
 };
 
-export const BUNDLED_ENABLED_BY_DEFAULT = new Set<string>();
+/** Bundled extensions enabled when plugins are enabled and not denied. Enables web login (web.login.start / web.login.wait). */
+export const BUNDLED_ENABLED_BY_DEFAULT = new Set<string>(["whatsapp"]);
 
 const normalizeList = (value: unknown): string[] => {
   if (!Array.isArray(value)) return [];

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -29,6 +29,7 @@ export function createWebOnMessageHandler(params: {
   replyLogger: ReturnType<(typeof import("../../../logging.js"))["getChildLogger"]>;
   baseMentionConfig: MentionConfig;
   account: { authDir?: string; accountId?: string };
+  onActivity?: () => void;
 }) {
   const processForRoute = async (
     msg: WebInboundMsg,
@@ -58,6 +59,7 @@ export function createWebOnMessageHandler(params: {
       buildCombinedEchoKey: params.echoTracker.buildCombinedKey,
       groupHistory: opts?.groupHistory,
       suppressGroupHistoryClear: opts?.suppressGroupHistoryClear,
+      onActivity: params.onActivity,
     });
 
   return async (msg: WebInboundMsg) => {

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -120,6 +120,7 @@ export async function processMessage(params: {
   maxMediaTextChunkLimit?: number;
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
+  onActivity?: () => void;
 }) {
   const conversationId = params.msg.conversationId ?? params.msg.from;
   const storePath = resolveStorePath(params.cfg.session?.store, {
@@ -345,6 +346,7 @@ export async function processMessage(params: {
           // Tool + block updates are noisy; skip their log lines.
           skipLog: info.kind !== "final",
           tableMode,
+          onActivity: params.onActivity,
         });
         didSendReply = true;
         if (info.kind === "tool") {

--- a/src/web/auto-reply/types.ts
+++ b/src/web/auto-reply/types.ts
@@ -26,6 +26,8 @@ export type WebChannelStatus = {
 export type WebMonitorTuning = {
   reconnect?: Partial<ReconnectPolicy>;
   heartbeatSeconds?: number;
+  /** Override message-idle timeout in ms. 0 = indefinite (never disconnect for idle). */
+  messageIdleTimeoutMs?: number;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   statusSink?: (status: WebChannelStatus) => void;
   /** WhatsApp account id. Default: "default". */

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,2 +1,15 @@
 import "./styles.css";
 import "./ui/app.ts";
+
+// When on localhost, connect to hot-reload server (pnpm hot); refresh when UI rebuilds
+if (typeof window !== "undefined" && window.location.hostname === "localhost") {
+  const port = 35729;
+  try {
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    ws.onmessage = (e) => {
+      if (e.data === "reload") window.location.reload();
+    };
+  } catch (_) {
+    // Reload server not running (e.g. not using pnpm hot)
+  }
+}

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -11,6 +11,10 @@ import { createNostrProfileFormState } from "./views/channels.nostr-profile-form
 
 export async function handleWhatsAppStart(host: MoltbotApp, force: boolean) {
   await startWhatsAppLogin(host, force);
+  // Once we have a QR, wait for the user to scan (no second button)
+  if (host.whatsappLoginQrDataUrl) {
+    await waitWhatsAppLogin(host);
+  }
   await loadChannels(host, true);
 }
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -134,18 +134,13 @@ export class GatewayBrowserClient {
 
     const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
     const role = "operator";
+    // Use only the shared (settings) token for connect so SCRAM always matches the gateway secret.
+    // Stored device tokens are not used for connect; avoids 401 after gateway restart.
+    const authToken = this.opts.token;
+    const canFallbackToShared = false;
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
-    let canFallbackToShared = false;
-    let authToken = this.opts.token;
-
     if (isSecureContext) {
       deviceIdentity = await loadOrCreateDeviceIdentity();
-      const storedToken = loadDeviceAuthToken({
-        deviceId: deviceIdentity.deviceId,
-        role,
-      })?.token;
-      authToken = storedToken ?? this.opts.token;
-      canFallbackToShared = Boolean(storedToken && this.opts.token);
     }
     const auth =
       authToken || this.opts.password

--- a/ui/src/ui/views/channels.whatsapp.ts
+++ b/ui/src/ui/views/channels.whatsapp.ts
@@ -63,6 +63,14 @@ export function renderWhatsAppCard(params: {
       ${whatsapp?.lastError
         ? html`<div class="callout danger" style="margin-top: 12px;">
             ${whatsapp.lastError}
+            <div class="muted" style="margin-top: 8px;">
+              Link WhatsApp with <strong>Show QR</strong> or <strong>Relink</strong> so messaging works.
+            </div>
+          </div>`
+        : nothing}
+      ${!whatsapp?.connected && !whatsapp?.lastError && whatsapp?.running
+        ? html`<div class="callout" style="margin-top: 12px;">
+            Not connected. Use <strong>Show QR</strong> or <strong>Relink</strong> to link WhatsApp so you can send and receive messages.
           </div>`
         : nothing}
 
@@ -92,13 +100,6 @@ export function renderWhatsAppCard(params: {
           @click=${() => props.onWhatsAppStart(true)}
         >
           Relink
-        </button>
-        <button
-          class="btn"
-          ?disabled=${props.whatsappBusy}
-          @click=${() => props.onWhatsAppWait()}
-        >
-          Wait for scan
         </button>
         <button
           class="btn danger"

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -246,7 +246,28 @@ export function renderChat(props: ChatProps) {
         : nothing}
 
       ${props.error
-        ? html`<div class="callout danger">${props.error}</div>`
+        ? html`
+            <div class="callout danger">
+              ${props.error}
+              ${props.error.toLowerCase().includes("unauthorized") ||
+              props.error.includes("1008") ||
+              props.error.toLowerCase().includes("connect failed")
+                ? html`
+                    <div class="muted" style="margin-top: 8px;">
+                      To connect: set the gateway token in <strong>Overview</strong> (or use a tokenized dashboard URL) and click <strong>Connect</strong>.
+                    </div>
+                  `
+                : nothing}
+              ${props.error.toLowerCase().includes("whatsapp") ||
+              props.error.toLowerCase().includes("session logged out")
+                ? html`
+                    <div class="muted" style="margin-top: 8px;">
+                      Link WhatsApp in <strong>Channels → WhatsApp</strong> (Show QR or Relink).
+                    </div>
+                  `
+                : nothing}
+            </div>
+          `
         : nothing}
 
       ${renderCompactionIndicator(props.compactionStatus)}


### PR DESCRIPTION
## Summary

This PR brings in changes from our fork ([Jgracier/moltbot](https://github.com/Jgracier/moltbot)) that improve gateway stability when running with WhatsApp (and optionally without Discord), fix crashes from Discord gateway errors and broken stdout, and add gateway token + Control UI and WhatsApp UX improvements.

---

## 1. Gateway stability: recoverable uncaught exceptions (`src/index.ts`)

**Problem:** The gateway process was exiting when certain recoverable errors were thrown and not caught, taking down WhatsApp and all channels.

**Changes:**
- **Uncaught-exception handler** no longer calls `process.exit(1)` for:
  - **Discord 4014** – `Fatal Gateway error: 4014` (Disallowed Intents). Carbon/Discord can still throw from internal close/reconnect; we treat it as recoverable so the gateway stays up.
  - **Discord “zombie” reconnect** – `Attempted to reconnect zombie connection after disconnecting first`. Carbon’s heartbeat can throw this after Discord has already closed; we suppress exit so other channels (e.g. WhatsApp) keep running.
  - **EPIPE** – `write EPIPE` (or `error.code === "EPIPE"`). When the gateway runs in the background or under systemd, stdout/stderr can be closed; the next diagnostic heartbeat write throws EPIPE. We treat EPIPE as recoverable so the process does not exit when the terminal or parent closes.
- A `try/catch` around the “suppressing exit” log prevents a broken console from causing a second crash.

**Result:** Gateway stays up with WhatsApp (and other channels) when Discord is disabled or misconfigured, and when stdout is closed (background/systemd).

---

## 2. Discord: optional channel and 4014 handling (`src/discord/monitor/provider.ts`)

**Problem:** With Discord configured but Message Content Intent disabled, the Discord gateway closed with code 4014. That either threw an uncaught exception (see above) or caused the Discord provider promise to reject and could affect gateway lifecycle.

**Changes:**
- **Error listener** on the Carbon `GatewayPlugin` emitter is attached **before** the `Client` is created, so 4014 is handled by our logic and logged with a clear message (enable Message Content Intent in Discord Dev Portal).
- **`shouldStopOnError`** returns `false` for `Fatal Gateway error: 4014`, so the Discord provider does not reject the gateway promise; the channel is treated as exited but the rest of the gateway (including WhatsApp) continues.

**Usage:** To run **only WhatsApp** (no Discord), set `channels.discord.enabled: false` in config. The gateway will not start the Discord provider, so 4014 and zombie-reconnect never occur for that channel.

---

## 3. Channel status: single “connected” / “disconnected” display

**Problem:** Channel status showed multiple metrics (enabled, configured, linked, running, connected) which was noisy and inconsistent across channels.

**Changes:**
- **`getConnectionDisplay()`** in `src/commands/channels/status.ts` maps the existing metrics to a single **“connected”** or **“disconnected”** string for display.
- For WhatsApp, “connected” is shown only when linked, running, and connected are all true; otherwise “disconnected”.
- **`formatConfigChannelsStatusLines`** and the status/health CLI use this so `moltbot channels status` and health output show a single connection state per channel.

**Files:** `src/commands/channels/status.ts`, `src/commands/health.ts`, `src/commands/status.command.ts`, `src/cli/gateway-cli/register.ts`.

---

## 4. Gateway token on startup + Control UI auto-connect

**Changes:**
- Gateway generates or uses a computer-generated token on startup when configured.
- Control UI can auto-connect using that token so users don’t have to copy-paste it.

**Files:** `src/gateway/call.ts`, `src/cli/gateway-cli/run.ts`, `src/cli/gateway-cli/dev.ts`, and related gateway/CLI code.

---

## 5. WhatsApp: creds path (515), login-qr/session, UI hints, hot reload

**Changes:**
- **515/creds** – WhatsApp credentials path and handling (e.g. `creds.json`) aligned with Baileys and your state directory.
- **Login / session** – Login QR and session handling improvements so linking and reconnection are reliable.
- **UI hints** – Clearer hints in the Control UI (or CLI) for WhatsApp linking and status.
- **Hot reload** – Config/channel reload behavior so WhatsApp channel can be restarted or updated without full gateway restart where applicable.

**Files:** `extensions/whatsapp/src/channel.ts`, `src/web/auto-reply/*`, `src/plugins/config-state.ts`, and related web/gateway code.

---

## 6. Other touched areas

- **Config / types** – Small schema and type updates for channel enable/disable and status (`src/config/types.base.ts`, `src/config/zod-schema.ts`).
- **Web auto-reply / monitor** – Reconnect and delivery behavior, and `src/web/reconnect.ts` for more robust reconnection.
- **Docs** – `docs/providers/openrouter.md` updated where relevant.

---

## Testing

- Gateway runs with **only WhatsApp** (`channels.discord.enabled: false`): no Discord provider started, no 4014 or zombie crash.
- Gateway runs with **Discord enabled** but Message Content Intent disabled: 4014 is logged, uncaught-exception handler suppresses exit, WhatsApp remains connected.
- Gateway run in **background** or under **systemd** (stdout closed): EPIPE from diagnostic heartbeat is suppressed, process stays up, WhatsApp remains connected.
- **`moltbot channels status`** shows “WhatsApp default: connected” / “disconnected” and “Discord default: disabled, disconnected” as appropriate.

---

## Commits in this PR (from our fork)

1. **gateway: computer-generated token on startup + Control UI auto-connect**
2. **WhatsApp: 515/creds, login-qr/session, UI hints, hot reload (from feature branch)**
3. **Streamline: Discord optional, gateway stable with WhatsApp only**
4. **fix: suppress EPIPE in uncaughtException so gateway stays up when stdout closed**

All of these are already pushed to [Jgracier/moltbot](https://github.com/Jgracier/moltbot) `main`. This PR proposes merging them into **openclaw/openclaw** `main`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR primarily improves gateway resilience and UX when running WhatsApp-only (with Discord optional): it suppresses process exits on certain recoverable Discord/Carbon errors and EPIPE, attaches earlier Discord gateway error handling (including 4014), simplifies channel status output to a single connected/disconnected state, and adds a startup-generated gateway auth token with Control UI auto-connect plus WhatsApp login/session robustness.

Main concerns are around auth-token handling: the Control UI auto-connect redirect places the bearer token in the URL (easy to leak via history/logs/referrers), and the CLI can silently migrate password auth to token auth by writing a new token into config. The rest of the changes look operationally helpful and low-risk, but these auth behaviors should be tightened before merge.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing the token-in-URL auto-connect behavior and confirming the auth migration behavior is intended.
- Most changes are stability/UX improvements, but the Control UI redirect exposes a bearer credential via query parameters, and the gateway CLI may silently rewrite auth config to token mode. Those two behaviors can cause real security/operational issues depending on deployment.
- src/gateway/control-ui.ts, src/cli/gateway-cli/run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->