### PR TITLE
docs: fix stale clawdbot references after OpenClaw rebrand

### DIFF
--- a/.agent/workflows/update_openclaw.md
+++ b/.agent/workflows/update_openclaw.md
@@ -1,8 +1,8 @@
 ---
-description: Update Clawdbot from upstream when branch has diverged (ahead/behind)
+description: Update OpenClaw from upstream when branch has diverged (ahead/behind)
 ---
 
-# Clawdbot Upstream Sync Workflow
+# OpenClaw Upstream Sync Workflow
 
 Use this workflow when your fork has diverged from upstream (e.g., "18 commits ahead, 29 commits behind").
 
@@ -113,7 +113,7 @@ pnpm build
 pnpm ui:build
 
 # Run diagnostics
-pnpm clawdbot doctor
+pnpm openclaw doctor
 ```
 
 ---
@@ -132,16 +132,16 @@ pnpm mac:package
 
 ```bash
 # Kill running app
-pkill -x "Clawdbot" || true
+pkill -x "OpenClaw" || true
 
 # Move old version
-mv /Applications/Clawdbot.app /tmp/Clawdbot-backup.app
+mv /Applications/OpenClaw.app /tmp/OpenClaw-backup.app
 
 # Install new build
-cp -R dist/Clawdbot.app /Applications/
+cp -R dist/OpenClaw.app /Applications/
 
 # Launch
-open /Applications/Clawdbot.app
+open /Applications/OpenClaw.app
 ```
 
 ---
@@ -152,13 +152,13 @@ After rebuilding the macOS app, always verify it works correctly:
 
 ```bash
 # Check gateway health
-pnpm clawdbot health
+pnpm openclaw health
 
 # Verify no zombie processes
-ps aux | grep -E "(clawdbot|gateway)" | grep -v grep
+ps aux | grep -E "(openclaw|gateway)" | grep -v grep
 
 # Test agent functionality by sending a verification message
-pnpm clawdbot agent --message "Verification: macOS app rebuild successful - agent is responding." --session-id YOUR_TELEGRAM_SESSION_ID
+pnpm openclaw agent --message "Verification: macOS app rebuild successful - agent is responding." --session-id YOUR_TELEGRAM_SESSION_ID
 
 # Confirm the message was received on Telegram
 # (Check your Telegram chat with the bot)
@@ -176,8 +176,8 @@ Upstream updates may introduce Swift 6.2 / macOS 26 SDK incompatibilities. Use a
 
 ```bash
 # Gather context with parallel agents
-morph-mcp_warpgrep_codebase_search search_string="Find deprecated FileManager.default and Thread.isMainThread usages in Swift files" repo_path="/Volumes/Main SSD/Developer/clawdis"
-morph-mcp_warpgrep_codebase_search search_string="Locate Peekaboo submodule and macOS app Swift files with concurrency issues" repo_path="/Volumes/Main SSD/Developer/clawdis"
+morph-mcp_warpgrep_codebase_search search_string="Find deprecated FileManager.default and Thread.isMainThread usages in Swift files" repo_path="<your-openclaw-repo-path>"
+morph-mcp_warpgrep_codebase_search search_string="Locate Peekaboo submodule and macOS app Swift files with concurrency issues" repo_path="<your-openclaw-repo-path>"
 ```
 
 ### Common Swift 6.2 Fixes
@@ -212,7 +212,7 @@ cd src/canvas-host/a2ui
 grep -r "Thread\.isMainThread\|FileManager\.default" . --include="*.swift"
 
 # Fix and rebuild submodule
-cd /Volumes/Main SSD/Developer/clawdis
+cd <your-openclaw-repo-path>
 pnpm canvas:a2ui:bundle
 ```
 
@@ -235,7 +235,7 @@ If upstream introduced new model configurations:
 # Check for OpenRouter API key requirements
 grep -r "openrouter\|OPENROUTER" src/ --include="*.ts" --include="*.js"
 
-# Update clawdbot.json with fallback chains
+# Update openclaw.json with fallback chains
 # Add model fallback configurations as needed
 ```
 
