### PR TITLE
fix: classify model 404 errors as failover reason to prevent bot hang

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -36,6 +36,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "model_not_found"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -50,6 +50,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 408;
     case "format":
       return 400;
+    case "model_not_found":
+      return 404;
     default:
       return undefined;
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -576,6 +576,26 @@ export function isCloudCodeAssistFormatError(raw: string): boolean {
   return !isImageDimensionErrorMessage(raw) && matchesErrorPatterns(raw, ERROR_PATTERNS.format);
 }
 
+export function isModelNotFoundErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const msg = raw.toLowerCase();
+  if (/\b404\b/.test(msg) && /not[_-]?found/i.test(msg)) {
+    return true;
+  }
+  if (msg.includes("not_found_error")) {
+    return true;
+  }
+  if (/is not found for api version/i.test(raw)) {
+    return true;
+  }
+  if (/model[:\s]+\S+/i.test(raw) && /not[_-]?\s*found/i.test(raw)) {
+    return true;
+  }
+  return false;
+}
+
 export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean {
   if (!msg || msg.stopReason !== "error") {
     return false;
@@ -607,6 +627,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isAuthErrorMessage(raw)) {
     return "auth";
+  }
+  if (isModelNotFoundErrorMessage(raw)) {
+    return "model_not_found";
   }
   return null;
 }

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "unknown";


### PR DESCRIPTION
## Summary

- Add `isModelNotFoundErrorMessage()` to detect 404/model-not-found errors from Google, Anthropic, and OpenAI APIs
- Wire it into `classifyFailoverReason()` as a new `"model_not_found"` failover reason
- Add `"model_not_found"` to `FailoverReason` and `AuthProfileFailureReason` types
- Map to HTTP 404 in `resolveFailoverStatus()`

## Root Cause

When a configured model returns a 404 "not found" error (e.g., deprecated Google Gemini models like `gemini-1.5-pro`), `classifyFailoverReason()` returned `null` because it had no pattern matcher for 404 errors. This caused `isFailoverErrorMessage()` to return `false`, preventing both auth profile rotation and model fallback. The bot hung indefinitely on Telegram.

## Error Patterns Detected

- `404 not found` (generic HTTP)
- `not_found_error` (error type)
- `is not found for api version` (Google-specific)
- `model: <id> not found` (model reference)

Fixes #4992
