### PR TITLE
fix(ui): use local favicon.svg instead of external CDN for logo

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -133,7 +133,7 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src="https://mintcdn.com/clawhub/4rYvG-uuZrMK_URE/assets/pixel-lobster.svg?fit=max&auto=format&n=4rYvG-uuZrMK_URE&q=85&s=da2032e9eac3b5d9bfe7eb96ca6a8a26" alt="OpenClaw" />
+              <img src="/favicon.svg" alt="OpenClaw" />
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
## Summary

Fixes #5934

The external CDN (mintcdn.com) returns **403 Forbidden**, causing the logo to show as a broken image in the Control UI header.

## Root Cause

```
curl -sI "https://mintcdn.com/clawhub/..." | head -2
HTTP/2 403
```

## Fix

Use the existing `/favicon.svg` which is already bundled locally, instead of the external CDN URL.

## Changes

- 1 line change in `ui/src/ui/app-render.ts`
- No new files needed

## Benefits

- Works offline/air-gapped
- Faster load times
- No external dependency

<img width="611" height="193" alt="image" src="https://github.com/user-attachments/assets/88ace6f2-3ae6-46ba-9e25-2b9b27aa9ea2" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes the Control UI header logo to load from the locally-bundled `/favicon.svg` instead of an external Mint CDN URL that can return 403s, improving reliability (including offline/air-gapped use) and removing an external dependency. This is a minimal, isolated change in `ui/src/ui/app-render.ts` that only affects the `<img>` source for the brand logo.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, static asset URL swap in the UI header. It removes reliance on an external CDN and uses an existing local asset path, with no behavioral changes elsewhere and no new dependencies.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->