### PR TITLE
fix: add id and aria-label attributes to webchat form inputs for acce…

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -87,6 +87,7 @@ export function renderChatControls(state: AppViewState) {
     <div class="chat-controls">
       <label class="field chat-controls__session">
         <select
+	  id="webchat-session-select"
           .value=${state.sessionKey}
           ?disabled=${!state.connected}
           @change=${(e: Event) => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -334,6 +334,8 @@ export function renderChat(props: ChatProps) {
           <label class="field chat-compose__field">
             <span>Message</span>
             <textarea
+	      id="webchat-message-input"
+	      aria-label="Message"
               ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
               .value=${props.draft}
               ?disabled=${!props.connected}


### PR DESCRIPTION
## Description
This PR adds missing `id` and `aria-label` attributes to webchat form elements to improve accessibility and enable proper browser autofill behavior.

## Changes
- Added `id="webchat-message-input"` and `aria-label="Message"` to the message textarea in `ui/src/ui/views/chat.ts`
- Added `id="webchat-session-select"` to the session selector dropdown in `ui/src/ui/app-render.helpers.ts`

## Why
- Improves accessibility for screen readers and assistive technologies
- Enables proper browser autofill behavior
- Eliminates DevTools accessibility warnings
- Follows HTML and WCAG best practices
- The visual label is hidden with CSS, so aria-label is necessary for screen reader users

## Related Issue
Fixes #5833

## Testing
- [x] Build passes without errors
- [x] No TypeScript errors
- [x] Form elements are properly accessible
- [x] Browser autofill works correctly
- [x] Screen readers can identify form elements

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes are minimal and focused
- [x] No breaking changes
- [x] Tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves webchat accessibility and autofill behavior by adding stable `id` attributes (and an `aria-label`) to form inputs. Specifically, the message textarea in `ui/src/ui/views/chat.ts` is given an `id` and an accessible name, and the session selector in `ui/src/ui/app-render.helpers.ts` is given an `id`, which helps assistive tech, DevTools a11y checks, and browser autofill associate fields reliably.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized to UI markup attributes, and unlikely to affect runtime behavior beyond improved accessibility/autofill.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->