### PR TITLE
fix(telegram): recognize 'timed out' errors as recoverable

### DIFF
--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -40,4 +40,10 @@ describe("isRecoverableTelegramNetworkError", () => {
   it("returns false for unrelated errors", () => {
     expect(isRecoverableTelegramNetworkError(new Error("invalid token"))).toBe(false);
   });
+
+  it("detects grammY getUpdates timeout errors", () => {
+    // grammY throws this message when long-polling times out
+    const err = new Error("Request to 'getUpdates' timed out after 500 seconds");
+    expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
+  });
 });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -36,6 +36,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "client network socket disconnected",
   "socket hang up",
   "getaddrinfo",
+  "timed out",
 ];
 
 function normalizeCode(code?: string): string {


### PR DESCRIPTION
grammY's getUpdates timeout error message contains 'timed out' but the recovery check only matched 'timeout'. This caused the polling loop to exit without retrying when long-polling timed out.

Added 'timed out' to RECOVERABLE_MESSAGE_SNIPPETS so these errors are properly recognized and the polling loop retries.

**Problem:**
- Telegram long-polling times out after ~8 minutes
- grammY throws: `Request to 'getUpdates' timed out after 500 seconds`
- Error contains 'timed out' but recovery only checked for 'timeout'
- Polling loop exits and never restarts

**Fix:**
- Added 'timed out' to RECOVERABLE_MESSAGE_SNIPPETS
- Added test case for grammY timeout error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram network error recovery detection to treat grammY long-polling timeouts as recoverable by adding the message snippet `"timed out"` to `RECOVERABLE_MESSAGE_SNIPPETS`, and adds a corresponding Vitest case to ensure `Request to 'getUpdates' timed out after 500 seconds` is recognized in polling context.

The change fits into the existing `isRecoverableTelegramNetworkError` flow in `src/telegram/network-errors.ts`, which classifies errors based on codes, names, and (for non-`send` contexts) message snippet matching across nested `cause`/`reason`/`errors` candidates.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to broadening a polling-context message snippet match and adding a unit test; no control flow changes beyond improving classification of an already-handled timeout scenario.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->