### PR TITLE
fix(process): resolve npm/pnpm spawn ENOENT on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Discord: inherit thread parent bindings when routing Discord messages. (#3892) Thanks @aerolalit.
+- Process: resolve Windows `spawn()` failures for npm-family CLIs by appending `.cmd` when needed. (#5815) Thanks @thejhinvirtuoso.
 - Docs: update MiniMax OAuth setup commands; Extensions: use OpenClaw plugin SDK for MiniMax OAuth. (#5402) Thanks @Maosghoul.
 - Discord: resolve PluralKit proxied senders for allowlists and labels. (#5838) Thanks @thewilloftheshadow.
 - Telegram: restore draft streaming partials. (#5543) Thanks @obviyus.

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -16,6 +16,11 @@ function resolveCommand(command: string): string {
     return command;
   }
   const basename = path.basename(command).toLowerCase();
+  // Skip if already has an extension (.cmd, .exe, .bat, etc.)
+  const ext = path.extname(basename);
+  if (ext) {
+    return command;
+  }
   // Common npm-related commands that need .cmd extension on Windows
   const cmdCommands = ["npm", "pnpm", "yarn", "npx"];
   if (cmdCommands.includes(basename)) {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -7,6 +7,23 @@ import { resolveCommandStdio } from "./spawn-utils.js";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Resolves a command for Windows compatibility.
+ * On Windows, non-.exe commands (like npm, pnpm) require their .cmd extension.
+ */
+function resolveCommand(command: string): string {
+  if (process.platform !== "win32") {
+    return command;
+  }
+  const basename = path.basename(command).toLowerCase();
+  // Common npm-related commands that need .cmd extension on Windows
+  const cmdCommands = ["npm", "pnpm", "yarn", "npx"];
+  if (cmdCommands.includes(basename)) {
+    return `${command}.cmd`;
+  }
+  return command;
+}
+
 // Simple promise-wrapped execFile with optional verbosity logging.
 export async function runExec(
   command: string,
@@ -22,7 +39,7 @@ export async function runExec(
           encoding: "utf8" as const,
         };
   try {
-    const { stdout, stderr } = await execFileAsync(command, args, options);
+    const { stdout, stderr } = await execFileAsync(resolveCommand(command), args, options);
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
         logDebug(stdout.trim());
@@ -89,7 +106,7 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const child = spawn(argv[0], argv.slice(1), {
+  const child = spawn(resolveCommand(argv[0]), argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,


### PR DESCRIPTION
## Summary

On Windows, non-.exe commands like `npm`, `pnpm`, `yarn`, `npx` require their `.cmd` extension when using `spawn()`. Without this, Node.js throws `ENOENT`.

This PR adds a `resolveCommand()` helper that automatically appends `.cmd` on Windows for these commands.

## Changes

- Added `resolveCommand()` function in `src/process/exec.ts`
- Applied to both `execFileAsync()` and `spawn()` calls
- No-op on non-Windows platforms

## Testing

- [ ] Tested on Windows
- [x] Tested on Linux (no regression)

Fixes #5773

---

🤖 AI-assisted: Built with OpenClaw (claude-opus-4-5)
The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces a `resolveCommand()` helper in `src/process/exec.ts` to improve Windows compatibility when spawning npm-family CLIs by appending `.cmd` on `win32`, and wires it into both `execFileAsync()` (used by `runExec`) and `spawn()` (used by `runCommandWithTimeout`). The intent is to avoid `spawn()`/`execFile()` `ENOENT` failures on Windows for commands like `npm`/`pnpm` that are typically shimmed as `*.cmd`.

Main concern: the current implementation appends `.cmd` based solely on basename matching, which can produce invalid command strings when the input already includes an extension or is a full path (e.g. `npm.cmd` → `npm.cmd.cmd`, `npm.exe` → `npm.exe.cmd`, or `C:\path\npm.cmd` → `...cmd.cmd`).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but has a Windows-specific edge case that can break command execution.
- The change is small and localized to command resolution, but the current `.cmd` appending logic can produce invalid command names/paths when callers already supply `*.cmd`/`*.exe` or full paths, which is plausible in CI/dev environments on Windows.
- src/process/exec.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->