### PR TITLE
fix: honor HTTP_PROXY/HTTPS_PROXY env vars for all fetch calls

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -7,6 +7,7 @@ import { normalizeEnv } from "../infra/env.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { setupGlobalProxy } from "../infra/proxy.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
@@ -28,6 +29,7 @@ export async function runCli(argv: string[] = process.argv) {
   const normalizedArgv = stripWindowsNodeExec(argv);
   loadDotEnv({ quiet: true });
   normalizeEnv();
+  setupGlobalProxy();
   ensureOpenClawCliOnPath();
 
   // Enforce the minimum supported runtime before doing any work.

--- a/src/infra/proxy.ts
+++ b/src/infra/proxy.ts
@@ -1,0 +1,14 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+
+/**
+ * Set up a global proxy dispatcher when HTTP_PROXY/HTTPS_PROXY env vars are set.
+ * Uses undici's EnvHttpProxyAgent which automatically reads HTTP_PROXY,
+ * HTTPS_PROXY, and NO_PROXY (case-insensitive) from the environment.
+ */
+export function setupGlobalProxy(env: Record<string, string | undefined> = process.env): void {
+  const proxyUrl = env.HTTPS_PROXY || env.https_proxy || env.HTTP_PROXY || env.http_proxy;
+  if (!proxyUrl) {
+    return;
+  }
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+}


### PR DESCRIPTION
## Summary

- Add global proxy support via undici's `EnvHttpProxyAgent` and `setGlobalDispatcher()`
- All `globalThis.fetch` calls now route through the configured proxy
- `NO_PROXY` is automatically respected
- No-op when no proxy env vars are set

## Root Cause

Node's `globalThis.fetch` (backed by undici internally) does not automatically honor `HTTP_PROXY`/`HTTPS_PROXY` environment variables. The codebase uses `globalThis.fetch` for media downloads, web fetch tool, and various API calls. Only Telegram had explicit `ProxyAgent` setup via per-account config. Users behind corporate proxies/VPNs had no way to route traffic through their proxy.

## Fix

Created `src/infra/proxy.ts` that:
1. Reads `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy` from the environment
2. If any are set, creates an `EnvHttpProxyAgent` (which also reads `NO_PROXY` automatically)
3. Calls `setGlobalDispatcher()` to apply it to all `globalThis.fetch` calls

Called early in `src/cli/run-main.ts` after `.env` loading and env normalization.

Fixes #2102
