### PR TITLE
fix(signal): preserve case for Base64 group IDs in target normalization

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,6 +28,11 @@ describe("signal target normalization", () => {
     ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
   });
 
+  it("strips whitespace from group IDs (handles copy-paste errors)", () => {
+    expect(normalizeSignalMessagingTarget("group: aBcDeF gHiJkL =")).toBe("group:aBcDeFgHiJkL=");
+    expect(normalizeSignalMessagingTarget("group:aBc\nDeF\t=")).toBe("group:aBcDeF=");
+  });
+
   it("accepts uuid prefixes for target detection", () => {
     expect(looksLikeSignalTargetId("uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);
     expect(looksLikeSignalTargetId("signal:uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);

--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -15,6 +15,19 @@ describe("signal target normalization", () => {
     );
   });
 
+  it("preserves case for Base64 group IDs", () => {
+    // Signal group IDs are Base64-encoded and case-sensitive
+    expect(
+      normalizeSignalMessagingTarget("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg="),
+    ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
+  });
+
+  it("preserves case for group IDs with signal: prefix", () => {
+    expect(
+      normalizeSignalMessagingTarget("signal:group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg="),
+    ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
+  });
+
   it("accepts uuid prefixes for target detection", () => {
     expect(looksLikeSignalTargetId("uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);
     expect(looksLikeSignalTargetId("signal:uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     // Signal group IDs are Base64-encoded and case-sensitive - preserve original case
-    const id = normalized.slice("group:".length).trim();
+    // Strip all whitespace since Base64 shouldn't contain spaces (handles copy-paste errors)
+    const id = normalized.slice("group:".length).replace(/\s+/g, "");
     return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -12,8 +12,9 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   }
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
+    // Signal group IDs are Base64-encoded and case-sensitive - preserve original case
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary

Fixes #5578 - Signal group IDs were being lowercased during target normalization, breaking group allowlist matching.

### Root Cause

Signal group IDs are Base64-encoded and case-sensitive (e.g., `aBcDeFgHiJkLmNoPqRsTuVwXyZ...`). The `normalizeSignalMessagingTarget()` function was lowercasing the entire group target:

```typescript
// Before (broken)
return id ? `group:${id}`.toLowerCase() : undefined;
```

This caused allowlist matching to fail because:
- Config stores: `group:aBcDeFgHiJ...` (proper case)
- Runtime comparison: `group:abcdefghij...` (lowercased)

### Fix

Preserve the original case for group IDs while keeping other target types (UUIDs, usernames, phone numbers) lowercase as they are case-insensitive:

```typescript
// After (fixed)
return id ? `group:${id}` : undefined;
```

## Test plan

- [x] Added test cases for Base64 group ID case preservation
- [x] `pnpm test src/channels/plugins/normalize/signal.test.ts` - 7/7 pass
- [x] `pnpm lint` - 0 warnings, 0 errors
- [x] `pnpm build` - success

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Signal target normalization so that `group:` targets preserve the original case of the Base64-encoded group ID (case-sensitive), fixing allowlist mismatches when configured group IDs contain uppercase characters. It also adds unit tests to ensure both `group:` and `signal:group:` inputs preserve group ID casing while leaving other target types (uuid/username/phone) normalized to lowercase.

This change fits into the existing `src/channels/plugins/normalize` plugin by keeping normalization behavior consistent for case-insensitive identifiers while treating group IDs as opaque identifiers.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and corrects a clear casing bug for Signal group IDs.
- Change is minimal and localized to `normalizeSignalMessagingTarget` with targeted tests covering both `group:` and `signal:group:` prefixes. Remaining concern is around preserving/accepting whitespace inside group IDs, which can still cause matching failures if users paste formatted Base64.
- src/channels/plugins/normalize/signal.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->