### PR TITLE
feat(hooks): add agentId support to /hooks/agent webhook

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -55,6 +55,7 @@ export type HookAction =
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      agentId?: string;
     };
 
 export type HookMappingResult =
@@ -94,6 +95,7 @@ type HookTransformResult = Partial<{
   model: string;
   thinking: string;
   timeoutSeconds: number;
+  agentId: string;
 }> | null;
 
 type HookTransformFn = (
@@ -297,6 +299,7 @@ function mergeAction(
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
+    agentId: override.agentId ?? baseAgent?.agentId,
   });
 }
 

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -130,6 +130,35 @@ describe("gateway hooks helpers", () => {
     const bad = normalizeAgentPayload({ message: "yo", channel: "sms" });
     expect(bad.ok).toBe(false);
   });
+
+  test("normalizeAgentPayload extracts agentId", () => {
+    const withAgentId = normalizeAgentPayload(
+      { message: "hello", agentId: "  reviewer  " },
+      { idFactory: () => "fixed" },
+    );
+    expect(withAgentId.ok).toBe(true);
+    if (withAgentId.ok) {
+      expect(withAgentId.value.agentId).toBe("reviewer");
+    }
+
+    const withoutAgentId = normalizeAgentPayload(
+      { message: "hello" },
+      { idFactory: () => "fixed" },
+    );
+    expect(withoutAgentId.ok).toBe(true);
+    if (withoutAgentId.ok) {
+      expect(withoutAgentId.value.agentId).toBeUndefined();
+    }
+
+    const emptyAgentId = normalizeAgentPayload(
+      { message: "hello", agentId: "   " },
+      { idFactory: () => "fixed" },
+    );
+    expect(emptyAgentId.ok).toBe(true);
+    if (emptyAgentId.ok) {
+      expect(emptyAgentId.value.agentId).toBeUndefined();
+    }
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -155,6 +155,7 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -224,6 +225,9 @@ export function normalizeAgentPayload(
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   return {
     ok: true,
     value: {
@@ -237,6 +241,7 @@ export function normalizeAgentPayload(
       model,
       thinking,
       timeoutSeconds,
+      agentId,
     },
   };
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -47,6 +47,7 @@ type HookDispatchers = {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    agentId?: string;
   }) => string;
 };
 
@@ -184,6 +185,7 @@ export function createHooksRequestHandler(
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            agentId: mapped.action.agentId,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -42,6 +42,7 @@ export function createGatewayHooksRequestHandler(params: {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    agentId?: string;
   }) => {
     const sessionKey = value.sessionKey.trim() ? value.sessionKey.trim() : `hook:${randomUUID()}`;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -56,6 +57,7 @@ export function createGatewayHooksRequestHandler(params: {
       schedule: { kind: "at", atMs: now },
       sessionTarget: "isolated",
       wakeMode: value.wakeMode,
+      agentId: value.agentId,
       payload: {
         kind: "agentTurn",
         message: value.message,


### PR DESCRIPTION
## Problem

The `/hooks/agent` webhook accepts an `agentId` parameter in the request body, but it's silently ignored — all webhook-triggered jobs run under the default agent regardless.

The underlying infrastructure already supports this: `runCronIsolatedAgentTurn` accepts `job.agentId` and routes to the correct agent config. The parameter just wasn't being wired through from the webhook layer.

## Solution

Thread `agentId` through the webhook pipeline:

- Extract and validate `agentId` in normalizeAgentPayload()
- Add to `HookAgentPayload` type and dispatcher signature
- Pass to the cron job in `dispatchAgentHook()`
- Add `agentId` to `HookAction` type (agent kind)
- Add `agentId` to `HookTransformResult` for custom transforms
- Thread through `mergeAction()` for override/base merging
- Pass to `dispatchAgentHook()` in the mapped-hooks branch

## Usage

```
curl -X POST http://localhost:18789/hooks/agent \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"message": "review this PR", "agentId": "reviewer"}'
```

The job now runs under the `reviewer` agent's config (workspace, model, system prompt, etc.) instead of the default.

## Testing

Added unit test for `agentId` extraction (trims whitespace, treats empty string as undefined).

## Greptile Note

I addressed the issue found by Greptile below.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires an optional `agentId` through the `/hooks/agent` webhook flow so webhook-triggered jobs can run under a non-default agent configuration. It adds `agentId` parsing/normalization in `normalizeAgentPayload()`, extends the relevant payload/dispatcher types, passes the value down into the cron job (`CronJob.agentId`), and adds a unit test covering trimming/empty-string behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one functional omission in the hook-mapping path.
- The change is small and well-tested for payload normalization, but `agentId` is not forwarded when the request is handled via hook mappings, which can lead to inconsistent behavior vs the direct `/hooks/agent` endpoint.
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->