### PR TITLE
feat(voice-call): OpenAI Realtime voice-to-voice mode for sub-second latency

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -161,6 +161,13 @@ export class CallManager {
         console.log(`[voice-call] Using inline TwiML for notify mode (voice: ${pollyVoice})`);
       }
 
+      // Mark call as realtime mode for Twilio provider
+      if (mode === "realtime" && this.provider.name === "twilio") {
+        const twilioProvider = this.provider as { markAsRealtimeCall?: (id: string) => void };
+        twilioProvider.markAsRealtimeCall?.(callId);
+        console.log(`[voice-call] Using realtime voice-to-voice mode for call ${callId}`);
+      }
+
       const result = await this.provider.initiateCall({
         callId,
         from,

--- a/extensions/voice-call/src/media-stream-realtime.ts
+++ b/extensions/voice-call/src/media-stream-realtime.ts
@@ -1,0 +1,318 @@
+/**
+ * Realtime Media Stream Handler
+ *
+ * Handles bidirectional audio streaming for OpenAI Realtime voice-to-voice mode.
+ * Audio flows directly between Twilio Media Streams and OpenAI Realtime API
+ * without intermediate STT → LLM → TTS processing.
+ */
+
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+
+import { WebSocket, WebSocketServer } from "ws";
+
+import {
+  OpenAIRealtimeVoiceProvider,
+  OpenAIRealtimeVoiceSession,
+  type RealtimeVoiceConfig,
+  type RealtimeVoiceEvents,
+} from "./providers/openai-realtime-voice.js";
+
+/**
+ * Configuration for the realtime media stream handler.
+ */
+export interface RealtimeMediaStreamConfig {
+  /** OpenAI Realtime Voice provider */
+  voiceProvider: OpenAIRealtimeVoiceProvider;
+  /** Default voice configuration overrides */
+  voiceConfig?: Partial<RealtimeVoiceConfig>;
+  /** Callback when user transcript is received */
+  onTranscript?: (callId: string, transcript: string) => void;
+  /** Callback when AI response is generated */
+  onResponse?: (callId: string, text: string) => void;
+  /** Callback when stream connects */
+  onConnect?: (callId: string, streamSid: string) => void;
+  /** Callback when stream disconnects */
+  onDisconnect?: (callId: string) => void;
+  /** Callback when speech starts (for UI updates) */
+  onSpeechStart?: (callId: string) => void;
+  /** Callback when speech stops */
+  onSpeechStop?: (callId: string) => void;
+}
+
+/**
+ * Active realtime stream session.
+ */
+interface RealtimeStreamSession {
+  callId: string;
+  streamSid: string;
+  ws: WebSocket;
+  voiceSession: OpenAIRealtimeVoiceSession;
+}
+
+/**
+ * Manages WebSocket connections for Twilio media streams with OpenAI Realtime.
+ */
+export class RealtimeMediaStreamHandler {
+  private wss: WebSocketServer | null = null;
+  private sessions = new Map<string, RealtimeStreamSession>();
+  private config: RealtimeMediaStreamConfig;
+
+  constructor(config: RealtimeMediaStreamConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Handle WebSocket upgrade for media stream connections.
+   */
+  handleUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
+    if (!this.wss) {
+      this.wss = new WebSocketServer({ noServer: true });
+      this.wss.on("connection", (ws, req) => this.handleConnection(ws, req));
+    }
+
+    this.wss.handleUpgrade(request, socket, head, (ws) => {
+      this.wss?.emit("connection", ws, request);
+    });
+  }
+
+  /**
+   * Handle new WebSocket connection from Twilio.
+   */
+  private async handleConnection(ws: WebSocket, _request: IncomingMessage): Promise<void> {
+    let session: RealtimeStreamSession | null = null;
+
+    ws.on("message", async (data: Buffer) => {
+      try {
+        const message = JSON.parse(data.toString()) as TwilioMediaMessage;
+
+        switch (message.event) {
+          case "connected":
+            console.log("[RealtimeStream] Twilio connected");
+            break;
+
+          case "start":
+            session = await this.handleStart(ws, message);
+            break;
+
+          case "media":
+            if (session && message.media?.payload) {
+              // Forward audio directly to OpenAI Realtime
+              const audioBuffer = Buffer.from(message.media.payload, "base64");
+              session.voiceSession.sendAudio(audioBuffer);
+            }
+            break;
+
+          case "stop":
+            if (session) {
+              this.handleStop(session);
+              session = null;
+            }
+            break;
+        }
+      } catch (error) {
+        console.error("[RealtimeStream] Error processing message:", error);
+      }
+    });
+
+    ws.on("close", () => {
+      if (session) {
+        this.handleStop(session);
+      }
+    });
+
+    ws.on("error", (error) => {
+      console.error("[RealtimeStream] WebSocket error:", error);
+    });
+  }
+
+  /**
+   * Handle stream start event - initialize OpenAI Realtime session.
+   */
+  private async handleStart(
+    ws: WebSocket,
+    message: TwilioMediaMessage,
+  ): Promise<RealtimeStreamSession> {
+    const streamSid = message.streamSid || "";
+    const callSid = message.start?.callSid || "";
+
+    console.log(`[RealtimeStream] Stream started: ${streamSid} (call: ${callSid})`);
+
+    // Create events for the voice session
+    const events: RealtimeVoiceEvents = {
+      onAudio: (audio: Buffer) => {
+        // Send audio back to Twilio
+        this.sendAudioToTwilio(streamSid, audio);
+      },
+      onTranscript: (transcript: string, isFinal: boolean) => {
+        if (isFinal) {
+          console.log(`[RealtimeStream] User: ${transcript}`);
+          this.config.onTranscript?.(callSid, transcript);
+        }
+      },
+      onResponseText: (text: string, isFinal: boolean) => {
+        if (isFinal) {
+          console.log(`[RealtimeStream] AI: ${text}`);
+          this.config.onResponse?.(callSid, text);
+        }
+      },
+      onSpeechStart: () => {
+        console.log(`[RealtimeStream] Speech started for ${callSid}`);
+        this.config.onSpeechStart?.(callSid);
+        // Clear any pending audio when user interrupts
+        this.clearAudio(streamSid);
+      },
+      onSpeechStop: () => {
+        this.config.onSpeechStop?.(callSid);
+      },
+      onError: (error: Error) => {
+        console.error(`[RealtimeStream] Voice error for ${callSid}:`, error);
+      },
+      onReady: () => {
+        console.log(`[RealtimeStream] Voice session ready for ${callSid}`);
+      },
+    };
+
+    // Create and connect the voice session
+    const voiceSession = this.config.voiceProvider.createSession(
+      events,
+      this.config.voiceConfig,
+    );
+
+    const session: RealtimeStreamSession = {
+      callId: callSid,
+      streamSid,
+      ws,
+      voiceSession,
+    };
+
+    this.sessions.set(streamSid, session);
+
+    // Connect to OpenAI Realtime (non-blocking)
+    voiceSession.connect().catch((err) => {
+      console.error(`[RealtimeStream] Failed to connect voice session:`, err);
+    });
+
+    // Notify connection
+    this.config.onConnect?.(callSid, streamSid);
+
+    return session;
+  }
+
+  /**
+   * Handle stream stop event.
+   */
+  private handleStop(session: RealtimeStreamSession): void {
+    console.log(`[RealtimeStream] Stream stopped: ${session.streamSid}`);
+
+    session.voiceSession.close();
+    this.sessions.delete(session.streamSid);
+    this.config.onDisconnect?.(session.callId);
+  }
+
+  /**
+   * Send audio to Twilio media stream.
+   */
+  private sendAudioToTwilio(streamSid: string, audio: Buffer): void {
+    const session = this.sessions.get(streamSid);
+    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+
+    session.ws.send(
+      JSON.stringify({
+        event: "media",
+        streamSid,
+        media: {
+          payload: audio.toString("base64"),
+        },
+      }),
+    );
+  }
+
+  /**
+   * Clear audio buffer (interrupt playback).
+   */
+  clearAudio(streamSid: string): void {
+    const session = this.sessions.get(streamSid);
+    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+
+    session.ws.send(
+      JSON.stringify({
+        event: "clear",
+        streamSid,
+      }),
+    );
+  }
+
+  /**
+   * Send a mark event to track audio position.
+   */
+  sendMark(streamSid: string, name: string): void {
+    const session = this.sessions.get(streamSid);
+    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+
+    session.ws.send(
+      JSON.stringify({
+        event: "mark",
+        streamSid,
+        mark: { name },
+      }),
+    );
+  }
+
+  /**
+   * Get session by call ID.
+   */
+  getSessionByCallId(callId: string): RealtimeStreamSession | undefined {
+    return [...this.sessions.values()].find((s) => s.callId === callId);
+  }
+
+  /**
+   * Inject a text message into the conversation.
+   */
+  injectMessage(callId: string, text: string, role: "user" | "assistant" = "user"): void {
+    const session = this.getSessionByCallId(callId);
+    if (session) {
+      session.voiceSession.sendTextMessage(text, role);
+    }
+  }
+
+  /**
+   * Close all sessions.
+   */
+  closeAll(): void {
+    for (const session of this.sessions.values()) {
+      session.voiceSession.close();
+      session.ws.close();
+    }
+    this.sessions.clear();
+  }
+}
+
+/**
+ * Twilio Media Stream message format.
+ */
+interface TwilioMediaMessage {
+  event: "connected" | "start" | "media" | "stop" | "mark" | "clear";
+  sequenceNumber?: string;
+  streamSid?: string;
+  start?: {
+    streamSid: string;
+    accountSid: string;
+    callSid: string;
+    tracks: string[];
+    mediaFormat: {
+      encoding: string;
+      sampleRate: number;
+      channels: number;
+    };
+  };
+  media?: {
+    track?: string;
+    chunk?: string;
+    timestamp?: string;
+    payload?: string;
+  };
+  mark?: {
+    name: string;
+  };
+}

--- a/extensions/voice-call/src/media-stream-realtime.ts
+++ b/extensions/voice-call/src/media-stream-realtime.ts
@@ -174,10 +174,7 @@ export class RealtimeMediaStreamHandler {
     };
 
     // Create and connect the voice session
-    const voiceSession = this.config.voiceProvider.createSession(
-      events,
-      this.config.voiceConfig,
-    );
+    const voiceSession = this.config.voiceProvider.createSession(events, this.config.voiceConfig);
 
     const session: RealtimeStreamSession = {
       callId: callSid,
@@ -215,7 +212,9 @@ export class RealtimeMediaStreamHandler {
    */
   private sendAudioToTwilio(streamSid: string, audio: Buffer): void {
     const session = this.sessions.get(streamSid);
-    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+    if (!session || session.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
 
     session.ws.send(
       JSON.stringify({
@@ -233,7 +232,9 @@ export class RealtimeMediaStreamHandler {
    */
   clearAudio(streamSid: string): void {
     const session = this.sessions.get(streamSid);
-    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+    if (!session || session.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
 
     session.ws.send(
       JSON.stringify({
@@ -248,7 +249,9 @@ export class RealtimeMediaStreamHandler {
    */
   sendMark(streamSid: string, name: string): void {
     const session = this.sessions.get(streamSid);
-    if (!session || session.ws.readyState !== WebSocket.OPEN) return;
+    if (!session || session.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
 
     session.ws.send(
       JSON.stringify({

--- a/extensions/voice-call/src/providers/index.ts
+++ b/extensions/voice-call/src/providers/index.ts
@@ -5,6 +5,12 @@ export {
   type RealtimeSTTConfig,
   type RealtimeSTTSession,
 } from "./stt-openai-realtime.js";
+export {
+  OpenAIRealtimeVoiceProvider,
+  OpenAIRealtimeVoiceSession,
+  type RealtimeVoiceConfig,
+  type RealtimeVoiceEvents,
+} from "./openai-realtime-voice.js";
 export { TelnyxProvider } from "./telnyx.js";
 export { TwilioProvider } from "./twilio.js";
 export { PlivoProvider } from "./plivo.js";

--- a/extensions/voice-call/src/providers/openai-realtime-voice.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-voice.ts
@@ -92,7 +92,9 @@ export class OpenAIRealtimeVoiceSession {
    * Connect to OpenAI Realtime API.
    */
   async connect(): Promise<void> {
-    if (this.connected) return;
+    if (this.connected) {
+      return;
+    }
 
     return new Promise((resolve, reject) => {
       const url = `wss://api.openai.com/v1/realtime?model=${this.config.model}`;
@@ -289,7 +291,9 @@ export class OpenAIRealtimeVoiceSession {
    * @param audio - mu-law encoded audio (8kHz mono)
    */
   sendAudio(audio: Buffer): void {
-    if (!this.connected) return;
+    if (!this.connected) {
+      return;
+    }
 
     this.sendEvent({
       type: "input_audio_buffer.append",
@@ -301,7 +305,9 @@ export class OpenAIRealtimeVoiceSession {
    * Commit the audio buffer (signal end of audio input).
    */
   commitAudio(): void {
-    if (!this.connected) return;
+    if (!this.connected) {
+      return;
+    }
 
     this.sendEvent({
       type: "input_audio_buffer.commit",
@@ -312,7 +318,9 @@ export class OpenAIRealtimeVoiceSession {
    * Cancel current response (for interruption/barge-in).
    */
   cancelResponse(): void {
-    if (!this.connected || !this.currentResponseId) return;
+    if (!this.connected || !this.currentResponseId) {
+      return;
+    }
 
     console.log(`[RealtimeVoice] Cancelling response: ${this.currentResponseId}`);
     this.sendEvent({
@@ -326,7 +334,9 @@ export class OpenAIRealtimeVoiceSession {
    * Send a text message to inject into the conversation.
    */
   sendTextMessage(text: string, role: "user" | "assistant" = "user"): void {
-    if (!this.connected) return;
+    if (!this.connected) {
+      return;
+    }
 
     this.sendEvent({
       type: "conversation.item.create",

--- a/extensions/voice-call/src/providers/openai-realtime-voice.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-voice.ts
@@ -1,0 +1,411 @@
+/**
+ * OpenAI Realtime Voice-to-Voice Provider
+ *
+ * Uses OpenAI's Realtime API for full voice-to-voice conversations with:
+ * - Sub-second latency (no separate STT → LLM → TTS chain)
+ * - GPT-4o generates responses AND audio in one stream
+ * - Built-in VAD, interruption handling, and turn detection
+ * - Direct mu-law audio support for Twilio Media Streams
+ *
+ * Trade-off: Uses GPT-4o instead of Claude for responses.
+ *
+ * @see https://platform.openai.com/docs/guides/realtime
+ */
+
+import WebSocket from "ws";
+
+/**
+ * Configuration for OpenAI Realtime Voice.
+ */
+export interface RealtimeVoiceConfig {
+  /** OpenAI API key */
+  apiKey: string;
+  /** Model to use (default: gpt-4o-realtime-preview-2024-12-17) */
+  model?: string;
+  /** Voice for TTS output (default: nova) */
+  voice?: "alloy" | "ash" | "ballad" | "coral" | "echo" | "sage" | "shimmer" | "verse" | "nova";
+  /** System prompt for the AI */
+  systemPrompt?: string;
+  /** Temperature for response generation (0-2, default: 0.8) */
+  temperature?: number;
+  /** Max response tokens (default: 4096) */
+  maxResponseTokens?: number | "inf";
+  /** VAD threshold 0-1 (default: 0.5) */
+  vadThreshold?: number;
+  /** Silence duration in ms before turn ends (default: 500) */
+  silenceDurationMs?: number;
+  /** Prefix padding in ms (default: 300) */
+  prefixPaddingMs?: number;
+}
+
+/**
+ * Events emitted by the realtime voice session.
+ */
+export interface RealtimeVoiceEvents {
+  /** Called when audio is ready to send to caller */
+  onAudio?: (audio: Buffer) => void;
+  /** Called when user's speech is transcribed */
+  onTranscript?: (transcript: string, isFinal: boolean) => void;
+  /** Called when AI response text is generated */
+  onResponseText?: (text: string, isFinal: boolean) => void;
+  /** Called when user starts speaking (for barge-in) */
+  onSpeechStart?: () => void;
+  /** Called when user stops speaking */
+  onSpeechStop?: () => void;
+  /** Called on errors */
+  onError?: (error: Error) => void;
+  /** Called when session is ready */
+  onReady?: () => void;
+}
+
+/**
+ * Session for full voice-to-voice conversations via OpenAI Realtime API.
+ */
+export class OpenAIRealtimeVoiceSession {
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private closed = false;
+  private sessionId: string | null = null;
+  private config: Required<RealtimeVoiceConfig>;
+  private events: RealtimeVoiceEvents;
+
+  // Track response state for interruption handling
+  private currentResponseId: string | null = null;
+  private isGenerating = false;
+
+  constructor(config: RealtimeVoiceConfig, events: RealtimeVoiceEvents = {}) {
+    this.config = {
+      apiKey: config.apiKey,
+      model: config.model || "gpt-4o-realtime-preview-2024-12-17",
+      voice: config.voice || "nova",
+      systemPrompt: config.systemPrompt || "You are a helpful assistant.",
+      temperature: config.temperature ?? 0.8,
+      maxResponseTokens: config.maxResponseTokens ?? 4096,
+      vadThreshold: config.vadThreshold ?? 0.5,
+      silenceDurationMs: config.silenceDurationMs ?? 500,
+      prefixPaddingMs: config.prefixPaddingMs ?? 300,
+    };
+    this.events = events;
+  }
+
+  /**
+   * Connect to OpenAI Realtime API.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    return new Promise((resolve, reject) => {
+      const url = `wss://api.openai.com/v1/realtime?model=${this.config.model}`;
+
+      this.ws = new WebSocket(url, {
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+          "OpenAI-Beta": "realtime=v1",
+        },
+      });
+
+      const timeout = setTimeout(() => {
+        if (!this.connected) {
+          this.ws?.close();
+          reject(new Error("Connection timeout"));
+        }
+      }, 15000);
+
+      this.ws.on("open", () => {
+        console.log("[RealtimeVoice] WebSocket connected");
+        clearTimeout(timeout);
+      });
+
+      this.ws.on("message", (data: Buffer) => {
+        try {
+          const event = JSON.parse(data.toString());
+          this.handleEvent(event, resolve, reject);
+        } catch (e) {
+          console.error("[RealtimeVoice] Failed to parse event:", e);
+        }
+      });
+
+      this.ws.on("error", (error) => {
+        console.error("[RealtimeVoice] WebSocket error:", error);
+        clearTimeout(timeout);
+        if (!this.connected) {
+          reject(error);
+        }
+        this.events.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+
+      this.ws.on("close", (code, reason) => {
+        console.log(`[RealtimeVoice] WebSocket closed: ${code} - ${reason?.toString() || "none"}`);
+        this.connected = false;
+        this.sessionId = null;
+      });
+    });
+  }
+
+  /**
+   * Handle incoming events from OpenAI.
+   */
+  private handleEvent(
+    event: Record<string, unknown>,
+    onConnected?: () => void,
+    onError?: (error: Error) => void,
+  ): void {
+    const type = event.type as string;
+
+    switch (type) {
+      case "session.created":
+        this.sessionId = event.session_id as string;
+        console.log(`[RealtimeVoice] Session created: ${this.sessionId}`);
+        // Configure the session for voice-to-voice
+        this.configureSession();
+        break;
+
+      case "session.updated":
+        console.log("[RealtimeVoice] Session configured");
+        this.connected = true;
+        this.events.onReady?.();
+        onConnected?.();
+        break;
+
+      case "input_audio_buffer.speech_started":
+        console.log("[RealtimeVoice] User started speaking");
+        this.events.onSpeechStart?.();
+        // Interrupt current response if generating
+        if (this.isGenerating && this.currentResponseId) {
+          this.cancelResponse();
+        }
+        break;
+
+      case "input_audio_buffer.speech_stopped":
+        console.log("[RealtimeVoice] User stopped speaking");
+        this.events.onSpeechStop?.();
+        break;
+
+      case "conversation.item.input_audio_transcription.completed":
+        const transcript = event.transcript as string;
+        console.log(`[RealtimeVoice] User said: ${transcript}`);
+        this.events.onTranscript?.(transcript, true);
+        break;
+
+      case "response.created":
+        this.currentResponseId = (event.response as Record<string, unknown>)?.id as string;
+        this.isGenerating = true;
+        console.log(`[RealtimeVoice] Response started: ${this.currentResponseId}`);
+        break;
+
+      case "response.audio.delta":
+        // Audio chunk from the AI - decode and forward to caller
+        const audioBase64 = event.delta as string;
+        if (audioBase64) {
+          const audioBuffer = Buffer.from(audioBase64, "base64");
+          this.events.onAudio?.(audioBuffer);
+        }
+        break;
+
+      case "response.audio_transcript.delta":
+        // Partial AI response text
+        const partialText = event.delta as string;
+        if (partialText) {
+          this.events.onResponseText?.(partialText, false);
+        }
+        break;
+
+      case "response.audio_transcript.done":
+        // Final AI response text
+        const finalText = event.transcript as string;
+        if (finalText) {
+          console.log(`[RealtimeVoice] AI said: ${finalText}`);
+          this.events.onResponseText?.(finalText, true);
+        }
+        break;
+
+      case "response.done":
+        this.isGenerating = false;
+        this.currentResponseId = null;
+        console.log("[RealtimeVoice] Response complete");
+        break;
+
+      case "error":
+        const errorMsg = (event.error as Record<string, unknown>)?.message as string;
+        console.error(`[RealtimeVoice] Error: ${errorMsg}`);
+        const error = new Error(errorMsg || "Unknown error");
+        this.events.onError?.(error);
+        onError?.(error);
+        break;
+
+      case "rate_limits.updated":
+        // Ignore rate limit updates
+        break;
+
+      default:
+        // Log unhandled events for debugging
+        if (!type.startsWith("input_audio_buffer.")) {
+          console.log(`[RealtimeVoice] Event: ${type}`);
+        }
+    }
+  }
+
+  /**
+   * Configure the session for voice-to-voice conversation.
+   */
+  private configureSession(): void {
+    this.sendEvent({
+      type: "session.update",
+      session: {
+        // Input configuration
+        input_audio_format: "g711_ulaw", // Twilio media stream format
+        input_audio_transcription: {
+          model: "whisper-1",
+        },
+
+        // Output configuration
+        output_audio_format: "g711_ulaw", // Send back in same format
+        voice: this.config.voice,
+
+        // Modalities - both text and audio
+        modalities: ["text", "audio"],
+
+        // Instructions (system prompt)
+        instructions: this.config.systemPrompt,
+
+        // Turn detection with server VAD
+        turn_detection: {
+          type: "server_vad",
+          threshold: this.config.vadThreshold,
+          prefix_padding_ms: this.config.prefixPaddingMs,
+          silence_duration_ms: this.config.silenceDurationMs,
+          create_response: true, // Auto-generate response when user stops
+        },
+
+        // Response settings
+        temperature: this.config.temperature,
+        max_response_output_tokens: this.config.maxResponseTokens,
+      },
+    });
+  }
+
+  /**
+   * Send audio from caller to OpenAI.
+   * @param audio - mu-law encoded audio (8kHz mono)
+   */
+  sendAudio(audio: Buffer): void {
+    if (!this.connected) return;
+
+    this.sendEvent({
+      type: "input_audio_buffer.append",
+      audio: audio.toString("base64"),
+    });
+  }
+
+  /**
+   * Commit the audio buffer (signal end of audio input).
+   */
+  commitAudio(): void {
+    if (!this.connected) return;
+
+    this.sendEvent({
+      type: "input_audio_buffer.commit",
+    });
+  }
+
+  /**
+   * Cancel current response (for interruption/barge-in).
+   */
+  cancelResponse(): void {
+    if (!this.connected || !this.currentResponseId) return;
+
+    console.log(`[RealtimeVoice] Cancelling response: ${this.currentResponseId}`);
+    this.sendEvent({
+      type: "response.cancel",
+    });
+    this.isGenerating = false;
+    this.currentResponseId = null;
+  }
+
+  /**
+   * Send a text message to inject into the conversation.
+   */
+  sendTextMessage(text: string, role: "user" | "assistant" = "user"): void {
+    if (!this.connected) return;
+
+    this.sendEvent({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role,
+        content: [
+          {
+            type: role === "user" ? "input_text" : "text",
+            text,
+          },
+        ],
+      },
+    });
+
+    // Trigger response if user message
+    if (role === "user") {
+      this.sendEvent({ type: "response.create" });
+    }
+  }
+
+  /**
+   * Send an event to OpenAI.
+   */
+  private sendEvent(event: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(event));
+    }
+  }
+
+  /**
+   * Check if session is connected and ready.
+   */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Check if AI is currently generating a response.
+   */
+  isResponding(): boolean {
+    return this.isGenerating;
+  }
+
+  /**
+   * Close the session.
+   */
+  close(): void {
+    this.closed = true;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connected = false;
+    this.sessionId = null;
+  }
+}
+
+/**
+ * Factory for creating OpenAI Realtime Voice sessions.
+ */
+export class OpenAIRealtimeVoiceProvider {
+  readonly name = "openai-realtime-voice";
+  private defaultConfig: RealtimeVoiceConfig;
+
+  constructor(config: RealtimeVoiceConfig) {
+    if (!config.apiKey) {
+      throw new Error("OpenAI API key required for Realtime Voice");
+    }
+    this.defaultConfig = config;
+  }
+
+  /**
+   * Create a new realtime voice session.
+   */
+  createSession(
+    events: RealtimeVoiceEvents,
+    overrides?: Partial<RealtimeVoiceConfig>,
+  ): OpenAIRealtimeVoiceSession {
+    return new OpenAIRealtimeVoiceSession({ ...this.defaultConfig, ...overrides }, events);
+  }
+}

--- a/extensions/voice-call/src/providers/openai-realtime-voice.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-voice.ts
@@ -138,8 +138,18 @@ export class OpenAIRealtimeVoiceSession {
 
       this.ws.on("close", (code, reason) => {
         console.log(`[RealtimeVoice] WebSocket closed: ${code} - ${reason?.toString() || "none"}`);
+        clearTimeout(timeout);
+        const wasConnected = this.connected;
         this.connected = false;
         this.sessionId = null;
+        // Reject if we never completed connection
+        if (!wasConnected) {
+          reject(
+            new Error(
+              `WebSocket closed before session ready: ${code} - ${reason?.toString() || "none"}`,
+            ),
+          );
+        }
       });
     });
   }

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -66,6 +66,8 @@ export class TwilioProvider implements VoiceCallProvider {
   private readonly twimlStorage = new Map<string, string>();
   /** Track notify-mode calls to avoid streaming on follow-up callbacks */
   private readonly notifyCalls = new Set<string>();
+  /** Track realtime-mode calls to use voice-to-voice stream */
+  private readonly realtimeCalls = new Set<string>();
 
   /**
    * Delete stored TwiML for a given `callId`.
@@ -76,6 +78,21 @@ export class TwilioProvider implements VoiceCallProvider {
   private deleteStoredTwiml(callId: string): void {
     this.twimlStorage.delete(callId);
     this.notifyCalls.delete(callId);
+    this.realtimeCalls.delete(callId);
+  }
+
+  /**
+   * Mark a call as using realtime voice-to-voice mode.
+   */
+  markAsRealtimeCall(callId: string): void {
+    this.realtimeCalls.add(callId);
+  }
+
+  /**
+   * Check if a call is using realtime voice-to-voice mode.
+   */
+  isRealtimeCall(callId: string): boolean {
+    return this.realtimeCalls.has(callId);
   }
 
   /**
@@ -329,9 +346,10 @@ export class TwilioProvider implements VoiceCallProvider {
         return TwilioProvider.EMPTY_TWIML;
       }
 
-      // Conversation mode: return streaming TwiML immediately for outbound calls.
+      // Conversation/realtime mode: return streaming TwiML immediately for outbound calls.
       if (isOutbound) {
-        const streamUrl = this.getStreamUrl();
+        const isRealtime = this.isRealtimeCall(callIdFromQuery);
+        const streamUrl = this.getStreamUrl(isRealtime);
         return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
       }
     }
@@ -343,6 +361,7 @@ export class TwilioProvider implements VoiceCallProvider {
 
     // Handle subsequent webhook requests (status callbacks, etc.)
     // For inbound calls, answer immediately with stream
+    // TODO: Support realtime mode for inbound calls (need to pass mode in query param)
     if (direction === "inbound") {
       const streamUrl = this.getStreamUrl();
       return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
@@ -360,8 +379,10 @@ export class TwilioProvider implements VoiceCallProvider {
   /**
    * Get the WebSocket URL for media streaming.
    * Derives from the public URL origin + stream path.
+   *
+   * @param realtime - If true, appends /realtime for voice-to-voice mode
    */
-  private getStreamUrl(): string | null {
+  private getStreamUrl(realtime = false): string | null {
     if (!this.currentPublicUrl || !this.options.streamPath) {
       return null;
     }
@@ -374,9 +395,14 @@ export class TwilioProvider implements VoiceCallProvider {
     const wsOrigin = origin.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");
 
     // Append the stream path
-    const path = this.options.streamPath.startsWith("/")
+    let path = this.options.streamPath.startsWith("/")
       ? this.options.streamPath
       : `/${this.options.streamPath}`;
+
+    // Append /realtime for voice-to-voice mode
+    if (realtime) {
+      path = `${path}/realtime`;
+    }
 
     return `${wsOrigin}${path}`;
   }

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -96,6 +96,16 @@ export class TwilioProvider implements VoiceCallProvider {
   }
 
   /**
+   * Clean up all state for a call when it ends.
+   * Call this to prevent memory leaks in long-running processes.
+   */
+  cleanupCall(callId: string): void {
+    this.realtimeCalls.delete(callId);
+    this.notifyCalls.delete(callId);
+    this.twimlStorage.delete(callId);
+  }
+
+  /**
    * Delete stored TwiML for a call, addressed by Twilio's provider call SID.
    *
    * This is used when we only have `providerCallId` (e.g. hangup).

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -7,6 +7,7 @@ import { MockProvider } from "./providers/mock.js";
 import { PlivoProvider } from "./providers/plivo.js";
 import { TelnyxProvider } from "./providers/telnyx.js";
 import { TwilioProvider } from "./providers/twilio.js";
+import { OpenAIRealtimeVoiceProvider } from "./providers/openai-realtime-voice.js";
 import type { TelephonyTtsRuntime } from "./telephony-tts.js";
 import { createTelephonyTtsProvider } from "./telephony-tts.js";
 import { startTunnel, type TunnelResult } from "./tunnel.js";
@@ -23,6 +24,8 @@ export type VoiceCallRuntime = {
   webhookServer: VoiceCallWebhookServer;
   webhookUrl: string;
   publicUrl: string | null;
+  /** OpenAI Realtime Voice provider (only set when realtime mode is available) */
+  realtimeVoiceProvider: OpenAIRealtimeVoiceProvider | null;
   stop: () => Promise<void>;
 };
 
@@ -147,6 +150,36 @@ export async function createVoiceCallRuntime(params: {
     (provider as TwilioProvider).setPublicUrl(publicUrl);
   }
 
+  // Initialize OpenAI Realtime Voice provider if realtime mode is configured
+  let realtimeVoiceProvider: OpenAIRealtimeVoiceProvider | null = null;
+  const realtimeApiKey =
+    config.realtime?.openaiApiKey ||
+    config.streaming?.openaiApiKey ||
+    process.env.OPENAI_API_KEY;
+
+  if (realtimeApiKey) {
+    try {
+      realtimeVoiceProvider = new OpenAIRealtimeVoiceProvider({
+        apiKey: realtimeApiKey,
+        model: config.realtime?.model,
+        voice: config.realtime?.voice,
+        systemPrompt: config.realtime?.systemPrompt || config.responseSystemPrompt,
+        temperature: config.realtime?.temperature,
+        maxResponseTokens: config.realtime?.maxResponseTokens,
+        vadThreshold: config.realtime?.vadThreshold,
+        silenceDurationMs: config.realtime?.silenceDurationMs,
+        prefixPaddingMs: config.realtime?.prefixPaddingMs,
+      });
+      log.info("[voice-call] OpenAI Realtime Voice provider configured");
+    } catch (err) {
+      log.warn(
+        `[voice-call] Failed to initialize Realtime Voice: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
   if (provider.name === "twilio" && config.streaming?.enabled) {
     const twilioProvider = provider as TwilioProvider;
     if (ttsRuntime?.textToSpeechTelephony) {
@@ -174,6 +207,12 @@ export async function createVoiceCallRuntime(params: {
       twilioProvider.setMediaStreamHandler(mediaHandler);
       log.info("[voice-call] Media stream handler wired to provider");
     }
+
+    // Pass realtime voice provider to webhook server for realtime mode calls
+    if (realtimeVoiceProvider) {
+      webhookServer.setRealtimeVoiceProvider(realtimeVoiceProvider);
+      log.info("[voice-call] Realtime Voice provider wired to webhook server");
+    }
   }
 
   manager.initialize(provider, webhookUrl);
@@ -199,6 +238,7 @@ export async function createVoiceCallRuntime(params: {
     webhookServer,
     webhookUrl,
     publicUrl,
+    realtimeVoiceProvider,
     stop,
   };
 }

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -153,9 +153,7 @@ export async function createVoiceCallRuntime(params: {
   // Initialize OpenAI Realtime Voice provider if realtime mode is configured
   let realtimeVoiceProvider: OpenAIRealtimeVoiceProvider | null = null;
   const realtimeApiKey =
-    config.realtime?.openaiApiKey ||
-    config.streaming?.openaiApiKey ||
-    process.env.OPENAI_API_KEY;
+    config.realtime?.openaiApiKey || config.streaming?.openaiApiKey || process.env.OPENAI_API_KEY;
 
   if (realtimeApiKey) {
     try {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -49,6 +49,12 @@ function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
     isLoopbackBind(config.serve?.bind) &&
     (config.tunnel?.allowNgrokFreeTierLoopbackBypass || config.tunnel?.allowNgrokFreeTier || false);
 
+  // Enable streaming if realtime mode is configured (realtime requires media streams)
+  const needsStreaming =
+    config.streaming?.enabled ||
+    config.outbound?.defaultMode === "realtime" ||
+    config.realtime?.openaiApiKey;
+
   switch (config.provider) {
     case "telnyx":
       return new TelnyxProvider({
@@ -66,7 +72,7 @@ function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
           allowNgrokFreeTierLoopbackBypass,
           publicUrl: config.publicUrl,
           skipVerification: config.skipSignatureVerification,
-          streamPath: config.streaming?.enabled ? config.streaming.streamPath : undefined,
+          streamPath: needsStreaming ? config.streaming?.streamPath || "/voice/stream" : undefined,
         },
       );
     case "plivo":

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -7,8 +7,13 @@ import type { CoreConfig } from "./core-bridge.js";
 import type { CallManager } from "./manager.js";
 import type { MediaStreamConfig } from "./media-stream.js";
 import { MediaStreamHandler } from "./media-stream.js";
+import {
+  RealtimeMediaStreamHandler,
+  type RealtimeMediaStreamConfig,
+} from "./media-stream-realtime.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
+import type { OpenAIRealtimeVoiceProvider } from "./providers/openai-realtime-voice.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
 
@@ -25,6 +30,12 @@ export class VoiceCallWebhookServer {
 
   /** Media stream handler for bidirectional audio (when streaming enabled) */
   private mediaStreamHandler: MediaStreamHandler | null = null;
+
+  /** Realtime media stream handler for voice-to-voice mode */
+  private realtimeMediaStreamHandler: RealtimeMediaStreamHandler | null = null;
+
+  /** OpenAI Realtime Voice provider (set from runtime) */
+  private realtimeVoiceProvider: OpenAIRealtimeVoiceProvider | null = null;
 
   constructor(
     config: VoiceCallConfig,
@@ -48,6 +59,84 @@ export class VoiceCallWebhookServer {
    */
   getMediaStreamHandler(): MediaStreamHandler | null {
     return this.mediaStreamHandler;
+  }
+
+  /**
+   * Set the OpenAI Realtime Voice provider for voice-to-voice mode.
+   */
+  setRealtimeVoiceProvider(provider: OpenAIRealtimeVoiceProvider): void {
+    this.realtimeVoiceProvider = provider;
+    this.initializeRealtimeMediaStreaming();
+  }
+
+  /**
+   * Initialize realtime media streaming for voice-to-voice mode.
+   */
+  private initializeRealtimeMediaStreaming(): void {
+    if (!this.realtimeVoiceProvider) {
+      console.warn("[voice-call] Cannot initialize realtime streaming without voice provider");
+      return;
+    }
+
+    const streamConfig: RealtimeMediaStreamConfig = {
+      voiceProvider: this.realtimeVoiceProvider,
+      voiceConfig: {
+        systemPrompt: this.config.realtime?.systemPrompt || this.config.responseSystemPrompt,
+        voice: this.config.realtime?.voice,
+        temperature: this.config.realtime?.temperature,
+        vadThreshold: this.config.realtime?.vadThreshold,
+        silenceDurationMs: this.config.realtime?.silenceDurationMs,
+      },
+      onTranscript: (callId, transcript) => {
+        console.log(`[voice-call] [realtime] User said: ${transcript}`);
+        // Look up call and add to transcript
+        const call = this.manager.getCallByProviderCallId(callId);
+        if (call) {
+          const event: NormalizedEvent = {
+            id: `realtime-transcript-${Date.now()}`,
+            type: "call.speech",
+            callId: call.callId,
+            providerCallId: callId,
+            timestamp: Date.now(),
+            transcript,
+            isFinal: true,
+          };
+          this.manager.processEvent(event);
+        }
+      },
+      onResponse: (callId, text) => {
+        console.log(`[voice-call] [realtime] AI said: ${text}`);
+        // Add AI response to transcript
+        const call = this.manager.getCallByProviderCallId(callId);
+        if (call) {
+          // Bot responses are tracked in call transcript via manager
+        }
+      },
+      onConnect: (callId, streamSid) => {
+        console.log(`[voice-call] [realtime] Stream connected: ${callId} -> ${streamSid}`);
+        if (this.provider.name === "twilio") {
+          (this.provider as TwilioProvider).registerCallStream(callId, streamSid);
+        }
+      },
+      onDisconnect: (callId) => {
+        console.log(`[voice-call] [realtime] Stream disconnected: ${callId}`);
+        if (this.provider.name === "twilio") {
+          (this.provider as TwilioProvider).unregisterCallStream(callId);
+        }
+      },
+    };
+
+    this.realtimeMediaStreamHandler = new RealtimeMediaStreamHandler(streamConfig);
+    console.log("[voice-call] Realtime media streaming initialized");
+  }
+
+  /**
+   * Check if a call should use realtime mode based on its metadata.
+   */
+  private isRealtimeCall(callId: string): boolean {
+    const call = this.manager.getCallByProviderCallId(callId);
+    if (!call) return false;
+    return call.metadata?.mode === "realtime";
   }
 
   /**
@@ -158,18 +247,23 @@ export class VoiceCallWebhookServer {
       });
 
       // Handle WebSocket upgrades for media streams
-      if (this.mediaStreamHandler) {
-        this.server.on("upgrade", (request, socket, head) => {
-          const url = new URL(request.url || "/", `http://${request.headers.host}`);
+      const realtimeStreamPath = `${streamPath}/realtime`;
 
-          if (url.pathname === streamPath) {
-            console.log("[voice-call] WebSocket upgrade for media stream");
-            this.mediaStreamHandler?.handleUpgrade(request, socket, head);
-          } else {
-            socket.destroy();
-          }
-        });
-      }
+      this.server.on("upgrade", (request, socket, head) => {
+        const url = new URL(request.url || "/", `http://${request.headers.host}`);
+
+        if (url.pathname === realtimeStreamPath && this.realtimeMediaStreamHandler) {
+          // Realtime voice-to-voice mode
+          console.log("[voice-call] WebSocket upgrade for REALTIME media stream");
+          this.realtimeMediaStreamHandler.handleUpgrade(request, socket, head);
+        } else if (url.pathname === streamPath && this.mediaStreamHandler) {
+          // Regular conversation mode (STT → Claude → TTS)
+          console.log("[voice-call] WebSocket upgrade for media stream");
+          this.mediaStreamHandler.handleUpgrade(request, socket, head);
+        } else {
+          socket.destroy();
+        }
+      });
 
       this.server.on("error", reject);
 
@@ -178,6 +272,9 @@ export class VoiceCallWebhookServer {
         console.log(`[voice-call] Webhook server listening on ${url}`);
         if (this.mediaStreamHandler) {
           console.log(`[voice-call] Media stream WebSocket on ws://${bind}:${port}${streamPath}`);
+        }
+        if (this.realtimeMediaStreamHandler) {
+          console.log(`[voice-call] Realtime stream WebSocket on ws://${bind}:${port}${realtimeStreamPath}`);
         }
         resolve(url);
       });

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -135,7 +135,9 @@ export class VoiceCallWebhookServer {
    */
   private isRealtimeCall(callId: string): boolean {
     const call = this.manager.getCallByProviderCallId(callId);
-    if (!call) return false;
+    if (!call) {
+      return false;
+    }
     return call.metadata?.mode === "realtime";
   }
 
@@ -274,7 +276,9 @@ export class VoiceCallWebhookServer {
           console.log(`[voice-call] Media stream WebSocket on ws://${bind}:${port}${streamPath}`);
         }
         if (this.realtimeMediaStreamHandler) {
-          console.log(`[voice-call] Realtime stream WebSocket on ws://${bind}:${port}${realtimeStreamPath}`);
+          console.log(
+            `[voice-call] Realtime stream WebSocket on ws://${bind}:${port}${realtimeStreamPath}`,
+          );
         }
         resolve(url);
       });

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -48,8 +48,12 @@ export class VoiceCallWebhookServer {
     this.provider = provider;
     this.coreConfig = coreConfig ?? null;
 
-    // Initialize media stream handler if streaming is enabled
-    if (config.streaming?.enabled) {
+    // Initialize media stream handler if streaming or realtime mode is enabled
+    const needsStreaming =
+      config.streaming?.enabled ||
+      config.outbound?.defaultMode === "realtime" ||
+      config.realtime?.openaiApiKey;
+    if (needsStreaming) {
       this.initializeMediaStreaming();
     }
   }


### PR DESCRIPTION
## Summary

Implements OpenAI Realtime API voice-to-voice mode for sub-second latency phone calls.

**Current architecture (3-5s latency):**
```
User speaks → STT → Claude → TTS → Audio back
             ~1s     ~2-3s    ~1-2s
```

**New architecture (<500ms latency):**
```
User speaks → OpenAI Realtime API → Audio back
             (GPT-4o handles everything in one stream)
```

## Changes

### New Files
- `providers/openai-realtime-voice.ts` - OpenAI Realtime API voice session handler
- `media-stream-realtime.ts` - Twilio media stream integration for realtime mode

### Modified Files
- `config.ts` - Added `realtime` mode and `VoiceCallRealtimeConfigSchema`
- `providers/index.ts` - Export new provider
- `runtime.ts` - Initialize realtime voice provider, wire to webhook server
- `webhook.ts` - Dual WebSocket paths (`/stream` vs `/stream/realtime`), route by mode
- `twilio.ts` - Track realtime calls, generate correct stream URLs
- `manager.ts` - Mark calls as realtime when `mode: 'realtime'`

## Configuration Example

```json
{
  "plugins": {
    "entries": {
      "voice-call": {
        "config": {
          "outbound": {
            "defaultMode": "realtime"
          },
          "realtime": {
            "voice": "nova",
            "systemPrompt": "You are Cheryl, a warm and loving assistant..."
          }
        }
      }
    }
  }
}
```

## Implementation Status

- [x] OpenAI Realtime Voice provider
- [x] Realtime media stream handler
- [x] Config schema with `realtime` mode
- [x] Wire up in `runtime.ts`
- [x] Route realtime calls in `webhook.ts`
- [x] Twilio provider realtime call tracking
- [x] Manager marks realtime calls
- [ ] Unit tests
- [ ] Documentation

## Trade-offs

| Current (Claude + TTS) | Realtime (GPT-4o) |
|------------------------|-------------------|
| Use any LLM | Must use GPT-4o |
| 3-5s latency | <500ms latency |
| Custom TTS voices | OpenAI voices only |

Closes #5606

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new “realtime” outbound call mode that routes Twilio Media Streams directly to OpenAI’s Realtime API (GPT‑4o voice-to-voice), alongside the existing conversation (STT→LLM→TTS) streaming mode. It introduces an OpenAI Realtime voice provider/session, a dedicated realtime media stream WebSocket handler, new config schema under `config.realtime`, and wires the webhook server to accept `/voice/stream/realtime` upgrades.

Key integration points:
- `CallManager` annotates outbound calls with `metadata.mode` and marks Twilio calls as realtime.
- `TwilioProvider` can generate a stream URL with an extra `/realtime` suffix.
- `VoiceCallWebhookServer` routes WebSocket upgrades either to the existing media stream handler or the new realtime handler.
- `createVoiceCallRuntime` optionally constructs and passes an `OpenAIRealtimeVoiceProvider` into the webhook server.

Main issues found are around lifecycle wiring (realtime mode currently depends on `streaming.enabled` to work at all) and a couple of cleanup/connection edge cases that can lead to leaks or hanging promises.

<h3>Confidence Score: 2/5</h3>

- This PR adds substantial functionality but has a couple of integration/lifecycle bugs that can prevent realtime mode from working in common configs.
- Score reduced due to a hard functional dependency between realtime mode and `streaming.enabled`, a likely in-memory leak for mode-tracking sets in Twilio provider depending on callback query params, and a connection Promise that can hang on WS close paths. The overall approach is coherent, but these issues can cause confusing failures in production.
- extensions/voice-call/src/runtime.ts, extensions/voice-call/src/providers/twilio.ts, extensions/voice-call/src/providers/openai-realtime-voice.ts, extensions/voice-call/src/media-stream-realtime.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->