### PR TITLE
feat(memory-lancedb): provenance fields + Memory refs footer

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -23,9 +24,7 @@ function resolveDefaultDbPath(): string {
   const home = homedir();
   const preferred = join(home, ".openclaw", "memory", "lancedb");
   try {
-    if (fs.existsSync(preferred)) {
-      return preferred;
-    }
+    if (fs.existsSync(preferred)) return preferred;
   } catch {
     // best-effort
   }
@@ -33,9 +32,7 @@ function resolveDefaultDbPath(): string {
   for (const legacy of LEGACY_STATE_DIRS) {
     const candidate = join(home, legacy, "memory", "lancedb");
     try {
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
+      if (fs.existsSync(candidate)) return candidate;
     } catch {
       // best-effort
     }
@@ -53,9 +50,7 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
   const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
-  if (unknown.length === 0) {
-    return;
-  }
+  if (unknown.length === 0) return;
   throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
 }
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -8,10 +8,11 @@
  * - Auto-capture filtering
  */
 
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-key";
 const HAS_OPENAI_KEY = Boolean(process.env.OPENAI_API_KEY);
@@ -41,7 +42,6 @@ describe("memory plugin e2e", () => {
     expect(memoryPlugin.name).toBe("Memory (LanceDB)");
     expect(memoryPlugin.kind).toBe("memory");
     expect(memoryPlugin.configSchema).toBeDefined();
-    // oxlint-disable-next-line typescript/unbound-method
     expect(memoryPlugin.register).toBeInstanceOf(Function);
   });
 
@@ -217,16 +217,14 @@ describeLive("memory plugin live tests", () => {
         registeredServices.push(service);
       },
       on: (hookName: string, handler: any) => {
-        if (!registeredHooks[hookName]) {
-          registeredHooks[hookName] = [];
-        }
+        if (!registeredHooks[hookName]) registeredHooks[hookName] = [];
         registeredHooks[hookName].push(handler);
       },
       resolvePath: (p: string) => p,
     };
 
     // Register plugin
-    memoryPlugin.register(mockApi as any);
+    await memoryPlugin.register(mockApi as any);
 
     // Check registration
     expect(registeredTools.length).toBe(3);


### PR DESCRIPTION
### What\nAdds optional provenance fields to memory-lancedb entries and appends a "Memory refs" footer to outbound assistant messages when memories were injected.\n\n### Why\nImproves auditability: users can see which memory ids were used (and any associated source metadata) and quickly correct bad memories.\n\n### Changes\n- Extend MemoryEntry schema with optional provenance fields (sourceKind/sourceId/sourceTs/sourceUrl/sourceHash).\n- Persist provenance in LanceDB table schema (backwards compatible defaults).\n- Track injected memory refs per session and append a "Memory refs" footer via message_sending hook.\n\n### Notes\n- Footer is only added when memories were injected for the current run.\n- If provenance fields are not provided, refs still include mem:<id> + category.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the LanceDB-backed memory plugin to persist optional provenance metadata on stored memories (`sourceKind/sourceId/sourceTs/sourceUrl/sourceHash`) and to surface which memories were auto-injected by appending a "Memory refs" footer to the next outbound assistant message when auto-recall runs.

Implementation-wise, `MemoryEntry` and tool schemas are expanded, the LanceDB table is seeded with the new columns for backward-compatible schema evolution, auto-recall records injected memory refs keyed by `sessionKey`, and a new `message_sending` hook appends the refs to outgoing content and clears the per-session tracking.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of edge-case correctness and lifecycle concerns around the new footer/ref tracking and provenance parsing.
- Core changes are straightforward schema/tool extensions, but (1) `sourceTs` is currently parsed with a falsy check that will drop legitimate `0` values, (2) the footer hook may apply when role is missing depending on the hook contract, and (3) per-session refs are only cleared on `message_sending`, which can retain stale data if that hook doesn’t run.
- extensions/memory-lancedb/index.ts (message_sending hook + provenance parsing)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->