### PR TITLE
feat(telegram): add createForumTopic support for thread creation (refined)

### DIFF
--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -12,6 +12,10 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const createForumTopicTelegram = vi.fn(async () => ({
+  threadId: 123,
+  name: "New Topic",
+}));
 const originalToken = process.env.TELEGRAM_BOT_TOKEN;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -19,6 +23,7 @@ vi.mock("../../telegram/send.js", () => ({
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegram(...args),
   sendStickerTelegram: (...args: unknown[]) => sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: unknown[]) => deleteMessageTelegram(...args),
+  createForumTopicTelegram: (...args: unknown[]) => createForumTopicTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -27,6 +32,7 @@ describe("handleTelegramAction", () => {
     sendMessageTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    createForumTopicTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -357,6 +363,33 @@ describe("handleTelegramAction", () => {
       456,
       expect.objectContaining({ token: "tok" }),
     );
+  });
+
+  it("creates a forum topic", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { threads: true } } },
+    } as OpenClawConfig;
+    const result = await handleTelegramAction(
+      {
+        action: "createForumTopic",
+        chatId: "123",
+        name: "New Topic",
+        iconColor: 0x6fb9f0,
+      },
+      cfg,
+    );
+    expect(createForumTopicTelegram).toHaveBeenCalledWith(
+      "123",
+      "New Topic",
+      expect.objectContaining({ token: "tok", iconColor: 0x6fb9f0 }),
+    );
+    expect(result).toEqual({
+      json: {
+        ok: true,
+        threadId: 123,
+        name: "New Topic",
+      },
+    });
   });
 
   it("respects deleteMessage gating", async () => {

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -383,12 +383,19 @@ describe("handleTelegramAction", () => {
       "New Topic",
       expect.objectContaining({ token: "tok", iconColor: 0x6fb9f0 }),
     );
+    const payload = {
+      ok: true,
+      threadId: 123,
+      name: "New Topic",
+    };
     expect(result).toEqual({
-      json: {
-        ok: true,
-        threadId: 123,
-        name: "New Topic",
-      },
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(payload, null, 2),
+        },
+      ],
+      details: payload,
     });
   });
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -60,6 +60,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
+    if (gate("threads", false)) {
+      actions.add("thread-create");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -193,6 +196,27 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "thread-create") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const name = readStringParam(params, "threadName", { required: true });
+      const iconColor = readNumberParam(params, "iconColor", { integer: true });
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "createForumTopic",
+          chatId,
+          name,
+          iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable thread actions (create forum topics). */
+  threads?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createForumTopicTelegram } from "./send.js";
+import { Bot, HttpError } from "grammy";
+import { type ForumTopic } from "@grammyjs/types";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    channels: {
+      telegram: {
+        botToken: "tok",
+      },
+    },
+  }),
+}));
+
+vi.mock("../infra/channel-activity.js", () => ({
+  recordChannelActivity: vi.fn(),
+}));
+
+vi.mock("../infra/retry-policy.js", () => ({
+  createTelegramRetryRunner: () => (fn: any) => fn(),
+}));
+
+vi.mock("./api-logging.js", () => ({
+  withTelegramApiErrorLogging: ({ fn }: any) => fn(),
+}));
+
+describe("createForumTopicTelegram", () => {
+  const mockApi = {
+    createForumTopic: vi.fn(),
+  } as unknown as Bot["api"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a forum topic with default parameters", async () => {
+    const mockResult: ForumTopic = {
+      message_thread_id: 123,
+      name: "Test Topic",
+      icon_color: 0x6fb9f0,
+    };
+    (mockApi.createForumTopic as any).mockResolvedValue(mockResult);
+
+    const result = await createForumTopicTelegram("123", "Test Topic", {
+      api: mockApi,
+      token: "tok",
+    });
+
+    expect(mockApi.createForumTopic).toHaveBeenCalledWith("123", "Test Topic", undefined);
+    expect(result).toEqual({
+      threadId: 123,
+      name: "Test Topic",
+      iconColor: 0x6fb9f0,
+    });
+  });
+
+  it("prefers iconCustomEmojiId over iconColor", async () => {
+    const mockResult: ForumTopic = {
+      message_thread_id: 123,
+      name: "Emoji Topic",
+      icon_custom_emoji_id: "emoji123",
+    };
+    (mockApi.createForumTopic as any).mockResolvedValue(mockResult);
+
+    await createForumTopicTelegram("123", "Emoji Topic", {
+      api: mockApi,
+      token: "tok",
+      iconColor: 0xff0000,
+      iconCustomEmojiId: "emoji123",
+    });
+
+    expect(mockApi.createForumTopic).toHaveBeenCalledWith("123", "Emoji Topic", {
+      icon_custom_emoji_id: "emoji123",
+    });
+  });
+
+  it("wraps chat not found error", async () => {
+    const error = new Error("400: Bad Request: chat not found");
+    (mockApi.createForumTopic as any).mockRejectedValue(error);
+
+    await expect(
+      createForumTopicTelegram("123", "Error Topic", {
+        api: mockApi,
+        token: "tok",
+      }),
+    ).rejects.toThrow(/chat not found/);
+  });
+
+  it("wraps missing rights error", async () => {
+    const error = new Error("400: Bad Request: not enough rights");
+    (mockApi.createForumTopic as any).mockRejectedValue(error);
+
+    await expect(
+      createForumTopicTelegram("123", "Error Topic", {
+        api: mockApi,
+        token: "tok",
+      }),
+    ).rejects.toThrow(/bot must be an administrator/);
+  });
+});

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -58,7 +58,7 @@ describe("createForumTopicTelegram", () => {
         api: mockApi,
         token: "tok",
       }),
