### PR TITLE
fix: patch buffer-equal-constant-time for Node.js 22+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,9 @@
     "overrides": {
       "@sinclair/typebox": "0.34.47",
       "tar": "7.5.7"
+    },
+    "patchedDependencies": {
+      "buffer-equal-constant-time@1.0.1": "patches/buffer-equal-constant-time@1.0.1.patch"
     }
   },
   "vitest": {

--- a/patches/buffer-equal-constant-time@1.0.1.patch
+++ b/patches/buffer-equal-constant-time@1.0.1.patch
@@ -1,0 +1,40 @@
+diff --git a/.npmignore b/.npmignore
+deleted file mode 100644
+index 34e4f5c298de294fa5c1c1769b6489eb047bde9a..0000000000000000000000000000000000000000
+diff --git a/index.js b/index.js
+index 5462c1f830bdbe79bf2b1fcfd811cd9799b4dd11..b10b0fa413a0a625badfe229a63a4e38b4043f9e 100644
+--- a/index.js
++++ b/index.js
+@@ -1,6 +1,7 @@
+ /*jshint node:true */
+ 'use strict';
+ var Buffer = require('buffer').Buffer; // browserify
++// SlowBuffer was removed in Node.js 22+
+ var SlowBuffer = require('buffer').SlowBuffer;
+ 
+ module.exports = bufferEq;
+@@ -28,14 +29,21 @@ function bufferEq(a, b) {
+ }
+ 
+ bufferEq.install = function() {
+-  Buffer.prototype.equal = SlowBuffer.prototype.equal = function equal(that) {
++  Buffer.prototype.equal = function equal(that) {
+     return bufferEq(this, that);
+   };
++  if (SlowBuffer) {
++    SlowBuffer.prototype.equal = function equal(that) {
++      return bufferEq(this, that);
++    };
++  }
+ };
+ 
+ var origBufEqual = Buffer.prototype.equal;
+-var origSlowBufEqual = SlowBuffer.prototype.equal;
++var origSlowBufEqual = SlowBuffer ? SlowBuffer.prototype.equal : undefined;
+ bufferEq.restore = function() {
+   Buffer.prototype.equal = origBufEqual;
+-  SlowBuffer.prototype.equal = origSlowBufEqual;
++  if (SlowBuffer && origSlowBufEqual !== undefined) {
++    SlowBuffer.prototype.equal = origSlowBufEqual;
++  }
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   '@sinclair/typebox': 0.34.47
   tar: 7.5.7
 
+patchedDependencies:
+  buffer-equal-constant-time@1.0.1:
+    hash: baf985cff1aa6ed59cabeb575c94c77794f8cd1cd50e7d0d4926a027077543a3
+    path: patches/buffer-equal-constant-time@1.0.1.patch
+
 importers:
 
   .:
@@ -8280,7 +8285,7 @@ snapshots:
 
   browser-or-node@1.3.0: {}
 
-  buffer-equal-constant-time@1.0.1: {}
+  buffer-equal-constant-time@1.0.1(patch_hash=baf985cff1aa6ed59cabeb575c94c77794f8cd1cd50e7d0d4926a027077543a3): {}
 
   buffer-from@1.1.2: {}
 
@@ -9231,7 +9236,7 @@ snapshots:
 
   jwa@2.0.1:
     dependencies:
-      buffer-equal-constant-time: 1.0.1
+      buffer-equal-constant-time: 1.0.1(patch_hash=baf985cff1aa6ed59cabeb575c94c77794f8cd1cd50e7d0d4926a027077543a3)
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 


### PR DESCRIPTION
## Summary
The `buffer-equal-constant-time@1.0.1` package fails on Node.js 22+ because `SlowBuffer` was removed from the buffer module. This patch adds guards around `SlowBuffer` access to prevent `Cannot read properties of undefined` errors.

## Problem
When loading the Matrix plugin (or any code path that loads JWT libraries), Node.js 22 throws:
```
Failed to start CLI: TypeError: Cannot read properties of undefined (reading 'prototype')
    at Object.<anonymous> (.../buffer-equal-constant-time/index.js:37:35)
```

## Affected dependency chains
- `@google/genai` → `google-auth-library` → `jws` → `jwa` → `buffer-equal-constant-time`
- `@slack/bolt` → `@slack/oauth` → `jsonwebtoken` → `jws` → `jwa` → `buffer-equal-constant-time`

## Solution
Add a pnpm patch that guards `SlowBuffer.prototype` access:
- Check if `SlowBuffer` exists before accessing its prototype
- Make `install()` and `restore()` functions handle the missing `SlowBuffer` gracefully

## Testing
Verified the patched module loads successfully on Node.js v22.22.0.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a pnpm `patchedDependencies` entry to apply a local patch to `buffer-equal-constant-time@1.0.1`, guarding `SlowBuffer` prototype access so the dependency chain used by JWT/JWA libraries doesn’t crash on Node.js 22+ (where `SlowBuffer` was removed). The lockfile is updated to record the patch hash and ensure the patched package is selected during installs.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to pnpm patching a transitive dependency to avoid a Node 22 runtime crash, and the patch is a simple defensive guard around `SlowBuffer` access. The main remaining concern is patch hygiene: the patch also deletes an unrelated `.npmignore`, which is unnecessary churn and could have unintended packaging side-effects if this patch were ever published/repacked.
- patches/buffer-equal-constant-time@1.0.1.patch

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->