### PR TITLE
feat(web): add per-code-block copy buttons in webchat

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -122,3 +122,113 @@
   border-top: 1px solid var(--border);
   margin: 1em 0;
 }
+
+/* =============================================
+   CODE BLOCK COPY BUTTON
+   ============================================= */
+
+.code-block-wrapper {
+  position: relative;
+}
+
+.code-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+  border-radius: var(--radius-md);
+  padding: 4px 6px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease-out,
+    background 120ms ease-out;
+  z-index: 1;
+}
+
+.code-block-wrapper:hover .code-copy-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.code-copy-btn:hover {
+  background: var(--bg-hover);
+}
+
+.code-copy-btn[data-copying="1"] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.code-copy-btn[data-error="1"] {
+  opacity: 1;
+  pointer-events: auto;
+  border-color: var(--danger-subtle);
+  background: var(--danger-subtle);
+  color: var(--danger);
+}
+
+.code-copy-btn[data-copied="1"] {
+  opacity: 1;
+  pointer-events: auto;
+  border-color: var(--ok-subtle);
+  background: var(--ok-subtle);
+  color: var(--ok);
+}
+
+.code-copy-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Icon structure */
+.code-copy-btn__icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  position: relative;
+}
+
+.code-copy-btn__icon svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.code-copy-btn__icon-copy,
+.code-copy-btn__icon-check {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: opacity 150ms ease;
+}
+
+.code-copy-btn__icon-check {
+  opacity: 0;
+}
+
+.code-copy-btn[data-copied="1"] .code-copy-btn__icon-copy {
+  opacity: 0;
+}
+
+.code-copy-btn[data-copied="1"] .code-copy-btn__icon-check {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .code-copy-btn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/ui/src/ui/chat/code-block-copy.test.ts
+++ b/ui/src/ui/chat/code-block-copy.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { enhanceCodeBlocks } from "./code-block-copy";
+
+function createContainer(html: string): HTMLElement {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  document.body.appendChild(div);
+  return div;
+}
+
+describe("enhanceCodeBlocks", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("adds copy button to pre elements", () => {
+    const container = createContainer("<pre><code>hello</code></pre>");
+    enhanceCodeBlocks(container);
+    expect(container.querySelector(".code-copy-btn")).not.toBeNull();
+    expect(container.querySelector(".code-block-wrapper")).not.toBeNull();
+  });
+
+  it("skips already-enhanced blocks (idempotency)", () => {
+    const container = createContainer("<pre><code>hello</code></pre>");
+    enhanceCodeBlocks(container);
+    enhanceCodeBlocks(container);
+    expect(container.querySelectorAll(".code-copy-btn")).toHaveLength(1);
+  });
+
+  it("copies code element textContent on click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const container = createContainer("<pre><code>console.log(1)</code></pre>");
+    enhanceCodeBlocks(container);
+
+    const btn = container.querySelector(".code-copy-btn") as HTMLButtonElement;
+    btn.click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("console.log(1)"));
+  });
+
+  it("falls back to pre textContent when no code child", () => {
+    const container = createContainer("<pre>plain text</pre>");
+    enhanceCodeBlocks(container);
+    expect(container.querySelector(".code-copy-btn")).not.toBeNull();
+  });
+
+  it("enhances multiple code blocks", () => {
+    const container = createContainer(
+      "<pre><code>block 1</code></pre><pre><code>block 2</code></pre>",
+    );
+    enhanceCodeBlocks(container);
+    expect(container.querySelectorAll(".code-copy-btn")).toHaveLength(2);
+    expect(container.querySelectorAll(".code-block-wrapper")).toHaveLength(2);
+  });
+
+  it("shows error state when copy fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const container = createContainer("<pre><code>test</code></pre>");
+    enhanceCodeBlocks(container);
+
+    const btn = container.querySelector(".code-copy-btn") as HTMLButtonElement;
+    btn.click();
+    await vi.waitFor(() => {
+      expect(btn.dataset.error).toBe("1");
+      expect(btn.title).toBe("Copy failed");
+    });
+  });
+
+  it("does not target inline code elements", () => {
+    const container = createContainer("<p>Use <code>npm install</code> to install</p>");
+    enhanceCodeBlocks(container);
+    expect(container.querySelector(".code-copy-btn")).toBeNull();
+  });
+});