-    ).rejects.toThrow("Forum topic name must be 128 characters or less");
+    ).rejects.toThrow("Forum topic name must be 128 characters or less (received: 129)");
   });
 
   it("creates a forum topic with default parameters", async () => {

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -43,7 +43,7 @@ describe("createForumTopicTelegram", () => {
     };
     createForumTopicMock.mockResolvedValue(mockResult);
 
-    const result = await createForumTopicTelegram("123", "Test Topic", {
+    const result = await createForumTopicTelegram(" telegram:123  ", "Test Topic", {
       api: mockApi,
       token: "tok",
     });

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createForumTopicTelegram } from "./send.js";
-import { Bot, HttpError } from "grammy";
+import { Bot } from "grammy";
 import { type ForumTopic } from "@grammyjs/types";
 
 vi.mock("../config/config.js", () => ({
@@ -26,8 +26,9 @@ vi.mock("./api-logging.js", () => ({
 }));
 
 describe("createForumTopicTelegram", () => {
+  const createForumTopicMock = vi.fn();
   const mockApi = {
-    createForumTopic: vi.fn(),
+    createForumTopic: createForumTopicMock,
   } as unknown as Bot["api"];
 
   beforeEach(() => {
@@ -40,14 +41,14 @@ describe("createForumTopicTelegram", () => {
       name: "Test Topic",
       icon_color: 0x6fb9f0,
     };
-    (mockApi.createForumTopic as any).mockResolvedValue(mockResult);
+    createForumTopicMock.mockResolvedValue(mockResult);
 
     const result = await createForumTopicTelegram("123", "Test Topic", {
       api: mockApi,
       token: "tok",
     });
 
-    expect(mockApi.createForumTopic).toHaveBeenCalledWith("123", "Test Topic", undefined);
+    expect(createForumTopicMock).toHaveBeenCalledWith("123", "Test Topic", undefined);
     expect(result).toEqual({
       threadId: 123,
       name: "Test Topic",
@@ -61,7 +62,7 @@ describe("createForumTopicTelegram", () => {
       name: "Emoji Topic",
       icon_custom_emoji_id: "emoji123",
     };
-    (mockApi.createForumTopic as any).mockResolvedValue(mockResult);
+    createForumTopicMock.mockResolvedValue(mockResult);
 
     await createForumTopicTelegram("123", "Emoji Topic", {
       api: mockApi,
@@ -70,14 +71,14 @@ describe("createForumTopicTelegram", () => {
       iconCustomEmojiId: "emoji123",
     });
 
-    expect(mockApi.createForumTopic).toHaveBeenCalledWith("123", "Emoji Topic", {
+    expect(createForumTopicMock).toHaveBeenCalledWith("123", "Emoji Topic", {
       icon_custom_emoji_id: "emoji123",
     });
   });
 
   it("wraps chat not found error", async () => {
     const error = new Error("400: Bad Request: chat not found");
-    (mockApi.createForumTopic as any).mockRejectedValue(error);
+    createForumTopicMock.mockRejectedValue(error);
 
     await expect(
       createForumTopicTelegram("123", "Error Topic", {
@@ -89,7 +90,7 @@ describe("createForumTopicTelegram", () => {
 
   it("wraps missing rights error", async () => {
     const error = new Error("400: Bad Request: not enough rights");
-    (mockApi.createForumTopic as any).mockRejectedValue(error);
+    createForumTopicMock.mockRejectedValue(error);
 
     await expect(
       createForumTopicTelegram("123", "Error Topic", {

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -1,7 +1,7 @@
+import { type ForumTopic } from "@grammyjs/types";
+import { Bot } from "grammy";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createForumTopicTelegram } from "./send.js";
-import { Bot } from "grammy";
-import { type ForumTopic } from "@grammyjs/types";
 
 vi.mock("../config/config.js", () => ({
   loadConfig: () => ({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,4 +1,5 @@
 import type {
+  ForumTopic,
   InlineKeyboardButton,
   InlineKeyboardMarkup,
   ReactionType,
@@ -747,4 +748,122 @@ export async function sendStickerTelegram(
   });
 
   return { messageId, chatId: resolvedChatId };
+}
+
+type TelegramCreateForumTopicOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: Bot["api"];
+  retry?: RetryConfig;
+  /** Icon color (one of Telegram's predefined colors: 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, 0xFB6F5F) */
+  iconColor?: number;
+  /** Custom emoji ID for the topic icon (requires Premium) */
+  iconCustomEmojiId?: string;
+};
+
+type TelegramCreateForumTopicResult = {
+  threadId: number;
+  name: string;
+  iconColor?: number;
+  iconCustomEmojiId?: string;
+};
+
+/**
+ * Create a forum topic in a Telegram supergroup with topics enabled.
+ * @param chatId - Chat ID of the supergroup (e.g., "-1001234567890")
+ * @param name - Name for the topic (1-128 characters)
+ * @param opts - Optional configuration
+ */
+export async function createForumTopicTelegram(
+  chatId: string | number,
+  name: string,
+  opts: TelegramCreateForumTopicOpts = {},
+): Promise<TelegramCreateForumTopicResult> {
+  if (!name?.trim()) {
+    throw new Error("Forum topic name is required");
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > 128) {
+    throw new Error("Forum topic name must be 128 characters or less");
+  }
+
+  const cfg = loadConfig();
+  const account = resolveTelegramAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const token = resolveToken(opts.token, account);
+  const normalizedChatId = normalizeChatId(String(chatId));
+  const client = resolveTelegramClientOptions(account);
+  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
+
+  const request = createTelegramRetryRunner({
+    retry: opts.retry,
+    configRetry: account.config.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  const requestWithDiag = <T>(fn: () => Promise<T>, label?: string) =>
+    withTelegramApiErrorLogging({
+      operation: label ?? "request",
+      fn: () => request(fn, label),
+    });
+
+  const wrapForumError = (err: unknown) => {
+    const errText = formatErrorMessage(err);
+    if (/400: Bad Request: chat not found/i.test(errText)) {
+      return new Error(
+        [
+          `Telegram createForumTopic failed: chat not found (chat_id=${normalizedChatId}).`,
+          "Verify the chat ID is correct and the bot is a member of the group.",
+        ].join(" "),
+      );
+    }
+    if (/CHAT_NOT_MODIFIED|not enough rights/i.test(errText)) {
+      return new Error(
+        `Telegram createForumTopic failed: bot must be an administrator with topic management rights.`,
+      );
+    }
+    if (/FORUM_ENABLED|forum/i.test(errText) && /disabled|not enabled/i.test(errText)) {
+      return new Error(
+        `Telegram createForumTopic failed: forum topics are not enabled in this group.`,
+      );
+    }
+    return err;
+  };
+
+  const topicParams: Record<string, unknown> = {};
+  if (opts.iconCustomEmojiId?.trim()) {
+    topicParams.icon_custom_emoji_id = opts.iconCustomEmojiId.trim();
+  } else if (opts.iconColor != null) {
+    topicParams.icon_color = opts.iconColor;
+  }
+
+  const result: ForumTopic = await requestWithDiag(
+    () =>
+      api.createForumTopic(
+        normalizedChatId,
+        trimmedName,
+        Object.keys(topicParams).length > 0 ? topicParams : undefined,
+      ),
+    "createForumTopic",
+  ).catch((err) => {
+    throw wrapForumError(err);
+  });
+
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  logVerbose(`[telegram] Created forum topic "${trimmedName}" in chat ${normalizedChatId}`);
+
+  return {
+    threadId: result.message_thread_id,
+    name: result.name,
+    ...(result.icon_color != null ? { iconColor: result.icon_color } : {}),
+    ...(result.icon_custom_emoji_id ? { iconCustomEmojiId: result.icon_custom_emoji_id } : {}),
+  };
 }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -171,7 +171,7 @@ function normalizeMessageId(raw: string | number): number {
       return parsed;
     }
   }
-  throw new Error("Message id is required for Telegram actions");
+  throw new Error(`Invalid message ID. Expected: finite number, received: "${String(raw)}"`);
 }
 
 export function buildInlineKeyboard(

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -820,7 +820,7 @@ export async function createForumTopicTelegram(
         ].join(" "),
       );
     }
-    if (/CHAT_NOT_MODIFIED|not enough rights/i.test(errText)) {
+    if (/not enough rights/i.test(errText)) {
       return new Error(
         `Telegram createForumTopic failed: bot must be an administrator with topic management rights.`,
       );

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -785,7 +785,9 @@ export async function createForumTopicTelegram(
   }
   const trimmedName = name.trim();
   if (trimmedName.length > 128) {
-    throw new Error("Forum topic name must be 128 characters or less");
+    throw new Error(
+      `Forum topic name must be 128 characters or less (received: ${trimmedName.length})`,
+    );
   }
 
   const cfg = loadConfig();

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -804,10 +804,14 @@ export async function createForumTopicTelegram(
     verbose: opts.verbose,
     shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
   });
+  const logHttpError = createTelegramHttpLogger(cfg);
   const requestWithDiag = <T>(fn: () => Promise<T>, label?: string) =>
     withTelegramApiErrorLogging({
       operation: label ?? "request",
       fn: () => request(fn, label),
+    }).catch((err) => {
+      logHttpError(label ?? "request", err);
+      throw err;
     });
 
   const wrapForumError = (err: unknown) => {


### PR DESCRIPTION
## Summary
This PR adds support for creating Telegram forum topics within a supergroup. This enables the `openclaw message thread create` command for the Telegram provider.

This is a refined version of PR #5755, addressing code review feedback regarding error mapping.

## Changes
- **Core API (`send.ts`)**: Added `createForumTopicTelegram` which implements the Telegram Bot API `createForumTopic` method.
    - Includes robust retry policy and error logging logic.
    - Wraps common Telegram errors (chat not found, insufficient rights, forums disabled) with user-friendly messages.
    - Adheres to API spec for mutually exclusive icon parameters (`icon_custom_emoji_id` vs `icon_color`).
    - **Fix:** Separated `CHAT_NOT_MODIFIED` check from admin rights check to avoid misleading error messages.
- **Action Handler (`telegram-actions.ts`)**: Added `createForumTopic` action to the Telegram tool handler.
- **Provider Adapter (`telegram.ts`)**: Exposed `thread-create` action in the Telegram provider.
- **Config (`types.telegram.ts`)**: Added a new `threads` action gate to the Telegram configuration.
- **Tests**: 
    - Integration tests in `telegram.test.ts`.
    - Action logic tests in `telegram-actions.test.ts`.
    - Targeted API tests in `send.create-forum-topic.test.ts`.

## Usage
1. Enable thread actions in your configuration:
```yaml
channels:
  telegram:
    actions:
      threads: true
```

2. Create a topic via CLI:
```bash
openclaw message thread create --channel telegram --target <chat_id> --thread-name "My Topic"
```

The resulting `threadId` (message_thread_id) is returned and can be used for subsequent `thread-reply` actions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Telegram support for creating forum topics (used to implement the `thread-create` message action), wiring it through the Telegram action handler, provider action adapter, and configuration gating (`channels.telegram.actions.threads`). It also adds unit/integration coverage for the new action mapping and the Telegram send-layer helper.

Overall the implementation follows existing Telegram send patterns (retry runner + API error logging + user-facing error mapping, and mutually exclusive icon params), and integrates cleanly with the message-action adapter and config gates.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with a couple of consistency/test issues worth addressing.
- Core wiring for thread-create -> createForumTopic looks consistent with existing action gating and retry/logging patterns, and the error mapping is reasonable. The main concerns are (1) the new create-forum-topic unit test asserting the pre-normalized chatId, which can make the suite flaky/fail as normalization expands, and (2) missing HTTP diagnostic logging parity in createForumTopicTelegram compared to other Telegram send helpers.
- src/telegram/send.ts, src/telegram/send.create-forum-topic.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->