### PR TITLE
fix(voice-call): add direction, from, to fields to Telnyx event normalization

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { WebhookContext } from "../types.js";
+import { TelnyxProvider } from "./telnyx.js";
+
+function createProvider(): TelnyxProvider {
+  return new TelnyxProvider({
+    apiKey: "KEY123",
+    connectionId: "conn-123",
+  });
+}
+
+function createContext(payload: object): WebhookContext {
+  return {
+    headers: {},
+    rawBody: JSON.stringify({ data: payload }),
+    url: "https://example.com/voice/telnyx",
+    method: "POST",
+  };
+}
+
+describe("TelnyxProvider", () => {
+  describe("parseWebhookEvent", () => {
+    it("parses direction as inbound for incoming calls", () => {
+      const provider = createProvider();
+      const ctx = createContext({
+        id: "evt-1",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "ctrl-1",
+          direction: "incoming",
+          from: "+15551234567",
+          to: "+15559876543",
+        },
+      });
+
+      const result = provider.parseWebhookEvent(ctx);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toMatchObject({
+        type: "call.initiated",
+        direction: "inbound",
+        from: "+15551234567",
+        to: "+15559876543",
+      });
+    });
+
+    it("parses direction as outbound for outgoing calls", () => {
+      const provider = createProvider();
+      const ctx = createContext({
+        id: "evt-2",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "ctrl-2",
+          direction: "outgoing",
+          from: "+15559876543",
+          to: "+15551234567",
+        },
+      });
+
+      const result = provider.parseWebhookEvent(ctx);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toMatchObject({
+        type: "call.initiated",
+        direction: "outbound",
+        from: "+15559876543",
+        to: "+15551234567",
+      });
+    });
+
+    it("handles missing direction gracefully", () => {
+      const provider = createProvider();
+      const ctx = createContext({
+        id: "evt-3",
+        event_type: "call.answered",
+        payload: {
+          call_control_id: "ctrl-3",
+        },
+      });
+
+      const result = provider.parseWebhookEvent(ctx);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toMatchObject({
+        type: "call.answered",
+        direction: undefined,
+      });
+    });
+
+    it("decodes callId from Base64 client_state", () => {
+      const provider = createProvider();
+      const callId = "my-call-123";
+      const ctx = createContext({
+        id: "evt-4",
+        event_type: "call.ringing",
+        payload: {
+          call_control_id: "ctrl-4",
+          client_state: Buffer.from(callId).toString("base64"),
+          direction: "incoming",
+        },
+      });
+
+      const result = provider.parseWebhookEvent(ctx);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toMatchObject({
+        callId: "my-call-123",
+        direction: "inbound",
+      });
+    });
+  });
+});

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -154,6 +154,19 @@ export class TelnyxProvider implements VoiceCallProvider {
   }
 
   /**
+   * Parse Telnyx direction to normalized format.
+   */
+  private static parseDirection(direction: string | undefined): "inbound" | "outbound" | undefined {
+    if (direction === "incoming") {
+      return "inbound";
+    }
+    if (direction === "outgoing") {
+      return "outbound";
+    }
+    return undefined;
+  }
+
+  /**
    * Convert Telnyx event to normalized event format.
    */
   private normalizeEvent(data: TelnyxEvent): NormalizedEvent | null {
@@ -176,6 +189,9 @@ export class TelnyxProvider implements VoiceCallProvider {
       callId,
       providerCallId: data.payload?.call_control_id,
       timestamp: Date.now(),
+      direction: TelnyxProvider.parseDirection(data.payload?.direction),
+      from: data.payload?.from || undefined,
+      to: data.payload?.to || undefined,
     };
 
     switch (data.event_type) {
@@ -338,6 +354,9 @@ interface TelnyxEvent {
   payload?: {
     call_control_id?: string;
     client_state?: string;
+    direction?: string;
+    from?: string;
+    to?: string;
     text?: string;
     transcription?: string;
     is_final?: boolean;

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -190,8 +190,8 @@ export class TelnyxProvider implements VoiceCallProvider {
       providerCallId: data.payload?.call_control_id,
       timestamp: Date.now(),
       direction: TelnyxProvider.parseDirection(data.payload?.direction),
-      from: data.payload?.from || undefined,
-      to: data.payload?.to || undefined,
+      from: data.payload?.from ?? undefined,
+      to: data.payload?.to ?? undefined,
     };
 
     switch (data.event_type) {


### PR DESCRIPTION
## Summary
- Fixes Telnyx voice-call provider not setting `direction`, `from`, and `to` fields in normalized events
- Inbound calls were silently dropped because `event.direction === 'inbound'` was never true
- Adds `parseDirection()` helper to convert Telnyx's `incoming`/`outgoing` to normalized `inbound`/`outbound`
- Updates `TelnyxEvent` interface to include the payload fields

Closes #5589

## Test plan
- [x] Added unit tests for direction parsing (inbound, outbound, undefined)
- [x] Added tests for from/to field extraction
- [x] Added test for Base64 client_state decoding
- [x] All tests pass (`pnpm test extensions/voice-call/src/providers/telnyx.test.ts`)
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telnyx voice-call webhook normalization to populate `direction`, `from`, and `to` on `NormalizedEvent`, including a small helper to map Telnyx’s `incoming`/`outgoing` strings to the project’s `inbound`/`outbound` values. It also extends the local `TelnyxEvent` payload type and adds a new Vitest suite to assert direction mapping, from/to extraction, and Base64 `client_state` callId decoding.

Overall this fits cleanly into the existing provider pattern: `parseWebhookEvent` parses the incoming webhook, then `normalizeEvent` produces a single normalized event (or drops unknown types).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and addresses a real normalization gap, with a small edge-case around empty-string `from`/`to` handling.
- Changes are localized to Telnyx webhook normalization plus unit tests; no broad refactors or API surface changes beyond adding optional fields. The only notable concern is the use of `|| undefined` for `from`/`to`, which can unintentionally drop empty-string values if Telnyx uses them as a meaningful sentinel.
- extensions/voice-call/src/providers/telnyx.ts (empty-string handling for from/to)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->