### PR TITLE
fix(compaction): resolve model from runtime when ctx.model is undefined

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,9 +1,7 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
-
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,7 +1,9 @@
-import type { Api, Model } from "@mariozechner/pi-ai";
-import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
+
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -91,6 +93,7 @@ export function buildEmbeddedExtensionPaths(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,6 +1,9 @@
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  // Model info passed from extensions.ts for fallback when ctx.model is undefined
+  model?: unknown;
+  modelRegistry?: unknown;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,7 +170,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -171,7 +171,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
     const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
-    const model = ctx.model ?? runtime?.model;
+    const model = ctx.model ?? (runtime?.model as typeof ctx.model);
     if (!model) {
       return {
         compaction: {


### PR DESCRIPTION
## Problem

In safeguard compaction mode, `ctx.model` can be undefined in two scenarios:

1. **Manual `/compact`**: `ExtensionRunner.initialize()` is never called in the embedded runner path
2. **Auto-compaction during session load**: Compaction triggers before `initialize()` is called

When `ctx.model` is undefined, the extension returns "Summary unavailable" instead of generating a proper summary.

Related: #5224

## Solution

Pass `model` to the compaction-safeguard runtime during `buildEmbeddedExtensionPaths()`, then use it as fallback when `ctx.model` is undefined.

## Testing

- Manual `/compact` with safeguard mode: ✅
- Gateway restart with high context: ✅
- Auto-compaction at 90%: ✅

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the current `model` into the compaction safeguard runtime during embedded extension setup, and updates the compaction safeguard extension to fall back to that runtime model when `ctx.model` is undefined. This addresses cases where compaction runs before `ExtensionRunner.initialize()` populates `ctx.model`, preventing the extension from returning the generic “Summary unavailable” fallback.

Main concern: the change in `src/agents/pi-embedded-runner/extensions.ts` introduces a syntax error (`gfimport`) that will break builds and should be fixed before merge.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a compilation-breaking syntax error.
- While the runtime model fallback looks reasonable and scoped, `src/agents/pi-embedded-runner/extensions.ts` currently starts with `gfimport`, which will fail parsing/TypeScript compilation and block any downstream testing or deployment.
- src/agents/pi-embedded-runner/extensions.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->