### PR TITLE
feat: add custom HTTPS port option for tailscale serve (AI-assisted)

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -48,6 +48,7 @@ Notes:
 - `--token <token>`: token override (also sets `OPENCLAW_GATEWAY_TOKEN` for the process).
 - `--password <password>`: password override (also sets `OPENCLAW_GATEWAY_PASSWORD` for the process).
 - `--tailscale <off|serve|funnel>`: expose the Gateway via Tailscale.
+- `--tailscale-https-port <port>`: custom HTTPS port for Tailscale Serve (default: 443).
 - `--tailscale-reset-on-exit`: reset Tailscale serve/funnel config on shutdown.
 - `--allow-unconfigured`: allow gateway start without `gateway.mode=local` in config.
 - `--dev`: create a dev config + workspace if missing (skips BOOTSTRAP.md).

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -51,6 +51,25 @@ force `gateway.auth.mode: "password"`.
 
 Open: `https://<magicdns>/` (or your configured `gateway.controlUi.basePath`)
 
+### Tailnet-only (Serve with custom HTTPS port)
+
+By default, Tailscale Serve uses port 443 for HTTPS. To use a different port,
+specify `httpsPort`:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    tailscale: { mode: "serve", httpsPort: 8443 },
+  },
+}
+```
+
+Open: `https://<magicdns>:8443/` (or your configured `gateway.controlUi.basePath`)
+
+Note: The Gateway still listens on its configured port (default: 18789) locally,
+while Tailscale Serve proxies HTTPS requests from the specified HTTPS port.
+
 ### Tailnet-only (bind to Tailnet IP)
 
 Use this when you want the Gateway to listen directly on the Tailnet IP (no Serve/Funnel).
@@ -90,6 +109,7 @@ Prefer `OPENCLAW_GATEWAY_PASSWORD` over committing a password to disk.
 ```bash
 openclaw gateway --tailscale serve
 openclaw gateway --tailscale funnel --auth password
+openclaw gateway --tailscale serve --tailscale-https-port 8443
 ```
 
 ## Notes
@@ -102,6 +122,8 @@ openclaw gateway --tailscale funnel --auth password
 - `gateway.bind: "auto"` prefers loopback; use `tailnet` if you want Tailnet-only.
 - Serve/Funnel only expose the **Gateway control UI + WS**. Nodes connect over
   the same Gateway WS endpoint, so Serve can work for node access.
+- `gateway.tailscale.httpsPort` allows specifying a custom HTTPS port for Tailscale Serve
+  (default: 443). The Gateway itself continues listening on its configured port locally.
 
 ## Browser control (remote Gateway + local browser)
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -92,6 +92,8 @@ export type GatewayTailscaleConfig = {
   mode?: GatewayTailscaleMode;
   /** Reset serve/funnel configuration on shutdown. */
   resetOnExit?: boolean;
+  /** Custom HTTPS port for tailscale serve (defaults to gateway port if not specified). */
+  httpsPort?: number;
 };
 
 export type GatewayRemoteConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -337,6 +337,7 @@ export const OpenClawSchema = z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),
             resetOnExit: z.boolean().optional(),
+            httpsPort: z.number().int().positive().optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -493,6 +493,7 @@ export async function startGatewayServer(
     tailscaleMode,
     resetOnExit: tailscaleConfig.resetOnExit,
     port,
+    httpsPort: tailscaleConfig.httpsPort,
     controlUiBasePath,
     logTailscale,
   });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -384,12 +384,22 @@ export async function ensureFunnel(
   }
 }
 
-export async function enableTailscaleServe(port: number, exec: typeof runExec = runExec) {
+export async function enableTailscaleServe(
+  port: number,
+  httpsPort: number | undefined,
+  exec: typeof runExec = runExec,
+) {
   const tailscaleBin = await getTailscaleBinary();
-  await execWithSudoFallback(exec, tailscaleBin, ["serve", "--bg", "--yes", `${port}`], {
-    maxBuffer: 200_000,
-    timeoutMs: 15_000,
-  });
+  const httpsPortValue = httpsPort ?? 443;
+  await execWithSudoFallback(
+    exec,
+    tailscaleBin,
+    ["serve", "--bg", "--yes", `--https=${httpsPortValue}`, String(port)],
+    {
+      maxBuffer: 200_000,
+      timeoutMs: 15_000,
+    },
+  );
 }
 
 export async function disableTailscaleServe(exec: typeof runExec = runExec) {


### PR DESCRIPTION
## What
Adds support for specifying a custom HTTPS port when using `tailscale serve` mode. Previously, Tailscale Serve would always use port 443. Now users can specify a custom port (e.g., 8443) via config or CLI flag.

## Why
Users may want to expose their Gateway via Tailscale Serve on a non-standard HTTPS port for various reasons (firewall rules, port conflicts, organizational policies, etc.).

## Changes
- Added `gateway.tailscale.httpsPort` config option (default: 443)
- Added `--tailscale-https-port` CLI flag
- Calls `tailscale serve` with internal flag `--https=PORT` to specify the frontend HTTPS port
- Updated logging to display custom port in the URL when non-default
- Added tests for the new functionality

## Usage

**Config:**
```json
{
  "gateway": {
    "tailscale": { "mode": "serve", "httpsPort": 8443 }
  }
}
```

**CLI:**
```bash
openclaw gateway --tailscale serve --tailscale-https-port 8443
```

## Testing
- ✅ Unit tests: All existing tests pass, added new test for custom httpsPort
- ✅ Manual: Verified with `tailscale serve status` and `curl https://bharats-home-mbp.panda-bull.ts.net:8443`
- ✅ Format: Passes `oxfmt --check`
- ✅ Build: Successful
<img width="2458" height="696" alt="ScreenShot 2026-01-31 at 19 54 46@2x" src="https://github.com/user-attachments/assets/9c2673ca-2731-4b95-bcd9-a14fb2f5f272" />
<img width="2742" height="1746" alt="ScreenShot 2026-01-31 at 19 52 54@2x" src="https://github.com/user-attachments/assets/dd453ee1-ed96-4e0c-ac65-f358003dcddc" />



## AI-Assisted PR
This PR was generated with assistance from Claude (Anthropic). I reviewed the changes and understand what the code does:
- The `--tailscale-https-port` flag sets the frontend HTTPS port that Tailscale Serve listens on
- Internally, OpenClaw calls `tailscale serve --https=8443 18789` where 8443 is the frontend and 18789 is the backend Gateway port
- Default behavior (port 443) is preserved when httpsPort is not specified

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds support for configuring the frontend HTTPS port used by Tailscale Serve when exposing the Gateway Control UI/WebSocket. This introduces a new `gateway.tailscale.httpsPort` config option (validated in the zod schema), a matching `--tailscale-https-port` CLI flag, and threads the value through gateway startup into the Tailscale integration so `tailscale serve` is invoked with `--https=<port>` (defaulting to 443). Logging and docs were updated to reflect the custom-port URL, and unit tests were extended to assert the new flag behavior.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are localized and covered by tests, with a couple of minor consistency/semantics nits.
- The new HTTPS-port option is plumbed end-to-end (CLI/config → gateway startup → tailscale serve invocation) and tests were updated/added to validate the command args. Main concerns are documentation/comment mismatches and a subtle config-shape change when only the CLI https-port flag is provided without an explicit tailscale mode.
- src/config/types.gateway.ts and src/cli/gateway-cli/run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->