### PR TITLE
fix(compaction): invoke hooks and prevent delivery race condition

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -61,6 +61,7 @@ import {
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { buildModelAliasLines, resolveModel } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
@@ -434,6 +435,32 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Run before_compaction hook
+        const messageCountBefore = session.messages.length;
+        let tokenCountBefore: number | undefined;
+        try {
+          tokenCountBefore = 0;
+          for (const message of session.messages) {
+            tokenCountBefore += estimateTokens(message);
+          }
+        } catch {
+          tokenCountBefore = undefined;
+        }
+        const hookRunner = getGlobalHookRunner();
+        const hookCtx = {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: params.messageChannel ?? params.messageProvider,
+        };
+        if (hookRunner?.hasHooks("before_compaction")) {
+          await hookRunner.runBeforeCompaction(
+            { messageCount: messageCountBefore, tokenCount: tokenCountBefore },
+            hookCtx,
+          );
+        }
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -450,6 +477,25 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Run after_compaction hook
+        const messageCountAfter = session.messages.length;
+        const compactedCount = messageCountBefore - messageCountAfter;
+        if (hookRunner?.hasHooks("after_compaction")) {
+          hookRunner
+            .runAfterCompaction(
+              {
+                messageCount: messageCountAfter,
+                tokenCount: tokensAfter,
+                compactedCount,
+              },
+              hookCtx,
+            )
+            .catch((err) => {
+              log.warn(`after_compaction hook error: ${String(err)}`);
+            });
+        }
+
         return {
           ok: true,
           compacted: true,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 
+import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
 import type { SessionEntry } from "./types.js";
 import { loadSessionStore, updateSessionStore } from "./store.js";
 import { resolveDefaultSessionStorePath, resolveSessionTranscriptPath } from "./paths.js";
@@ -108,42 +109,48 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   const sessionFile =
     entry.sessionFile?.trim() || resolveSessionTranscriptPath(entry.sessionId, params.agentId);
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  // Acquire session write lock to prevent race with compaction
+  const lock = await acquireSessionWriteLock({ sessionFile });
+  try {
+    await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
-  const sessionManager = SessionManager.open(sessionFile);
-  sessionManager.appendMessage({
-    role: "assistant",
-    content: [{ type: "text", text: mirrorText }],
-    api: "openai-responses",
-    provider: "openclaw",
-    model: "delivery-mirror",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: mirrorText }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: {
         input: 0,
         output: 0,
         cacheRead: 0,
         cacheWrite: 0,
-        total: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
       },
-    },
-    stopReason: "stop",
-    timestamp: Date.now(),
-  });
-
-  if (!entry.sessionFile || entry.sessionFile !== sessionFile) {
-    await updateSessionStore(storePath, (current) => {
-      current[sessionKey] = {
-        ...entry,
-        sessionFile,
-      };
+      stopReason: "stop",
+      timestamp: Date.now(),
     });
-  }
 
-  emitSessionTranscriptUpdate(sessionFile);
-  return { ok: true, sessionFile };
+    if (!entry.sessionFile || entry.sessionFile !== sessionFile) {
+      await updateSessionStore(storePath, (current) => {
+        current[sessionKey] = {
+          ...entry,
+          sessionFile,
+        };
+      });
+    }
+
+    emitSessionTranscriptUpdate(sessionFile);
+    return { ok: true, sessionFile };
+  } finally {
+    await lock.release();
+  }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in the compaction/delivery system:

1. **Compaction hooks never invoked**: `runBeforeCompaction` and `runAfterCompaction` hooks were defined in the plugin system but never called. Now invoked in `compactEmbeddedPiSessionDirect()`.

2. **Race condition between delivery and compaction**: `appendAssistantMessageToSessionTranscript()` was appending to the session transcript without acquiring the write lock, while compaction holds the lock during modification. Added session write lock to coordinate both operations.

## Changes

- `src/agents/pi-embedded-runner/compact.ts`: Add hook invocations with context (agentId, sessionKey, workspace, messageProvider)
- `src/config/sessions/transcript.ts`: Wrap transcript append in session write lock

## Test plan

- [x] Existing test suite passes (800+ tests)
- [x] `pnpm lint` passes
- [x] `pnpm build` passes

Split from #5400 for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes two issues in the embedded Pi compaction/delivery flow: it wires the previously-defined `before_compaction` / `after_compaction` plugin hooks into `compactEmbeddedPiSessionDirect()`, and it adds a session write lock around `appendAssistantMessageToSessionTranscript()` to prevent concurrent transcript writes from racing with compaction.

Overall this fits the existing design where compaction and other session mutations coordinate via `acquireSessionWriteLock`, and where plugin hooks are dispatched through the global hook runner.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there are a couple of hook/locking edge cases to resolve or align on.
- Core changes are small and aligned with existing concurrency patterns, but the compaction hook context may pass an undefined sessionKey, and the fire-and-forget `after_compaction` hook can interact poorly with the session write lock and session disposal if plugins touch the transcript.
- src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->