### PR TITLE
fix(wizard): resume interrupted installation from last completed step

### DIFF
--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -73,6 +73,22 @@ vi.mock("../tui/tui.js", () => ({
   runTui,
 }));
 
+// Mock wizard-state to return no incomplete state by default
+const loadWizardState = vi.hoisted(() => vi.fn(async () => null));
+const updateWizardStep = vi.hoisted(() => vi.fn(async () => {}));
+const completeWizard = vi.hoisted(() => vi.fn(async () => {}));
+const clearWizardState = vi.hoisted(() => vi.fn(async () => {}));
+const shouldSkipStep = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("./wizard-state.js", () => ({
+  loadWizardState,
+  updateWizardStep,
+  completeWizard,
+  clearWizardState,
+  shouldSkipStep,
+  getResumeStep: vi.fn(() => "risk-ack"),
+}));
+
 describe("runOnboardingWizard", () => {
   it("exits when config is invalid", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({

--- a/src/wizard/wizard-state.test.ts
+++ b/src/wizard/wizard-state.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearWizardState,
+  completeWizard,
+  createEmptyState,
+  getResumeStep,
+  hasIncompleteWizard,
+  loadWizardState,
+  saveWizardState,
+  shouldSkipStep,
+  updateWizardStep,
+  type WizardState,
+} from "./wizard-state.js";
+
+describe("wizard-state", () => {
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wizard-state-test-"));
+    originalEnv = { ...process.env };
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("loadWizardState", () => {
+    it("returns null when no state file exists", async () => {
+      const state = await loadWizardState(process.env);
+      expect(state).toBeNull();
+    });
+
+    it("loads existing state from disk", async () => {
+      const testState: WizardState = {
+        version: 1,
+        startedAt: new Date().toISOString(),
+        lastCompletedStep: "flow-select",
+        completed: false,
+        answers: { flow: "quickstart" },
+      };
+      await fs.writeFile(path.join(tempDir, "wizard-state.json"), JSON.stringify(testState));
+
+      const loaded = await loadWizardState(process.env);
+      expect(loaded).toEqual(testState);
+    });
+
+    it("returns null for invalid JSON", async () => {
+      await fs.writeFile(path.join(tempDir, "wizard-state.json"), "not valid json");
+
+      const state = await loadWizardState(process.env);
+      expect(state).toBeNull();
+    });
+
+    it("returns null for unknown version", async () => {
+      await fs.writeFile(path.join(tempDir, "wizard-state.json"), JSON.stringify({ version: 999 }));
+
+      const state = await loadWizardState(process.env);
+      expect(state).toBeNull();
+    });
+  });
+
+  describe("saveWizardState", () => {
+    it("saves state to disk", async () => {
+      const testState: WizardState = {
+        version: 1,
+        startedAt: new Date().toISOString(),
+        lastCompletedStep: "auth-choice",
+        completed: false,
+        answers: { authChoice: "apiKey" },
+      };
+
+      await saveWizardState(testState, process.env);
+
+      const raw = await fs.readFile(path.join(tempDir, "wizard-state.json"), "utf-8");
+      const parsed = JSON.parse(raw);
+      expect(parsed).toEqual(testState);
+    });
+
+    it("creates state directory if it does not exist", async () => {
+      const nestedDir = path.join(tempDir, "nested", "state");
+      process.env.OPENCLAW_STATE_DIR = nestedDir;
+
+      const testState = createEmptyState();
+      await saveWizardState(testState, process.env);
+
+      const exists = await fs
+        .stat(path.join(nestedDir, "wizard-state.json"))
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+  });
+
+  describe("clearWizardState", () => {
+    it("removes state file from disk", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "wizard-state.json"),
+        JSON.stringify(createEmptyState()),
+      );
+
+      await clearWizardState(process.env);
+
+      const exists = await fs
+        .stat(path.join(tempDir, "wizard-state.json"))
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(false);
+    });
+
+    it("does not throw if file does not exist", async () => {
+      await expect(clearWizardState(process.env)).resolves.not.toThrow();
+    });
+  });
+
+  describe("updateWizardStep", () => {
+    it("creates new state if none exists", async () => {
+      await updateWizardStep("risk-ack", { riskAccepted: true }, process.env);
+
+      const state = await loadWizardState(process.env);
+      expect(state?.lastCompletedStep).toBe("risk-ack");
+      expect(state?.answers.riskAccepted).toBe(true);
+    });
+
+    it("updates existing state", async () => {
+      await updateWizardStep("risk-ack", { riskAccepted: true }, process.env);
+      await updateWizardStep("flow-select", { flow: "quickstart" }, process.env);
+
+      const state = await loadWizardState(process.env);
+      expect(state?.lastCompletedStep).toBe("flow-select");
+      expect(state?.answers.riskAccepted).toBe(true);
+      expect(state?.answers.flow).toBe("quickstart");
+    });
+
+    it("marks as completed when step is done", async () => {
+      await updateWizardStep("done", undefined, process.env);
+
+      const state = await loadWizardState(process.env);
+      expect(state?.completed).toBe(true);
+    });
+  });
+
+  describe("hasIncompleteWizard", () => {
+    it("returns false when no state exists", async () => {
+      const result = await hasIncompleteWizard(process.env);
+      expect(result).toBe(false);
+    });
+
+    it("returns true when incomplete state exists", async () => {
+      await updateWizardStep("flow-select", { flow: "quickstart" }, process.env);
+
+      const result = await hasIncompleteWizard(process.env);
+      expect(result).toBe(true);
+    });
+
+    it("returns false when state is completed", async () => {
+      await updateWizardStep("done", undefined, process.env);
+
+      const result = await hasIncompleteWizard(process.env);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getResumeStep", () => {
+    it("returns risk-ack when no step completed", () => {
+      const state = createEmptyState();
+      expect(getResumeStep(state)).toBe("risk-ack");
+    });
+
+    it("returns next step after last completed", () => {
+      const state: WizardState = {
+        ...createEmptyState(),
+        lastCompletedStep: "flow-select",
+      };
+      expect(getResumeStep(state)).toBe("config-handling");
+    });
+
+    it("returns risk-ack for completed wizard", () => {
+      const state: WizardState = {
+        ...createEmptyState(),
+        lastCompletedStep: "done",
+        completed: true,
+      };
+      expect(getResumeStep(state)).toBe("risk-ack");
+    });
+  });
+
+  describe("shouldSkipStep", () => {
+    it("returns false when no state", () => {
+      expect(shouldSkipStep("risk-ack", null)).toBe(false);
+    });
+
+    it("returns true for steps before lastCompletedStep", () => {
+      const state: WizardState = {
+        ...createEmptyState(),
+        lastCompletedStep: "channels",
+      };
+      expect(shouldSkipStep("risk-ack", state)).toBe(true);
+      expect(shouldSkipStep("flow-select", state)).toBe(true);
+      expect(shouldSkipStep("gateway-config", state)).toBe(true);
+    });
+
+    it("returns false for steps after lastCompletedStep", () => {
+      const state: WizardState = {
+        ...createEmptyState(),
+        lastCompletedStep: "channels",
+      };
+      expect(shouldSkipStep("skills", state)).toBe(false);
+      expect(shouldSkipStep("hooks", state)).toBe(false);
+    });
+
+    it("returns true for the lastCompletedStep itself", () => {
+      const state: WizardState = {
+        ...createEmptyState(),
+        lastCompletedStep: "channels",
+      };
+      expect(shouldSkipStep("channels", state)).toBe(true);
+    });
+  });
+
+  describe("completeWizard", () => {
+    it("clears state file", async () => {
+      await updateWizardStep("channels", undefined, process.env);
+      await completeWizard(process.env);
+
+      const state = await loadWizardState(process.env);
+      expect(state).toBeNull();
+    });
+  });
+});

--- a/src/wizard/wizard-state.ts
+++ b/src/wizard/wizard-state.ts
@@ -1,0 +1,210 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const WIZARD_STATE_FILENAME = "wizard-state.json";
+
+/**
+ * Steps in the onboarding wizard flow.
+ * Each step represents a checkpoint that can be resumed.
+ */
+export type WizardStep =
+  | "risk-ack"
+  | "flow-select"
+  | "config-handling"
+  | "workspace"
+  | "auth-choice"
+  | "model-select"
+  | "gateway-config"
+  | "channels"
+  | "skills"
+  | "hooks"
+  | "completion"
+  | "done";
+
+/**
+ * Persisted wizard state for resumption after interruption.
+ */
+export interface WizardState {
+  /** Version for state schema migrations */
+  version: 1;
+  /** Timestamp when wizard was started */
+  startedAt: string;
+  /** Last completed step */
+  lastCompletedStep: WizardStep | null;
+  /** Whether wizard completed successfully */
+  completed: boolean;
+  /** Collected answers to resume from */
+  answers: {
+    riskAccepted?: boolean;
+    flow?: "quickstart" | "advanced";
+    configAction?: "keep" | "modify" | "reset";
+    workspace?: string;
+    authChoice?: string;
+    model?: string;
+  };
+}
+
+function createEmptyState(): WizardState {
+  return {
+    version: 1,
+    startedAt: new Date().toISOString(),
+    lastCompletedStep: null,
+    completed: false,
+    answers: {},
+  };
+}
+
+function resolveWizardStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveStateDir(env);
+  return path.join(stateDir, WIZARD_STATE_FILENAME);
+}
+
+/**
+ * Load wizard state from disk.
+ * Returns null if no state exists or state is invalid.
+ */
+export async function loadWizardState(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<WizardState | null> {
+  const statePath = resolveWizardStatePath(env);
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    const parsed = JSON.parse(raw) as WizardState;
+    if (parsed.version !== 1) {
+      // Unknown version, start fresh
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save wizard state to disk.
+ */
+export async function saveWizardState(
+  state: WizardState,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const statePath = resolveWizardStatePath(env);
+  const stateDir = path.dirname(statePath);
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(statePath, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Clear wizard state (called on successful completion or explicit reset).
+ */
+export async function clearWizardState(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const statePath = resolveWizardStatePath(env);
+  try {
+    await fs.unlink(statePath);
+  } catch {
+    // Ignore if doesn't exist
+  }
+}
+
+/**
+ * Update wizard state with a completed step and optional answers.
+ */
+export async function updateWizardStep(
+  step: WizardStep,
+  answers?: Partial<WizardState["answers"]>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  let state = await loadWizardState(env);
+  if (!state) {
+    state = createEmptyState();
+  }
+  state.lastCompletedStep = step;
+  if (answers) {
+    state.answers = { ...state.answers, ...answers };
+  }
+  if (step === "done") {
+    state.completed = true;
+  }
+  await saveWizardState(state, env);
+}
+
+/**
+ * Mark wizard as complete and clear state.
+ */
+export async function completeWizard(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  await clearWizardState(env);
+}
+
+/**
+ * Check if there's an incomplete wizard session.
+ */
+export async function hasIncompleteWizard(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
+  const state = await loadWizardState(env);
+  return state !== null && !state.completed;
+}
+
+/**
+ * Get the step to resume from (the one after lastCompletedStep).
+ */
+export function getResumeStep(state: WizardState): WizardStep {
+  const stepOrder: WizardStep[] = [
+    "risk-ack",
+    "flow-select",
+    "config-handling",
+    "workspace",
+    "auth-choice",
+    "model-select",
+    "gateway-config",
+    "channels",
+    "skills",
+    "hooks",
+    "completion",
+    "done",
+  ];
+
+  if (!state.lastCompletedStep) {
+    return "risk-ack";
+  }
+
+  const lastIndex = stepOrder.indexOf(state.lastCompletedStep);
+  if (lastIndex === -1 || lastIndex >= stepOrder.length - 1) {
+    return "risk-ack";
+  }
+
+  return stepOrder[lastIndex + 1];
+}
+
+/**
+ * Check if a step should be skipped based on previous state.
+ */
+export function shouldSkipStep(step: WizardStep, state: WizardState | null): boolean {
+  if (!state) {
+    return false;
+  }
+
+  const stepOrder: WizardStep[] = [
+    "risk-ack",
+    "flow-select",
+    "config-handling",
+    "workspace",
+    "auth-choice",
+    "model-select",
+    "gateway-config",
+    "channels",
+    "skills",
+    "hooks",
+    "completion",
+    "done",
+  ];
+
+  if (!state.lastCompletedStep) {
+    return false;
+  }
+
+  const stepIndex = stepOrder.indexOf(step);
+  const lastIndex = stepOrder.indexOf(state.lastCompletedStep);
+
+  return stepIndex <= lastIndex;
+}
+
+export { createEmptyState };


### PR DESCRIPTION
## Summary
Fixes #5804

When the installation wizard is interrupted (e.g., by `Ctrl+Z` + `kill %%`), subsequent runs now detect the incomplete state and offer to resume from where it left off.

## Changes
- Add `wizard-state.ts` module to persist wizard progress to disk
- Track completion of each major wizard step (risk-ack, flow-select, channels, etc.)
- On wizard start, detect incomplete state and prompt user to resume or restart
- Skip already-completed steps when resuming  
- Clear state file on successful wizard completion

## Implementation Details
The wizard state is stored in `$OPENCLAW_STATE_DIR/wizard-state.json` and includes:
- `lastCompletedStep`: The most recent step that was fully completed
- `answers`: Collected user choices (flow type, auth choice, model selection, etc.)
- `completed`: Boolean flag indicating successful completion

## User Experience
When an incomplete wizard is detected, the user sees:
```
┌ Incomplete setup detected
│
│ A previous setup was interrupted.
│ Last completed step: channels
│ Would resume from: skills
│
└

○ How would you like to proceed?
│ ○ Resume where I left off — Continue from the last completed step
│ ○ Start fresh — Begin setup from the beginning
└
```

## Testing
- 22 unit tests for wizard-state module (all passing)
- TypeScript compiles cleanly
- Lint passes (on new code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a persisted `wizard-state.json` (under `OPENCLAW_STATE_DIR`) and wires onboarding to detect an interrupted wizard run, prompt the user to resume or restart, and attempt to skip already-completed steps. It introduces a new `src/wizard/wizard-state.ts` module with load/save/update helpers plus unit tests, and updates `runOnboardingWizard` to checkpoint progress during key steps and clear state on successful completion.

Main concerns are around the resume logic not actually skipping most steps (due to state not being updated in-memory and several steps not being gated), and a behavior change where skipping `channels` also skips writing the updated config to disk.


<h3>Confidence Score: 2/5</h3>

- This PR has user-facing resume logic issues that likely prevent correct resumption in common cases.
- While the new wizard-state module is straightforward and well-tested, the onboarding integration appears to have multiple logic gaps: resumed runs won’t skip most steps as intended, and resuming past channels can skip persisting config updates. These are likely to be hit by real users resuming interrupted installs.
- src/wizard/onboarding.ts, src/wizard/wizard-state.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->