### PR TITLE
fix: recognize versioned node binaries like node24 (openSUSE)

### DIFF
--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -1,3 +1,5 @@
+import { isBunRuntime, isNodeRuntime } from "../daemon/runtime-detect.js";
+
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-v", "-V", "--version"]);
 const FLAG_TERMINATOR = "--";
@@ -122,29 +124,13 @@ export function buildParseArgv(params: {
       : baseArgv[0]?.endsWith("openclaw")
         ? baseArgv.slice(1)
         : baseArgv;
-  const executable = (normalizedArgv[0]?.split(/[/\\]/).pop() ?? "").toLowerCase();
+  const executable = normalizedArgv[0] ?? "";
   const looksLikeNode =
-    normalizedArgv.length >= 2 && (isNodeExecutable(executable) || isBunExecutable(executable));
+    normalizedArgv.length >= 2 && (isNodeRuntime(executable) || isBunRuntime(executable));
   if (looksLikeNode) {
     return normalizedArgv;
   }
   return ["node", programName || "openclaw", ...normalizedArgv];
-}
-
-const nodeExecutablePattern = /^node-\d+(?:\.\d+)*(?:\.exe)?$/;
-
-function isNodeExecutable(executable: string): boolean {
-  return (
-    executable === "node" ||
-    executable === "node.exe" ||
-    executable === "nodejs" ||
-    executable === "nodejs.exe" ||
-    nodeExecutablePattern.test(executable)
-  );
-}
-
-function isBunExecutable(executable: string): boolean {
-  return executable === "bun" || executable === "bun.exe";
 }
 
 export function shouldMigrateStateFromPath(path: string[]): boolean {

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isBunRuntime, isNodeRuntime } from "./runtime-detect.js";
 
 type GatewayProgramArgs = {
   programArguments: string[];
@@ -7,16 +8,6 @@ type GatewayProgramArgs = {
 };
 
 type GatewayRuntimePreference = "auto" | "node" | "bun";
-
-function isNodeRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
-  return base === "node" || base === "node.exe";
-}
-
-function isBunRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
-  return base === "bun" || base === "bun.exe";
-}
 
 async function resolveCliEntrypointPathForService(): Promise<string> {
   const argv1 = process.argv[1];

--- a/src/daemon/runtime-detect.test.ts
+++ b/src/daemon/runtime-detect.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { isBunRuntime, isNodeRuntime } from "./runtime-detect.js";
+
+describe("isNodeRuntime", () => {
+  it("should recognize standard node binary", () => {
+    expect(isNodeRuntime("/usr/bin/node")).toBe(true);
+    expect(isNodeRuntime("/usr/local/bin/node")).toBe(true);
+    expect(isNodeRuntime("C:\\Program Files\\nodejs\\node.exe")).toBe(true);
+  });
+
+  it("should recognize nodejs (Debian/Ubuntu)", () => {
+    expect(isNodeRuntime("/usr/bin/nodejs")).toBe(true);
+    expect(isNodeRuntime("C:\\nodejs.exe")).toBe(true);
+  });
+
+  it("should recognize openSUSE-style versioned binaries", () => {
+    expect(isNodeRuntime("/usr/bin/node24")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node22")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node18")).toBe(true);
+  });
+
+  it("should recognize hyphen-style versioned binaries", () => {
+    expect(isNodeRuntime("/usr/bin/node-22")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node-22.2.0")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node-18.19.1")).toBe(true);
+  });
+
+  it("should recognize versioned binaries with .exe extension", () => {
+    expect(isNodeRuntime("C:\\node24.exe")).toBe(true);
+    expect(isNodeRuntime("C:\\node-22.exe")).toBe(true);
+    expect(isNodeRuntime("C:\\node-22.2.0.exe")).toBe(true);
+  });
+
+  it("should be case-insensitive", () => {
+    expect(isNodeRuntime("/usr/bin/Node")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/NODE")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/Node24")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/NODE-22")).toBe(true);
+    expect(isNodeRuntime("C:\\NODEJS.EXE")).toBe(true);
+  });
+
+  it("should handle quoted paths", () => {
+    expect(isNodeRuntime('"C:\\Program Files\\nodejs\\node.exe"')).toBe(true);
+    expect(isNodeRuntime("'/usr/bin/node'")).toBe(true);
+  });
+
+  it("should reject non-node runtimes", () => {
+    expect(isNodeRuntime("/usr/bin/bun")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/deno")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/python")).toBe(false);
+  });
+
+  it("should reject node-like but different binaries", () => {
+    expect(isNodeRuntime("/usr/bin/node-dev")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/nodeenv")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/nodemon")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/node_modules")).toBe(false);
+  });
+});
+
+describe("isBunRuntime", () => {
+  it("should recognize bun binary", () => {
+    expect(isBunRuntime("/usr/bin/bun")).toBe(true);
+    expect(isBunRuntime("/usr/local/bin/bun")).toBe(true);
+    expect(isBunRuntime("C:\\bun.exe")).toBe(true);
+  });
+
+  it("should be case-insensitive", () => {
+    expect(isBunRuntime("/usr/bin/Bun")).toBe(true);
+    expect(isBunRuntime("/usr/bin/BUN")).toBe(true);
+    expect(isBunRuntime("C:\\BUN.EXE")).toBe(true);
+  });
+
+  it("should reject non-bun runtimes", () => {
+    expect(isBunRuntime("/usr/bin/node")).toBe(false);
+    expect(isBunRuntime("/usr/bin/deno")).toBe(false);
+    expect(isBunRuntime("/usr/bin/bunx")).toBe(false);
+  });
+});

