### PR TITLE
fix: curly lint errors and formal conformance fork permissions

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -73,12 +73,17 @@ jobs:
               'If this change is intentional, follow up by updating the formal models repo or regenerating the extracted artifacts there.',
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            } catch (err) {
+              // Fork PRs don't have write permissions — log and continue
+              core.warning(`Could not comment on PR: ${err.message}`);
+            }
 
       - name: Summary
         run: |

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -58,7 +58,9 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
 }
 
 function buildTimeSection(params: { userTimezone?: string }) {
-  if (!params.userTimezone) return [];
+  if (!params.userTimezone) {
+    return [];
+  }
   return [
     "## Current Date & Time",
     `Time zone: ${params.userTimezone}`,

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -221,7 +221,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));
-    if (parentPeerMatch) return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    if (parentPeerMatch) {
+      return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    }
   }
 
   if (guildId) {


### PR DESCRIPTION
## Summary
- Adds curly braces to two single-line `if` statements that violate the recently enabled `curly` lint rule
  - `src/routing/resolve-route.ts:224` — parentPeerMatch early return
  - `src/agents/system-prompt.ts:61` — userTimezone guard clause
- Wraps the `formal_conformance` workflow PR comment in a try/catch so it doesn't fail on fork PRs that lack write permissions

Both lint errors are currently failing on `main`. The formal conformance failure affects all fork PRs.

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (no behavior change)
- [ ] `formal_conformance` job no longer fails on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes two small TypeScript changes to satisfy the newly enabled `curly` ESLint rule by adding braces around single-line `if` early returns in `src/routing/resolve-route.ts` and `src/agents/system-prompt.ts`.

It also updates the `formal_conformance` GitHub Actions workflow to avoid failing on fork PRs without write permissions by wrapping the `github.rest.issues.createComment` call in a `try/catch` and logging a warning when commenting is not permitted. This keeps the job informational while still surfacing drift via uploaded artifacts and the final step summary.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped (curly-brace lint fixes and a workflow try/catch) and do not affect runtime logic beyond formatting; the workflow change only prevents non-critical permission failures on fork PRs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->