### PR TITLE
fix: rewrite sessionFile paths during state dir migration

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -354,4 +354,41 @@ describe("doctor legacy state migrations", () => {
     expect(result.skipped).toBe(true);
     expect(result.migrated).toBe(false);
   });
+
+  it("rewrites sessionFile paths from legacy to new state dir", async () => {
+    const root = await makeTempRoot();
+    const cfg: OpenClawConfig = {};
+    const legacySessionsDir = path.join(root, "sessions");
+    fs.mkdirSync(legacySessionsDir, { recursive: true });
+
+    // Simulate legacy sessions.json with hardcoded .clawdbot paths
+    const legacySessionFile = "/Users/test/.clawdbot/agents/main/sessions/2024-01-01_abc.jsonl";
+    writeJson5(path.join(legacySessionsDir, "sessions.json"), {
+      "+1555": {
+        sessionId: "a",
+        updatedAt: 10,
+        sessionFile: legacySessionFile,
+      },
+    });
+    fs.writeFileSync(path.join(legacySessionsDir, "2024-01-01_abc.jsonl"), "content", "utf-8");
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    await runLegacyStateMigrations({ detected, now: () => 123 });
+
+    const targetDir = path.join(root, "agents", "main", "sessions");
+    const store = JSON.parse(
+      fs.readFileSync(path.join(targetDir, "sessions.json"), "utf-8"),
+    ) as Record<string, { sessionId: string; sessionFile?: string }>;
+
+    const entry = store["agent:main:+1555"];
+    expect(entry?.sessionId).toBe("a");
+    // sessionFile path should be rewritten to use new state dir
+    expect(entry?.sessionFile).not.toContain(".clawdbot");
+    if (entry?.sessionFile) {
+      expect(entry.sessionFile).toContain(root);
+    }
+  });
 });

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -199,6 +199,26 @@ function normalizeSessionEntry(entry: SessionEntryLike): SessionEntry | null {
   return normalized;
 }
 
+const LEGACY_STATE_DIR_PATTERNS = [
+  /[/\\]\.clawdbot[/\\]/,
+  /[/\\]\.moltbot[/\\]/,
+  /[/\\]\.moldbot[/\\]/,
+];
+
+function rewriteSessionFilePath(entry: SessionEntry, targetDir: string): void {
+  const sessionFile = (entry as unknown as Record<string, unknown>).sessionFile;
+  if (typeof sessionFile !== "string" || !sessionFile.trim()) {
+    return;
+  }
+  for (const pattern of LEGACY_STATE_DIR_PATTERNS) {
+    if (pattern.test(sessionFile)) {
+      const filename = path.basename(sessionFile);
+      (entry as unknown as Record<string, unknown>).sessionFile = path.join(targetDir, filename);
+      return;
+    }
+  }
+}
+
 function resolveUpdatedAt(entry: SessionEntryLike): number {
   return typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
     ? entry.updatedAt
@@ -666,6 +686,7 @@ async function migrateLegacySessions(
       if (!normalizedEntry) {
         continue;
       }
+      rewriteSessionFilePath(normalizedEntry, detected.sessions.targetDir);
       normalized[key] = normalizedEntry;
     }
     await saveSessionStore(detected.sessions.targetStorePath, normalized);


### PR DESCRIPTION
## Summary

Fixes #5631

When migrating from legacy state directories (`.clawdbot`, `.moltbot`, `.moldbot`) to `.openclaw`, the `sessionFile` paths inside `sessions.json` were not being updated. This caused the old directory to be recreated when sessions were written.

## Root Cause

`sessions.json` contained hardcoded paths like:
```json
{
  "sessionFile": "/Users/username/.clawdbot/agents/main/sessions/xxx.jsonl"
}
```

The migration moved the file itself but didn't rewrite the paths inside.

## Changes

- Add `rewriteSessionFilePath()` to update legacy paths in session entries
- Detect `.clawdbot`/`.moltbot`/`.moldbot` patterns and rewrite to target dir
- Add regression test to verify path rewriting

## Testing

- Added regression test that verifies `sessionFile` paths are rewritten
- All 16 state migration tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes legacy state-dir migrations so that `sessionFile` paths embedded in `sessions.json` are rewritten from `.clawdbot`/`.moltbot`/`.moldbot` to the new OpenClaw state directory during `migrateLegacySessions`.

Implementation adds a small helper that detects legacy state-dir substrings (cross-platform path separators) and rewrites the stored path to point at the migrated sessions directory, preventing the old legacy directory from being recreated later when sessions are persisted. A regression test exercises the migration by seeding a legacy `sessions.json` containing a hardcoded legacy path and verifying the stored entry no longer references the legacy dir.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; changes are localized and covered by a targeted regression test.
- The migration behavior change is narrow (rewrite of `sessionFile` only when a legacy dir pattern is present) and is applied during the existing normalization pass. The added test reduces regression risk, though it could be strengthened to assert the exact rewritten target path.
- src/commands/doctor-state-migrations.test.ts (tighten assertion to match intended target path).

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->