### PR TITLE
feat(plugins): add runtime.outbound.sendToSession for session-aware delivery

### DIFF
--- a/src/infra/outbound/send-to-session.test.ts
+++ b/src/infra/outbound/send-to-session.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendToSession } from "./send-to-session.js";
+
+// Mock deliverOutboundPayloads
+vi.mock("./deliver.js", () => ({
+  deliverOutboundPayloads: vi
+    .fn()
+    .mockResolvedValue([{ channel: "telegram", messageId: "123", chatId: "456" }]),
+}));
+
+describe("sendToSession", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp("/tmp/send-to-session-test-");
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("returns error when session not found", async () => {
+    // Create empty session store
+    await fs.promises.writeFile(storePath, JSON.stringify({}));
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Session not found");
+    }
+  });
+
+  it("returns error when session has no channel", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastTo: "456",
+          // no lastChannel
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No channel found");
+    }
+  });
+
+  it("returns error when session has no destination", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          // no lastTo
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No destination found");
+    }
+  });
+
+  it("delivers message when session has valid routing", async () => {
+    const { deliverOutboundPayloads } = await import("./deliver.js");
+
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "telegram:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "456",
+          lastAccountId: "bot1",
+          lastThreadId: "789",
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "telegram:123",
+      text: "Hello world",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].channel).toBe("telegram");
+    }
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "456",
+        accountId: "bot1",
+        threadId: "789",
+        payloads: [{ text: "Hello world" }],
+      }),
+    );
+  });
+
+  it("skips webchat channel", async () => {
+    await fs.promises.writeFile(
+      storePath,
+      JSON.stringify({
+        "webchat:123": {
+          sessionId: "abc",
+          updatedAt: Date.now(),
+          lastChannel: "webchat",
+          lastTo: "456",
+        },
+      }),
+    );
+
+    const result = await sendToSession({
+      sessionKey: "webchat:123",
+      text: "Hello",
+      cfg: { session: { store: storePath } } as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("No channel found");
+    }
+  });
+});

--- a/src/infra/outbound/send-to-session.ts
+++ b/src/infra/outbound/send-to-session.ts
@@ -1,0 +1,138 @@
+/**
+ * Session-aware outbound delivery.
+ *
+ * Provides a unified way to send messages to the active channel for a session
+ * without needing to know the channel type or conversation details.
+ */
+
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { loadSessionStore } from "../../config/sessions/store.js";
+import type { SessionChannelId } from "../../config/sessions/types.js";
+import { deliverOutboundPayloads, type OutboundDeliveryResult } from "./deliver.js";
+import type { OutboundChannel } from "./targets.js";
+
+export type SendToSessionParams = {
+  /** The session key to send to. */
+  sessionKey: string;
+  /** The text message to send. */
+  text: string;
+  /** Optional agent ID (defaults to "main"). */
+  agentId?: string;
+  /** Optional config override (will load from disk if not provided). */
+  cfg?: OpenClawConfig;
+  /** Optional media URLs to include. */
+  mediaUrls?: string[];
+  /** If true, errors are caught and logged instead of thrown. */
+  bestEffort?: boolean;
+};
+
+export type SendToSessionResult =
+  | { ok: true; results: OutboundDeliveryResult[] }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the outbound channel from a session channel ID.
+ * Returns undefined if the channel is not a valid outbound channel.
+ */
+function resolveOutboundChannel(
+  channel: SessionChannelId | undefined,
+): Exclude<OutboundChannel, "none"> | undefined {
+  if (!channel) {
+    return undefined;
+  }
+  // webchat is not a valid outbound channel for this purpose
+  if (channel === "webchat") {
+    return undefined;
+  }
+  return channel;
+}
+
+/**
+ * Send a message to the active channel for a session.
+ *
+ * Looks up the session metadata to determine the channel, destination, and
+ * threading context, then delivers the message through the unified outbound
+ * delivery system.
+ *
+ * @example
+ * ```typescript
+ * const result = await sendToSession({
+ *   sessionKey: "telegram:123456789",
+ *   text: "🔄 Compacting context...",
+ * });
+ * if (!result.ok) {
+ *   console.error("Failed to send:", result.error);
+ * }
+ * ```
+ */
+export async function sendToSession(params: SendToSessionParams): Promise<SendToSessionResult> {
+  const { sessionKey, text, agentId, mediaUrls, bestEffort } = params;
+
+  // Load config if not provided
+  let cfg = params.cfg;
+  if (!cfg) {
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      return { ok: false, error: `Failed to load config: ${String(err)}` };
+    }
+  }
+
+  // Resolve the session store path
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+
+  // Load the session entry
+  let store: Record<string, import("../../config/sessions/types.js").SessionEntry>;
+  try {
+    store = loadSessionStore(storePath);
+  } catch (err) {
+    return { ok: false, error: `Failed to load session store: ${String(err)}` };
+  }
+
+  const entry = store[sessionKey];
+  if (!entry) {
+    return { ok: false, error: `Session not found: ${sessionKey}` };
+  }
+
+  // Extract delivery context from session
+  const channel = resolveOutboundChannel(entry.lastChannel);
+  const to = entry.lastTo;
+  const accountId = entry.lastAccountId;
+  const threadId = entry.lastThreadId;
+
+  if (!channel) {
+    return { ok: false, error: `No channel found for session: ${sessionKey}` };
+  }
+  if (!to) {
+    return { ok: false, error: `No destination found for session: ${sessionKey}` };
+  }
+
+  // Build payloads
+  const payloads: ReplyPayload[] = [];
+  if (mediaUrls?.length) {
+    for (const url of mediaUrls) {
+      payloads.push({ text: payloads.length === 0 ? text : "", mediaUrl: url });
+    }
+  } else {
+    payloads.push({ text });
+  }
+
+  // Deliver
+  try {
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel,
+      to,
+      accountId,
+      payloads,
+      threadId,
+      bestEffort,
+    });
+    return { ok: true, results };
+  } catch (err) {
+    return { ok: false, error: `Delivery failed: ${String(err)}` };
+  }
+}

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -69,6 +69,7 @@ import { resolveDiscordChannelAllowlist } from "../../discord/resolve-channels.j
 import { resolveDiscordUserAllowlist } from "../../discord/resolve-users.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../discord/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { sendToSession } from "../../infra/outbound/send-to-session.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
