### PR TITLE
fix: use configured model for slug generator (AI-assisted)

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
 /**
@@ -26,6 +27,7 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+    const { provider, model } = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -45,6 +47,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       workspaceDir,
       agentDir,
       config: params.cfg,
+      provider,
+      model,
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,


### PR DESCRIPTION
## Summary
- Use the configured default agent model for LLM slug generation instead of falling back to Anthropic defaults.
- Prevent /new hook failures in setups that only configure non-Anthropic providers (e.g., google-antigravity + google-gemini-cli).

## Details
Slug generation uses a temporary embedded agent without specifying provider/model, which defaults to Anthropic. In environments without Anthropic auth, /new triggers FailoverError and can disrupt message handling. This change resolves the default model from config and passes provider/model into the embedded run.

## Testing
- Not run (local reproduction from a live server setup).

## AI Assistance
AI-assisted (OpenCode). Prompt history available on request.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the LLM-based slug generator hook to use the default model configured for the resolved default agent, instead of implicitly falling back to the global Anthropic defaults. Concretely, `src/hooks/llm-slug-generator.ts` now calls `resolveDefaultModelForAgent({ cfg, agentId })` and passes the returned `{ provider, model }` into `runEmbeddedPiAgent`, preventing failures in environments where Anthropic is not configured but other providers are.

This fits existing patterns in the codebase: other embedded/agent flows resolve a model ref from config (with agent overrides) before running, while the embedded runner itself still retains a final fallback to `DEFAULT_PROVIDER/DEFAULT_MODEL` if nothing is provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one hook), follows existing model-selection utilities, and simply plumbs an already-supported `provider/model` pair into `runEmbeddedPiAgent` to avoid unintended Anthropic defaults. No behavior changes outside slug generation and no new side effects beyond selecting the configured default model.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->