### PR TITLE
fix(web): filter system-role messages from webchat transcript

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -72,6 +72,42 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
+  it("filters system-role messages from chat transcript", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            { role: "system", content: "You are a helpful assistant. Greet the user.", timestamp: 1 },
+            { role: "assistant", content: "Hello! How can I help?", timestamp: 2 },
+            { role: "user", content: "Hi there", timestamp: 3 },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("You are a helpful assistant");
+    expect(text).toContain("Hello! How can I help?");
+    expect(text).toContain("Hi there");
+  });
+
+  it("shows history truncation notice even though it uses system role", () => {
+    // The UI-generated "Showing last N messages" notice uses role: "system"
+    // but is added before the filtering loop, so it should still appear.
+    const messages = Array.from({ length: 250 }, (_, i) => ({
+      role: "user",
+      content: `Message ${i}`,
+      timestamp: i,
+    }));
+    const container = document.createElement("div");
+    render(renderChat(createProps({ messages })), container);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("hidden");
+  });
+
   it("shows a new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -78,7 +78,11 @@ describe("chat view", () => {
       renderChat(
         createProps({
           messages: [
-            { role: "system", content: "You are a helpful assistant. Greet the user.", timestamp: 1 },
+            {
+              role: "system",
+              content: "You are a helpful assistant. Greet the user.",
+              timestamp: 1,
+            },
             { role: "assistant", content: "Hello! How can I help?", timestamp: 2 },
             { role: "user", content: "Hi there", timestamp: 3 },
           ],

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -109,7 +109,7 @@ describe("chat view", () => {
     render(renderChat(createProps({ messages })), container);
 
     const text = container.textContent ?? "";
-    expect(text).toContain("hidden");
+    expect(text).toMatch(/Showing last \d+ messages \(\d+ hidden\)/);
   });
 
   it("shows a new session button when aborting is unavailable", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -435,6 +435,12 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
 
+    // System-injected messages (greeting prompts, reset instructions) should
+    // never be visible to users in the chat transcript.
+    if (normalized.role.toLowerCase() === "system") {
+      continue;
+    }
+
     if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
       continue;
     }


### PR DESCRIPTION
## Summary

  Filters system-injected messages (greeting prompts, session reset instructions) from the WebChat chat transcript. Closes #5772.

 ## Problem

  buildChatItems() in ui/src/ui/views/chat.ts iterates session history and only filters toolresult messages — system-role messages pass straight through
  to rendering. After /new or /reset, the raw system injection prompt is displayed as a visible chat message.

  ## Fix

  Skip messages with role === "system" in the history rendering loop. The UI-generated history truncation notice (which also uses role: "system") is
  unaffected because it's pushed to the items array before the filtering loop.

 ## Changes

  - Modified: ui/src/ui/views/chat.ts — added system role filter in buildChatItems() (4 lines)
  - Modified: ui/src/ui/views/chat.test.ts — 2 new tests: system messages excluded from transcript; history truncation notice still renders

  ## Test plan

  - 4 vitest tests passing (2 existing + 2 new)
  - Full gate clean: pnpm lint (0 errors), pnpm build, pnpm test (4882/4906 — 24 pre-existing memory subsystem failures)

  ## AI usage

  - Pair programming w/ Claude Opus 4.5, fully tested.
  - Claude generated the implementation following my design decisions (filter in history loop, preserve UI-generated notices), then I reviewed and
  iterated.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the web chat transcript rendering to skip `system`-role messages from the session history so internal/system-injected prompts don’t show up to end users. The accompanying tests verify that system-role history messages are hidden while the UI-generated “Showing last N messages … hidden” truncation notice still renders.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small risk of a runtime edge case if message roles are not guaranteed to be strings.
- Change is localized to chat transcript item building and covered by targeted tests. Main concern is the new unconditional `toLowerCase()` call on `normalized.role`, which could throw if `normalizeMessage` can emit a non-string role for malformed/legacy messages.
- ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->