### PR TITLE
Doctor: rewrite legacy sessionFile paths

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -267,6 +267,7 @@ describe("doctor legacy state migrations", () => {
     const homedir = () => root;
     const targetStateDir = path.join(root, ".openclaw");
     const legacyStateDir = path.join(root, ".clawdbot");
+    const legacyStateDirAlt = path.join(root, ".moltbot");
     const targetDir = path.join(targetStateDir, "agents", "main", "sessions");
     writeJson5(path.join(targetDir, "sessions.json"), {
       "agent:main:main": {
@@ -279,6 +280,33 @@ describe("doctor legacy state migrations", () => {
           "sessions",
           "legacy.jsonl",
         ),
+      },
+      "agent:main:alt": {
+        sessionId: "legacy-alt",
+        updatedAt: 10,
+        sessionFile: path.join(
+          legacyStateDirAlt,
+          "agents",
+          "main",
+          "sessions",
+          "legacy-alt.jsonl",
+        ),
+      },
+      "agent:main:already": {
+        sessionId: "already",
+        updatedAt: 11,
+        sessionFile: path.join(
+          targetStateDir,
+          "agents",
+          "main",
+          "sessions",
+          "current.jsonl",
+        ),
+      },
+      "agent:main:root": {
+        sessionId: "root",
+        updatedAt: 12,
+        sessionFile: legacyStateDir,
       },
     });
 
@@ -295,6 +323,13 @@ describe("doctor legacy state migrations", () => {
     expect(store["agent:main:main"]?.sessionFile).toBe(
       path.join(targetStateDir, "agents", "main", "sessions", "legacy.jsonl"),
     );
+    expect(store["agent:main:alt"]?.sessionFile).toBe(
+      path.join(targetStateDir, "agents", "main", "sessions", "legacy-alt.jsonl"),
+    );
+    expect(store["agent:main:already"]?.sessionFile).toBe(
+      path.join(targetStateDir, "agents", "main", "sessions", "current.jsonl"),
+    );
+    expect(store["agent:main:root"]?.sessionFile).toBe(legacyStateDir);
   });
 
   it("prefers the newest entry when collapsing main aliases", async () => {


### PR DESCRIPTION
## Summary
- detect legacy sessionFile paths during state migrations
- rewrite legacy sessionFile paths to the active state dir during migration
- add coverage for sessionFile path rewriting

## Testing
- `pnpm test -- doctor-state-migrations.test.ts` (fails: missing dependencies / vitest not installed)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the doctor state-migration flow to detect `sessionFile` fields in the target `sessions.json` that still point at a legacy state directory, and rewrites them to the active `stateDir` during migration. It also adds a regression test covering `sessionFile` path rewriting.

The changes integrate into the existing `detectLegacyStateMigrations` → `runLegacyStateMigrations` pipeline by adding legacy-path detection (`legacySessionFiles`) and applying the rewrite after canonicalization/merge but before persisting the normalized store.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, with a couple of edge cases in the path-rewrite logic worth tightening.
- Core behavior is straightforward and covered by a new test, but the rewrite helpers can produce a directory path when `sessionFile` equals a legacy root, and they may miss legacy `~`/relative formats if those exist in the wild.
- src/infra/state-migrations.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->