### PR TITLE
add support_human_readable_time_format in cron

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -107,7 +107,10 @@ Jobs can optionally auto-delete after a successful one-shot run via `deleteAfter
 
 Cron supports three schedule kinds:
 
-- `at`: one-shot timestamp (ms since epoch). Gateway accepts ISO 8601 and coerces to UTC.
+- `at`: one-shot at an absolute time. Prefer human-readable `at` (with optional `tz`) so agents and tools do not compute Unix timestamps:
+  - `at`: ISO 8601 string (e.g. `2026-02-01T23:00:00+08:00`) or local datetime without offset (e.g. `2026-02-01 23:00:00`).
+  - `tz`: optional IANA timezone (e.g. `Asia/Shanghai`); used only when `at` has no trailing `Z` or offset.
+  - Legacy: `atMs` (number) epoch milliseconds.
 - `every`: fixed interval (ms).
 - `cron`: 5-field cron expression with optional IANA timezone.
 
@@ -219,23 +222,24 @@ Prefixed targets like `telegram:...` / `telegram:group:...` are also accepted:
 ## JSON schema for tool calls
 
 Use these shapes when calling Gateway `cron.*` tools directly (agent tool calls or RPC).
-CLI flags accept human durations like `20m`, but tool calls use epoch milliseconds for
-`atMs` and `everyMs` (ISO timestamps are accepted for `at` times).
+CLI flags accept human durations like `20m`. For one-shot tool calls, prefer human-readable `at` (ISO or `YYYY-MM-DD HH:mm:ss`) with optional `tz` (IANA); legacy `atMs` is epoch milliseconds.
 
 ### cron.add params
 
-One-shot, main session job (system event):
+One-shot, main session job (system event). Prefer human-readable `at` so agents do not compute Unix timestamps:
 
 ```json
 {
   "name": "Reminder",
-  "schedule": { "kind": "at", "atMs": 1738262400000 },
+  "schedule": { "kind": "at", "at": "2026-02-01T23:00:00+08:00" },
   "sessionTarget": "main",
   "wakeMode": "now",
   "payload": { "kind": "systemEvent", "text": "Reminder text" },
   "deleteAfterRun": true
 }
 ```
+
+Or with explicit timezone: `"schedule": { "kind": "at", "at": "2026-02-01 23:00:00", "tz": "Asia/Shanghai" }`.
 
 Recurring, isolated job with delivery:
 
@@ -259,8 +263,9 @@ Recurring, isolated job with delivery:
 
 Notes:
 
-- `schedule.kind`: `at` (`atMs`), `every` (`everyMs`), or `cron` (`expr`, optional `tz`).
-- `atMs` and `everyMs` are epoch milliseconds.
+- `schedule.kind`: `at` (human-readable `at` + optional `tz`, or legacy `atMs`), `every` (`everyMs`), or `cron` (`expr`, optional `tz`).
+- For one-shot: prefer `at` (ISO or `YYYY-MM-DD HH:mm:ss`) with optional `tz` (IANA); legacy `atMs` is epoch milliseconds.
+- `everyMs` is epoch milliseconds.
 - `sessionTarget` must be `"main"` or `"isolated"` and must match `payload.kind`.
 - Optional fields: `agentId`, `description`, `enabled`, `deleteAfterRun`, `isolation`.
 - `wakeMode` defaults to `"next-heartbeat"` when omitted.

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -179,8 +179,10 @@ JOB SCHEMA (for add action):
 }
 
 SCHEDULE TYPES (schedule.kind):
-- "at": One-shot at absolute time
-  { "kind": "at", "atMs": <unix-ms-timestamp> }
+- "at": One-shot at absolute time. Prefer human-readable "at" (with optional "tz") so the model does not compute Unix timestamps:
+  { "kind": "at", "at": "2026-02-01T23:00:00+08:00" }
+  { "kind": "at", "at": "2026-02-01 23:00:00", "tz": "Asia/Shanghai" }
+  Legacy: { "kind": "at", "atMs": <unix-ms-timestamp> }
 - "every": Recurring interval
   { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
 - "cron": Cron expression

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -111,4 +111,28 @@ describe("normalizeCronJobCreate", () => {
     expect(schedule.kind).toBe("at");
     expect(schedule.atMs).toBe(Date.parse("2026-01-12T18:00:00Z"));
   });
+
+  it("coerces schedule.at with tz to atMs (IANA timezone)", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "at with tz",
+      enabled: true,
+      schedule: {
+        kind: "at",
+        at: "2026-02-01 23:00:00",
+        tz: "Asia/Shanghai",
+      },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("at");
+    expect(schedule.atMs).toBe(Date.parse("2026-02-01T15:00:00.000Z"));
+    expect("at" in schedule).toBe(false);
+    expect("tz" in schedule).toBe(false);
+  });
 });

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -135,4 +135,27 @@ describe("normalizeCronJobCreate", () => {
     expect("at" in schedule).toBe(false);
     expect("tz" in schedule).toBe(false);
   });
+
+  it("strips at and tz when kind is inferred from at+tz (no explicit kind)", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "inferred at",
+      enabled: true,
+      schedule: {
+        at: "2026-02-01 23:00:00",
+        tz: "Asia/Shanghai",
+      },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("at");
+    expect(schedule.atMs).toBe(Date.parse("2026-02-01T15:00:00.000Z"));
+    expect("at" in schedule).toBe(false);
+    expect("tz" in schedule).toBe(false);
+  });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -22,11 +22,12 @@ function coerceSchedule(schedule: UnknownRecord) {
   const kind = typeof schedule.kind === "string" ? schedule.kind : undefined;
   const atMsRaw = schedule.atMs;
   const atRaw = schedule.at;
+  const tzRaw = typeof schedule.tz === "string" ? schedule.tz.trim() || undefined : undefined;
   const parsedAtMs =
     typeof atMsRaw === "string"
-      ? parseAbsoluteTimeMs(atMsRaw)
+      ? parseAbsoluteTimeMs(atMsRaw, tzRaw)
       : typeof atRaw === "string"
-        ? parseAbsoluteTimeMs(atRaw)
+        ? parseAbsoluteTimeMs(atRaw, tzRaw)
         : null;
 
   if (!kind) {
@@ -49,6 +50,9 @@ function coerceSchedule(schedule: UnknownRecord) {
 
   if ("at" in next) {
     delete next.at;
+  }
+  if (kind === "at" && "tz" in next) {
+    delete next.tz;
   }
 
   return next;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -51,7 +51,7 @@ function coerceSchedule(schedule: UnknownRecord) {
   if ("at" in next) {
     delete next.at;
   }
-  if (kind === "at" && "tz" in next) {
+  if (next.kind === "at" && "tz" in next) {
     delete next.tz;
   }
 

--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -51,4 +51,8 @@ describe("parseAbsoluteTimeMs", () => {
   it("returns null for invalid timezone", () => {
     expect(parseAbsoluteTimeMs("2026-02-01 23:00:00", "Invalid/Zone")).toBeNull();
   });
+
+  it("returns null for date-only when tz provided (avoid silent UTC midnight)", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01", "Asia/Shanghai")).toBeNull();
+  });
 });

--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAbsoluteTimeMs } from "./parse.js";
+
+describe("parseAbsoluteTimeMs", () => {
+  it("returns null for empty or whitespace", () => {
+    expect(parseAbsoluteTimeMs("")).toBeNull();
+    expect(parseAbsoluteTimeMs("   ")).toBeNull();
+  });
+
+  it("parses epoch milliseconds", () => {
+    const ms = 1769871600000;
+    expect(parseAbsoluteTimeMs(String(ms))).toBe(ms);
+  });
+
+  it("parses ISO date (UTC midnight)", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12")).toBe(Date.parse("2026-01-12T00:00:00Z"));
+  });
+
+  it("parses ISO datetime without TZ (coerced to UTC)", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12T18:00:00")).toBe(Date.parse("2026-01-12T18:00:00Z"));
+  });
+
+  it("parses ISO datetime with Z", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12T18:00:00Z")).toBe(Date.parse("2026-01-12T18:00:00Z"));
+  });
+
+  it("parses ISO datetime with offset", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01T23:00:00+08:00")).toBe(
+      Date.parse("2026-02-01T15:00:00Z"),
+    );
+  });
+
+  it("parses local time in IANA timezone when tz provided", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01 23:00:00", "Asia/Shanghai");
+    expect(ms).not.toBeNull();
+    expect(new Date(ms!).toISOString()).toBe("2026-02-01T15:00:00.000Z");
+  });
+
+  it("parses local time with T separator when tz provided", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01T23:00:00", "Asia/Shanghai");
+    expect(ms).not.toBeNull();
+    expect(new Date(ms!).toISOString()).toBe("2026-02-01T15:00:00.000Z");
+  });
+
+  it("ignores tz when string has explicit offset", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01T23:00:00+08:00", "America/New_York");
+    expect(ms).toBe(Date.parse("2026-02-01T15:00:00Z"));
+  });
+
+  it("returns null for invalid timezone", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01 23:00:00", "Invalid/Zone")).toBeNull();
+  });
+});

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -30,7 +30,9 @@ function formatUtcMsInZone(ms: number, timeZone: string): string {
   }).formatToParts(d);
   const map: Record<string, string> = {};
   for (const p of parts) {
-    if (p.type !== "literal") map[p.type] = p.value;
+    if (p.type !== "literal") {
+      map[p.type] = p.value;
+    }
   }
   const y = map.year ?? "0000";
   const mo = map.month ?? "01";
@@ -46,7 +48,9 @@ function parseLocalTimeInZone(localStr: string, timeZone: string): number | null
   const match = normalized.match(
     /^(\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?$/,
   );
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   const [, y, mo, day, h, min, s, frac] = match;
   const sec = s ? Number(s) : 0;
   const ms = frac ? Math.floor(Number(`0.${frac}`) * 1000) : 0;
@@ -61,7 +65,9 @@ function parseLocalTimeInZone(localStr: string, timeZone: string): number | null
   const trialMs = Date.parse(
     `${y}-${mo}-${day}T${h.padStart(2, "0")}:${min}:${String(sec).padStart(2, "0")}.${String(ms).padStart(3, "0")}Z`,
   );
-  if (!Number.isFinite(trialMs)) return null;
+  if (!Number.isFinite(trialMs)) {
+    return null;
+  }
   const halfDay = 12 * 60 * 60 * 1000;
   let low = trialMs - halfDay;
   let high = trialMs + halfDay;
@@ -69,13 +75,20 @@ function parseLocalTimeInZone(localStr: string, timeZone: string): number | null
   for (let i = 0; i < 30; i++) {
     const mid = Math.floor((low + high) / 2);
     const formatted = formatUtcMsInZone(mid, timeZone);
-    if (formatted === target) return roundToSecond(mid);
-    if (formatted < target) low = mid;
-    else high = mid;
+    if (formatted === target) {
+      return roundToSecond(mid);
+    }
+    if (formatted < target) {
+      low = mid;
+    } else {
+      high = mid;
+    }
   }
   const mid = Math.floor((low + high) / 2);
   const result = formatUtcMsInZone(mid, timeZone) === target ? mid : null;
-  if (result === null) return null;
+  if (result === null) {
+    return null;
+  }
   return roundToSecond(result);
 }
 

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -111,6 +111,9 @@ export function parseAbsoluteTimeMs(input: string, tz?: string): number | null {
     const inTz = parseLocalTimeInZone(raw, tz);
     return inTz;
   }
+  if (tz && ISO_DATE_RE.test(raw)) {
+    return null;
+  }
   const parsed = Date.parse(normalizeUtcIso(raw));
   return Number.isFinite(parsed) ? parsed : null;
 }

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -1,6 +1,7 @@
 const ISO_TZ_RE = /(Z|[+-]\d{2}:?\d{2})$/i;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}T/;
+const ISO_DATE_TIME_SPACE_RE = /^\d{4}-\d{2}-\d{2}[T\s]\d{1,2}:\d{2}(:\d{2})?(\.\d+)?$/;
 
 function normalizeUtcIso(raw: string) {
   if (ISO_TZ_RE.test(raw)) {
@@ -15,7 +16,70 @@ function normalizeUtcIso(raw: string) {
   return raw;
 }
 
-export function parseAbsoluteTimeMs(input: string): number | null {
+function formatUtcMsInZone(ms: number, timeZone: string): string {
+  const d = new Date(ms);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const map: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== "literal") map[p.type] = p.value;
+  }
+  const y = map.year ?? "0000";
+  const mo = map.month ?? "01";
+  const day = map.day ?? "01";
+  const h = map.hour ?? "00";
+  const min = map.minute ?? "00";
+  const s = map.second ?? "00";
+  return `${y}-${mo}-${day} ${h}:${min}:${s}`;
+}
+
+function parseLocalTimeInZone(localStr: string, timeZone: string): number | null {
+  const normalized = localStr.trim().replace(/[T\s]+/, " ");
+  const match = normalized.match(
+    /^(\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?$/,
+  );
+  if (!match) return null;
+  const [, y, mo, day, h, min, s, frac] = match;
+  const sec = s ? Number(s) : 0;
+  const ms = frac ? Math.floor(Number(`0.${frac}`) * 1000) : 0;
+  const target = `${y}-${mo}-${day} ${h.padStart(2, "0")}:${min}:${String(sec).padStart(2, "0")}`;
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+  } catch {
+    return null;
+  }
+
+  const trialMs = Date.parse(
+    `${y}-${mo}-${day}T${h.padStart(2, "0")}:${min}:${String(sec).padStart(2, "0")}.${String(ms).padStart(3, "0")}Z`,
+  );
+  if (!Number.isFinite(trialMs)) return null;
+  const halfDay = 12 * 60 * 60 * 1000;
+  let low = trialMs - halfDay;
+  let high = trialMs + halfDay;
+  const roundToSecond = (n: number) => (ms === 0 ? Math.floor(n / 1000) * 1000 : n);
+  for (let i = 0; i < 30; i++) {
+    const mid = Math.floor((low + high) / 2);
+    const formatted = formatUtcMsInZone(mid, timeZone);
+    if (formatted === target) return roundToSecond(mid);
+    if (formatted < target) low = mid;
+    else high = mid;
+  }
+  const mid = Math.floor((low + high) / 2);
+  const result = formatUtcMsInZone(mid, timeZone) === target ? mid : null;
+  if (result === null) return null;
+  return roundToSecond(result);
+}
+
+export function parseAbsoluteTimeMs(input: string, tz?: string): number | null {
   const raw = input.trim();
   if (!raw) {
     return null;
@@ -25,6 +89,14 @@ export function parseAbsoluteTimeMs(input: string): number | null {
     if (Number.isFinite(n) && n > 0) {
       return Math.floor(n);
     }
+  }
+  if (ISO_TZ_RE.test(raw)) {
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (tz && ISO_DATE_TIME_SPACE_RE.test(raw)) {
+    const inTz = parseLocalTimeInZone(raw, tz);
+    return inTz;
   }
   const parsed = Date.parse(normalizeUtcIso(raw));
   return Number.isFinite(parsed) ? parsed : null;


### PR DESCRIPTION
## Summary
One-shot cron jobs (`schedule.kind: "at"`) no longer require callers to send Unix timestamps. Agents and tools can send a human-readable `at` string (and optional `tz`) instead, avoiding timestamp math and timezone mistakes.

## Problem
- Models struggle to convert phrases like "tomorrow 11pm" into correct Unix ms.
- Off-by-one or timezone errors can create jobs in the past, so they are marked `enabled: false` / `lastStatus: "ok"` without running (e.g. user: "提醒我睡觉" → job 1 minute after scheduled time).

## Solution
- **`schedule.at`** (string): ISO 8601 with offset (e.g. `2026-02-01T23:00:00+08:00`) or local datetime without offset (e.g. `2026-02-01 23:00:00`).
- **`schedule.tz`** (optional): IANA timezone when `at` has no trailing `Z` or offset (e.g. `Asia/Shanghai`).
- Gateway normalizes to `atMs` before validation and storage; existing `atMs` (number) remains supported.

## Changes
- **`src/cron/parse.ts`**: `parseAbsoluteTimeMs(input, tz?)` — optional `tz`; if set and string has no offset, interpret as local time in that IANA zone (Intl-only, no new deps). Round to whole seconds when input has no fractional part.
- **`src/cron/normalize.ts`**: Coerce `schedule.at` / `schedule.atMs` (string) using `schedule.tz`; strip `at` and `tz` from stored schedule.
- **`src/agents/tools/cron-tool.ts`**: Tool description updated to recommend human-readable `at` (with optional `tz`).
- **`docs/automation/cron-jobs.md`**: Schedules and JSON examples updated for `at` + `tz`.
- **Tests**: `src/cron/parse.test.ts` (new), `src/cron/normalize.test.ts` (new case for `at` + `tz`).

## Example
{ "kind": "at", "at": "2026-02-01T23:00:00+08:00" }
{ "kind": "at", "at": "2026-02-01 23:00:00", "tz": "Asia/Shanghai" }

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for specifying one-shot cron schedules as a human-readable `schedule.at` string (optionally with `schedule.tz` IANA timezone) instead of requiring callers to send epoch milliseconds. Gateway normalization now coerces `at`/string `atMs` into numeric `atMs` using the updated `parseAbsoluteTimeMs(input, tz?)`, and docs/tool descriptions are updated accordingly.

The change primarily touches the cron input normalization layer (`src/cron/normalize.ts`) and time parsing utilities (`src/cron/parse.ts`), with new tests covering ISO strings and timezone-local parsing behavior.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge after addressing one correctness issue around stripping `tz` during inferred-kind normalization.
- Core behavior (parsing/normalizing `at` to `atMs`) is localized and covered by new tests, but `normalize.ts` currently only deletes `tz` when the original input included `kind: "at"`, which can cause unexpected persisted fields when `kind` is inferred. The timezone parsing logic is non-trivial but appears deterministic and guarded against invalid IANA zones.
- src/cron/normalize.ts; src/cron/parse.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->