### PR TITLE
fix: guard against undefined model name in Ollama discovery

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -109,20 +109,22 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
       console.warn("No Ollama models found on local instance");
       return [];
     }
-    return data.models.map((model) => {
-      const modelId = model.name;
-      const isReasoning =
-        modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
-      return {
-        id: modelId,
-        name: modelId,
-        reasoning: isReasoning,
-        input: ["text"],
-        cost: OLLAMA_DEFAULT_COST,
-        contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-      };
-    });
+    return data.models
+      .filter((model) => model.name)
+      .map((model) => {
+        const modelId = model.name;
+        const isReasoning =
+          modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
+        return {
+          id: modelId,
+          name: modelId,
+          reasoning: isReasoning,
+          input: ["text"],
+          cost: OLLAMA_DEFAULT_COST,
+          contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
+          maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+        };
+      });
   } catch (error) {
     console.warn(`Failed to discover Ollama models: ${String(error)}`);
     return [];


### PR DESCRIPTION
## Summary

- Filter out Ollama models with undefined/empty `name` before processing
- Prevents `TypeError: Cannot read properties of undefined (reading 'includes')` during model discovery

## Root Cause

The Ollama `/api/tags` endpoint can return models with undefined `name` in edge cases. The code called `.toLowerCase().includes("r1")` directly on `model.name` without checking for undefined first, causing a TypeError.

## Fix

Added `.filter((model) => model.name)` before `.map()` to skip models with no name, since they wouldn't be usable anyway.

Fixes #5062
