### PR TITLE
CI: informational formal models conformance (clawdbot-formal-models)

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -1,0 +1,88 @@
+name: Formal models (informational conformance)
+
+on:
+  pull_request:
+
+jobs:
+  formal_conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout openclaw (PR)
+        uses: actions/checkout@v4
+        with:
+          path: openclaw
+
+      - name: Checkout formal models
+        uses: actions/checkout@v4
+        with:
+          repository: vignesh07/clawdbot-formal-models
+          path: clawdbot-formal-models
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Regenerate extracted constants from openclaw
+        run: |
+          set -euo pipefail
+          cd clawdbot-formal-models
+          export OPENCLAW_REPO_DIR="${GITHUB_WORKSPACE}/openclaw"
+          node scripts/extract-tool-groups.mjs
+
+      - name: Compute drift
+        id: drift
+        run: |
+          set -euo pipefail
+          cd clawdbot-formal-models
+
+          if git diff --quiet; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "drift=true" >> "$GITHUB_OUTPUT"
+          git diff > "${GITHUB_WORKSPACE}/formal-models-drift.diff"
+
+      - name: Upload drift diff artifact
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: formal-models-conformance-drift
+          path: formal-models-drift.diff
+
+      - name: Comment on PR (informational)
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '⚠️ **Formal models conformance drift detected**',
+              '',
+              'The formal models extracted constants (`generated/*`) do not match this openclaw PR.',
+              '',
+              'This check is **informational** (not blocking merges yet).',
+              'See the `formal-models-conformance-drift` artifact for the diff.',
+              '',
+              'If this change is intentional, follow up by updating the formal models repo or regenerating the extracted artifacts there.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.drift.outputs.drift }}" = "true" ]; then
+            echo "Formal conformance drift detected (informational)."
+          else
+            echo "Formal conformance: no drift."
+          fi


### PR DESCRIPTION
Adds an **informational** conformance check that runs the external formal models repo (`vignesh07/clawdbot-formal-models`) against the current openclaw PR.

What it does:
- Checks out openclaw (PR branch)
- Checks out `vignesh07/clawdbot-formal-models`
- Regenerates extracted constants (currently: tool groups + aliases) using `OPENCLAW_REPO_DIR`
- If regeneration causes a diff, uploads `formal-models-drift.diff` as an artifact and comments on the PR

This does **not** fail the build yet (informational only). We can tighten it later.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new GitHub Actions workflow (`.github/workflows/formal-conformance.yml`) that, on each PR, checks out the OpenClaw PR and an external formal-models repository, regenerates extracted constants, and if regeneration produces a diff, uploads that diff as an artifact and leaves an informational PR comment.

It integrates as a non-blocking CI signal to detect drift between OpenClaw’s current constants and the formal models’ generated artifacts.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but the workflow as written introduces avoidable supply-chain and stability concerns.
- Main concerns are: running code from an unpinned external repository and granting `pull-requests: write` in the same job, and potential CI breakage if the external repo requires dependencies that are not installed. The rest of the workflow is straightforward and unlikely to impact product code.
- .github/workflows/formal-conformance.yml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->