### PR TITLE
feat(auth): sync Claude Code CLI OAuth credentials for auto-refresh

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.test.ts
+++ b/src/agents/auth-profiles/external-cli-sync.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuthProfileStore } from "./types.js";
+import { syncExternalCliCredentials } from "./external-cli-sync.js";
+
+function makeStore(profiles: AuthProfileStore["profiles"] = {}): AuthProfileStore {
+  return {
+    version: 1,
+    profiles,
+  };
+}
+
+describe("syncExternalCliCredentials — Claude CLI", () => {
+  let originalHome: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-sync-test-"));
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    if (originalHome) process.env.USERPROFILE = originalHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeClaudeCredentials(credentials: Record<string, unknown>): void {
+    const claudeDir = path.join(tempDir, ".claude");
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, ".credentials.json"), JSON.stringify(credentials));
+  }
+
+  it("imports full OAuth credentials from Claude CLI", () => {
+    const futureExpiry = Date.now() + 8 * 60 * 60 * 1000;
+    writeClaudeCredentials({
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-test-access",
+        refreshToken: "sk-ant-ort01-test-refresh",
+        expiresAt: futureExpiry,
+        scopes: ["user:inference", "user:profile"],
+      },
+    });
+
+    const store = makeStore();
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(true);
+    const profile = store.profiles["anthropic:claude-cli"];
+    expect(profile).toBeDefined();
+    expect(profile?.type).toBe("oauth");
+    expect(profile?.provider).toBe("anthropic");
+    if (profile?.type === "oauth") {
+      expect(profile.access).toBe("sk-ant-oat01-test-access");
+      expect(profile.refresh).toBe("sk-ant-ort01-test-refresh");
+      expect(profile.expires).toBe(futureExpiry);
+    }
+  });
+
+  it("imports setup-token credentials (no refresh token)", () => {
+    const futureExpiry = Date.now() + 8 * 60 * 60 * 1000;
+    writeClaudeCredentials({
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-setup-token",
+        // No refreshToken — this is a setup-token
+        expiresAt: futureExpiry,
+      },
+    });
+
+    const store = makeStore();
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(true);
+    const profile = store.profiles["anthropic:claude-cli"];
+    expect(profile).toBeDefined();
+    expect(profile?.type).toBe("token");
+    if (profile?.type === "token") {
+      expect(profile.token).toBe("sk-ant-oat01-setup-token");
+    }
+  });
+
+  it("updates expired OAuth profile with fresher credentials", () => {
+    const freshExpiry = Date.now() + 8 * 60 * 60 * 1000;
+    writeClaudeCredentials({
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-new-access",
+        refreshToken: "sk-ant-ort01-new-refresh",
+        expiresAt: freshExpiry,
+      },
+    });
+
+    const expiredTime = Date.now() - 60 * 1000;
+    const store = makeStore({
+      "anthropic:claude-cli": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "sk-ant-oat01-old-access",
+        refresh: "sk-ant-ort01-old-refresh",
+        expires: expiredTime,
+      },
+    });
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(true);
+    const profile = store.profiles["anthropic:claude-cli"];
+    if (profile?.type === "oauth") {
+      expect(profile.access).toBe("sk-ant-oat01-new-access");
+      expect(profile.refresh).toBe("sk-ant-ort01-new-refresh");
+    }
+  });
+
+  it("skips sync when existing profile is still fresh", () => {
+    // Don't write any credential file — should not even try to read
+    const freshExpiry = Date.now() + 2 * 60 * 60 * 1000;
+    const store = makeStore({
+      "anthropic:claude-cli": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "sk-ant-oat01-existing",
+        refresh: "sk-ant-ort01-existing",
+        expires: freshExpiry,
+      },
+    });
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(false);
+    // Profile should be unchanged
+    if (store.profiles["anthropic:claude-cli"]?.type === "oauth") {
+      expect(store.profiles["anthropic:claude-cli"].access).toBe("sk-ant-oat01-existing");
+    }
+  });
+
+  it("does not mutate when no Claude CLI credentials exist", () => {
+    // No .claude directory at all
+    const store = makeStore();
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(false);
+    expect(store.profiles["anthropic:claude-cli"]).toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/external-cli-sync.test.ts
+++ b/src/agents/auth-profiles/external-cli-sync.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
 import type { AuthProfileStore } from "./types.js";
 import { syncExternalCliCredentials } from "./external-cli-sync.js";
 
@@ -26,7 +25,9 @@ describe("syncExternalCliCredentials — Claude CLI", () => {
 
   afterEach(() => {
     process.env.HOME = originalHome;
-    if (originalHome) process.env.USERPROFILE = originalHome;
+    if (originalHome) {
+      process.env.USERPROFILE = originalHome;
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,8 +1,10 @@
 import {
+  readClaudeCliCredentialsCached,
   readQwenCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
+  CLAUDE_CLI_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -30,19 +32,15 @@ function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCr
   );
 }
 
-function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: number): boolean {
-  if (!cred) {
-    return false;
-  }
-  if (cred.type !== "oauth" && cred.type !== "token") {
-    return false;
-  }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
-    return false;
-  }
-  if (typeof cred.expires !== "number") {
-    return true;
-  }
+function isExternalProfileFresh(
+  cred: AuthProfileCredential | undefined,
+  now: number,
+  provider?: string,
+): boolean {
+  if (!cred) return false;
+  if (cred.type !== "oauth" && cred.type !== "token") return false;
+  if (provider && cred.provider !== provider) return false;
+  if (typeof cred.expires !== "number") return true;
   return cred.expires > now + EXTERNAL_CLI_NEAR_EXPIRY_MS;
 }
 
@@ -56,7 +54,7 @@ function syncExternalCliCredentialsForProvider(
 ): boolean {
   const existing = store.profiles[profileId];
   const shouldSync =
-    !existing || existing.provider !== provider || !isExternalProfileFresh(existing, now);
+    !existing || existing.provider !== provider || !isExternalProfileFresh(existing, now, provider);
   const creds = shouldSync ? readCredentials() : null;
   if (!creds) {
     return false;
@@ -82,7 +80,14 @@ function syncExternalCliCredentialsForProvider(
 }
 
 /**
- * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI) into the store.
+ * Sync OAuth credentials from external CLI tools (Claude Code CLI, Qwen Code CLI, MiniMax CLI)
+ * into the store.
+ *
+ * Claude Code CLI stores full OAuth credentials (access + refresh + scopes) at
+ * ~/.claude/.credentials.json. When available, these are imported as `type: "oauth"`
+ * profiles so that OpenClaw can auto-refresh them when the access token expires.
+ * This avoids the need to re-run onboarding when tokens expire and preserves
+ * all OAuth scopes including `user:profile` (required for usage tracking).
  *
  * Returns true if any credentials were updated.
  */
@@ -90,32 +95,72 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   let mutated = false;
   const now = Date.now();
 
-  // Sync from Qwen Code CLI
-  const existingQwen = store.profiles[QWEN_CLI_PROFILE_ID];
-  const shouldSyncQwen =
-    !existingQwen ||
-    existingQwen.provider !== "qwen-portal" ||
-    !isExternalProfileFresh(existingQwen, now);
-  const qwenCreds = shouldSyncQwen
-    ? readQwenCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS })
+  // Sync from Claude Code CLI
+  const existingClaude = store.profiles[CLAUDE_CLI_PROFILE_ID];
+  const shouldSyncClaude =
+    !existingClaude ||
+    existingClaude.provider !== "anthropic" ||
+    !isExternalProfileFresh(existingClaude, now, "anthropic");
+  const claudeCreds = shouldSyncClaude
+    ? readClaudeCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS })
     : null;
-  if (qwenCreds) {
-    const existing = store.profiles[QWEN_CLI_PROFILE_ID];
-    const existingOAuth = existing?.type === "oauth" ? existing : undefined;
-    const shouldUpdate =
-      !existingOAuth ||
-      existingOAuth.provider !== "qwen-portal" ||
-      existingOAuth.expires <= now ||
-      qwenCreds.expires > existingOAuth.expires;
+  if (claudeCreds) {
+    if (claudeCreds.type === "oauth") {
+      // Full OAuth credential with refresh token — preferred path.
+      const existing = store.profiles[CLAUDE_CLI_PROFILE_ID];
+      const existingOAuth = existing?.type === "oauth" ? existing : undefined;
+      const shouldUpdate =
+        !existingOAuth ||
+        existingOAuth.provider !== "anthropic" ||
+        existingOAuth.expires <= now ||
+        claudeCreds.expires > existingOAuth.expires;
 
-    if (shouldUpdate && !shallowEqualOAuthCredentials(existingOAuth, qwenCreds)) {
-      store.profiles[QWEN_CLI_PROFILE_ID] = qwenCreds;
-      mutated = true;
-      log.info("synced qwen credentials from qwen cli", {
-        profileId: QWEN_CLI_PROFILE_ID,
-        expires: new Date(qwenCreds.expires).toISOString(),
-      });
+      const oauthCred: OAuthCredential = {
+        type: "oauth",
+        provider: "anthropic",
+        access: claudeCreds.access,
+        refresh: claudeCreds.refresh,
+        expires: claudeCreds.expires,
+      };
+
+      if (shouldUpdate && !shallowEqualOAuthCredentials(existingOAuth, oauthCred)) {
+        store.profiles[CLAUDE_CLI_PROFILE_ID] = oauthCred;
+        mutated = true;
+        log.info("synced anthropic OAuth credentials from claude cli", {
+          profileId: CLAUDE_CLI_PROFILE_ID,
+          expires: new Date(claudeCreds.expires).toISOString(),
+        });
+      }
+    } else if (claudeCreds.type === "token") {
+      // Setup-token (no refresh) — import but warn that usage tracking won't work.
+      const existing = store.profiles[CLAUDE_CLI_PROFILE_ID];
+      if (!existing || existing.provider !== "anthropic") {
+        store.profiles[CLAUDE_CLI_PROFILE_ID] = {
+          type: "token",
+          provider: "anthropic",
+          token: claudeCreds.token,
+          expires: claudeCreds.expires,
+        };
+        mutated = true;
+        log.info("synced anthropic token from claude cli (setup-token, no refresh)", {
+          profileId: CLAUDE_CLI_PROFILE_ID,
+          expires: new Date(claudeCreds.expires).toISOString(),
+        });
+      }
     }
+  }
+
+  // Sync from Qwen Code CLI
+  if (
+    syncExternalCliCredentialsForProvider(
+      store,
+      QWEN_CLI_PROFILE_ID,
+      "qwen-portal",
+      () => readQwenCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS }),
+      now,
+    )
+  ) {
+    mutated = true;
   }
 
   // Sync from MiniMax Portal CLI

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -108,6 +108,7 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   const shouldSyncClaude =
     !existingClaude ||
     existingClaude.provider !== "anthropic" ||
+    existingClaude.type === "token" || // Always re-check: CLI may have upgraded to OAuth
     !isExternalProfileFresh(existingClaude, now, "anthropic");
   const claudeCreds = shouldSyncClaude
     ? readClaudeCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS })

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -37,10 +37,18 @@ function isExternalProfileFresh(
   now: number,
   provider?: string,
 ): boolean {
-  if (!cred) return false;
-  if (cred.type !== "oauth" && cred.type !== "token") return false;
-  if (provider && cred.provider !== provider) return false;
-  if (typeof cred.expires !== "number") return true;
+  if (!cred) {
+    return false;
+  }
+  if (cred.type !== "oauth" && cred.type !== "token") {
+    return false;
+  }
+  if (provider && cred.provider !== provider) {
+    return false;
+  }
+  if (typeof cred.expires !== "number") {
+    return true;
+  }
   return cred.expires > now + EXTERNAL_CLI_NEAR_EXPIRY_MS;
 }
 

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -100,12 +100,15 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
     const raw = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
       profiles?: Record<string, unknown>;
     };
