### PR TITLE
fix: add missing Emacs key bindings to TUI editor

### DIFF
--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -52,7 +52,19 @@ export class CustomEditor extends Editor {
     if (matchesKey(data, Key.ctrl("d"))) {
       if (this.getText().length === 0 && this.onCtrlD) {
         this.onCtrlD();
+        return;
       }
+      // Emacs delete-char: forward to parent as Delete key
+      super.handleInput("\x1b[3~");
+      return;
+    }
+    // Emacs cursor movement: Ctrl+B → left, Ctrl+F → right
+    if (matchesKey(data, Key.ctrl("b"))) {
+      super.handleInput("\x1b[D");
+      return;
+    }
+    if (matchesKey(data, Key.ctrl("f"))) {
+      super.handleInput("\x1b[C");
       return;
     }
     super.handleInput(data);


### PR DESCRIPTION
## Summary

- Add Ctrl+B (backward-char), Ctrl+F (forward-char), and fix Ctrl+D (delete-char) in the TUI input editor
- Standard Emacs/readline key bindings now work as expected

## Root Cause

The `CustomEditor` class intercepted Ctrl+D and returned early without forwarding to the parent `Editor` class, even when the input was non-empty. Ctrl+B and Ctrl+F were not handled at all, and the pi-tui base `Editor` class doesn't bind them by default.

## Fix

In `src/tui/components/custom-editor.ts`:
- **Ctrl+D**: Only triggers exit when input is empty (EOF behavior). When non-empty, forwards as Delete key to delete character under cursor
- **Ctrl+B**: Forwards as left arrow key to move cursor left one character
- **Ctrl+F**: Forwards as right arrow key to move cursor right one character

Fixes #5083
