### PR TITLE
Fix: /status shows correct think level when used with /think (fixes #5919)fix(auto-reply): /status shows correct think level when combined with…

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.returns-status-alongside-directive-only-acks.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.returns-status-alongside-directive-only-acks.e2e.test.ts
@@ -94,7 +94,7 @@ describe("directive behavior", () => {
       expect(text).toContain("Thinking level set to high.");
       expect(text).toContain("Think: high");
       const store = loadSessionStore(storePath);
-      expect(store["agent:main:main"]?.thinkingLevel).toBe("high");
+      expect(store[MAIN_SESSION_KEY]?.thinkingLevel).toBe("high");
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });
   });
@@ -138,7 +138,7 @@ describe("directive behavior", () => {
       expect(optionsLine).not.toContain("elevated");
 
       const store = loadSessionStore(storePath);
-      expect(store["agent:main:main"]?.elevatedLevel).toBe("off");
+      expect(store[MAIN_SESSION_KEY]?.elevatedLevel).toBe("off");
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });
   });

--- a/src/auto-reply/reply.directive.directive-behavior.returns-status-alongside-directive-only-acks.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.returns-status-alongside-directive-only-acks.e2e.test.ts
@@ -60,6 +60,44 @@ describe("directive behavior", () => {
     vi.restoreAllMocks();
   });
 
+  it("shows think level in status after /think in same message (e.g. /think high /status)", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+      vi.mocked(loadModelCatalog).mockResolvedValue([
+        { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", provider: "google", reasoning: true },
+      ]);
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/think high\n/status",
+          From: "+1222",
+          To: "+1222",
+          Provider: "whatsapp",
+          SenderE164: "+1222",
+          CommandAuthorized: true,
+        },
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "google/gemini-2.5-flash",
+              workspace: path.join(home, "openclaw"),
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["+1222"] } },
+          session: { store: storePath },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("Thinking level set to high.");
+      expect(text).toContain("Think: high");
+      const store = loadSessionStore(storePath);
+      expect(store["agent:main:main"]?.thinkingLevel).toBe("high");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
   it("returns status alongside directive-only acks", async () => {
     await withTempHome(async (home) => {
       vi.mocked(runEmbeddedPiAgent).mockReset();

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -184,6 +184,12 @@ export async function applyInlineDirectiveOverrides(params: {
       currentReasoningLevel,
       currentElevatedLevel,
     });
+
+    const effectiveThinkLevel =
+      directives.thinkLevel ??
+      (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+      resolvedDefaultThinkLevel;
+
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {
       statusReply = await buildStatusReply({
@@ -195,11 +201,11 @@ export async function applyInlineDirectiveOverrides(params: {
         provider,
         model,
         contextTokens,
-        resolvedThinkLevel: resolvedDefaultThinkLevel,
+        resolvedThinkLevel: effectiveThinkLevel,
         resolvedVerboseLevel: currentVerboseLevel ?? "off",
         resolvedReasoningLevel: currentReasoningLevel ?? "off",
         resolvedElevatedLevel,
-        resolveDefaultThinkingLevel: async () => resolvedDefaultThinkLevel,
+        resolveDefaultThinkingLevel: async () => effectiveThinkLevel,
         isGroup,
         defaultGroupActivation: defaultActivation,
         mediaDecisions: ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -205,7 +205,7 @@ export async function applyInlineDirectiveOverrides(params: {
         resolvedVerboseLevel: currentVerboseLevel ?? "off",
         resolvedReasoningLevel: currentReasoningLevel ?? "off",
         resolvedElevatedLevel,
-        resolveDefaultThinkingLevel: async () => effectiveThinkLevel,
+        resolveDefaultThinkingLevel: modelState.resolveDefaultThinkingLevel,
         isGroup,
         defaultGroupActivation: defaultActivation,
         mediaDecisions: ctx.MediaUnderstandingDecisions,


### PR DESCRIPTION
## Summary
When `/think` and `/status` were used in the same message (directive-only path), `/status` still showed the previous thinking level (e.g. "low") instead of the level just set by `/think`. This made it look like the `/think` command wasn’t applied, especially with reasoning-capable models like Gemini.

## Changes
- In the directive-only reply path, status now uses `effectiveThinkLevel` (directive + session + default) when building the status reply, so the reported think level matches what is actually in effect after applying `/think`.
- Ensures the status line reflects the level set by `/think` in the same message, not the pre-directive default.

## Testing
- `reply.directive.directive-behavior.returns-status-alongside-directive-only-acks.e2e.test.ts` covers the combined `/think` + `/status` behavior.
- Manual: send `/think high` and `/status` in one message; status should show "Think: high".

Fixes #5919

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `/status` in the directive-only path to report the *effective* thinking level when `/think` and `/status` are used in the same message. It adds an E2E test covering `/think high\n/status` and updates `applyInlineDirectiveOverrides` to compute `effectiveThinkLevel` (directive → session → default) and pass it into `buildStatusReply`, so status reflects the newly applied `/think` value.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the change to `resolveDefaultThinkingLevel` could subtly affect status semantics depending on how `buildStatusReply` uses it.
- The functional change is small and well-covered by a new E2E test for the reported bug. However, repurposing a callback named `resolveDefaultThinkingLevel` to return an overridden/effective value may create incorrect status output in other scenarios if `buildStatusReply` relies on it to compute or display defaults.
- src/auto-reply/reply/get-reply-directives-apply.ts (check how `buildStatusReply` interprets `resolveDefaultThinkingLevel`).

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->