### PR TITLE
PR checklist template + heartbeat efficiency runbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+- What does this change do?
+
+## Why
+- What user pain / bug / risk does it address?
+
+## Checklist
+- [ ] Plan/approach documented (short is fine)
+- [ ] Implemented the change
+- [ ] Updated docs/runbook **or** explained why docs aren’t needed
+- [ ] Verified docs ↔ code consistency (the docs describe the actual behavior)
+- [ ] Added/updated tests **or** explained why not
+- [ ] Considered safety/permissions (external side effects, secrets, destructive ops)
+
+## Notes for reviewers
+- Anything non-obvious? edge cases?
+
+## Screenshots / output (if applicable)

--- a/docs/runbooks/heartbeat-efficiency.md
+++ b/docs/runbooks/heartbeat-efficiency.md
@@ -1,0 +1,56 @@
+# Heartbeat efficiency (cost + latency)
+
+Heartbeats are meant to be cheap, boring, and frequent.
+
+This runbook collects patterns to reduce cost/latency and avoid accidental “expensive no-ops.”
+
+## Principles
+
+1) **No-op fast when there’s nothing to do**
+- If the heartbeat checklist is empty, do not call external tools.
+- If there are no deltas since the last run, emit a heartbeat ack and stop.
+
+2) **Cache + diff, don’t re-scan**
+- Store lightweight state (last run timestamp, last seen IDs, hashes) per source.
+- Only fetch new items since the last watermark.
+
+3) **Batch checks**
+- Prefer a single heartbeat that checks 2–4 sources over many tiny jobs.
+
+4) **Keep prompts tiny**
+- Heartbeats should not include large chat history.
+- Keep output terse unless something actionable is found.
+
+## Recommended implementation patterns
+
+### A) State file per heartbeat
+Keep a small JSON state file, e.g.
+
+```json
+{
+  "lastRunAt": 0,
+  "sources": {
+    "email": { "lastId": "..." },
+    "x": { "lastSeenTweetId": "..." }
+  }
+}
+```
+
+### B) Delta-only fetch
+- Use provider APIs’ “since” cursor when available.
+- Otherwise, store a content hash and ignore duplicates.
+
+### C) Cost ceilings
+- Route heartbeats to cheaper models (or local) by default.
+- Use a fallback chain only when validation fails (not on every run).
+
+## Operator guidance
+
+If a heartbeat is costing money and producing no output:
+- shrink the checklist
+- add state+diffing
+- reduce model size / switch to local
+- add a hard stop condition
+
+## Related
+- Model routing + receipts: see `docs/runbooks/model-routing-and-cost-receipts.md`


### PR DESCRIPTION
Adds two small quality-of-life artifacts:

- .github/pull_request_template.md: lightweight plan→implement→docs→verify checklist
- docs/runbooks/heartbeat-efficiency.md: patterns to keep heartbeats cheap (no-op fast, cache+diff, batch checks, prompt discipline)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a GitHub PR template with a lightweight plan→implement→docs→verify checklist, and introduces a new runbook documenting patterns for keeping heartbeat jobs cheap (no-op fast paths, cache+diff, batching, and prompt discipline).

The PR template lives under `.github/` and will standardize author checklists for new changes. The heartbeat runbook extends the existing `docs/runbooks/` guidance by describing practical implementation patterns and operator troubleshooting steps when heartbeats are costly but unproductive.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing doc hygiene issues (broken reference and heading anchor risk).
- Changes are documentation-only and low blast radius, but the runbook currently references a likely-nonexistent file and uses an em dash in a heading that may break Mintlify anchors per repo docs guidance.
- docs/runbooks/heartbeat-efficiency.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->