--- a/src/daemon/runtime-detect.ts
+++ b/src/daemon/runtime-detect.ts
@@ -1,0 +1,23 @@
+const NODE_VERSIONED_PATTERN = /^node-?\d+(?:\.\d+)*(?:\.exe)?$/;
+
+function getBasename(execPath: string): string {
+  const trimmed = execPath.trim().replace(/^["']|["']$/g, "");
+  const lastSlash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
+}
+
+export function isNodeRuntime(execPath: string): boolean {
+  const base = getBasename(execPath).toLowerCase();
+  return (
+    base === "node" ||
+    base === "node.exe" ||
+    base === "nodejs" ||
+    base === "nodejs.exe" ||
+    NODE_VERSIONED_PATTERN.test(base)
+  );
+}
+
+export function isBunRuntime(execPath: string): boolean {
+  const base = getBasename(execPath).toLowerCase();
+  return base === "bun" || base === "bun.exe";
+}

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
+import { isBunRuntime, isNodeRuntime } from "./runtime-detect.js";
 import {
   isSystemNodePath,
   isVersionManagedNodePath,
@@ -198,16 +199,6 @@ function auditGatewayCommand(programArguments: string[] | undefined, issues: Ser
       level: "aggressive",
     });
   }
-}
-
-function isNodeRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
-  return base === "node" || base === "node.exe";
-}
-
-function isBunRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
-  return base === "bun" || base === "bun.exe";
 }
 
 function getPathModule(platform: NodeJS.Platform) {


### PR DESCRIPTION
## Summary

Fixes #5691

- Fixes runtime detection for versioned Node binaries like `node24` (openSUSE) and `node-22`
- On openSUSE, Node.js is installed as `/usr/bin/node24` (no hyphen), which wasn't recognized
- This caused gateway service generation and CLI argument parsing to fail

## Changes

- Create shared `src/daemon/runtime-detect.ts` module with `isNodeRuntime()` and `isBunRuntime()`
- Fix regex pattern: `/^node-\d+/` → `/^node-?\d+/` (make hyphen optional)
- Remove duplicate implementations from `program-args.ts` and `service-audit.ts`
- Fix same pattern in `src/cli/argv.ts` for CLI argument parsing
- Add comprehensive tests (11 test cases)

## Test plan

- [x] Tested on openSUSE server with `/usr/bin/node24`
- [x] Gateway service runs without workarounds
- [x] All existing tests pass
- [x] `pnpm format && pnpm lint && pnpm build && pnpm test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)