### PR TITLE
feat(imessage): add myNumbers config to filter by destination phone number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+package-lock.json

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -31,6 +31,12 @@ export type IMessageAccountConfig = {
   region?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /**
+   * Filter to only process messages sent TO these phone numbers.
+   * Useful when the Mac has multiple iMessage numbers (e.g., dual-SIM).
+   * Messages with destination_caller_id not matching any of these are ignored.
+   */
+  myNumbers?: string[];
   /** Optional allowlist for inbound handles or chat_id targets. */
   allowFrom?: Array<string | number>;
   /** Optional allowlist for group senders or chat_id targets. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -582,6 +582,7 @@ export const IMessageAccountSchemaBase = z
     service: z.union([z.literal("imessage"), z.literal("sms"), z.literal("auto")]).optional(),
     region: z.string().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    myNumbers: z.array(z.string()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/imessage/monitor/types.ts
+++ b/src/imessage/monitor/types.ts
@@ -23,6 +23,12 @@ export type IMessagePayload = {
   chat_name?: string | null;
   participants?: string[] | null;
   is_group?: boolean | null;
+  /**
+   * The destination phone number for this message (from imsg).
+   * Useful for distinguishing which iMessage number received the message
+   * on a dual-SIM or multi-number setup.
+   */
+  destination_caller_id?: string | null;
 };
 
 export type MonitorIMessageOpts = {


### PR DESCRIPTION
Adds a `myNumbers` config option to the iMessage channel that filters inbound messages by destination caller ID. This allows agents with multiple phone numbers to only respond to messages sent to specific numbers.

## Changes
- Added `myNumbers: string[]` to iMessage channel config schema
- Filters inbound messages where `destination_caller_id` matches configured numbers
- Logs skipped messages for debugging

## Dependency
Requires [steipete/imsg#29](https://github.com/steipete/imsg/pull/29) to expose the `destination_caller_id` field.

---
*AI-assisted PR*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `myNumbers: string[]` configuration option to the iMessage channel, extends the config schema to accept it, and updates the iMessage monitor to drop inbound messages whose `destination_caller_id` does not match the configured numbers. It also logs when messages are skipped to aid debugging. The change fits cleanly into the existing iMessage inbound processing path (`monitorIMessageProvider`) by applying the filter early, before allowlist/pairing/group handling.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and low-risk.
- The implementation is a straightforward early-return filter gated behind an optional config field, with no changes to core routing logic beyond skipping some inbound messages. Main risk is around config ergonomics/validation and runtime override expectations rather than correctness or security.
- src/imessage/monitor/monitor-provider.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->