### PR TITLE
feat(ui): virtualize chat message list for large conversations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
 
   ui:
     dependencies:
+      '@lit-labs/virtualizer':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@noble/ed25519':
         specifier: 3.0.0
         version: 3.0.0
@@ -1290,6 +1293,9 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit-labs/virtualizer@2.1.1':
+    resolution: {integrity: sha512-JWxMwnlouLdwpw8spLTuax53WMnSP3xt0dCyxAS7GJr5Otda9MGgR/ghAdfwhSY75TmjbE1T2TqChwoGCw3ggw==}
 
   '@lit/context@1.1.6':
     resolution: {integrity: sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==}
@@ -6309,6 +6315,11 @@ snapshots:
       signal-polyfill: 0.2.2
 
   '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit-labs/virtualizer@2.1.1':
+    dependencies:
+      lit: 3.3.2
+      tslib: 2.8.1
 
   '@lit/context@1.1.6':
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@lit-labs/virtualizer": "^2.1.1",
     "@noble/ed25519": "3.0.0",
     "dompurify": "^3.3.1",
     "lit": "^3.3.2",


### PR DESCRIPTION
## Summary
Adds virtualization to the chat message list using `@lit-labs/virtualizer`, preventing UI crashes and lag when chat history grows large.

## Changes
- Add `@lit-labs/virtualizer` dependency
- Replace `repeat()` with `virtualize()` directive in chat thread rendering
- Remove the 200 message render limit (virtualization handles unlimited messages efficiently)

## Why
The current UI renders all messages in the DOM, which causes performance issues and crashes with long chat histories. Virtualization only renders visible messages + a small buffer, keeping memory and render time constant regardless of history size.

## Testing
Tested with 500+ message conversations - smooth scrolling, no crashes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds chat-thread list virtualization in the UI by introducing `@lit-labs/virtualizer` and switching the chat message rendering from `repeat()` to `virtualize()`. It also removes the prior 200-message render cap so long chat histories can be displayed without DOM growth driving lag/crashes. The core change lives in `ui/src/ui/views/chat.ts`, where chat items are precomputed and passed into `virtualize({ items, keyFunction, renderItem, scroller: true })` for efficient rendering.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and behaviorally straightforward.
- The virtualization swap is small and well-scoped, and dependency updates look standard. The main issues spotted are minor maintainability/lint items (unused import, now-dead constant) rather than functional regressions, but it would still be good to ensure UI build/lint passes with the new directive usage.
- ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->