### PR TITLE
fix: use configured model in llm-slug-generator instead of hardcoded defaults

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -38,6 +39,11 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    const modelRef = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId,
+    });
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -48,6 +54,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
+      provider: modelRef.provider,
+      model: modelRef.model,
     });
 
     // Extract text from payloads


### PR DESCRIPTION
Fixes #5583. This PR ensures that the llm-slug-generator uses the user's configured primary model instead of falling back to hardcoded Anthropic defaults, which caused failures for users without Anthropic API keys.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the LLM-based session slug generator (`src/hooks/llm-slug-generator.ts`) to select the model/provider via `resolveDefaultModelForAgent({ cfg, agentId })` and pass that through to `runEmbeddedPiAgent`, instead of relying on `runEmbeddedPiAgent`’s internal Anthropic defaults.

In the broader codebase, `runEmbeddedPiAgent` falls back to `DEFAULT_PROVIDER/DEFAULT_MODEL` when `params.provider` / `params.model` are omitted (`src/agents/pi-embedded-runner/run.ts:97-99`), which can break users who don’t have Anthropic credentials configured. Using `resolveDefaultModelForAgent` aligns this hook with how other CLI/agent execution paths pick configured models (`src/agents/model-selection.ts:197+`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and scoped: it threads an already-existing config-based model resolver into a single `runEmbeddedPiAgent` call site. It aligns with existing model selection behavior and reduces reliance on Anthropic defaults, without altering other execution paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->