### PR TITLE
fix(discord): resolve TypeScript build error in message preflight

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -55,8 +55,8 @@ import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./t
 export type {
   DiscordMessagePreflightContext,
   DiscordMessagePreflightParams,
-  DiscordSenderIdentity,
 } from "./message-handler.preflight.types.js";
+export type { DiscordSenderIdentity } from "./sender-identity.js";
 
 export async function preflightDiscordMessage(
   params: DiscordMessagePreflightParams,


### PR DESCRIPTION
## Problem

The build process failed on Debian 12 when running the `./docker-setup.sh` script, which executes `pnpm build` within a Docker container. The build terminated with a TypeScript error:

```
error TS2459: Module './message-handler.preflight.types.js' declares 'DiscordSenderIdentity' locally, but it is not exported.
```

## Solution

The error occurred because `message-handler.preflight.ts` was attempting to re-export the `DiscordSenderIdentity` type from `message-handler.preflight.types.ts`, where it was only imported but not declared.

This fix modifies `message-handler.preflight.ts` to import and re-export `DiscordSenderIdentity` directly from its source file, `./sender-identity.js`, correcting the module's export structure and resolving the compilation error.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a TS2459 build error by stopping `message-handler.preflight.ts` from re-exporting `DiscordSenderIdentity` from `message-handler.preflight.types.ts` (where it is only imported), and instead re-exporting the type directly from its source module `sender-identity.ts`.

This change is localized to the Discord monitor preflight module and only affects the public type surface (no runtime logic changes), ensuring the preflight entrypoint exports match actual declarations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is a narrow type-only re-export fix that aligns exports with actual type declarations; it does not change runtime behavior. The new export target (`sender-identity.ts`) already declares `DiscordSenderIdentity`, matching how other modules import it.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->