### PR TITLE
feat(tools): add proxy support for web_fetch tool

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -58,7 +58,9 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
 }
 
 function buildTimeSection(params: { userTimezone?: string }) {
-  if (!params.userTimezone) return [];
+  if (!params.userTimezone) {
+    return [];
+  }
   return [
     "## Current Date & Time",
     `Time zone: ${params.userTimezone}`,

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,4 +1,5 @@
 import type { Dispatcher } from "undici";
+import { ProxyAgent } from "undici";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
@@ -99,6 +100,12 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   return true;
 }
 
+function resolveFetchProxy(fetch?: WebFetchConfig): string | undefined {
+  if (!fetch || typeof fetch !== "object") return undefined;
+  const proxy = "proxy" in fetch && typeof fetch.proxy === "string" ? fetch.proxy.trim() : "";
+  return proxy || undefined;
+}
+
 function resolveFirecrawlConfig(fetch?: WebFetchConfig): FirecrawlFetchConfig {
   if (!fetch || typeof fetch !== "object") {
     return undefined;
@@ -192,25 +199,37 @@ async function fetchWithRedirects(params: {
   maxRedirects: number;
   timeoutSeconds: number;
   userAgent: string;
+  proxy?: string;
 }): Promise<{ response: Response; finalUrl: string; dispatcher: Dispatcher }> {
   const signal = withTimeout(undefined, params.timeoutSeconds * 1000);
   const visited = new Set<string>();
   let currentUrl = params.url;
   let redirectCount = 0;
 
+  // Create proxy dispatcher if configured
+  const proxyDispatcher = params.proxy ? new ProxyAgent(params.proxy) : null;
+
   while (true) {
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(currentUrl);
     } catch {
+      if (proxyDispatcher) await closeDispatcher(proxyDispatcher);
       throw new Error("Invalid URL: must be http or https");
     }
     if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      if (proxyDispatcher) await closeDispatcher(proxyDispatcher);
       throw new Error("Invalid URL: must be http or https");
     }
 
-    const pinned = await resolvePinnedHostname(parsedUrl.hostname);
-    const dispatcher = createPinnedDispatcher(pinned);
+    // Use proxy dispatcher if available, otherwise use pinned dispatcher for SSRF protection
+    let dispatcher: Dispatcher;
+    if (proxyDispatcher) {
+      dispatcher = proxyDispatcher;
+    } else {
+      const pinned = await resolvePinnedHostname(parsedUrl.hostname);
+      dispatcher = createPinnedDispatcher(pinned);
+    }
     let res: Response;
     try {
       res = await fetch(parsedUrl.toString(), {
@@ -225,29 +244,35 @@ async function fetchWithRedirects(params: {
         dispatcher,
       } as RequestInit);
     } catch (err) {
-      await closeDispatcher(dispatcher);
+      // Only close non-proxy dispatchers on error; proxy dispatcher is reused
+      if (!proxyDispatcher) await closeDispatcher(dispatcher);
+      else await closeDispatcher(proxyDispatcher);
       throw err;
     }
 
     if (isRedirectStatus(res.status)) {
       const location = res.headers.get("location");
       if (!location) {
-        await closeDispatcher(dispatcher);
+        if (!proxyDispatcher) await closeDispatcher(dispatcher);
+        else await closeDispatcher(proxyDispatcher);
         throw new Error(`Redirect missing location header (${res.status})`);
       }
       redirectCount += 1;
       if (redirectCount > params.maxRedirects) {
-        await closeDispatcher(dispatcher);
+        if (!proxyDispatcher) await closeDispatcher(dispatcher);
+        else await closeDispatcher(proxyDispatcher);
         throw new Error(`Too many redirects (limit: ${params.maxRedirects})`);
       }
       const nextUrl = new URL(location, parsedUrl).toString();
       if (visited.has(nextUrl)) {
-        await closeDispatcher(dispatcher);
+        if (!proxyDispatcher) await closeDispatcher(dispatcher);
+        else await closeDispatcher(proxyDispatcher);
         throw new Error("Redirect loop detected");
       }
       visited.add(nextUrl);
       void res.body?.cancel();
-      await closeDispatcher(dispatcher);
+      // Only close pinned dispatcher on redirect; proxy dispatcher is reused
+      if (!proxyDispatcher) await closeDispatcher(dispatcher);
       currentUrl = nextUrl;
       continue;
     }
@@ -359,6 +384,7 @@ async function runWebFetch(params: {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  proxy?: string;
   firecrawlEnabled: boolean;
   firecrawlApiKey?: string;
   firecrawlBaseUrl: string;
@@ -396,6 +422,7 @@ async function runWebFetch(params: {
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
       userAgent: params.userAgent,
+      proxy: params.proxy,
     });
     res = result.response;
     finalUrl = result.finalUrl;
@@ -605,6 +632,7 @@ export function createWebFetchTool(options?: {
     return null;
   }
   const readabilityEnabled = resolveFetchReadabilityEnabled(fetch);
+  const proxy = resolveFetchProxy(fetch);
   const firecrawl = resolveFirecrawlConfig(fetch);
   const firecrawlApiKey = resolveFirecrawlApiKey(firecrawl);
   const firecrawlEnabled = resolveFirecrawlEnabled({ firecrawl, apiKey: firecrawlApiKey });
@@ -638,6 +666,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        proxy,
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -199,6 +199,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.proxy": "Web Fetch Proxy",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
@@ -456,6 +457,7 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+  "tools.web.fetch.proxy": "HTTP proxy URL for web_fetch requests (e.g. http://127.0.0.1:7890).",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
   "tools.web.fetch.firecrawl.baseUrl":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -371,6 +371,8 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** HTTP proxy URL for fetch requests (e.g. http://127.0.0.1:7890). */
+      proxy?: string;
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -195,6 +195,7 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    proxy: z.string().optional(),
   })
   .strict()
   .optional();

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -221,7 +221,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));
-    if (parentPeerMatch) return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    if (parentPeerMatch) {
+      return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    }
   }
 
   if (guildId) {


### PR DESCRIPTION
Add HTTP proxy configuration option for the web_fetch tool, allowing requests to be routed through a proxy server.

Configuration example:
  tools.web.fetch.proxy: "http://127.0.0.1:7890"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `tools.web.fetch.proxy` config option and wires it through `createWebFetchTool()` into the fetch path, using undici’s `ProxyAgent` so `web_fetch` requests can be routed via an HTTP proxy. It also updates the config UI hints/types/runtime zod schema and adds tests intended to cover the new proxy behavior.

The main concern is that the implementation switches from the existing pinned-dispatcher SSRF protection to a raw proxy dispatcher when proxy is enabled, which changes the security model of `web_fetch` in a way that can allow fetching internal resources if the proxy can reach them. Additionally, the proxy agent lifecycle/closing behavior looks inconsistent with the “reused” intent, and the new tests don’t currently validate that proxy mode is actually being exercised.

<h3>Confidence Score: 2/5</h3>

- This PR has meaningful security/behavioral risk due to proxy mode bypassing SSRF protections and should not merge as-is.
- While the config plumbing is straightforward, enabling proxy currently skips the pinned-dispatcher SSRF defense, which is a significant behavioral change in a security-sensitive tool. There’s also likely confusion around ProxyAgent lifecycle (closed in finally despite comments about reuse), and the added tests don’t strongly validate proxy behavior, increasing the chance of regressions going unnoticed.
- src/agents/tools/web-fetch.ts (proxy vs SSRF behavior; dispatcher lifecycle); src/agents/tools/web-tools.fetch.test.ts (strengthen assertions)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->