### PR TITLE
 /new: use agent personality in session greeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.
 - Process: resolve Windows `spawn()` failures for npm-family CLIs by appending `.cmd` when needed. (#5815) Thanks @thejhinvirtuoso.
 - Docs: update MiniMax OAuth setup commands; Extensions: use OpenClaw plugin SDK for MiniMax OAuth. (#5402) Thanks @Maosghoul.
 - Discord: resolve PluralKit proxied senders for allowlists and labels. (#5838) Thanks @thewilloftheshadow.

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -48,7 +48,7 @@ type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 const BARE_SESSION_RESET_PROMPT =
-  "A new session was started via /new or /reset. Say hi briefly (1-2 sentences) and ask what the user wants to do next. If the runtime model differs from default_model in the system prompt, mention the default model in the greeting. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Greet the user as your character from your personality/identity files (if any exist in your workspace). Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
 type RunPreparedReplyParams = {
   ctx: MsgContext;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -48,7 +48,7 @@ type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 const BARE_SESSION_RESET_PROMPT =
-  "A new session was started via /new or /reset. Greet the user as your character from your personality/identity files (if any exist in your workspace). Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
 type RunPreparedReplyParams = {
   ctx: MsgContext;


### PR DESCRIPTION
## Summary

When using `/new` or `/reset`, agents with personality files (IDENTITY.md, SOUL.md, etc.) now greet users **in character** from the very first message.

## Problem

Previously, the session reset prompt was generic:
> "Say hi briefly (1-2 sentences) and ask what the user wants to do next."

This meant agents would respond out of character until the conversation got going — breaking immersion for users who have set up custom agent personalities.

## Solution

Updated the prompt to:
> "Greet the user as your character from your personality/identity files (if any exist in your workspace). Be yourself - use your defined voice, mannerisms, and mood."

Agents without personality files still get a normal greeting. Agents with them now stay in character from the start.

## Testing

- [x] Tested with an agent that has IDENTITY.md and SOUL.md — `/new` now produces a greeting that matches the agent's defined personality, voice, and mannerisms
- [x] `pnpm format && pnpm build && pnpm test` passes (lint has pre-existing extension type errors on main)

## AI Assistance 🤖

This PR was AI-assisted (Claude). The change is fully understood — it updates a single prompt constant to instruct the model to use personality files when greeting.
