### PR TITLE
feat(config): transactional config changes with automatic rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,178 @@
-AGENTS.md
+# Repository Guidelines
+
+- Repo: https://github.com/openclaw/openclaw
+- GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
+
+## Project Structure & Module Organization
+
+- Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
+- Tests: colocated `*.test.ts`.
+- Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
+- Plugins/extensions: live under `extensions/*` (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
+- Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
+- Installers served from `https://openclaw.ai/*`: live in the sibling repo `../openclaw.ai` (`public/install.sh`, `public/install-cli.sh`, `public/install.ps1`).
+- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs).
+  - Core channel docs: `docs/channels/`
+  - Core channel code: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web` (WhatsApp web), `src/channels`, `src/routing`
+  - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
+- When adding channels/extensions/apps/docs, review `.github/labeler.yml` for label coverage.
+
+## Docs Linking (Mintlify)
+
+- Docs are hosted on Mintlify (docs.openclaw.ai).
+- Internal doc links in `docs/**/*.md`: root-relative, no `.md`/`.mdx` (example: `[Config](/configuration)`).
+- Section cross-references: use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
+- Doc headings and anchors: avoid em dashes and apostrophes in headings because they break Mintlify anchor links.
+- When Peter asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
+- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
+- README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
+- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
+
+## exe.dev VM ops (general)
+
+- Access: stable path is `ssh exe.dev` then `ssh vm-name` (assume SSH key already set).
+- SSH flaky: use exe.dev web terminal or Shelley (web agent); keep a tmux session for long ops.
+- Update: `sudo npm i -g openclaw@latest` (global install needs root on `/usr/lib/node_modules`).
+- Config: use `openclaw config set ...`; ensure `gateway.mode=local` is set.
+- Discord: store raw token only (no `DISCORD_BOT_TOKEN=` prefix).
+- Restart: stop old gateway and run:
+  `pkill -9 -f openclaw-gateway || true; nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &`
+- Verify: `openclaw channels status --probe`, `ss -ltnp | rg 18789`, `tail -n 120 /tmp/openclaw-gateway.log`.
+
+## Build, Test, and Development Commands
+
+- Runtime baseline: Node **22+** (keep Node + Bun paths working).
+- Install deps: `pnpm install`
+- Pre-commit hooks: `prek install` (runs same checks as CI)
+- Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches).
+- Prefer Bun for TypeScript execution (scripts, dev, tests): `bun <file.ts>` / `bunx <tool>`.
+- Run CLI in dev: `pnpm openclaw ...` (bun) or `pnpm dev`.
+- Node remains supported for running built output (`dist/*`) and production installs.
+- Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
+- Type-check/build: `pnpm build`
+- Lint/format: `pnpm lint` (oxlint), `pnpm format` (oxfmt)
+- Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+
+## Coding Style & Naming Conventions
+
+- Language: TypeScript (ESM). Prefer strict typing; avoid `any`.
+- Formatting/linting via Oxlint and Oxfmt; run `pnpm lint` before commits.
+- Add brief code comments for tricky or non-obvious logic.
+- Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
+- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
+- Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
+
+## Release Channels (Naming)
+
+- stable: tagged releases only (e.g. `vYYYY.M.D`), npm dist-tag `latest`.
+- beta: prerelease tags `vYYYY.M.D-beta.N`, npm dist-tag `beta` (may ship without macOS app).
+- dev: moving head on `main` (no tag; git checkout main).
+
+## Testing Guidelines
+
+- Framework: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
+- Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
+- Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
+- Do not set test workers above 16; tried already.
+- Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
+- Full kit + what’s covered: `docs/testing.md`.
+- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
+- Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
+
+## Commit & Pull Request Guidelines
+
+- Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
+- Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).
+- Group related changes; avoid bundling unrelated refactors.
+- Changelog workflow: keep latest released version at top (no `Unreleased`); after publishing, bump version and start a new top section.
+- PRs should summarize scope, note testing performed, and mention any user-facing changes or new flags.
+- PR review flow: when given a PR link, review via `gh pr view`/`gh pr diff` and do **not** change branches.
+- PR review calls: prefer a single `gh pr view --json ...` to batch metadata/comments; run `gh pr diff` only when needed.
+- Before starting a review when a GH Issue/PR is pasted: run `git pull`; if there are local changes or unpushed commits, stop and alert the user before reviewing.
+- Goal: merge PRs. Prefer **rebase** when commits are clean; **squash** when history is messy.
+- PR merge flow: create a temp branch from `main`, merge the PR branch into it (prefer squash unless commit history is important; use rebase/merge when it is). Always try to merge the PR unless it’s truly difficult, then use another approach. If we squash, add the PR author as a co-contributor. Apply fixes, add changelog entry (include PR # + thanks), run full gate before the final commit, commit, merge back to `main`, delete the temp branch, and end on `main`.
+- If you review a PR and later do work on it, land via merge/squash (no direct-main commits) and always add the PR author as a co-contributor.
+- When working on a PR: add a changelog entry with the PR number and thank the contributor.
+- When working on an issue: reference the issue in the changelog entry.
+- When merging a PR: leave a PR comment that explains exactly what we did and include the SHA hashes.
+- When merging a PR from a new contributor: add their avatar to the README “Thanks to all clawtributors” thumbnail list.
+- After merging a PR: run `bun scripts/update-clawtributors.ts` if the contributor is missing, then commit the regenerated README.
+
+## Shorthand Commands
+
+- `sync`: if working tree is dirty, commit all changes (pick a sensible Conventional Commit message), then `git pull --rebase`; if rebase conflicts and cannot resolve, stop; otherwise `git push`.
+
+### PR Workflow (Review vs Land)
+
+- **Review mode (PR link only):** read `gh pr view/diff`; **do not** switch branches; **do not** change code.
+- **Landing mode:** create an integration branch from `main`, bring in PR commits (**prefer rebase** for linear history; **merge allowed** when complexity/conflicts make it safer), apply fixes, add changelog (+ thanks + PR #), run full gate **locally before committing** (`pnpm lint && pnpm build && pnpm test`), commit, merge back to `main`, then `git switch main` (never stay on a topic branch after landing). Important: contributor needs to be in git graph after this!
+
+## Security & Configuration Tips
+
+- Web provider stores creds at `~/.openclaw/credentials/`; rerun `openclaw login` if logged out.
+- Pi sessions live under `~/.openclaw/sessions/` by default; the base directory is not configurable.
+- Environment variables: see `~/.profile`.
+- Never commit or publish real phone numbers, videos, or live configuration values. Use obviously fake placeholders in docs, tests, and examples.
+- Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
+
+## Troubleshooting
+
+- Rebrand/migration issues or legacy config/service warnings: run `openclaw doctor` (see `docs/gateway/doctor.md`).
+
+## Agent-Specific Notes
+
+- Vocabulary: "makeup" = "mac app".
+- Never edit `node_modules` (global/Homebrew/npm/git installs too). Updates overwrite. Skill notes go in `tools.md` or `AGENTS.md`.
+- Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
+- When working on a GitHub Issue or PR, print the full URL at the end of the task.
+- When answering questions, respond with high-confidence answers only: verify in code; do not guess.
+- Never update the Carbon dependency.
+- Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
+- Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
+- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.
+- Status output: keep tables + ANSI-safe wrapping (`src/terminal/table.ts`); `status --all` = read-only/pasteable, `status --deep` = probes.
+- Gateway currently runs only as the menubar app; there is no separate LaunchAgent/helper label installed. Restart via the OpenClaw Mac app or `scripts/restart-mac.sh`; to verify/kill use `launchctl print gui/$UID | grep openclaw` rather than assuming a fixed label. **When debugging on macOS, start/stop the gateway via the app, not ad-hoc tmux sessions; kill any temporary tunnels before handoff.**
+- macOS logs: use `./scripts/clawlog.sh` to query unified logs for the OpenClaw subsystem; it supports follow/tail/category filters and expects passwordless sudo for `/usr/bin/log`.
+- If shared guardrails are available locally, review them; otherwise follow this repo's guidance.
+- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don’t introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
+- Connection providers: when adding a new connection, update every UI surface and docs (macOS app, web UI, mobile if applicable, onboarding/overview docs) and add matching status + configuration forms so provider lists and settings stay in sync.
+- Version locations: `package.json` (CLI), `apps/android/app/build.gradle.kts` (versionName/versionCode), `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `docs/install/updating.md` (pinned npm version), `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples), Peekaboo Xcode projects/Info.plists (MARKETING_VERSION/CURRENT_PROJECT_VERSION).
+- **Restart apps:** “restart iOS/Android apps” means rebuild (recompile/install) and relaunch, not just kill/launch.
+- **Device checks:** before testing, verify connected real devices (iOS/Android) before reaching for simulators/emulators.
+- iOS Team ID lookup: `security find-identity -p codesigning -v` → use Apple Development (…) TEAMID. Fallback: `defaults read com.apple.dt.Xcode IDEProvisioningTeamIdentifiers`.
+- A2UI bundle hash: `src/canvas-host/a2ui/.bundle.hash` is auto-generated; ignore unexpected changes, and only regenerate via `pnpm canvas:a2ui:bundle` (or `scripts/bundle-a2ui.sh`) when needed. Commit the hash as a separate commit.
+- Release signing/notary keys are managed outside the repo; follow internal release docs.
+- Notary auth env vars (`APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY_P8`) are expected in your environment (per internal release docs).
+- **Multi-agent safety:** do **not** create/apply/drop `git stash` entries unless explicitly requested (this includes `git pull --rebase --autostash`). Assume other agents may be working; keep unrelated WIP untouched and avoid cross-cutting state changes.
+- **Multi-agent safety:** when the user says "push", you may `git pull --rebase` to integrate latest changes (never discard other agents' work). When the user says "commit", scope to your changes only. When the user says "commit all", commit everything in grouped chunks.
+- **Multi-agent safety:** do **not** create/remove/modify `git worktree` checkouts (or edit `.worktrees/*`) unless explicitly requested.
+- **Multi-agent safety:** do **not** switch branches / check out a different branch unless explicitly requested.
+- **Multi-agent safety:** running multiple agents is OK as long as each agent has its own session.
+- **Multi-agent safety:** when you see unrecognized files, keep going; focus on your changes and commit only those.
+- Lint/format churn:
+  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
+  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
+  - Only ask when changes are semantic (logic/data/behavior).
+- Lobster seam: use the shared CLI palette in `src/terminal/palette.ts` (no hardcoded colors); apply palette to onboarding/config prompts and other TTY UI output as needed.
+- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
+- Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
+- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
+- Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
+- Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
+- When asked to open a “session” file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
+- Do not rebuild the macOS app over SSH; rebuilds must be run directly on the Mac.
+- Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.
+- Voice wake forwarding tips:
+  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don’t add extra quotes.
+  - launchd PATH is minimal; ensure the app’s launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
+- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool’s escaping.
+- Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
+
+## NPM + 1Password (publish/verify)
+
+- Use the 1password skill; all `op` commands must run inside a fresh tmux session.
+- Sign in: `eval "$(op signin --account my.1password.com)"` (app unlocked + integration on).
+- OTP: `op read 'op://Private/Npmjs/one-time password?attribute=otp'`.
+- Publish: `npm publish --access public --otp="<otp>"` (run from the package dir).
+- Verify without local npmrc side effects: `npm view <pkg> version --userconfig "$(mktemp)"`.
+- Kill the tmux session after publish.

--- a/src/config/config-pending.test.ts
+++ b/src/config/config-pending.test.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { withTempHome } from "./test-helpers.js";
+
+// We need to dynamically import the module after setting up the temp home
+// because the module reads paths at import time
+
+describe("config-pending", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe("writePendingMarker", () => {
+    it("creates pending marker and pre-restart snapshot", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const markerPath = path.join(stateDir, "config-pending.json");
+        const bakPath = path.join(stateDir, "openclaw.json.bak");
+
+        // Create initial config
+        await fs.writeFile(configPath, JSON.stringify({ version: "original" }), "utf-8");
+
+        const { writePendingMarker } = await import("./config-pending.js");
+        await writePendingMarker({ reason: "test", timeoutMs: 5000 });
+
+        // Check marker was created
+        const marker = JSON.parse(await fs.readFile(markerPath, "utf-8"));
+        expect(marker.reason).toBe("test");
+        expect(marker.timeoutMs).toBe(5000);
+        expect(marker.appliedAt).toBeDefined();
+
+        // Check pre-restart snapshot was saved
+        const bak = JSON.parse(await fs.readFile(bakPath, "utf-8"));
+        expect(bak.version).toBe("original");
+      });
+    });
+
+    it("uses verified config as rollback target when available", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const verifiedPath = path.join(stateDir, "openclaw.json.verified");
+        const markerPath = path.join(stateDir, "config-pending.json");
+
+        // Create config and verified
+        await fs.writeFile(configPath, JSON.stringify({ version: "current" }), "utf-8");
+        await fs.writeFile(verifiedPath, JSON.stringify({ version: "verified" }), "utf-8");
+
+        const { writePendingMarker } = await import("./config-pending.js");
+        await writePendingMarker({ reason: "test" });
+
+        const marker = JSON.parse(await fs.readFile(markerPath, "utf-8"));
+        expect(marker.rollbackTo).toBe(verifiedPath);
+        expect(marker.preRestartSnapshot).toContain(".bak");
+      });
+    });
+
+    it("falls back to .bak when no verified config exists", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const markerPath = path.join(stateDir, "config-pending.json");
+
+        await fs.writeFile(configPath, JSON.stringify({ version: "current" }), "utf-8");
+
+        const { writePendingMarker } = await import("./config-pending.js");
+        await writePendingMarker({ reason: "first-run" });
+
+        const marker = JSON.parse(await fs.readFile(markerPath, "utf-8"));
+        expect(marker.rollbackTo).toContain(".bak");
+      });
+    });
+  });
+
+  describe("clearPendingMarker", () => {
+    it("removes the pending marker file", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const markerPath = path.join(stateDir, "config-pending.json");
+
+        await fs.writeFile(markerPath, JSON.stringify({ test: true }), "utf-8");
+
+        const { clearPendingMarker } = await import("./config-pending.js");
+        await clearPendingMarker();
+
+        await expect(fs.access(markerPath)).rejects.toThrow();
+      });
+    });
+
+    it("does not throw if marker does not exist", async () => {
+      await withTempHome(async () => {
+        const { clearPendingMarker } = await import("./config-pending.js");
+        await expect(clearPendingMarker()).resolves.not.toThrow();
+      });
+    });
+  });
+
+  describe("markConfigVerified", () => {
+    it("saves current config to .verified", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const verifiedPath = path.join(stateDir, "openclaw.json.verified");
+
+        await fs.writeFile(configPath, JSON.stringify({ version: "good" }), "utf-8");
+
+        const { markConfigVerified } = await import("./config-pending.js");
+        await markConfigVerified();
+
+        const verified = JSON.parse(await fs.readFile(verifiedPath, "utf-8"));
+        expect(verified.version).toBe("good");
+      });
+    });
+  });
+
+  describe("checkPendingOnStartup", () => {
+    it("returns rolledBack: false when no marker exists", async () => {
+      await withTempHome(async () => {
+        const { checkPendingOnStartup } = await import("./config-pending.js");
+        const result = await checkPendingOnStartup();
+        expect(result.rolledBack).toBe(false);
+      });
+    });
+
+    it("clears marker and returns rolledBack: false when elapsed > timeout", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const markerPath = path.join(stateDir, "config-pending.json");
+        const bakPath = path.join(stateDir, "openclaw.json.bak");
+
+        // Create config and backup
+        await fs.writeFile(configPath, JSON.stringify({ version: "new" }), "utf-8");
+        await fs.writeFile(bakPath, JSON.stringify({ version: "old" }), "utf-8");
+
+        // Create marker with old timestamp (success scenario)
+        const oldTime = new Date(Date.now() - 60000).toISOString(); // 60s ago
+        await fs.writeFile(
+          markerPath,
+          JSON.stringify({
+            appliedAt: oldTime,
+            rollbackTo: bakPath,
+            timeoutMs: 30000,
+          }),
+          "utf-8",
+        );
+
+        const { checkPendingOnStartup } = await import("./config-pending.js");
+        const result = await checkPendingOnStartup();
+
+        expect(result.rolledBack).toBe(false);
+        // Marker should be cleared
+        await expect(fs.access(markerPath)).rejects.toThrow();
+        // Config should NOT be changed
+        const config = JSON.parse(await fs.readFile(configPath, "utf-8"));
+        expect(config.version).toBe("new");
+      });
+    });
+
+    it("rolls back when elapsed < timeout (crash detected)", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const markerPath = path.join(stateDir, "config-pending.json");
+        const verifiedPath = path.join(stateDir, "openclaw.json.verified");
+        const failedPath = path.join(stateDir, "openclaw.json.failed");
+
+        // Create config (the "crashed" one) and verified backup
+        await fs.writeFile(configPath, JSON.stringify({ version: "crashed" }), "utf-8");
+        await fs.writeFile(verifiedPath, JSON.stringify({ version: "verified-good" }), "utf-8");
+
+        // Create marker with recent timestamp (crash scenario)
+        const recentTime = new Date(Date.now() - 1000).toISOString(); // 1s ago
+        await fs.writeFile(
+          markerPath,
+          JSON.stringify({
+            appliedAt: recentTime,
+            rollbackTo: verifiedPath,
+            timeoutMs: 30000,
+            reason: "test-crash",
+          }),
+          "utf-8",
+        );
+
+        const { checkPendingOnStartup } = await import("./config-pending.js");
+        const result = await checkPendingOnStartup();
+
+        expect(result.rolledBack).toBe(true);
+        expect(result.reason).toBe("test-crash");
+
+        // Config should be restored from verified
+        const config = JSON.parse(await fs.readFile(configPath, "utf-8"));
+        expect(config.version).toBe("verified-good");
+
+        // Failed config should be saved
+        const failed = JSON.parse(await fs.readFile(failedPath, "utf-8"));
+        expect(failed.version).toBe("crashed");
+
+        // Marker should be cleared
+        await expect(fs.access(markerPath)).rejects.toThrow();
+      });
+    });
+
+    it("appends to rollback history on rollback", async () => {
+      await withTempHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const markerPath = path.join(stateDir, "config-pending.json");
+        const verifiedPath = path.join(stateDir, "openclaw.json.verified");
+        const historyPath = path.join(stateDir, "config-rollback-history.json");
+
+        await fs.writeFile(configPath, JSON.stringify({ version: "crashed" }), "utf-8");
+        await fs.writeFile(verifiedPath, JSON.stringify({ version: "good" }), "utf-8");
+
+        const recentTime = new Date(Date.now() - 500).toISOString();
+        await fs.writeFile(
+          markerPath,
+          JSON.stringify({
+            appliedAt: recentTime,
+            rollbackTo: verifiedPath,
+            timeoutMs: 30000,
+            reason: "history-test",
+          }),
+          "utf-8",
+        );
+
+        const { checkPendingOnStartup } = await import("./config-pending.js");
+        await checkPendingOnStartup();
+
+        const history = JSON.parse(await fs.readFile(historyPath, "utf-8"));
+        expect(Array.isArray(history)).toBe(true);
+        expect(history.length).toBe(1);
+        expect(history[0].reason).toBe("history-test");
+        expect(history[0].elapsedMs).toBeLessThan(30000);
+      });
+    });
+  });
+});

--- a/src/config/config-pending.ts
+++ b/src/config/config-pending.ts
@@ -71,14 +71,20 @@ async function copyDir(src: string, dest: string): Promise<void> {
 /**
  * Backup the dist/ directory for code rollback.
  * Call this before building new code.
+ *
+ * @param sourceDir - Directory to backup (default: DIST_DIR)
+ * @param destDir - Where to save backup (default: DIST_BACKUP_DIR)
  */
