### PR TITLE
feat: add Azure AI Foundry provider support

### DIFF
--- a/docs/providers/azure-foundry.md
+++ b/docs/providers/azure-foundry.md
@@ -1,0 +1,240 @@
+---
+summary: "Run OpenClaw with Azure AI Foundry (Azure OpenAI and other Azure-hosted models)"
+read_when:
+  - You want to run OpenClaw with Azure AI Foundry
+  - You need Azure OpenAI or Azure-hosted model setup guidance
+  - You want to use custom Azure model deployments
+---
+
+# Azure AI Foundry
+
+Azure AI Foundry is Microsoft's unified AI platform that provides access to OpenAI models (GPT-4, GPT-4.1, etc.) and other models through Azure. OpenClaw integrates with Azure AI Foundry using the OpenAI-compatible API.
+
+## Quick start
+
+1. Create an Azure AI Foundry resource and deploy a model (e.g., `gpt-4.1`)
+
+2. Get your API key and endpoint from the Azure Portal
+
+3. Configure OpenClaw:
+
+```bash
+# Set environment variable
+export AZURE_FOUNDRY_API_KEY="your-azure-api-key"
+
+# Configure the provider in your config file
+moltbot config set models.providers.azure-foundry.baseUrl "https://your-resource.openai.azure.com"
+```
+
+4. Add your model deployment:
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-foundry": {
+        baseUrl: "https://your-resource.openai.azure.com",
+        apiKey: "AZURE_FOUNDRY_API_KEY",
+        api: "openai-completions",
+        models: [
+          {
+            id: "your-deployment-name", // e.g., "my-gpt-4"
+            name: "GPT-4.1 on Azure",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 16384,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "azure-foundry/your-deployment-name" },
+    },
+  },
+}
+```
+
+## Configuration
+
+### Environment variable
+
+Set your Azure API key:
+
+```bash
+export AZURE_FOUNDRY_API_KEY="your-azure-api-key"
+```
+
+### Provider configuration
+
+Azure AI Foundry requires explicit model configuration because deployment names are custom:
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-foundry": {
+        // Your Azure OpenAI endpoint
+        baseUrl: "https://your-resource.openai.azure.com",
+        // Reference the env var or set directly
+        apiKey: "AZURE_FOUNDRY_API_KEY",
+        // Azure uses OpenAI-compatible API
+        api: "openai-completions",
+        models: [
+          {
+            // Your deployment name (not the model name)
+            id: "dbandaru-gpt-4.1",
+            name: "GPT-4.1",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 16384,
+          },
+          {
+            id: "my-gpt-4o",
+            name: "GPT-4o",
+            reasoning: false,
+            input: ["text", "image"], // Vision model
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 16384,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+### Model selection
+
+Once configured, use your Azure models:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "azure-foundry/dbandaru-gpt-4.1",
+        fallback: ["azure-foundry/my-gpt-4o"],
+      },
+    },
+  },
+}
+```
+
+## Key differences from OpenAI
+
+| Aspect           | OpenAI                     | Azure AI Foundry                        |
+| ---------------- | -------------------------- | --------------------------------------- |
+| Model ID         | `gpt-4.1`                  | Your deployment name (e.g., `my-gpt-4`) |
+| Endpoint         | `api.openai.com`           | `your-resource.openai.azure.com`        |
+| API Key          | `OPENAI_API_KEY`           | `AZURE_FOUNDRY_API_KEY`                 |
+| Model validation | Checked against known list | You define models in config             |
+
+## Multiple Azure deployments
+
+You can configure multiple Azure endpoints by using different provider names:
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-foundry": {
+        baseUrl: "https://prod-resource.openai.azure.com",
+        apiKey: "AZURE_FOUNDRY_API_KEY",
+        api: "openai-completions",
+        models: [
+          { id: "prod-gpt-4", name: "Production GPT-4", ... }
+        ]
+      },
+      "azure-foundry-dev": {
+        baseUrl: "https://dev-resource.openai.azure.com",
+        apiKey: "AZURE_FOUNDRY_DEV_KEY",
+        api: "openai-completions",
+        models: [
+          { id: "dev-gpt-4", name: "Dev GPT-4", ... }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Reasoning models
+
+For Azure-hosted reasoning models (e.g., o1, o1-mini):
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-foundry": {
+        baseUrl: "https://your-resource.openai.azure.com",
+        apiKey: "AZURE_FOUNDRY_API_KEY",
+        api: "openai-completions",
+        models: [
+          {
+            id: "my-o1",
+            name: "o1 on Azure",
+            reasoning: true, // Enable reasoning mode
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 65536,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Troubleshooting
+
+### Authentication failed
+
+Verify your API key:
+
+```bash
+curl -H "api-key: $AZURE_FOUNDRY_API_KEY" \
+  "https://your-resource.openai.azure.com/openai/deployments?api-version=2024-02-01"
+```
+
+### Model not found
+
+Azure uses deployment names, not model names. Check your deployment name in the Azure Portal:
+
+1. Go to Azure AI Foundry
+2. Navigate to Deployments
+3. Copy the exact deployment name (not the model name)
+
+### Rate limiting
+
+Azure has separate rate limits per deployment. If you hit limits, consider:
+
+- Creating additional deployments
+- Requesting quota increases in Azure Portal
+
+### Context window mismatch
+
+Set the correct `contextWindow` for your model:
+
+| Model       | Context Window |
+| ----------- | -------------- |
+| GPT-4       | 8,192          |
+| GPT-4-32k   | 32,768         |
+| GPT-4 Turbo | 128,000        |
+| GPT-4.1     | 128,000        |
+| GPT-4o      | 128,000        |
+
+## See Also
+
+- [Model Providers](/concepts/model-providers) - Overview of all providers
+- [Model Selection](/concepts/models) - How to choose models
+- [Configuration](/gateway/configuration) - Full config reference
+- [OpenAI Provider](/providers/openai) - For direct OpenAI API usage

--- a/docs/providers/azure-foundry.md
+++ b/docs/providers/azure-foundry.md
@@ -19,11 +19,12 @@ Azure AI Foundry is Microsoft's unified AI platform that provides access to Open
 3. Configure OpenClaw:
 
 ```bash
-# Set environment variable
+# Set environment variables
 export AZURE_FOUNDRY_API_KEY="your-azure-api-key"
+export AZURE_FOUNDRY_BASE_URL="https://your-resource.openai.azure.com"
 
-# Configure the provider in your config file
-moltbot config set models.providers.azure-foundry.baseUrl "https://your-resource.openai.azure.com"
+# Or configure the provider in your config file
+openclaw config set models.providers.azure-foundry.baseUrl "https://your-resource.openai.azure.com"
 ```
 
 4. Add your model deployment:
@@ -198,12 +199,18 @@ For Azure-hosted reasoning models (e.g., o1, o1-mini):
 
 ### Authentication failed
 
-Verify your API key:
+Verify your API key in the Azure Portal, or test with this command (optional, requires curl):
 
 ```bash
 curl -H "api-key: $AZURE_FOUNDRY_API_KEY" \
   "https://your-resource.openai.azure.com/openai/deployments?api-version=2024-02-01"
 ```
+
+Alternatively, check that:
+
+1. Your API key is correct in the Azure Portal under "Keys and Endpoint"
+2. The `AZURE_FOUNDRY_API_KEY` environment variable is set
+3. Your Azure resource is in an active state
 
 ### Model not found
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -43,6 +43,7 @@ See [Venice AI](/providers/venice).
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)
 - [Amazon Bedrock](/bedrock)
+- [Azure AI Foundry](/providers/azure-foundry)
 - [Z.AI](/providers/zai)
 - [Xiaomi](/providers/xiaomi)
 - [GLM models](/providers/glm)

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -301,6 +301,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    "azure-foundry": "AZURE_FOUNDRY_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -76,6 +76,16 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+// Azure AI Foundry provider - uses OpenAI-compatible API with custom deployments
+const AZURE_FOUNDRY_DEFAULT_CONTEXT_WINDOW = 128000;
+const AZURE_FOUNDRY_DEFAULT_MAX_TOKENS = 16384;
+const AZURE_FOUNDRY_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -389,6 +399,38 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   const models = await discoverOllamaModels();
   return {
     baseUrl: OLLAMA_BASE_URL,
+    api: "openai-completions",
+    models,
+  };
+}
+
+/**
+ * Build an Azure AI Foundry provider with a placeholder model.
+ * Users should configure their actual models via models.json.
+ * This enables auto-detection when AZURE_FOUNDRY_API_KEY is set.
+ */
+export function buildAzureFoundryProvider(params: {
+  baseUrl: string;
+  models?: Array<{
+    id: string;
+    name?: string;
+    contextWindow?: number;
+    maxTokens?: number;
+    reasoning?: boolean;
+    input?: Array<"text" | "image">;
+  }>;
+}): ProviderConfig {
+  const models: ModelDefinitionConfig[] = (params.models ?? []).map((model) => ({
+    id: model.id,
+    name: model.name ?? model.id,
+    reasoning: model.reasoning ?? false,
+    input: model.input ?? ["text"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: model.contextWindow ?? AZURE_FOUNDRY_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: model.maxTokens ?? AZURE_FOUNDRY_DEFAULT_MAX_TOKENS,
+  }));
+  return {
+    baseUrl: params.baseUrl,
     api: "openai-completions",
     models,
   };

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -503,6 +503,18 @@ export async function resolveImplicitProviders(params: {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
   }
 
+  // Azure AI Foundry provider - requires both API key and base URL
+  const azureFoundryKey =
+    resolveEnvApiKeyVarName("azure-foundry") ??
+    resolveApiKeyFromProfiles({ provider: "azure-foundry", store: authStore });
+  const azureFoundryBaseUrl = process.env.AZURE_FOUNDRY_BASE_URL?.trim();
+  if (azureFoundryKey && azureFoundryBaseUrl) {
+    providers["azure-foundry"] = {
+      ...buildAzureFoundryProvider({ baseUrl: azureFoundryBaseUrl }),
+      apiKey: azureFoundryKey,
+    };
+  }
+
   return providers;
 }
 


### PR DESCRIPTION
## Summary

Adds support for Azure AI Foundry (Azure OpenAI) as a model provider.

## Changes

- **\src/agents/model-auth.ts\**: Added \AZURE_FOUNDRY_API_KEY\ env var mapping
- **\src/agents/models-config.providers.ts\**: Added \uildAzureFoundryProvider()\ function
- **\docs/providers/azure-foundry.md\**: Full documentation for Azure AI Foundry setup
- **\docs/providers/index.md\**: Added link to Azure Foundry docs

## Why

Azure AI Foundry provides enterprise access to OpenAI models with Azure-specific features (custom deployments, regional endpoints, enterprise security). This PR enables OpenClaw users to use their existing Azure OpenAI resources.

## Testing

- [x] Tested with Discord bot deployment on Azure Container Apps
- [x] Verified chat completions work with GPT-4.1 deployment  
- [x] TypeScript compiles (\pnpm tsgo\)
- [x] Formatting passes (\pnpm format\)
- [x] Related tests pass (\itest run models-config\)

## AI Disclosure

This PR was developed with assistance from GitHub Copilot CLI. The code has been reviewed and tested by me.

## Notes

Azure OpenAI uses a different URL format than standard OpenAI (\/openai/deployments/{name}/chat/completions?api-version=xxx\). Users configure their deployment names in \models.json\ since Azure deployments are custom-named.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an Azure AI Foundry provider identifier and maps it to `AZURE_FOUNDRY_API_KEY` for auth resolution, plus documentation for configuring Azure OpenAI-compatible endpoints and custom deployment IDs.

Code changes are localized to model auth/env var resolution and a new `buildAzureFoundryProvider()` helper in `src/agents/models-config.providers.ts`, while docs add a new provider page and link from the providers index.

Main issue: `buildAzureFoundryProvider()` is not currently used by implicit provider discovery, so setting `AZURE_FOUNDRY_API_KEY` will not actually auto-detect/add an `azure-foundry` provider as the comment/docs imply; users must fully configure the provider manually. Docs also include a likely incorrect CLI command (`moltbot`).

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the implicit-provider wiring/docs mismatch.
- Changes are small and additive (env var mapping + provider builder + docs), but there’s a functional gap: Azure Foundry isn’t actually auto-discovered/added anywhere, so expected behavior from docs/comments won’t occur and users may think the integration is broken.
- src/agents/models-config.providers.ts; docs/providers/azure-foundry.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->