### PR TITLE
fix(signal): preserve Base64 group ID case

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -3,6 +3,23 @@ import { describe, expect, it } from "vitest";
 import { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./signal.js";
 
 describe("signal target normalization", () => {
+  it("preserves case for Base64 group IDs", () => {
+    // Signal group IDs are Base64-encoded and case-sensitive.
+    expect(
+      normalizeSignalMessagingTarget("group:mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w="),
+    ).toBe("group:mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w=");
+  });
+
+  it("preserves case for group IDs with signal: prefix", () => {
+    expect(
+      normalizeSignalMessagingTarget("signal:group:mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w="),
+    ).toBe("group:mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w=");
+  });
+
+  it("strips whitespace from group IDs", () => {
+    expect(normalizeSignalMessagingTarget("group: mb+09 B3m =")).toBe("group:mb+09B3m=");
+  });
+
   it("normalizes uuid targets by stripping uuid:", () => {
     expect(normalizeSignalMessagingTarget("uuid:123E4567-E89B-12D3-A456-426614174000")).toBe(
       "123e4567-e89b-12d3-a456-426614174000",

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -12,8 +12,10 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   }
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
-    const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Signal group IDs are Base64-encoded and case-sensitive.
+    // Strip whitespace (copy-paste errors) but preserve the ID casing.
+    const id = normalized.slice("group:".length).replace(/\s+/g, "");
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -183,14 +183,19 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
-    const sessionKey = buildAgentSessionKey({
+    const sessionKeyRaw = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
       accountId,
       peer,
       dmScope,
       identityLinks,
-    }).toLowerCase();
+    });
+    // Historically we lowercased the whole session key for stable comparison.
+    // Signal group IDs are Base64-encoded and case-sensitive; lowercasing breaks downstream actions
+    // that reconstruct targets from the session key (e.g. reactions).
+    const sessionKey =
+      channel === "signal" && peer?.kind === "group" ? sessionKeyRaw : sessionKeyRaw.toLowerCase();
     const mainSessionKey = buildAgentMainSessionKey({
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildAgentPeerSessionKey } from "./session-key.js";
 
 describe("session-key", () => {
-  it("preserves case for Signal group peer IDs (Base64 is case-sensitive)", () => {
+  it("preserves case for Signal group peer IDs", () => {
     const groupId = "mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w=";
     expect(
       buildAgentPeerSessionKey({

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentPeerSessionKey } from "./session-key.js";
+
+describe("session-key", () => {
+  it("preserves case for Signal group peer IDs (Base64 is case-sensitive)", () => {
+    const groupId = "mb+09B3md7Tnu0/bLVJaOJUxtc/Zig83EwXvh3zmu3w=";
+    expect(
+      buildAgentPeerSessionKey({
+        agentId: "arjun",
+        channel: "signal",
+        peerKind: "group",
+        peerId: groupId,
+      }),
+    ).toBe(`agent:arjun:signal:group:${groupId}`);
+  });
+});

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -168,7 +168,11 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
-  const peerId = ((params.peerId ?? "").trim() || "unknown").toLowerCase();
+  const rawPeerId = (params.peerId ?? "").trim() || "unknown";
+  // Most session keys normalize peer IDs to lowercase for stable, comparable keys across providers.
+  // Signal group IDs are Base64-encoded and case-sensitive, so lowercasing breaks downstream actions
+  // that reconstruct targets from session keys (e.g. reactions).
+  const peerId = channel === "signal" && peerKind === "group" ? rawPeerId : rawPeerId.toLowerCase();
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 


### PR DESCRIPTION
## Summary
Signal group IDs are Base64-encoded and case-sensitive. Some routing and normalization paths were lowercasing these IDs, which breaks sending/reactions and can cause allowlist mismatches.

Fixes #4068 and #5578.

This was written with GPT 5.2-high but reviewed myself.

## What changed
- Preserve `peerId` casing when building Signal **group** session keys.
- Preserve session key casing for Signal **group** routes (avoid lowercasing the whole key).
- Preserve case for `group:` targets in Signal target normalization (strip whitespace but keep ID casing).

## Test plan
- `pnpm build`
- `pnpm lint`
- `pnpm format`
- `bunx vitest run src/routing/session-key.test.ts src/channels/plugins/normalize/signal.test.ts`