### PR TITLE
fix: add timeout to WhatsApp connection wait

### DIFF
--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -164,20 +164,30 @@ export async function createWaSocket(
   return sock;
 }
 
-export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>) {
+export async function waitForWaConnection(
+  sock: ReturnType<typeof makeWASocket>,
+  timeoutMs = 60_000,
+) {
   return new Promise<void>((resolve, reject) => {
     type OffCapable = {
       off?: (event: string, listener: (...args: unknown[]) => void) => void;
     };
     const evWithOff = sock.ev as unknown as OffCapable;
 
+    const timer = setTimeout(() => {
+      evWithOff.off?.("connection.update", handler);
+      reject(new Error("WhatsApp connection timed out"));
+    }, timeoutMs);
+
     const handler = (...args: unknown[]) => {
       const update = (args[0] ?? {}) as Partial<import("@whiskeysockets/baileys").ConnectionState>;
       if (update.connection === "open") {
+        clearTimeout(timer);
         evWithOff.off?.("connection.update", handler);
         resolve();
       }
       if (update.connection === "close") {
+        clearTimeout(timer);
         evWithOff.off?.("connection.update", handler);
         reject(update.lastDisconnect ?? new Error("Connection closed"));
       }


### PR DESCRIPTION
## Summary

- Add a 60-second timeout to `waitForWaConnection()` to prevent indefinite hangs
- Clean up event listener and timer on all code paths (open, close, timeout)

## Root Cause

`waitForWaConnection()` in `src/web/session.ts` waited for the WhatsApp socket to emit either "open" or "close" connection state, but had no timeout. If the connection entered a perpetual reconnecting/intermediate state (e.g. network interruption during QR code scanning, authentication failure), the promise hung forever — blocking startup flows, preventing reconnection handlers, and leaking event listeners.

## Fix

Added a configurable timeout (default 60 seconds) that rejects with a clear error message if neither "open" nor "close" fires within the limit. The timer is properly cleaned up on all resolution paths.

Fixes #4956
