### PR TITLE
feat(web): add ui.user.name and ui.user.avatar config for webchat

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -280,6 +280,8 @@ const FIELD_LABELS: Record<string, string> = {
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
+  "ui.user.name": "User Name",
+  "ui.user.avatar": "User Avatar",
   "browser.evaluateEnabled": "Browser Evaluate Enabled",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
@@ -676,6 +678,9 @@ const FIELD_HELP: Record<string, string> = {
     "Enable the Guild Members privileged intent. Must also be enabled in the Discord Developer Portal. Default: false.",
   "channels.slack.dm.policy":
     'Direct message access control ("pairing" recommended). "open" requires channels.slack.dm.allowFrom=["*"].',
+  "ui.user.name": 'Display name shown for the user in the webchat UI (default: "You").',
+  "ui.user.avatar":
+    "User avatar in the webchat UI (http(s) URL, data URI, or emoji/text character).",
 };
 
 const FIELD_PLACEHOLDERS: Record<string, string> = {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -73,6 +73,12 @@ export type OpenClawConfig = {
       /** Assistant avatar (emoji, short text, or image URL/data URI). */
       avatar?: string;
     };
+    user?: {
+      /** User display name for the webchat UI. */
+      name?: string;
+      /** User avatar (emoji, short text, or image URL/data URI). */
+      avatar?: string;
+    };
   };
   skills?: SkillsConfig;
   plugins?: PluginsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -176,6 +176,13 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        user: z
+          .object({
+            name: z.string().max(50).optional(),
+            avatar: z.string().max(200).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -178,10 +178,12 @@ interface ControlUiInjectionOpts {
   basePath: string;
   assistantName?: string;
   assistantAvatar?: string;
+  userName?: string;
+  userAvatar?: string;
 }
 
 function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): string {
-  const { basePath, assistantName, assistantAvatar } = opts;
+  const { basePath, assistantName, assistantAvatar, userName, userAvatar } = opts;
   const script =
     `<script>` +
     `window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${JSON.stringify(basePath)};` +
@@ -191,6 +193,8 @@ function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): stri
     `window.__OPENCLAW_ASSISTANT_AVATAR__=${JSON.stringify(
       assistantAvatar ?? DEFAULT_ASSISTANT_IDENTITY.avatar,
     )};` +
+    `window.__OPENCLAW_USER_NAME__=${JSON.stringify(userName ?? "You")};` +
+    `window.__OPENCLAW_USER_AVATAR__=${JSON.stringify(userAvatar ?? null)};` +
     `</script>`;
   // Check if already injected
   if (html.includes("__OPENCLAW_ASSISTANT_NAME__")) {
@@ -224,6 +228,9 @@ function serveIndexHtml(res: ServerResponse, indexPath: string, opts: ServeIndex
       agentId: resolvedAgentId,
       basePath,
     }) ?? identity.avatar;
+  const userConfig = config?.ui?.user;
+  const userName = userConfig?.name?.trim() || undefined;
+  const userAvatar = userConfig?.avatar?.trim() || undefined;
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
   const raw = fs.readFileSync(indexPath, "utf8");
@@ -232,6 +239,8 @@ function serveIndexHtml(res: ServerResponse, indexPath: string, opts: ServeIndex
       basePath,
       assistantName: identity.name,
       assistantAvatar: avatarValue,
+      userName,
+      userAvatar,
     }),
   );
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -512,6 +512,8 @@ export function renderApp(state: AppViewState) {
                 onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
                 assistantName: state.assistantName,
                 assistantAvatar: state.assistantAvatar,
+                userName: state.userName,
+                userAvatar: state.userAvatar,
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -42,6 +42,8 @@ export type AppViewState = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  userName: string;
+  userAvatar: string | null;
   sessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -2,7 +2,10 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway";
-import { resolveInjectedAssistantIdentity } from "./assistant-identity";
+import {
+  resolveInjectedAssistantIdentity,
+  resolveInjectedUserIdentity,
+} from "./assistant-identity";
 import { loadSettings, type UiSettings } from "./storage";
 import { renderApp } from "./app-render";
 import type { Tab } from "./navigation";
@@ -83,6 +86,7 @@ declare global {
 }
 
 const injectedAssistantIdentity = resolveInjectedAssistantIdentity();
+const injectedUserIdentity = resolveInjectedUserIdentity();
 
 function resolveOnboardingMode(): boolean {
   if (!window.location.search) return false;
@@ -112,6 +116,9 @@ export class OpenClawApp extends LitElement {
   @state() assistantName = injectedAssistantIdentity.name;
   @state() assistantAvatar = injectedAssistantIdentity.avatar;
   @state() assistantAgentId = injectedAssistantIdentity.agentId ?? null;
+
+  @state() userName = injectedUserIdentity.name;
+  @state() userAvatar = injectedUserIdentity.avatar;
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;

--- a/ui/src/ui/assistant-identity.ts
+++ b/ui/src/ui/assistant-identity.ts
@@ -4,8 +4,16 @@ const MAX_ASSISTANT_AVATAR = 200;
 export const DEFAULT_ASSISTANT_NAME = "Assistant";
 export const DEFAULT_ASSISTANT_AVATAR = "A";
 
+export const DEFAULT_USER_NAME = "You";
+export const DEFAULT_USER_AVATAR = null;
+
 export type AssistantIdentity = {
   agentId?: string | null;
+  name: string;
+  avatar: string | null;
+};
+
+export type UserIdentity = {
   name: string;
   avatar: string | null;
 };
@@ -14,6 +22,8 @@ declare global {
   interface Window {
     __OPENCLAW_ASSISTANT_NAME__?: string;
     __OPENCLAW_ASSISTANT_AVATAR__?: string;
+    __OPENCLAW_USER_NAME__?: string;
+    __OPENCLAW_USER_AVATAR__?: string;
   }
 }
 
@@ -42,5 +52,24 @@ export function resolveInjectedAssistantIdentity(): AssistantIdentity {
   return normalizeAssistantIdentity({
     name: window.__OPENCLAW_ASSISTANT_NAME__,
     avatar: window.__OPENCLAW_ASSISTANT_AVATAR__,
+  });
+}
+
+const MAX_USER_NAME = 50;
+const MAX_USER_AVATAR = 200;
+
+export function normalizeUserIdentity(input?: Partial<UserIdentity> | null): UserIdentity {
+  const name = coerceIdentityValue(input?.name, MAX_USER_NAME) ?? DEFAULT_USER_NAME;
+  const avatar = coerceIdentityValue(input?.avatar ?? undefined, MAX_USER_AVATAR) ?? null;
+  return { name, avatar };
+}
+
+export function resolveInjectedUserIdentity(): UserIdentity {
+  if (typeof window === "undefined") {
+    return normalizeUserIdentity({});
+  }
+  return normalizeUserIdentity({
+    name: window.__OPENCLAW_USER_NAME__,
+    avatar: window.__OPENCLAW_USER_AVATAR__,
   });
 }

--- a/ui/src/ui/chat/grouped-render-avatar.test.ts
+++ b/ui/src/ui/chat/grouped-render-avatar.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { render } from "lit";
+import { renderMessageGroup } from "./grouped-render";
+
+function renderToContainer(template: unknown): HTMLElement {
+  const container = document.createElement("div");
+  render(template as Parameters<typeof render>[0], container);
+  return container;
+}
+
+function makeGroup(role: string) {
+  return {
+    role,
+    timestamp: Date.now(),
+    isStreaming: false,
+    messages: [
+      {
+        key: "1",
+        message: { role, content: [{ type: "text", text: "hello" }] },
+      },
+    ],
+  };
+}
+
+describe("renderMessageGroup user identity", () => {
+  it("shows 'You' as default user sender name", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), { showReasoning: false }),
+    );
+    const senderName = container.querySelector(".chat-sender-name");
+    expect(senderName?.textContent).toBe("You");
+  });
+
+  it("shows configured user name in sender footer", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), {
+        showReasoning: false,
+        userName: "Jonathan",
+      }),
+    );
+    const senderName = container.querySelector(".chat-sender-name");
+    expect(senderName?.textContent).toBe("Jonathan");
+  });
+
+  it("shows first char of user name as avatar initial", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), {
+        showReasoning: false,
+        userName: "Jonathan",
+      }),
+    );
+    const avatar = container.querySelector(".chat-avatar.user");
+    expect(avatar?.textContent).toBe("J");
+  });
+
+  it("renders img tag for user avatar URL", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), {
+        showReasoning: false,
+        userName: "Jonathan",
+        userAvatar: "https://example.com/avatar.png",
+      }),
+    );
+    const img = container.querySelector("img.chat-avatar.user");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://example.com/avatar.png");
+  });
+
+  it("renders emoji avatar for non-URL user avatar", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), {
+        showReasoning: false,
+        userAvatar: "\u{1F9D1}",
+      }),
+    );
+    const avatar = container.querySelector(".chat-avatar.user");
+    expect(avatar?.tagName).toBe("DIV");
+    expect(avatar?.textContent).toContain("\u{1F9D1}");
+  });
+
+  it("falls back to Y initial when no user identity provided", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("user"), { showReasoning: false }),
+    );
+    const avatar = container.querySelector(".chat-avatar.user");
+    expect(avatar?.textContent).toBe("Y");
+  });
+
+  it("does not affect assistant avatar rendering", () => {
+    const container = renderToContainer(
+      renderMessageGroup(makeGroup("assistant"), {
+        showReasoning: false,
+        assistantName: "Bot",
+        assistantAvatar: "https://example.com/bot.png",
+        userName: "Jonathan",
+        userAvatar: "https://example.com/user.png",
+      }),
+    );
+    const img = container.querySelector("img.chat-avatar.assistant");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://example.com/bot.png");
+    // User avatar should not appear anywhere in the assistant group
+    const userImg = container.querySelector("img.chat-avatar.user");
+    expect(userImg).toBeNull();
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -50,6 +50,8 @@ export type ChatProps = {
   splitRatio?: number;
   assistantName: string;
   assistantAvatar: string | null;
+  userName: string;
+  userAvatar: string | null;
   // Image attachments
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
@@ -183,6 +185,10 @@ export function renderChat(props: ChatProps) {
     name: props.assistantName,
     avatar: props.assistantAvatar ?? props.assistantAvatarUrl ?? null,
   };
+  const userIdentity = {
+    name: props.userName,
+    avatar: props.userAvatar,
+  };
 
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
   const composePlaceholder = props.connected
@@ -230,6 +236,8 @@ export function renderChat(props: ChatProps) {
               showReasoning,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
+              userName: props.userName,
+              userAvatar: userIdentity.avatar,
             });
           }
 


### PR DESCRIPTION
## Summary

  Adds `ui.user.name` and `ui.user.avatar` config options to customize the user's avatar and
  display name in the webchat UI, mirroring the existing `ui.assistant.*` pattern.

  Closes #5594

  ## What changed

  - **Modified:** `src/config/zod-schema.ts` — added `ui.user` object (name + avatar) to schema
  - **Modified:** `src/config/schema.ts` — added field labels and help text for `ui.user.*`
  - **Modified:** `src/config/types.openclaw.ts` — added `user` property to the `ui` type
  - **Modified:** `src/gateway/control-ui.ts` — injects `window.__OPENCLAW_USER_NAME__` and
  `__OPENCLAW_USER_AVATAR__` into the Control UI HTML
  - **Modified:** `ui/src/ui/assistant-identity.ts` — added `UserIdentity` type,
  `normalizeUserIdentity`, `resolveInjectedUserIdentity`
  - **Modified:** `ui/src/ui/app.ts` — reads user identity on startup
  - **Modified:** `ui/src/ui/app-view-state.ts` — added `userName`/`userAvatar` to state type
  - **Modified:** `ui/src/ui/app-render.ts` — passes user identity to chat component
  - **Modified:** `ui/src/ui/views/chat.ts` — extended `ChatProps`, threads user identity
  through
  - **Modified:** `ui/src/ui/chat/grouped-render.ts` — `renderAvatar()` now renders user
  avatars (URL → img, emoji → div, name initial → letter)
  - **New:** `ui/src/ui/chat/grouped-render-avatar.test.ts` — 7 tests

  ## Approach

  Mirrors the existing `ui.assistant.*` config flow end-to-end: config schema → gateway HTML
  injection → UI global → app state → render. User avatars support remote URLs, data URIs, and
  emoji/text only (no local file serving, no new endpoints). When no config is set, behavior is
   unchanged except the default avatar initial is now "Y" (from "You") instead of the previous
  "U".

  ## Config example

  ```json
  {
    "ui": {
      "user": {
        "name": "Jonathan",
        "avatar": "https://example.com/avatar.png"
      }
    }
  }
```

  Test plan

  - 7 vitest tests passing (default name, configured name, name initial, URL avatar, emoji
  avatar, fallback, assistant unaffected)
  - Full gate clean: pnpm format, pnpm lint (0 errors), pnpm build, pnpm test (4882/4906 — 24
  pre-existing failures in memory subsystem)

  AI usage

  - Pair programming w/ Claude Opus 4.5, fully tested.
  - Claude generated the implementation following my design decisions (mirror existing pattern,
   no new endpoints, config → gateway → UI data flow), then I reviewed and iterated.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `ui.user.name` and `ui.user.avatar` configuration support end-to-end, mirroring the existing assistant identity flow: config schema/types, gateway HTML injection (`window.__OPENCLAW_USER_*__`), UI startup identity resolution, view state plumbing, and avatar rendering logic for user message groups. It also adds Vitest coverage for the user avatar/name rendering behavior in grouped chat rendering.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main remaining risks are around Control UI injection idempotency and a slightly misleading test.
- Changes are straightforward configuration plumbing with minimal behavioral surface area, and values are injected via JSON.stringify. I found one likely correctness issue where the injection guard could prevent the new user globals from being injected when the assistant marker is present, plus one test whose description doesn’t match what it actually asserts.
- src/gateway/control-ui.ts, ui/src/ui/chat/grouped-render-avatar.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->