### PR TITLE
fix(cron): default enabled=true + gateway retry logic

### DIFF
--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -3,6 +3,15 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-
 
 export const DEFAULT_GATEWAY_URL = "ws://127.0.0.1:18789";
 
+/** Default timeout for gateway tool calls (increased from 10s to 30s for busy gateways) */
+const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
+
+/** Maximum retry attempts on timeout */
+const MAX_RETRY_ATTEMPTS = 2;
+
+/** Delay between retries (doubles each attempt) */
+const RETRY_BASE_DELAY_MS = 500;
+
 export type GatewayCallOptions = {
   gatewayUrl?: string;
   gatewayToken?: string;
@@ -22,8 +31,16 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
   const timeoutMs =
     typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))
-      : 10_000;
+      : DEFAULT_TOOL_TIMEOUT_MS;
   return { url, token, timeoutMs };
+}
+
+function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("gateway timeout");
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function callGatewayTool<T = Record<string, unknown>>(
@@ -31,17 +48,43 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   opts: GatewayCallOptions,
   params?: unknown,
   extra?: { expectFinal?: boolean },
-) {
+): Promise<T> {
   const gateway = resolveGatewayOptions(opts);
-  return await callGateway<T>({
-    url: gateway.url,
-    token: gateway.token,
-    method,
-    params,
-    timeoutMs: gateway.timeoutMs,
-    expectFinal: extra?.expectFinal,
-    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-    clientDisplayName: "agent",
-    mode: GATEWAY_CLIENT_MODES.BACKEND,
-  });
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await callGateway<T>({
+        url: gateway.url,
+        token: gateway.token,
+        method,
+        params,
+        timeoutMs: gateway.timeoutMs,
+        expectFinal: extra?.expectFinal,
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        clientDisplayName: "agent",
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      });
+    } catch (err) {
+      lastError = err as Error;
+
+      // Only retry on timeout errors
+      if (!isTimeoutError(err)) {
+        throw err;
+      }
+
+      // Don't retry if we've exhausted attempts
+      if (attempt >= MAX_RETRY_ATTEMPTS) {
+        break;
+      }
+
+      // Exponential backoff before retry
+      const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+      await sleep(delay);
+    }
+  }
+
+  // All retries exhausted
+  throw lastError;
 }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -94,7 +94,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     agentId: normalizeOptionalAgentId(input.agentId),
     name: normalizeRequiredName(input.name),
     description: normalizeOptionalText(input.description),
-    enabled: input.enabled,
+    enabled: input.enabled ?? true,
     deleteAfterRun: input.deleteAfterRun,
     createdAtMs: now,
     updatedAtMs: now,


### PR DESCRIPTION
## Changes

### 1. fix(cron): default enabled=true for new jobs
New cron jobs should default to enabled unless explicitly set to false.

### 2. feat(gateway): add retry logic with exponential backoff for timeout errors
- Increase default timeout from 10s to 30s for busy gateways
- Add up to 2 retry attempts on timeout errors only
- Implement exponential backoff (500ms, 1s) between retries
- Non-timeout errors still fail immediately

This helps with transient gateway timeouts during high load.