### PR TITLE
fix(telegram): enforce 100 command limit for setMyCommands

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -29,7 +29,7 @@ import {
   normalizeTelegramCommandName,
   TELEGRAM_COMMAND_NAME_PATTERN,
 } from "../config/telegram-custom-commands.js";
-import { danger, logVerbose } from "../globals.js";
+import { danger, warn, logVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import {
@@ -356,6 +356,8 @@ export const registerTelegramNativeCommands = ({
     existingCommands.add(normalized);
     pluginCommands.push({ command: normalized, description });
   }
+  const TELEGRAM_MAX_COMMANDS = 100;
+
   const allCommands: Array<{ command: string; description: string }> = [
     ...nativeCommands.map((command) => ({
       command: command.name,
@@ -365,11 +367,23 @@ export const registerTelegramNativeCommands = ({
     ...customCommands,
   ];
 
-  if (allCommands.length > 0) {
+  if (allCommands.length > TELEGRAM_MAX_COMMANDS) {
+    runtime.error?.(
+      warn(
+        `Telegram limits bots to ${TELEGRAM_MAX_COMMANDS} commands. ` +
+          `${allCommands.length} commands configured; registering first ${TELEGRAM_MAX_COMMANDS}. ` +
+          `Set channels.telegram.commands.native: false to disable skill command registration.`,
+      ),
+    );
+  }
+
+  const commandsToRegister = allCommands.slice(0, TELEGRAM_MAX_COMMANDS);
+
+  if (commandsToRegister.length > 0) {
     withTelegramApiErrorLogging({
       operation: "setMyCommands",
       runtime,
-      fn: () => bot.api.setMyCommands(allCommands),
+      fn: () => bot.api.setMyCommands(commandsToRegister),
     }).catch(() => {});
 
     if (typeof (bot as unknown as { command?: unknown }).command !== "function") {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -368,11 +368,11 @@ export const registerTelegramNativeCommands = ({
   ];
 
   if (allCommands.length > TELEGRAM_MAX_COMMANDS) {
-    runtime.error?.(
+    runtime.log?.(
       warn(
         `Telegram limits bots to ${TELEGRAM_MAX_COMMANDS} commands. ` +
           `${allCommands.length} commands configured; registering first ${TELEGRAM_MAX_COMMANDS}. ` +
-          `Set channels.telegram.commands.native: false to disable skill command registration.`,
+          `Set channels.telegram.commands.skills: false to disable skill command registration.`,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Telegram's Bot API limits `setMyCommands` to 100 commands maximum. With 52+ bundled skills plus custom agent skills, OpenClaw easily exceeds this limit, causing `BOT_COMMANDS_TOO_MUCH` errors on every gateway startup.

## Changes

- Add `TELEGRAM_MAX_COMMANDS` constant (100)
- Truncate command list to first 100 commands before registration
- Log warning when limit exceeded with guidance on how to disable
- Prioritizes: native commands > plugin commands > custom commands

## Before

```
[telegram] setMyCommands failed: Call to 'setMyCommands' failed! (400: Bad Request: BOT_COMMANDS_TOO_MUCH)
```

Repeats on every startup/reload with no indication of cause.

## After

```
Telegram limits bots to 100 commands. 127 commands configured; registering first 100. 
Set channels.telegram.commands.native: false to disable skill command registration.
```

Commands register successfully, user gets actionable guidance.

## Test plan

- [ ] Verify warning is logged when >100 commands configured
- [ ] Verify first 100 commands are registered successfully
- [ ] Verify no `BOT_COMMANDS_TOO_MUCH` error occurs
- [ ] Verify command handlers still work for registered commands

Fixes #5787

🦞 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents Telegram startup failures caused by exceeding the Bot API’s `setMyCommands` limit by introducing a 100-command cap. It builds the combined command list (native commands, plugin commands, then custom commands), logs a warning when the configured list exceeds the limit, and registers only the first 100 commands via `bot.api.setMyCommands(...)`.

The change fits into the existing Telegram gateway initialization flow by adjusting command registration inside `registerTelegramNativeCommands`, keeping handler registration logic unchanged while ensuring the API call no longer trips `BOT_COMMANDS_TOO_MUCH`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should stop repeated Telegram startup errors, with only minor logging-level concerns.
- The change is localized to command registration, uses a straightforward slice to enforce Telegram’s documented limit, and does not alter command parsing or handler execution. Main remaining concern is that the warning is emitted via `runtime.error` (potentially misclassified as an error), but functional behavior should still improve.
- src/telegram/bot-native-commands.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->