### PR TITLE
fix: handle hyphenated ARIA roles and escaped quotes in snapshot parsing

### DIFF
--- a/src/browser/pw-role-snapshot.ts
+++ b/src/browser/pw-role-snapshot.ts
@@ -229,7 +229,7 @@ function processLine(
 
   let enhanced = `${prefix}${roleRaw}`;
   if (name) {
-    enhanced += ` "${name}"`;
+    enhanced += ` "${name.replace(/"/g, '\\"')}"`;
   }
   enhanced += ` [ref=${ref}]`;
   if (nth > 0) {
@@ -301,7 +301,7 @@ export function buildRoleSnapshotFromAriaSnapshot(
 
       let enhanced = `- ${roleRaw}`;
       if (name) {
-        enhanced += ` "${name}"`;
+        enhanced += ` "${name.replace(/"/g, '\\"')}"`;
       }
       enhanced += ` [ref=${ref}]`;
       if (nth > 0) {
@@ -378,7 +378,7 @@ export function buildRoleSnapshotFromAiSnapshot(
         continue;
       }
       refs[ref] = { role, ...(name ? { name } : {}) };
-      out.push(`- ${roleRaw}${name ? ` "${name}"` : ""}${suffix}`);
+      out.push(`- ${roleRaw}${name ? ` "${name.replace(/"/g, '\\"')}"` : ""}${suffix}`);
     }
     return {
       snapshot: out.join("\n") || "(no interactive elements)",

--- a/src/browser/pw-role-snapshot.ts
+++ b/src/browser/pw-role-snapshot.ts
@@ -191,7 +191,7 @@ function processLine(
     return null;
   }
 
-  const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+  const match = line.match(/^(\s*-\s*)([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?(.*)$/);
   if (!match) {
     return options.interactive ? null : line;
   }
@@ -276,7 +276,7 @@ export function buildRoleSnapshotFromAriaSnapshot(
         continue;
       }
 
-      const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+      const match = line.match(/^(\s*-\s*)([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?(.*)$/);
       if (!match) {
         continue;
       }
@@ -361,7 +361,7 @@ export function buildRoleSnapshotFromAiSnapshot(
       if (options.maxDepth !== undefined && depth > options.maxDepth) {
         continue;
       }
-      const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+      const match = line.match(/^(\s*-\s*)([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?(.*)$/);
       if (!match) {
         continue;
       }
@@ -393,7 +393,7 @@ export function buildRoleSnapshotFromAiSnapshot(
       continue;
     }
 
-    const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+    const match = line.match(/^(\s*-\s*)([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?(.*)$/);
     if (!match) {
       out.push(line);
       continue;


### PR DESCRIPTION
**Problem**
The snapshot parser in pw-role-snapshot.ts was dropping elements in two cases:

1. Hyphenated ARIA roles: Elements like <div role="doc-subtitle"> were parsed as role "doc" instead of "doc-subtitle". Since "doc" isn't in INTERACTIVE_ROLES, these elements disappeared from the snapshot entirely.
2. Escaped quotes in names: Element names containing escaped quotes (e.g. button "Say \"Hello\"") were truncated at the first escaped quote, corrupting both the name and the rest of the line.

This is particularly noticeable on sites using modern web components or ARIA landmarks with compound roles.

**Solution**
Updated the regex pattern in 4 places to:
- Match hyphens in role names: [\w-]+ instead of \w+
- Properly handle escaped characters in quoted strings:  (?:[^"\]|\.)* instead of [^"]*

**Testing**
Created a reproduction script that validates:

- Standard roles: button "Submit" ✅
- Japanese text: button "送信" ✅
- Hyphenated roles: doc-subtitle "Chapter 1" ✅ (previously failed)
- Escaped quotes: button "Say \"Hello\"" ✅ (previously corrupted)

All cases now parse correctly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the snapshot-line parsing regex in `src/browser/pw-role-snapshot.ts` to support hyphenated ARIA roles (`[\w-]+`) and correctly capture quoted names that include escape sequences (`((?:[^"\\]|\\.)*)`). These changes prevent elements from being dropped or truncated when roles include hyphens or names contain escaped quotes, improving snapshot fidelity across modern ARIA usage.

The change is localized to the four code paths that parse snapshot lines (generic processing, aria snapshot interactive mode, and AI snapshot interactive/non-interactive paths), keeping behavior consistent across snapshot sources.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new parsing behavior likely needs a small follow-up to ensure names with escaped characters round-trip correctly.
- Regex updates look correct for matching hyphenated roles and escaped quotes, and they’re applied consistently in all four parsing sites. The main concern is that the captured `name` is re-embedded into the output without escaping, which can produce an invalid/ambiguous snapshot line for names containing quotes/backslashes and may break downstream parsing or snapshot comparisons.
- src/browser/pw-role-snapshot.ts (output construction for names after new regex capture)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->