### PR TITLE
feat(tools): add fs.restrictToWorkspace config option

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2020,6 +2020,30 @@ Per-agent heartbeats:
 Heartbeats run full agent turns. Shorter intervals burn more tokens; be mindful
 of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 
+`tools.fs` configures filesystem tool restrictions:
+
+- `restrictToWorkspace`: when `true`, restricts `read`, `write`, and `edit` tools to the agent's workspace directory. Paths outside workspace will be rejected. This provides path-based security without requiring Docker sandbox. Default: `false`.
+
+Example:
+```json5
+{
+  tools: {
+    fs: {
+      restrictToWorkspace: true
+    }
+  }
+}
+```
+
+When enabled, the agent cannot:
+- Read files outside the workspace
+- Write files outside the workspace
+- Edit files outside the workspace
+- Use path traversal (`../`) to escape the workspace
+- Follow symlinks that point outside the workspace
+
+Note: This only restricts the filesystem tools (`read`, `write`, `edit`). The `exec` tool can still access the full filesystem unless you also enable Docker sandboxing or restrict `exec` via tool policy.
+
 `tools.exec` configures background exec defaults:
 
 - `backgroundMs`: time before auto-background (ms, default 10000)

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2025,17 +2025,19 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 - `restrictToWorkspace`: when `true`, restricts `read`, `write`, and `edit` tools to the agent's workspace directory. Paths outside workspace will be rejected. This provides path-based security without requiring Docker sandbox. Default: `false`.
 
 Example:
+
 ```json5
 {
   tools: {
     fs: {
-      restrictToWorkspace: true
-    }
-  }
+      restrictToWorkspace: true,
+    },
+  },
 }
 ```
 
 When enabled, the agent cannot:
+
 - Read files outside the workspace
 - Write files outside the workspace
 - Edit files outside the workspace
@@ -2043,6 +2045,8 @@ When enabled, the agent cannot:
 - Follow symlinks that point outside the workspace
 
 Note: This only restricts the filesystem tools (`read`, `write`, `edit`). The `exec` tool can still access the full filesystem unless you also enable Docker sandboxing or restrict `exec` via tool policy.
