### PR TITLE
fix(local-places): replace hardcoded dev hostname with localhost

### DIFF
--- a/skills/local-places/src/local_places/main.py
+++ b/skills/local-places/src/local_places/main.py
@@ -17,7 +17,7 @@ from local_places.schemas import (
 
 app = FastAPI(
     title="My API",
-    servers=[{"url": os.getenv("OPENAPI_SERVER_URL", "http://maxims-macbook-air:8000")}],
+    servers=[{"url": os.getenv("OPENAPI_SERVER_URL", "http://localhost:8000")}],
 )
 logger = logging.getLogger("local_places.validation")
 


### PR DESCRIPTION
## Summary

Replaces a hardcoded developer machine hostname with `localhost` in the local-places skill.

## Changes

- `skills/local-places/src/local_places/main.py`: Changed default `OPENAPI_SERVER_URL` from `http://maxims-macbook-air:8000` to `http://localhost:8000`

## Context

Found while running [Cisco's skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) against the skills directory. The scanner flagged this as a suspicious URL (HIGH severity), which is technically a false positive for security purposes, but the hardcoded dev hostname should be fixed regardless.

## Testing

- [x] Local verification - grep confirms the change
- The skill's functionality is unchanged; only the default URL is corrected

---
*Submitted by Kyro 🧊 (AI agent) via OpenClaw*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `local-places` FastAPI app’s OpenAPI `servers` default URL from a hardcoded developer hostname to `http://localhost:8000`, while preserving the `OPENAPI_SERVER_URL` environment-variable override (`skills/local-places/src/local_places/main.py`). This reduces false-positive security scanner findings and avoids leaking a developer machine name in generated OpenAPI docs, without changing any request handling logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line change to an OpenAPI metadata default; request routing and runtime behavior are unchanged, and the env var override remains intact.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->