### PR TITLE
fix: scope rate_limit cooldowns per-model instead of per-profile

### DIFF
--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { ensureAuthProfileStore, markAuthProfileFailure } from "./auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  markAuthProfileFailure,
+  markAuthProfileUsed,
+} from "./auth-profiles.js";
 
 describe("markAuthProfileFailure", () => {
   it("disables billing failures for ~5 hours by default", async () => {
@@ -124,6 +129,164 @@ describe("markAuthProfileFailure", () => {
 
       expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(1);
       expect(store.usageStats?.["anthropic:default"]?.failureCounts?.billing).toBe(1);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rate_limit with modelId sets model-scoped cooldown, not profile-level", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-1",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        modelId: "gemini-3-flash",
+      });
+
+      const stats = store.usageStats?.["google:default"];
+      // Profile-level cooldownUntil should NOT be set
+      expect(stats?.cooldownUntil).toBeUndefined();
+      // Model-scoped cooldown should be set
+      const modelEntry = stats?.modelCooldowns?.["gemini-3-flash"];
+      expect(modelEntry).toBeDefined();
+      expect(typeof modelEntry?.cooldownUntil).toBe("number");
+      expect(modelEntry!.errorCount).toBe(1);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("model-scoped cooldown blocks only the specific model", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-1",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        modelId: "gemini-3-flash",
+      });
+
+      // The rate-limited model should be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+      // A different model on the same profile should NOT be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(false);
+      // Profile-level check (no modelId) should NOT be in cooldown
+      expect(isProfileInCooldown(store, "google:default")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("auth failure still sets profile-level cooldown even with modelId", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-1",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "auth",
+        agentDir,
+        modelId: "gemini-3-flash",
+      });
+
+      const stats = store.usageStats?.["google:default"];
+      // Auth errors should set profile-level cooldown, not model-scoped
+      expect(typeof stats?.cooldownUntil).toBe("number");
+      expect(stats?.modelCooldowns).toBeUndefined();
+      // All models should be blocked
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("markAuthProfileUsed clears model-scoped cooldowns", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-1",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        modelId: "gemini-3-flash",
+      });
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+
+      await markAuthProfileUsed({
+        store,
+        profileId: "google:default",
+        agentDir,
+      });
+
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(false);
+      expect(store.usageStats?.["google:default"]?.modelCooldowns).toBeUndefined();
     } finally {
       fs.rmSync(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -25,6 +25,7 @@ export type {
   AuthProfileFailureReason,
   AuthProfileIdRepairResult,
   AuthProfileStore,
+  ModelCooldownEntry,
   OAuthCredential,
   ProfileUsageStats,
   TokenCredential,

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -39,6 +39,13 @@ export type AuthProfileFailureReason =
   | "timeout"
   | "unknown";
 
+/** Per-model cooldown entry for model-scoped rate limit tracking */
+export type ModelCooldownEntry = {
+  cooldownUntil?: number;
+  errorCount?: number;
+  lastFailureAt?: number;
+};
+
 /** Per-profile usage statistics for round-robin and cooldown tracking */
 export type ProfileUsageStats = {
   lastUsed?: number;
@@ -48,6 +55,8 @@ export type ProfileUsageStats = {
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /** Model-scoped cooldowns for rate_limit errors (keyed by model ID) */
+  modelCooldowns?: Record<string, ModelCooldownEntry>;
 };
 
 export type AuthProfileStore = {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -261,7 +261,9 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, candidate.model),
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
         // All profiles for this provider are in cooldown; skip without attempting

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -254,7 +254,7 @@ export async function runEmbeddedPiAgent(
         let nextIndex = profileIndex + 1;
         while (nextIndex < profileCandidates.length) {
           const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
+          if (candidate && isProfileInCooldown(authStore, candidate, modelId)) {
             nextIndex += 1;
             continue;
           }
@@ -280,7 +280,7 @@ export async function runEmbeddedPiAgent(
           if (
             candidate &&
             candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
+            isProfileInCooldown(authStore, candidate, modelId)
           ) {
             profileIndex += 1;
             continue;
@@ -489,6 +489,7 @@ export async function runEmbeddedPiAgent(
                 reason: promptFailoverReason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId,
               });
             }
             if (
@@ -576,6 +577,7 @@ export async function runEmbeddedPiAgent(
                 reason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId,
               });
               if (timedOut && !isProbeSession) {
                 log.warn(


### PR DESCRIPTION
## Summary

- When one model (e.g. `gemini-3-flash`) hits its TPM rate limit, only that model enters cooldown on the affected profile. Other models (e.g. `gemini-2.5-flash-lite`) with unused quota remain available.
- Auth, billing, and timeout errors still apply profile-wide cooldown (unchanged behavior).
- Adds `ModelCooldownEntry` type and `modelCooldowns` map to `ProfileUsageStats` for model-scoped tracking.

Closes #5744

## Test plan

- [x] TypeScript build passes with no errors
- [x] All 3 existing `markAuthProfileFailure` tests pass (no regressions)
- [x] New test: `rate_limit` with `modelId` sets model-scoped cooldown, not profile-level
- [x] New test: model-scoped cooldown blocks only the specific model, not other models on the same profile
- [x] New test: `auth` failure with `modelId` still sets profile-level cooldown (blocks all models)
- [x] New test: `markAuthProfileUsed` clears model-scoped cooldowns
- [ ] Manual test: simulate rate limit on one Google model, verify other models on same profile aren't blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR scopes `rate_limit` cooldown tracking to the specific model (per profile) via a new `modelCooldowns` map in `ProfileUsageStats`, while keeping auth/billing/timeout cooldown behavior profile-wide. Call sites in model fallback and the embedded runner now pass `modelId` into `isProfileInCooldown`, and the test suite adds coverage for the new semantics.

Main things to double-check before merge:
- `resolveAuthProfileOrder` and other “cooldown display / selection” helpers still consider only profile-level cooldown fields, so they may continue selecting or showing profiles as available even when the current model is rate-limited (model-scoped cooldown). If profile selection is model-dependent in those paths, they likely need to incorporate `modelId` as well.
- There is an unused type-only import in `auth-profiles/usage.ts` that may fail lint/tsconfig settings depending on repo configuration.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of correctness/polish issues around model-scoped cooldown integration that should be addressed.
- Core behavior change is localized and covered by new tests, and key call sites were updated to pass `modelId`. However, some selection/display paths still use profile-level cooldown only (risking suboptimal profile choice under model-scoped rate limits), and there’s an unused import that could break CI depending on lint/tsconfig settings.
- src/agents/auth-profiles/order.ts, src/agents/auth-profiles/usage.ts, src/agents/auth-profiles/session-override.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->