### PR TITLE
fix(venice-models): improve discovery reliability with retry, timeout, and caching

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -3,10 +3,29 @@ import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channel
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import type { MoltbotConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { computeBackoff } from "../infra/backoff.js";
+import { formatDurationMs } from "../infra/format-duration.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+
+/**
+ * Auto-restart policy for channels that exit unexpectedly.
+ * Uses exponential backoff starting at 2s, capping at 60s.
+ */
+const CHANNEL_RESTART_POLICY = {
+  initialMs: 2000,
+  maxMs: 60_000,
+  factor: 2,
+  jitter: 0.2,
+};
+
+/** Maximum consecutive restart attempts before giving up. */
+const MAX_RESTART_ATTEMPTS = 10;
+
+/** Reset restart attempts after this many ms of successful running. */
+const RESTART_ATTEMPT_RESET_MS = 5 * 60 * 1000; // 5 minutes
 
 export type ChannelRuntimeSnapshot = {
   channels: Partial<Record<ChannelId, ChannelAccountSnapshot>>;
@@ -19,6 +38,12 @@ type ChannelRuntimeStore = {
   aborts: Map<string, AbortController>;
   tasks: Map<string, Promise<unknown>>;
   runtimes: Map<string, ChannelAccountSnapshot>;
+  /** Track restart attempts per account for backoff/giving up. */
+  restartAttempts: Map<string, number>;
+  /** Track when the channel started (for measuring run duration). */
+  channelStartTime: Map<string, number>;
+  /** Track pending restart timers so they can be cancelled. */
+  restartTimers: Map<string, ReturnType<typeof setTimeout>>;
 };
 
 function createRuntimeStore(): ChannelRuntimeStore {
@@ -26,6 +51,9 @@ function createRuntimeStore(): ChannelRuntimeStore {
     aborts: new Map(),
     tasks: new Map(),
     runtimes: new Map(),
+    restartAttempts: new Map(),
+    channelStartTime: new Map(),
+    restartTimers: new Map(),
   };
 }
 
@@ -138,6 +166,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         });
 
         const log = channelLogs[channelId];
+        // Record start time for measuring run duration
+        store.channelStartTime.set(id, Date.now());
+
+        // Cancel any pending restart timer (prevents race conditions)
+        const existingTimer = store.restartTimers.get(id);
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+          store.restartTimers.delete(id);
+        }
+
         const task = startAccount({
           cfg,
           accountId: id,
@@ -148,13 +186,17 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           getStatus: () => getRuntime(channelId, id),
           setStatus: (next) => setRuntime(channelId, id, next),
         });
+
+        let exitedWithError = false;
         const tracked = Promise.resolve(task)
           .catch((err) => {
+            exitedWithError = true;
             const message = formatErrorMessage(err);
             setRuntime(channelId, id, { accountId: id, lastError: message });
             log.error?.(`[${id}] channel exited: ${message}`);
           })
           .finally(() => {
+            const wasAborted = abort.signal.aborted;
             store.aborts.delete(id);
             store.tasks.delete(id);
             setRuntime(channelId, id, {
@@ -162,6 +204,57 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               running: false,
               lastStopAt: Date.now(),
             });
+
+            // Auto-restart logic: restart if not deliberately stopped
+            if (!wasAborted) {
+              const startTime = store.channelStartTime.get(id) ?? 0;
+              const runDuration = Date.now() - startTime;
+              store.channelStartTime.delete(id);
+
+              // Reset attempt counter if ran without error for a while
+              // Only reset if we didn't exit with an error (indicates healthy operation)
+              if (!exitedWithError && runDuration >= RESTART_ATTEMPT_RESET_MS) {
+                store.restartAttempts.set(id, 0);
+              }
+
+              const attempts = (store.restartAttempts.get(id) ?? 0) + 1;
+              store.restartAttempts.set(id, attempts);
+
+              if (attempts <= MAX_RESTART_ATTEMPTS) {
+                const delayMs = computeBackoff(CHANNEL_RESTART_POLICY, attempts);
+                const reason = exitedWithError ? "error" : "unexpected exit";
+                log.warn?.(
+                  `[${id}] channel ${reason}; scheduling restart in ${formatDurationMs(delayMs)} (attempt ${attempts}/${MAX_RESTART_ATTEMPTS})`,
+                );
+
+                // Cancel any existing restart timer before scheduling new one
+                const existingTimer = store.restartTimers.get(id);
+                if (existingTimer) {
+                  clearTimeout(existingTimer);
+                }
+
+                // Schedule restart
+                const timer = setTimeout(() => {
+                  store.restartTimers.delete(id);
+                  // Re-check if channel should still restart
+                  // Skip if already running, has a pending task, or timer was orphaned
+                  if (store.aborts.has(id) || store.tasks.has(id)) {
+                    log.debug?.(`[${id}] skipping scheduled restart; channel already running`);
+                    return;
+                  }
+                  void startChannel(channelId, id);
+                }, delayMs);
+                store.restartTimers.set(id, timer);
+              } else {
+                log.error?.(
+                  `[${id}] channel exceeded max restart attempts (${MAX_RESTART_ATTEMPTS}); giving up. Manual restart required.`,
+                );
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  lastError: `exceeded max restart attempts (${MAX_RESTART_ATTEMPTS})`,
+                });
+              }
+            }
           });
         store.tasks.set(id, tracked);
       }),
