### PR TITLE
fix(test): match docker-compose.yml single-quote style in gateway sync test

### DIFF
--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -136,6 +136,6 @@ describe("docker-setup.sh", () => {
   it("keeps docker-compose gateway command in sync", async () => {
     const compose = await readFile(join(repoRoot, "docker-compose.yml"), "utf8");
     expect(compose).not.toContain("gateway-daemon");
-    expect(compose).toContain('"gateway"');
+    expect(compose).toContain("'gateway'");
   });
 });


### PR DESCRIPTION
## Summary

- Fix the `docker-setup.test.ts` test that fails on every PR branch
- The `docker-compose.yml` was updated to use single quotes (`'gateway'`) but the test still asserted double quotes (`"gateway"`)
- This one-character fix unblocks CI for all open PRs

## Root Cause

A recent commit switched `docker-compose.yml` from double-quoted YAML flow sequences to single-quoted ones, but the sync test wasn't updated to match.

## Test plan

- [ ] Verify `pnpm test -- src/docker-setup.test.ts` passes
- [ ] Verify CI test jobs (node, bun, windows) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `src/docker-setup.test.ts` sync assertion to match a recent quoting change in `docker-compose.yml` (from `"gateway"` to `'gateway'`). This keeps the test aligned with the repo’s compose file so CI no longer fails due to a string-literal mismatch.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a one-character test assertion update that aligns with an existing config formatting change; it’s isolated to a single test and does not affect runtime code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
