### PR TITLE
feat: support providerParams for vendor-specific API parameters

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -8,6 +8,10 @@ import { log } from "./logger.js";
  * Resolve provider-specific extra params from model config.
  * Used to pass through stream params like temperature/maxTokens.
  *
+ * Also checks for providerParams in models.providers config, which allows
+ * passing arbitrary vendor-specific parameters (e.g., metadata for third-party
+ * API caching, venice_parameters for Venice.ai features).
+ *
  * @internal Exported for testing only
  */
 export function resolveExtraParams(params: {
@@ -17,7 +21,15 @@ export function resolveExtraParams(params: {
 }): Record<string, unknown> | undefined {
   const modelKey = `${params.provider}/${params.modelId}`;
   const modelConfig = params.cfg?.agents?.defaults?.models?.[modelKey];
-  return modelConfig?.params ? { ...modelConfig.params } : undefined;
+  const modelParams = modelConfig?.params ? { ...modelConfig.params } : {};
+
+  // Also check provider-level providerParams from models.providers config
+  const providerConfig = params.cfg?.models?.providers?.[params.provider];
+  if (providerConfig?.providerParams && typeof providerConfig.providerParams === "object") {
+    Object.assign(modelParams, providerConfig.providerParams);
+  }
+
+  return Object.keys(modelParams).length > 0 ? modelParams : undefined;
 }
 
 type CacheControlTtl = "5m" | "1h";
@@ -60,6 +72,15 @@ function createStreamFnWithExtraParams(
   const cacheControlTtl = resolveCacheControlTtl(extraParams, provider, modelId);
   if (cacheControlTtl) {
     streamParams.cacheControlTtl = cacheControlTtl;
+  }
+
+  // Pass through any additional provider-specific params (e.g., metadata, venice_parameters)
+  // These are spread into the stream options and passed to the underlying provider
+  const knownParams = new Set(["temperature", "maxTokens", "cacheControlTtl"]);
+  for (const [key, value] of Object.entries(extraParams)) {
+    if (!knownParams.has(key) && value !== undefined) {
+      (streamParams as Record<string, unknown>)[key] = value;
+    }
   }
 
   if (Object.keys(streamParams).length === 0) {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -24,12 +24,15 @@ export function resolveExtraParams(params: {
   const modelParams = modelConfig?.params ? { ...modelConfig.params } : {};
 
   // Also check provider-level providerParams from models.providers config
+  // Model-level params take precedence over provider-level defaults
   const providerConfig = params.cfg?.models?.providers?.[params.provider];
-  if (providerConfig?.providerParams && typeof providerConfig.providerParams === "object") {
-    Object.assign(modelParams, providerConfig.providerParams);
-  }
+  const providerParams =
+    providerConfig?.providerParams && typeof providerConfig.providerParams === "object"
+      ? providerConfig.providerParams
+      : {};
 
-  return Object.keys(modelParams).length > 0 ? modelParams : undefined;
+  const mergedParams = { ...providerParams, ...modelParams };
+  return Object.keys(mergedParams).length > 0 ? mergedParams : undefined;
 }
 
 type CacheControlTtl = "5m" | "1h";

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -41,6 +41,8 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  /** Arbitrary vendor-specific parameters to pass through to API requests (e.g., metadata, venice_parameters) */
+  providerParams?: Record<string, unknown>;
 };
 
 export type BedrockDiscoveryConfig = {


### PR DESCRIPTION
## Summary

Add support for passing arbitrary vendor-specific parameters through to API requests via `providerParams` in `models.providers` config.

This enables features like:
- Third-party API prompt caching via `metadata.user_id`
- Venice.ai's `venice_parameters` for web scraping
- Any other vendor-specific API parameters

Closes #3061

## Changes

- Modified `resolveExtraParams()` to also check `models.providers.<provider>.providerParams`
- Modified `createStreamFnWithExtraParams()` to pass through unknown params to the stream options

## Example Config

```json
{
  "models": {
    "providers": {
      "exampleapi": {
        "baseUrl": "https://example.com/v1",
        "apiKey": "$API_KEY}",
        "api": "anthropic-messages",
        "providerParams": {
          "metadata": {
            "user_id": "my-user-id"
          }
        }
      }
    }
  }
}
```

## Dependencies

This PR requires corresponding changes in `@mariozechner/pi-ai` to:
1. Add `metadata` field to `StreamOptions` interface
2. Pass `metadata` through in `buildBaseOptions()`
3. Include `metadata` in Anthropic API request params

## Testing

Tested with third-party API - metadata is correctly passed through and prompt caching is triggered.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Pi embedded runner model parameter handling so that, in addition to per-model `agents.defaults.models["<provider>/<modelId>"].params`, provider-wide `models.providers.<provider>.providerParams` can be merged and then forwarded into the `SimpleStreamOptions` passed to the underlying streaming implementation (defaulting to `streamSimple`). It also updates the config type (`ModelProviderConfig`) to include `providerParams?: Record<string, unknown>` for vendor-specific request parameters like metadata.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but merge/precedence and unvalidated passthrough could cause surprising runtime behavior for some configs/providers.
- Changes are small and localized, but they alter parameter precedence and introduce a broad “forward unknown keys” behavior that can conflict with existing or future stream option fields and provider expectations.
- src/agents/pi-embedded-runner/extra-params.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->