### PR TITLE
fix(gateway): add timeout to GatewayClient.request() to prevent resource leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: add timeout to GatewayClient.request() to prevent resource leak (CWE-400). (#5835) Thanks @hclsys.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -441,6 +441,7 @@ export class GatewayClient {
         this.pending.delete(id);
         reject(new Error(`Gateway request timeout for ${method}`));
       }, timeoutMs);
+      timeout.unref();
 
       this.pending.set(id, {
         resolve: (value) => {


### PR DESCRIPTION
## Summary

Fixes #4954 - `GatewayClient.request()` has no timeout (CWE-400: Uncontrolled Resource Consumption)

- Add 30-second default timeout with `setTimeout`/`clearTimeout` pattern
- Add optional `timeoutMs` parameter for caller customization
- Wrap `ws.send()` in try/catch to handle race condition (socket closes between readyState check and send)
- Clear timeout and pending map entry on all exit paths

## Attack Vector Mitigated

Without timeout, if the gateway never responds, the Promise hangs forever, accumulating pending requests and eventually exhausting memory.

## Implementation Pattern

References the correct implementation in `src/imessage/client.ts:127-163` as mentioned in the issue.

## Race Condition Fix

The `ws.send()` can fail even after `readyState === OPEN` check due to timing. Without try/catch:
1. Timeout and pending entry are created
2. `ws.send()` throws
3. Caller gets exception but timeout is still running
4. Timeout fires later causing unhandled rejection + pending map leak

With try/catch: cleanup happens immediately on send failure.

## Test Plan

- [ ] Existing gateway tests pass
- [ ] Manual test: Normal requests work with default timeout
- [ ] Manual test: Request with custom `timeoutMs` respects the value
- [ ] Manual test: Timeout error message includes method name for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `GatewayClient.request()` (`src/gateway/client.ts`) to add a default 30s timeout and a caller-configurable `timeoutMs`, and ensures pending requests/timeouts are cleaned up on resolution, rejection, and `ws.send()` failures. This addresses the reported resource-leak behavior where requests could hang indefinitely and accumulate in the `pending` map.

The change fits the existing client design by keeping per-request state in `pending` and enforcing completion via a timer, similar to patterns used elsewhere in the repo.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully reduces the risk of hung gateway requests leaking memory.
- The timeout/cleanup logic is straightforward and localized to `GatewayClient.request()`. Main remaining concerns are runtime semantics (Node timers keeping the event loop alive via referenced timeouts) and edge-case `timeoutMs` inputs, which are easy to adjust if desired.
- src/gateway/client.ts (timer lifecycle / unref behavior, timeoutMs edge cases)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->