### PR TITLE
feat(imessage): add myNumbers config to filter by destination phone number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+package-lock.json

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -31,6 +31,12 @@ export type IMessageAccountConfig = {
   region?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /**
+   * Filter to only process messages sent TO these phone numbers.
+   * Useful when the Mac has multiple iMessage numbers (e.g., dual-SIM).
+   * Messages with destination_caller_id not matching any of these are ignored.
+   */
+  myNumbers?: string[];
   /** Optional allowlist for inbound handles or chat_id targets. */
   allowFrom?: Array<string | number>;
   /** Optional allowlist for group senders or chat_id targets. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -582,6 +582,7 @@ export const IMessageAccountSchemaBase = z
     service: z.union([z.literal("imessage"), z.literal("sms"), z.literal("auto")]).optional(),
     region: z.string().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    myNumbers: z.array(z.string()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/imessage/monitor/types.ts
+++ b/src/imessage/monitor/types.ts
@@ -23,6 +23,12 @@ export type IMessagePayload = {
   chat_name?: string | null;
   participants?: string[] | null;
   is_group?: boolean | null;
+  /**
+   * The destination phone number for this message (from imsg).
+   * Useful for distinguishing which iMessage number received the message
+   * on a dual-SIM or multi-number setup.
+   */
+  destination_caller_id?: string | null;
 };
 
 export type MonitorIMessageOpts = {


### PR DESCRIPTION
## Summary

Adds `myNumbers` config option for iMessage channel to filter messages by destination phone number. This enables proper multi-SIM support where the bot only responds to messages sent to its designated number(s).

**Discussion:** #5653

## Problem

On a Mac with multiple iMessage-capable phone numbers (dual-SIM iPhone synced via Continuity), the Messages app receives messages for ALL numbers. Without filtering, the bot can respond to messages meant for the user's personal number.

## Solution

New config option:
```json
{
  "channels": {
    "imessage": {
      "myNumbers": ["+15551234567"]
    }
  }
}
```

Messages where `destination_caller_id` doesn't match any configured number are silently skipped.

## Changes

- `src/config/types.imessage.ts`: Added `myNumbers?: string[]` to config type
- `src/config/zod-schema.providers-core.ts`: Added `myNumbers` to Zod schema
- `src/imessage/monitor/types.ts`: Added `destination_caller_id` to payload type
- `src/imessage/monitor/monitor-provider.ts`: Added filtering logic

## Dependencies

Requires `imsg` CLI to expose `destination_caller_id` field:
- PR: https://github.com/steipete/imsg/pull/29

## Testing

Tested locally with dual-SIM setup. Messages to non-configured numbers are logged as skipped and not processed.

---
*This PR was developed with AI assistance.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new iMessage configuration option (`myNumbers`) to restrict inbound processing to messages sent to specific destination phone numbers (using the `destination_caller_id` field from `imsg`). It updates the iMessage config types and Zod validation, extends the iMessage monitor payload type, and adds a guard in the iMessage monitor provider to skip messages whose destination number isn’t in the configured allowlist.

This fits into the existing iMessage monitor pipeline by filtering early in `monitorIMessageProvider` before the existing DM/group allowlist and policy checks, preventing the bot from responding on unintended numbers in multi-number (e.g., dual‑SIM) setups.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but the new filtering can be bypassed when `destination_caller_id` is missing and the lockfile addition should be verified as intentional.
- Core changes are small and localized (type/schema + an early filter), but behavior under missing/older payloads is inconsistent with the stated goal, and committing a brand-new 13k-line lockfile is a process decision that can cause downstream churn if unintended.
- src/imessage/monitor/monitor-provider.ts, package-lock.json

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->