@@ -184,6 +277,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
     await Promise.all(
       Array.from(knownIds.values()).map(async (id) => {
+        // Cancel any pending restart timer
+        const restartTimer = store.restartTimers.get(id);
+        if (restartTimer) {
+          clearTimeout(restartTimer);
+          store.restartTimers.delete(id);
+        }
+        // Reset restart attempts and clear start time on deliberate stop
+        store.restartAttempts.delete(id);
+        store.channelStartTime.delete(id);
+
         const abort = store.aborts.get(id);
         const task = store.tasks.get(id);
         if (!abort && !task && !plugin?.gateway?.stopAccount) return;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -125,31 +125,27 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     network: telegramCfg.network,
   });
   const shouldProvideFetch = Boolean(fetchImpl);
+  // Default to 60s timeout (grammY defaults to 500s which is too long for recovery).
+  // This timeout applies to API calls like sendMessage, getMe, etc.
+  // Note: The long-polling getUpdates timeout is controlled separately in monitor.ts runner options.
+  const DEFAULT_API_TIMEOUT_SECONDS = 60;
   const timeoutSeconds =
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
-      : undefined;
-  const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
-      ? {
-          ...(shouldProvideFetch && fetchImpl
-            ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
-            : {}),
-          ...(timeoutSeconds ? { timeoutSeconds } : {}),
-        }
-      : undefined;
+      : DEFAULT_API_TIMEOUT_SECONDS;
+  const client: ApiClientOptions = {
+    ...(shouldProvideFetch && fetchImpl
+      ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
+      : {}),
+    timeoutSeconds,
+  };
 
-  const bot = new Bot(opts.token, client ? { client } : undefined);
+  const bot = new Bot(opts.token, { client });
   bot.api.config.use(apiThrottler());
   bot.use(sequentialize(getTelegramSequentialKey));
-  bot.catch((err) => {
-    runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
-  });
-
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
-    const message = err instanceof Error ? err.message : String(err);
-    runtime.error?.(danger(`telegram bot error: ${message}`));
+    runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
   });
 
   const recentUpdates = createTelegramUpdateDedupe();


### PR DESCRIPTION
## Problem
Venice model discovery was occasionally timing out with:
```
[venice-models] Discovery failed: TimeoutError: The operation was aborted due to timeout, using static catalog
```

## Changes
1. **Increased timeout**: 5s → 15s (more headroom for slow connections)
2. **Retry logic**: 3 attempts with exponential backoff (1-5s delay, 20% jitter)
3. **In-memory caching**: 1 hour TTL, reduces API calls after first success
4. **Better error messages**: Distinguishes retry exhaustion from single failures

## Note
The Venice API typically responds in <1s, so the timeout rarely triggers. But when it does (network hiccups, cold starts), this provides graceful recovery instead of falling back to the static catalog.

## Testing
- Discovery works (~800ms first call)
- Cache works (0ms subsequent calls)
- Build passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds resilience improvements in two main areas:

- **Gateway channel lifecycle** (`src/gateway/server-channels.ts`): tracks per-account start time and restart attempts, and introduces an auto-restart mechanism with exponential backoff + jitter, plus a maximum restart-attempt cap and timer cancellation to avoid restart races.
- **Telegram client configuration** (`src/telegram/bot.ts`): sets a default grammY API timeout of 60 seconds (overridable via config) and simplifies `Bot` construction so the client options are always passed consistently.

A new `skills/qmd` submodule pointer is also included in the changeset.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there are a couple of restart-path edge cases that can leave channels wedged or give up too aggressively.
- Most changes are localized and straightforward, but the new auto-restart logic has two failure modes: synchronous `startAccount` throws can bypass cleanup, and restart-attempt accounting can exhaust even on non-error exits. Both could impact gateway availability if hit by certain channel implementations.
- src/gateway/server-channels.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->