### PR TITLE
fix: preserve Slack thread context in queued message drain

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -80,7 +80,7 @@ export function scheduleFollowupDrain(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null,
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({


### PR DESCRIPTION
## Summary

- Fix queue drain to preserve string-type thread IDs (Slack thread_ts, Matrix thread event IDs)
- Queued Slack thread messages now correctly reply in-thread instead of posting to the main channel

## Root Cause

In `src/auto-reply/reply/queue/drain.ts` (line 74-76), the collect-mode drain searched for `originatingThreadId` using `typeof === "number"`, which only matched Telegram topic IDs (numbers). Slack's `thread_ts` and Matrix thread event IDs are strings, so they were silently dropped when collecting queued messages.

## Fix

Changed the type check from `typeof i.originatingThreadId === "number"` to `i.originatingThreadId != null` to match thread IDs of any type (string or number).

Fixes #5233
