### PR TITLE
fix(signal): preserve case for group ids

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,4 +28,11 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves case for group ids (often base64 + case-sensitive)", () => {
+    expect(normalizeSignalMessagingTarget("signal:group:AbC+DeF/=")).toBe("group:AbC+DeF/=");
+    expect(
+      normalizeSignalMessagingTarget("group:qu30zBG/2Oh/XvCULSsEenPrtAsf3AYNKPYn+wlCjTE="),
+    ).toBe("group:qu30zBG/2Oh/XvCULSsEenPrtAsf3AYNKPYn+wlCjTE=");
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -12,8 +12,9 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   }
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
+    // NOTE: group ids are often base64 and can be case-sensitive; do NOT lowercase the id.
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
This PR fixes Signal group messaging target normalization.

Problem:
- Group IDs are often base64/case-sensitive.
- The target normalizer lowercased `group:<id>` which broke routing and caused `Group not found` errors.

Change:
- Preserve group id casing while still matching the `group:` prefix case-insensitively.
- Add a unit test to ensure group ids are not lowercased.

Testing:
- `pnpm test --filter ./src/channels/plugins/normalize/signal.test.ts` (vitest suite passed locally; ran via test-parallel).

AI-assisted: yes (implemented with assistance; verified with local tests).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal messaging target normalization so that `group:<id>` targets preserve the original group ID casing (while still matching the `group:` prefix case-insensitively), preventing case-sensitive/base64 group IDs from being corrupted during normalization. A Vitest unit test was added to assert that group IDs are not lowercased for both `signal:group:<id>` and `group:<id>` inputs.

The change is localized to the Signal normalize plugin (`src/channels/plugins/normalize/signal.ts`), which standardizes target strings used for routing; preserving casing for group IDs aligns behavior with Signal’s case-sensitive identifiers while leaving username/UUID normalization behavior unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, well-scoped, and matches the described bug: it avoids lowercasing the group ID while still detecting the `group:` prefix case-insensitively. Existing normalization behavior for usernames/UUIDs remains unchanged, and a focused unit test covers the regression scenario.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->