### PR TITLE
refactor: extract unified withTimeout utility

### DIFF
--- a/src/line/probe.ts
+++ b/src/line/probe.ts
@@ -1,4 +1,6 @@
 import { messagingApi } from "@line/bot-sdk";
+
+import { withTimeout } from "../utils/with-timeout.js";
 import type { LineProbeResult } from "./types.js";
 
 export async function probeLineBot(
@@ -14,7 +16,7 @@ export async function probeLineBot(
   });
 
   try {
-    const profile = await withTimeout(client.getBotInfo(), timeoutMs);
+    const profile = await withTimeout(client.getBotInfo(), timeoutMs, "timeout");
 
     return {
       ok: true,
@@ -29,19 +31,4 @@ export async function probeLineBot(
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };
   }
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  if (!timeoutMs || timeoutMs <= 0) {
-    return promise;
-  }
-  let timer: NodeJS.Timeout | null = null;
-  const timeout = new Promise<T>((_, reject) => {
-    timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
-  });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  });
 }

--- a/src/utils/with-timeout.consistency.test.ts
+++ b/src/utils/with-timeout.consistency.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Consistency tests to verify that the unified withTimeout behaves
+ * identically to the original inline implementations.
+ */
+import { describe, expect, it } from "vitest";
+
+import { withTimeout } from "./with-timeout.js";
+
+// Original implementation from slack/probe.ts and line/probe.ts
+function originalWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+}
+
+describe("withTimeout consistency with original implementation", () => {
+  it("both resolve when promise completes before timeout", async () => {
+    const promise = Promise.resolve("ok");
+
+    const originalResult = await originalWithTimeout(promise, 1000);
+    const newResult = await withTimeout(Promise.resolve("ok"), 1000, "timeout");
+
+    expect(originalResult).toBe("ok");
+    expect(newResult).toBe("ok");
+  });
+
+  it("both reject with same error message on timeout", async () => {
+    const createSlowPromise = () =>
+      new Promise((resolve) => setTimeout(() => resolve("late"), 100));
+
+    let originalError: Error | null = null;
+    let newError: Error | null = null;
+
+    try {
+      await originalWithTimeout(createSlowPromise(), 10);
+    } catch (err) {
+      originalError = err as Error;
+    }
+
+    try {
+      await withTimeout(createSlowPromise(), 10, "timeout");
+    } catch (err) {
+      newError = err as Error;
+    }
+
+    expect(originalError).not.toBeNull();
+    expect(newError).not.toBeNull();
+    expect(originalError!.message).toBe("timeout");
+    expect(newError!.message).toBe("timeout");
+  });
+
+  it("both return promise directly when timeoutMs is 0", async () => {
+    const promise = Promise.resolve("ok");
+
+    const originalResult = await originalWithTimeout(promise, 0);
+    const newResult = await withTimeout(Promise.resolve("ok"), 0, "timeout");
+
+    expect(originalResult).toBe("ok");
+    expect(newResult).toBe("ok");
+  });
+
+  it("both return promise directly when timeoutMs is negative", async () => {
+    const promise = Promise.resolve("ok");
+
+    const originalResult = await originalWithTimeout(promise, -1);
+    const newResult = await withTimeout(Promise.resolve("ok"), -1, "timeout");
+
+    expect(originalResult).toBe("ok");
+    expect(newResult).toBe("ok");
+  });
+
+  it("both propagate rejection from original promise", async () => {
+    let originalError: Error | null = null;
+    let newError: Error | null = null;
+
+    try {
+      await originalWithTimeout(Promise.reject(new Error("original error")), 1000);
+    } catch (err) {
+      originalError = err as Error;
+    }
+
+    try {
+      await withTimeout(Promise.reject(new Error("original error")), 1000, "timeout");
+    } catch (err) {
+      newError = err as Error;
+    }
+
+    expect(originalError).not.toBeNull();
+    expect(newError).not.toBeNull();
+    expect(originalError!.message).toBe("original error");
+    expect(newError!.message).toBe("original error");
+  });
+});

