### PR TITLE
fix(memory): correctly normalize FTS5 BM25 scores

### DIFF
--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -34,8 +34,12 @@ export function buildFtsQuery(raw: string): string | null {
 }
 
 export function bm25RankToScore(rank: number): number {
-  const normalized = Number.isFinite(rank) ? Math.max(0, rank) : 999;
-  return 1 / (1 + normalized);
+  if (!Number.isFinite(rank)) {
+    return 0;
+  }
+  // FTS5 bm25() returns negative values; more negative = more relevant
+  const absRank = Math.abs(rank);
+  return absRank / (1 + absRank);
 }
 
 export function mergeHybridResults(params: {


### PR DESCRIPTION
The bm25RankToScore function clamped negative values to zero via Math.max(0, rank), causing all FTS5 BM25 scores to return 1.0. SQLite FTS5's bm25() returns negative values where more negative means more relevant. The fix uses Math.abs() to preserve ranking.

Fixes #5767

🤖 AI-assisted: Built with Claude Code (claude-opus-4-5) Testing: Fully tested - lint, build, and all tests pass The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes BM25 score normalization for SQLite FTS5 by treating `bm25()` outputs as negative ranks where more-negative is more relevant. The previous `Math.max(0, rank)` clamp collapsed all negative ranks to 0, producing a constant score of 1.0. The updated `bm25RankToScore` returns 0 for non-finite values and maps finite ranks into a [0,1) score using `abs(rank)/(1+abs(rank))`, with tests updated to reflect FTS5 semantics.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes an obvious ranking bug, with minor edge-case behavior to confirm.
- The change aligns with FTS5 BM25 semantics and adds targeted tests. Main remaining concern is that `Math.abs()` will also boost any positive ranks if they ever occur, so behavior depends on `bm25RankToScore` only being used with FTS5 negative outputs.
- src/memory/hybrid.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->