### PR TITLE
UI: improve chat compose layout on mobile

### DIFF
--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -247,7 +247,7 @@
     height: 44px;
     min-height: 44px;
     max-height: 44px;
-  } 
+  }
 
   .chat-compose__field textarea {
     min-height: 60px;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -232,6 +232,23 @@
     gap: 8px;
   }
 
+  .chat-compose__row {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .chat-compose__actions {
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .chat-compose__actions .btn {
+    flex: 1;
+    height: 44px;
+    min-height: 44px;
+    max-height: 44px;
+  } 
+
   .chat-compose__field textarea {
     min-height: 60px;
     padding: 8px 10px;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -238,15 +238,11 @@
   }
 
   .chat-compose__actions {
-    justify-content: stretch;
     width: 100%;
   }
 
   .chat-compose__actions .btn {
     flex: 1;
-    height: 44px;
-    min-height: 44px;
-    max-height: 44px;
   }
 
   .chat-compose__field textarea {


### PR DESCRIPTION
Stack textarea and buttons vertically in phone mode for better usability.

**AI-assisted**: AI generated initial code changes, human reviewed and refined

**Testing**: Tested - verified layout changes visually in UI dev mode

**Summary**: Improved chat compose layout on mobile devices by stacking the textarea and buttons vertically for better usability in phone mode.

**What the code does**:
- Changed `.chat-compose__row` to `flex-direction: column` on mobile breakpoints (≤600px)
- Made `.chat-compose__actions` stretch to 100% width
- Added `flex: 1` to action buttons for equal-width touch targets
- Increased button height to 44px for better mobile accessibility (it was too short fon my opinion)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the mobile (`@media (max-width: 600px)`) chat compose layout to stack the compose row vertically and make the action area span full width, with larger/taller buttons for touch usability. The changes are confined to `ui/src/styles/layout.mobile.css` and target the `.chat-compose__row`, `.chat-compose__actions`, and `.chat-compose__actions .btn` selectors used by the chat compose UI.

One issue to address: `justify-content: stretch` is not a valid flexbox value and will be ignored, so the intended stretching behavior won’t occur as written.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing a small CSS invalid-value issue.
- Changes are limited to a single mobile CSS file and are unlikely to affect non-chat UI. The main concern is `justify-content: stretch` being invalid and silently ignored, which may prevent the intended layout on mobile; otherwise the adjustments are straightforward.
- ui/src/styles/layout.mobile.css

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->