### PR TITLE
Model routing rules + usage receipts rollup

### DIFF
--- a/docs/runbooks/model-routing-and-cost-receipts.md
+++ b/docs/runbooks/model-routing-and-cost-receipts.md
@@ -1,0 +1,83 @@
+# Model routing + cost receipts
+
+This runbook documents OpenClaw’s rule-based model router and per-run cost/usage receipts.
+
+## Goals
+- Pick provider/model per *context* (channel, cron lane, session key prefix, agent id)
+- Support explicit per-run fallbacks
+- Emit receipts + rollups so you can see where spend is coming from
+
+## Configuration
+
+### 1) Enable per-run usage logging (for rollups)
+
+```json5
+{
+  models: {
+    routing: {
+      usageLog: { enabled: true }
+    }
+  }
+}
+```
+
+This writes an append-only log to:
+- `~/.openclaw/usage/runs.jsonl`
+
+### 2) Add routing rules
+Rules are evaluated in order; first match wins.
+
+```json5
+{
+  models: {
+    routing: {
+      rules: [
+        {
+          name: "Discord chat: cheap by default",
+          match: { channel: "discord", isCron: false },
+          model: { primary: "openai-codex/gpt-5.2" }
+        },
+        {
+          name: "Cron jobs: cheaper model",
+          match: { isCron: true },
+          model: {
+            primary: "kimi/kimi-code",
+            fallbacks: ["zai/glm-4.7"]
+          }
+        },
+        {
+          name: "Gmail hook: safer/stronger",
+          match: { sessionKeyPrefix: "hook:gmail:" },
+          model: { primary: "anthropic/claude-sonnet-4-5" }
+        }
+      ],
+      receipts: {
+        // Optional global default for usage footer behavior in chat
+        defaultMode: "off" // off | tokens | cost | full
+      }
+    }
+  }
+}
+```
+
+Notes:
+- `model.primary` and `model.fallbacks[]` accept either `provider/model` or a configured alias.
+- Cron routing uses the cron job’s resolved delivery channel + lane.
+
+## Receipts
+
+### Per-message receipts (chat)
+- Session-level receipts are controlled via `/usage` (existing behavior).
+- Routing rules can override the session setting with `receipt: "tokens"|"cost"|"full"`.
+
+### Rollups
+Use:
+- `/usage rollup` (defaults to 1 day)
+- `/usage rollup 7`
+- `/usage rollup 7 channel:discord`
+
+Rollups are computed from `~/.openclaw/usage/runs.jsonl`.
+
+## Troubleshooting
+- If costs show as `n/a`, you likely have OAuth-based auth for that provider/model (no API-key cost accounting) or missing per-model cost entries.
+- If rollup says “no data”, ensure `models.routing.usageLog.enabled=true` and run at least one chat/cron turn.

