### PR TITLE
CI: extend formal conformance to run alias consistency check

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -34,6 +34,7 @@ jobs:
           cd clawdbot-formal-models
           export OPENCLAW_REPO_DIR="${GITHUB_WORKSPACE}/openclaw"
           node scripts/extract-tool-groups.mjs
+          node scripts/check-tool-group-alias.mjs
 
       - name: Compute drift
         id: drift


### PR DESCRIPTION
Extends the informational formal conformance job to run  after regenerating extracted constants. This verifies pure group renames (openclaw/clawdbot/moltbot) don't silently change the underlying tool list.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the existing “Formal models (informational conformance)” GitHub Actions workflow by running an additional validation script (`scripts/check-tool-group-alias.mjs`) immediately after regenerating extracted constants from the PR checkout. The intent is to ensure tool-group alias renames (e.g., org/name changes) don’t silently alter the underlying tool list before the drift check runs.

The change fits naturally into the current conformance flow: it stays within the same job step that regenerates constants in the external `clawdbot-formal-models` repo, and it leverages the existing `set -euo pipefail` behavior so any alias inconsistency fails the workflow early (while still being an informational job overall).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single additional command in an existing CI job step, with no production/runtime impact. It preserves existing workflow structure and failure behavior (via `set -euo pipefail`) while adding a deterministic validation step.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->