-    expect(raw.profiles?.["anthropic:claude-cli"]).toBeUndefined();
+    // anthropic:claude-cli is no longer deprecated — it provides full OAuth
+    // credentials (including refresh token) synced from Claude Code CLI.
+    expect(raw.profiles?.["anthropic:claude-cli"]).toBeDefined();
     expect(raw.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
 
-    expect(next.auth?.profiles?.["anthropic:claude-cli"]).toBeUndefined();
+    expect(next.auth?.profiles?.["anthropic:claude-cli"]).toBeDefined();
     expect(next.auth?.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
-    expect(next.auth?.order?.anthropic).toBeUndefined();
+    // anthropic order preserved since claude-cli is no longer deprecated
+    expect(next.auth?.order?.anthropic).toBeDefined();
     expect(next.auth?.order?.["openai-codex"]).toBeUndefined();
   });
 });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -115,9 +115,9 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
 ): Promise<OpenClawConfig> {
   const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
   const deprecated = new Set<string>();
-  if (store.profiles[CLAUDE_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CLAUDE_CLI_PROFILE_ID]) {
-    deprecated.add(CLAUDE_CLI_PROFILE_ID);
-  }
+  // Note: CLAUDE_CLI_PROFILE_ID is no longer deprecated — it provides full OAuth
+  // credentials (including refresh token and user:profile scope) synced from
+  // Claude Code CLI, enabling auto-refresh and usage tracking.
   if (store.profiles[CODEX_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CODEX_CLI_PROFILE_ID]) {
     deprecated.add(CODEX_CLI_PROFILE_ID);
   }
@@ -127,11 +127,6 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
   }
 
   const lines = ["Deprecated external CLI auth profiles detected (no longer supported):"];