-export async function backupDist(): Promise<string | null> {
+export async function backupDist(
+  sourceDir: string = DIST_DIR,
+  destDir: string = DIST_BACKUP_DIR,
+): Promise<string | null> {
   try {
     // Remove old backup if exists
-    await fs.rm(DIST_BACKUP_DIR, { recursive: true, force: true });
-    await copyDir(DIST_DIR, DIST_BACKUP_DIR);
-    log.info(`config-pending: backed up dist to ${DIST_BACKUP_DIR}`);
-    return DIST_BACKUP_DIR;
+    await fs.rm(destDir, { recursive: true, force: true });
+    await copyDir(sourceDir, destDir);
+    log.info(`config-pending: backed up dist to ${destDir}`);
+    return destDir;
   } catch (err) {
     log.warn(`config-pending: failed to backup dist: ${err}`);
     return null;
@@ -87,12 +93,18 @@ export async function backupDist(): Promise<string | null> {
 
 /**
  * Restore dist/ from backup.
+ *
+ * @param backupPath - Directory to restore from
+ * @param targetDir - Where to restore to (default: DIST_DIR)
  */
-async function restoreDist(backupPath: string): Promise<boolean> {
+export async function restoreDist(
+  backupPath: string,
+  targetDir: string = DIST_DIR,
+): Promise<boolean> {
   try {
-    await fs.rm(DIST_DIR, { recursive: true, force: true });
-    await copyDir(backupPath, DIST_DIR);
-    log.info(`config-pending: restored dist from ${backupPath}`);
+    await fs.rm(targetDir, { recursive: true, force: true });
+    await copyDir(backupPath, targetDir);
+    log.info(`config-pending: restored dist from ${backupPath} to ${targetDir}`);
     return true;
   } catch (err) {
     log.error(`config-pending: failed to restore dist: ${err}`);

--- a/src/config/config-pending.ts
+++ b/src/config/config-pending.ts
@@ -250,13 +250,20 @@ async function appendRollbackHistory(entry: RollbackHistoryEntry): Promise<void>
   log.debug(`config-pending: appended rollback to history (${history.length} entries)`);
 }
 
+export interface CheckPendingOptions {
+  /** Override dist target dir for testing (default: DIST_DIR) */
+  distTargetDir?: string;
+}
+
 /**
  * Check for pending marker on startup and rollback if needed.
  * Should be called early in gateway startup, before loading config.
  *
  * Returns info about whether rollback occurred (for error injection).
  */
-export async function checkPendingOnStartup(): Promise<RollbackResult> {
+export async function checkPendingOnStartup(
+  opts: CheckPendingOptions = {},
+): Promise<RollbackResult> {
   let marker: ConfigPendingMarker;
 
   // Try to read the pending marker
@@ -337,7 +344,7 @@ export async function checkPendingOnStartup(): Promise<RollbackResult> {
   // Perform dist rollback if we have a backup
   let distRolledBack = false;
   if (marker.distBackupPath) {
-    distRolledBack = await restoreDist(marker.distBackupPath);
+    distRolledBack = await restoreDist(marker.distBackupPath, opts.distTargetDir);
     if (!distRolledBack) {
       log.warn(`config-pending: dist rollback failed, continuing with config-only rollback`);
     }

--- a/src/config/config-pending.ts
+++ b/src/config/config-pending.ts
@@ -8,6 +8,7 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { getLogger } from "../logging/logger.js";
 import { CONFIG_PATH, STATE_DIR } from "./paths.js";
 
@@ -21,7 +22,8 @@ const FAILED_CONFIG_PATH = path.join(CONFIG_DIR, "openclaw.json.failed");
 const ROLLBACK_HISTORY_PATH = path.join(CONFIG_DIR, "config-rollback-history.json");
 
 // Dist backup paths (for code/schema rollback)
-const DIST_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../");
+// Use fileURLToPath for cross-platform compatibility (Windows paths)
+const DIST_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../");
 const DIST_BACKUP_DIR = path.join(CONFIG_DIR, "dist.bak");
 
 export interface ConfigPendingMarker {

--- a/src/config/config-pending.ts
+++ b/src/config/config-pending.ts
@@ -1,0 +1,201 @@
+/**
+ * Transactional config changes with automatic rollback on startup failure.
+ *
+ * When a config change is applied with `rollbackOnFail: true`, a pending marker
+ * is written before the change. On next startup, if the marker exists and the
+ * gateway crashed quickly (within timeoutMs), the previous config is restored.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { getLogger } from "../logging/logger.js";
+import { CONFIG_PATH, STATE_DIR } from "./paths.js";
+
+const log = getLogger();
+const CONFIG_DIR = STATE_DIR;
+
+const PENDING_MARKER_PATH = path.join(CONFIG_DIR, "config-pending.json");
+const BACKUP_PATH = path.join(CONFIG_DIR, "openclaw.json.bak");
+
+export interface ConfigPendingMarker {
+  /** ISO timestamp when config change was applied */
+  appliedAt: string;
+  /** Path to backup file */
+  rollbackTo: string;
+  /** Crash detection window in ms */
+  timeoutMs: number;
+  /** What triggered the change */
+  reason?: string;
+  /** Session to notify on rollback */
+  sessionKey?: string;
+}
+
+export interface PendingMarkerOptions {
+  timeoutMs?: number;
+  reason?: string;
+  sessionKey?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Write a pending marker before applying a config change.
+ * Also backs up the current config to .bak.
+ */
+export async function writePendingMarker(opts: PendingMarkerOptions = {}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Backup current config
+  try {
+    await fs.copyFile(CONFIG_PATH, BACKUP_PATH);
+    log.debug(`config-pending: backed up config to ${BACKUP_PATH}`);
+  } catch (err) {
+    log.warn(`config-pending: failed to backup config: ${err}`);
+    // Continue anyway - we'll still write the marker
+  }
+
+  const marker: ConfigPendingMarker = {
+    appliedAt: new Date().toISOString(),
+    rollbackTo: BACKUP_PATH,
+    timeoutMs,
+    reason: opts.reason,
+    sessionKey: opts.sessionKey,
+  };
+
+  await fs.writeFile(PENDING_MARKER_PATH, JSON.stringify(marker, null, 2), "utf-8");
+  log.debug(`config-pending: wrote pending marker (timeout=${timeoutMs}ms)`);
+}
+
+/**
+ * Clear the pending marker (called after successful startup or rollback).
+ */
+export async function clearPendingMarker(): Promise<void> {
+  try {
+    await fs.unlink(PENDING_MARKER_PATH);
+    log.debug("config-pending: cleared pending marker");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn(`config-pending: failed to clear pending marker: ${err}`);
+    }
+  }
+}
+
+export interface RollbackResult {
+  /** Whether a rollback was performed */
+  rolledBack: boolean;
+  /** Error message if rollback occurred */
+  error?: string;
+  /** Session key to notify */
+  sessionKey?: string;
+  /** Reason from the original change */
+  reason?: string;
+}
+
+/**
+ * Check for pending marker on startup and rollback if needed.
+ * Should be called early in gateway startup, before loading config.
+ *
+ * Returns info about whether rollback occurred (for error injection).
+ */
+export async function checkPendingOnStartup(): Promise<RollbackResult> {
+  let marker: ConfigPendingMarker;
+
+  // Try to read the pending marker
+  try {
+    const content = await fs.readFile(PENDING_MARKER_PATH, "utf-8");
+    marker = JSON.parse(content) as ConfigPendingMarker;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // No pending marker - normal startup
+      return { rolledBack: false };
+    }
+    log.warn(`config-pending: failed to read pending marker: ${err}`);
+    return { rolledBack: false };
+  }
+
+  // Check if we crashed within the timeout window
+  const appliedAt = new Date(marker.appliedAt).getTime();
+  const now = Date.now();
+  const elapsed = now - appliedAt;
+
+  if (elapsed >= marker.timeoutMs) {
+    // Config change succeeded - clear marker and continue
+    log.info(
+      `config-pending: config change successful (ran for ${Math.round(elapsed / 1000)}s), clearing marker`,
+    );
+    await clearPendingMarker();
+    return { rolledBack: false };
+  }
+
+  // We crashed too quickly - rollback needed
+  log.warn(
+    `config-pending: startup crash detected (elapsed=${elapsed}ms < timeout=${marker.timeoutMs}ms), rolling back`,
+  );
+
+  // Capture error from logs if possible
+  let capturedError: string | undefined;
+  try {
+    // Try to read last few lines of the log file for context
+    const logDir = process.env.OPENCLAW_LOG_DIR ?? "/tmp/openclaw";
+    const today = new Date().toISOString().split("T")[0];
+    const logPath = path.join(logDir, `openclaw-${today}.log`);
+    const logContent = await fs.readFile(logPath, "utf-8").catch(() => "");
+    const lines = logContent.split("\n").slice(-50);
+    const errorLines = lines.filter(
+      (line) => line.includes("error") || line.includes("Error") || line.includes("FATAL"),
+    );
+    if (errorLines.length > 0) {
+      capturedError = errorLines.slice(-3).join("\n");
+    }
+  } catch {
+    // Ignore log capture errors
+  }
+
+  // Perform rollback
+  try {
+    await fs.copyFile(marker.rollbackTo, CONFIG_PATH);
+    log.info(`config-pending: restored config from ${marker.rollbackTo}`);
+  } catch (err) {
+    log.error(`config-pending: CRITICAL - failed to restore config: ${err}`);
+    // Clear marker anyway to prevent rollback loop
+    await clearPendingMarker();
+    return {
+      rolledBack: false,
+      error: `Failed to restore config: ${err}`,
+    };
+  }
+
+  await clearPendingMarker();
+
+  const errorMsg = capturedError
+    ? `Startup failed within ${marker.timeoutMs}ms of config change.\nLast errors:\n${capturedError}`
+    : `Startup failed within ${marker.timeoutMs}ms of config change (reason: ${marker.reason ?? "unknown"}).`;
+
+  return {
+    rolledBack: true,
+    error: errorMsg,
+    sessionKey: marker.sessionKey,
+    reason: marker.reason,
+  };
+}
+
+/**
+ * Schedule clearing the pending marker after successful startup.
+ * Call this once the gateway is confirmed running.
+ */
+export function schedulePendingMarkerClear(delayMs: number = 5000): void {
+  setTimeout(async () => {
+    try {
+      const exists = await fs
+        .access(PENDING_MARKER_PATH)
+        .then(() => true)
+        .catch(() => false);
+      if (exists) {
+        await clearPendingMarker();
+        log.info("config-pending: startup confirmed successful, marker cleared");
+      }
+    } catch (err) {
+      log.warn(`config-pending: failed to clear marker after startup: ${err}`);
+    }
+  }, delayMs);
+}

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -31,6 +31,12 @@ export type IMessageAccountConfig = {
   region?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /**
+   * Filter to only process messages sent TO these phone numbers.
+   * Useful when the Mac has multiple iMessage numbers (e.g., dual-SIM).
+   * Messages with destination_caller_id not matching any of these are ignored.
+   */
+  myNumbers?: string[];
   /** Optional allowlist for inbound handles or chat_id targets. */
   allowFrom?: Array<string | number>;
   /** Optional allowlist for group senders or chat_id targets. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -582,6 +582,7 @@ export const IMessageAccountSchemaBase = z
     service: z.union([z.literal("imessage"), z.literal("sms"), z.literal("auto")]).optional(),
     region: z.string().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    myNumbers: z.array(z.string()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/imessage/monitor/types.ts
+++ b/src/imessage/monitor/types.ts
@@ -23,6 +23,12 @@ export type IMessagePayload = {
   chat_name?: string | null;
   participants?: string[] | null;
   is_group?: boolean | null;
+  /**
+   * The destination phone number for this message (from imsg).
+   * Useful for distinguishing which iMessage number received the message
+   * on a dual-SIM or multi-number setup.
+   */
+  destination_caller_id?: string | null;
 };
 
 export type MonitorIMessageOpts = {


### PR DESCRIPTION
Adds automatic rollback for config changes that crash the gateway on startup. When a config change is applied, a pending marker is written. If the gateway crashes within the timeout window (default 30s), the previous config is automatically restored.

## Features
- **Transactional config changes**: Write pending marker before applying, clear after successful startup
- **Three config states**: `.json` (current), `.verified` (last known good), `.bak` (pre-restart snapshot)
- **Failed config preservation**: Crashed configs saved to `.failed` for debugging
- **Rollback history**: Logged to `config-rollback-history.json`
- **Session notification**: Uses `cron.wake` to notify the session that triggered the change
- **Dist backup/rollback**: Optionally backup and restore `dist/` for code/schema changes

## Usage
```typescript
// In gateway tool or config apply:
await writePendingMarker({ 
  reason: 'config change',
  timeoutMs: 30000,
  sessionKey: 'session-to-notify'
});
// Apply config and restart...
```

On startup, `checkPendingOnStartup()` detects crashes and auto-restores.

## Tests
18 unit tests covering all rollback scenarios.

---
*AI-assisted PR*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a transactional config-apply flow: `config.patch` can write a pending marker before restart, and early gateway startup (`startGatewayServer`) checks that marker to decide whether to rollback `openclaw.json` (and optionally `dist/`) to a last-known-good state. It also adds test coverage for the pending-marker and rollback history behaviors.

Key pieces live in `src/config/config-pending.ts` (marker writing, rollback decision, config/dist backup/restore, history file) and are wired into the gateway startup path in `src/gateway/server.impl.ts` and the config RPC handler in `src/gateway/server-methods/config.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a few correctness issues around session-targeted notifications and what is considered “verified” config.
- Core rollback logic is straightforward and well-tested, and the changes are localized. However, the session notification appears untargeted despite carrying a session key, and the delayed verification step can mark a config as verified even if the process later fails, which can undermine future rollbacks. Dist path derivation via `import.meta.url.pathname` is also brittle cross-platform.
- src/gateway/server.impl.ts, src/config/config-pending.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->