### PR TITLE
Android: Add BouncyCastle Ed25519 fallback and gateway token UI

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -115,6 +115,9 @@ dependencies {
   // Unicast DNS-SD (Wide-Area Bonjour) for tailnet discovery domains.
   implementation("dnsjava:dnsjava:3.6.4")
 
+  // BouncyCastle for Ed25519 fallback when system KeyPairGenerator fails
+  implementation("org.bouncycastle:bcprov-jdk18on:1.80")
+
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:6.0.7")

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -51,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val gatewayToken: StateFlow<String> = runtime.gatewayToken
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +103,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setGatewayToken(value: String) {
+    runtime.setGatewayToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -284,6 +284,7 @@ class NodeRuntime(context: Context) {
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
+  val gatewayToken: StateFlow<String> = prefs.gatewayToken
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
 
@@ -426,6 +427,10 @@ class NodeRuntime(context: Context) {
 
   fun setManualTls(value: Boolean) {
     prefs.setManualTls(value)
+  }
+
+  fun setGatewayToken(value: String) {
+    prefs.setGatewayToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -6,10 +6,18 @@ import java.io.File
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.MessageDigest
+import java.security.Security
 import java.security.Signature
 import java.security.spec.PKCS8EncodedKeySpec
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.SecureRandom
 
 @Serializable
 data class DeviceIdentity(
@@ -22,6 +30,12 @@ data class DeviceIdentity(
 class DeviceIdentityStore(context: Context) {
   private val json = Json { ignoreUnknownKeys = true }
   private val identityFile = File(context.filesDir, "openclaw/identity/device.json")
+
+  init {
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      Security.addProvider(BouncyCastleProvider())
+    }
+  }
 
   @Synchronized
   fun loadOrCreate(): DeviceIdentity {
@@ -41,18 +55,51 @@ class DeviceIdentityStore(context: Context) {
   }
 
   fun signPayload(payload: String, identity: DeviceIdentity): String? {
+    val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
+
+    // Try system JCA provider first (expects PKCS8 encoded key)
+    if (privateKeyBytes.size > 32) {
+      try {
+        val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+        val keyFactory = KeyFactory.getInstance("Ed25519")
+        val privateKey = keyFactory.generatePrivate(keySpec)
+        val signature = Signature.getInstance("Ed25519")
+        signature.initSign(privateKey)
+        signature.update(payload.toByteArray(Charsets.UTF_8))
+        return base64UrlEncode(signature.sign())
+      } catch (_: Throwable) {
+        // Fall through to BouncyCastle
+      }
+    }
+
+    // Fall back to BouncyCastle lightweight API (expects raw 32-byte key)
     return try {
-      val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
-      val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
-      val keyFactory = KeyFactory.getInstance("Ed25519")
-      val privateKey = keyFactory.generatePrivate(keySpec)
-      val signature = Signature.getInstance("Ed25519")
-      signature.initSign(privateKey)
-      signature.update(payload.toByteArray(Charsets.UTF_8))
-      base64UrlEncode(signature.sign())
+      val rawPrivateKey = if (privateKeyBytes.size == 32) {
+        privateKeyBytes
+      } else {
+        stripPkcs8PrivateKeyPrefix(privateKeyBytes)
+      }
+      val privateKeyParams = Ed25519PrivateKeyParameters(rawPrivateKey, 0)
+      val signer = Ed25519Signer()
+      signer.init(true, privateKeyParams)
+      val payloadBytes = payload.toByteArray(Charsets.UTF_8)
+      signer.update(payloadBytes, 0, payloadBytes.size)
+      base64UrlEncode(signer.generateSignature())
     } catch (_: Throwable) {
       null
     }
+  }
+
+  private fun stripPkcs8PrivateKeyPrefix(pkcs8: ByteArray): ByteArray {
+    // Ed25519 PKCS8 structure: prefix + 32-byte raw key
+    // The prefix is typically 16 bytes for Ed25519
+    if (pkcs8.size == ED25519_PKCS8_PREFIX.size + 32 &&
+      pkcs8.copyOfRange(0, ED25519_PKCS8_PREFIX.size).contentEquals(ED25519_PKCS8_PREFIX)
+    ) {
+      return pkcs8.copyOfRange(ED25519_PKCS8_PREFIX.size, pkcs8.size)
+    }
+    // If we can't parse it, return as-is and let BouncyCastle fail with a clear error
+    return pkcs8
   }
 
   fun publicKeyBase64Url(identity: DeviceIdentity): String? {
@@ -97,15 +144,37 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun generate(): DeviceIdentity {
-    val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
-    val spki = keyPair.public.encoded
-    val rawPublic = stripSpkiPrefix(spki)
+    // Try system Ed25519 first, fall back to BouncyCastle if it fails
+    return try {
+      val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+      val spki = keyPair.public.encoded
+      val rawPublic = stripSpkiPrefix(spki)
+      val deviceId = sha256Hex(rawPublic)
+      val privateKey = keyPair.private.encoded
+      DeviceIdentity(
+        deviceId = deviceId,
+        publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
+        privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
+        createdAtMs = System.currentTimeMillis(),
+      )
+    } catch (_: Throwable) {
+      generateWithBouncyCastle()
+    }
+  }
+
+  private fun generateWithBouncyCastle(): DeviceIdentity {
+    val generator = Ed25519KeyPairGenerator()
+    generator.init(Ed25519KeyGenerationParameters(SecureRandom()))
+    val keyPair = generator.generateKeyPair()
+    val publicKeyParams = keyPair.public as Ed25519PublicKeyParameters
+    val privateKeyParams = keyPair.private as Ed25519PrivateKeyParameters
+    val rawPublic = publicKeyParams.encoded
+    val rawPrivate = privateKeyParams.encoded
     val deviceId = sha256Hex(rawPublic)
-    val privateKey = keyPair.private.encoded
     return DeviceIdentity(
       deviceId = deviceId,
       publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
-      privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
+      privateKeyPkcs8Base64 = Base64.encodeToString(rawPrivate, Base64.NO_WRAP),
       createdAtMs = System.currentTimeMillis(),
     )
   }
@@ -142,9 +211,17 @@ class DeviceIdentityStore(context: Context) {
   }
 
   companion object {
+    // SPKI prefix for Ed25519 public keys (12 bytes)
     private val ED25519_SPKI_PREFIX =
       byteArrayOf(
         0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+      )
+
+    // PKCS8 prefix for Ed25519 private keys (16 bytes)
+    // 30 2e 02 01 00 30 05 06 03 2b 65 70 04 22 04 20
+    private val ED25519_PKCS8_PREFIX =
+      byteArrayOf(
+        0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
       )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -258,6 +258,7 @@ class GatewaySession(
             val nonce = awaitConnectNonce()
             sendConnect(nonce)
           } catch (err: Throwable) {
+            Log.w(loggerTag, "connect failed: ${err.message}")
             connectDeferred.completeExceptionally(err)
             closeQuietly()
           }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -82,6 +82,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val gatewayToken by viewModel.gatewayToken.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
   val serverName by viewModel.serverName.collectAsState()
@@ -408,6 +409,14 @@ fun SettingsSheet(viewModel: MainViewModel) {
             supportingContent = { Text("Pin the gateway certificate on first connect.") },
             trailingContent = { Switch(checked = manualTls, onCheckedChange = viewModel::setManualTls, enabled = manualEnabled) },
             modifier = Modifier.alpha(if (manualEnabled) 1f else 0.5f),
+          )
+          OutlinedTextField(
+            value = gatewayToken,
+            onValueChange = viewModel::setGatewayToken,
+            label = { Text("Gateway Token") },
+            supportingText = { Text("Auth token from gateway config") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
           )
 
           val hostOk = manualHost.trim().isNotEmpty()


### PR DESCRIPTION
## Summary

Fixes Android app connection issues on devices where the system Ed25519 KeyPairGenerator fails with "Not initialized" (observed on Android 16).

## Changes

- **BouncyCastle fallback**: Added BouncyCastle dependency and lightweight API fallback for Ed25519 key generation and signing when the system provider fails
- **Gateway token UI**: Added a Gateway Token input field in Settings > Advanced section so users can authenticate with token-based gateways

## Details

### Ed25519 Fallback
- `DeviceIdentityStore.generate()`: Tries system `KeyPairGenerator.getInstance("Ed25519")` first, falls back to BouncyCastle's `Ed25519KeyPairGenerator`
- `DeviceIdentityStore.signPayload()`: Tries system JCA first, falls back to BouncyCastle's `Ed25519Signer`
- Handles both PKCS8-encoded keys (from system provider) and raw 32-byte keys (from BouncyCastle)

### Gateway Token UI
- Added `gatewayToken` StateFlow and setter through SecurePrefs → NodeRuntime → MainViewModel
- Added OutlinedTextField in SettingsSheet under the Advanced section
- Token is loaded during connection and used for gateway authentication

## Testing

Tested on Android 16 device where system Ed25519 was failing. Connection now succeeds using BouncyCastle fallback and token authentication.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an Android Ed25519 keygen/signing fallback using BouncyCastle to address devices where the platform `Ed25519` provider fails, and introduces a “Gateway Token” setting surfaced via `SecurePrefs` → `NodeRuntime` → `MainViewModel` and shown in the Settings Advanced section.

The crypto changes are localized to `DeviceIdentityStore` (load/create identity, sign payloads) and the UI/settings changes thread a new token value into runtime configuration used during gateway connection. Overall this fits the existing pattern of storing advanced connection settings in `SecurePrefs` and exposing them as `StateFlow`s.

Main concern: the fallback signing path assumes a very specific PKCS#8 encoding shape; on devices where the system signer fails but an existing identity was generated earlier by the system provider, BouncyCastle fallback may still fail to sign and return `null`, keeping the connection broken.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a meaningful risk of still failing on some devices due to PKCS#8 parsing assumptions in the Ed25519 fallback.
- The changes are small and targeted, but the BouncyCastle fallback’s handling of existing PKCS#8-encoded keys is brittle; if the system provider fails and the stored key encoding doesn’t match the hard-coded prefix+32 layout, signing will return null and connections can still fail. The new UI/settings wiring looks straightforward with low blast radius.
- apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->