### PR TITLE
fix(memory): handle negative BM25 scores from SQLite FTS5

### DIFF
--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -34,8 +34,15 @@ export function buildFtsQuery(raw: string): string | null {
 }
 
 export function bm25RankToScore(rank: number): number {
-  const normalized = Number.isFinite(rank) ? Math.max(0, rank) : 999;
-  return 1 / (1 + normalized);
+  // SQLite FTS5 bm25() returns negative values; more negative = more relevant
+  if (!Number.isFinite(rank)) {
+    return 0;
+  }
+  // Negate to get positive value (more negative → larger positive)
+  // Clamp to handle any unexpected positive inputs
+  const positive = Math.max(0, -rank);
+  // Normalize to 0-1 where higher positive → higher score
+  return positive / (1 + positive);
 }
 
 export function mergeHybridResults(params: {


### PR DESCRIPTION
## Summary

Fixes #5767

SQLite FTS5's `bm25()` function returns **negative** values where more negative = more relevant. The previous implementation clamped all negative values to zero via `Math.max(0, rank)`, causing every keyword match to receive the same normalized score of `1.0`.

## The Bug

```typescript
// Before
export function bm25RankToScore(rank: number): number {
  const normalized = Number.isFinite(rank) ? Math.max(0, rank) : 999;
  return 1 / (1 + normalized);
}

bm25RankToScore(-4.2)  // => 1.0
bm25RankToScore(-2.1)  // => 1.0  
bm25RankToScore(-0.5)  // => 1.0  (all the same!)
```

## The Fix

```typescript
// After
export function bm25RankToScore(rank: number): number {
  if (!Number.isFinite(rank)) {
    return 0;
  }
  const positive = Math.max(0, -rank);
  return positive / (1 + positive);
}

bm25RankToScore(-4.2)  // => 0.81 (best match)
bm25RankToScore(-2.1)  // => 0.68
bm25RankToScore(-0.5)  // => 0.33 (weakest match)
```

## Changes

- **`hybrid.ts`**: Fixed `bm25RankToScore` to negate the rank and use `x/(1+x)` normalization
- **`hybrid.test.ts`**: Updated tests to verify correct BM25 behavior with negative scores

## Testing

- [x] All 43 memory tests pass
- [x] Lint and format checks pass on changed files

## AI Disclosure

🤖 This PR was developed with AI assistance (Claude/OpenClaw). The fix was analyzed, implemented, and tested collaboratively. We understand what the code does and why it fixes the issue.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `bm25RankToScore` in `src/memory/hybrid.ts` to account for SQLite FTS5’s negative `bm25()` values by negating the rank and normalizing with `x/(1+x)` so that more relevant (more negative) ranks produce higher scores. Tests in `src/memory/hybrid.test.ts` are updated accordingly to assert monotonic behavior across negative ranks and to define behavior for non-finite and positive inputs.

Overall, the change fits cleanly into the hybrid retrieval pipeline by restoring meaningful keyword score differentiation before weighted merging in `mergeHybridResults`.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should improve keyword ranking behavior for SQLite FTS5 results.
- The core change is small and well-covered by updated unit tests; the main remaining concern is the intentionality of changing non-finite rank handling from a tiny non-zero score to zero, which could affect edge-case ordering if upstream ever produces NaN/Infinity.
- src/memory/hybrid.ts (non-finite rank fallback semantics)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->