### PR TITLE
fix(gateway): include message field in WebChat error payloads

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -202,12 +202,22 @@ export function createAgentEventHandler({
       nodeSendToSession(sessionKey, "chat", payload);
       return;
     }
+    // Include a renderable message so WebChat clients that only display the
+    // `message` field still show the error instead of an empty bubble.
+    const errorText = text || (error ? formatForLog(error) : undefined);
     const payload = {
       runId: clientRunId,
       sessionKey,
       seq,
       state: "error" as const,
       errorMessage: error ? formatForLog(error) : undefined,
+      message: errorText
+        ? {
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: errorText }],
+            timestamp: Date.now(),
+          }
+        : undefined,
     };
     broadcast("chat", payload);
     nodeSendToSession(sessionKey, "chat", payload);


### PR DESCRIPTION
## Summary

- When the agent fails with persistent API errors (429 rate limit, 402 billing), the WebChat error payload only contained `errorMessage` but no `message` object
- WebChat clients that render the `message` field showed empty bubbles instead of the error description
- Now includes a renderable `message` using any partial streamed text or the formatted error description
- Backwards compatible — existing clients that read `errorMessage` continue to work

## Test plan

- [x] `pnpm build` passes
- [ ] Trigger a persistent 429 error in WebChat and verify the error text is displayed instead of an empty bubble

Fixes #2202
