### PR TITLE
fix(line): add timeout and size limit to readRequestBody to prevent DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Line: add timeout and size limit to readRequestBody to prevent DoS (CWE-400). (#5834) Thanks @hclsys.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -96,14 +96,18 @@ async function readRequestBody(
     const chunks: Buffer[] = [];
 
     const timeout = setTimeout(() => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       req.destroy();
       reject(new Error("Request body read timeout"));
     }, timeoutMs);
 
     req.on("data", (chunk: Buffer) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       totalSize += chunk.length;
       if (totalSize > maxSizeBytes) {
         done = true;
@@ -116,21 +120,27 @@ async function readRequestBody(
     });
 
     req.on("end", () => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timeout);
       resolve(Buffer.concat(chunks).toString("utf-8"));
     });
 
     req.on("error", (err) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timeout);
       reject(err);
     });
 
     req.on("close", () => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timeout);
       reject(new Error("Client disconnected"));


### PR DESCRIPTION
## Summary

Fixes #5125 - LINE monitor `readRequestBody()` has no timeout or size limit (CWE-400: Uncontrolled Resource Consumption)

- Add 30-second timeout with `setTimeout`/`clearTimeout` pattern
- Add 1MB size limit to prevent memory exhaustion
- Add `done` flag to prevent race conditions between event handlers
- Add `close` event handler for client disconnect detection
- Call `req.destroy()` to terminate malicious connections

## Attack Vectors Mitigated

1. **Slowloris DoS**: Attacker sends data very slowly to hold connections indefinitely
2. **Memory Exhaustion**: Attacker sends oversized request body to cause OOM

## Implementation Pattern

Follows the same pattern as `readJsonBody()` in `src/gateway/hooks.ts:74-139` which was already correctly implemented.

## Test Plan

- [ ] Existing LINE webhook tests pass
- [ ] Manual test: Send normal webhook request (should work)
- [ ] Manual test: Slow connection times out after 30s
- [ ] Manual test: Large body (>1MB) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the LINE webhook request-body reader by adding a 30s timeout, a 1MB maximum size, and extra safeguards (`done` flag + `close` handling) to prevent slowloris-style hangs and memory exhaustion.

The change is localized to `src/line/monitor.ts` and affects how the webhook handler reads the raw request body before validating the LINE signature and parsing JSON.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and improves DoS resilience, with minor behavioral edge cases to consider.
- The change is small and well-scoped, adds clear resource limits, and uses guarded event handlers to avoid double-resolve/reject. Remaining concerns are mostly about semantics (absolute vs inactivity timeout) and returning more appropriate HTTP status codes for body-read failures.
- src/line/monitor.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->