### PR TITLE
fix: use shell mode on Windows for command spawning

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -111,11 +111,13 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const child = spawn(resolveCommand(argv[0]), argv.slice(1), {
+  const isWindows = process.platform === "win32";
+  const child = spawn(isWindows ? argv[0] : resolveCommand(argv[0]), argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: isWindows,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Fixes `spawn npm ENOENT` error on Windows when installing plugins or running npm commands
- Adds `shell: true` to `spawn()` options on Windows in `runCommandWithTimeout()`, allowing PATH-based command resolution for `.cmd`/`.exe` executables like `npm`

Closes #4557
