### PR TITLE
fix(whatsapp): pass document filename instead of hardcoding "file"

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName ?? "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -131,7 +131,10 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+      accountId: undefined,
+    });
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -44,11 +44,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -69,9 +71,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
The sendMessage function hardcoded fileName: "file" for document payloads, ignoring the actual filename from loadWebMedia(). Documents now display with their original filename instead of always showing as "file".

Fixes #5781

🤖 AI-assisted: Built with Claude Code (claude-opus-4-5) Testing: Fully tested - lint, build, and all tests pass The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes WhatsApp Web document outbound messaging so the original filename from `loadWebMedia()` is forwarded into the Baileys `document` payload instead of always hardcoding `fileName: "file"`.

Concretely, `ActiveWebSendOptions` is extended with an optional `fileName` field (`src/web/active-listener.ts`), `sendMessageWhatsApp` now plumbs `media.fileName` through to the active listener when present (`src/web/outbound.ts`), and the inbound web send API uses that `sendOptions.fileName` value when constructing a document message payload (`src/web/inbound/send-api.ts`). Tests are updated to assert the extra argument for document sends (`src/web/outbound.test.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to plumbing an optional filename through existing WhatsApp send options, keep the previous default ("file") as a fallback, and include a targeted test update for the document path.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->