--- a/src/agents/model-routing.ts
+++ b/src/agents/model-routing.ts
@@ -1,0 +1,169 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { ThinkLevel } from "./model-selection.js";
+import { buildModelAliasIndex, modelKey, resolveModelRefFromString } from "./model-selection.js";
+
+export type ModelRoutingMatch = {
+  /** Originating message channel/provider (e.g. "discord", "telegram", "slack"). */
+  channel?: string;
+  /** Cron lane (e.g. "cron", "heartbeat", "ops"). */
+  lane?: string;
+  /** Session key prefix match (e.g. "cron:" or "hook:gmail:"). */
+  sessionKeyPrefix?: string;
+  /** Agent id (normalized). */
+  agentId?: string;
+  /** Whether the run is from cron. */
+  isCron?: boolean;
+  /** Whether the run originated from a group chat. */
+  isGroup?: boolean;
+};
+
+export type ModelRoutingReceiptMode = "off" | "tokens" | "cost" | "full";
+
+export type ModelRoutingRule = {
+  name?: string;
+  match?: ModelRoutingMatch;
+  /** Optional model override (provider/model or alias). */
+  model?: {
+    primary?: string;
+    fallbacks?: string[];
+  };
+  /** Optional thinking override. */
+  thinking?: ThinkLevel;
+  /** Optional per-run usage/cost receipt mode (overrides session /usage mode). */
+  receipt?: ModelRoutingReceiptMode;
+};
+
+export type ModelRoutingDecision = {
+  modelPrimary?: string;
+  modelFallbacksOverride?: string[];
+  thinking?: ThinkLevel;
+  receipt?: ModelRoutingReceiptMode;
+  /** Human-readable rule name used (if any). */
+  rule?: string;
+};
+
+function normalizeMaybe(value?: string): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function matchRule(params: {
+  match?: ModelRoutingMatch;
+  ctx: {
+    channel?: string;
+    lane?: string;
+    sessionKey?: string;
+    agentId?: string;
+    isCron?: boolean;
+    isGroup?: boolean;
+  };
+}): boolean {
+  const m = params.match;
+  if (!m) {
+    return true;
+  }
+  const channel = normalizeMaybe(params.ctx.channel);
+  const lane = normalizeMaybe(params.ctx.lane);
+  const sessionKey = (params.ctx.sessionKey ?? "").trim();
+  const agentId = normalizeMaybe(params.ctx.agentId);
+
+  if (m.channel && normalizeMaybe(m.channel) !== channel) {
+    return false;
+  }
+  if (m.lane && normalizeMaybe(m.lane) !== lane) {
+    return false;
+  }
+  if (m.sessionKeyPrefix && !sessionKey.startsWith(m.sessionKeyPrefix)) {
+    return false;
+  }
+  if (m.agentId && normalizeMaybe(m.agentId) !== agentId) {
+    return false;
+  }
+  if (typeof m.isCron === "boolean" && m.isCron !== Boolean(params.ctx.isCron)) {
+    return false;
+  }
+  if (typeof m.isGroup === "boolean" && m.isGroup !== Boolean(params.ctx.isGroup)) {
+    return false;
+  }
+  return true;
+}
+
+function normalizeModelStrings(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+  models?: { primary?: string; fallbacks?: string[] };
+}): { primary?: string; fallbacks?: string[] } {
+  const rawPrimary = params.models?.primary?.trim();
+  const rawFallbacks = (params.models?.fallbacks ?? []).map((s) => String(s ?? "").trim());
+
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  const normalizeRef = (raw: string): string | undefined => {
+    const resolved = resolveModelRefFromString({
+      raw,
+      defaultProvider: params.defaultProvider,
+      aliasIndex,
+    });
+    if (!resolved) {
+      return undefined;
+    }
+    return modelKey(resolved.ref.provider, resolved.ref.model);
+  };
+
+  const primary = rawPrimary ? normalizeRef(rawPrimary) : undefined;
+  const fallbacks = rawFallbacks
+    .map((raw) => normalizeRef(raw))
+    .filter((v): v is string => Boolean(v));
+
+  return {
+    ...(primary ? { primary } : {}),
+    ...(fallbacks.length ? { fallbacks } : {}),
+  };
+}
+
+/**
+ * Resolve a model routing decision based on run context.
+ *
+ * Notes:
+ * - This is intentionally minimal: it picks an explicit model + fallbacks list when configured.
+ * - Cost/latency/quality constraints can be layered on later by expanding match + rule actions.
+ */
+export function resolveModelRoutingDecision(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+  ctx: {
+    channel?: string;
+    lane?: string;
+    sessionKey?: string;
+    agentId?: string;
+    isCron?: boolean;
+    isGroup?: boolean;
+  };
+}): ModelRoutingDecision {
+  const rules = params.cfg.models?.routing?.rules ?? [];
+  for (const rule of rules) {
+    if (!matchRule({ match: rule.match, ctx: params.ctx })) {
+      continue;
+    }
+    const normalizedModels = normalizeModelStrings({
+      cfg: params.cfg,
+      defaultProvider: params.defaultProvider,
+      models: rule.model,
+    });
+
+    return {
+      ...(normalizedModels.primary ? { modelPrimary: normalizedModels.primary } : {}),
+      ...(normalizedModels.fallbacks ? { modelFallbacksOverride: normalizedModels.fallbacks } : {}),
+      ...(rule.thinking ? { thinking: rule.thinking } : {}),
+      ...(rule.receipt ? { receipt: rule.receipt } : {}),
+      rule: rule.name,
+    };
+  }
+
+  const defaultReceipt = params.cfg.models?.routing?.receipts?.defaultMode;
+  return {
+    ...(defaultReceipt ? { receipt: defaultReceipt } : {}),
+  };
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -147,10 +147,12 @@ export async function runAgentTurnWithFallback(params: {
         provider: params.followupRun.run.provider,
         model: params.followupRun.run.model,
         agentDir: params.followupRun.run.agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(
-          params.followupRun.run.config,
-          resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-        ),
+        fallbacksOverride:
+          params.followupRun.run.modelFallbacksOverride ??
+          resolveAgentModelFallbacksOverride(
+            params.followupRun.run.config,
+            resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+          ),
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -26,6 +26,7 @@ import {
   handleStopCommand,
   handleUsageCommand,
 } from "./commands-session.js";
+import { handleUsageRollupCommand } from "./commands-usage-rollup.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import type {
   CommandHandler,
@@ -39,6 +40,7 @@ const HANDLERS: CommandHandler[] = [
   handleBashCommand,
   handleActivationCommand,
   handleSendPolicyCommand,
+  handleUsageRollupCommand,
   handleUsageCommand,
   handleRestartCommand,
   handleTtsCommands,

--- a/src/auto-reply/reply/commands-usage-rollup.ts
+++ b/src/auto-reply/reply/commands-usage-rollup.ts
@@ -1,0 +1,72 @@
+import type { CommandHandler } from "./commands-types.js";
+import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+import { loadRunUsageRollup } from "../../infra/run-usage-log.js";
+
+function parseArgs(raw: string): { days: number; channel?: string } {
+  const parts = raw
+    .split(/\s+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  let days = 1;
+  let channel: string | undefined;
+
+  for (const p of parts) {
+    if (/^\d+$/.test(p)) {
+      days = Math.max(1, Math.min(90, Number.parseInt(p, 10)));
+      continue;
+    }
+    if (p.toLowerCase().startsWith("channel:")) {
+      channel = p.slice("channel:".length).trim();
+      continue;
+    }
+  }
+
+  return { days, channel };
+}
+
+export const handleUsageRollupCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (normalized !== "/usage rollup" && !normalized.startsWith("/usage rollup ")) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    return { shouldContinue: false };
+  }
+
+  const rawArgs =
+    normalized === "/usage rollup" ? "" : normalized.slice("/usage rollup".length).trim();
+  const { days, channel } = parseArgs(rawArgs);
+
+  const summary = await loadRunUsageRollup({ days, channel });
+  if (summary.entries.length === 0) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `💸 Usage rollup: no data yet (enable models.routing.usageLog.enabled=true).`,
+      },
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`💸 Usage rollup (${days}d)${channel ? ` · ${channel}` : ""}`);
+
+  for (const entry of summary.entries) {
+    const cost = formatUsd(entry.totalCostUsd);
+    const tokens = formatTokenCount(entry.totalTokens);
+    const missing =
+      entry.missingCostRuns > 0 ? ` (partial ${entry.missingCostRuns}/${entry.runs})` : "";
+    const labelParts = [entry.key.date];
+    if (entry.key.channel) labelParts.push(entry.key.channel);
+    if (entry.key.jobName) labelParts.push(entry.key.jobName);
+    const label = labelParts.join(" · ");
+    lines.push(`- ${label}: ${cost ?? "n/a"}${missing} · ${tokens} tokens · ${entry.runs} runs`);
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text: lines.join("\n") },
+  };
+};

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -43,6 +43,8 @@ export type FollowupRun = {
   originatingChatType?: string;
   run: {
     agentId: string;
+    /** Logical lane for diagnostics/routing (e.g. "chat", "cron", "heartbeat"). */
+    lane?: string;
     agentDir: string;
     sessionId: string;
     sessionKey?: string;
@@ -61,6 +63,10 @@ export type FollowupRun = {
     skillsSnapshot?: SkillSnapshot;
     provider: string;
     model: string;
+    /** Optional explicit fallbacks list (provider/model strings) overriding config defaults. */
+    modelFallbacksOverride?: string[];
+    /** Optional per-run usage/cost receipt mode (overrides session /usage). */
+    usageReceiptMode?: "off" | "tokens" | "cost" | "full";
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
     thinkLevel?: ThinkLevel;

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -52,8 +52,44 @@ export type BedrockDiscoveryConfig = {
   defaultMaxTokens?: number;
 };
 
+export type ModelRoutingConfig = {
+  /**
+   * Rule-based model routing.
+   *
+   * Rules are evaluated in order; first match wins.
+   */
+  rules?: Array<{
+    name?: string;
+    match?: {
+      channel?: string;
+      lane?: string;
+      sessionKeyPrefix?: string;
+      agentId?: string;
+      isCron?: boolean;
+      isGroup?: boolean;
+    };
+    model?: {
+      /** provider/model or alias */
+      primary?: string;
+      /** provider/model or alias */
+      fallbacks?: string[];
+    };
+    thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+    receipt?: "off" | "tokens" | "cost" | "full";
+  }>;
+  receipts?: {
+    /** Optional global default receipt mode applied when no rule matches. */
+    defaultMode?: "off" | "tokens" | "cost" | "full";
+  };
+  usageLog?: {
+    /** When enabled, persist per-run usage+cost events for rollups. */
+    enabled?: boolean;
+  };
+};
+
 export type ModelsConfig = {
   mode?: "merge" | "replace";
   providers?: Record<string, ModelProviderConfig>;
   bedrockDiscovery?: BedrockDiscoveryConfig;
+  routing?: ModelRoutingConfig;
 };

--- a/src/infra/run-usage-log.ts
+++ b/src/infra/run-usage-log.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+import type { NormalizedUsage } from "../agents/usage.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+
+export type RunUsageEvent = {
+  ts: number;
+  kind: "chat" | "cron";
+  sessionKey?: string;
+  sessionId?: string;
+  lane?: string;
+  channel?: string;
+  accountId?: string;
+  to?: string;
+  /** Cron job context. */
+  jobId?: string;
+  jobName?: string;
+  provider?: string;
+  model?: string;
+  usage: NormalizedUsage;
+  costUsd?: number;
+  durationMs?: number;
+};
+
+export type RunUsageRollupKey = {
+  date: string;
+  channel?: string;
+  jobName?: string;
+};
+
+export type RunUsageRollupEntry = {
+  key: RunUsageRollupKey;
+  runs: number;
+  totalTokens: number;
+  totalCostUsd?: number;
+  missingCostRuns: number;
+};
+
+function dayKey(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString("en-CA", {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
+}
+
+export function resolveRunUsageLogPath(env: NodeJS.ProcessEnv = process.env): string {
+  const root = resolveStateDir(env);
+  return path.join(root, "usage", "runs.jsonl");
+}
+
+export async function appendRunUsageEvent(params: {
+  cfg?: OpenClawConfig;
+  event: RunUsageEvent;
+}): Promise<void> {
+  const enabled = params.cfg?.models?.routing?.usageLog?.enabled === true;
+  if (!enabled) {
+    return;
+  }
+  const filePath = resolveRunUsageLogPath();
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.appendFile(filePath, `${JSON.stringify(params.event)}\n`, "utf8");
+}
+
+function totalTokensFromUsage(usage: NormalizedUsage): number {
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  const total = usage.total;
+  if (typeof total === "number" && Number.isFinite(total) && total >= 0) {
+    return total;
+  }
+  return input + output + cacheRead + cacheWrite;
+}
+
+export async function loadRunUsageRollup(params: {
+  days: number;
+  /** Optional filter for a specific channel (e.g. "discord"). */
+  channel?: string;
+}): Promise<{ updatedAt: number; days: number; entries: RunUsageRollupEntry[] }> {
+  const filePath = resolveRunUsageLogPath();
+  const daysSafe = Math.max(1, Math.floor(params.days));
+  const now = Date.now();
+  const since = new Date();
+  since.setDate(since.getDate() - (daysSafe - 1));
+  const sinceMs = since.getTime();
+
+  if (!fs.existsSync(filePath)) {
+    return { updatedAt: Date.now(), days: daysSafe, entries: [] };
+  }
+
+  const wantedChannel = params.channel?.trim().toLowerCase();
+
+  const map = new Map<string, RunUsageRollupEntry>();
+  const stream = fs.createReadStream(filePath, { encoding: "utf8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const evt = JSON.parse(trimmed) as RunUsageEvent;
+      if (!evt || typeof evt.ts !== "number" || evt.ts < sinceMs || evt.ts > now + 60_000) {
+        continue;
+      }
+      const evtChannel = evt.channel?.trim().toLowerCase();
+      if (wantedChannel && evtChannel !== wantedChannel) {
+        continue;
+      }
+
+      const key: RunUsageRollupKey = {
+        date: dayKey(evt.ts),
+        channel: evtChannel,
+        jobName: evt.kind === "cron" ? evt.jobName : undefined,
+      };
+      const mapKey = `${key.date}::${key.channel ?? ""}::${key.jobName ?? ""}`;
+      const existing = map.get(mapKey) ?? {
+        key,
+        runs: 0,
+        totalTokens: 0,
+        totalCostUsd: 0,
+        missingCostRuns: 0,
+      };
+
+      existing.runs += 1;
+      existing.totalTokens += totalTokensFromUsage(evt.usage);
+      if (typeof evt.costUsd === "number" && Number.isFinite(evt.costUsd) && evt.costUsd >= 0) {
+        existing.totalCostUsd = (existing.totalCostUsd ?? 0) + evt.costUsd;
+      } else {
+        existing.missingCostRuns += 1;
+      }
+
+      map.set(mapKey, existing);
+    } catch {
+      // ignore malformed
+    }
+  }
+
+  const entries = Array.from(map.values()).sort((a, b) => {
+    const d = a.key.date.localeCompare(b.key.date);
+    if (d !== 0) return d;
+    const c = (a.key.channel ?? "").localeCompare(b.key.channel ?? "");
+    if (c !== 0) return c;
+    return (a.key.jobName ?? "").localeCompare(b.key.jobName ?? "");
+  });
+
+  // Normalize totalCostUsd: if every entry is missing, set undefined to avoid implying $0.
+  for (const entry of entries) {
+    if ((entry.totalCostUsd ?? 0) === 0 && entry.missingCostRuns === entry.runs) {
+      delete (entry as { totalCostUsd?: number }).totalCostUsd;
+    }
+  }
+
+  return { updatedAt: Date.now(), days: daysSafe, entries };
+}


### PR DESCRIPTION
Implements a first pass at cost-aware ops tooling:

- Rule-based model router (channel/lane/sessionKeyPrefix/isCron/agentId) with optional per-run fallback override
- Per-run usage log (opt-in) at ~/.openclaw/usage/runs.jsonl
- New chat command: /usage rollup [days] [channel:discord]
- Routing can optionally force a receipt mode for chat (tokens/cost/full)
- Cron isolated agent turns now also apply routing + write to usage log

Docs:
- docs/runbooks/model-routing-and-cost-receipts.md

Notes:
- UI “usage limits” surfacing is not included yet; this PR lays the data plumbing needed for it.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a first-pass “cost-aware ops” plumbing layer: a rule-based model router (`models.routing.rules`) that can pick a primary model + fallback list and optionally force a per-run receipt mode, plus an opt-in append-only per-run usage log (`~/.openclaw/usage/runs.jsonl`) and a new `/usage rollup [days] [channel:…]` command that aggregates that log. Routing is applied to both chat runs (`get-reply-run.ts` → `FollowupRun`) and cron isolated agent turns (`cron/isolated-agent/run.ts`), and usage/cost events are recorded after successful runs.

Key issues to address before relying on lane-based routing/receipts: chat routing currently passes a session queue key as the “lane”, so `match.lane` rules won’t work as intended, and per-run receipt overrides cannot explicitly disable receipts (a `receipt: "off"` rule won’t override a session `/usage` setting).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but lane-based routing and per-run receipt overrides have correctness issues that can make the feature behave unexpectedly.
- Core changes are additive and guarded (usage logging is opt-in), but there are at least two behavior bugs: chat routing passes a per-session queue key as the routing “lane”, breaking `match.lane`, and per-run receipt overrides cannot disable receipts. Rollup date bucketing is also host-timezone dependent, which can confuse reporting.
- src/auto-reply/reply/get-reply-run.ts, src/cron/isolated-agent/run.ts, src/auto-reply/reply/agent-runner.ts, src/infra/run-usage-log.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->