### PR TITLE
feat(whatsapp): detect replies to bot as implicit mention in groups

### DIFF
--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -39,7 +39,9 @@ export function resolveMentionTargets(msg: WebInboundMsg, authDir?: string): Men
  * Example: `98157853687950:5@lid` -> `98157853687950@lid`
  */
 function normalizeBareId(jid: string | null | undefined): string | null {
-  if (!jid) return null;
+  if (!jid) {
+    return null;
+  }
   return jid.replace(/:\d+(@)/, "$1");
 }
 
@@ -49,7 +51,9 @@ function normalizeBareId(jid: string | null | undefined): string | null {
  */
 function isReplyToBot(msg: WebInboundMsg, targets: MentionTargets): boolean {
   const replyToJid = msg.replyToSenderJid;
-  if (!replyToJid) return false;
+  if (!replyToJid) {
+    return false;
+  }
 
   const replyToJidBare = normalizeBareId(replyToJid);
 

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -66,6 +66,7 @@ export async function monitorWebInbox(options: {
   }
 
   const selfJid = sock.user?.id;
+  const selfLid = sock.user?.lid;
   const selfE164 = selfJid ? jidToE164(selfJid) : null;
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
@@ -319,6 +320,7 @@ export async function monitorWebInbox(options: {
         groupParticipants,
         mentionedJids: mentionedJids ?? undefined,
         selfJid,
+        selfLid,
         selfE164,
         location: location ?? undefined,
         sendComposing,

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -31,6 +31,7 @@ export type WebInboundMessage = {
   mentionedJids?: string[];
   selfJid?: string | null;
   selfE164?: string | null;
+  selfLid?: string | null;
   location?: NormalizedLocation;
   sendComposing: () => Promise<void>;
   reply: (text: string) => Promise<void>;


### PR DESCRIPTION
## Summary

When a user replies to a bot's message in a WhatsApp group, this PR treats it as an implicit mention so the bot responds without requiring an explicit @mention or name pattern.

**Problem:** Previously, to trigger the bot in a group chat, users had to either:
- Use an explicit @mention
- Include the bot's name in the message (matching `mentionPatterns`)

This was unintuitive — users expected that replying directly to the bot's message would trigger a response.

**Solution:** Detect when `replyToSenderJid` matches the bot's own JID/LID and treat it as an implicit mention.

## Technical Details

WhatsApp uses LID (Linked ID) format in some contexts instead of the traditional JID format. For example:
- JID: `557588566305@s.whatsapp.net`
- LID: `98157853687950@lid`

Both can have device suffixes (e.g., `:5`) that need to be normalized for comparison.

### Changes

- **`src/web/inbound/types.ts`**: Added `selfLid` to `WebInboundMessage` type
- **`src/web/inbound/monitor.ts`**: Extract and pass `selfLid` from socket user info
- **`src/web/auto-reply/mentions.ts`**:
  - Added `normalizeBareId()` to strip device suffixes from JID/LID
  - Added `isReplyToBot()` to detect replies to bot's messages (supports both JID and LID formats)
  - Updated `isBotMentionedFromTargets()` to check reply-to-bot before other mention methods
  - Expanded `debugMention()` output with LID and reply detection info for troubleshooting

## Test Plan

- [x] Tested on live WhatsApp group with bot
- [x] Verified reply detection works with LID format
- [x] Confirmed existing @mention and name pattern detection still works
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds WhatsApp group behavior to treat “replying to the bot’s message” as an implicit mention, in addition to the existing explicit @mention and name-pattern triggers. It threads the bot’s own LID (`selfLid`) through the inbound message type (`src/web/inbound/types.ts`) and monitor (`src/web/inbound/monitor.ts`), then updates mention detection (`src/web/auto-reply/mentions.ts`) with JID/LID normalization and reply-to-bot matching.

Main issue spotted: the LID reply detection currently checks `replyToJid.endsWith("@lid")`, which will fail when the reply JID includes a device suffix (e.g. `...:5@lid`), causing implicit mentions to be missed for that common form.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing the LID `:device@lid` reply matching edge case.
- Changes are scoped to mention detection and inbound metadata plumbing, with minimal surface area. The main correctness risk is the `endsWith("@lid")` check missing the common `:N@lid` form, which would make the new feature unreliable in the scenario it targets.
- src/web/auto-reply/mentions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->