### PR TITLE
feat(memory): add recency decay and RRF merge strategy to hybrid search

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -312,6 +312,17 @@ export type MemorySearchConfig = {
       textWeight?: number;
       /** Multiplier for candidate pool size (default: 4). */
       candidateMultiplier?: number;
+      /** Merge strategy: "weighted" (default) or "rrf" (Reciprocal Rank Fusion). */
+      mergeStrategy?: "weighted" | "rrf";
+      /** RRF constant k (default: 60). Only used when mergeStrategy is "rrf". */
+      rrfK?: number;
+      /** Optional recency decay to boost newer memories. */
+      recencyDecay?: {
+        /** Enable recency decay (default: false). */
+        enabled?: boolean;
+        /** Half-life in days — score halves after this many days (default: 7). */
+        halfLifeDays?: number;
+      };
     };
   };
   /** Index cache behavior. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -395,6 +395,15 @@ export const MemorySearchSchema = z
             vectorWeight: z.number().min(0).max(1).optional(),
             textWeight: z.number().min(0).max(1).optional(),
             candidateMultiplier: z.number().int().positive().optional(),
+            mergeStrategy: z.union([z.literal("weighted"), z.literal("rrf")]).optional(),
+            rrfK: z.number().positive().optional(),
+            recencyDecay: z
+              .object({
+                enabled: z.boolean().optional(),
+                halfLifeDays: z.number().positive().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
+import {
+  bm25RankToScore,
+  buildFtsQuery,
+  computeRecencyFactor,
+  computeRrfScores,
+  mergeHybridResults,
+} from "./hybrid.js";
 
 describe("memory hybrid helpers", () => {
   it("buildFtsQuery tokenizes and AND-joins", () => {
@@ -82,5 +88,325 @@ describe("memory hybrid helpers", () => {
     expect(merged).toHaveLength(1);
     expect(merged[0]?.snippet).toBe("kw-a");
     expect(merged[0]?.score).toBeCloseTo(0.5 * 0.2 + 0.5 * 1.0);
+  });
+});
+
+describe("computeRecencyFactor", () => {
+  it("returns 1 for items at current time", () => {
+    const now = Date.now();
+    expect(computeRecencyFactor(now, now, 7)).toBeCloseTo(1);
+  });
+
+  it("returns ~0.5 at the half-life", () => {
+    const now = Date.now();
+    const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+    expect(computeRecencyFactor(sevenDaysAgo, now, 7)).toBeCloseTo(0.5, 4);
+  });
+
+  it("returns ~0.25 at two half-lives", () => {
+    const now = Date.now();
+    const fourteenDaysAgo = now - 14 * 24 * 60 * 60 * 1000;
+    expect(computeRecencyFactor(fourteenDaysAgo, now, 7)).toBeCloseTo(0.25, 4);
+  });
+
+  it("returns 1 when halfLifeDays is 0 (disabled)", () => {
+    const now = Date.now();
+    const old = now - 365 * 24 * 60 * 60 * 1000;
+    expect(computeRecencyFactor(old, now, 0)).toBe(1);
+  });
+
+  it("clamps negative age to 0", () => {
+    const now = Date.now();
+    const future = now + 1000;
+    expect(computeRecencyFactor(future, now, 7)).toBeCloseTo(1);
+  });
+});
+
+describe("computeRrfScores", () => {
+  it("computes correct RRF scores for single list", () => {
+    const scores = computeRrfScores([["a", "b", "c"]], 60);
+    // rank 0 → 1/(60+1), rank 1 → 1/(60+2), rank 2 → 1/(60+3)
+    expect(scores.get("a")).toBeCloseTo(1 / 61);
+    expect(scores.get("b")).toBeCloseTo(1 / 62);
+    expect(scores.get("c")).toBeCloseTo(1 / 63);
+  });
+
+  it("sums scores across multiple lists", () => {
+    const scores = computeRrfScores(
+      [
+        ["a", "b"],
+        ["b", "a"],
+      ],
+      60,
+    );
+    // a: 1/61 + 1/62, b: 1/62 + 1/61
+    expect(scores.get("a")).toBeCloseTo(1 / 61 + 1 / 62);
+    expect(scores.get("b")).toBeCloseTo(1 / 62 + 1 / 61);
+  });
+
+  it("handles items appearing in only one list", () => {
+    const scores = computeRrfScores(
+      [
+        ["a", "b"],
+        ["c", "a"],
+      ],
+      60,
+    );
+    expect(scores.get("a")).toBeCloseTo(1 / 61 + 1 / 62);
+    expect(scores.get("b")).toBeCloseTo(1 / 62);
+    expect(scores.get("c")).toBeCloseTo(1 / 61);
+  });
+});
+
+describe("mergeHybridResults with RRF strategy", () => {
+  it("ranks by RRF score instead of weighted", () => {
+    const merged = mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      mergeStrategy: "rrf",
+      rrfK: 60,
+      vector: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "vec-a",
+          vectorScore: 0.9,
+        },
+        {
+          id: "b",
+          path: "memory/b.md",
+          startLine: 3,
+          endLine: 4,
+          source: "memory",
+          snippet: "vec-b",
+          vectorScore: 0.1,
+        },
+      ],
+      keyword: [
+        {
+          id: "b",
+          path: "memory/b.md",
+          startLine: 3,
+          endLine: 4,
+          source: "memory",
+          snippet: "kw-b",
+          textScore: 0.9,
+        },
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "kw-a",
+          textScore: 0.1,
+        },
+      ],
+    });
+
+    expect(merged).toHaveLength(2);
+    // Both appear at rank 0 in one list and rank 1 in the other → equal RRF scores
+    expect(merged[0]?.score).toBeCloseTo(merged[1]!.score);
+  });
+
+  it("RRF boosts items that appear in both lists over single-list items", () => {
+    const merged = mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      mergeStrategy: "rrf",
+      rrfK: 60,
+      vector: [
+        {
+          id: "both",
+          path: "memory/both.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "both",
+          vectorScore: 0.5,
+        },
+      ],
+      keyword: [
+        {
+          id: "both",
+          path: "memory/both.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "both",
+          textScore: 0.5,
+        },
+        {
+          id: "kw-only",
+          path: "memory/kw.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "kw-only",
+          textScore: 0.9,
+        },
+      ],
+    });
+
+    const both = merged.find((r) => r.path === "memory/both.md");
+    const kwOnly = merged.find((r) => r.path === "memory/kw.md");
+    // "both" gets 1/61 + 1/61, "kw-only" gets only 1/62
+    expect(both!.score).toBeGreaterThan(kwOnly!.score);
+  });
+});
+
+describe("mergeHybridResults with recency decay", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it("boosts newer results over older ones", () => {
+    const now = Date.now();
+    const merged = mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      recencyDecay: { enabled: true, halfLifeDays: 7 },
+      now,
+      vector: [
+        {
+          id: "old",
+          path: "memory/old.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "old",
+          vectorScore: 0.8,
+          updatedAt: now - 30 * DAY_MS,
+        },
+        {
+          id: "new",
+          path: "memory/new.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "new",
+          vectorScore: 0.7,
+          updatedAt: now - 1 * DAY_MS,
+        },
+      ],
+      keyword: [],
+    });
+
+    // "new" should rank higher despite lower vectorScore due to recency
+    expect(merged[0]?.path).toBe("memory/new.md");
+    expect(merged[1]?.path).toBe("memory/old.md");
+  });
+
+  it("does not affect scoring when disabled", () => {
+    const now = Date.now();
+    const merged = mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      recencyDecay: { enabled: false, halfLifeDays: 7 },
+      now,
+      vector: [
+        {
+          id: "old",
+          path: "memory/old.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "old",
+          vectorScore: 0.8,
+          updatedAt: now - 30 * DAY_MS,
+        },
+        {
+          id: "new",
+          path: "memory/new.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "new",
+          vectorScore: 0.7,
+          updatedAt: now - 1 * DAY_MS,
+        },
+      ],
+      keyword: [],
+    });
+
+    // Without decay, higher vectorScore wins
+    expect(merged[0]?.path).toBe("memory/old.md");
+    expect(merged[0]?.score).toBeCloseTo(0.8);
+  });
+
+  it("works with RRF strategy and recency decay combined", () => {
+    const now = Date.now();
+    const merged = mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      mergeStrategy: "rrf",
+      rrfK: 60,
+      recencyDecay: { enabled: true, halfLifeDays: 7 },
+      now,
+      vector: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "a",
+          vectorScore: 0.9,
+          updatedAt: now - 30 * DAY_MS,
+        },
+        {
+          id: "b",
+          path: "memory/b.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "b",
+          vectorScore: 0.5,
+          updatedAt: now,
+        },
+      ],
+      keyword: [],
+    });
+
+    // b is much newer so recency decay should push it higher despite lower RRF base
+    const a = merged.find((r) => r.path === "memory/a.md");
+    const b = merged.find((r) => r.path === "memory/b.md");
+    expect(b!.score).toBeGreaterThan(a!.score);
+  });
+});
+
+describe("backward compatibility", () => {
+  it("default params produce same behavior as original weighted merge", () => {
+    const merged = mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      // No mergeStrategy, rrfK, or recencyDecay — all defaults
+      vector: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "vec-a",
+          vectorScore: 0.9,
+        },
+      ],
+      keyword: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "kw-a",
+          textScore: 0.8,
+        },
+      ],
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.score).toBeCloseTo(0.7 * 0.9 + 0.3 * 0.8);
   });
 });

--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -209,7 +209,7 @@ describe("mergeHybridResults with RRF strategy", () => {
 
     expect(merged).toHaveLength(2);
     // Both appear at rank 0 in one list and rank 1 in the other → equal RRF scores
-    expect(merged[0]?.score).toBeCloseTo(merged[1]!.score);
+    expect(merged[0]?.score).toBeCloseTo(merged[1]?.score ?? 0);
   });
 
   it("RRF boosts items that appear in both lists over single-list items", () => {

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -171,11 +171,11 @@ export function mergeHybridResults(params: {
     const rawK = params.rrfK ?? 60;
     const k = Number.isFinite(rawK) && rawK > 0 ? rawK : 60;
     // Build ranked lists sorted by their respective scores (descending)
-    const vectorRanked = params.vector
-      .toSorted((a, b) => b.vectorScore - a.vectorScore)
+    const vectorRanked = [...params.vector]
+      .sort((a, b) => b.vectorScore - a.vectorScore)
       .map((r) => r.id);
-    const keywordRanked = params.keyword
-      .toSorted((a, b) => b.textScore - a.textScore)
+    const keywordRanked = [...params.keyword]
+      .sort((a, b) => b.textScore - a.textScore)
       .map((r) => r.id);
     const rrfScores = computeRrfScores([vectorRanked, keywordRanked], k);
     const listsUsed = (vectorRanked.length > 0 ? 1 : 0) + (keywordRanked.length > 0 ? 1 : 0);
@@ -215,5 +215,5 @@ export function mergeHybridResults(params: {
     }
   }
 
-  return merged.toSorted((a, b) => b.score - a.score).map(({ updatedAt: _, ...rest }) => rest);
+  return [...merged].sort((a, b) => b.score - a.score).map(({ updatedAt: _, ...rest }) => rest);
 }

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -8,6 +8,7 @@ export type HybridVectorResult = {
   source: HybridSource;
   snippet: string;
   vectorScore: number;
+  updatedAt?: number;
 };
 
 export type HybridKeywordResult = {
@@ -18,6 +19,14 @@ export type HybridKeywordResult = {
   source: HybridSource;
   snippet: string;
   textScore: number;
+  updatedAt?: number;
+};
+
+export type MergeStrategy = "weighted" | "rrf";
+
+export type RecencyDecayConfig = {
+  enabled: boolean;
+  halfLifeDays: number;
 };
 
 export function buildFtsQuery(raw: string): string | null {
@@ -38,11 +47,50 @@ export function bm25RankToScore(rank: number): number {
   return 1 / (1 + normalized);
 }
 
+/**
+ * Compute a recency decay factor using exponential half-life decay.
+ * Returns a value in (0, 1] where 1 means "just now" and decays toward 0.
+ */
+export function computeRecencyFactor(updatedAt: number, now: number, halfLifeDays: number): number {
+  if (
+    !Number.isFinite(updatedAt) ||
+    !Number.isFinite(now) ||
+    !Number.isFinite(halfLifeDays) ||
+    halfLifeDays <= 0
+  ) {
+    return 1;
+  }
+  const ageDays = Math.max(0, (now - updatedAt) / (1000 * 60 * 60 * 24));
+  const lambda = Math.LN2 / halfLifeDays;
+  return Math.exp(-lambda * ageDays);
+}
+
+/**
+ * Compute RRF (Reciprocal Rank Fusion) scores for a set of results across
+ * multiple ranked lists. Each result gets: sum(1 / (k + rank_i)) across lists.
+ */
+export function computeRrfScores(rankedLists: Array<string[]>, k: number): Map<string, number> {
+  const scores = new Map<string, number>();
+  const safeK = Number.isFinite(k) && k > 0 ? k : 1;
+  for (const list of rankedLists) {
+    for (let rank = 0; rank < list.length; rank++) {
+      const id = list[rank]!;
+      const current = scores.get(id) ?? 0;
+      scores.set(id, current + 1 / (safeK + rank + 1)); // rank is 0-indexed, RRF uses 1-indexed
+    }
+  }
+  return scores;
+}
+
 export function mergeHybridResults(params: {
   vector: HybridVectorResult[];
   keyword: HybridKeywordResult[];
   vectorWeight: number;
   textWeight: number;
+  mergeStrategy?: MergeStrategy;
+  rrfK?: number;
+  recencyDecay?: RecencyDecayConfig;
+  now?: number;
 }): Array<{
   path: string;
   startLine: number;
@@ -51,6 +99,8 @@ export function mergeHybridResults(params: {
   snippet: string;
   source: HybridSource;
 }> {
+  const strategy = params.mergeStrategy ?? "weighted";
+
   const byId = new Map<
     string,
     {
@@ -62,6 +112,7 @@ export function mergeHybridResults(params: {
       snippet: string;
       vectorScore: number;
       textScore: number;
+      updatedAt?: number;
     }
   >();
 
@@ -75,6 +126,7 @@ export function mergeHybridResults(params: {
       snippet: r.snippet,
       vectorScore: r.vectorScore,
       textScore: 0,
+      updatedAt: r.updatedAt,
     });
   }
 
@@ -84,6 +136,11 @@ export function mergeHybridResults(params: {
       existing.textScore = r.textScore;
       if (r.snippet && r.snippet.length > 0) {
         existing.snippet = r.snippet;
+      }
+      // Keep the most recent updatedAt
+      if (r.updatedAt != null) {
+        existing.updatedAt =
+          existing.updatedAt != null ? Math.max(existing.updatedAt, r.updatedAt) : r.updatedAt;
       }
     } else {
       byId.set(r.id, {
@@ -95,21 +152,68 @@ export function mergeHybridResults(params: {
         snippet: r.snippet,
         vectorScore: 0,
         textScore: r.textScore,
+        updatedAt: r.updatedAt,
       });
     }
   }
 
-  const merged = Array.from(byId.values()).map((entry) => {
-    const score = params.vectorWeight * entry.vectorScore + params.textWeight * entry.textScore;
-    return {
+  let merged: Array<{
+    path: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    snippet: string;
+    source: HybridSource;
+    updatedAt?: number;
+  }>;
+
+  if (strategy === "rrf") {
+    const rawK = params.rrfK ?? 60;
+    const k = Number.isFinite(rawK) && rawK > 0 ? rawK : 60;
+    // Build ranked lists sorted by their respective scores (descending)
+    const vectorRanked = params.vector
+      .toSorted((a, b) => b.vectorScore - a.vectorScore)
+      .map((r) => r.id);
+    const keywordRanked = params.keyword
+      .toSorted((a, b) => b.textScore - a.textScore)
+      .map((r) => r.id);
+    const rrfScores = computeRrfScores([vectorRanked, keywordRanked], k);
+    const listsUsed = (vectorRanked.length > 0 ? 1 : 0) + (keywordRanked.length > 0 ? 1 : 0);
+    const normalization = listsUsed > 0 ? (k + 1) / listsUsed : 1;
+
+    merged = Array.from(byId.values()).map((entry) => ({
       path: entry.path,
       startLine: entry.startLine,
       endLine: entry.endLine,
-      score,
+      score: (rrfScores.get(entry.id) ?? 0) * normalization,
       snippet: entry.snippet,
       source: entry.source,
-    };
-  });
+      updatedAt: entry.updatedAt,
+    }));
+  } else {
+    // Default: weighted merge
+    merged = Array.from(byId.values()).map((entry) => ({
+      path: entry.path,
+      startLine: entry.startLine,
+      endLine: entry.endLine,
+      score: params.vectorWeight * entry.vectorScore + params.textWeight * entry.textScore,
+      snippet: entry.snippet,
+      source: entry.source,
+      updatedAt: entry.updatedAt,
+    }));
+  }
 
-  return merged.toSorted((a, b) => b.score - a.score);
+  // Apply recency decay if enabled
+  const decay = params.recencyDecay;
+  if (decay?.enabled && decay.halfLifeDays > 0) {
+    const now = params.now ?? Date.now();
+    for (const entry of merged) {
+      if (entry.updatedAt != null) {
+        const factor = computeRecencyFactor(entry.updatedAt, now, decay.halfLifeDays);
+        entry.score *= factor;
+      }
+    }
+  }
+
+  return merged.toSorted((a, b) => b.score - a.score).map(({ updatedAt: _, ...rest }) => rest);
 }

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -74,7 +74,7 @@ export function computeRrfScores(rankedLists: Array<string[]>, k: number): Map<s
   const safeK = Number.isFinite(k) && k > 0 ? k : 1;
   for (const list of rankedLists) {
     for (let rank = 0; rank < list.length; rank++) {
-      const id = list[rank]!;
+      const id = list[rank];
       const current = scores.get(id) ?? 0;
       scores.set(id, current + 1 / (safeK + rank + 1)); // rank is 0-indexed, RRF uses 1-indexed
     }
@@ -171,11 +171,11 @@ export function mergeHybridResults(params: {
     const rawK = params.rrfK ?? 60;
     const k = Number.isFinite(rawK) && rawK > 0 ? rawK : 60;
     // Build ranked lists sorted by their respective scores (descending)
-    const vectorRanked = [...params.vector]
-      .sort((a, b) => b.vectorScore - a.vectorScore)
+    const vectorRanked = params.vector
+      .toSorted((a, b) => b.vectorScore - a.vectorScore)
       .map((r) => r.id);
-    const keywordRanked = [...params.keyword]
-      .sort((a, b) => b.textScore - a.textScore)
+    const keywordRanked = params.keyword
+      .toSorted((a, b) => b.textScore - a.textScore)
       .map((r) => r.id);
     const rrfScores = computeRrfScores([vectorRanked, keywordRanked], k);
     const listsUsed = (vectorRanked.length > 0 ? 1 : 0) + (keywordRanked.length > 0 ? 1 : 0);
@@ -215,5 +215,5 @@ export function mergeHybridResults(params: {
     }
   }
 
-  return [...merged].sort((a, b) => b.score - a.score).map(({ updatedAt: _, ...rest }) => rest);
+  return merged.toSorted((a, b) => b.score - a.score).map(({ updatedAt: _, ...rest }) => rest);
 }

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -167,7 +167,7 @@ export async function searchKeyword(params: {
         `       c.updated_at\n` +
         `  FROM ${params.ftsTable} f\n` +
         `  LEFT JOIN chunks c ON c.id = f.id\n` +
-        ` WHERE ${params.ftsTable} MATCH ? AND f.model = ?${params.sourceFilter.sql.replaceAll("source", "f.source")}\n` +
+        ` WHERE ${params.ftsTable} MATCH ? AND f.model = ?${params.sourceFilter.sql}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,
     )

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -16,6 +16,7 @@ export type SearchRowResult = {
   score: number;
   snippet: string;
   source: SearchSource;
+  updatedAt?: number;
 };
 
 export async function searchVector(params: {
@@ -36,7 +37,7 @@ export async function searchVector(params: {
     const rows = params.db
       .prepare(
         `SELECT c.id, c.path, c.start_line, c.end_line, c.text,\n` +
-          `       c.source,\n` +
+          `       c.source, c.updated_at,\n` +
           `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
           `  FROM ${params.vectorTable} v\n` +
           `  JOIN chunks c ON c.id = v.id\n` +
@@ -56,6 +57,7 @@ export async function searchVector(params: {
       end_line: number;
       text: string;
       source: SearchSource;
+      updated_at: number;
       dist: number;
     }>;
     return rows.map((row) => ({
@@ -66,6 +68,7 @@ export async function searchVector(params: {
       score: 1 - row.dist,
       snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
       source: row.source,
+      updatedAt: row.updated_at,
     }));
   }
 
@@ -91,6 +94,7 @@ export async function searchVector(params: {
       score: entry.score,
       snippet: truncateUtf16Safe(entry.chunk.text, params.snippetMaxChars),
       source: entry.chunk.source,
+      updatedAt: entry.chunk.updatedAt,
     }));
 }
 
@@ -106,10 +110,11 @@ export function listChunks(params: {
   text: string;
   embedding: number[];
   source: SearchSource;
+  updatedAt?: number;
 }> {
   const rows = params.db
     .prepare(
-      `SELECT id, path, start_line, end_line, text, embedding, source\n` +
+      `SELECT id, path, start_line, end_line, text, embedding, source, updated_at\n` +
         `  FROM chunks\n` +
         ` WHERE model = ?${params.sourceFilter.sql}`,
     )
@@ -121,6 +126,7 @@ export function listChunks(params: {
     text: string;
     embedding: string;
     source: SearchSource;
+    updated_at: number;
   }>;
 
   return rows.map((row) => ({
@@ -131,6 +137,7 @@ export function listChunks(params: {
     text: row.text,
     embedding: parseEmbedding(row.embedding),
     source: row.source,
+    updatedAt: row.updated_at,
   }));
 }
 
@@ -155,10 +162,12 @@ export async function searchKeyword(params: {
 
   const rows = params.db
     .prepare(
-      `SELECT id, path, source, start_line, end_line, text,\n` +
-        `       bm25(${params.ftsTable}) AS rank\n` +
-        `  FROM ${params.ftsTable}\n` +
-        ` WHERE ${params.ftsTable} MATCH ? AND model = ?${params.sourceFilter.sql}\n` +
+      `SELECT f.id, f.path, f.source, f.start_line, f.end_line, f.text,\n` +
+        `       bm25(${params.ftsTable}) AS rank,\n` +
+        `       c.updated_at\n` +
+        `  FROM ${params.ftsTable} f\n` +
+        `  LEFT JOIN chunks c ON c.id = f.id\n` +
+        ` WHERE ${params.ftsTable} MATCH ? AND f.model = ?${params.sourceFilter.sql.replaceAll("source", "f.source")}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,
     )
@@ -170,6 +179,7 @@ export async function searchKeyword(params: {
     end_line: number;
     text: string;
     rank: number;
+    updated_at: number | null;
   }>;
 
   return rows.map((row) => {
@@ -183,6 +193,7 @@ export async function searchKeyword(params: {
       textScore,
       snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
       source: row.source,
+      updatedAt: row.updated_at ?? undefined,
     };
   });
 }

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -348,7 +348,7 @@ export class MemoryIndexManager {
     if (!this.fts.enabled || !this.fts.available) {
       return [];
     }
-    const sourceFilter = this.buildSourceFilter();
+    const sourceFilter = this.buildSourceFilter("f");
     const results = await searchKeyword({
       db: this.db,
       ftsTable: FTS_TABLE,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -322,7 +322,7 @@ export class MemoryIndexManager {
   private async searchVector(
     queryVec: number[],
     limit: number,
-  ): Promise<Array<MemorySearchResult & { id: string }>> {
+  ): Promise<Array<MemorySearchResult & { id: string; updatedAt?: number }>> {
     const results = await searchVector({
       db: this.db,
       vectorTable: VECTOR_TABLE,
@@ -334,7 +334,7 @@ export class MemoryIndexManager {
       sourceFilterVec: this.buildSourceFilter("c"),
       sourceFilterChunks: this.buildSourceFilter(),
     });
-    return results.map((entry) => entry as MemorySearchResult & { id: string });
+    return results.map((entry) => entry as MemorySearchResult & { id: string; updatedAt?: number });
   }
 
   private buildFtsQuery(raw: string): string | null {
@@ -344,7 +344,7 @@ export class MemoryIndexManager {
   private async searchKeyword(
     query: string,
     limit: number,
-  ): Promise<Array<MemorySearchResult & { id: string; textScore: number }>> {
+  ): Promise<Array<MemorySearchResult & { id: string; textScore: number; updatedAt?: number }>> {
     if (!this.fts.enabled || !this.fts.available) {
       return [];
     }
@@ -360,15 +360,19 @@ export class MemoryIndexManager {
       buildFtsQuery: (raw) => this.buildFtsQuery(raw),
       bm25RankToScore,
     });
-    return results.map((entry) => entry as MemorySearchResult & { id: string; textScore: number });
+    return results.map(
+      (entry) =>
+        entry as MemorySearchResult & { id: string; textScore: number; updatedAt?: number },
+    );
   }
 
   private mergeHybridResults(params: {
-    vector: Array<MemorySearchResult & { id: string }>;
-    keyword: Array<MemorySearchResult & { id: string; textScore: number }>;
+    vector: Array<MemorySearchResult & { id: string; updatedAt?: number }>;
+    keyword: Array<MemorySearchResult & { id: string; textScore: number; updatedAt?: number }>;
     vectorWeight: number;
     textWeight: number;
   }): MemorySearchResult[] {
+    const hybrid = this.settings.query.hybrid;
     const merged = mergeHybridResults({
       vector: params.vector.map((r) => ({
         id: r.id,
@@ -378,6 +382,7 @@ export class MemoryIndexManager {
         source: r.source,
         snippet: r.snippet,
         vectorScore: r.score,
+        updatedAt: r.updatedAt,
       })),
       keyword: params.keyword.map((r) => ({
         id: r.id,
@@ -387,9 +392,13 @@ export class MemoryIndexManager {
         source: r.source,
         snippet: r.snippet,
         textScore: r.textScore,
+        updatedAt: r.updatedAt,
       })),
       vectorWeight: params.vectorWeight,
       textWeight: params.textWeight,
+      mergeStrategy: hybrid.mergeStrategy,
+      rrfK: hybrid.rrfK,
+      recencyDecay: hybrid.recencyDecay,
     });
     return merged.map((entry) => entry as MemorySearchResult);
   }


### PR DESCRIPTION
## Summary

Adds two new capabilities to the memory hybrid search system:

1. **Reciprocal Rank Fusion (RRF)** as an alternative merge strategy alongside the existing weighted scoring
2. **Recency decay** to optionally boost newer memories in search results

Both features are disabled/defaulted for full backward compatibility — existing behavior is unchanged unless explicitly configured.

## Motivation

The current weighted merge combines vector and keyword scores linearly, which works well but has two limitations:

- **Score scale mismatch**: Vector similarity and BM25 scores operate on different scales, making weight tuning sensitive
- **No temporal signal**: A memory from 6 months ago scores the same as one from yesterday, even when recency matters

RRF solves the first by ranking instead of scoring (no scale calibration needed). Recency decay solves the second with an exponential half-life function.

## Changes

| File | What |
|---|---|
| `src/memory/hybrid.ts` | `computeRecencyFactor()`, `computeRrfScores()`, extended `mergeHybridResults()` |
| `src/memory/manager-search.ts` | SQL returns `updated_at` for decay calculation |
| `src/agents/memory-search.ts` | New config fields with validation/clamping |
| `src/config/types.tools.ts` | `mergeStrategy`, `rrfK`, `recencyDecay` config types |
| `src/config/zod-schema.agent-runtime.ts` | Schema validation for new fields |
| `src/memory/hybrid.test.ts` | 18 tests (all passing) |
| `docs/concepts/memory.md` | Config examples and formulas |

## Config Example

```json5
agents: {
  defaults: {
    memorySearch: {
      query: {
        hybrid: {
          enabled: true,
          mergeStrategy: "rrf",       // or "weighted" (default)
          rrfK: 60,                    // RRF smoothing constant
          recencyDecay: {
            enabled: true,
            halfLifeDays: 7            // score halves every 7 days
          }
        }
      }
    }
  }
}
```

## Key Design Decisions

- **Backward compatible**: Default `mergeStrategy: "weighted"` + `recencyDecay.enabled: false` = identical behavior to current release
- **No schema migration**: Reuses existing `chunks.updated_at` column
- **RRF normalization**: Scores normalized to 0..1 range (`score * (k+1) / listsUsed`) so existing `minScore` threshold works correctly
- **Defensive math**: `computeRecencyFactor` returns 1 on invalid inputs; `computeRrfScores` clamps k to safe positive value

## Formula Reference

**Recency decay**: `recencyFactor = exp(-λ × ageDays)` where `λ = ln(2) / halfLifeDays`
**RRF**: `score = Σ 1/(k + rank)` across vector + keyword result lists

## Testing

All 18 tests pass:
- `computeRecencyFactor`: half-life, double half-life, zero age, negative age
- `computeRrfScores`: single list, multi-list, partial overlap
- RRF merge: rank agreement, dual-list boosting
- Recency decay: newer boost, disabled no-op, combined with RRF
- Backward compatibility: default params = weighted behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the memory hybrid search merge logic with two optional ranking features: Reciprocal Rank Fusion (RRF) as an alternative to the existing weighted score merge, and an exponential recency decay multiplier based on each chunk’s `updated_at`. The implementation threads `updated_at` through vector/keyword search results (SQL + in-memory fallback), adds config/schema wiring for the new knobs (`mergeStrategy`, `rrfK`, `recencyDecay`), and introduces a comprehensive new test suite covering recency decay, RRF scoring, and backward-compatible defaults.

The main correctness concerns are around brittle SQL construction in `searchKeyword` (string-rewriting the source filter) and a couple of runtime-robustness assumptions (e.g., use of `toSorted` depending on Node support).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a brittle SQL construction pattern.
- Core ranking/decay logic looks internally consistent and is covered by tests, but `searchKeyword`’s `sourceFilter.sql.replaceAll("source", "f.source")` is fragile and could break or mis-filter if the filter SQL ever changes. There’s also a potential runtime-compat concern with `Array.prototype.toSorted` depending on supported Node versions.
- src/memory/manager-search.ts (SQL construction), src/memory/hybrid.ts (runtime compat assumptions)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->