### PR TITLE
feat(gateway): add helpful hint to device identity error

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -414,9 +414,12 @@ export function attachGatewayWsMessageHandler(params: {
               type: "res",
               id: frame.id,
               ok: false,
-              error: errorShape(ErrorCodes.NOT_PAIRED, "device identity required"),
+              error: errorShape(
+                ErrorCodes.NOT_PAIRED,
+                "device identity required (missing keypair? see https://docs.openclaw.ai)",
+              ),
             });
-            close(1008, "device identity required");
+            close(1008, "device identity required (missing keypair? see https://docs.openclaw.ai)");
             return;
           }
         }


### PR DESCRIPTION
## Summary
Improves the developer experience when connecting to the Gateway without a valid device keypair.
Instead of a generic `device identity required` error, it now points the user to the documentation.

## Changes
- Modified `src/gateway/server/ws-connection/message-handler.ts` to append a documentation link to the error message.

## Motivation
During security testing, it wasn't clear why the connection was rejected despite using the correct protocol version. This hint saves debugging time.

## Testing
- Verified locally by attempting a connection without a device payload.
- Received the new error message: `device identity required (missing keypair? see https://docs.openclaw.ai)`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the Gateway WS handshake failure UX when a client connects without a device identity payload (and cannot skip device auth). The NOT_PAIRED error message and websocket close reason are updated to include a hint about a missing keypair and a link to the OpenClaw docs, which should make debugging protocol/version vs. auth issues faster.


<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge.
- The change is localized to a single error path in the WS handshake and only adjusts user-facing strings. No control-flow, auth decisions, or protocol behavior changes were introduced. The only noteworthy concern is maintainability due to duplicating the message/link in two places in the same block.
- src/gateway/server/ws-connection/message-handler.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->