### PR TITLE
perf: optimize workspace setup and Chrome extension asset loading

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -58,7 +58,9 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
 }
 
 function buildTimeSection(params: { userTimezone?: string }) {
-  if (!params.userTimezone) return [];
+  if (!params.userTimezone) {
+    return [];
+  }
   return [
     "## Current Date & Time",
     `Time zone: ${params.userTimezone}`,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -166,22 +166,30 @@ export async function ensureAgentWorkspace(params?: {
     return existing.every((v) => !v);
   })();
 
-  const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
-  const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
-  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
-  const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
-  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
-  const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
+  // Check if workspace is incomplete and copy missing files
+  const filesToEnsure = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+  const templates = [
+    DEFAULT_AGENTS_FILENAME,
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_TOOLS_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+  ];
 
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  for (let i = 0; i < filesToEnsure.length; i++) {
+    try {
+      await fs.access(filesToEnsure[i]);
+    } catch {
+      await writeFileIfMissing(filesToEnsure[i], await loadTemplate(templates[i]));
+    }
+  }
   if (isBrandNewWorkspace) {
-    await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
+    try {
+      await fs.access(bootstrapPath);
+    } catch {
+      await writeFileIfMissing(bootstrapPath, await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME));
+    }
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
 

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -35,7 +35,7 @@ async function ensureExtensionSourceInWorkspace(): Promise<string> {
   // Find the source assets - try multiple possible locations
   const possibleSources = [
     // Relative to compiled code location (current approach)
-    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../assets/chrome-extension"),
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../assets/chrome-extension"),
     // Relative to project root when running from source
     path.resolve(process.cwd(), "assets/chrome-extension"),
     // In case we're in a subdirectory
@@ -59,7 +59,7 @@ async function ensureExtensionSourceInWorkspace(): Promise<string> {
   // Copy source assets to workspace
   fs.mkdirSync(path.dirname(workspaceSourceDir), { recursive: true });
   if (fs.existsSync(workspaceSourceDir)) {
-    await fs.promises.rm(workspaceSourceDir, { recursive: true });
+    await fs.promises.rm(workspaceSourceDir, { recursive: true, force: true });
   }
 
   await fs.promises.cp(foundSource, workspaceSourceDir, { recursive: true });

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -221,7 +221,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));
-    if (parentPeerMatch) return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    if (parentPeerMatch) {
+      return choose(parentPeerMatch.agentId, "binding.peer.parent");
+    }
   }
 
   if (guildId) {


### PR DESCRIPTION
## Summary

This PR improves startup performance and reliability by optimizing how OpenClaw handles workspace files and Chrome extension assets.

### Changes

**1. Lazy template loading in workspace setup** (`src/agents/workspace.ts`)
- Only loads templates when files are actually missing (vs. loading all templates upfront)
- Reduces unnecessary file I/O on subsequent startups when workspace already exists

**2. Workspace-based Chrome extension assets** (`src/cli/browser-cli-extension.ts`)
- Copies extension source to `STATE_DIR/browser/chrome-extension-source` on first use
- Searches multiple fallback locations for bundled assets
- Avoids hardcoded path assumptions that can break in different install scenarios (npm global, local dev, etc.)

### Testing
- [x] Tested locally with fresh workspace setup
- [x] Tested Chrome extension installation flow
- [x] Linter passes (`npm run lint`)

### AI Disclosure
🤖 This PR was AI-assisted (Claude via OpenClaw). I understand the changes and have tested them locally.

---

Happy to address any feedback! 🦞

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR optimizes startup by lazily loading workspace bootstrap templates only when a file is missing, and changes Chrome extension installation to first copy the extension source into `STATE_DIR/browser/chrome-extension-source` with fallback asset discovery. There are also small formatting-only changes to satisfy lint rules.

Overall the direction is good, but the new extension asset discovery/copy path has a likely incorrect relative candidate for the bundled assets (can break installs when running from source/compiled layouts), and the workspace copy cleanup uses `rm` without `force`, which can fail due to TOCTOU or concurrent state changes.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the Chrome extension asset resolution has a probable path bug that could break extension installation in some environments.
- Workspace template lazy-loading looks correct and preserves error visibility (only ENOENT triggers template load). The main risk is in `ensureExtensionSourceInWorkspace` where the first fallback candidate appears to resolve to `src/assets/...` instead of the intended packaged `assets/...`, plus a small robustness issue around deleting the workspace source directory without `force`.
- src/cli/browser-cli-extension.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->