### PR TITLE
fix(web): add timeout parameter to waitForWaConnection (CWE-400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web: add timeout parameter to waitForWaConnection to prevent indefinite hangs (CWE-400). (#5916) Thanks @hclsys.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -40,7 +40,7 @@ export async function monitorWebInbox(options: {
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
   });
-  await waitForWaConnection(sock);
+  await waitForWaConnection(sock, 120_000);
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -21,7 +21,7 @@ export async function loginWeb(
   });
   logInfo("Waiting for WhatsApp connection...", runtime);
   try {
-    await wait(sock);
+    await wait(sock, 120_000);
     console.log(success("✅ Linked! Credentials saved for future sends."));
   } catch (err) {
     const code =
@@ -42,7 +42,7 @@ export async function loginWeb(
         authDir: account.authDir,
       });
       try {
-        await wait(retry);
+        await wait(retry, 120_000);
         console.log(success("✅ Linked after restart; web session ready."));
         return;
       } finally {


### PR DESCRIPTION
## Summary

Add configurable timeout to `waitForWaConnection()` to prevent indefinite hangs (DoS via CWE-400).

**Changes:**
- Add `timeoutMs` parameter with default `0` (no timeout, backward compatible)
- Add `removeListener` fallback for EventEmitter compatibility
- Proper `cleanup()` function clears timeout AND removes handler on all exit paths
- Updated callers with 120s timeout: `monitor.ts`, `login.ts` (2 call sites)
- `login-qr.ts` unchanged (has external 3min TTL)

## Test plan

- [x] All 208 existing tests pass
- [x] `pnpm format` passes
- [ ] Manual test: WhatsApp monitor starts and times out correctly if connection stalls

## Security

**CWE-400** (Uncontrolled Resource Consumption) - Fixed by adding timeout parameter.

Fixes #4956

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `timeoutMs` parameter to `waitForWaConnection()` and ensures the event handler + timer are cleaned up on success/failure/timeout. Updates the CLI login and inbound monitor flows to pass a 120s timeout to avoid hanging indefinitely while waiting for WhatsApp Web to connect.

This change fits into the web channel/session layer (`src/web/session.ts`) by making connection-waiting behavior bounded, and then applies it at the higher-level entry points (`src/web/login.ts`, `src/web/inbound/monitor.ts`) that initiate sockets and block on connection establishment.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves resilience by bounding connection waits.
- The timeout + cleanup logic is straightforward and localized, and existing behavior remains unless callers opt in. Main risk is around the `waitForConnection` injection point in `loginWeb`, where passing a callback with the old arity could now break at runtime. Also, some call sites still use the default no-timeout behavior.
- src/web/login.ts (waitForConnection callback typing/arity); src/web/session.ts (timeout default vs security intent)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->