### PR TITLE
fix: Clawdbot gateway compatibility for Android app

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -105,6 +105,9 @@ dependencies {
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
 
+  // BouncyCastle for Ed25519 (not all Android devices have native support)
+  implementation("org.bouncycastle:bcprov-jdk18on:1.80")
+
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")
   implementation("androidx.camera:camera-camera2:1.5.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -51,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val manualToken: StateFlow<String> = runtime.manualToken
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +103,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setManualToken(value: String) {
+    runtime.setManualToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -1118,11 +1118,11 @@ class NodeRuntime(context: Context) {
     val nodeRaw = nodeSession.currentCanvasHostUrl()?.trim().orEmpty()
     val operatorRaw = operatorSession.currentCanvasHostUrl()?.trim().orEmpty()
     val raw = if (nodeRaw.isNotBlank()) nodeRaw else operatorRaw
-    android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: nodeRaw=$nodeRaw operatorRaw=$operatorRaw raw=$raw")
+    if (BuildConfig.DEBUG) android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: nodeRaw=$nodeRaw operatorRaw=$operatorRaw raw=$raw")
     if (raw.isBlank()) return null
     val base = raw.trimEnd('/')
     val result = "${base}/__clawdbot__/a2ui/?platform=android"
-    android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: result=$result")
+    if (BuildConfig.DEBUG) android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: result=$result")
     return result
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -284,6 +284,7 @@ class NodeRuntime(context: Context) {
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
+  val manualToken: StateFlow<String> = prefs.manualToken
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
 
@@ -428,6 +429,10 @@ class NodeRuntime(context: Context) {
     prefs.setManualTls(value)
   }
 
+  fun setManualToken(value: String) {
+    prefs.setManualToken(value)
+  }
+
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
   }
@@ -529,7 +534,7 @@ class NodeRuntime(context: Context) {
       caps = buildCapabilities(),
       commands = buildInvokeCommands(),
       permissions = emptyMap(),
-      client = buildClientInfo(clientId = "openclaw-android", clientMode = "node"),
+      client = buildClientInfo(clientId = "clawdbot-android", clientMode = "node"),
       userAgent = buildUserAgent(),
     )
   }
@@ -541,14 +546,14 @@ class NodeRuntime(context: Context) {
       caps = emptyList(),
       commands = emptyList(),
       permissions = emptyMap(),
-      client = buildClientInfo(clientId = "openclaw-control-ui", clientMode = "ui"),
+      client = buildClientInfo(clientId = "clawdbot-control-ui", clientMode = "ui"),
       userAgent = buildUserAgent(),
     )
   }
 
   fun refreshGatewayConnection() {
     val endpoint = connectedEndpoint ?: return
-    val token = prefs.loadGatewayToken()
+    val token = prefs.manualToken.value.ifBlank { prefs.loadGatewayToken() }
     val password = prefs.loadGatewayPassword()
     val tls = resolveTlsParams(endpoint)
     operatorSession.connect(endpoint, token, password, buildOperatorConnectOptions(), tls)
@@ -562,7 +567,7 @@ class NodeRuntime(context: Context) {
     operatorStatusText = "Connecting…"
     nodeStatusText = "Connecting…"
     updateStatus()
-    val token = prefs.loadGatewayToken()
+    val token = prefs.manualToken.value.ifBlank { prefs.loadGatewayToken() }
     val password = prefs.loadGatewayPassword()
     val tls = resolveTlsParams(endpoint)
     operatorSession.connect(endpoint, token, password, buildOperatorConnectOptions(), tls)
@@ -1113,9 +1118,12 @@ class NodeRuntime(context: Context) {
     val nodeRaw = nodeSession.currentCanvasHostUrl()?.trim().orEmpty()
     val operatorRaw = operatorSession.currentCanvasHostUrl()?.trim().orEmpty()
     val raw = if (nodeRaw.isNotBlank()) nodeRaw else operatorRaw
+    android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: nodeRaw=$nodeRaw operatorRaw=$operatorRaw raw=$raw")
     if (raw.isBlank()) return null
     val base = raw.trimEnd('/')
-    return "${base}/__openclaw__/a2ui/?platform=android"
+    val result = "${base}/__clawdbot__/a2ui/?platform=android"
+    android.util.Log.d("OpenClawCanvas", "resolveA2uiHostUrl: result=$result")
+    return result
   }
 
   private suspend fun ensureA2uiReady(a2uiUrl: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -71,6 +71,10 @@ class SecurePrefs(context: Context) {
     MutableStateFlow(prefs.getBoolean("gateway.manual.tls", true))
   val manualTls: StateFlow<Boolean> = _manualTls
 
+  private val _manualToken =
+    MutableStateFlow(prefs.getString("gateway.manual.token", "") ?: "")
+  val manualToken: StateFlow<String> = _manualToken
+
   private val _lastDiscoveredStableId =
     MutableStateFlow(
       prefs.getString("gateway.lastDiscoveredStableID", "") ?: "",
@@ -141,6 +145,12 @@ class SecurePrefs(context: Context) {
   fun setManualTls(value: Boolean) {
     prefs.edit { putBoolean("gateway.manual.tls", value) }
     _manualTls.value = value
+  }
+
+  fun setManualToken(value: String) {
+    val trimmed = value.trim()
+    prefs.edit { putString("gateway.manual.token", trimmed) }
+    _manualToken.value = trimmed
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -159,13 +159,20 @@ class DeviceIdentityStore(context: Context) {
 
     private var bcRegistered = false
 
+    /**
+     * Ensures BouncyCastle is registered for Ed25519 support.
+     * Required on Android <13 where native Ed25519 support is missing or incomplete.
+     * Positioned at index 1 to take precedence over potentially broken platform providers.
+     */
     @Synchronized
     private fun ensureBouncyCastle() {
-      if (!bcRegistered) {
+      if (bcRegistered) return
+      val existing = Security.getProvider("BC")
+      if (existing == null || existing !is BouncyCastleProvider) {
         Security.removeProvider("BC")
         Security.insertProviderAt(BouncyCastleProvider(), 1)
-        bcRegistered = true
       }
+      bcRegistered = true
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -6,10 +6,12 @@ import java.io.File
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.MessageDigest
+import java.security.Security
 import java.security.Signature
 import java.security.spec.PKCS8EncodedKeySpec
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 @Serializable
 data class DeviceIdentity(
@@ -22,6 +24,10 @@ data class DeviceIdentity(
 class DeviceIdentityStore(context: Context) {
   private val json = Json { ignoreUnknownKeys = true }
   private val identityFile = File(context.filesDir, "openclaw/identity/device.json")
+
+  init {
+    ensureBouncyCastle()
+  }
 
   @Synchronized
   fun loadOrCreate(): DeviceIdentity {
@@ -44,9 +50,9 @@ class DeviceIdentityStore(context: Context) {
     return try {
       val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
       val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
-      val keyFactory = KeyFactory.getInstance("Ed25519")
+      val keyFactory = KeyFactory.getInstance("Ed25519", "BC")
       val privateKey = keyFactory.generatePrivate(keySpec)
-      val signature = Signature.getInstance("Ed25519")
+      val signature = Signature.getInstance("Ed25519", "BC")
       signature.initSign(privateKey)
       signature.update(payload.toByteArray(Charsets.UTF_8))
       base64UrlEncode(signature.sign())
@@ -97,7 +103,7 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun generate(): DeviceIdentity {
-    val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+    val keyPair = generateEd25519KeyPair()
     val spki = keyPair.public.encoded
     val rawPublic = stripSpkiPrefix(spki)
     val deviceId = sha256Hex(rawPublic)
@@ -108,6 +114,10 @@ class DeviceIdentityStore(context: Context) {
       privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
       createdAtMs = System.currentTimeMillis(),
     )
+  }
+
+  private fun generateEd25519KeyPair(): java.security.KeyPair {
+    return KeyPairGenerator.getInstance("Ed25519", "BC").generateKeyPair()
   }
 
   private fun deriveDeviceId(publicKeyRawBase64: String): String? {
@@ -146,5 +156,16 @@ class DeviceIdentityStore(context: Context) {
       byteArrayOf(
         0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
       )
+
+    private var bcRegistered = false
+
+    @Synchronized
+    private fun ensureBouncyCastle() {
+      if (!bcRegistered) {
+        Security.removeProvider("BC")
+        Security.insertProviderAt(BouncyCastleProvider(), 1)
+        bcRegistered = true
+      }
+    }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.android.gateway
 
+import ai.openclaw.android.BuildConfig
 import android.util.Log
 import java.util.Locale
 import java.util.UUID
@@ -245,7 +246,7 @@ class GatewaySession(
         val tlsConfig = buildGatewayTlsConfig(tls) { fingerprint ->
           onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
         }
-        Log.d(loggerTag, "TLS config: ${if (tlsConfig != null) "custom" else "default"}")
+        if (BuildConfig.DEBUG) Log.d(loggerTag, "TLS config: ${if (tlsConfig != null) "custom" else "default"}")
         if (tlsConfig != null) {
           builder.sslSocketFactory(tlsConfig.sslSocketFactory, tlsConfig.trustManager)
           builder.hostnameVerifier(tlsConfig.hostnameVerifier)
@@ -261,11 +262,11 @@ class GatewaySession(
       override fun onOpen(webSocket: WebSocket, response: Response) {
         scope.launch {
           try {
-            Log.d(loggerTag, "WebSocket opened, awaiting connect nonce...")
+            if (BuildConfig.DEBUG) Log.d(loggerTag, "WebSocket opened, awaiting connect nonce...")
             val nonce = awaitConnectNonce()
-            Log.d(loggerTag, "Got nonce: ${nonce?.take(8)}..., sending connect...")
+            if (BuildConfig.DEBUG) Log.d(loggerTag, "Got nonce: ${nonce?.take(8)}..., sending connect...")
             sendConnect(nonce)
-            Log.d(loggerTag, "Connect sent successfully")
+            if (BuildConfig.DEBUG) Log.d(loggerTag, "Connect sent successfully")
           } catch (err: Throwable) {
             Log.e(loggerTag, "Connect failed: ${err.message}", err)
             connectDeferred.completeExceptionally(err)
@@ -302,19 +303,19 @@ class GatewaySession(
     }
 
     private suspend fun sendConnect(connectNonce: String?) {
-      Log.d(loggerTag, "Loading identity...")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Loading identity...")
       val identity = identityStore.loadOrCreate()
-      Log.d(loggerTag, "Identity loaded: ${identity.deviceId.take(8)}...")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Identity loaded: ${identity.deviceId.take(8)}...")
       val storedToken = deviceAuthStore.loadToken(identity.deviceId, options.role)
       val trimmedToken = token?.trim().orEmpty()
       val authToken = if (storedToken.isNullOrBlank()) trimmedToken else storedToken
-      Log.d(loggerTag, "Auth token present: ${authToken.isNotEmpty()}")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Auth token present: ${authToken.isNotEmpty()}")
       val canFallbackToShared = !storedToken.isNullOrBlank() && trimmedToken.isNotBlank()
-      Log.d(loggerTag, "Building connect params...")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Building connect params...")
       val payload = buildConnectParams(identity, connectNonce, authToken, password?.trim())
-      Log.d(loggerTag, "Sending connect request...")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Sending connect request...")
       val res = request("connect", payload, timeoutMs = 8_000)
-      Log.d(loggerTag, "Connect response: ok=${res.ok}")
+      if (BuildConfig.DEBUG) Log.d(loggerTag, "Connect response: ok=${res.ok}")
       if (!res.ok) {
         val msg = res.error?.message ?: "connect failed"
         if (canFallbackToShared) {
@@ -635,31 +636,41 @@ class GatewaySession(
     val port = parsed?.port ?: -1
     val scheme = parsed?.scheme?.trim().orEmpty().ifBlank { "http" }
 
-    Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: raw=$raw host=$host isLoopback=${isLoopbackHost(host)} endpoint.host=${endpoint.host}")
+    if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: raw=$raw host=$host isLoopback=${isLoopbackHost(host)} endpoint.host=${endpoint.host}")
+
+    // Handle schemeless .ts.net hostnames (URI treats them as paths, leaving host empty)
+    if (host.isBlank() && trimmed.contains(".ts.net", ignoreCase = true)) {
+      val hostPart = trimmed.substringBefore(":").substringBefore("/")
+      if (hostPart.endsWith(".ts.net", ignoreCase = true)) {
+        val result = "https://$hostPart"
+        if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: schemeless .ts.net detected, using=$result")
+        return result
+      }
+    }
 
     // If it's a Tailscale hostname, use HTTPS on port 443 (strip any other port)
     if (host.endsWith(".ts.net", ignoreCase = true)) {
       val result = "https://$host"
-      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net in raw URL, using=$result")
+      if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net in raw URL, using=$result")
       return result
     }
 
     if (trimmed.isNotBlank() && !isLoopbackHost(host)) {
-      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: returning trimmed=$trimmed")
+      if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: returning trimmed=$trimmed")
       return trimmed
     }
 
     // Prefer tailnet DNS (uses HTTPS on port 443 via Tailscale serve)
     val tailnetHost = endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
     if (tailnetHost != null) {
-      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: using tailnetDns=$tailnetHost")
+      if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: using tailnetDns=$tailnetHost")
       return "https://$tailnetHost"
     }
 
     // Check if the endpoint host is a Tailscale DNS name (uses port 443)
     val endpointHost = endpoint.host.trim()
     if (endpointHost.endsWith(".ts.net", ignoreCase = true)) {
-      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net host=$endpointHost")
+      if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net host=$endpointHost")
       return "https://$endpointHost"
     }
 
@@ -671,7 +682,7 @@ class GatewaySession(
     val fallbackPort = endpoint.canvasPort ?: if (port > 0) port else 18793
     val formattedHost = if (fallbackHost.contains(":")) "[${fallbackHost}]" else fallbackHost
     val result = "$scheme://$formattedHost:$fallbackPort"
-    Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: fallback result=$result")
+    if (BuildConfig.DEBUG) Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: fallback result=$result")
     return result
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -241,12 +241,18 @@ class GatewaySession(
 
     private fun buildClient(): OkHttpClient {
       val builder = OkHttpClient.Builder()
-      val tlsConfig = buildGatewayTlsConfig(tls) { fingerprint ->
-        onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
-      }
-      if (tlsConfig != null) {
-        builder.sslSocketFactory(tlsConfig.sslSocketFactory, tlsConfig.trustManager)
-        builder.hostnameVerifier(tlsConfig.hostnameVerifier)
+      try {
+        val tlsConfig = buildGatewayTlsConfig(tls) { fingerprint ->
+          onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
+        }
+        Log.d(loggerTag, "TLS config: ${if (tlsConfig != null) "custom" else "default"}")
+        if (tlsConfig != null) {
+          builder.sslSocketFactory(tlsConfig.sslSocketFactory, tlsConfig.trustManager)
+          builder.hostnameVerifier(tlsConfig.hostnameVerifier)
+        }
+      } catch (err: Throwable) {
+        Log.e(loggerTag, "Failed to build TLS config: ${err.message}", err)
+        throw err
       }
       return builder.build()
     }
@@ -255,9 +261,13 @@ class GatewaySession(
       override fun onOpen(webSocket: WebSocket, response: Response) {
         scope.launch {
           try {
+            Log.d(loggerTag, "WebSocket opened, awaiting connect nonce...")
             val nonce = awaitConnectNonce()
+            Log.d(loggerTag, "Got nonce: ${nonce?.take(8)}..., sending connect...")
             sendConnect(nonce)
+            Log.d(loggerTag, "Connect sent successfully")
           } catch (err: Throwable) {
+            Log.e(loggerTag, "Connect failed: ${err.message}", err)
             connectDeferred.completeExceptionally(err)
             closeQuietly()
           }
@@ -292,13 +302,19 @@ class GatewaySession(
     }
 
     private suspend fun sendConnect(connectNonce: String?) {
+      Log.d(loggerTag, "Loading identity...")
       val identity = identityStore.loadOrCreate()
+      Log.d(loggerTag, "Identity loaded: ${identity.deviceId.take(8)}...")
       val storedToken = deviceAuthStore.loadToken(identity.deviceId, options.role)
       val trimmedToken = token?.trim().orEmpty()
       val authToken = if (storedToken.isNullOrBlank()) trimmedToken else storedToken
+      Log.d(loggerTag, "Auth token present: ${authToken.isNotEmpty()}")
       val canFallbackToShared = !storedToken.isNullOrBlank() && trimmedToken.isNotBlank()
+      Log.d(loggerTag, "Building connect params...")
       val payload = buildConnectParams(identity, connectNonce, authToken, password?.trim())
+      Log.d(loggerTag, "Sending connect request...")
       val res = request("connect", payload, timeoutMs = 8_000)
+      Log.d(loggerTag, "Connect response: ok=${res.ok}")
       if (!res.ok) {
         val msg = res.error?.message ?: "connect failed"
         if (canFallbackToShared) {
@@ -619,19 +635,44 @@ class GatewaySession(
     val port = parsed?.port ?: -1
     val scheme = parsed?.scheme?.trim().orEmpty().ifBlank { "http" }
 
+    Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: raw=$raw host=$host isLoopback=${isLoopbackHost(host)} endpoint.host=${endpoint.host}")
+
+    // If it's a Tailscale hostname, use HTTPS on port 443 (strip any other port)
+    if (host.endsWith(".ts.net", ignoreCase = true)) {
+      val result = "https://$host"
+      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net in raw URL, using=$result")
+      return result
+    }
+
     if (trimmed.isNotBlank() && !isLoopbackHost(host)) {
+      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: returning trimmed=$trimmed")
       return trimmed
     }
 
+    // Prefer tailnet DNS (uses HTTPS on port 443 via Tailscale serve)
+    val tailnetHost = endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
+    if (tailnetHost != null) {
+      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: using tailnetDns=$tailnetHost")
+      return "https://$tailnetHost"
+    }
+
+    // Check if the endpoint host is a Tailscale DNS name (uses port 443)
+    val endpointHost = endpoint.host.trim()
+    if (endpointHost.endsWith(".ts.net", ignoreCase = true)) {
+      Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: detected .ts.net host=$endpointHost")
+      return "https://$endpointHost"
+    }
+
     val fallbackHost =
-      endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.host.trim()
+      endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
+        ?: endpointHost
     if (fallbackHost.isEmpty()) return trimmed.ifBlank { null }
 
     val fallbackPort = endpoint.canvasPort ?: if (port > 0) port else 18793
     val formattedHost = if (fallbackHost.contains(":")) "[${fallbackHost}]" else fallbackHost
-    return "$scheme://$formattedHost:$fallbackPort"
+    val result = "$scheme://$formattedHost:$fallbackPort"
+    Log.d("OpenClawCanvas", "normalizeCanvasHostUrl: fallback result=$result")
+    return result
   }
 
   private fun isLoopbackHost(raw: String?): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -82,6 +82,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val manualToken by viewModel.manualToken.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
   val serverName by viewModel.serverName.collectAsState()
@@ -402,6 +403,14 @@ fun SettingsSheet(viewModel: MainViewModel) {
             label = { Text("Port") },
             modifier = Modifier.fillMaxWidth(),
             enabled = manualEnabled,
+          )
+          OutlinedTextField(
+            value = manualToken,
+            onValueChange = viewModel::setManualToken,
+            label = { Text("Token") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = manualEnabled,
+            singleLine = true,
           )
           ListItem(
             headlineContent = { Text("Require TLS") },


### PR DESCRIPTION
Fixes several compatibility issues when connecting the OpenClaw Android app to a Clawdbot gateway instance.

## Changes

### 1. Use BouncyCastle for Ed25519 cryptography
Android's native JCA providers don't reliably support Ed25519 across all devices. Tested on Pixel 9 Pro Fold (Android 16) where native provider threw "Not initialized" errors from `AndroidKeyStoreKeyPairGeneratorSpi`. BouncyCastle provides consistent cross-device support.

### 2. Update client IDs for Clawdbot
- `openclaw-android` → `clawdbot-android`
- `openclaw-control-ui` → `clawdbot-control-ui`

### 3. Update canvas/A2UI path
- `/__openclaw__/a2ui/` → `/__clawdbot__/a2ui/`

### 4. Fix Tailscale serve compatibility
Strip explicit port from `.ts.net` hostnames since Tailscale serve proxies on port 443.

## Notes
- BouncyCastle adds ~2MB to APK size
- Client IDs and paths could potentially be made configurable via build flavours in a future PR

## Testing
Tested on Pixel 9 Pro Fold (Android 16):
- ✅ Node connection
- ✅ Operator connection  
- ✅ Chat
- ✅ Canvas/A2UI

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Android client’s gateway compatibility by (1) switching Ed25519 keygen/signing to BouncyCastle for consistent support across devices, (2) renaming Android/control-ui client IDs to their Clawdbot equivalents, (3) updating the A2UI path under the canvas host, and (4) adjusting canvas host normalization to better support Tailscale Serve (`.ts.net` → HTTPS on 443).

The changes are primarily in the Android gateway/session and identity code paths: `DeviceIdentityStore` now ensures a BC provider is registered and uses it for Ed25519 operations, while `GatewaySession` tweaks canvas host URL handling and adds more connection/TLS debug logs. The UI/prefs additions expose a manual token override for gateway connections and thread it through `NodeRuntime` → `GatewaySession` connect.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a couple of edge-case correctness and privacy concerns worth addressing.
- Core changes are straightforward and localized, but the `.ts.net` URL normalization can fail for schemeless advertised URLs, and additional logcat logging may leak sensitive connection details. The global JCA provider reordering could also impact other crypto consumers in-process.
- apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt; apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt; apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->