### PR TITLE
fix(history): re-repair tool_use/tool_result pairing after truncation

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -44,6 +44,7 @@ import {
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
 import {
   applySkillEnvOverrides,
@@ -425,10 +426,14 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const limited = limitHistoryTurns(
+        const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
+        // Re-repair tool_use/tool_result pairing after truncation, since
+        // limitHistoryTurns may slice in the middle of a paired exchange.
+        const limited =
+          truncated.length < validated.length ? sanitizeToolUseResultPairing(truncated) : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }


### PR DESCRIPTION
## Summary
- `limitHistoryTurns()` can slice in the middle of a tool_use/tool_result pair, leaving orphaned tool_result blocks that the Anthropic API rejects with "unexpected tool_use_id found in tool_result blocks".
- Added a call to `sanitizeToolUseResultPairing()` after truncation (only when messages were actually removed) to repair any broken pairs.
- Applied to both code paths: `attempt.ts` (embedded run) and `compact.ts` (session compaction).

## Test plan
- [x] `pnpm build` passes
- [x] All 54 embedded runner + transcript repair tests pass (7 test files)
- [ ] Manual: maintain a long conversation with tool calls, configure a history limit that triggers truncation, verify no API rejection errors

Fixes #4367
