### PR TITLE
feat: expose /compact as a native Telegram command

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -409,9 +409,9 @@ function buildChatCommands(): ChatCommandDefinition[] {
     }),
     defineChatCommand({
       key: "compact",
+      nativeName: "compact",
       description: "Compact the session context.",
       textAlias: "/compact",
-      scope: "text",
       category: "session",
       args: [
         {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -39,7 +39,7 @@ describe("commands registry", () => {
     expect(specs.find((spec) => spec.name === "stop")).toBeTruthy();
     expect(specs.find((spec) => spec.name === "skill")).toBeTruthy();
     expect(specs.find((spec) => spec.name === "whoami")).toBeTruthy();
-    expect(specs.find((spec) => spec.name === "compact")).toBeFalsy();
+    expect(specs.find((spec) => spec.name === "compact")).toBeTruthy();
   });
 
   it("filters commands based on config flags", () => {


### PR DESCRIPTION
## What
Expose the existing `/compact` command as a native Telegram bot menu command by adding `nativeName: "compact"` to its definition.

## Why
`/compact` is a commonly used command but was previously text-only (`scope: "text"`), meaning it did not appear in the Telegram `/` command menu. Users had to know the command existed and type it manually. Adding `nativeName` makes it discoverable alongside other native commands like `/status`, `/model`, etc.

## Changes
- `src/auto-reply/commands-registry.data.ts`: Added `nativeName: "compact"` and removed explicit `scope: "text"` (auto-resolves to `"both"` with both nativeName and textAlias)
- `src/auto-reply/commands-registry.test.ts`: Updated assertion to expect compact in the native command list

## Testing
- [x] Unit tests pass (`commands-registry.test.ts` — 16/16)
- [x] Lightly tested locally

🤖 AI-assisted (Claude Opus 4.5 via OpenClaw)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `/compact` discoverable in Telegram’s native slash-command UI by adding `nativeName: "compact"` to its command definition and updating the native command-spec test expectation accordingly.

It also includes a separate change in the media-understanding pipeline to prevent binary audio/video attachments from being injected as text `<file ...>` blocks by combining text-likeness heuristics with MIME detection/sniffing, plus a new regression test for OGG audio.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the Telegram command exposure is straightforward, with minor test/perf nits in the media-understanding additions.
- Command-registry changes are minimal and covered by existing unit tests. The media-understanding change is more behavior-affecting but is localized and comes with a regression test; remaining concerns are mainly non-deterministic test data and potential redundant MIME sniffing.
- src/media-understanding/apply.ts, src/media-understanding/apply.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->