### PR TITLE
fix(cron): normalize delivery target comparison to prevent double-delivery

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -44,6 +44,7 @@ import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-de
 import { resolveSessionTranscriptPath, updateSessionStore } from "../../config/sessions.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
+import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { logWarn } from "../../logger.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
@@ -78,7 +79,10 @@ function matchesMessagingToolDeliveryTarget(
   if (target.accountId && delivery.accountId && target.accountId !== delivery.accountId) {
     return false;
   }
-  return target.to === delivery.to;
+  // Normalize both sides to prevent case-sensitivity mismatches (e.g. "User@Example.com" vs "user@example.com").
+  const normalizedTargetTo = normalizeTargetForProvider(channel, target.to);
+  const normalizedDeliveryTo = normalizeTargetForProvider(channel, delivery.to);
+  return normalizedTargetTo === normalizedDeliveryTo;
 }
 
 export type RunCronAgentTurnResult = {


### PR DESCRIPTION
## Summary
Fixes #5915

The `matchesMessagingToolDeliveryTarget` function in cron delivery performed a case-sensitive comparison on target identifiers (`target.to === delivery.to`), which could cause double-delivery when the agent-side target and the delivery-side target differed only in casing (e.g. `User@Example.com` vs `user@example.com`).

## Changes
- **`src/cron/isolated-agent/run.ts`**: Use `normalizeTargetForProvider()` on both `target.to` and `delivery.to` before comparison, matching the pattern already used in `shouldSuppressMessagingToolReplies` at `src/auto-reply/reply/reply-payloads.ts:89-103`.
- **Test**: Added a test case verifying that mixed-case targets are correctly matched and delivery is skipped.

## Test Plan
- New test: "skips auto-delivery when messaging tool target differs only by case"
- All 803 test files pass (4919 tests); the only failure is a pre-existing `DefaultResourceLoader` issue in `pi-embedded-runner.test.ts` unrelated to this change.
- Lint: 0 issues in changed files (pre-existing issues in other files are unrelated).

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a double-delivery edge case in cron auto-delivery suppression when an agent already sent via the messaging tool: `matchesMessagingToolDeliveryTarget` now compares normalized target identifiers instead of doing a case-sensitive `target.to === delivery.to`. A regression test was added to verify that mixed-case `to` values are treated as the same target and auto-delivery is skipped.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and narrowly scoped to target comparison normalization.
- The change is small, localized to the delivery-target match check, and uses an existing normalization helper already used elsewhere in the codebase. Main risk is behavioral: some channels’ identifiers might be case-sensitive, and the new test’s target choice doesn’t strongly validate channel-specific expectations.
- src/cron/isolated-agent/run.ts; src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->