### PR TITLE
fix(onboard): parse space-separated channel allowlist entries

### DIFF
--- a/src/channels/plugins/onboarding/channel-access.test.ts
+++ b/src/channels/plugins/onboarding/channel-access.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { formatAllowlistEntries, parseAllowlistEntries } from "./channel-access.js";
+
+describe("parseAllowlistEntries", () => {
+  it("parses comma-separated entries", () => {
+    expect(parseAllowlistEntries("#general, #random, #dev")).toEqual([
+      "#general",
+      "#random",
+      "#dev",
+    ]);
+  });
+
+  it("parses space-separated entries", () => {
+    // User entered "#ryan #openclaw-discussion" without commas
+    expect(parseAllowlistEntries("#ryan #openclaw-discussion")).toEqual([
+      "#ryan",
+      "#openclaw-discussion",
+    ]);
+  });
+
+  it("parses semicolon-separated entries", () => {
+    expect(parseAllowlistEntries("#chan1; #chan2; #chan3")).toEqual(["#chan1", "#chan2", "#chan3"]);
+  });
+
+  it("parses newline-separated entries", () => {
+    expect(parseAllowlistEntries("#chan1\n#chan2\n#chan3")).toEqual(["#chan1", "#chan2", "#chan3"]);
+  });
+
+  it("handles mixed separators", () => {
+    expect(parseAllowlistEntries("#a, #b #c; #d\n#e")).toEqual(["#a", "#b", "#c", "#d", "#e"]);
+  });
+
+  it("handles channel IDs", () => {
+    expect(parseAllowlistEntries("C123 C456, C789")).toEqual(["C123", "C456", "C789"]);
+  });
+
+  it("trims whitespace from entries", () => {
+    expect(parseAllowlistEntries("  #general  ,  #random  ")).toEqual(["#general", "#random"]);
+  });
+
+  it("filters empty entries", () => {
+    expect(parseAllowlistEntries("#general,, ,#random")).toEqual(["#general", "#random"]);
+  });
+
+  it("handles empty input", () => {
+    expect(parseAllowlistEntries("")).toEqual([]);
+    expect(parseAllowlistEntries(null as unknown as string)).toEqual([]);
+    expect(parseAllowlistEntries(undefined as unknown as string)).toEqual([]);
+  });
+
+  it("handles single entry", () => {
+    expect(parseAllowlistEntries("#general")).toEqual(["#general"]);
+  });
+});
+
+describe("formatAllowlistEntries", () => {
+  it("formats entries as comma-separated string", () => {
+    expect(formatAllowlistEntries(["#general", "#random", "#dev"])).toBe("#general, #random, #dev");
+  });
+
+  it("trims entries", () => {
+    expect(formatAllowlistEntries(["  #general  ", "  #random  "])).toBe("#general, #random");
+  });
+
+  it("filters empty entries", () => {
+    expect(formatAllowlistEntries(["#general", "", "  ", "#random"])).toBe("#general, #random");
+  });
+
+  it("handles empty array", () => {
+    expect(formatAllowlistEntries([])).toBe("");
+  });
+});

--- a/src/channels/plugins/onboarding/channel-access.ts
+++ b/src/channels/plugins/onboarding/channel-access.ts
@@ -3,8 +3,10 @@ import type { WizardPrompter } from "../../../wizard/prompts.js";
 export type ChannelAccessPolicy = "allowlist" | "open" | "disabled";
 
 export function parseAllowlistEntries(raw: string): string[] {
+  // Split on comma, semicolon, newline, or space
+  // Handles: "#chan1, #chan2" or "#chan1 #chan2" or "#chan1; #chan2"
   return String(raw ?? "")
-    .split(/[,\n]/g)
+    .split(/[,;\s]+/g)
     .map((entry) => entry.trim())
     .filter(Boolean);
 }


### PR DESCRIPTION
## Summary

Fixes #5617

The channel allowlist prompt during `openclaw onboard` says "comma-separated" but users often enter space-separated values like `#ryan #openclaw-discussion`. Previously this was saved as a single config key, causing channel matching to fail silently.

**Before:** `"#ryan #openclaw-discussion": { "allow": true }` (one broken key)
**After:** `"#ryan": { "allow": true }, "#openclaw-discussion": { "allow": true }` (two correct keys)

## Changes

- Updated `parseAllowlistEntries()` to split on comma, semicolon, space, or newline
- Added comprehensive test coverage for the parsing function

## Test plan

- [x] All 14 new tests pass
- [x] Verified fix handles: comma-separated, space-separated, semicolon-separated, newline-separated, and mixed inputs
- [x] Edge cases covered: empty input, single entry, extra whitespace

🦞 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `openclaw onboard` allowlist parsing so users can enter channels separated by spaces (and other common separators) instead of only commas/newlines. The core change updates `parseAllowlistEntries()` to split on commas, semicolons, and whitespace, and adds a new `channel-access.test.ts` suite with a range of parsing/formatting cases.

This fits into the onboarding plugin by ensuring `promptChannelAllowlist()` produces a normalized `string[]` even when user input doesn’t match the prompt’s stated “comma-separated” format, preventing silent allowlist mismatches in downstream channel matching logic.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported onboarding allowlist parsing issue.
- Change is localized to a small helper function and adds targeted unit tests. The main risk is subtle over-splitting due to using `\s` (broader than space/newline) and the tests using type casts for null/undefined despite the function being typed as `string`.
- src/channels/plugins/onboarding/channel-access.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->