### PR TITLE
fix(gateway): send terminal chunk before [DONE] in OpenAI streaming

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -273,6 +273,28 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let sawAssistantDelta = false;
   let closed = false;
+  let sentTerminalChunk = false;
+
+  /** Send a terminal chunk with finish_reason before [DONE]. */
+  const endStream = () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (!sentTerminalChunk) {
+      sentTerminalChunk = true;
+      writeSse(res, {
+        id: runId,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      });
+    }
+    unsubscribe();
+    writeDone(res);
+    res.end();
+  };
 
   const unsubscribe = onAgentEvent((evt) => {
     if (evt.runId !== runId) {
@@ -321,17 +343,16 @@ export async function handleOpenAiHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        closed = true;
-        unsubscribe();
-        writeDone(res);
-        res.end();
+        endStream();
       }
     }
   });
 
   req.on("close", () => {
-    closed = true;
-    unsubscribe();
+    if (!closed) {
+      closed = true;
+      unsubscribe();
+    }
   });
 
   void (async () => {
@@ -394,6 +415,7 @@ export async function handleOpenAiHttpRequest(
       if (closed) {
         return;
       }
+      sentTerminalChunk = true;
       writeSse(res, {
         id: runId,
         object: "chat.completion.chunk",
@@ -413,12 +435,7 @@ export async function handleOpenAiHttpRequest(
         data: { phase: "error" },
       });
     } finally {
-      if (!closed) {
-        closed = true;
-        unsubscribe();
-        writeDone(res);
-        res.end();
-      }
+      endStream();
     }
   })();
 


### PR DESCRIPTION
## Summary
- OpenAI-compatible streaming clients expect a **terminal chunk** (empty `delta` + `finish_reason: "stop"`) before the `[DONE]` sentinel
- Without it, some clients crash while finalizing the stream
- Added a centralized `endStream()` helper that ensures the terminal chunk is written exactly once before `[DONE]`, preventing duplicate sends across the lifecycle event handler, error path, and finally block

Closes #4298

## Test plan
- [x] `pnpm build` passes
- [ ] Connect an OpenAI-compatible client (e.g. `openai` Python SDK) to the gateway streaming endpoint and verify the terminal chunk appears before `[DONE]`
