### PR TITLE
feat: add Vertex AI Anthropic provider for Claude on GCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Models: add Vertex AI Anthropic provider for Claude on GCP. Use your GCP credits directly with `vertex-anthropic/claude-opus-4-5@20251101`. (#XXXX) Thanks @ch_hao.
+
 ### Fixes
 
 - Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.

--- a/docs/vertex-anthropic.md
+++ b/docs/vertex-anthropic.md
@@ -1,0 +1,142 @@
+# Vertex AI Anthropic (Claude on GCP)
+
+OpenClaw supports Claude models hosted on Google Cloud Vertex AI. This allows you to use your GCP credits directly without routing through OpenRouter or other intermediaries.
+
+## Benefits
+
+- **No middleman fees**: Use your GCP credits directly (no 5% OpenRouter fee)
+- **Same Claude experience**: Full feature parity with direct Anthropic API
+- **GCP integration**: Uses your existing gcloud credentials
+
+## Prerequisites
+
+1. **GCP Project** with Vertex AI API enabled
+2. **Claude models enabled** in your project's Model Garden
+3. **gcloud CLI** configured with Application Default Credentials
+
+## Setup
+
+### 1. Enable Claude on Vertex AI
+
+1. Go to [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden)
+2. Search for "Claude" and enable the models you want to use
+3. Note your project ID and region (e.g., `us-east5`)
+
+### 2. Configure gcloud ADC
+
+```bash
+gcloud auth application-default login
+```
+
+Or use a service account:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+### 3. Set Environment Variables
+
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project-id
+export GOOGLE_CLOUD_LOCATION=us-east5  # or your region
+```
+
+### 4. Verify Setup
+
+```bash
+openclaw models list | grep vertex-anthropic
+```
+
+## Available Models
+
+| Model | ID | Features |
+|-------|-----|----------|
+| Claude Opus 4.5 | `claude-opus-4-5@20251101` | Reasoning, Vision |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5@20250929` | Reasoning, Vision |
+| Claude Opus 4.1 | `claude-opus-4-1@20250805` | Reasoning, Vision |
+| Claude Haiku 4.5 | `claude-haiku-4-5@20251001` | Reasoning, Vision |
+| Claude Opus 4 | `claude-opus-4@20250514` | Reasoning, Vision |
+| Claude Sonnet 4 | `claude-sonnet-4@20250514` | Reasoning, Vision |
+| Claude 3.7 Sonnet | `claude-3-7-sonnet@20250219` | Reasoning, Vision |
+| Claude 3.5 Sonnet v2 | `claude-3-5-sonnet-v2@20241022` | Vision |
+| Claude 3.5 Haiku | `claude-3-5-haiku@20241022` | Vision |
+
+## Configuration
+
+### Using Default Model
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "vertex-anthropic/claude-opus-4-5@20251101"
+      }
+    }
+  }
+}
+```
+
+### Custom Configuration
+
+You can also manually configure the provider:
+
+```json
+{
+  "models": {
+    "providers": {
+      "vertex-anthropic": {
+        "baseUrl": "https://us-east5-aiplatform.googleapis.com/v1/projects/YOUR_PROJECT/locations/us-east5/publishers/anthropic/models",
+        "api": "anthropic-messages",
+        "auth": "token",
+        "models": [
+          {
+            "id": "claude-opus-4-5@20251101",
+            "name": "Claude Opus 4.5",
+            "contextWindow": 200000,
+            "maxTokens": 32768,
+            "reasoning": true,
+            "input": ["text", "image"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Regions
+
+Claude on Vertex AI is available in these regions:
+- `us-east5` (Ohio)
+- `europe-west1` (Belgium)
+- `asia-southeast1` (Singapore)
+
+Check [Vertex AI documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude) for the latest availability.
+
+## Troubleshooting
+
+### "No API key found for provider vertex-anthropic"
+
+Ensure gcloud ADC is configured:
+```bash
+gcloud auth application-default login
+```
+
+### "Project not found"
+
+Set the project environment variable:
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project-id
+```
+
+### "Location not found"
+
+Set the location where Claude is enabled:
+```bash
+export GOOGLE_CLOUD_LOCATION=us-east5
+```
+
+### "Model not found"
+
+Ensure you've enabled Claude models in your project's Model Garden.

--- a/docs/vertex-anthropic.md
+++ b/docs/vertex-anthropic.md
@@ -49,17 +49,17 @@ openclaw models list | grep vertex-anthropic
 
 ## Available Models
 
-| Model | ID | Features |
-|-------|-----|----------|
-| Claude Opus 4.5 | `claude-opus-4-5@20251101` | Reasoning, Vision |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5@20250929` | Reasoning, Vision |
-| Claude Opus 4.1 | `claude-opus-4-1@20250805` | Reasoning, Vision |
-| Claude Haiku 4.5 | `claude-haiku-4-5@20251001` | Reasoning, Vision |
-| Claude Opus 4 | `claude-opus-4@20250514` | Reasoning, Vision |
-| Claude Sonnet 4 | `claude-sonnet-4@20250514` | Reasoning, Vision |
-| Claude 3.7 Sonnet | `claude-3-7-sonnet@20250219` | Reasoning, Vision |
-| Claude 3.5 Sonnet v2 | `claude-3-5-sonnet-v2@20241022` | Vision |
-| Claude 3.5 Haiku | `claude-3-5-haiku@20241022` | Vision |
+| Model                | ID                              | Features          |
+| -------------------- | ------------------------------- | ----------------- |
+| Claude Opus 4.5      | `claude-opus-4-5@20251101`      | Reasoning, Vision |
+| Claude Sonnet 4.5    | `claude-sonnet-4-5@20250929`    | Reasoning, Vision |
+| Claude Opus 4.1      | `claude-opus-4-1@20250805`      | Reasoning, Vision |
+| Claude Haiku 4.5     | `claude-haiku-4-5@20251001`     | Reasoning, Vision |
+| Claude Opus 4        | `claude-opus-4@20250514`        | Reasoning, Vision |
+| Claude Sonnet 4      | `claude-sonnet-4@20250514`      | Reasoning, Vision |
+| Claude 3.7 Sonnet    | `claude-3-7-sonnet@20250219`    | Reasoning, Vision |
+| Claude 3.5 Sonnet v2 | `claude-3-5-sonnet-v2@20241022` | Vision            |
+| Claude 3.5 Haiku     | `claude-3-5-haiku@20241022`     | Vision            |
 
 ## Configuration
 
@@ -108,6 +108,7 @@ You can also manually configure the provider:
 ## Regions
 
 Claude on Vertex AI is available in these regions:
+
 - `us-east5` (Ohio)
 - `europe-west1` (Belgium)
 - `asia-southeast1` (Singapore)
@@ -119,6 +120,7 @@ Check [Vertex AI documentation](https://cloud.google.com/vertex-ai/generative-ai
 ### "No API key found for provider vertex-anthropic"
 
 Ensure gcloud ADC is configured:
+
 ```bash
 gcloud auth application-default login
 ```
@@ -126,6 +128,7 @@ gcloud auth application-default login
 ### "Project not found"
 
 Set the project environment variable:
+
 ```bash
 export GOOGLE_CLOUD_PROJECT=your-project-id
 ```
@@ -133,6 +136,7 @@ export GOOGLE_CLOUD_PROJECT=your-project-id
 ### "Location not found"
 
 Set the location where Claude is enabled:
+
 ```bash
 export GOOGLE_CLOUD_LOCATION=us-east5
 ```

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -192,10 +192,17 @@ export async function resolveApiKeyForProvider(params: {
 
   const envResolved = resolveEnvApiKey(provider);
   if (envResolved) {
+    // Determine mode: oauth for *_OAUTH_TOKEN, token for gcloud ADC, otherwise api-key
+    let mode: ModelAuthMode = "api-key";
+    if (envResolved.source.includes("OAUTH_TOKEN")) {
+      mode = "oauth";
+    } else if (envResolved.source === "gcloud adc") {
+      mode = "token";
+    }
     return {
       apiKey: envResolved.apiKey,
       source: envResolved.source,
-      mode: envResolved.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
+      mode,
     };
   }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -268,6 +268,14 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return { apiKey: envKey, source: "gcloud adc" };
   }
 
+  if (normalized === "vertex-anthropic") {
+    const envKey = getEnvApiKey("google-vertex"); // Uses same gcloud ADC
+    if (!envKey) {
+      return null;
+    }
+    return { apiKey: envKey, source: "gcloud adc" };
+  }
+
   if (normalized === "opencode") {
     return pick("OPENCODE_API_KEY") ?? pick("OPENCODE_ZEN_API_KEY");
   }

--- a/src/agents/vertex-anthropic-models.test.ts
+++ b/src/agents/vertex-anthropic-models.test.ts
@@ -57,14 +57,14 @@ describe("vertex-anthropic-models", () => {
       expect(hasGcloudAdc(env)).toBe(true);
     });
 
-    it("returns true when GOOGLE_CLOUD_PROJECT is set", () => {
+    it("returns false when only GOOGLE_CLOUD_PROJECT is set (not credentials)", () => {
       const env = { GOOGLE_CLOUD_PROJECT: "my-project" };
-      expect(hasGcloudAdc(env)).toBe(true);
+      expect(hasGcloudAdc(env)).toBe(false);
     });
 
-    it("returns true when GCLOUD_PROJECT is set", () => {
+    it("returns false when only GCLOUD_PROJECT is set (not credentials)", () => {
       const env = { GCLOUD_PROJECT: "my-project" };
-      expect(hasGcloudAdc(env)).toBe(true);
+      expect(hasGcloudAdc(env)).toBe(false);
     });
 
     it("returns false when no GCP env is set", () => {

--- a/src/agents/vertex-anthropic-models.test.ts
+++ b/src/agents/vertex-anthropic-models.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVertexAnthropicBaseUrl,
+  buildVertexAnthropicProvider,
+  getVertexClaudeModels,
+  hasGcloudAdc,
+  resolveGcpLocation,
+  resolveGcpProject,
+} from "./vertex-anthropic-models.js";
+
+describe("vertex-anthropic-models", () => {
+  describe("resolveGcpProject", () => {
+    it("returns GOOGLE_CLOUD_PROJECT when set", () => {
+      const env = { GOOGLE_CLOUD_PROJECT: "my-project" };
+      expect(resolveGcpProject(env)).toBe("my-project");
+    });
+
+    it("returns GCLOUD_PROJECT as fallback", () => {
+      const env = { GCLOUD_PROJECT: "fallback-project" };
+      expect(resolveGcpProject(env)).toBe("fallback-project");
+    });
+
+    it("returns CLOUDSDK_CORE_PROJECT as fallback", () => {
+      const env = { CLOUDSDK_CORE_PROJECT: "sdk-project" };
+      expect(resolveGcpProject(env)).toBe("sdk-project");
+    });
+
+    it("returns undefined when no project env is set", () => {
+      expect(resolveGcpProject({})).toBeUndefined();
+    });
+
+    it("trims whitespace", () => {
+      const env = { GOOGLE_CLOUD_PROJECT: "  spaced-project  " };
+      expect(resolveGcpProject(env)).toBe("spaced-project");
+    });
+  });
+
+  describe("resolveGcpLocation", () => {
+    it("returns GOOGLE_CLOUD_LOCATION when set", () => {
+      const env = { GOOGLE_CLOUD_LOCATION: "us-east5" };
+      expect(resolveGcpLocation(env)).toBe("us-east5");
+    });
+
+    it("returns CLOUDSDK_COMPUTE_REGION as fallback", () => {
+      const env = { CLOUDSDK_COMPUTE_REGION: "europe-west1" };
+      expect(resolveGcpLocation(env)).toBe("europe-west1");
+    });
+
+    it("returns undefined when no location env is set", () => {
+      expect(resolveGcpLocation({})).toBeUndefined();
+    });
+  });
+
+  describe("hasGcloudAdc", () => {
+    it("returns true when GOOGLE_APPLICATION_CREDENTIALS is set", () => {
+      const env = { GOOGLE_APPLICATION_CREDENTIALS: "/path/to/key.json" };
+      expect(hasGcloudAdc(env)).toBe(true);
+    });
+
+    it("returns true when GOOGLE_CLOUD_PROJECT is set", () => {
+      const env = { GOOGLE_CLOUD_PROJECT: "my-project" };
+      expect(hasGcloudAdc(env)).toBe(true);
+    });
+
+    it("returns true when GCLOUD_PROJECT is set", () => {
+      const env = { GCLOUD_PROJECT: "my-project" };
+      expect(hasGcloudAdc(env)).toBe(true);
+    });
+
+    it("returns false when no GCP env is set", () => {
+      expect(hasGcloudAdc({})).toBe(false);
+    });
+  });
+
+  describe("buildVertexAnthropicBaseUrl", () => {
+    it("builds correct URL for project and location", () => {
+      const url = buildVertexAnthropicBaseUrl("my-project", "us-east5");
+      expect(url).toBe(
+        "https://us-east5-aiplatform.googleapis.com/v1/projects/my-project/locations/us-east5/publishers/anthropic/models",
+      );
+    });
+
+    it("handles different regions", () => {
+      const url = buildVertexAnthropicBaseUrl("test-proj", "asia-southeast1");
+      expect(url).toContain("asia-southeast1-aiplatform.googleapis.com");
+      expect(url).toContain("projects/test-proj");
+      expect(url).toContain("locations/asia-southeast1");
+    });
+  });
+
+  describe("buildVertexAnthropicProvider", () => {
+    it("returns valid provider config", () => {
+      const provider = buildVertexAnthropicProvider({
+        project: "my-project",
+        location: "us-east5",
+      });
+
+      expect(provider.baseUrl).toContain("us-east5-aiplatform.googleapis.com");
+      expect(provider.api).toBe("anthropic-messages");
+      expect(provider.auth).toBe("token");
+      expect(provider.models).toBeDefined();
+      expect(provider.models.length).toBeGreaterThan(0);
+    });
+
+    it("includes Claude models with correct properties", () => {
+      const provider = buildVertexAnthropicProvider({
+        project: "test",
+        location: "us-east5",
+      });
+
+      const opus = provider.models.find((m) => m.id.includes("opus-4-5"));
+      expect(opus).toBeDefined();
+      expect(opus?.reasoning).toBe(true);
+      expect(opus?.input).toContain("text");
+      expect(opus?.input).toContain("image");
+      expect(opus?.contextWindow).toBe(200000);
+    });
+  });
+
+  describe("getVertexClaudeModels", () => {
+    it("returns array of models", () => {
+      const models = getVertexClaudeModels();
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+    });
+
+    it("includes expected model IDs with version suffix", () => {
+      const models = getVertexClaudeModels();
+      const ids = models.map((m) => m.id);
+
+      expect(ids.some((id) => id.includes("claude-opus-4-5@"))).toBe(true);
+      expect(ids.some((id) => id.includes("claude-sonnet-4@"))).toBe(true);
+      expect(ids.some((id) => id.includes("claude-haiku"))).toBe(true);
+    });
+
+    it("all models have required fields", () => {
+      const models = getVertexClaudeModels();
+
+      for (const model of models) {
+        expect(model.id).toBeDefined();
+        expect(model.name).toBeDefined();
+        expect(typeof model.reasoning).toBe("boolean");
+        expect(Array.isArray(model.input)).toBe(true);
+        expect(model.contextWindow).toBeGreaterThan(0);
+        expect(model.maxTokens).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/agents/vertex-anthropic-models.ts
+++ b/src/agents/vertex-anthropic-models.ts
@@ -176,15 +176,14 @@ export function resolveGcpLocation(env: NodeJS.ProcessEnv = process.env): string
 }
 
 /**
- * Check if gcloud ADC is available
+ * Check if gcloud ADC credentials are available (not just project env vars)
  */
 export function hasGcloudAdc(env: NodeJS.ProcessEnv = process.env): boolean {
-  // Check for service account or ADC
-  return !!(
-    env.GOOGLE_APPLICATION_CREDENTIALS?.trim() ||
-    env.GOOGLE_CLOUD_PROJECT?.trim() ||
-    env.GCLOUD_PROJECT?.trim()
-  );
+  // Only return true if actual credentials are available:
+  // - GOOGLE_APPLICATION_CREDENTIALS points to a service account key file
+  // - Or we're on GCE/Cloud Run with implicit credentials (check via metadata server at runtime)
+  // Project env vars alone are not credentials
+  return !!env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
 }
 
 /**
@@ -207,10 +206,9 @@ export function buildVertexAnthropicProvider(params: {
 /**
  * Resolve implicit Vertex Anthropic provider if GCP credentials are available
  */
-export async function resolveImplicitVertexAnthropicProvider(params: {
-  agentDir: string;
+export function resolveImplicitVertexAnthropicProvider(params: {
   env?: NodeJS.ProcessEnv;
-}): Promise<ProviderConfig | null> {
+}): ProviderConfig | null {
   const env = params.env ?? process.env;
 
   const project = resolveGcpProject(env);

--- a/src/agents/vertex-anthropic-models.ts
+++ b/src/agents/vertex-anthropic-models.ts
@@ -176,13 +176,13 @@ export function resolveGcpLocation(env: NodeJS.ProcessEnv = process.env): string
 }
 
 /**
- * Check if gcloud ADC credentials are available (not just project env vars)
+ * Check if gcloud ADC credentials are available
+ * Note: GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT alone are not credentials,
+ * only GOOGLE_APPLICATION_CREDENTIALS provides auth
  */
 export function hasGcloudAdc(env: NodeJS.ProcessEnv = process.env): boolean {
-  // Only return true if actual credentials are available:
-  // - GOOGLE_APPLICATION_CREDENTIALS points to a service account key file
-  // - Or we're on GCE/Cloud Run with implicit credentials (check via metadata server at runtime)
-  // Project env vars alone are not credentials
+  // Only GOOGLE_APPLICATION_CREDENTIALS provides actual auth credentials
+  // GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT are just project identifiers
   return !!env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
 }
 
@@ -219,7 +219,7 @@ export function resolveImplicitVertexAnthropicProvider(params: {
     return null;
   }
 
-  // Check if we have GCP credentials
+  // Check if we have GCP credentials (service account key file)
   if (!hasGcloudAdc(env)) {
     return null;
   }

--- a/src/agents/vertex-anthropic-models.ts
+++ b/src/agents/vertex-anthropic-models.ts
@@ -1,0 +1,237 @@
+/**
+ * Vertex AI Anthropic Claude Models Provider
+ *
+ * This module provides support for Claude models hosted on Google Cloud Vertex AI.
+ * Uses gcloud ADC for authentication, eliminating the need for API keys.
+ *
+ * Benefits:
+ * - Use GCP credits directly (no OpenRouter fee)
+ * - Same Claude API experience as direct Anthropic
+ * - Supports all Claude features (streaming, tools, thinking)
+ */
+
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { ProviderConfig } from "./models-config.providers.js";
+
+// Vertex AI Claude model catalog
+// Model IDs include version suffix as required by Vertex AI
+const VERTEX_CLAUDE_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "claude-opus-4-5@20251101",
+    name: "Claude Opus 4.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32768,
+    cost: {
+      input: 15,
+      output: 75,
+      cacheRead: 1.875,
+      cacheWrite: 18.75,
+    },
+  },
+  {
+    id: "claude-sonnet-4-5@20250929",
+    name: "Claude Sonnet 4.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 16384,
+    cost: {
+      input: 3,
+      output: 15,
+      cacheRead: 0.375,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-opus-4-1@20250805",
+    name: "Claude Opus 4.1",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32768,
+    cost: {
+      input: 15,
+      output: 75,
+      cacheRead: 1.875,
+      cacheWrite: 18.75,
+    },
+  },
+  {
+    id: "claude-haiku-4-5@20251001",
+    name: "Claude Haiku 4.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 8192,
+    cost: {
+      input: 0.8,
+      output: 4,
+      cacheRead: 0.1,
+      cacheWrite: 1,
+    },
+  },
+  {
+    id: "claude-opus-4@20250514",
+    name: "Claude Opus 4",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32768,
+    cost: {
+      input: 15,
+      output: 75,
+      cacheRead: 1.875,
+      cacheWrite: 18.75,
+    },
+  },
+  {
+    id: "claude-sonnet-4@20250514",
+    name: "Claude Sonnet 4",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 16384,
+    cost: {
+      input: 3,
+      output: 15,
+      cacheRead: 0.375,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-3-7-sonnet@20250219",
+    name: "Claude 3.7 Sonnet",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 16384,
+    cost: {
+      input: 3,
+      output: 15,
+      cacheRead: 0.375,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-3-5-sonnet-v2@20241022",
+    name: "Claude 3.5 Sonnet v2",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 8192,
+    cost: {
+      input: 3,
+      output: 15,
+      cacheRead: 0.375,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-3-5-haiku@20241022",
+    name: "Claude 3.5 Haiku",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 8192,
+    cost: {
+      input: 0.8,
+      output: 4,
+      cacheRead: 0.1,
+      cacheWrite: 1,
+    },
+  },
+];
+
+/**
+ * Build the Vertex AI endpoint URL for Anthropic models
+ */
+export function buildVertexAnthropicBaseUrl(project: string, location: string): string {
+  return `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
+}
+
+/**
+ * Resolve GCP project from environment
+ */
+export function resolveGcpProject(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return (
+    env.GOOGLE_CLOUD_PROJECT?.trim() ||
+    env.GCLOUD_PROJECT?.trim() ||
+    env.CLOUDSDK_CORE_PROJECT?.trim() ||
+    undefined
+  );
+}
+
+/**
+ * Resolve GCP location from environment
+ */
+export function resolveGcpLocation(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return (
+    env.GOOGLE_CLOUD_LOCATION?.trim() ||
+    env.CLOUDSDK_COMPUTE_REGION?.trim() ||
+    // Default locations for Claude on Vertex
+    undefined
+  );
+}
+
+/**
+ * Check if gcloud ADC is available
+ */
+export function hasGcloudAdc(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Check for service account or ADC
+  return !!(
+    env.GOOGLE_APPLICATION_CREDENTIALS?.trim() ||
+    env.GOOGLE_CLOUD_PROJECT?.trim() ||
+    env.GCLOUD_PROJECT?.trim()
+  );
+}
+
+/**
+ * Build the Vertex Anthropic provider configuration
+ */
+export function buildVertexAnthropicProvider(params: {
+  project: string;
+  location: string;
+}): ProviderConfig {
+  const baseUrl = buildVertexAnthropicBaseUrl(params.project, params.location);
+
+  return {
+    baseUrl,
+    api: "anthropic-messages",
+    auth: "token", // Uses gcloud ADC token
+    models: VERTEX_CLAUDE_MODELS,
+  };
+}
+
+/**
+ * Resolve implicit Vertex Anthropic provider if GCP credentials are available
+ */
+export async function resolveImplicitVertexAnthropicProvider(params: {
+  agentDir: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ProviderConfig | null> {
+  const env = params.env ?? process.env;
+
+  const project = resolveGcpProject(env);
+  const location = resolveGcpLocation(env);
+
+  // Need both project and location to use Vertex AI
+  if (!project || !location) {
+    return null;
+  }
+
+  // Check if we have GCP credentials
+  if (!hasGcloudAdc(env)) {
+    return null;
+  }
+
+  return buildVertexAnthropicProvider({ project, location });
+}
+
+/**
+ * Get the list of available Vertex Claude models
+ */
+export function getVertexClaudeModels(): ModelDefinitionConfig[] {
+  return [...VERTEX_CLAUDE_MODELS];
+}

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -152,6 +152,7 @@ export async function modelsStatusCommand(
     "anthropic",
     "github-copilot",
     "google-vertex",
+    "vertex-anthropic",
     "openai",
     "google",
     "groq",


### PR DESCRIPTION
## Summary

Adds support for Claude models hosted on Google Cloud Vertex AI, allowing users to leverage their GCP credits directly without routing through intermediaries like OpenRouter (which charges 5% on all requests).

## Motivation

Users with GCP credits want to use Claude models directly on Vertex AI without paying intermediary fees. This PR adds a new `vertex-anthropic` provider that:
- Uses gcloud Application Default Credentials for authentication
- Auto-discovers when `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are set
- Provides full feature parity with the direct Anthropic API

## Changes

| File | Description |
|------|-------------|
| `src/agents/vertex-anthropic-models.ts` | Model catalog and provider builder |
| `src/agents/vertex-anthropic-models.test.ts` | Unit tests |
| `src/agents/models-config.providers.ts` | Import and auto-discovery integration |
| `src/agents/model-auth.ts` | Add gcloud ADC auth support |
| `src/commands/models/list.status-command.ts` | Add to env probe list |
| `docs/vertex-anthropic.md` | Setup and usage documentation |
| `CHANGELOG.md` | Changelog entry |

## Usage

```bash
# Configure GCP credentials
gcloud auth application-default login
export GOOGLE_CLOUD_PROJECT=my-project
export GOOGLE_CLOUD_LOCATION=us-east5

# Verify
openclaw models list | grep vertex-anthropic

# Use in config
# agents.defaults.model.primary: vertex-anthropic/claude-opus-4-5@20251101
```

## Testing

- [x] Tested locally on GCP VM with real Vertex AI Claude calls
- [x] Unit tests for helper functions
- [ ] CI validation pending

## AI Disclosure

This PR was developed with AI assistance (Claude). The implementation was tested on a live GCP instance with actual Vertex AI API calls confirming functionality.

---

cc @steipete

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `vertex-anthropic` model provider that targets Claude models hosted on Google Cloud Vertex AI, including a static model catalog, env-based auto-discovery when GCP project/location are set, and wiring into `models list/status` so users can see the provider and credential state. Also extends env auth resolution so `vertex-anthropic` reuses the existing `google-vertex` gcloud ADC token flow.

Main integration points are provider auto-discovery (`src/agents/models-config.providers.ts`) and env credential resolution (`src/agents/model-auth.ts`), with supporting docs and tests for the new helper module.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but a couple auth/discovery edge cases can misreport availability or auth mode.
- Core changes are additive and well-scoped (new provider module + wiring), but current auto-discovery can enable the provider without real ADC credentials, and env-based auth resolution reports the wrong auth mode for gcloud ADC sources. These are likely to cause confusing UX and some runtime failures for users relying on implicit discovery.
- src/agents/models-config.providers.ts, src/agents/model-auth.ts, src/agents/vertex-anthropic-models.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->