### PR TITLE
fix: return clear error when compacting CLI provider sessions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -31,6 +31,7 @@ import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../d
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
+import { isCliProvider } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   ensureSessionHeader,
@@ -113,6 +114,15 @@ export async function compactEmbeddedPiSessionDirect(
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
   const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+
+  if (isCliProvider(provider, params.config)) {
+    return {
+      ok: false,
+      compacted: false,
+      reason: `Compaction is not supported for CLI providers (${provider}/${modelId}). Switch to an API-based model to use /compact.`,
+    };
+  }
+
   const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
   await ensureOpenClawModelsJson(params.config, agentDir);
   const { model, error, authStorage, modelRegistry } = resolveModel(


### PR DESCRIPTION
## Summary

- Adds an early `isCliProvider()` check in `compactEmbeddedPiSessionDirect()` before attempting to resolve the model
- CLI providers (claude-cli, codex-cli, custom backends) don't have models in the standard registry, so compaction would fail with a confusing "Unknown model: claude-cli/opus" error
- Now returns a clear message: "Compaction is not supported for CLI providers"

## Test plan

- [x] Build passes
- [ ] Verify `/compact` with a CLI provider returns the new clear error instead of "Unknown model"

Fixes #3874
