### PR TITLE
fix(memory): truncate oversized chunks before embedding

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1707,7 +1707,8 @@ export class MemoryIndexManager {
         currentTokens = 0;
       }
       if (current.length === 0 && estimate > EMBEDDING_BATCH_MAX_TOKENS) {
-        batches.push([chunk]);
+        const maxChars = EMBEDDING_BATCH_MAX_TOKENS * EMBEDDING_APPROX_CHARS_PER_TOKEN;
+        batches.push([{ ...chunk, text: chunk.text.slice(0, maxChars) }]);
         continue;
       }
       current.push(chunk);


### PR DESCRIPTION
When a single chunk exceeds EMBEDDING_BATCH_MAX_TOKENS, it was pushed to the batch without truncation, causing OpenAI API 400 errors. Now truncates text to fit within the token limit.

Fixes #5696

🤖 AI-assisted: Built with Claude Code (claude-opus-4-5) Testing: Fully tested - lint, build, and all tests pass The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a batching edge case in `MemoryIndexManager` where a single `MemoryChunk` larger than `EMBEDDING_BATCH_MAX_TOKENS` was being placed into its own batch without truncation, which could trigger OpenAI 400 errors. The change now truncates the chunk text before pushing it as a single-item batch, keeping batch construction aligned with the embedding API limits.

The change is localized to `src/memory/manager.ts` in the embedding batch-building logic used by both the non-batch embedding path and as the fallback path when remote batch embeddings are unavailable/fail.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real failure mode, with a small remaining edge case around the truncation heuristic.
- The change is small and correctly targets the oversized-single-chunk path in batching, but the truncation is derived from an approximate chars/token constant; depending on how that constant is tuned, truncation may still produce an estimated token count over the max due to rounding, which could reintroduce the original 400s in a corner case.
- src/memory/manager.ts (batch truncation math)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->