### PR TITLE
fix: add context window info to /usage full footer

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -80,6 +80,8 @@ export const formatResponseUsageLine = (params: {
     cacheRead: number;
     cacheWrite: number;
   };
+  contextUsed?: number;
+  contextLimit?: number;
 }): string | null => {
   const usage = params.usage;
   if (!usage) {
@@ -105,8 +107,17 @@ export const formatResponseUsageLine = (params: {
         })
       : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
-  return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
+  const costSuffix = costLabel ? ` · est ${costLabel}` : "";
+  let contextSuffix = "";
+  if (
+    typeof params.contextUsed === "number" &&
+    typeof params.contextLimit === "number" &&
+    params.contextLimit > 0
+  ) {
+    const pct = Math.min(999, Math.round((params.contextUsed / params.contextLimit) * 100));
+    contextSuffix = ` · context ${formatTokenCount(params.contextUsed)}/${formatTokenCount(params.contextLimit)} (${pct}%)`;
+  }
+  return `Usage: ${inputLabel} in / ${outputLabel} out${costSuffix}${contextSuffix}`;
 };
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -478,10 +478,18 @@ export async function runReplyAgent(params: {
             config: cfg,
           })
         : undefined;
+      const input = usage.input ?? 0;
+      const output = usage.output ?? 0;
+      const cacheRead = usage.cacheRead ?? 0;
+      const cacheWrite = usage.cacheWrite ?? 0;
+      const promptTokens = input + cacheRead + cacheWrite;
+      const totalTokens = usage.total ?? promptTokens + output;
       let formatted = formatResponseUsageLine({
         usage,
         showCost,
         costConfig,
+        contextUsed: responseUsageMode === "full" ? totalTokens : undefined,
+        contextLimit: responseUsageMode === "full" ? contextTokensUsed : undefined,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session ${sessionKey}`;


### PR DESCRIPTION
## Bug: `/usage full` missing context window info

The `/usage full` mode is supposed to show complete usage information, but it was missing context window usage that the TUI footer already displays. This is a **parity bug** — "full" mode should match the TUI's level of detail.

Related: #4753 (closed during triage, but correctly identified the gap — framing this as a bug fix rather than a new feature)

### Before (Discord/Telegram with `/usage full`)
```
Usage: 47k in / 71 out · session agent:main:discord:channel:123
```

### After (Discord/Telegram with `/usage full`)
```
Usage: 47k in / 71 out · context 54k/128k (42%) · session agent:main:discord:channel:123
```

### TUI footer (already shows this)
```
tokens 57k/128k (44%)
```

## Why this is a bug

- `/usage full` claims to show "full" information but omits context window usage
- Users on messaging channels have no visibility into context consumption
- TUI users already see this info — messaging users should too
- The data is already available (`contextTokensUsed` is calculated); it just was not being displayed

## Changes

- **agent-runner-utils.ts**: Add optional `contextUsed`/`contextLimit` params to `formatResponseUsageLine`
- **agent-runner.ts**: Pass context info when `responseUsageMode === "full"`

## Testing

- [x] `pnpm build` passes
- [x] `pnpm test` for affected files passes
- [x] Manual: `/usage full` → verify context info appears
- [x] Manual: `/usage tokens` → verify no change (stays minimal)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds context-window usage reporting to the `/usage full` footer for messaging surfaces, matching the TUI footer’s level of detail. It does so by extending `formatResponseUsageLine` to optionally append a `context used/limit (pct)` segment, and by wiring `agent-runner` to pass context values when `responseUsageMode === "full"`. Two additional files (`system-prompt.ts`, `resolve-route.ts`) only change brace formatting (lint/style) and don’t affect behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but has a likely user-visible correctness bug in the new `/usage full` context display wiring.
- Changes are small and localized, but the new `contextUsed`/`contextLimit` parameters appear to be passed in the wrong order in `agent-runner.ts`, which would produce incorrect output and percentages for `/usage full` on messaging channels.
- src/auto-reply/reply/agent-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->