### PR TITLE
fix(config): add firecrawl and readability to web fetch schema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -187,6 +187,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -195,6 +207,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- The `tools.web.fetch` Zod schema used `.strict()` (`additionalProperties: false`) but was missing the `readability` boolean and `firecrawl` nested object properties.
- This caused config validation to reject `tools.web.fetch.firecrawl.*` settings with `Unrecognized key: 'firecrawl'`, even though the code in `web-fetch.ts` and the uiHints in `schema.ts` already supported them.
- Added `ToolsWebFetchFirecrawlSchema` with all six documented properties (`enabled`, `apiKey`, `baseUrl`, `onlyMainContent`, `maxAgeMs`, `timeoutSeconds`) and the `readability` boolean to `ToolsWebFetchSchema`.

## Test plan
- [x] `pnpm build` passes (type-check clean)
- [x] All 192 tests pass
- [ ] Manual: set `tools.web.fetch.firecrawl.enabled: true` and `tools.web.fetch.firecrawl.baseUrl` in config — verify no validation error

Fixes #2527
