### PR TITLE
fix(security): guard local media reads + accept all MEDIA path types

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -442,7 +442,8 @@ async function hydrateSetGroupIconParams(params: {
       channel: params.channel,
       accountId: params.accountId,
     });
-    const media = await loadWebMedia(mediaSource, maxBytes);
+    // localRoots: "any" — media paths are already validated by normalizeSandboxMediaList above.
+    const media = await loadWebMedia(mediaSource, maxBytes, { localRoots: "any" });
     params.args.buffer = media.buffer.toString("base64");
     if (!contentTypeParam && media.contentType) {
       params.args.contentType = media.contentType;
@@ -506,7 +507,8 @@ async function hydrateSendAttachmentParams(params: {
       channel: params.channel,
       accountId: params.accountId,
     });
-    const media = await loadWebMedia(mediaSource, maxBytes);
+    // localRoots: "any" — media paths are already validated by normalizeSandboxMediaList above.
+    const media = await loadWebMedia(mediaSource, maxBytes, { localRoots: "any" });
     params.args.buffer = media.buffer.toString("base64");
     if (!contentTypeParam && media.contentType) {
       params.args.contentType = media.contentType;

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -8,33 +8,39 @@ describe("splitMediaFromOutput", () => {
     expect(result.text).toBe("Hello world");
   });
 
-  it("rejects absolute media paths to prevent LFI", () => {
+  it("accepts absolute media paths", () => {
     const result = splitMediaFromOutput("MEDIA:/Users/pete/My File.png");
-    expect(result.mediaUrls).toBeUndefined();
-    expect(result.text).toBe("MEDIA:/Users/pete/My File.png");
+    expect(result.mediaUrls).toEqual(["/Users/pete/My File.png"]);
+    expect(result.text).toBe("");
   });
 
-  it("rejects quoted absolute media paths to prevent LFI", () => {
+  it("accepts quoted absolute media paths", () => {
     const result = splitMediaFromOutput('MEDIA:"/Users/pete/My File.png"');
-    expect(result.mediaUrls).toBeUndefined();
-    expect(result.text).toBe('MEDIA:"/Users/pete/My File.png"');
+    expect(result.mediaUrls).toEqual(["/Users/pete/My File.png"]);
+    expect(result.text).toBe("");
   });
 
-  it("rejects tilde media paths to prevent LFI", () => {
+  it("accepts tilde media paths", () => {
     const result = splitMediaFromOutput("MEDIA:~/Pictures/My File.png");
-    expect(result.mediaUrls).toBeUndefined();
-    expect(result.text).toBe("MEDIA:~/Pictures/My File.png");
+    expect(result.mediaUrls).toEqual(["~/Pictures/My File.png"]);
+    expect(result.text).toBe("");
   });
 
-  it("rejects directory traversal media paths to prevent LFI", () => {
+  it("accepts traversal-like media paths (validated at load time)", () => {
     const result = splitMediaFromOutput("MEDIA:../../etc/passwd");
-    expect(result.mediaUrls).toBeUndefined();
-    expect(result.text).toBe("MEDIA:../../etc/passwd");
+    expect(result.mediaUrls).toEqual(["../../etc/passwd"]);
+    expect(result.text).toBe("");
   });
 
   it("captures safe relative media paths", () => {
     const result = splitMediaFromOutput("MEDIA:./screenshots/image.png");
     expect(result.mediaUrls).toEqual(["./screenshots/image.png"]);
+    expect(result.text).toBe("");
+  });
+
+  it("accepts sandbox-relative media paths", () => {
+    const result = splitMediaFromOutput("MEDIA:media/inbound/image.png");
+    expect(result.mediaUrls).toEqual(["media/inbound/image.png"]);
     expect(result.text).toBe("");
   });
 
@@ -57,5 +63,28 @@ describe("splitMediaFromOutput", () => {
     const result = splitMediaFromOutput("  MEDIA:./screenshot.png");
     expect(result.mediaUrls).toEqual(["./screenshot.png"]);
     expect(result.text).toBe("");
+  });
+
+  it("accepts Windows-style paths", () => {
+    const result = splitMediaFromOutput("MEDIA:C:\\Users\\pete\\Pictures\\snap.png");
+    expect(result.mediaUrls).toEqual(["C:\\Users\\pete\\Pictures\\snap.png"]);
+    expect(result.text).toBe("");
+  });
+
+  it("accepts TTS temp file paths", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/tts-fAJy8C/voice-1770246885083.opus");
+    expect(result.mediaUrls).toEqual(["/tmp/tts-fAJy8C/voice-1770246885083.opus"]);
+    expect(result.text).toBe("");
+  });
+
+  it("accepts bare filenames with extensions", () => {
+    const result = splitMediaFromOutput("MEDIA:image.png");
+    expect(result.mediaUrls).toEqual(["image.png"]);
+    expect(result.text).toBe("");
+  });
+
+  it("rejects bare words without file extensions", () => {
+    const result = splitMediaFromOutput("MEDIA:screenshot");
+    expect(result.mediaUrls).toBeUndefined();
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -14,7 +14,29 @@ function cleanCandidate(raw: string) {
   return raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");
 }
 
-function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
+const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+const HAS_FILE_EXT = /\.\w{1,10}$/;
+
+// Recognize local file path patterns. Security validation is deferred to the
+// load layer (loadWebMedia / resolveSandboxedMediaSource) which has the context
+// needed to enforce sandbox roots and allowed directories.
+function isLikelyLocalPath(candidate: string): boolean {
+  return (
+    candidate.startsWith("/") ||
+    candidate.startsWith("./") ||
+    candidate.startsWith("../") ||
+    candidate.startsWith("~") ||
+    WINDOWS_DRIVE_RE.test(candidate) ||
+    candidate.startsWith("\\\\") ||
+    (!SCHEME_RE.test(candidate) && (candidate.includes("/") || candidate.includes("\\")))
+  );
+}
+
+function isValidMedia(
+  candidate: string,
+  opts?: { allowSpaces?: boolean; allowBareFilename?: boolean },
+) {
   if (!candidate) {
     return false;
   }
@@ -28,8 +50,17 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
     return true;
   }
 
-  // Local paths: only allow safe relative paths starting with ./ that do not traverse upwards.
-  return candidate.startsWith("./") && !candidate.includes("..");
+  if (isLikelyLocalPath(candidate)) {
+    return true;
+  }
+
+  // Accept bare filenames (e.g. "image.png") only when the caller opts in.
+  // This avoids treating space-split path fragments as separate media items.
+  if (opts?.allowBareFilename && !SCHEME_RE.test(candidate) && HAS_FILE_EXT.test(candidate)) {
+    return true;
+  }
+
+  return false;
 }
 
 function unwrapQuoted(value: string): string | undefined {
@@ -128,11 +159,7 @@ export function splitMediaFromOutput(raw: string): {
 
       const trimmedPayload = payloadValue.trim();
       const looksLikeLocalPath =
-        trimmedPayload.startsWith("/") ||
-        trimmedPayload.startsWith("./") ||
-        trimmedPayload.startsWith("../") ||
-        trimmedPayload.startsWith("~") ||
-        trimmedPayload.startsWith("file://");
+        isLikelyLocalPath(trimmedPayload) || trimmedPayload.startsWith("file://");
       if (
         !unwrapped &&
         validCount === 1 &&
@@ -152,7 +179,7 @@ export function splitMediaFromOutput(raw: string): {
 
       if (!hasValidMedia) {
         const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
-        if (isValidMedia(fallback, { allowSpaces: true })) {
+        if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {
           media.push(fallback);
           hasValidMedia = true;
           foundMediaToken = true;


### PR DESCRIPTION
## Summary

Fix confused-deputy vulnerability in MEDIA directive handling. The parser was accidentally providing security by restricting paths to `./` only — this broke tool outputs (TTS, camera, screen-record) while giving a false sense of safety. This PR moves security to the right layer:

1. Opens the parser to accept all local path types (absolute, tilde, Windows, bare filenames)
2. Adds a load-time guard in `loadWebMedia` that validates paths against allowed directory roots before `fs.readFile`

Originally planned as separate PRs, but combined to avoid shipping parser permissiveness without the corresponding security guard.

## Problem

Agent tools output `MEDIA:` tokens with paths the parser rejects:
- TTS: `MEDIA:/tmp/tts-xxx/voice.opus` (absolute, rejected)
- Camera: `MEDIA:/tmp/openclaw-camera-xxx/snap.jpg` (absolute, rejected)
- CLI tools: `MEDIA:~/...` via `shortenHomePath` (tilde, rejected)

Meanwhile, **14+ call sites** of `loadWebMedia` pass paths directly to `fs.readFile` with zero validation. The parser restriction was the only gate — accidentally blocking both legitimate tools AND the exfiltration vector.

## Solution

**Parser** (`src/media/parse.ts`): Replace restrictive `./`-only check with `isLikelyLocalPath()` that recognizes all local path forms. Bare filenames (e.g. `image.png`) accepted via `allowBareFilename` option in the full-payload fallback only, avoiding false positives with space-split fragments.

**Load guard** (`src/web/media.ts`): Add `localRoots` option to `loadWebMedia`. Before any `fs.readFile`, validate the resolved path (with `fs.realpath` symlink resolution) is under an allowed root. Defaults: `os.tmpdir()`, `~/.openclaw/media/`, `~/.openclaw/agents/`.

**Action runner** (`src/infra/outbound/message-action-runner.ts`): Passes `localRoots: "any"` since it already validates via `normalizeSandboxMediaList`/`resolveSandboxedMediaSource`.

## Security context

- SSRF: already guarded by `fetchWithSsrFGuard` (81c68f582)
- Action runner: already guarded by `sandboxRoot` (4434cae56)
- **All other delivery paths**: NOW guarded by `assertLocalMediaAllowed` in this PR

Follow-up to #4880 and #4930.

## Supersedes

- #9168 (TTS-only regex whitelist — this handles all tools generically)
- #7400 (temp-dir containment with P1 symlink bypass — this handles all path types with proper symlink resolution)

## Test plan

- [x] `pnpm vitest run src/media/parse.test.ts` — 14 tests, all path types accepted
- [x] `pnpm vitest run src/web/media.test.ts` — guard rejects paths outside roots, allows paths under roots, respects `localRoots: "any"` bypass
- [x] `pnpm build` — clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR loosens MEDIA token parsing to accept more local path shapes (absolute, tilde, traversal-like, Windows-style, and bare filenames with extensions) and moves the actual security enforcement into `loadWebMedia()`.

On the loading side, `src/web/media.ts` now adds an allowlist guard for local filesystem reads: before `fs.readFile`, local paths are resolved (preferring `fs.realpath` for symlink resolution) and must fall under an allowed root directory. The default roots cover `os.tmpdir()` and OpenClaw’s per-user media/agent directories, while callers with their own validation can bypass with `localRoots: "any"`.

`message-action-runner` is updated to pass `localRoots: "any"` because those call sites already normalize and sandbox-resolve media paths via `resolveSandboxedMediaSource`, and tests are updated/added to cover the new parsing and root-guard behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to MEDIA parsing and local media loading. The new local-root guard is applied immediately before local `fs.readFile` and includes symlink resolution, and the only intentional bypass (`localRoots: "any"`) is confined to a call path that already enforces sandbox root + no-symlink constraints. Added tests cover both the broadened parser acceptance and the allowlist behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->