### PR TITLE
feat(slack): add block action handling via Socket Mode

### DIFF
--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -1,6 +1,7 @@
 import type { ResolvedSlackAccount } from "../accounts.js";
 
 import type { SlackMonitorContext } from "./context.js";
+import { registerSlackBlockActions } from "./events/actions.js";
 import { registerSlackChannelEvents } from "./events/channels.js";
 import { registerSlackMemberEvents } from "./events/members.js";
 import { registerSlackMessageEvents } from "./events/messages.js";
@@ -21,4 +22,5 @@ export function registerSlackMonitorEvents(params: {
   registerSlackMemberEvents({ ctx: params.ctx });
   registerSlackChannelEvents({ ctx: params.ctx });
   registerSlackPinEvents({ ctx: params.ctx });
+  registerSlackBlockActions({ ctx: params.ctx });
 }

--- a/src/slack/monitor/events/actions.ts
+++ b/src/slack/monitor/events/actions.ts
@@ -14,7 +14,7 @@ export function registerSlackBlockActions(params: { ctx: SlackMonitorContext }) 
     return;
   }
 
-  // Match all action_ids with "clawdbot_" prefix from our skills
+  // Match all action_ids with "openclaw_" prefix from our skills
   (
     ctx.app as unknown as {
       action: (
@@ -22,7 +22,7 @@ export function registerSlackBlockActions(params: { ctx: SlackMonitorContext }) 
         handler: (args: SlackActionMiddlewareArgs) => Promise<void>,
       ) => void;
     }
-  ).action(/^clawdbot_/, async (args: SlackActionMiddlewareArgs) => {
+  ).action(/^openclaw_/, async (args: SlackActionMiddlewareArgs) => {
     const { ack, body } = args;
     const action = args.action as { action_id?: string; value?: string; action_ts?: string };
 

--- a/src/slack/monitor/events/actions.ts
+++ b/src/slack/monitor/events/actions.ts
@@ -29,7 +29,12 @@ export function registerSlackBlockActions(params: { ctx: SlackMonitorContext }) 
         return;
       }
 
-      const channelId = (body as { channel?: { id?: string } }).channel?.id;
+      // Channel ID can be in body.channel.id or body.container.channel_id depending on context
+      const typedBody = body as {
+        channel?: { id?: string };
+        container?: { channel_id?: string };
+      };
+      const channelId = typedBody.channel?.id ?? typedBody.container?.channel_id;
       const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : undefined;
       const channelType = channelInfo?.type;
 


### PR DESCRIPTION
## Summary

- Add handler for `block_actions` interactive component callbacks (button clicks) via Socket Mode
- Match action_ids with `clawdbot_` prefix from skills (e.g., `clawdbot_schedule_morning`)
- Deliver actions to the agent as system events through the existing heartbeat mechanism

This eliminates the need for a separate HTTP webhook server for interactive Slack components.

## Test plan

- [x] Start OpenClaw with Slack extension in Socket Mode
- [x] Send a message with a button using `openclaw_` prefix action_id
- [x] Click the button in Slack
- [x] Verify system event is enqueued and agent receives it on next heartbeat

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires Slack interactive `block_actions` (button clicks with `clawdbot_`-prefixed `action_id`s) into the existing Slack monitor by registering a Bolt `app.action()` handler and translating clicks into `enqueueSystemEvent` entries scoped by `resolveSlackSystemEventSessionKey`. This keeps interactive components in Socket Mode without requiring a separate HTTP endpoint.

Main things to watch are payload shape differences for `block_actions` vs event callbacks (notably where channel IDs live) and ensuring channel allowlist logic still applies consistently for interactions.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there are likely functional edge cases in how `block_actions` payloads are parsed and routed.
- Core wiring is straightforward and matches existing system-event patterns, but the handler assumes `body.channel.id` and `trigger_id` are present. In common Slack interaction payloads, channel information is instead under `body.container.channel_id`, which can cause mis-routing to the main session and bypass channel allowlist checks.
- src/slack/monitor/events/actions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->