### PR TITLE
require TLS 1.3 as minimum

### DIFF
--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -134,7 +134,7 @@ export async function loadGatewayTlsRuntime(
         cert,
         key,
         ca,
-        minVersion: "TLSv1.2",
+        minVersion: "TLSv1.3",
       },
     };
   } catch (err) {


### PR DESCRIPTION
TLS 1.2 is not getting any protocol update anytime soon. 
https://www.ietf.org/archive/id/draft-ietf-tls-tls12-frozen-08.html

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR raises the gateway TLS minimum protocol version from `TLSv1.2` to `TLSv1.3` in the runtime TLS options returned by `loadGatewayTlsRuntime` (`src/infra/tls/gateway.ts`). This tightens transport security for the gateway’s TLS listener by preventing negotiation of older TLS versions when Node’s `tls` stack creates the server context.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but it can cause connection failures for clients/environments that don’t support TLS 1.3.
- The change is small and localized (one TLS option), but it is behavior-changing at runtime and may break older clients/proxies or environments with TLS 1.3 disabled, so it warrants a quick compatibility check in gateway consumers.
- src/infra/tls/gateway.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->