@@ -245,7 +245,7 @@ grep -r "openrouter\|OPENROUTER" src/ --include="*.ts" --include="*.js"
 
 ```bash
 # Verify everything works
-pnpm clawdbot health
+pnpm openclaw health
 pnpm test
 
 # Push (force required after rebase)
@@ -299,7 +299,7 @@ pnpm install 2>&1 | grep -i patch
 
 ```bash
 # Exhaustive search for deprecated APIs
-morph-mcp_warpgrep_codebase_search search_string="Find all Swift files using deprecated FileManager.default or Thread.isMainThread" repo_path="/Volumes/Main SSD/Developer/clawdis"
+morph-mcp_warpgrep_codebase_search search_string="Find all Swift files using deprecated FileManager.default or Thread.isMainThread" repo_path="<your-openclaw-repo-path>"
 ```
 
 **Quick Fix Commands:**
@@ -356,13 +356,13 @@ pnpm build
 pnpm ui:build
 
 echo "==> Running doctor..."
-pnpm clawdbot doctor
+pnpm openclaw doctor
 
 echo "==> Rebuilding macOS app..."
 ./scripts/restart-mac.sh
 
 echo "==> Verifying gateway health..."
-pnpm clawdbot health
+pnpm openclaw health
 
 echo "==> Checking for Swift 6.2 compatibility issues..."
 if grep -r "FileManager\.default\|Thread\.isMainThread" src/ apps/ --include="*.swift" --quiet; then
@@ -374,7 +374,7 @@ fi
 
 echo "==> Testing agent functionality..."
 # Note: Update YOUR_TELEGRAM_SESSION_ID with actual session ID
-pnpm clawdbot agent --message "Verification: Upstream sync and macOS rebuild completed successfully." --session-id YOUR_TELEGRAM_SESSION_ID || echo "Warning: Agent test failed - check Telegram for verification message"
+pnpm openclaw agent --message "Verification: Upstream sync and macOS rebuild completed successfully." --session-id YOUR_TELEGRAM_SESSION_ID || echo "Warning: Agent test failed - check Telegram for verification message"
 
 echo "==> Done! Check Telegram for verification message, then run 'git push --force-with-lease' when ready."
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@
 - Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
-- Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
+- Live tests (real keys): `OPENCLAW_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
 - Full kit + what’s covered: `docs/testing.md`.
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
 - Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.


### PR DESCRIPTION
## Summary

Fixes stale `clawdbot` references that were missed during the OpenClaw rebrand.

### Changes

- **AGENTS.md line 77**: Fix `CLAWDBOT_LIVE_TEST` → `OPENCLAW_LIVE_TEST`
  - This is a **functional bug**: the old env var name silently fails, so live tests won't actually run when following the documented instructions
- **Rename** `.agent/workflows/update_clawdbot.md` → `update_openclaw.md`
- **Update all references** in the workflow file:
  - CLI commands: `pnpm clawdbot` → `pnpm openclaw`
  - App paths: `Clawdbot.app` → `OpenClaw.app`
  - Config: `clawdbot.json` → `openclaw.json`
  - Process grep: `(clawdbot|gateway)` → `(openclaw|gateway)`

### Testing

- Verified `OPENCLAW_LIVE_TEST` is the correct env var name used in source code
- Grep confirmed no remaining `clawdbot` references in modified files

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates internal contributor/agent docs to complete the OpenClaw rebrand: it fixes the live-test env var name in `AGENTS.md` and renames/updates the upstream-sync workflow to use `openclaw` CLI/config/app naming.

Overall the changes are straightforward documentation fixes. The main remaining issues are a few stale or machine-specific references in the workflow doc (e.g., hard-coded local paths and a leftover `Clawdbot` backup filename) that could confuse contributors following the instructions.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are documentation-only with minor correctness/portability nits.
- The PR mostly performs straightforward renames and an env var correction; the remaining issues are limited to a few confusing/stale doc snippets (hard-coded local paths, leftover Clawdbot naming, and an arguably risky push example) rather than code behavior changes.
- .agent/workflows/update_openclaw.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->