### PR TITLE
fix: preserve config settings when plugin validation fails

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -261,10 +261,22 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           loggedInvalidConfigs.add(configPath);
           deps.logger.error(`Invalid config at ${configPath}:\\n${details}`);
         }
-        const error = new Error("Invalid config");
-        (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
-        (error as { code?: string; details?: string }).details = details;
-        throw error;
+        // Preserve the parsed config with defaults applied instead of
+        // returning {} which silently drops all security settings (#5052).
+        const fallback = applyModelDefaults(
+          applyCompactionDefaults(
+            applyContextPruningDefaults(
+              applyAgentDefaults(
+                applySessionDefaults(
+                  applyLoggingDefaults(applyMessageDefaults(resolvedConfig as OpenClawConfig)),
+                ),
+              ),
+            ),
+          ),
+        );
+        normalizeConfigPaths(fallback);
+        applyConfigEnv(fallback, deps.env);
+        return applyConfigOverrides(fallback);
       }
       if (validated.warnings.length > 0) {
         const details = validated.warnings
@@ -310,10 +322,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);
         throw err;
-      }
-      const error = err as { code?: string };
-      if (error?.code === "INVALID_CONFIG") {
-        return {};
       }
       deps.logger.error(`Failed to read config at ${configPath}`, err);
       return {};


### PR DESCRIPTION
## Summary

- When `validateConfigObjectWithPlugins()` fails (e.g. missing plugin manifest), `loadConfig()` now preserves the parsed config with defaults applied instead of returning `{}`
- This prevents security-critical settings like `dmPolicy` and `allowFrom` from being silently dropped

## Root Cause

In `src/config/io.ts`, when config validation failed (e.g. due to a missing plugin manifest), the `INVALID_CONFIG` error was thrown and caught, returning an empty `{}` object. This caused all user settings to be lost, including:

- `channels.whatsapp.dmPolicy` (defaults to `"pairing"` instead of user's `"allowlist"`)
- `channels.whatsapp.allowFrom` (lost entirely)
- `channels.defaults.groupPolicy` (defaults to `"open"`)
- All other channel security configuration

## Fix

Instead of throwing `INVALID_CONFIG` and returning `{}` in the catch block, the validation failure is now handled inline: the parsed config gets the same defaults applied as the success path and is returned directly. The error is still logged so users know validation failed, but their security settings remain in effect.

Fixes #5052
