### PR TITLE
fix(ui): handle optional agentId and add updateCronJob function

### DIFF
--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -92,7 +92,7 @@ export async function addCronJob(state: CronState) {
   try {
     const schedule = buildCronSchedule(state.cronForm);
     const payload = buildCronPayload(state.cronForm);
-    const agentId = state.cronForm.agentId.trim();
+    const agentId = (state.cronForm.agentId ?? "").trim();
     const job = {
       name: state.cronForm.name.trim(),
       description: state.cronForm.description.trim() || undefined,
@@ -183,5 +183,39 @@ export async function loadCronRuns(state: CronState, jobId: string) {
     state.cronRuns = Array.isArray(res.entries) ? res.entries : [];
   } catch (err) {
     state.cronError = String(err);
+  }
+}
+
+export async function updateCronJob(state: CronState, jobId: string) {
+  if (!state.client || !state.connected || state.cronBusy) return;
+  state.cronBusy = true;
+  state.cronError = null;
+  try {
+    const schedule = buildCronSchedule(state.cronForm);
+    const payload = buildCronPayload(state.cronForm);
+    const agentId = (state.cronForm.agentId ?? "").trim();
+    const patch = {
+      name: state.cronForm.name.trim(),
+      description: state.cronForm.description.trim() || undefined,
+      agentId: agentId || undefined,
+      enabled: state.cronForm.enabled,
+      schedule,
+      sessionTarget: state.cronForm.sessionTarget,
+      wakeMode: state.cronForm.wakeMode,
+      payload,
+      isolation:
+        state.cronForm.postToMainPrefix.trim() &&
+        state.cronForm.sessionTarget === "isolated"
+          ? { postToMainPrefix: state.cronForm.postToMainPrefix.trim() }
+          : undefined,
+    };
+    if (!patch.name) throw new Error("Name required.");
+    await state.client.request("cron.update", { id: jobId, patch });
+    await loadCronJobs(state);
+    await loadCronStatus(state);
+  } catch (err) {
+    state.cronError = String(err);
+  } finally {
+    state.cronBusy = false;
   }
 }


### PR DESCRIPTION
- Use nullish coalescing operator to handle undefined/null agentId before calling .trim() to prevent runtime errors in addCronJob
- Add updateCronJob function to support editing existing cron jobs via cron.update RPC endpoint

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `addCronJob` against `agentId` being `null`/`undefined` by defaulting to an empty string before trimming, and adds a new `updateCronJob` controller helper that calls the `cron.update` RPC and refreshes cron jobs/status afterward.

These changes live in the UI cron controller (`ui/src/ui/controllers/cron.ts`) and mirror the existing add/toggle/run/remove patterns by building schedule/payload from `cronForm` and using the gateway client RPC methods.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the changes are localized and straightforward.
- `addCronJob` nullish-coalescing is a clear runtime safety fix. The new `updateCronJob` mirrors existing RPC usage, but there’s some functional ambiguity around whether blank/omitted fields should clear or preserve existing values (notably `agentId`), which could lead to unintended overwrites depending on how the UI invokes it.
- ui/src/ui/controllers/cron.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->