### PR TITLE
fix: only replace backslashes in PATH entries on Windows

### DIFF
--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -216,9 +216,9 @@ function getPathModule(platform: NodeJS.Platform) {
 
 function normalizePathEntry(entry: string, platform: NodeJS.Platform): string {
   const pathModule = getPathModule(platform);
-  const normalized = pathModule.normalize(entry).replaceAll("\\", "/");
+  const normalized = pathModule.normalize(entry);
   if (platform === "win32") {
-    return normalized.toLowerCase();
+    return normalized.replaceAll("\\", "/").toLowerCase();
   }
   return normalized;
 }


### PR DESCRIPTION
## Summary

- Fix `normalizePathEntry()` in `service-audit.ts` to only replace backslashes with forward slashes on Windows
- On Linux/macOS, backslashes can appear in PATH entries (e.g. `\/home/user/.npm-global/bin`) and should not be stripped
- This caused false "missing npm global bin dir" warnings during `openclaw doctor` PATH audit

## Root Cause

`normalizePathEntry()` unconditionally ran `.replaceAll("\\", "/")` on all platforms. On Linux, a PATH entry like `\/home/ubuntu/.npm-global/bin` had its backslash stripped to `/home/ubuntu/.npm-global/bin`, but the actual PATH still contained the backslash version — so the comparison failed and the doctor incorrectly reported the directory as missing.

## Fix

Move the `.replaceAll("\\", "/")` call inside the `platform === "win32"` branch where it belongs.

Fixes #5158

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed platform-specific path normalization in `normalizePathEntry()` by moving the backslash-to-forward-slash replacement into the Windows-only branch. On Linux/macOS, backslashes can legitimately appear in PATH entries (e.g., escaped paths like `\/home/user/.npm-global/bin`) and should not be stripped. The previous implementation unconditionally replaced all backslashes, causing the PATH audit in `openclaw doctor` to incorrectly report missing directories when the actual PATH contained escaped backslashes.

- Moved `.replaceAll("\\", "/")` inside the `platform === "win32"` conditional in `src/daemon/service-audit.ts:201`
- Fixes false positive "missing npm global bin dir" warnings during PATH validation on Unix systems

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, correct, and well-justified. It properly isolates Windows-specific path normalization logic and fixes a legitimate bug where Unix path entries with backslashes were incorrectly modified. The change maintains existing Windows behavior while correcting Unix behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
