### PR TITLE
Fix: Twilio can send signatures that are calculated without the port in the url

### DIFF
--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -200,7 +200,12 @@ export function verifyTwilioWebhook(
     // checks for is whether the signature matches when omitting the port from the URL.  We'll do the same
     // hack here.
     // Try again with the URL without the port
-    isValid = validateTwilioSignature(authToken, signature, verificationUrl.replace(/:\d+$/, ""), params);
+    isValid = validateTwilioSignature(
+      authToken,
+      signature,
+      verificationUrl.replace(/:\d+$/, ""),
+      params,
+    );
   }
 
   if (isValid) {

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -199,11 +199,13 @@ export function verifyTwilioWebhook(
     // backend that is not compatible with the new signature algorithm.  One of the things their library
     // checks for is whether the signature matches when omitting the port from the URL.  We'll do the same
     // hack here.
-    // Try again with the URL without the port
+    // Try again with the URL without the authority port (path/query preserved)
+    const urlWithoutPort = new URL(verificationUrl);
+    urlWithoutPort.port = "";
     isValid = validateTwilioSignature(
       authToken,
       signature,
-      verificationUrl.replace(/:\d+$/, ""),
+      urlWithoutPort.toString(),
       params,
     );
   }

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -194,23 +194,10 @@ export function verifyTwilioWebhook(
 
   const urlObject = new URL(verificationUrl);
 
-  const isValidSignatureWithoutPort = validateTwilioSignature(
-    authToken,
-    signature,
-    removePort(urlObject),
-    params,
-  );
-  if (isValidSignatureWithoutPort) {
-    return { ok: true, verificationUrl };
-  }
-
-  const isValidSignatureWithPort = validateTwilioSignature(
-    authToken,
-    signature,
-    verificationUrl,
-    params,
-  );
-  if (isValidSignatureWithPort) {
+  if (
+    validateTwilioSignature(authToken, signature, removePort(urlObject), params) ||
+    validateTwilioSignature(authToken, signature, verificationUrl, params)
+  ) {
     return { ok: true, verificationUrl };
   }
 

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -202,12 +202,7 @@ export function verifyTwilioWebhook(
     // Try again with the URL without the authority port (path/query preserved)
     const urlWithoutPort = new URL(verificationUrl);
     urlWithoutPort.port = "";
-    isValid = validateTwilioSignature(
-      authToken,
-      signature,
-      urlWithoutPort.toString(),
-      params,
-    );
+    isValid = validateTwilioSignature(authToken, signature, urlWithoutPort.toString(), params);
   }
 
   if (isValid) {


### PR DESCRIPTION
Their library accepts signatures for either case.  This fixes a situation where we include a port in our Twilio webhook and calculate the signature with that port (correctly) while Twilio sends a signature that was generated without the port (legacy signature)"
[main 1feb38a9f] fix: Twilio can send a signature that uses the URL with or without the port included.  Their library accepts signatures for either case.  This fixes a situation where we include a port in our Twilio webhook and calculate the signature with that port (correctly) while Twilio sends a signature that was generated without the port (legacy signature)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Twilio webhook signature verification to accept both “port-included” and “port-omitted” URL variants (matching Twilio’s legacy behavior) by attempting signature validation with a port-stripped URL as well as the original reconstructed URL. It also includes a minor workflow formatting change in the formal conformance GitHub Action (node-version quoting).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but has one edge-case that can crash verification when `publicUrl` is not an absolute URL.
- The main behavior change is localized to Twilio webhook verification and aligns with intended compatibility; however, the new unconditional `new URL(verificationUrl)` introduces a throwing path if `options.publicUrl` is invalid/relative, which can turn a verification failure into a server error. No other high-risk changes were found.
- extensions/voice-call/src/webhook-security.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->