@@ -337,6 +338,9 @@ export function createPluginRuntime(): PluginRuntime {
         buildTemplateMessageFromPayload,
         monitorLineProvider,
       },
+    },
+    outbound: {
+      sendToSession,
     },
     logging: {
       shouldLogVerbose,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -73,6 +73,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type SendToSession = typeof import("../../infra/outbound/send-to-session.js").sendToSession;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -347,6 +348,9 @@ export type PluginRuntime = {
       buildTemplateMessageFromPayload: BuildTemplateMessageFromPayload;
       monitorLineProvider: MonitorLineProvider;
     };
+  };
+  outbound: {
+    sendToSession: SendToSession;
   };
   logging: {
     shouldLogVerbose: ShouldLogVerbose;


### PR DESCRIPTION
## Summary

Adds `runtime.outbound.sendToSession()` to the plugin runtime, enabling plugins to send messages to the active conversation without knowing channel-specific details upfront.

The function resolves channel and destination from session metadata, then routes through the unified `deliverOutboundPayloads` system.

## API

```typescript
const result = await runtime.outbound.sendToSession({
  sessionKey: ctx.sessionKey,
  text: "🔄 Compacting context...",
});
```

## Use cases

- Plugin hooks (before_compaction, after_compaction) notifying users
- Plugins that need to send follow-up messages to the current conversation
- Any scenario where the plugin doesn't know/care which channel initiated the session

## Changes

- `src/infra/outbound/send-to-session.ts`: Core implementation
- `src/infra/outbound/send-to-session.test.ts`: Unit tests (5 test cases)
- `src/plugins/runtime/index.ts`: Expose in plugin runtime
- `src/plugins/runtime/types.ts`: Type definitions

## Test plan

- [x] Unit tests for sendToSession covering: session not found, no channel, no destination, valid routing, webchat skip
- [x] `pnpm lint` passes
- [x] Existing test suite passes (800+ tests)

Split from #5400 for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new session-aware outbound helper (`sendToSession`) that resolves channel/destination from the session store and routes messages through the existing `deliverOutboundPayloads` pipeline, then exposes it on the plugin runtime as `runtime.outbound.sendToSession`. Includes unit tests covering missing session metadata, successful routing, and webchat exclusion.

This integrates with the existing sessions subsystem (`resolveStorePath` + `loadSessionStore`) to look up `lastChannel/lastTo` routing state, and reuses the outbound delivery layer rather than implementing per-channel sending logic in plugins.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge with low risk.
- Changes are additive and well-scoped, with unit coverage for key branches and minimal interaction surface (session store lookup + existing outbound delivery). Only notable issue is a misleading `bestEffort` docstring/semantics mismatch that could confuse plugin authors, but it doesn’t appear to break runtime behavior.
- src/infra/outbound/send-to-session.ts (parameter semantics/documentation)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->