### PR TITLE
docs: fix anchor link for Google Vertex/Antigravity/Gemini section

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/_ moonshot-kimi-k2-model-refs:start _/}
+  {/* moonshot-kimi-k2-model-refs:start */}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-    {/_ moonshot-kimi-k2-model-refs:end _/}
+  {/* moonshot-kimi-k2-model-refs:end */}
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -81,7 +81,7 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 - Example model: `google/gemini-3-pro-preview`
 - CLI: `openclaw onboard --auth-choice gemini-api-key`
 
-### Google Vertex / Antigravity / Gemini CLI
+### Google Vertex, Antigravity, and Gemini CLI
 
 - Providers: `google-vertex`, `google-antigravity`, `google-gemini-cli`
 - Auth: Vertex uses gcloud ADC; Antigravity/Gemini CLI use their respective auth flows


### PR DESCRIPTION
Fixes Mintlify anchor link generation issue by replacing forward slashes with commas in the heading.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Google provider section heading in `docs/concepts/model-providers.md` to avoid Mintlify anchor-generation issues caused by forward slashes, replacing `Google Vertex / Antigravity / Gemini CLI` with `Google Vertex, Antigravity, and Gemini CLI` so section links resolve consistently.

This is a docs-only change localized to the model provider reference page; it does not affect any runtime code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a minimal docs-only heading change.
- Reviewed the only diff: a single Markdown heading rename to improve Mintlify anchor stability; no code paths, configs, or links were altered beyond the heading text.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->