### PR TITLE
Agents: fix orphaned toolResult after history truncation

### DIFF
--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -10,8 +10,65 @@ function stripThreadSuffix(value: string): string {
 }
 
 /**
+ * Extracts tool call IDs from an assistant message's content blocks.
+ */
+function extractToolCallIds(msg: AgentMessage): Set<string> {
+  if (msg.role !== "assistant") return new Set();
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) return new Set();
+
+  const ids = new Set<string>();
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const rec = block as { type?: unknown; id?: unknown };
+    if (typeof rec.id !== "string" || !rec.id) continue;
+    if (rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall") {
+      ids.add(rec.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Extracts the tool call ID from a toolResult message.
+ */
+function extractToolResultId(msg: AgentMessage): string | null {
+  if (msg.role !== "toolResult") return null;
+  const toolCallId = (msg as { toolCallId?: unknown }).toolCallId;
+  if (typeof toolCallId === "string" && toolCallId) return toolCallId;
+  const toolUseId = (msg as { toolUseId?: unknown }).toolUseId;
+  if (typeof toolUseId === "string" && toolUseId) return toolUseId;
+  return null;
+}
+
+/**
+ * Removes orphaned toolResult messages that reference tool calls not present
+ * in any assistant message within the given message list.
+ */
+function dropOrphanedToolResults(messages: AgentMessage[]): AgentMessage[] {
+  // Collect all tool call IDs from assistant messages
+  const availableToolCallIds = new Set<string>();
+  for (const msg of messages) {
+    for (const id of extractToolCallIds(msg)) {
+      availableToolCallIds.add(id);
+    }
+  }
+
+  // Filter out toolResult messages that reference missing tool calls
+  return messages.filter((msg) => {
+    if (msg.role !== "toolResult") return true;
+    const id = extractToolResultId(msg);
+    // Keep if we can't determine the ID (defensive) or if the ID exists
+    return !id || availableToolCallIds.has(id);
+  });
+}
+
+/**
  * Limits conversation history to the last N user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
+ *
+ * Also removes any orphaned toolResult messages that would reference tool calls
+ * from truncated assistant messages, preventing API validation errors.
  */
 export function limitHistoryTurns(
   messages: AgentMessage[],
@@ -28,7 +85,10 @@ export function limitHistoryTurns(
     if (messages[i].role === "user") {
       userCount++;
       if (userCount > limit) {
-        return messages.slice(lastUserIndex);
+        const truncated = messages.slice(lastUserIndex);
+        // Remove any toolResult messages that reference tool calls from truncated
+        // assistant messages. This prevents "unexpected tool_use_id" API errors.
+        return dropOrphanedToolResults(truncated);
       }
       lastUserIndex = i;
     }


### PR DESCRIPTION
## Summary

Fixes the "unexpected tool_use_id found in tool_result blocks" API error that occurs when `limitHistoryTurns()` truncates conversation history.

- When `dmHistoryLimit` config is set, history truncation could leave orphaned `toolResult` messages whose matching `toolCall` was in the truncated portion
- This caused Anthropic API to reject the request with validation errors
- Fix adds detection and removal of orphaned toolResult messages after truncation

## Changes

- Added helper functions in `history.ts` to extract tool call IDs and detect orphans
- Modified `limitHistoryTurns()` to call `dropOrphanedToolResults()` after truncation
- Added 3 new test cases covering the orphan detection scenarios

## Test plan

- [x] All 12 `limitHistoryTurns` tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `limitHistoryTurns()` to post-process truncated history and drop `toolResult` messages whose referenced tool call no longer exists in the kept assistant messages. It adds small helper extractors in `history.ts` to collect tool call IDs from assistant content blocks and to read tool call IDs from toolResult messages, plus new unit tests that cover orphaned tool results (including `toolUse` naming).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real API validation failure, with only a small remaining edge case around toolResult blocks with unrecognized/missing IDs.
- Changes are localized to history truncation logic and backed by new unit tests. The main risk is that the orphan filter intentionally keeps toolResult messages when it can’t extract an ID, which could still allow invalid history through if the toolResult schema differs from what’s expected.
- src/agents/pi-embedded-runner/history.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->