--- a/src/utils/with-timeout.test.ts
+++ b/src/utils/with-timeout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { withTimeout } from "./with-timeout.js";
+
+describe("withTimeout", () => {
+  it("resolves when promise completes before timeout", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 1000);
+    expect(result).toBe("ok");
+  });
+
+  it("rejects when promise times out", async () => {
+    const slow = new Promise((resolve) => setTimeout(() => resolve("late"), 100));
+    await expect(withTimeout(slow, 10)).rejects.toThrow(/Timed out after 10ms/);
+  });
+
+  it("uses custom error message when provided", async () => {
+    const slow = new Promise((resolve) => setTimeout(() => resolve("late"), 100));
+    await expect(withTimeout(slow, 10, "Custom timeout")).rejects.toThrow("Custom timeout");
+  });
+
+  it("returns promise directly when timeoutMs is 0", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 0);
+    expect(result).toBe("ok");
+  });
+
+  it("returns promise directly when timeoutMs is negative", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), -1);
+    expect(result).toBe("ok");
+  });
+
+  it("clears timer when promise resolves", async () => {
+    const start = Date.now();
+    await withTimeout(Promise.resolve("ok"), 5000);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("propagates rejection from original promise", async () => {
+    const failing = Promise.reject(new Error("original error"));
+    await expect(withTimeout(failing, 1000)).rejects.toThrow("original error");
+  });
+});

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,29 @@
+/**
+ * Wraps a promise with a timeout. If the promise doesn't resolve within
+ * the specified time, it rejects with a timeout error.
+ *
+ * @param promise - The promise to wrap
+ * @param timeoutMs - Timeout in milliseconds (0 or negative means no timeout)
+ * @param message - Optional custom error message
+ * @returns The wrapped promise
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message?: string,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(message ?? `Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Extracts a unified `withTimeout` utility function to reduce code duplication across the codebase.

## Changes

- Add `src/utils/with-timeout.ts` with configurable timeout and custom error message
- Add comprehensive unit tests for `withTimeout`
- Add **consistency tests** to verify behavior matches original implementations
- Refactor `slack/probe.ts` to use unified `withTimeout`
- Refactor `line/probe.ts` to use unified `withTimeout`

## Consistency Verification

Created dedicated consistency tests that compare the new implementation against the original inline implementations:

| Test Case | Original | New | Status |
|-----------|----------|-----|--------|
| Normal completion | ✅ | ✅ | Match |
| Timeout error message | `"timeout"` | `"timeout"` | Match |
| timeoutMs=0 | Returns directly | Returns directly | Match |
| timeoutMs=-1 | Returns directly | Returns directly | Match |
| Error propagation | ✅ | ✅ | Match |

## Benefits

- Reduces code duplication (7+ similar implementations in codebase)
- Consistent behavior across all usages
- Easier to maintain and test
- Other files can be refactored incrementally

## Testing

- 7 unit tests for `withTimeout`
- 5 consistency tests comparing with original implementation
- 128 existing tests in `slack/` and `line/` modules pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a shared `src/utils/with-timeout.ts` helper and updates the Slack and LINE probe flows to use it (passing `"timeout"` to preserve the old error string). It also adds unit tests plus “consistency” tests that compare the new helper against the previous inline implementations.

Overall the refactor looks low-risk and the new helper matches the prior behavior for the call sites touched. The main items to watch are (1) `withTimeout`’s `!timeoutMs` check, which can silently treat `NaN` the same as `0` and skip timeouts, and (2) one timing-based unit test that’s likely to be flaky in CI.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor follow-up tweaks.
- The change is a contained refactor with good test coverage and call-site preservation of the legacy timeout error message. Remaining concerns are limited to edge-case input handling (`NaN`/falsy timeout values) and a potentially flaky, timing-based test; neither suggests a broad behavioral regression for typical usage.
- src/utils/with-timeout.ts; src/utils/with-timeout.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->