### PR TITLE
fix(gateway): persist user messages from chat.send to session transcript

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -145,6 +145,56 @@ function appendAssistantTranscriptMessage(params: {
   return { ok: true, messageId, message: transcriptEntry.message };
 }
 
+function appendUserTranscriptMessage(params: {
+  message: string;
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  senderId?: string;
+  senderName?: string;
+}): TranscriptAppendResult {
+  const transcriptPath = resolveTranscriptPath({
+    sessionId: params.sessionId,
+    storePath: params.storePath,
+    sessionFile: params.sessionFile,
+  });
+  if (!transcriptPath) {
+    return { ok: false, error: "transcript path not resolved" };
+  }
+
+  if (!fs.existsSync(transcriptPath)) {
+    return { ok: false, error: "transcript file not found" };
+  }
+
+  const now = Date.now();
+  const messageId = randomUUID().slice(0, 8);
+  const messageBody: Record<string, unknown> = {
+    role: "user",
+    content: [{ type: "text", text: params.message }],
+    timestamp: now,
+  };
+  if (params.senderId) {
+    messageBody.senderId = params.senderId;
+  }
+  if (params.senderName) {
+    messageBody.senderName = params.senderName;
+  }
+  const transcriptEntry = {
+    type: "message",
+    id: messageId,
+    timestamp: new Date(now).toISOString(),
+    message: messageBody,
+  };
+
+  try {
+    fs.appendFileSync(transcriptPath, `${JSON.stringify(transcriptEntry)}\n`, "utf-8");
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  return { ok: true, messageId, message: transcriptEntry.message };
+}
+
 function nextChatSeq(context: { agentRunSeq: Map<string, number> }, runId: string) {
   const next = (context.agentRunSeq.get(runId) ?? 0) + 1;
   context.agentRunSeq.set(runId, next);
@@ -369,7 +419,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
-    const { cfg, entry } = loadSessionEntry(p.sessionKey);
+    const { cfg, storePath, entry } = loadSessionEntry(p.sessionKey);
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,
@@ -444,12 +494,29 @@ export const chatHandlers: GatewayRequestHandlers = {
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
 
+      // Persist user message to transcript before dispatching (fixes #5735)
+      const clientInfo = client?.connect?.client;
+      if (entry?.sessionId && parsedMessage.trim()) {
+        const userAppended = appendUserTranscriptMessage({
+          message: parsedMessage,
+          sessionId: entry.sessionId,
+          storePath,
+          sessionFile: entry.sessionFile,
+          senderId: clientInfo?.id,
+          senderName: clientInfo?.displayName,
+        });
+        if (!userAppended.ok) {
+          context.logGateway.debug?.(
+            `webchat user transcript append skipped: ${userAppended.error ?? "unknown"}`,
+          );
+        }
+      }
+
       const trimmedMessage = parsedMessage.trim();
       const injectThinking = Boolean(
         p.thinking && trimmedMessage && !trimmedMessage.startsWith("/"),
       );
       const commandBody = injectThinking ? `/think ${p.thinking} ${parsedMessage}` : parsedMessage;
-      const clientInfo = client?.connect?.client;
       // Inject timestamp so agents know the current date/time.
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658


### PR DESCRIPTION
## Summary

- User messages sent via Gateway WebSocket (`chat.send`) are now persisted to the session transcript JSONL file
- Previously, only assistant messages were written, causing `chat.history` to return incomplete history

## Changes

- Add `appendUserTranscriptMessage()` function (mirrors existing `appendAssistantTranscriptMessage()`)
- Call it in `chat.send` handler before dispatching to agent

## Test plan

- [x] Existing gateway tests pass (208/208)
- [ ] Manual: send message via webchat, verify user message appears in `~/.openclaw/agents/<id>/sessions/<session>.jsonl`
- [ ] Manual: call `chat.history` and verify user messages are included

Fixes #5735

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds persistence of inbound user messages from the Gateway WebSocket `chat.send` handler into the session transcript JSONL, mirroring the existing assistant transcript append behavior. This is intended to make `chat.history` return complete conversation history by ensuring user messages are written alongside assistant messages.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but it likely still misses the first user message in new sessions due to transcript file creation ordering.
- Change is localized and follows existing transcript format, but `appendUserTranscriptMessage()` currently refuses to create the transcript file, and the call site runs before any code that would create it, undermining the intended fix for fresh sessions.
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->