### PR TITLE
fix(ui): use local logo to prevent 403 errors from CDN

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -133,7 +133,7 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src="https://mintcdn.com/clawhub/4rYvG-uuZrMK_URE/assets/pixel-lobster.svg?fit=max&auto=format&n=4rYvG-uuZrMK_URE&q=85&s=da2032e9eac3b5d9bfe7eb96ca6a8a26" alt="OpenClaw" />
+              <img src="./favicon.svg" alt="OpenClaw" />
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
## 🐛 Bug Fix
The OpenClaw logo in the Gateway Dashboard was failing to load (403 Forbidden) because it relied on a hardcoded MintCDN URL that is currently restricted.

## 🔧 Changes
- Replaced the hardcoded CDN URL in `ui/src/ui/app-render.ts` with a relative path to the local `favicon.svg`.
- This ensures the logo always loads from the local installation.

## 🧪 Testing
- [x] Verified the image path points to a valid local asset (`ui/public/favicon.svg`).

## 🦞 Lobster Checklist
- [x] Small bug fix
- [x] No breaking changes

Fixes: #5650, #5652

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Gateway Dashboard header logo to load from a local asset (`favicon.svg`) instead of a hardcoded MintCDN URL that was returning 403s. This keeps the UI from depending on an external CDN for a core brand image and should make the dashboard render reliably in restricted environments.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge; watch for route-relative asset resolution issues.
- Change is small and localized, but using a `./` relative image URL can break when the app is served from nested routes or a non-root base path, depending on the router/static server setup.
- ui/src/ui/app-render.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->