### PR TITLE
fix(gateway): add timeout to readJsonBody to prevent Slowloris DoS

### DIFF
--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -84,7 +84,6 @@ export async function readJsonBody(
     const timeout = setTimeout(() => {
       if (done) return;
       done = true;
-      clearTimeout(timeout);
       req.destroy();
       resolve({ ok: false, error: "body read timeout" });
     }, timeoutMs);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -74,11 +74,21 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
 export async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
+  timeoutMs = 30000,
 ): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
   return await new Promise((resolve) => {
     let done = false;
     let total = 0;
     const chunks: Buffer[] = [];
+
+    const timeout = setTimeout(() => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      req.destroy();
+      resolve({ ok: false, error: "body read timeout" });
+    }, timeoutMs);
+
     req.on("data", (chunk: Buffer) => {
       if (done) {
         return;
@@ -86,6 +96,7 @@ export async function readJsonBody(
       total += chunk.length;
       if (total > maxBytes) {
         done = true;
+        clearTimeout(timeout);
         resolve({ ok: false, error: "payload too large" });
         req.destroy();
         return;
@@ -97,6 +108,7 @@ export async function readJsonBody(
         return;
       }
       done = true;
+      clearTimeout(timeout);
       const raw = Buffer.concat(chunks).toString("utf-8").trim();
       if (!raw) {
         resolve({ ok: true, value: {} });
@@ -114,7 +126,14 @@ export async function readJsonBody(
         return;
       }
       done = true;
+      clearTimeout(timeout);
       resolve({ ok: false, error: String(err) });
+    });
+    req.on("close", () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      resolve({ ok: false, error: "client disconnected" });
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #5122

Add a configurable timeout (default 30s) to `readJsonBody()` to prevent Slowloris denial-of-service attacks. While the function already has a size limit (256KB), an attacker could send data extremely slowly (e.g., 1 byte/minute) to hold connections indefinitely.

## Changes

- Add optional `timeoutMs` parameter to `readJsonBody()` (default: 30000ms)
- Add `close` event handler for proper cleanup on client disconnection
- Properly cleanup timeout on all exit paths (end, error, size limit, timeout, close)

## Security Issue

- **CWE**: CWE-400 (Uncontrolled Resource Consumption)
- **Impact**: Without timeout, attackers can exhaust server connections via Slowloris attack

## Test Plan

- [x] Existing tests pass (`pnpm test src/gateway/hooks.test.ts`)
- [x] Format check passes (`pnpm format`)
- [x] Backward compatible - new `timeoutMs` parameter has default value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a configurable timeout (default 30s) to `readJsonBody()` in `src/gateway/hooks.ts` to mitigate Slowloris-style slow request bodies holding connections open indefinitely. The implementation sets a timer that destroys the request and resolves with an error on expiry, and clears the timer on other termination paths (payload too large, end, error, close).

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and improves resilience against slow-body attacks.
- Change is small and localized, and the timeout/clearTimeout paths look consistent. Main remaining concerns are minor cleanup/clarity issues around event listener removal and a redundant clearTimeout inside the timer callback.
- src/gateway/hooks.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->