### PR TITLE
feat: include Chromium in Docker image (browser + PDF)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,17 @@ RUN corepack enable
 WORKDIR /app
 
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
-RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
-    fi
+
+# Install a system Chromium so the built-in browser tool can render JS-heavy pages and generate PDFs.
+# Note: users can still add more packages via OPENCLAW_DOCKER_APT_PACKAGES.
+ARG OPENCLAW_DOCKER_BROWSER_PACKAGES="chromium ca-certificates fonts-liberation fonts-noto-color-emoji"
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      $OPENCLAW_DOCKER_BROWSER_PACKAGES \
+      $OPENCLAW_DOCKER_APT_PACKAGES && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -47,7 +47,7 @@ This script:
 
 Optional env vars:
 
-- `OPENCLAW_DOCKER_APT_PACKAGES` — install extra apt packages during build
+- `OPENCLAW_DOCKER_APT_PACKAGES` — install extra apt packages during build (in addition to the built-in Chromium + fonts)
 - `OPENCLAW_EXTRA_MOUNTS` — add extra host bind mounts
 - `OPENCLAW_HOME_VOLUME` — persist `/home/node` in a named volume
 
@@ -123,7 +123,11 @@ Notes:
 
 ### Install extra apt packages (optional)
 
-If you need system packages inside the image (for example, build tools or media
+The Docker image includes a system **Chromium** + basic fonts by default (used for browser automation and PDF generation).
+
+If Chromium fails to start in your Docker environment with a sandbox error, set `browser.noSandbox=true` in your OpenClaw config (this adds `--no-sandbox`).
+
+If you need additional system packages inside the image (for example, build tools or media
 libraries), set `OPENCLAW_DOCKER_APT_PACKAGES` before running `docker-setup.sh`.
 This installs the packages during the image build, so they persist even if the
 container is deleted.


### PR DESCRIPTION
## Summary
- Install system Chromium (+ basic fonts) in the main Docker image so the browser tool can render JS-heavy pages and generate PDFs.
- Document Docker note and the `browser.noSandbox=true` workaround for sandbox-restricted environments.

## Why
- Without a Chromium/Chrome binary in the gateway container, the browser control server cannot start a local browser, blocking JS rendering and PDF generation.

## Test Plan
- (Local) `docker build -t openclaw:local -f Dockerfile .`
- `docker compose up -d openclaw-gateway`
- Verify browser status no longer errors with “No supported browser found”.
- Generate a PDF via browser tool / CLI (prints PDF path).

## Notes
- Repo-wide lint currently fails on main for unrelated issues; this PR does not introduce new lint rules or errors.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway Docker image build to install a system Chromium (plus basic fonts) during `apt-get install`, and updates the Docker install docs to note that Chromium is included by default and that `browser.noSandbox=true` can be used when Docker sandboxing prevents Chromium from starting.

The Dockerfile change shifts from an optional `OPENCLAW_DOCKER_APT_PACKAGES` install block to always running `apt-get install` with a new `OPENCLAW_DOCKER_BROWSER_PACKAGES` default, while still allowing additional packages via `OPENCLAW_DOCKER_APT_PACKAGES`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the Dockerfile change introduces a realistic footgun around unquoted ARG expansion during `apt-get install`.
- The PR is small (Dockerfile + docs) and the intended behavior is straightforward, but unquoted expansion of build args in a RUN step can lead to surprising build failures and, in some environments, command injection if args are sourced from untrusted inputs.
- Dockerfile (ARG expansion / package install line)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->