-  if (deprecated.has(CLAUDE_CLI_PROFILE_ID)) {
-    lines.push(
-      `- ${CLAUDE_CLI_PROFILE_ID} (Anthropic): use setup-token → ${formatCliCommand("openclaw models auth setup-token")}`,
-    );
-  }
   if (deprecated.has(CODEX_CLI_PROFILE_ID)) {
     lines.push(
       `- ${CODEX_CLI_PROFILE_ID} (OpenAI Codex): use OAuth → ${formatCliCommand(
@@ -208,9 +203,7 @@ type AuthIssue = {
 
 function formatAuthIssueHint(issue: AuthIssue): string | null {
   if (issue.provider === "anthropic" && issue.profileId === CLAUDE_CLI_PROFILE_ID) {
-    return `Deprecated profile. Use ${formatCliCommand("openclaw models auth setup-token")} or ${formatCliCommand(
-      "openclaw configure",
-    )}.`;
+    return `Auto-synced from Claude Code CLI. Run ${formatCliCommand("claude login")} to refresh, then restart.`;
   }
   if (issue.provider === "openai-codex" && issue.profileId === CODEX_CLI_PROFILE_ID) {
     return `Deprecated profile. Use ${formatCliCommand(


### PR DESCRIPTION
Add Claude Code CLI credential sync to external-cli-sync, matching the
existing Qwen CLI pattern. When `~/.claude/.credentials.json` contains
full OAuth credentials (access + refresh token), they are imported as
`type: "oauth"` profiles enabling automatic token refresh.

## Problem

Three issues affect users who authenticate via Claude Code CLI:

1. **Token expiry requires manual re-auth** — access tokens expire and there's no auto-refresh
2. **Re-onboarding with setup-token loses `user:profile` scope** — full OAuth preserves all scopes including usage tracking
3. **No easy path to import Claude Code credentials** — users must manually configure auth

## Solution

Sync OAuth credentials from Claude Code CLI (`~/.claude/.credentials.json`) into OpenClaw's auth profile store:

- **Full OAuth credentials** (access + refresh token) are imported as `type: "oauth"` profiles, enabling automatic token refresh
- **Setup-token credentials** (no refresh token) are imported as `type: "token"` fallback
- The `anthropic:claude-cli` profile is **un-deprecated** since it now provides genuine value

## Changes

- `external-cli-sync.ts`: Add Claude CLI sync with OAuth + setup-token fallback
- `doctor-auth.ts`: Un-deprecate `anthropic:claude-cli` profile, update hint to recommend `claude login` for refresh
- `external-cli-sync.test.ts`: Integration tests covering OAuth import, setup-token import, expired profile update, fresh profile skip, and missing credentials
- `isExternalProfileFresh`: Accept optional `provider` param for multi-CLI use
- Refactored Qwen sync to use shared `syncExternalCliCredentialsForProvider` helper

## Testing

- 5 test cases in `external-cli-sync.test.ts` using temp credential files
- Updated `doctor-auth.deprecated-cli-profiles.test.ts` to expect claude-cli profile preserved

Supersedes #4615 (scope hint) by addressing the root cause.
Complements #4593 (don't warn about expired tokens with refresh tokens).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds synchronization of Claude Code CLI credentials (`~/.claude/.credentials.json`) into OpenClaw’s auth profile store, importing full OAuth (access+refresh) as `type: "oauth"` and setup-token-only creds as `type: "token"`. It refactors the existing Qwen/MiniMax sync into a shared helper and updates `doctor-auth` to stop treating `anthropic:claude-cli` as deprecated, with a new hint recommending `claude login` for refresh.

The main functional risk is around upgrade/refresh behavior when a token-based `anthropic:claude-cli` profile already exists: current freshness gating and write conditions can prevent importing newly-available OAuth creds until the token expires/near-expiry, which undermines the “auto-refresh” and “easy import” intent for some users. Tests mostly cover the expected paths, but one teardown detail can leak env var state across the suite.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable but has a likely behavior gap around upgrading existing token profiles to OAuth.
- Core changes are localized and follow existing external CLI sync patterns, but the current freshness gating plus the token-branch write condition can prevent importing newly-available refresh tokens (OAuth) until the existing token expires, which is a user-visible correctness issue for a common upgrade path. Also a small test env teardown bug could cause flaky failures depending on runner env vars.
- src/agents/auth-profiles/external-cli-sync.ts; src/agents/auth-profiles/external-cli-sync.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->