--- a/ui/src/ui/chat/code-block-copy.ts
+++ b/ui/src/ui/chat/code-block-copy.ts
@@ -1,0 +1,97 @@
+const COPIED_FOR_MS = 1500;
+const ERROR_FOR_MS = 2000;
+const COPY_LABEL = "Copy code";
+const COPIED_LABEL = "Copied";
+const ERROR_LABEL = "Copy failed";
+const ENHANCED_ATTR = "data-code-copy";
+
+const COPY_SVG = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+const CHECK_SVG = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+function setLabel(btn: HTMLButtonElement, label: string): void {
+  btn.title = label;
+  btn.setAttribute("aria-label", label);
+}
+
+function createCodeCopyButton(pre: HTMLElement): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = "code-copy-btn";
+  btn.type = "button";
+  setLabel(btn, COPY_LABEL);
+  btn.innerHTML = `<span class="code-copy-btn__icon" aria-hidden="true"><span class="code-copy-btn__icon-copy">${COPY_SVG}</span><span class="code-copy-btn__icon-check">${CHECK_SVG}</span></span>`;
+
+  btn.addEventListener("click", async () => {
+    if (btn.dataset.copying === "1") return;
+
+    const code = pre.querySelector("code");
+    const text = (code ?? pre).textContent ?? "";
+    if (!text) return;
+
+    btn.dataset.copying = "1";
+    btn.setAttribute("aria-busy", "true");
+    btn.disabled = true;
+
+    let success = false;
+    try {
+      await navigator.clipboard.writeText(text);
+      success = true;
+    } catch {
+      /* clipboard access denied */
+    }
+
+    if (!btn.isConnected) return;
+    delete btn.dataset.copying;
+    btn.removeAttribute("aria-busy");
+    btn.disabled = false;
+
+    if (!success) {
+      btn.dataset.error = "1";
+      setLabel(btn, ERROR_LABEL);
+      window.setTimeout(() => {
+        if (!btn.isConnected) return;
+        delete btn.dataset.error;
+        setLabel(btn, COPY_LABEL);
+      }, ERROR_FOR_MS);
+      return;
+    }
+
+    btn.dataset.copied = "1";
+    setLabel(btn, COPIED_LABEL);
+    window.setTimeout(() => {
+      if (!btn.isConnected) return;
+      delete btn.dataset.copied;
+      setLabel(btn, COPY_LABEL);
+    }, COPIED_FOR_MS);
+  });
+
+  return btn;
+}
+
+/** Walk all `<pre>` elements inside `container` and inject a copy button into each. */
+export function enhanceCodeBlocks(container: HTMLElement): void {
+  const pres = container.querySelectorAll<HTMLPreElement>("pre");
+
+  for (const pre of pres) {
+    if (pre.hasAttribute(ENHANCED_ATTR)) continue;
+    const parent = pre.parentNode;
+    if (!parent) continue;
+    pre.setAttribute(ENHANCED_ATTR, "");
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "code-block-wrapper";
+    parent.insertBefore(wrapper, pre);
+    wrapper.appendChild(pre);
+    wrapper.appendChild(createCodeCopyButton(pre));
+  }
+}
+
+/**
+ * Lit `ref` callback -- call from the `.chat-text` div.
+ * Defers via rAF to ensure `unsafeHTML` content is committed.
+ */
+export function codeBlockCopyRef(el: Element | undefined): void {
+  if (!(el instanceof HTMLElement)) return;
+  requestAnimationFrame(() => {
+    if (el.isConnected) enhanceCodeBlocks(el);
+  });
+}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1,9 +1,11 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import type { AssistantIdentity } from "../assistant-identity";
 import { toSanitizedMarkdownHtml } from "../markdown";
 import type { MessageGroup } from "../types/chat-types";
+import { codeBlockCopyRef } from "./code-block-copy";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer";
 import {
@@ -267,7 +269,7 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div class="chat-text" ${opts.isStreaming ? nothing : ref(codeBlockCopyRef)}>${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}


### PR DESCRIPTION
## Summary
Adds individual copy-to-clipboard buttons for each code block that appears in the webchat UI.  Closes #5524 

## What changed

  - **New:** `ui/src/ui/chat/code-block-copy.ts` — `enhanceCodeBlocks()` walks `<pre>` elements
  post-render, wraps each in a `.code-block-wrapper`, and injects a copy button with clipboard
  handling + success/error states
  - **New:** `ui/src/ui/chat/code-block-copy.test.ts` — 7 tests covering: button injection,
  idempotency, clipboard copy, multi-block, error state, pre-without-code fallback, inline code
  exclusion
  - **Modified:** `ui/src/ui/chat/grouped-render.ts` — added Lit `ref` callback on `.chat-text`
  to trigger enhancement after render (skipped during streaming)
  - **Modified:** `ui/src/styles/chat/text.css` — CSS for `.code-block-wrapper` and
  `.code-copy-btn` (hover reveal, copied/error states, touch/focus, icon transitions), matching
  the existing `.chat-copy-btn` pattern

  The existing whole-message "Copy as markdown" button is unchanged.

  ## Approach

  Post-render DOM enhancement via a Lit `ref` callback. After `unsafeHTML` commits the markdown,
   `requestAnimationFrame` defers `enhanceCodeBlocks()` which finds un-enhanced `<pre>` elements
   and wraps them. This avoids touching the markdown rendering pipeline and is idempotent across
   re-renders.

  ## Test plan

  - [x] 7 vitest tests passing (button injection, idempotency, clipboard copy, multi-block,
  error state, fallback, inline code exclusion)
  - [x] Full project gate clean: `pnpm lint`, `pnpm build`, `pnpm test` (4876/4906 pass — 30
  pre-existing failures in memory subsystem, unrelated)
  - [x] Visually verified with a static HTML preview with side-by-side 

## AI usage: 
  - Pair programming w/ Claude Opus 4.5 and fully tested. 
  - Claude generated the initial code based on my design decisions, then I reviewed and iterated through code review findings (null-pointer guard, SVG stroke attributes, additional test cases)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-code-block copy buttons to the webchat message renderer by post-processing rendered markdown: a Lit `ref` callback (`codeBlockCopyRef`) defers to `requestAnimationFrame` and runs `enhanceCodeBlocks()` to wrap each `<pre>` in a `.code-block-wrapper` and inject a `.code-copy-btn` that writes the block’s text to `navigator.clipboard`. Styling is added in `ui/src/styles/chat/text.css`, and a new Vitest file covers injection/idempotency, multiple blocks, clipboard copy success/failure, and inline-code exclusion.

The approach avoids modifying the markdown pipeline (`unsafeHTML(toSanitizedMarkdownHtml(...))`) and instead does idempotent DOM enhancement after render (skipping streaming renders).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of DOM-lifecycle edge cases worth addressing.
- Core behavior is straightforward and covered by unit tests, but the click handler can leave the button in a stuck disabled state if the element is detached while an async clipboard write is pending. There is also some risk from mutating DOM structure by wrapping `<pre>` elements, depending on any external selectors/scripts.
- ui/src/ui/chat/code-block-copy.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->