+
+> **Important:** `restrictToWorkspace` is designed for use **without Docker sandbox**. If Docker sandbox is enabled, `write` and `edit` tools are handled differently (removed for security). Do not combine both settings — use one or the other.
 
 `tools.exec` configures background exec defaults:
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -224,6 +224,10 @@ export function createOpenClawCodingTools(options?: {
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();
+  // Check if filesystem restriction is enabled (restricts read/write/edit to workspace)
+  const fsRestrictToWorkspace = options?.config?.tools?.fs?.restrictToWorkspace === true;
+  // Use sandbox path guards when Docker sandbox OR fs restriction is enabled
+  const effectiveFsRoot = sandboxRoot ?? (fsRestrictToWorkspace ? workspaceRoot : undefined);
   const applyPatchConfig = options?.config?.tools?.exec?.applyPatch;
   const applyPatchEnabled =
     !!applyPatchConfig?.enabled &&
@@ -236,8 +240,9 @@ export function createOpenClawCodingTools(options?: {
 
   const base = (codingTools as unknown as AnyAgentTool[]).flatMap((tool) => {
     if (tool.name === readTool.name) {
-      if (sandboxRoot) {
-        return [createSandboxedReadTool(sandboxRoot)];
+      if (effectiveFsRoot) {
+        // Use sandboxed read tool when Docker sandbox OR fs restriction is enabled
+        return [createSandboxedReadTool(effectiveFsRoot)];
       }
       const freshReadTool = createReadTool(workspaceRoot);
       return [createOpenClawReadTool(freshReadTool)];
@@ -247,7 +252,12 @@ export function createOpenClawCodingTools(options?: {
     }
     if (tool.name === "write") {
       if (sandboxRoot) {
+        // Docker sandbox handles write differently (returns empty)
         return [];
+      }
+      if (effectiveFsRoot) {
+        // fs restriction enabled: use sandboxed write tool with path guards
+        return [createSandboxedWriteTool(effectiveFsRoot)];
       }
       // Wrap with param normalization for Claude Code compatibility
       return [
@@ -256,7 +266,12 @@ export function createOpenClawCodingTools(options?: {
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
+        // Docker sandbox handles edit differently (returns empty)
         return [];
+      }
+      if (effectiveFsRoot) {
+        // fs restriction enabled: use sandboxed edit tool with path guards
+        return [createSandboxedEditTool(effectiveFsRoot)];
       }
       // Wrap with param normalization for Claude Code compatibility
       return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit)];

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -232,7 +232,7 @@ export function createOpenClawCodingTools(options?: {
     logWarn(
       "Both Docker sandbox and tools.fs.restrictToWorkspace are enabled. " +
         "Docker sandbox takes precedence: write/edit tools will be disabled (not restricted to workspace). " +
-        "Use one setting or the other, not both."
+        "Use one setting or the other, not both.",
     );
   }
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -226,6 +226,16 @@ export function createOpenClawCodingTools(options?: {
   const workspaceRoot = options?.workspaceDir ?? process.cwd();
   // Check if filesystem restriction is enabled (restricts read/write/edit to workspace)
   const fsRestrictToWorkspace = options?.config?.tools?.fs?.restrictToWorkspace === true;
+
+  // Warn if both sandbox and fs restriction are enabled (sandbox takes precedence for write/edit)
+  if (sandboxRoot && fsRestrictToWorkspace) {
+    logWarn(
+      "Both Docker sandbox and tools.fs.restrictToWorkspace are enabled. " +
+        "Docker sandbox takes precedence: write/edit tools will be disabled (not restricted to workspace). " +
+        "Use one setting or the other, not both."
+    );
+  }
+
   // Use sandbox path guards when Docker sandbox OR fs restriction is enabled
   const effectiveFsRoot = sandboxRoot ?? (fsRestrictToWorkspace ? workspaceRoot : undefined);
   const applyPatchConfig = options?.config?.tools?.exec?.applyPatch;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -323,6 +323,16 @@ export type MemorySearchConfig = {
   };
 };
 
+export type FsToolsConfig = {
+  /**
+   * Restrict read/write/edit tools to the agent's workspace directory.
+   * When enabled, filesystem tools cannot access paths outside workspace.
+   * This provides path-based security without requiring Docker sandbox.
+   * Default: false.
+   */
+  restrictToWorkspace?: boolean;
+};
+
 export type ToolsConfig = {
   /** Base tool profile applied before allow/deny lists. */
   profile?: ToolProfileId;
@@ -332,6 +342,8 @@ export type ToolsConfig = {
   deny?: string[];
   /** Optional tool policy overrides keyed by provider id or "provider/model". */
   byProvider?: Record<string, ToolPolicyConfig>;
+  /** Filesystem tool restrictions. */
+  fs?: FsToolsConfig;
   web?: {
     search?: {
       /** Enable web search tool (default: true when API key is present). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -454,6 +454,13 @@ export const AgentEntrySchema = z
   })
   .strict();
 
+export const ToolsFsSchema = z
+  .object({
+    restrictToWorkspace: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsSchema = z
   .object({
     profile: ToolProfileSchema,
@@ -461,6 +468,7 @@ export const ToolsSchema = z
     alsoAllow: z.array(z.string()).optional(),
     deny: z.array(z.string()).optional(),
     byProvider: z.record(z.string(), ToolPolicyWithProfileSchema).optional(),
+    fs: ToolsFsSchema,
     web: ToolsWebSchema,
     media: ToolsMediaSchema,
     links: ToolsLinksSchema,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -249,6 +249,13 @@ export const AgentSandboxSchema = z
   .strict()
   .optional();
 
+export const ToolsFsSchema = z
+  .object({
+    restrictToWorkspace: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 export const AgentToolsSchema = z
   .object({
     profile: ToolProfileSchema,
@@ -292,6 +299,7 @@ export const AgentToolsSchema = z
       })
       .strict()
       .optional(),
+    fs: ToolsFsSchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -453,13 +461,6 @@ export const AgentEntrySchema = z
     tools: AgentToolsSchema,
   })
   .strict();
-
-export const ToolsFsSchema = z
-  .object({
-    restrictToWorkspace: z.boolean().optional(),
-  })
-  .strict()
-  .optional();
 
 export const ToolsSchema = z
   .object({


### PR DESCRIPTION
## Summary

Adds a new configuration option `tools.fs.restrictToWorkspace` that restricts `read`, `write`, and `edit` tools to the agent's workspace directory **without requiring Docker sandbox**.

## Motivation

Currently, the only way to restrict filesystem access to specific directories is through Docker sandboxing. However, many users:

1. Don't have Docker installed or don't want to run Docker
2. Trust the agent but want guardrails against accidental access to sensitive files  
3. Want a lightweight security layer without container overhead

The path validation logic already exists in `sandbox-paths.ts` — this PR exposes it via config.

## Changes

- **`src/config/types.tools.ts`**: Added `FsToolsConfig` type with `restrictToWorkspace` option
- **`src/config/zod-schema.agent-runtime.ts`**: Added `ToolsFsSchema` for validation  
- **`src/agents/pi-tools.ts`**: Modified tool creation to use sandboxed tools when `restrictToWorkspace` is enabled
- **`docs/gateway/configuration.md`**: Added documentation

## Usage

```json5
{
  tools: {
    fs: {
      restrictToWorkspace: true
    }
  }
}
```

When enabled:
- `read`, `write`, and `edit` tools are restricted to the workspace
- Path traversal (`../`) is blocked
- Symlinks pointing outside workspace are blocked

## Notes

- This only restricts filesystem tools — `exec` can still access the full filesystem unless Docker sandbox is also enabled
- The implementation reuses the existing `wrapSandboxPathGuard` / `assertSandboxPath` logic

Closes #5948

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new config surface `tools.fs.restrictToWorkspace` (types + runtime zod validation) and wires it into tool construction so `read`/`write`/`edit` can be restricted to a workspace-root path guard even without Docker sandboxing. It also documents the new option in the gateway configuration docs.

Main thing to double-check is how this interacts with sandbox mode and with per-agent config: in `createOpenClawCodingTools` the new flag won’t have any effect for write/edit when `sandboxRoot` is present (those tools are still removed), and `AgentToolsSchema` currently doesn’t accept `tools.fs` so the setting is global-only even though it’s described generically in docs.

<h3>Confidence Score: 3/5</h3>

- This PR looks mostly safe, but has a couple of configuration/behavior mismatches worth fixing before merge.
- Core change is localized and reuses existing path-guard tooling, but there are edge-case behavior differences: the new option currently can’t be set per-agent due to zod `.strict()` in `AgentToolsSchema`, and enabling it alongside sandbox mode doesn’t yield the expected restricted write/edit behavior. These are likely to surprise users and should be clarified or adjusted.
- src/agents/pi-tools.ts and src/config/zod-schema.agent-runtime.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->