### PR TITLE
add whatsapp qr with http

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,39 @@
 services:
+  # Docker Socket Proxy - filters dangerous Docker API calls
+  docker-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: clawdbot-docker-proxy
+    restart: unless-stopped
+    environment:
+      # Allow container management (needed for sandboxing)
+      CONTAINERS: 1
+      # Allow running new containers
+      POST: 1
+      # Allow reading info
+      INFO: 1
+      IMAGES: 1
+      # Deny dangerous operations
+      BUILD: 0
+      COMMIT: 0
+      CONFIGS: 0
+      DISTRIBUTION: 0
+      EXEC: 0
+      GRPC: 0
+      NETWORKS: 0
+      NODES: 0
+      PLUGINS: 0
+      SECRETS: 0
+      SERVICES: 0
+      SESSION: 0
+      SWARM: 0
+      SYSTEM: 0
+      TASKS: 0
+      VOLUMES: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - openclaw-net
+
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
@@ -8,14 +43,31 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      # Point to proxy instead of real socket
+      DOCKER_HOST: tcp://docker-proxy:2375
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/clawd
+      # NO direct socket access - uses proxy instead
     ports:
-      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "127.0.0.1:${CLAWDBOT_GATEWAY_PORT:-18789}:18789"
+      - "127.0.0.1:${CLAWDBOT_BRIDGE_PORT:-18790}:18790"
+      - "127.0.0.1:5173:5173"
+    networks:
+      - openclaw-net
     init: true
     restart: unless-stopped
+    depends_on:
+      - docker-proxy
     command:
       [
         "node",
@@ -33,13 +85,20 @@ services:
       HOME: /home/node
       TERM: xterm-256color
       BROWSER: echo
+      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/clawd
+    networks:
+      - openclaw-net
     stdin_open: true
     tty: true
     init: true
     entrypoint: ["node", "dist/index.js"]
+
+networks:
+  openclaw-net:
+    driver: bridge

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,17 +314,17 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/imessage: {}
 
   extensions/line:
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/llm-task: {}
 
@@ -348,17 +348,17 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/mattermost: {}
 
   extensions/memory-core:
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/memory-lancedb:
     dependencies:
@@ -386,9 +386,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -397,12 +397,12 @@ importers:
 
   extensions/nostr:
     dependencies:
-      moltbot:
-        specifier: workspace:*
-        version: link:../../packages/moltbot
       nostr-tools:
         specifier: ^2.20.0
         version: 2.20.0(typescript@5.9.3)
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -439,9 +439,9 @@ importers:
         specifier: ^4.3.5
         version: 4.3.6
     devDependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   extensions/voice-call:
     dependencies:
@@ -459,9 +459,9 @@ importers:
 
   extensions/zalo:
     dependencies:
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
       undici:
         specifier: 7.19.0
         version: 7.19.0
@@ -471,9 +471,9 @@ importers:
       '@sinclair/typebox':
         specifier: 0.34.47
         version: 0.34.47
-      moltbot:
+      openclaw:
         specifier: workspace:*
-        version: link:../../packages/moltbot
+        version: link:../..
 
   packages/clawdbot:
     dependencies:

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -30,6 +30,7 @@ import { applyHookMappings } from "./hooks-mapping.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
+import { handleWhatsAppQrHttpRequest } from "./whatsapp-qr-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -241,6 +242,13 @@ export function createGatewayHttpServer(opts: {
       if (await handleHooksRequest(req, res)) return;
       if (
         await handleToolsInvokeHttpRequest(req, res, {
+          auth: resolvedAuth,
+          trustedProxies,
+        })
+      )
+        return;
+      if (
+        await handleWhatsAppQrHttpRequest(req, res, {
           auth: resolvedAuth,
           trustedProxies,
         })

--- a/src/gateway/whatsapp-qr-http.ts
+++ b/src/gateway/whatsapp-qr-http.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { authorizeGatewayConnect } from "./auth.js";
+import { getBearerToken } from "./http-utils.js";
+import { readJsonBodyOrError } from "./http-common.js";
+import { ensureWebLogin, getWebLoginSnapshot } from "../web/login-qr.js";
+
+type WhatsAppQrHttpOptions = {
+  auth: import("./auth.js").ResolvedGatewayAuth;
+  trustedProxies: string[];
+};
+
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+export async function handleWhatsAppQrHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: WhatsAppQrHttpOptions,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
+  if (url.pathname !== "/channels/whatsapp/qr") return false;
+
+  if (req.method !== "GET" && req.method !== "POST") {
+    res.statusCode = 405;
+    res.setHeader("Allow", "GET, POST");
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Method Not Allowed");
+    return true;
+  }
+
+  const token = getBearerToken(req);
+  const authResult = await authorizeGatewayConnect({
+    auth: opts.auth,
+    connectAuth: { token, password: token },
+    req,
+    trustedProxies: opts.trustedProxies,
+  });
+  if (!authResult.ok) {
+    res.statusCode = 401;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Unauthorized");
+    return true;
+  }
+
+  const action = url.searchParams.get("action")?.trim() || "status";
+  const force = url.searchParams.get("force") === "1";
+
+  if (req.method === "POST") {
+    await readJsonBodyOrError(req, res, 128 * 1024);
+  }
+
+  const result = action === "start" ? await ensureWebLogin({ force }) : await getWebLoginSnapshot();
+
+  sendJson(res, 200, result);
+  return true;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new authenticated gateway HTTP route (`/channels/whatsapp/qr`) that can start a WhatsApp Web login flow and return a status/QR snapshot, wiring the handler into the main gateway HTTP server. Also updates docker-compose to introduce a Docker socket proxy container and adjust gateway/cli container settings, and renames internal workspace links in `pnpm-lock.yaml` from `moltbot` to `openclaw`.

The new route delegates the WhatsApp session/QR state to `src/web/login-qr.ts` (via `ensureWebLogin` / `getWebLoginSnapshot`) and returns JSON suitable for polling from a UI or automation client.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple of correctness edge cases in the new WhatsApp QR HTTP handler and snapshot logic.
- Main risk is request handling correctness: the POST body parse result is ignored (can lead to double responses), and `readWebSelfId()` is invoked even when the auth directory may not exist, which can break the new endpoint for unlinked accounts. Compose changes may also not behave as intended outside Swarm for GPU reservations.
- src/gateway/whatsapp-qr-http.ts, src/web/login-qr.ts, docker-compose.yml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->