### PR TITLE
docs(install): add pnpm approve-builds step for global installs

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -73,11 +73,14 @@ SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
 
 If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
 
-Or:
+Or with pnpm:
 
 ```bash
 pnpm add -g openclaw@latest
+pnpm approve-builds -g   # select openclaw, node-llama-cpp, sharp, etc.
 ```
+
+pnpm requires explicit approval for packages with build scripts. After `pnpm add -g`, run `pnpm approve-builds -g` and approve the listed packages (openclaw, node-llama-cpp, sharp, protobufjs, etc.), then pnpm will run their postinstall scripts.
 
 Then:
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -77,10 +77,11 @@ Or with pnpm:
 
 ```bash
 pnpm add -g openclaw@latest
-pnpm approve-builds -g   # select openclaw, node-llama-cpp, sharp, etc.
+pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
+pnpm add -g openclaw@latest           # re-run to execute postinstall scripts
 ```
 
-pnpm requires explicit approval for packages with build scripts. After `pnpm add -g`, run `pnpm approve-builds -g` and approve the listed packages (openclaw, node-llama-cpp, sharp, protobufjs, etc.), then pnpm will run their postinstall scripts.
+pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages, then re-run the install so postinstall scripts execute.
 
 Then:
 


### PR DESCRIPTION
## Summary
- Document the required `pnpm approve-builds -g` step when installing openclaw globally with pnpm
- pnpm requires explicit approval for packages with build scripts; without this step, postinstall scripts don't run

## Test plan
- [x] Verified documentation renders correctly

Fixes #5579

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the global install docs to include pnpm-specific guidance: after `pnpm add -g openclaw@latest`, users may need to run `pnpm approve-builds -g` to allow dependency build/postinstall scripts (e.g., sharp/node-llama-cpp) to execute. This fits into the existing “Global install (manual)” section as an alternative to npm-based global installation and helps avoid incomplete installs caused by pnpm’s build-script approval requirement.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and safe to merge, with minor doc-accuracy nits to consider.
- Change is confined to installation documentation and doesn’t affect runtime behavior. The only concerns are potential pnpm-version differences and whether approval alone triggers postinstall scripts without an explicit reinstall step.
- docs/install/index.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->