### PR TITLE
fix(security): harden file permissions and header merging

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-gemini.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-gemini.ts
@@ -12,7 +12,11 @@ import type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
 import type { EmbeddingInput } from "./embedding-inputs.js";
 import { sanitizeAndNormalizeEmbedding } from "./embedding-vectors.js";
 import { debugEmbeddingsLog } from "./embeddings-debug.js";
-import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+import {
+  sanitizeHeaders,
+  type EmbeddingProvider,
+  type EmbeddingProviderOptions,
+} from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy, withRemoteHttpResponse } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 
@@ -309,7 +313,8 @@ export async function resolveGeminiEmbeddingClient(
     remoteBaseUrl || providerConfig?.baseUrl?.trim() || DEFAULT_GOOGLE_API_BASE_URL;
   const baseUrl = normalizeGeminiBaseUrl(rawBaseUrl);
   const ssrfPolicy = buildRemoteBaseUrlPolicy(baseUrl);
-  const headerOverrides = Object.assign({}, providerConfig?.headers, remote?.headers);
+  // Merge headers while filtering out prototype pollution keys
+  const headerOverrides = sanitizeHeaders(providerConfig?.headers, remote?.headers);
   const headers: Record<string, string> = {
     ...headerOverrides,
   };

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -1,6 +1,6 @@
 import { requireApiKey, resolveApiKeyForProvider } from "../../../../src/agents/model-auth.js";
 import type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
-import type { EmbeddingProviderOptions } from "./embeddings.js";
+import { sanitizeHeaders, type EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 
@@ -29,7 +29,7 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
         params.provider,
       );
   const baseUrl = remoteBaseUrl || providerConfig?.baseUrl?.trim() || params.defaultBaseUrl;
-  const headerOverrides = Object.assign({}, providerConfig?.headers, remote?.headers);
+  const headerOverrides = sanitizeHeaders(providerConfig?.headers, remote?.headers);
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Authorization: `Bearer ${apiKey}`,

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -26,6 +26,33 @@ export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
 export type { OllamaEmbeddingClient } from "./embeddings-ollama.js";
 
+// Header keys that could cause prototype pollution if merged via Object.assign
+const DANGEROUS_HEADER_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Safely merge header objects while filtering out prototype pollution keys.
+ */
+export function sanitizeHeaders(
+  ...sources: Array<Record<string, SecretInput> | Record<string, string> | undefined>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const source of sources) {
+    if (!source || typeof source !== "object") {
+      continue;
+    }
+    for (const key of Object.keys(source)) {
+      if (DANGEROUS_HEADER_KEYS.has(key)) {
+        continue;
+      }
+      const value = source[key];
+      if (typeof value === "string") {
+        result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
 export type EmbeddingProvider = {
   id: string;
   model: string;


### PR DESCRIPTION
## Summary
Defensive security hardening for two low-severity issues.

## Changes
- Atomic file permissions in JSON writes (CWE-377)
- Filter prototype pollution keys in header merging (CWE-1321)

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens two security-sensitive areas:

- **JSON writes** (`src/infra/json-file.ts`): sets file mode during `writeFileSync` to reduce a race window where secrets could be briefly world-readable, with a best-effort `chmodSync` fallback.
- **Embedding client header merging** (`src/memory/embeddings*.ts`): replaces `Object.assign` with a dedicated `sanitizeHeaders()` helper that filters prototype-pollution keys when combining configured and remote header overrides.

The changes fit cleanly into existing infrastructure utilities (`saveJsonFile`) and the embeddings provider setup path (OpenAI/Gemini client resolution), without altering the higher-level provider selection logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped, maintain existing behavior, and add defensive hardening in two well-defined places (file mode during writes and header merging). No functional regressions were identified in the modified code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->