### PR TITLE
fix: trigger model failover on malformed tool-call JSON

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3,11 +3,13 @@ summary: "All configuration options for ~/.openclaw/openclaw.json with examples"
 read_when:
   - Adding or modifying config fields
 ---
+
 # Configuration 🔧
 
 OpenClaw reads an optional **JSON5** config from `~/.openclaw/openclaw.json` (comments + trailing commas allowed).
 
 If the file is missing, OpenClaw uses safe-ish defaults (embedded Pi agent + per-sender sessions + workspace `~/.openclaw/workspace`). You usually only need a config to:
+
 - restrict who can trigger the bot (`channels.whatsapp.allowFrom`, `channels.telegram.allowFrom`, etc.)
 - control group allowlists + mention behavior (`channels.whatsapp.groups`, `channels.telegram.groups`, `channels.discord.guilds`, `agents.list[].groupChat`)
 - customize message prefixes (`messages`)
@@ -23,6 +25,7 @@ OpenClaw only accepts configurations that fully match the schema.
 Unknown keys, malformed types, or invalid values cause the Gateway to **refuse to start** for safety.
 
 When validation fails:
+
 - The Gateway does not boot.
 - Only diagnostic commands are allowed (for example: `openclaw doctor`, `openclaw logs`, `openclaw health`, `openclaw status`, `openclaw service`, `openclaw help`).
 - Run `openclaw doctor` to see the exact issues.
@@ -50,6 +53,7 @@ Warning: `config.apply` replaces the **entire config**. If you want to change on
 use `config.patch` or `openclaw config set`. Keep a backup of `~/.openclaw/openclaw.json`.
 
 Params:
+
 - `raw` (string) — JSON5 payload for the entire config
 - `baseHash` (optional) — config hash from `config.get` (required when a config already exists)
 - `sessionKey` (optional) — last active session key for the wake-up ping
@@ -72,13 +76,15 @@ openclaw gateway call config.apply --params '{
 
 Use `config.patch` to merge a partial update into the existing config without clobbering
 unrelated keys. It applies JSON merge patch semantics:
+
 - objects merge recursively
 - `null` deletes a key
 - arrays replace
-Like `config.apply`, it validates, writes the config, stores a restart sentinel, and schedules
-the Gateway restart (with an optional wake when `sessionKey` is provided).
+  Like `config.apply`, it validates, writes the config, stores a restart sentinel, and schedules
+  the Gateway restart (with an optional wake when `sessionKey` is provided).
 
 Params:
+
 - `raw` (string) — JSON5 payload containing just the keys to change
 - `baseHash` (required) — config hash from `config.get`
 - `sessionKey` (optional) — last active session key for the wake-up ping
@@ -102,11 +108,12 @@ openclaw gateway call config.patch --params '{
 ```json5
 {
   agents: { defaults: { workspace: "~/.openclaw/workspace" } },
-  channels: { whatsapp: { allowFrom: ["+15555550123"] } }
+  channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
 
 Build the default image once with:
+
 ```bash
 scripts/sandbox-setup.sh
 ```
@@ -122,23 +129,24 @@ To prevent the bot from responding to WhatsApp @-mentions in groups (only respon
     list: [
       {
         id: "main",
-        groupChat: { mentionPatterns: ["@openclaw", "reisponde"] }
-      }
-    ]
+        groupChat: { mentionPatterns: ["@openclaw", "reisponde"] },
+      },
+    ],
   },
   channels: {
     whatsapp: {
       // Allowlist is DMs only; including your own number enables self-chat mode.
       allowFrom: ["+15555550123"],
-      groups: { "*": { requireMention: true } }
-    }
-  }
+      groups: { "*": { requireMention: true } },
+    },
+  },
 }
 ```
 
 ## Config Includes (`$include`)
 
 Split your config into multiple files using the `$include` directive. This is useful for:
+
 - Organizing large configs (e.g., per-client agent definitions)
 - Sharing common settings across environments
 - Keeping sensitive configs separate
@@ -149,17 +157,14 @@ Split your config into multiple files using the `$include` directive. This is us
 // ~/.openclaw/openclaw.json
 {
   gateway: { port: 18789 },
-  
+
   // Include a single file (replaces the key's value)
-  agents: { "$include": "./agents.json5" },
-  
+  agents: { $include: "./agents.json5" },
+
   // Include multiple files (deep-merged in order)
-  broadcast: { 
-    "$include": [
-      "./clients/mueller.json5",
-      "./clients/schmidt.json5"
-    ]
-  }
+  broadcast: {
+    $include: ["./clients/mueller.json5", "./clients/schmidt.json5"],
+  },
 }
 ```
 
@@ -167,9 +172,7 @@ Split your config into multiple files using the `$include` directive. This is us
 // ~/.openclaw/agents.json5
 {
   defaults: { sandbox: { mode: "all", scope: "session" } },
-  list: [
-    { id: "main", workspace: "~/.openclaw/workspace" }
-  ]
+  list: [{ id: "main", workspace: "~/.openclaw/workspace" }],
 }
 ```
 
@@ -183,8 +186,8 @@ Split your config into multiple files using the `$include` directive. This is us
 ```json5
 // Sibling keys override included values
 {
-  "$include": "./base.json5",   // { a: 1, b: 2 }
-  b: 99                          // Result: { a: 1, b: 99 }
+  $include: "./base.json5", // { a: 1, b: 2 }
+  b: 99, // Result: { a: 1, b: 99 }
 }
 ```
 
@@ -195,8 +198,8 @@ Included files can themselves contain `$include` directives (up to 10 levels dee
 ```json5
 // clients/mueller.json5
 {
-  agents: { "$include": "./mueller/agents.json5" },
-  broadcast: { "$include": "./mueller/broadcast.json5" }
+  agents: { $include: "./mueller/agents.json5" },
+  broadcast: { $include: "./mueller/broadcast.json5" },
 }
 ```
 
@@ -224,26 +227,22 @@ Included files can themselves contain `$include` directives (up to 10 levels dee
 // ~/.openclaw/openclaw.json
 {
   gateway: { port: 18789, auth: { token: "secret" } },
-  
+
   // Common agent defaults
   agents: {
     defaults: {
-      sandbox: { mode: "all", scope: "session" }
+      sandbox: { mode: "all", scope: "session" },
     },
     // Merge agent lists from all clients
-    list: { "$include": [
-      "./clients/mueller/agents.json5",
-      "./clients/schmidt/agents.json5"
-    ]}
+    list: { $include: ["./clients/mueller/agents.json5", "./clients/schmidt/agents.json5"] },
   },
-  
+
   // Merge broadcast configs
-  broadcast: { "$include": [
-    "./clients/mueller/broadcast.json5",
-    "./clients/schmidt/broadcast.json5"
-  ]},
-  
-  channels: { whatsapp: { groupPolicy: "allowlist" } }
+  broadcast: {
+    $include: ["./clients/mueller/broadcast.json5", "./clients/schmidt/broadcast.json5"],
+  },
+
+  channels: { whatsapp: { groupPolicy: "allowlist" } },
 }
 ```
 
@@ -251,14 +250,14 @@ Included files can themselves contain `$include` directives (up to 10 levels dee
 // ~/.openclaw/clients/mueller/agents.json5
 [
   { id: "mueller-transcribe", workspace: "~/clients/mueller/transcribe" },
-  { id: "mueller-docs", workspace: "~/clients/mueller/docs" }
+  { id: "mueller-docs", workspace: "~/clients/mueller/docs" },
 ]
 ```
 
 ```json5
 // ~/.openclaw/clients/mueller/broadcast.json5
 {
-  "120363403215116621@g.us": ["mueller-transcribe", "mueller-docs"]
+  "120363403215116621@g.us": ["mueller-transcribe", "mueller-docs"],
 }
 ```
 
@@ -269,6 +268,7 @@ Included files can themselves contain `$include` directives (up to 10 levels dee
 OpenClaw reads env vars from the parent process (shell, launchd/systemd, CI, etc.).
 
 Additionally, it loads:
+
 - `.env` from the current working directory (if present)
 - a global fallback `.env` from `~/.openclaw/.env` (aka `$OPENCLAW_STATE_DIR/.env`)
 
@@ -282,9 +282,9 @@ process env is missing the key (same non-overriding rule):
   env: {
     OPENROUTER_API_KEY: "sk-or-...",
     vars: {
-      GROQ_API_KEY: "gsk-..."
-    }
-  }
+      GROQ_API_KEY: "gsk-...",
+    },
+  },
 }
 ```
 
@@ -300,13 +300,14 @@ This effectively sources your shell profile.
   env: {
     shellEnv: {
       enabled: true,
-      timeoutMs: 15000
-    }
-  }
+      timeoutMs: 15000,
+    },
+  },
 }
 ```
 
 Env var equivalent:
+
 - `OPENCLAW_LOAD_SHELL_ENV=1`
 - `OPENCLAW_SHELL_ENV_TIMEOUT_MS=15000`
 
@@ -320,19 +321,20 @@ You can reference environment variables directly in any config string value usin
   models: {
     providers: {
       "vercel-gateway": {
-        apiKey: "${VERCEL_GATEWAY_API_KEY}"
-      }
-    }
+        apiKey: "${VERCEL_GATEWAY_API_KEY}",
+      },
+    },
   },
   gateway: {
     auth: {
-      token: "${OPENCLAW_GATEWAY_TOKEN}"
-    }
-  }
+      token: "${OPENCLAW_GATEWAY_TOKEN}",
+    },
+  },
 }
 ```
 
 **Rules:**
+
 - Only uppercase env var names are matched: `[A-Z_][A-Z0-9_]*`
 - Missing or empty env vars throw an error at config load
 - Escape with `$${VAR}` to output a literal `${VAR}`
@@ -345,30 +347,35 @@ You can reference environment variables directly in any config string value usin
   models: {
     providers: {
       custom: {
-        baseUrl: "${CUSTOM_API_BASE}/v1"  // → "https://api.example.com/v1"
-      }
-    }
-  }
+        baseUrl: "${CUSTOM_API_BASE}/v1", // → "https://api.example.com/v1"
+      },
+    },
+  },
 }
 ```
 
 ### Auth storage (OAuth + API keys)
 
 OpenClaw stores **per-agent** auth profiles (OAuth + API keys) in:
+
 - `<agentDir>/auth-profiles.json` (default: `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`)
 
 See also: [/concepts/oauth](/concepts/oauth)
 
 Legacy OAuth imports:
+
 - `~/.openclaw/credentials/oauth.json` (or `$OPENCLAW_STATE_DIR/credentials/oauth.json`)
 
 The embedded Pi agent maintains a runtime cache at:
+
 - `<agentDir>/auth.json` (managed automatically; don’t edit manually)
 
 Legacy agent dir (pre multi-agent):
+
 - `~/.openclaw/agent/*` (migrated by `openclaw doctor` into `~/.openclaw/agents/<defaultAgentId>/agent/*`)
 
 Overrides:
+
 - OAuth dir (legacy import only): `OPENCLAW_OAUTH_DIR`
 - Agent dir (default agent root override): `OPENCLAW_AGENT_DIR` (preferred), `PI_CODING_AGENT_DIR` (legacy)
 
@@ -385,12 +392,12 @@ rotation order used for failover.
   auth: {
     profiles: {
       "anthropic:me@example.com": { provider: "anthropic", mode: "oauth", email: "me@example.com" },
-      "anthropic:work": { provider: "anthropic", mode: "api_key" }
+      "anthropic:work": { provider: "anthropic", mode: "api_key" },
     },
     order: {
-      anthropic: ["anthropic:me@example.com", "anthropic:work"]
-    }
-  }
+      anthropic: ["anthropic:me@example.com", "anthropic:work"],
+    },
+  },
 }
 ```
 
@@ -399,11 +406,13 @@ rotation order used for failover.
 Optional per-agent identity used for defaults and UX. This is written by the macOS onboarding assistant.
 
 If set, OpenClaw derives defaults (only when you haven’t set them explicitly):
+
 - `messages.ackReaction` from the **active agent**’s `identity.emoji` (falls back to 👀)
 - `agents.list[].groupChat.mentionPatterns` from the agent’s `identity.name`/`identity.emoji` (so “@Samantha” works in groups across Telegram/Slack/Discord/Google Chat/iMessage/WhatsApp)
 - `identity.avatar` accepts a workspace-relative image path or a remote URL/data URL. Local files must live inside the agent workspace.
 
 `identity.avatar` accepts:
+
 - Workspace-relative path (must stay within the agent workspace)
 - `http(s)` URL
 - `data:` URI
@@ -418,11 +427,11 @@ If set, OpenClaw derives defaults (only when you haven’t set them explicitly):
           name: "Samantha",
           theme: "helpful sloth",
           emoji: "🦥",
-          avatar: "avatars/samantha.png"
-        }
-      }
-    ]
-  }
+          avatar: "avatars/samantha.png",
+        },
+      },
+    ],
+  },
 }
 ```
 
@@ -437,8 +446,8 @@ Metadata written by CLI wizards (`onboard`, `configure`, `doctor`).
     lastRunVersion: "2026.1.4",
     lastRunCommit: "abc1234",
     lastRunCommand: "configure",
-    lastRunMode: "local"
-  }
+    lastRunMode: "local",
+  },
 }
 ```
 
@@ -464,15 +473,16 @@ Metadata written by CLI wizards (`onboard`, `configure`, `doctor`).
     redactPatterns: [
       // Example: override defaults with your own rules.
       "\\bTOKEN\\b\\s*[=:]\\s*([\"']?)([^\\s\"']+)\\1",
-      "/\\bsk-[A-Za-z0-9_-]{8,}\\b/gi"
-    ]
-  }
+      "/\\bsk-[A-Za-z0-9_-]{8,}\\b/gi",
+    ],
+  },
 }
 ```
 
 ### `channels.whatsapp.dmPolicy`
 
 Controls how WhatsApp direct chats (DMs) are handled:
+
 - `"pairing"` (default): unknown senders get a pairing code; owner must approve
 - `"allowlist"`: only allow senders in `channels.whatsapp.allowFrom` (or paired allow store)
 - `"open"`: allow all inbound DMs (**requires** `channels.whatsapp.allowFrom` to include `"*"`)
@@ -481,6 +491,7 @@ Controls how WhatsApp direct chats (DMs) are handled:
 Pairing codes expire after 1 hour; the bot only sends a pairing code when a new request is created. Pending DM pairing requests are capped at **3 per channel** by default.
 
 Pairing approvals:
+
 - `openclaw pairing list whatsapp`
 - `openclaw pairing approve whatsapp <code>`
 
@@ -498,9 +509,9 @@ For groups, use `channels.whatsapp.groupPolicy` + `channels.whatsapp.groupAllowF
       allowFrom: ["+15555550123", "+447700900123"],
       textChunkLimit: 4000, // optional outbound chunk size (chars)
       chunkMode: "length", // optional chunking mode (length | newline)
-      mediaMaxMb: 50 // optional inbound media cap (MB)
-    }
-  }
+      mediaMaxMb: 50, // optional inbound media cap (MB)
+    },
+  },
 }
 ```
 
@@ -515,8 +526,8 @@ Per-account override: `channels.whatsapp.accounts.<id>.sendReadReceipts`.
 ```json5
 {
   channels: {
-    whatsapp: { sendReadReceipts: false }
-  }
+    whatsapp: { sendReadReceipts: false },
+  },
 }
 ```
 
@@ -534,14 +545,15 @@ Run multiple WhatsApp accounts in one gateway:
         biz: {
           // Optional override. Default: ~/.openclaw/credentials/whatsapp/biz
           // authDir: "~/.openclaw/credentials/whatsapp/biz",
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Outbound commands default to account `default` if present; otherwise the first configured account id (sorted).
 - The legacy single-account Baileys auth dir is migrated by `openclaw doctor` into `whatsapp/default`.
 
@@ -556,19 +568,20 @@ Run multiple accounts per channel (each account has its own `accountId` and opti
       accounts: {
         default: {
           name: "Primary bot",
-          botToken: "123456:ABC..."
+          botToken: "123456:ABC...",
         },
         alerts: {
           name: "Alerts bot",
-          botToken: "987654:XYZ..."
-        }
-      }
-    }
-  }
+          botToken: "987654:XYZ...",
+        },
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - `default` is used when `accountId` is omitted (CLI + routing).
 - Env tokens only apply to the **default** account.
 - Base channel settings (group policy, mention gating, etc.) apply to all accounts unless overridden per account.
@@ -579,6 +592,7 @@ Notes:
 Group messages default to **require mention** (either metadata mention or regex patterns). Applies to WhatsApp, Telegram, Discord, Google Chat, and iMessage group chats.
 
 **Mention types:**
+
 - **Metadata mentions**: Native platform @-mentions (e.g., WhatsApp tap-to-mention). Ignored in WhatsApp self-chat mode (see `channels.whatsapp.allowFrom`).
 - **Text patterns**: Regex patterns defined in `agents.list[].groupChat.mentionPatterns`. Always checked regardless of self-chat mode.
 - Mention gating is enforced only when mention detection is possible (native mentions or at least one `mentionPattern`).
@@ -586,13 +600,11 @@ Group messages default to **require mention** (either metadata mention or regex 
 ```json5
 {
   messages: {
-    groupChat: { historyLimit: 50 }
+    groupChat: { historyLimit: 50 },
   },
   agents: {
-    list: [
-      { id: "main", groupChat: { mentionPatterns: ["@openclaw", "openclaw"] } }
-    ]
-  }
+    list: [{ id: "main", groupChat: { mentionPatterns: ["@openclaw", "openclaw"] } }],
+  },
 }
 ```
 
@@ -606,16 +618,17 @@ DM conversations use session-based history managed by the agent. You can limit t
 {
   channels: {
     telegram: {
-      dmHistoryLimit: 30,  // limit DM sessions to 30 user turns
+      dmHistoryLimit: 30, // limit DM sessions to 30 user turns
       dms: {
-        "123456789": { historyLimit: 50 }  // per-user override (user ID)
-      }
-    }
-  }
+        "123456789": { historyLimit: 50 }, // per-user override (user ID)
+      },
+    },
+  },
 }
 ```
 
 Resolution order:
+
 1. Per-DM override: `channels.<provider>.dms[userId].historyLimit`
 2. Provider default: `channels.<provider>.dmHistoryLimit`
 3. No limit (all history retained)
@@ -623,28 +636,30 @@ Resolution order:
 Supported providers: `telegram`, `whatsapp`, `discord`, `slack`, `signal`, `imessage`, `msteams`.
 
 Per-agent override (takes precedence when set, even `[]`):
+
 ```json5
 {
   agents: {
     list: [
       { id: "work", groupChat: { mentionPatterns: ["@workbot", "\\+15555550123"] } },
-      { id: "personal", groupChat: { mentionPatterns: ["@homebot", "\\+15555550999"] } }
-    ]
-  }
+      { id: "personal", groupChat: { mentionPatterns: ["@homebot", "\\+15555550999"] } },
+    ],
+  },
 }
 ```
 
 Mention gating defaults live per channel (`channels.whatsapp.groups`, `channels.telegram.groups`, `channels.imessage.groups`, `channels.discord.guilds`). When `*.groups` is set, it also acts as a group allowlist; include `"*"` to allow all groups.
 
 To respond **only** to specific text triggers (ignoring native @-mentions):
+
 ```json5
 {
   channels: {
     whatsapp: {
       // Include your own number to enable self-chat mode (ignore native @-mentions).
       allowFrom: ["+15555550123"],
-      groups: { "*": { requireMention: true } }
-    }
+      groups: { "*": { requireMention: true } },
+    },
   },
   agents: {
     list: [
@@ -652,11 +667,11 @@ To respond **only** to specific text triggers (ignoring native @-mentions):
         id: "main",
         groupChat: {
           // Only these text patterns will trigger responses
-          mentionPatterns: ["reisponde", "@openclaw"]
-        }
-      }
-    ]
-  }
+          mentionPatterns: ["reisponde", "@openclaw"],
+        },
+      },
+    ],
+  },
 }
 ```
 
@@ -669,41 +684,42 @@ Use `channels.*.groupPolicy` to control whether group/room messages are accepted
   channels: {
     whatsapp: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["+15551234567"]
+      groupAllowFrom: ["+15551234567"],
     },
     telegram: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["tg:123456789", "@alice"]
+      groupAllowFrom: ["tg:123456789", "@alice"],
     },
     signal: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["+15551234567"]
+      groupAllowFrom: ["+15551234567"],
     },
     imessage: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["chat_id:123"]
+      groupAllowFrom: ["chat_id:123"],
     },
     msteams: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["user@org.com"]
+      groupAllowFrom: ["user@org.com"],
     },
     discord: {
       groupPolicy: "allowlist",
       guilds: {
-        "GUILD_ID": {
-          channels: { help: { allow: true } }
-        }
-      }
+        GUILD_ID: {
+          channels: { help: { allow: true } },
+        },
+      },
     },
     slack: {
       groupPolicy: "allowlist",
-      channels: { "#general": { allow: true } }
-    }
-  }
+      channels: { "#general": { allow: true } },
+    },
+  },
 }
 ```
 
 Notes:
+
 - `"open"`: groups bypass allowlists; mention-gating still applies.
 - `"disabled"`: block all group/room messages.
 - `"allowlist"`: only allow groups/rooms that match the configured allowlist.
@@ -752,12 +768,13 @@ Inbound messages are routed to an agent via bindings.
   - `match.guildId` / `match.teamId` (optional; channel-specific)
 
 Deterministic match order:
-1) `match.peer`
-2) `match.guildId`
-3) `match.teamId`
-4) `match.accountId` (exact, no peer/guild/team)
-5) `match.accountId: "*"` (channel-wide, no peer/guild/team)
-6) default agent (`agents.list[].default`, else first list entry, else `"main"`)
+
+1. `match.peer`
+2. `match.guildId`
+3. `match.teamId`
+4. `match.accountId` (exact, no peer/guild/team)
+5. `match.accountId: "*"` (channel-wide, no peer/guild/team)
+6. default agent (`agents.list[].default`, else first list entry, else `"main"`)
 
 Within each match tier, the first matching entry in `bindings` wins.
 
@@ -765,6 +782,7 @@ Within each match tier, the first matching entry in `bindings` wins.
 
 Each agent can carry its own sandbox + tool policy. Use this to mix access
 levels in one gateway:
+
 - **Full access** (personal agent)
 - **Read-only** tools + workspace
 - **No filesystem access** (messaging/session tools only)
@@ -773,6 +791,7 @@ See [Multi-Agent Sandbox & Tools](/multi-agent-sandbox-tools) for precedence and
 additional examples.
 
 Full access (no sandbox):
+
 ```json5
 {
   agents: {
@@ -780,14 +799,15 @@ Full access (no sandbox):
       {
         id: "personal",
         workspace: "~/.openclaw/workspace-personal",
-        sandbox: { mode: "off" }
-      }
-    ]
-  }
+        sandbox: { mode: "off" },
+      },
+    ],
+  },
 }
 ```
 
 Read-only tools + read-only workspace:
+
 ```json5
 {
   agents: {
@@ -798,19 +818,27 @@ Read-only tools + read-only workspace:
         sandbox: {
           mode: "all",
           scope: "agent",
-          workspaceAccess: "ro"
+          workspaceAccess: "ro",
         },
         tools: {
-          allow: ["read", "sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "session_status"],
-          deny: ["write", "edit", "apply_patch", "exec", "process", "browser"]
-        }
-      }
-    ]
-  }
+          allow: [
+            "read",
+            "sessions_list",
+            "sessions_history",
+            "sessions_send",
+            "sessions_spawn",
+            "session_status",
+          ],
+          deny: ["write", "edit", "apply_patch", "exec", "process", "browser"],
+        },
+      },
+    ],
+  },
 }
 ```
 
 No filesystem access (messaging/session tools enabled):
+
 ```json5
 {
   agents: {
@@ -821,15 +849,39 @@ No filesystem access (messaging/session tools enabled):
         sandbox: {
           mode: "all",
           scope: "agent",
-          workspaceAccess: "none"
+          workspaceAccess: "none",
         },
         tools: {
-          allow: ["sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "session_status", "whatsapp", "telegram", "slack", "discord", "gateway"],
-          deny: ["read", "write", "edit", "apply_patch", "exec", "process", "browser", "canvas", "nodes", "cron", "gateway", "image"]
-        }
-      }
-    ]
-  }
+          allow: [
+            "sessions_list",
+            "sessions_history",
+            "sessions_send",
+            "sessions_spawn",
+            "session_status",
+            "whatsapp",
+            "telegram",
+            "slack",
+            "discord",
+            "gateway",
+          ],
+          deny: [
+            "read",
+            "write",
+            "edit",
+            "apply_patch",
+            "exec",
+            "process",
+            "browser",
+            "canvas",
+            "nodes",
+            "cron",
+            "gateway",
+            "image",
+          ],
+        },
+      },
+    ],
+  },
 }
 ```
 
@@ -840,21 +892,21 @@ Example: two WhatsApp accounts → two agents:
   agents: {
     list: [
       { id: "home", default: true, workspace: "~/.openclaw/workspace-home" },
-      { id: "work", workspace: "~/.openclaw/workspace-work" }
-    ]
+      { id: "work", workspace: "~/.openclaw/workspace-work" },
+    ],
   },
   bindings: [
     { agentId: "home", match: { channel: "whatsapp", accountId: "personal" } },
-    { agentId: "work", match: { channel: "whatsapp", accountId: "biz" } }
+    { agentId: "work", match: { channel: "whatsapp", accountId: "biz" } },
   ],
   channels: {
     whatsapp: {
       accounts: {
         personal: {},
         biz: {},
-      }
-    }
-  }
+      },
+    },
+  },
 }
 ```
 
@@ -867,9 +919,9 @@ Agent-to-agent messaging is opt-in:
   tools: {
     agentToAgent: {
       enabled: false,
-      allow: ["home", "work"]
-    }
-  }
+      allow: ["home", "work"],
+    },
+  },
 }
 ```
 
@@ -890,10 +942,10 @@ Controls how inbound messages behave when an agent run is already active.
         telegram: "collect",
         discord: "collect",
         imessage: "collect",
-        webchat: "collect"
-      }
-    }
-  }
+        webchat: "collect",
+      },
+    },
+  },
 }
 ```
 
@@ -911,14 +963,15 @@ and uses the most recent message for reply threading/IDs.
       byChannel: {
         whatsapp: 5000,
         slack: 1500,
-        discord: 1500
-      }
-    }
-  }
+        discord: 1500,
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Debounce batches **text-only** messages; media/attachments flush immediately.
 - Control commands (e.g. `/queue`, `/new`) bypass debouncing so they stay standalone.
 
@@ -929,19 +982,20 @@ Controls how chat commands are enabled across connectors.
 ```json5
 {
   commands: {
-    native: "auto",         // register native commands when supported (auto)
-    text: true,             // parse slash commands in chat messages
-    bash: false,            // allow ! (alias: /bash) (host-only; requires tools.elevated allowlists)
+    native: "auto", // register native commands when supported (auto)
+    text: true, // parse slash commands in chat messages
+    bash: false, // allow ! (alias: /bash) (host-only; requires tools.elevated allowlists)
     bashForegroundMs: 2000, // bash foreground window (0 backgrounds immediately)
-    config: false,          // allow /config (writes to disk)
-    debug: false,           // allow /debug (runtime-only overrides)
-    restart: false,         // allow /restart + gateway restart tool
-    useAccessGroups: true   // enforce access-group allowlists/policies for commands
-  }
+    config: false, // allow /config (writes to disk)
+    debug: false, // allow /debug (runtime-only overrides)
+    restart: false, // allow /restart + gateway restart tool
+    useAccessGroups: true, // enforce access-group allowlists/policies for commands
+  },
 }
 ```
 
 Notes:
+
 - Text commands must be sent as a **standalone** message and use the leading `/` (no plain-text aliases).
 - `commands.text: false` disables parsing chat messages for commands.
 - `commands.native: "auto"` (default) turns on native commands for Discord/Telegram and leaves Slack off; unsupported channels stay text-only.
@@ -972,9 +1026,9 @@ Set `web.enabled: false` to keep it off by default.
       maxMs: 120000,
       factor: 1.4,
       jitter: 0.2,
-      maxAttempts: 0
-    }
-  }
+      maxAttempts: 0,
+    },
+  },
 }
 ```
 
@@ -991,8 +1045,8 @@ Set `channels.telegram.configWrites: false` to block Telegram-initiated config w
     telegram: {
       enabled: true,
       botToken: "your-bot-token",
-      dmPolicy: "pairing",                 // pairing | allowlist | open | disabled
-      allowFrom: ["tg:123456789"],         // optional; "open" requires ["*"]
+      dmPolicy: "pairing", // pairing | allowlist | open | disabled
+      allowFrom: ["tg:123456789"], // optional; "open" requires ["*"]
       groups: {
         "*": { requireMention: true },
         "-1001234567890": {
@@ -1002,50 +1056,54 @@ Set `channels.telegram.configWrites: false` to block Telegram-initiated config w
             "99": {
               requireMention: false,
               skills: ["search"],
-              systemPrompt: "Stay on topic."
-            }
-          }
-        }
+              systemPrompt: "Stay on topic.",
+            },
+          },
+        },
       },
       customCommands: [
         { command: "backup", description: "Git backup" },
-        { command: "generate", description: "Create an image" }
+        { command: "generate", description: "Create an image" },
       ],
-      historyLimit: 50,                     // include last N group messages as context (0 disables)
-      replyToMode: "first",                 // off | first | all
-      linkPreview: true,                   // toggle outbound link previews
-      streamMode: "partial",               // off | partial | block (draft streaming; separate from block streaming)
-      draftChunk: {                        // optional; only for streamMode=block
+      historyLimit: 50, // include last N group messages as context (0 disables)
+      replyToMode: "first", // off | first | all
+      linkPreview: true, // toggle outbound link previews
+      streamMode: "partial", // off | partial | block (draft streaming; separate from block streaming)
+      draftChunk: {
+        // optional; only for streamMode=block
         minChars: 200,
         maxChars: 800,
-        breakPreference: "paragraph"       // paragraph | newline | sentence
+        breakPreference: "paragraph", // paragraph | newline | sentence
       },
       actions: { reactions: true, sendMessage: true }, // tool action gates (false disables)
-      reactionNotifications: "own",   // off | own | all
+      reactionNotifications: "own", // off | own | all
       mediaMaxMb: 5,
-      retry: {                             // outbound retry policy
+      retry: {
+        // outbound retry policy
         attempts: 3,
         minDelayMs: 400,
         maxDelayMs: 30000,
-        jitter: 0.1
+        jitter: 0.1,
       },
-      network: {                           // transport overrides
-        autoSelectFamily: false
+      network: {
+        // transport overrides
+        autoSelectFamily: false,
       },
       proxy: "socks5://localhost:9050",
       webhookUrl: "https://example.com/telegram-webhook",
       webhookSecret: "secret",
-      webhookPath: "/telegram-webhook"
-    }
-  }
+      webhookPath: "/telegram-webhook",
+    },
+  },
 }
 ```
 
 Draft streaming notes:
+
 - Uses Telegram `sendMessageDraft` (draft bubble, not a real message).
 - Requires **private chat topics** (message_thread_id in DMs; bot has topics enabled).
 - `/reasoning stream` streams reasoning into the draft, then sends the final answer.
-Retry policy defaults and behavior are documented in [Retry policy](/concepts/retry).
+  Retry policy defaults and behavior are documented in [Retry policy](/concepts/retry).
 
 ### `channels.discord` (bot transport)
 
@@ -1058,9 +1116,10 @@ Multi-account support lives under `channels.discord.accounts` (see the multi-acc
     discord: {
       enabled: true,
       token: "your-bot-token",
-      mediaMaxMb: 8,                          // clamp inbound media size
-      allowBots: false,                       // allow bot-authored messages
-      actions: {                              // tool action gates (false disables)
+      mediaMaxMb: 8, // clamp inbound media size
+      allowBots: false, // allow bot-authored messages
+      actions: {
+        // tool action gates (false disables)
         reactions: true,
         stickers: true,
         polls: true,
@@ -1075,22 +1134,23 @@ Multi-account support lives under `channels.discord.accounts` (see the multi-acc
         channelInfo: true,
         voiceStatus: true,
         events: true,
-        moderation: false
+        moderation: false,
       },
-      replyToMode: "off",                     // off | first | all
+      replyToMode: "off", // off | first | all
       dm: {
-        enabled: true,                        // disable all DMs when false
-        policy: "pairing",                    // pairing | allowlist | open | disabled
+        enabled: true, // disable all DMs when false
+        policy: "pairing", // pairing | allowlist | open | disabled
         allowFrom: ["1234567890", "steipete"], // optional DM allowlist ("open" requires ["*"])
-        groupEnabled: false,                 // enable group DMs
-        groupChannels: ["openclaw-dm"]          // optional group DM allowlist
+        groupEnabled: false, // enable group DMs
+        groupChannels: ["openclaw-dm"], // optional group DM allowlist
       },
       guilds: {
-        "123456789012345678": {               // guild id (preferred) or slug
+        "123456789012345678": {
+          // guild id (preferred) or slug
           slug: "friends-of-openclaw",
-          requireMention: false,              // per-guild default
-          reactionNotifications: "own",       // off | own | all | allowlist
-          users: ["987654321098765432"],      // optional per-guild user allowlist
+          requireMention: false, // per-guild default
+          reactionNotifications: "own", // off | own | all | allowlist
+          users: ["987654321098765432"], // optional per-guild user allowlist
           channels: {
             general: { allow: true },
             help: {
@@ -1098,23 +1158,24 @@ Multi-account support lives under `channels.discord.accounts` (see the multi-acc
               requireMention: true,
               users: ["987654321098765432"],
               skills: ["docs"],
-              systemPrompt: "Short answers only."
-            }
-          }
-        }
+              systemPrompt: "Short answers only.",
+            },
+          },
+        },
       },
-      historyLimit: 20,                       // include last N guild messages as context
-      textChunkLimit: 2000,                   // optional outbound text chunk size (chars)
-      chunkMode: "length",                    // optional chunking mode (length | newline)
-      maxLinesPerMessage: 17,                 // soft max lines per message (Discord UI clipping)
-      retry: {                                // outbound retry policy
+      historyLimit: 20, // include last N guild messages as context
+      textChunkLimit: 2000, // optional outbound text chunk size (chars)
+      chunkMode: "length", // optional chunking mode (length | newline)
+      maxLinesPerMessage: 17, // soft max lines per message (Discord UI clipping)
+      retry: {
+        // outbound retry policy
         attempts: 3,
         minDelayMs: 500,
         maxDelayMs: 30000,
-        jitter: 0.1
-      }
-    }
-  }
+        jitter: 0.1,
+      },
+    },
+  },
 }
 ```
 
@@ -1122,12 +1183,13 @@ OpenClaw starts Discord only when a `channels.discord` config section exists. Th
 Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged channel name (no leading `#`). Prefer guild ids as keys to avoid rename ambiguity.
 Bot-authored messages are ignored by default. Enable with `channels.discord.allowBots` (own messages are still filtered to prevent self-reply loops).
 Reaction notification modes:
+
 - `off`: no reaction events.
 - `own`: reactions on the bot's own messages (default).
 - `all`: all reactions on all messages.
 - `allowlist`: reactions from `guilds.<id>.users` on all messages (empty list disables).
-Outbound text is chunked by `channels.discord.textChunkLimit` (default 2000). Set `channels.discord.chunkMode="newline"` to split on blank lines (paragraph boundaries) before length chunking. Discord clients can clip very tall messages, so `channels.discord.maxLinesPerMessage` (default 17) splits long multi-line replies even when under 2000 chars.
-Retry policy defaults and behavior are documented in [Retry policy](/concepts/retry).
+  Outbound text is chunked by `channels.discord.textChunkLimit` (default 2000). Set `channels.discord.chunkMode="newline"` to split on blank lines (paragraph boundaries) before length chunking. Discord clients can clip very tall messages, so `channels.discord.maxLinesPerMessage` (default 17) splits long multi-line replies even when under 2000 chars.
+  Retry policy defaults and behavior are documented in [Retry policy](/concepts/retry).
 
 ### `channels.googlechat` (Chat API webhook)
 
@@ -1137,31 +1199,32 @@ Multi-account support lives under `channels.googlechat.accounts` (see the multi-
 ```json5
 {
   channels: {
-    "googlechat": {
+    googlechat: {
       enabled: true,
       serviceAccountFile: "/path/to/service-account.json",
-      audienceType: "app-url",             // app-url | project-number
+      audienceType: "app-url", // app-url | project-number
       audience: "https://gateway.example.com/googlechat",
       webhookPath: "/googlechat",
-      botUser: "users/1234567890",        // optional; improves mention detection
+      botUser: "users/1234567890", // optional; improves mention detection
       dm: {
         enabled: true,
-        policy: "pairing",                // pairing | allowlist | open | disabled
-        allowFrom: ["users/1234567890"]   // optional; "open" requires ["*"]
+        policy: "pairing", // pairing | allowlist | open | disabled
+        allowFrom: ["users/1234567890"], // optional; "open" requires ["*"]
       },
       groupPolicy: "allowlist",
       groups: {
-        "spaces/AAAA": { allow: true, requireMention: true }
+        "spaces/AAAA": { allow: true, requireMention: true },
       },
       actions: { reactions: true },
       typingIndicator: "message",
-      mediaMaxMb: 20
-    }
-  }
+      mediaMaxMb: 20,
+    },
+  },
 }
 ```
 
 Notes:
+
 - Service account JSON can be inline (`serviceAccount`) or file-based (`serviceAccountFile`).
 - Env fallbacks for the default account: `GOOGLE_CHAT_SERVICE_ACCOUNT` or `GOOGLE_CHAT_SERVICE_ACCOUNT_FILE`.
 - `audienceType` + `audience` must match the Chat app’s webhook auth config.
@@ -1183,7 +1246,7 @@ Slack runs in Socket Mode and requires both a bot token and app token:
         policy: "pairing", // pairing | allowlist | open | disabled
         allowFrom: ["U123", "U456", "*"], // optional; "open" requires ["*"]
         groupEnabled: false,
-        groupChannels: ["G123"]
+        groupChannels: ["G123"],
       },
       channels: {
         C123: { allow: true, requireMention: true, allowBots: false },
@@ -1193,36 +1256,36 @@ Slack runs in Socket Mode and requires both a bot token and app token:
           allowBots: false,
           users: ["U123"],
           skills: ["docs"],
-          systemPrompt: "Short answers only."
-        }
+          systemPrompt: "Short answers only.",
+        },
       },
-      historyLimit: 50,          // include last N channel/group messages as context (0 disables)
+      historyLimit: 50, // include last N channel/group messages as context (0 disables)
       allowBots: false,
       reactionNotifications: "own", // off | own | all | allowlist
       reactionAllowlist: ["U123"],
-      replyToMode: "off",           // off | first | all
+      replyToMode: "off", // off | first | all
       thread: {
-        historyScope: "thread",     // thread | channel
-        inheritParent: false
+        historyScope: "thread", // thread | channel
+        inheritParent: false,
       },
       actions: {
         reactions: true,
         messages: true,
         pins: true,
         memberInfo: true,
-        emojiList: true
+        emojiList: true,
       },
       slashCommand: {
         enabled: true,
         name: "openclaw",
         sessionPrefix: "slack:slash",
-        ephemeral: true
+        ephemeral: true,
       },
       textChunkLimit: 4000,
       chunkMode: "length",
-      mediaMaxMb: 20
-    }
-  }
+      mediaMaxMb: 20,
+    },
+  },
 }
 ```
 
@@ -1234,12 +1297,14 @@ Set `channels.slack.configWrites: false` to block Slack-initiated config writes 
 Bot-authored messages are ignored by default. Enable with `channels.slack.allowBots` or `channels.slack.channels.<id>.allowBots`.
 
 Reaction notification modes:
+
 - `off`: no reaction events.
 - `own`: reactions on the bot's own messages (default).
 - `all`: all reactions on all messages.
 - `allowlist`: reactions from `channels.slack.reactionAllowlist` on all messages (empty list disables).
 
 Thread session isolation:
+
 - `channels.slack.thread.historyScope` controls whether thread history is per-thread (`thread`, default) or shared across the channel (`channel`).
 - `channels.slack.thread.inheritParent` controls whether new thread sessions inherit the parent channel transcript (default: false).
 
@@ -1270,20 +1335,22 @@ Mattermost requires a bot token plus the base URL for your server:
       chatmode: "oncall", // oncall | onmessage | onchar
       oncharPrefixes: [">", "!"],
       textChunkLimit: 4000,
-      chunkMode: "length"
-    }
-  }
+      chunkMode: "length",
+    },
+  },
 }
 ```
 
 OpenClaw starts Mattermost when the account is configured (bot token + base URL) and enabled. The token + base URL are resolved from `channels.mattermost.botToken` + `channels.mattermost.baseUrl` or `MATTERMOST_BOT_TOKEN` + `MATTERMOST_URL` for the default account (unless `channels.mattermost.enabled` is `false`).
 
 Chat modes:
+
 - `oncall` (default): respond to channel messages only when @mentioned.
 - `onmessage`: respond to every channel message.
 - `onchar`: respond when a message starts with a trigger prefix (`channels.mattermost.oncharPrefixes`, default `[">", "!"]`).
 
 Access control:
+
 - Default DMs: `channels.mattermost.dmPolicy="pairing"` (unknown senders get a pairing code).
 - Public DMs: `channels.mattermost.dmPolicy="open"` plus `channels.mattermost.allowFrom=["*"]`.
 - Groups: `channels.mattermost.groupPolicy="allowlist"` by default (mention-gated). Use `channels.mattermost.groupAllowFrom` to restrict senders.
@@ -1301,13 +1368,14 @@ Signal reactions can emit system events (shared reaction tooling):
     signal: {
       reactionNotifications: "own", // off | own | all | allowlist
       reactionAllowlist: ["+15551234567", "uuid:123e4567-e89b-12d3-a456-426614174000"],
-      historyLimit: 50 // include last N group messages as context (0 disables)
-    }
-  }
+      historyLimit: 50, // include last N group messages as context (0 disables)
+    },
+  },
 }
 ```
 
 Reaction notification modes:
+
 - `off`: no reaction events.
 - `own`: reactions on the bot's own messages (default).
 - `all`: all reactions on all messages.
@@ -1327,19 +1395,20 @@ OpenClaw spawns `imsg rpc` (JSON-RPC over stdio). No daemon or port required.
       remoteHost: "user@gateway-host", // SCP for remote attachments when using SSH wrapper
       dmPolicy: "pairing", // pairing | allowlist | open | disabled
       allowFrom: ["+15555550123", "user@example.com", "chat_id:123"],
-      historyLimit: 50,    // include last N group messages as context (0 disables)
+      historyLimit: 50, // include last N group messages as context (0 disables)
       includeAttachments: false,
       mediaMaxMb: 16,
       service: "auto",
-      region: "US"
-    }
-  }
+      region: "US",
+    },
+  },
 }
 ```
 
 Multi-account support lives under `channels.imessage.accounts` (see the multi-account section above).
 
 Notes:
+
 - Requires Full Disk Access to the Messages DB.
 - The first send will prompt for Messages automation permission.
 - Prefer `chat_id:<id>` targets. Use `imsg chats --limit 20` to list chats.
@@ -1347,6 +1416,7 @@ Notes:
 - For remote SSH wrappers, set `channels.imessage.remoteHost` to fetch attachments via SCP when `includeAttachments` is enabled.
 
 Example wrapper:
+
 ```bash
 #!/usr/bin/env bash
 exec ssh -T gateway-host imsg "$@"
@@ -1360,7 +1430,7 @@ Default: `~/.openclaw/workspace`.
 
 ```json5
 {
-  agents: { defaults: { workspace: "~/.openclaw/workspace" } }
+  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
 }
 ```
 
@@ -1375,7 +1445,7 @@ working directory). The path must exist to be used.
 
 ```json5
 {
-  agents: { defaults: { repoRoot: "~/Projects/openclaw" } }
+  agents: { defaults: { repoRoot: "~/Projects/openclaw" } },
 }
 ```
 
@@ -1387,7 +1457,7 @@ Use this for pre-seeded deployments where your workspace files come from a repo.
 
 ```json5
 {
-  agents: { defaults: { skipBootstrap: true } }
+  agents: { defaults: { skipBootstrap: true } },
 }
 ```
 
@@ -1401,7 +1471,7 @@ head/tail with a marker.
 
 ```json5
 {
-  agents: { defaults: { bootstrapMaxChars: 20000 } }
+  agents: { defaults: { bootstrapMaxChars: 20000 } },
 }
 ```
 
@@ -1412,7 +1482,7 @@ message envelopes). If unset, OpenClaw uses the host timezone at runtime.
 
 ```json5
 {
-  agents: { defaults: { userTimezone: "America/Chicago" } }
+  agents: { defaults: { userTimezone: "America/Chicago" } },
 }
 ```
 
@@ -1423,7 +1493,7 @@ Default: `auto` (OS preference).
 
 ```json5
 {
-  agents: { defaults: { timeFormat: "auto" } } // auto | 12 | 24
+  agents: { defaults: { timeFormat: "auto" } }, // auto | 12 | 24
 }
 ```
 
@@ -1438,8 +1508,8 @@ See [Messages](/concepts/messages) for queueing, sessions, and streaming context
     responsePrefix: "🦞", // or "auto"
     ackReaction: "👀",
     ackReactionScope: "group-mentions",
-    removeAckAfterReply: false
-  }
+    removeAckAfterReply: false,
+  },
 }
 ```
 
@@ -1455,13 +1525,13 @@ Set it to `"auto"` to derive `[{identity.name}]` for the routed agent (when set)
 
 The `responsePrefix` string can include template variables that resolve dynamically:
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `{model}` | Short model name | `claude-opus-4-5`, `gpt-4o` |
-| `{modelFull}` | Full model identifier | `anthropic/claude-opus-4-5` |
-| `{provider}` | Provider name | `anthropic`, `openai` |
-| `{thinkingLevel}` | Current thinking level | `high`, `low`, `off` |
-| `{identity.name}` | Agent identity name | (same as `"auto"` mode) |
+| Variable          | Description            | Example                     |
+| ----------------- | ---------------------- | --------------------------- |
+| `{model}`         | Short model name       | `claude-opus-4-5`, `gpt-4o` |
+| `{modelFull}`     | Full model identifier  | `anthropic/claude-opus-4-5` |
+| `{provider}`      | Provider name          | `anthropic`, `openai`       |
+| `{thinkingLevel}` | Current thinking level | `high`, `low`, `off`        |
+| `{identity.name}` | Agent identity name    | (same as `"auto"` mode)     |
 
 Variables are case-insensitive (`{MODEL}` = `{model}`). `{think}` is an alias for `{thinkingLevel}`.
 Unresolved variables remain as literal text.
@@ -1469,8 +1539,8 @@ Unresolved variables remain as literal text.
 ```json5
 {
   messages: {
-    responsePrefix: "[{model} | think:{thinkingLevel}]"
-  }
+    responsePrefix: "[{model} | think:{thinkingLevel}]",
+  },
 }
 ```
 
@@ -1487,6 +1557,7 @@ on channels that support reactions (Slack/Discord/Telegram/Google Chat). Default
 active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` to disable.
 
 `ackReactionScope` controls when reactions fire:
+
 - `group-mentions` (default): only when a group/room requires mentions **and** the bot was mentioned
 - `group-all`: all group/room messages
 - `direct`: direct messages only
@@ -1510,7 +1581,7 @@ voice notes; other channels send MP3 audio.
       provider: "elevenlabs",
       summaryModel: "openai/gpt-4.1-mini",
       modelOverrides: {
-        enabled: true
+        enabled: true,
       },
       maxTextLength: 4000,
       timeoutMs: 30000,
@@ -1528,20 +1599,21 @@ voice notes; other channels send MP3 audio.
           similarityBoost: 0.75,
           style: 0.0,
           useSpeakerBoost: true,
-          speed: 1.0
-        }
+          speed: 1.0,
+        },
       },
       openai: {
         apiKey: "openai_api_key",
         model: "gpt-4o-mini-tts",
-        voice: "alloy"
-      }
-    }
-  }
+        voice: "alloy",
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - `messages.tts.auto` controls auto‑TTS (`off`, `always`, `inbound`, `tagged`).
 - `/tts off|always|inbound|tagged` sets the per‑session auto mode (overrides config).
 - `messages.tts.enabled` is legacy; doctor migrates it to `messages.tts.auto`.
@@ -1568,13 +1640,13 @@ Defaults for Talk mode (macOS/iOS/Android). Voice IDs fall back to `ELEVENLABS_V
     voiceId: "elevenlabs_voice_id",
     voiceAliases: {
       Clawd: "EXAVITQu4vr4xnSDxMaL",
-      Roger: "CwhRBWXzGAHq8TQ4Fs17"
+      Roger: "CwhRBWXzGAHq8TQ4Fs17",
     },
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
-    interruptOnSpeech: true
-  }
+    interruptOnSpeech: true,
+  },
 }
 ```
 
@@ -1585,6 +1657,7 @@ Controls the embedded agent runtime (model/thinking/verbose/timeouts).
 `agents.defaults.model.primary` sets the default model; `agents.defaults.model.fallbacks` are global failovers.
 `agents.defaults.imageModel` is optional and is **only used if the primary model lacks image input**.
 Each `agents.defaults.models` entry can include:
+
 - `alias` (optional model shortcut, e.g. `/opus`).
 - `params` (optional provider-specific API params passed through to the model request).
 
@@ -1598,18 +1671,19 @@ Example:
     defaults: {
       models: {
         "anthropic/claude-sonnet-4-5-20250929": {
-          params: { temperature: 0.6 }
+          params: { temperature: 0.6 },
         },
         "openai/gpt-5.2": {
-          params: { maxTokens: 8192 }
-        }
-      }
-    }
-  }
+          params: { maxTokens: 8192 },
+        },
+      },
+    },
+  },
 }
 ```
 
 Z.AI GLM-4.x models automatically enable thinking mode unless you:
+
 - set `--thinking off`, or
 - define `agents.defaults.models["zai/<model>"].params.thinking` yourself.
 
@@ -1633,14 +1707,14 @@ Example: Opus 4.5 primary with MiniMax M2.1 fallback (hosted MiniMax):
     defaults: {
       models: {
         "anthropic/claude-opus-4-5": { alias: "opus" },
-        "minimax/MiniMax-M2.1": { alias: "minimax" }
+        "minimax/MiniMax-M2.1": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-5",
-        fallbacks: ["minimax/MiniMax-M2.1"]
-      }
-    }
-  }
+        fallbacks: ["minimax/MiniMax-M2.1"],
+      },
+    },
+  },
 }
 ```
 
@@ -1653,6 +1727,7 @@ backup path when API providers fail. Image pass-through is supported when you co
 an `imageArg` that accepts file paths.
 
 Notes:
+
 - CLI backends are **text-first**; tools are always disabled.
 - Sessions are supported when `sessionArg` is set; session ids are persisted per backend.
 - For `claude-cli`, defaults are wired in. Override the command path if PATH is minimal
@@ -1666,7 +1741,7 @@ Example:
     defaults: {
       cliBackends: {
         "claude-cli": {
-          command: "/opt/homebrew/bin/claude"
+          command: "/opt/homebrew/bin/claude",
         },
         "my-cli": {
           command: "my-cli",
@@ -1678,11 +1753,11 @@ Example:
           systemPromptArg: "--system",
           systemPromptWhen: "first",
           imageArg: "--image",
-          imageMode: "repeat"
-        }
-      }
-    }
-  }
+          imageMode: "repeat",
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -1699,23 +1774,21 @@ Example:
           params: {
             thinking: {
               type: "enabled",
-              clear_thinking: false
-            }
-          }
-        }
+              clear_thinking: false,
+            },
+          },
+        },
       },
       model: {
         primary: "anthropic/claude-opus-4-5",
         fallbacks: [
           "openrouter/deepseek/deepseek-r1:free",
-          "openrouter/meta-llama/llama-3.3-70b-instruct:free"
-        ]
+          "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+        ],
       },
       imageModel: {
         primary: "openrouter/qwen/qwen-2.5-vl-72b-instruct:free",
-        fallbacks: [
-          "openrouter/google/gemini-2.0-flash-vision:free"
-        ]
+        fallbacks: ["openrouter/google/gemini-2.0-flash-vision:free"],
       },
       thinkingDefault: "low",
       verboseDefault: "off",
@@ -1724,22 +1797,22 @@ Example:
       mediaMaxMb: 5,
       heartbeat: {
         every: "30m",
-        target: "last"
+        target: "last",
       },
       maxConcurrent: 3,
       subagents: {
         model: "minimax/MiniMax-M2.1",
         maxConcurrent: 1,
-        archiveAfterMinutes: 60
+        archiveAfterMinutes: 60,
       },
       exec: {
         backgroundMs: 10000,
         timeoutSec: 1800,
-        cleanupMs: 1800000
+        cleanupMs: 1800000,
       },
-      contextTokens: 200000
-    }
-  }
+      contextTokens: 200000,
+    },
+  },
 }
 ```
 
@@ -1751,15 +1824,19 @@ It does **not** modify the session history on disk (`*.jsonl` remains complete).
 This is intended to reduce token usage for chatty agents that accumulate large tool outputs over time.
 
 High level:
+
 - Never touches user/assistant messages.
 - Protects the last `keepLastAssistants` assistant messages (no tool results after that point are pruned).
 - Protects the bootstrap prefix (nothing before the first user message is pruned).
 - Modes:
-  - `cache-ttl`: prunes old tool results when the Anthropic prompt cache TTL expires. Soft-trims oversized tool results (keep head/tail) when the estimated context ratio crosses `softTrimRatio`, then hard-clears the oldest eligible tool results when the estimated context ratio crosses `hardClearRatio` **and** there's enough prunable tool-result bulk (`minPrunableToolChars`).
-  - `off`: disables context pruning entirely.
+  - `adaptive`: soft-trims oversized tool results (keep head/tail) when the estimated context ratio crosses `softTrimRatio`.
+    Then hard-clears the oldest eligible tool results when the estimated context ratio crosses `hardClearRatio` **and**
+    there’s enough prunable tool-result bulk (`minPrunableToolChars`).
+  - `aggressive`: always replaces eligible tool results before the cutoff with the `hardClear.placeholder` (no ratio checks).
 
 Soft vs hard pruning (what changes in the context sent to the LLM):
-- **Soft-trim**: only for *oversized* tool results. Keeps the beginning + end and inserts `...` in the middle.
+
+- **Soft-trim**: only for _oversized_ tool results. Keeps the beginning + end and inserts `...` in the middle.
   - Before: `toolResult("…very long output…")`
   - After: `toolResult("HEAD…\n...\n…TAIL\n\n[Tool result trimmed: …]")`
 - **Hard-clear**: replaces the entire tool result with the placeholder.
@@ -1767,41 +1844,53 @@ Soft vs hard pruning (what changes in the context sent to the LLM):
   - After: `toolResult("[Old tool result content cleared]")`
 
 Notes / current limitations:
+
 - Tool results containing **image blocks are skipped** (never trimmed/cleared) right now.
 - The estimated “context ratio” is based on **characters** (approximate), not exact tokens.
-- If the session doesn't contain at least `keepLastAssistants` assistant messages yet, pruning is skipped.
+- If the session doesn’t contain at least `keepLastAssistants` assistant messages yet, pruning is skipped.
+- In `aggressive` mode, `hardClear.enabled` is ignored (eligible tool results are always replaced with `hardClear.placeholder`).
 
-Default (`cache-ttl` is auto-enabled for Anthropic credentials):
+Default (adaptive):
+
 ```json5
 {
-  agents: { defaults: { contextPruning: { mode: "cache-ttl" } } }
+  agents: { defaults: { contextPruning: { mode: "adaptive" } } },
 }
 ```
 
 To disable:
+
 ```json5
 {
-  agents: { defaults: { contextPruning: { mode: "off" } } }
+  agents: { defaults: { contextPruning: { mode: "off" } } },
 }
 ```
 
-Defaults (when `mode` is `"cache-ttl"`):
-- `ttl`: `"1h"` (cache TTL duration; pruning only triggers after this expires)
+Defaults (when `mode` is `"adaptive"` or `"aggressive"`):
+
 - `keepLastAssistants`: `3`
-- `softTrimRatio`: `0.3`
-- `hardClearRatio`: `0.5`
-- `minPrunableToolChars`: `50000`
-- `softTrim`: `{ maxChars: 4000, headChars: 1500, tailChars: 1500 }`
+- `softTrimRatio`: `0.3` (adaptive only)
+- `hardClearRatio`: `0.5` (adaptive only)
+- `minPrunableToolChars`: `50000` (adaptive only)
+- `softTrim`: `{ maxChars: 4000, headChars: 1500, tailChars: 1500 }` (adaptive only)
 - `hardClear`: `{ enabled: true, placeholder: "[Old tool result content cleared]" }`
 
-Example (cache-ttl tuned):
+Example (aggressive, minimal):
+
+```json5
+{
+  agents: { defaults: { contextPruning: { mode: "aggressive" } } },
+}
+```
+
+Example (adaptive tuned):
+
 ```json5
 {
   agents: {
     defaults: {
       contextPruning: {
-        mode: "cache-ttl",
-        ttl: "30m",
+        mode: "adaptive",
         keepLastAssistants: 3,
         softTrimRatio: 0.3,
         hardClearRatio: 0.5,
@@ -1810,9 +1899,9 @@ Example (cache-ttl tuned):
         hardClear: { enabled: true, placeholder: "[Old tool result content cleared]" },
         // Optional: restrict pruning to specific tools (deny wins; supports "*" wildcards)
         tools: { deny: ["browser", "canvas"] },
-      }
-    }
-  }
+      },
+    },
+  },
 }
 ```
 
@@ -1831,6 +1920,7 @@ auto-compaction, instructing the model to store durable memories on disk (e.g.
 soft threshold below the compaction limit.
 
 Legacy defaults:
+
 - `memoryFlush.enabled`: `true`
 - `memoryFlush.softThresholdTokens`: `4000`
 - `memoryFlush.prompt` / `memoryFlush.systemPrompt`: built-in defaults with `NO_REPLY`
@@ -1838,6 +1928,7 @@ Legacy defaults:
   (`agents.defaults.sandbox.workspaceAccess: "ro"` or `"none"`).
 
 Example (tuned):
+
 ```json5
 {
   agents: {
@@ -1849,15 +1940,16 @@ Example (tuned):
           enabled: true,
           softThresholdTokens: 6000,
           systemPrompt: "Session nearing compaction. Store durable memories now.",
-          prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store."
-        }
-      }
-    }
-  }
+          prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store.",
+        },
+      },
+    },
+  },
 }
 ```
 
 Block streaming:
+
 - `agents.defaults.blockStreamingDefault`: `"on"`/`"off"` (default off).
 - Channel overrides: `*.blockStreaming` (and per-account variants) to force block streaming on/off.
   Non-Telegram channels require an explicit `*.blockStreaming: true` to enable block replies.
@@ -1867,7 +1959,7 @@ Block streaming:
   Example:
   ```json5
   {
-    agents: { defaults: { blockStreamingChunk: { minChars: 800, maxChars: 1200 } } }
+    agents: { defaults: { blockStreamingChunk: { minChars: 800, maxChars: 1200 } } },
   }
   ```
 - `agents.defaults.blockStreamingCoalesce`: merge streamed blocks before sending.
@@ -1885,18 +1977,19 @@ Block streaming:
   Example:
   ```json5
   {
-    agents: { defaults: { humanDelay: { mode: "natural" } } }
+    agents: { defaults: { humanDelay: { mode: "natural" } } },
   }
   ```
-See [/concepts/streaming](/concepts/streaming) for behavior + chunking details.
+  See [/concepts/streaming](/concepts/streaming) for behavior + chunking details.
 
 Typing indicators:
+
 - `agents.defaults.typingMode`: `"never" | "instant" | "thinking" | "message"`. Defaults to
   `instant` for direct chats / mentions and `message` for unmentioned group chats.
 - `session.typingMode`: per-session override for the mode.
 - `agents.defaults.typingIntervalSeconds`: how often the typing signal is refreshed (default: 6s).
 - `session.typingIntervalSeconds`: per-session override for the refresh interval.
-See [/concepts/typing-indicators](/concepts/typing-indicators) for behavior details.
+  See [/concepts/typing-indicators](/concepts/typing-indicators) for behavior details.
 
 `agents.defaults.model.primary` should be set as `provider/model` (e.g. `anthropic/claude-opus-4-5`).
 Aliases come from `agents.defaults.models.*.alias` (e.g. `Opus`).
@@ -1906,6 +1999,7 @@ Z.AI models are available as `zai/<model>` (e.g. `zai/glm-4.7`) and require
 `ZAI_API_KEY` (or legacy `Z_AI_API_KEY`) in the environment.
 
 `agents.defaults.heartbeat` configures periodic heartbeat runs:
+
 - `every`: duration string (`ms`, `s`, `m`, `h`); default unit minutes. Default:
   `30m`. Set `0m` to disable.
 - `model`: optional override model for heartbeat runs (`provider/model`).
@@ -1917,6 +2011,7 @@ Z.AI models are available as `zai/<model>` (e.g. `zai/glm-4.7`) and require
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery (default: 300).
 
 Per-agent heartbeats:
+
 - Set `agents.list[].heartbeat` to enable or override heartbeat settings for a specific agent.
 - If any agent entry defines `heartbeat`, **only those agents** run heartbeats; defaults
   become the shared baseline for those agents.
@@ -1925,15 +2020,17 @@ Heartbeats run full agent turns. Shorter intervals burn more tokens; be mindful
 of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 
 `tools.exec` configures background exec defaults:
+
 - `backgroundMs`: time before auto-background (ms, default 10000)
 - `timeoutSec`: auto-kill after this runtime (seconds, default 1800)
 - `cleanupMs`: how long to keep finished sessions in memory (ms, default 1800000)
 - `notifyOnExit`: enqueue a system event + request heartbeat when backgrounded exec exits (default true)
 - `applyPatch.enabled`: enable experimental `apply_patch` (OpenAI/OpenAI Codex only; default false)
 - `applyPatch.allowModels`: optional allowlist of model ids (e.g. `gpt-5.2` or `openai/gpt-5.2`)
-Note: `applyPatch` is only under `tools.exec`.
+  Note: `applyPatch` is only under `tools.exec`.
 
 `tools.web` configures web search + fetch tools:
+
 - `tools.web.search.enabled` (default: true when key is present)
 - `tools.web.search.apiKey` (recommended: set via `openclaw configure --section web`, or use `BRAVE_API_KEY` env var)
 - `tools.web.search.maxResults` (1–10, default 5)
@@ -1953,6 +2050,7 @@ Note: `applyPatch` is only under `tools.exec`.
 - `tools.web.fetch.firecrawl.timeoutSeconds` (optional)
 
 `tools.media` configures inbound media understanding (image/audio/video):
+
 - `tools.media.models`: shared model list (capability-tagged; used after per-cap lists).
 - `tools.media.concurrency`: max concurrent capability runs (default 2).
 - `tools.media.image` / `tools.media.audio` / `tools.media.video`:
@@ -1981,6 +2079,7 @@ If no models are configured (or `enabled: false`), understanding is skipped; the
 Provider auth follows the standard model auth order (auth profiles, env vars like `OPENAI_API_KEY`/`GROQ_API_KEY`/`GEMINI_API_KEY`, or `models.providers.*.apiKey`).
 
 Example:
+
 ```json5
 {
   tools: {
@@ -1990,30 +2089,32 @@ Example:
         maxBytes: 20971520,
         scope: {
           default: "deny",
-          rules: [{ action: "allow", match: { chatType: "direct" } }]
+          rules: [{ action: "allow", match: { chatType: "direct" } }],
         },
         models: [
           { provider: "openai", model: "gpt-4o-mini-transcribe" },
-          { type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] }
-        ]
+          { type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] },
+        ],
       },
       video: {
         enabled: true,
         maxBytes: 52428800,
-        models: [{ provider: "google", model: "gemini-3-flash-preview" }]
-      }
-    }
-  }
+        models: [{ provider: "google", model: "gemini-3-flash-preview" }],
+      },
+    },
+  },
 }
 ```
 
 `agents.defaults.subagents` configures sub-agent defaults:
+
 - `model`: default model for spawned sub-agents (string or `{ primary, fallbacks }`). If omitted, sub-agents inherit the caller’s model unless overridden per agent or per call.
 - `maxConcurrent`: max concurrent sub-agent runs (default 1)
 - `archiveAfterMinutes`: auto-archive sub-agent sessions after N minutes (default 60; set `0` to disable)
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny` (deny wins)
 
 `tools.profile` sets a **base tool allowlist** before `tools.allow`/`tools.deny`:
+
 - `minimal`: `session_status` only
 - `coding`: `group:fs`, `group:runtime`, `group:sessions`, `group:memory`, `image`
 - `messaging`: `group:messaging`, `sessions_list`, `sessions_history`, `sessions_send`, `session_status`
@@ -2022,22 +2123,24 @@ Example:
 Per-agent override: `agents.list[].tools.profile`.
 
 Example (messaging-only by default, allow Slack + Discord tools too):
+
 ```json5
 {
   tools: {
     profile: "messaging",
-    allow: ["slack", "discord"]
-  }
+    allow: ["slack", "discord"],
+  },
 }
 ```
 
 Example (coding profile, but deny exec/process everywhere):
+
 ```json5
 {
   tools: {
     profile: "coding",
-    deny: ["group:runtime"]
-  }
+    deny: ["group:runtime"],
+  },
 }
 ```
 
@@ -2049,26 +2152,28 @@ Provider keys accept either `provider` (e.g. `google-antigravity`) or `provider/
 (e.g. `openai/gpt-5.2`).
 
 Example (keep global coding profile, but minimal tools for Google Antigravity):
+
 ```json5
 {
   tools: {
     profile: "coding",
     byProvider: {
-      "google-antigravity": { profile: "minimal" }
-    }
-  }
+      "google-antigravity": { profile: "minimal" },
+    },
+  },
 }
 ```
 
 Example (provider/model-specific allowlist):
+
 ```json5
 {
   tools: {
     allow: ["group:fs", "group:runtime", "sessions_list"],
     byProvider: {
-      "openai/gpt-5.2": { allow: ["group:fs", "sessions_list"] }
-    }
-  }
+      "openai/gpt-5.2": { allow: ["group:fs", "sessions_list"] },
+    },
+  },
 }
 ```
 
@@ -2077,13 +2182,15 @@ Matching is case-insensitive and supports `*` wildcards (`"*"` means all tools).
 This is applied even when the Docker sandbox is **off**.
 
 Example (disable browser/canvas everywhere):
+
 ```json5
 {
-  tools: { deny: ["browser", "canvas"] }
+  tools: { deny: ["browser", "canvas"] },
 }
 ```
 
 Tool groups (shorthands) work in **global** and **per-agent** tool policies:
+
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
@@ -2096,6 +2203,7 @@ Tool groups (shorthands) work in **global** and **per-agent** tool policies:
 - `group:openclaw`: all built-in OpenClaw tools (excludes provider plugins)
 
 `tools.elevated` controls elevated (host) exec access:
+
 - `enabled`: allow elevated mode (default true)
 - `allowFrom`: per-channel allowlists (empty = disabled)
   - `whatsapp`: E.164 numbers
@@ -2106,6 +2214,7 @@ Tool groups (shorthands) work in **global** and **per-agent** tool policies:
   - `webchat`: session ids or usernames
 
 Example:
+
 ```json5
 {
   tools: {
@@ -2113,14 +2222,15 @@ Example:
       enabled: true,
       allowFrom: {
         whatsapp: ["+15555550123"],
-        discord: ["steipete", "1234567890123"]
-      }
-    }
-  }
+        discord: ["steipete", "1234567890123"],
+      },
+    },
+  },
 }
 ```
 
 Per-agent override (further restrict):
+
 ```json5
 {
   agents: {
@@ -2128,15 +2238,16 @@ Per-agent override (further restrict):
       {
         id: "family",
         tools: {
-          elevated: { enabled: false }
-        }
-      }
-    ]
-  }
+          elevated: { enabled: false },
+        },
+      },
+    ],
+  },
 }
 ```
 
 Notes:
+
 - `tools.elevated` is the global baseline. `agents.list[].tools.elevated` can only further restrict (both must allow).
 - `/elevated on|off|ask|full` stores state per session key; inline directives apply to a single message.
 - Elevated `exec` runs on the host and bypasses sandboxing.
@@ -2154,6 +2265,7 @@ sessions so they cannot access your host system.
 Details: [Sandboxing](/gateway/sandboxing)
 
 Defaults (if enabled):
+
 - scope: `"agent"` (one container + workspace per agent)
 - Debian bookworm-slim based image
 - agent workspace access: `workspaceAccess: "none"` (default)
@@ -2203,13 +2315,13 @@ For package installs, ensure network egress, a writable root FS, and a root user
           cpus: 1,
           ulimits: {
             nofile: { soft: 1024, hard: 2048 },
-            nproc: 256
+            nproc: 256,
           },
           seccompProfile: "/path/to/seccomp.json",
           apparmorProfile: "openclaw-sandbox",
           dns: ["1.1.1.1", "8.8.8.8"],
           extraHosts: ["internal.service:10.0.0.5"],
-          binds: ["/var/run/docker.sock:/var/run/docker.sock", "/home/user/source:/source:rw"]
+          binds: ["/var/run/docker.sock:/var/run/docker.sock", "/home/user/source:/source:rw"],
         },
         browser: {
           enabled: false,
@@ -2225,27 +2337,40 @@ For package installs, ensure network egress, a writable root FS, and a root user
           allowedControlHosts: ["browser.lab.local", "10.0.0.42"],
           allowedControlPorts: [18791],
           autoStart: true,
-          autoStartTimeoutMs: 12000
+          autoStartTimeoutMs: 12000,
         },
         prune: {
-          idleHours: 24,  // 0 disables idle pruning
-          maxAgeDays: 7   // 0 disables max-age pruning
-        }
-      }
-    }
+          idleHours: 24, // 0 disables idle pruning
+          maxAgeDays: 7, // 0 disables max-age pruning
+        },
+      },
+    },
   },
   tools: {
     sandbox: {
       tools: {
-        allow: ["exec", "process", "read", "write", "edit", "apply_patch", "sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "session_status"],
-        deny: ["browser", "canvas", "nodes", "cron", "discord", "gateway"]
-      }
-    }
-  }
+        allow: [
+          "exec",
+          "process",
+          "read",
+          "write",
+          "edit",
+          "apply_patch",
+          "sessions_list",
+          "sessions_history",
+          "sessions_send",
+          "sessions_spawn",
+          "session_status",
+        ],
+        deny: ["browser", "canvas", "nodes", "cron", "discord", "gateway"],
+      },
+    },
+  },
 }
 ```
 
 Build the default sandbox image once with:
+
 ```bash
 scripts/sandbox-setup.sh
 ```
@@ -2258,6 +2383,7 @@ Note: inbound attachments are staged into the active workspace at `media/inbound
 Note: `docker.binds` mounts additional host directories; global and per-agent binds are merged.
 
 Build the optional browser image with:
+
 ```bash
 scripts/sandbox-browser-setup.sh
 ```
@@ -2274,10 +2400,11 @@ via the browser tool (`target: "host"`). Leave this off if you want strict
 sandbox isolation.
 
 Allowlists for remote control:
+
 - `allowedControlUrls`: exact control URLs permitted for `target: "custom"`.
 - `allowedControlHosts`: hostnames permitted (hostname only, no port).
 - `allowedControlPorts`: ports permitted (defaults: http=80, https=443).
-Defaults: all allowlists are unset (no restriction). `allowHostControl` defaults to false.
+  Defaults: all allowlists are unset (no restriction). `allowHostControl` defaults to false.
 
 ### `models` (custom providers + base URLs)
 
@@ -2289,6 +2416,7 @@ Provider-by-provider overview + examples: [/concepts/model-providers](/concepts/
 
 When `models.providers` is present, OpenClaw writes/merges a `models.json` into
 `~/.openclaw/agents/<agentId>/agent/` on startup:
+
 - default behavior: **merge** (keeps existing providers, overrides on name)
 - set `models.mode: "replace"` to overwrite the file contents
 
@@ -2300,9 +2428,9 @@ Select the model via `agents.defaults.model.primary` (provider/model).
     defaults: {
       model: { primary: "custom-proxy/llama-3.1-8b" },
       models: {
-        "custom-proxy/llama-3.1-8b": {}
-      }
-    }
+        "custom-proxy/llama-3.1-8b": {},
+      },
+    },
   },
   models: {
     mode: "merge",
@@ -2319,12 +2447,12 @@ Select the model via `agents.defaults.model.primary` (provider/model).
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 128000,
-            maxTokens: 32000
-          }
-        ]
-      }
-    }
-  }
+            maxTokens: 32000,
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 
@@ -2335,6 +2463,7 @@ the built-in `opencode` provider from pi-ai; set `OPENCODE_API_KEY` (or
 `OPENCODE_ZEN_API_KEY`) from https://opencode.ai/auth.
 
 Notes:
+
 - Model refs use `opencode/<modelId>` (example: `opencode/claude-opus-4-5`).
 - If you enable an allowlist via `agents.defaults.models`, add each model you plan to use.
 - Shortcut: `openclaw onboard --auth-choice opencode-zen`.
@@ -2344,9 +2473,9 @@ Notes:
   agents: {
     defaults: {
       model: { primary: "opencode/claude-opus-4-5" },
-      models: { "opencode/claude-opus-4-5": { alias: "Opus" } }
-    }
-  }
+      models: { "opencode/claude-opus-4-5": { alias: "Opus" } },
+    },
+  },
 }
 ```
 
@@ -2362,13 +2491,14 @@ Shortcut: `openclaw onboard --auth-choice zai-api-key`.
   agents: {
     defaults: {
       model: { primary: "zai/glm-4.7" },
-      models: { "zai/glm-4.7": {} }
-    }
-  }
+      models: { "zai/glm-4.7": {} },
+    },
+  },
 }
 ```
 
 Notes:
+
 - `z.ai/*` and `z-ai/*` are accepted aliases and normalize to `zai/*`.
 - If `ZAI_API_KEY` is missing, requests to `zai/*` will fail with an auth error at runtime.
 - Example error: `No API key found for provider "zai".`
@@ -2389,8 +2519,8 @@ Use Moonshot's OpenAI-compatible endpoint:
   agents: {
     defaults: {
       model: { primary: "moonshot/kimi-k2.5" },
-      models: { "moonshot/kimi-k2.5": { alias: "Kimi K2.5" } }
-    }
+      models: { "moonshot/kimi-k2.5": { alias: "Kimi K2.5" } },
+    },
   },
   models: {
     mode: "merge",
@@ -2407,62 +2537,41 @@ Use Moonshot's OpenAI-compatible endpoint:
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 256000,
-            maxTokens: 8192
-          }
-        ]
-      }
-    }
-  }
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Set `MOONSHOT_API_KEY` in the environment or use `openclaw onboard --auth-choice moonshot-api-key`.
 - Model ref: `moonshot/kimi-k2.5`.
 - Use `https://api.moonshot.cn/v1` if you need the China endpoint.
 
-### Kimi Code
+### Kimi Coding
 
-Use Kimi Code's dedicated OpenAI-compatible endpoint (separate from Moonshot):
+Use Moonshot AI's Kimi Coding endpoint (Anthropic-compatible, built-in provider):
 
 ```json5
 {
-  env: { KIMICODE_API_KEY: "sk-..." },
+  env: { KIMI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "kimi-code/kimi-for-coding" },
-      models: { "kimi-code/kimi-for-coding": { alias: "Kimi Code" } }
-    }
+      model: { primary: "kimi-coding/k2p5" },
+      models: { "kimi-coding/k2p5": { alias: "Kimi K2.5" } },
+    },
   },
-  models: {
-    mode: "merge",
-    providers: {
-      "kimi-code": {
-        baseUrl: "https://api.kimi.com/coding/v1",
-        apiKey: "${KIMICODE_API_KEY}",
-        api: "openai-completions",
-        models: [
-          {
-            id: "kimi-for-coding",
-            name: "Kimi For Coding",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 262144,
-            maxTokens: 32768,
-            headers: { "User-Agent": "KimiCLI/0.77" },
-            compat: { supportsDeveloperRole: false }
-          }
-        ]
-      }
-    }
-  }
 }
 ```
 
 Notes:
-- Set `KIMICODE_API_KEY` in the environment or use `openclaw onboard --auth-choice kimi-code-api-key`.
-- Model ref: `kimi-code/kimi-for-coding`.
+
+- Set `KIMI_API_KEY` in the environment or use `openclaw onboard --auth-choice kimi-code-api-key`.
+- Model ref: `kimi-coding/k2p5`.
 
 ### Synthetic (Anthropic-compatible)
 
@@ -2474,8 +2583,8 @@ Use Synthetic's Anthropic-compatible endpoint:
   agents: {
     defaults: {
       model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.1" },
-      models: { "synthetic/hf:MiniMaxAI/MiniMax-M2.1": { alias: "MiniMax M2.1" } }
-    }
+      models: { "synthetic/hf:MiniMaxAI/MiniMax-M2.1": { alias: "MiniMax M2.1" } },
+    },
   },
   models: {
     mode: "merge",
@@ -2492,16 +2601,17 @@ Use Synthetic's Anthropic-compatible endpoint:
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 192000,
-            maxTokens: 65536
-          }
-        ]
-      }
-    }
-  }
+            maxTokens: 65536,
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Set `SYNTHETIC_API_KEY` or use `openclaw onboard --auth-choice synthetic-api-key`.
 - Model ref: `synthetic/hf:MiniMaxAI/MiniMax-M2.1`.
 - Base URL should omit `/v1` because the Anthropic client appends it.
@@ -2520,8 +2630,8 @@ Use MiniMax M2.1 directly without LM Studio:
     model: { primary: "minimax/MiniMax-M2.1" },
     models: {
       "anthropic/claude-opus-4-5": { alias: "Opus" },
-      "minimax/MiniMax-M2.1": { alias: "Minimax" }
-    }
+      "minimax/MiniMax-M2.1": { alias: "Minimax" },
+    },
   },
   models: {
     mode: "merge",
@@ -2539,16 +2649,17 @@ Use MiniMax M2.1 directly without LM Studio:
             // Pricing: update in models.json if you need exact cost tracking.
             cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
             contextWindow: 200000,
-            maxTokens: 8192
-          }
-        ]
-      }
-    }
-  }
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Set `MINIMAX_API_KEY` environment variable or use `openclaw onboard --auth-choice minimax-api`.
 - Available model: `MiniMax-M2.1` (default).
 - Update pricing in `models.json` if you need exact cost tracking.
@@ -2564,13 +2675,13 @@ Use Cerebras via their OpenAI-compatible endpoint:
     defaults: {
       model: {
         primary: "cerebras/zai-glm-4.7",
-        fallbacks: ["cerebras/zai-glm-4.6"]
+        fallbacks: ["cerebras/zai-glm-4.6"],
       },
       models: {
         "cerebras/zai-glm-4.7": { alias: "GLM 4.7 (Cerebras)" },
-        "cerebras/zai-glm-4.6": { alias: "GLM 4.6 (Cerebras)" }
-      }
-    }
+        "cerebras/zai-glm-4.6": { alias: "GLM 4.6 (Cerebras)" },
+      },
+    },
   },
   models: {
     mode: "merge",
@@ -2581,19 +2692,21 @@ Use Cerebras via their OpenAI-compatible endpoint:
         api: "openai-completions",
         models: [
           { id: "zai-glm-4.7", name: "GLM 4.7 (Cerebras)" },
-          { id: "zai-glm-4.6", name: "GLM 4.6 (Cerebras)" }
-        ]
-      }
-    }
-  }
+          { id: "zai-glm-4.6", name: "GLM 4.6 (Cerebras)" },
+        ],
+      },
+    },
+  },
 }
 ```
 
 Notes:
+
 - Use `cerebras/zai-glm-4.7` for Cerebras; use `zai/glm-4.7` for Z.AI direct.
 - Set `CEREBRAS_API_KEY` in the environment or config.
 
 Notes:
+
 - Supported APIs: `openai-completions`, `openai-responses`, `anthropic-messages`,
   `google-generative-ai`
 - Use `authHeader: true` + `headers` for custom auth needs.
@@ -2610,17 +2723,17 @@ Controls session scoping, reset policy, reset triggers, and where the session st
     scope: "per-sender",
     dmScope: "main",
     identityLinks: {
-      alice: ["telegram:123456789", "discord:987654321012345678"]
+      alice: ["telegram:123456789", "discord:987654321012345678"],
     },
     reset: {
       mode: "daily",
       atHour: 4,
-      idleMinutes: 60
+      idleMinutes: 60,
     },
     resetByType: {
       thread: { mode: "daily", atHour: 4 },
       dm: { mode: "idle", idleMinutes: 240 },
-      group: { mode: "idle", idleMinutes: 120 }
+      group: { mode: "idle", idleMinutes: 120 },
     },
     resetTriggers: ["/new", "/reset"],
     // Default is already per-agent under ~/.openclaw/agents/<agentId>/sessions/sessions.json
@@ -2630,19 +2743,18 @@ Controls session scoping, reset policy, reset triggers, and where the session st
     mainKey: "main",
     agentToAgent: {
       // Max ping-pong reply turns between requester/target (0–5).
-      maxPingPongTurns: 5
+      maxPingPongTurns: 5,
     },
     sendPolicy: {
-      rules: [
-        { action: "deny", match: { channel: "discord", chatType: "group" } }
-      ],
-      default: "allow"
-    }
-  }
+      rules: [{ action: "deny", match: { channel: "discord", chatType: "group" } }],
+      default: "allow",
+    },
+  },
 }
 ```
 
 Fields:
+
 - `mainKey`: direct-chat bucket key (default: `"main"`). Useful when you want to “rename” the primary DM thread without changing `agentId`.
   - Sandbox note: `agents.defaults.sandbox.mode: "non-main"` uses this key to detect the main session. Any session key that does not match `mainKey` (groups/channels) is sandboxed.
 - `dmScope`: how DM sessions are grouped (default: `"main"`).
@@ -2670,6 +2782,7 @@ overrides. Applies to **bundled** skills and `~/.openclaw/skills` (workspace ski
 still win on name conflicts).
 
 Fields:
+
 - `allowBundled`: optional allowlist for **bundled** skills only. If set, only those
   bundled skills are eligible (managed/workspace skills unaffected).
 - `load.extraDirs`: additional skill directories to scan (lowest precedence).
@@ -2678,6 +2791,7 @@ Fields:
 - `entries.<skillKey>`: per-skill config overrides.
 
 Per-skill fields:
+
 - `enabled`: set `false` to disable a skill even if it’s bundled/installed.
 - `env`: environment variables injected for the agent run (only if not already set).
 - `apiKey`: optional convenience for skills that declare a primary env var (e.g. `nano-banana-pro` → `GEMINI_API_KEY`).
@@ -2689,26 +2803,23 @@ Example:
   skills: {
     allowBundled: ["gemini", "peekaboo"],
     load: {
-      extraDirs: [
-        "~/Projects/agent-scripts/skills",
-        "~/Projects/oss/some-skill-pack/skills"
-      ]
+      extraDirs: ["~/Projects/agent-scripts/skills", "~/Projects/oss/some-skill-pack/skills"],
     },
     install: {
       preferBrew: true,
-      nodeManager: "npm"
+      nodeManager: "npm",
     },
     entries: {
       "nano-banana-pro": {
         apiKey: "GEMINI_KEY_HERE",
         env: {
-          GEMINI_API_KEY: "GEMINI_KEY_HERE"
-        }
+          GEMINI_API_KEY: "GEMINI_KEY_HERE",
+        },
       },
       peekaboo: { enabled: true },
-      sag: { enabled: false }
-    }
-  }
+      sag: { enabled: false },
+    },
+  },
 }
 ```
 
@@ -2720,6 +2831,7 @@ from `~/.openclaw/extensions`, `<workspace>/.openclaw/extensions`, plus any
 See [/plugin](/plugin) for full usage.
 
 Fields:
+
 - `enabled`: master toggle for plugin loading (default: true).
 - `allow`: optional allowlist of plugin ids; when set, only listed plugins load.
 - `deny`: optional denylist of plugin ids (deny wins).
@@ -2736,17 +2848,17 @@ Example:
     enabled: true,
     allow: ["voice-call"],
     load: {
-      paths: ["~/Projects/oss/voice-call-extension"]
+      paths: ["~/Projects/oss/voice-call-extension"],
     },
     entries: {
       "voice-call": {
         enabled: true,
         config: {
-          provider: "twilio"
-        }
-      }
-    }
-  }
+          provider: "twilio",
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -2760,6 +2872,7 @@ profiles are attach-only (start/stop/reset are disabled).
 scheme/host for profiles that only set `cdpPort`.
 
 Defaults:
+
 - enabled: `true`
 - evaluateEnabled: `true` (set `false` to disable `act:evaluate` and `wait --fn`)
 - control service: loopback only (port derived from `gateway.port`, default `18791`)
@@ -2778,7 +2891,7 @@ Defaults:
     profiles: {
       openclaw: { cdpPort: 18800, color: "#FF4500" },
       work: { cdpPort: 18801, color: "#0066CC" },
-      remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" }
+      remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" },
     },
     color: "#FF4500",
     // Advanced:
@@ -2786,7 +2899,7 @@ Defaults:
     // noSandbox: false,
     // executablePath: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
     // attachOnly: false, // set true when tunneling a remote CDP to localhost
-  }
+  },
 }
 ```
 
@@ -2804,9 +2917,9 @@ If unset, clients fall back to a muted light-blue.
     // If unset, the Control UI uses the active agent identity (config or IDENTITY.md).
     assistant: {
       name: "OpenClaw",
-      avatar: "CB" // emoji, short text, or image URL/data URI
-    }
-  }
+      avatar: "CB", // emoji, short text, or image URL/data URI
+    },
+  },
 }
 ```
 
@@ -2815,6 +2928,7 @@ If unset, clients fall back to a muted light-blue.
 Use `gateway.mode` to explicitly declare whether this machine should run the Gateway.
 
 Defaults:
+
 - mode: **unset** (treated as “do not auto-start”)
 - bind: `loopback`
 - port: `18789` (single port for WS + HTTP)
@@ -2828,11 +2942,12 @@ Defaults:
     // controlUi: { enabled: true, basePath: "/openclaw" }
     // auth: { mode: "token", token: "your-token" } // token gates WS + Control UI access
     // tailscale: { mode: "off" | "serve" | "funnel" }
-  }
+  },
 }
 ```
 
 Control UI base path:
+
 - `gateway.controlUi.basePath` sets the URL prefix where the Control UI is served.
 - Examples: `"/ui"`, `"/openclaw"`, `"/apps/openclaw"`.
 - Default: root (`/`) (unchanged).
@@ -2843,17 +2958,20 @@ Control UI base path:
   Control UI (token/password only). Default: `false`. Break-glass only.
 
 Related docs:
+
 - [Control UI](/web/control-ui)
 - [Web overview](/web)
 - [Tailscale](/gateway/tailscale)
 - [Remote access](/gateway/remote)
 
 Trusted proxies:
+
 - `gateway.trustedProxies`: list of reverse proxy IPs that terminate TLS in front of the Gateway.
 - When a connection comes from one of these IPs, OpenClaw uses `x-forwarded-for` (or `x-real-ip`) to determine the client IP for local pairing checks and HTTP auth/local checks.
 - Only list proxies you fully control, and ensure they **overwrite** incoming `x-forwarded-for`.
 
 Notes:
+
 - `openclaw gateway` refuses to start unless `gateway.mode` is set to `local` (or you pass the override flag).
 - `gateway.port` controls the single multiplexed port used for WebSocket + HTTP (control UI, hooks, A2UI).
 - OpenAI Chat Completions endpoint: **disabled by default**; enable with `gateway.http.endpoints.chatCompletions.enabled: true`.
@@ -2863,6 +2981,7 @@ Notes:
 - `gateway.remote.token` is **only** for remote CLI calls; it does not enable local gateway auth. `gateway.token` is ignored.
 
 Auth and Tailscale:
+
 - `gateway.auth.mode` sets the handshake requirements (`token` or `password`). When unset, token auth is assumed.
 - `gateway.auth.token` stores the shared token for token auth (used by the CLI on the same machine).
 - When `gateway.auth.mode` is set, only that method is accepted (plus optional Tailscale headers).
@@ -2879,12 +2998,14 @@ Auth and Tailscale:
 - `gateway.tailscale.resetOnExit` resets Serve/Funnel config on shutdown.
 
 Remote client defaults (CLI):
+
 - `gateway.remote.url` sets the default Gateway WebSocket URL for CLI calls when `gateway.mode = "remote"`.
 - `gateway.remote.transport` selects the macOS remote transport (`ssh` default, `direct` for ws/wss). When `direct`, `gateway.remote.url` must be `ws://` or `wss://`. `ws://host` defaults to port `18789`.
 - `gateway.remote.token` supplies the token for remote calls (leave unset for no auth).
 - `gateway.remote.password` supplies the password for remote calls (leave unset for no auth).
 
 macOS app behavior:
+
 - OpenClaw.app watches `~/.openclaw/openclaw.json` and switches modes live when `gateway.mode` or `gateway.remote.url` changes.
 - If `gateway.mode` is unset but `gateway.remote.url` is set, the macOS app treats it as remote mode.
 - When you change connection mode in the macOS app, it writes `gateway.mode` (and `gateway.remote.url` + `gateway.remote.transport` in remote mode) back to the config file.
@@ -2896,9 +3017,9 @@ macOS app behavior:
     remote: {
       url: "ws://gateway.tailnet:18789",
       token: "your-token",
-      password: "your-password"
-    }
-  }
+      password: "your-password",
+    },
+  },
 }
 ```
 
@@ -2911,9 +3032,9 @@ Direct transport example (macOS app):
     remote: {
       transport: "direct",
       url: "wss://gateway.example.ts.net",
-      token: "your-token"
-    }
-  }
+      token: "your-token",
+    },
+  },
 }
 ```
 
@@ -2922,6 +3043,7 @@ Direct transport example (macOS app):
 The Gateway watches `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`) and applies changes automatically.
 
 Modes:
+
 - `hybrid` (default): hot-apply safe changes; restart the Gateway for critical changes.
 - `hot`: only apply hot-safe changes; log when a restart is required.
 - `restart`: restart the Gateway on any config change.
@@ -2932,18 +3054,20 @@ Modes:
   gateway: {
     reload: {
       mode: "hybrid",
-      debounceMs: 300
-    }
-  }
+      debounceMs: 300,
+    },
+  },
 }
 ```
 
 #### Hot reload matrix (files + impact)
 
 Files watched:
+
 - `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)
 
 Hot-applied (no full gateway restart):
+
 - `hooks` (webhook auth/path/mappings) + `hooks.gmail` (Gmail watcher restarted)
 - `browser` (browser control server restart)
 - `cron` (cron service restart + concurrency update)
@@ -2953,6 +3077,7 @@ Hot-applied (no full gateway restart):
 - `agent`, `models`, `routing`, `messages`, `session`, `whatsapp`, `logging`, `skills`, `ui`, `talk`, `identity`, `wizard` (dynamic reads)
 
 Requires full Gateway restart:
+
 - `gateway` (port/bind/auth/control UI/tailscale)
 - `bridge` (legacy)
 - `discovery`
@@ -2963,12 +3088,14 @@ Requires full Gateway restart:
 ### Multi-instance isolation
 
 To run multiple gateways on one host (for redundancy or a rescue bot), isolate per-instance state + config and use unique ports:
+
 - `OPENCLAW_CONFIG_PATH` (per-instance config)
 - `OPENCLAW_STATE_DIR` (sessions/creds)
 - `agents.defaults.workspace` (memories)
 - `gateway.port` (unique per instance)
 
 Convenience flags (CLI):
+
 - `openclaw --dev …` → uses `~/.openclaw-dev` + shifts ports from base `19001`
 - `openclaw --profile <name> …` → uses `~/.openclaw-<name>` (port via config/env/flags)
 
@@ -2976,6 +3103,7 @@ See [Gateway runbook](/gateway) for the derived port mapping (gateway/browser/ca
 See [Multiple gateways](/gateway/multiple-gateways) for browser/CDP port isolation details.
 
 Example:
+
 ```bash
 OPENCLAW_CONFIG_PATH=~/.openclaw/a.json \
 OPENCLAW_STATE_DIR=~/.openclaw-a \
@@ -2987,6 +3115,7 @@ openclaw gateway --port 19001
 Enable a simple HTTP webhook endpoint on the Gateway HTTP server.
 
 Defaults:
+
 - enabled: `false`
 - path: `/hooks`
 - maxBodyBytes: `262144` (256 KB)
@@ -3006,23 +3135,24 @@ Defaults:
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
-        messageTemplate:
-          "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}",
+        messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}",
         deliver: true,
         channel: "last",
         model: "openai/gpt-5.2-mini",
       },
     ],
-  }
+  },
 }
 ```
 
 Requests must include the hook token:
+
 - `Authorization: Bearer <token>` **or**
 - `x-openclaw-token: <token>` **or**
 - `?token=<token>`
 
 Endpoints:
+
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
 - `POST /hooks/agent` → `{ message, name?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
@@ -3030,6 +3160,7 @@ Endpoints:
 `/hooks/agent` always posts a summary into the main session (and can optionally trigger an immediate heartbeat via `wakeMode: "now"`).
 
 Mapping notes:
+
 - `match.path` matches the sub-path after `/hooks` (e.g. `/hooks/gmail` → `gmail`).
 - `match.source` matches a payload field (e.g. `{ source: "gmail" }`) so you can use a generic `/hooks/ingest` path.
 - Templates like `{{messages[0].subject}}` read from the payload.
@@ -3060,12 +3191,13 @@ Gmail helper config (used by `openclaw webhooks gmail setup` / `run`):
       model: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
       // Optional: default thinking level for Gmail hooks
       thinking: "off",
-    }
-  }
+    },
+  },
 }
 ```
 
 Model override for Gmail hooks:
+
 - `hooks.gmail.model` specifies a model to use for Gmail hook processing (defaults to session primary).
 - Accepts `provider/model` refs or aliases from `agents.defaults.models`.
 - Falls back to `agents.defaults.model.fallbacks`, then `agents.defaults.model.primary`, on auth/rate-limit/timeouts.
@@ -3074,6 +3206,7 @@ Model override for Gmail hooks:
 - `hooks.gmail.thinking` sets the default thinking level for Gmail hooks and is overridden by per-hook `thinking`.
 
 Gateway auto-start:
+
 - If `hooks.enabled=true` and `hooks.gmail.account` is set, the Gateway starts
   `gog gmail watch serve` on boot and auto-renews the watch.
 - Set `OPENCLAW_SKIP_GMAIL_WATCHER=1` to disable the auto-start (for manual runs).
@@ -3094,6 +3227,7 @@ Default port: `18793` (chosen to avoid the openclaw browser CDP port `18792`)
 The server listens on the **gateway bind host** (LAN or Tailnet) so nodes can reach it.
 
 The server:
+
 - serves files under `canvasHost.root`
 - injects a tiny live-reload client into served HTML
 - watches the directory and broadcasts reloads over a WebSocket endpoint at `/__openclaw__/ws`
@@ -3102,6 +3236,7 @@ The server:
   (always used by nodes for Canvas/A2UI)
 
 Disable live reload (and file watching) if the directory is large or you hit `EMFILE`:
+
 - config: `canvasHost: { liveReload: false }`
 
 ```json5
@@ -3109,14 +3244,15 @@ Disable live reload (and file watching) if the directory is large or you hit `EM
   canvasHost: {
     root: "~/.openclaw/workspace/canvas",
     port: 18793,
-    liveReload: true
-  }
+    liveReload: true,
+  },
 }
 ```
 
 Changes to `canvasHost.*` require a gateway restart (config reload will restart).
 
 Disable with:
+
 - config: `canvasHost: { enabled: false }`
 - env: `OPENCLAW_SKIP_CANVAS_HOST=1`
 
@@ -3126,20 +3262,24 @@ Current builds no longer include the TCP bridge listener; `bridge.*` config keys
 Nodes connect over the Gateway WebSocket. This section is kept for historical reference.
 
 Legacy behavior:
+
 - The Gateway could expose a simple TCP bridge for nodes (iOS/Android), typically on port `18790`.
 
 Defaults:
+
 - enabled: `true`
 - port: `18790`
 - bind: `lan` (binds to `0.0.0.0`)
 
 Bind modes:
+
 - `lan`: `0.0.0.0` (reachable on any interface, including LAN/Wi‑Fi and Tailscale)
 - `tailnet`: bind only to the machine’s Tailscale IP (recommended for Vienna ⇄ London)
 - `loopback`: `127.0.0.1` (local only)
 - `auto`: prefer tailnet IP if present, else `lan`
 
 TLS:
+
 - `bridge.tls.enabled`: enable TLS for bridge connections (TLS-only when enabled).
 - `bridge.tls.autoGenerate`: generate a self-signed cert when no cert/key are present (default: true).
 - `bridge.tls.certPath` / `bridge.tls.keyPath`: PEM paths for the bridge certificate + private key.
@@ -3161,8 +3301,8 @@ Auto-generated certs require `openssl` on PATH; if generation fails, the bridge 
       // Uses ~/.openclaw/bridge/tls/bridge-{cert,key}.pem when omitted.
       // certPath: "~/.openclaw/bridge/tls/bridge-cert.pem",
       // keyPath: "~/.openclaw/bridge/tls/bridge-key.pem"
-    }
-  }
+    },
+  },
 }
 ```
 
@@ -3177,7 +3317,7 @@ Controls LAN mDNS discovery broadcasts (`_openclaw-gw._tcp`).
 
 ```json5
 {
-  discovery: { mdns: { mode: "minimal" } }
+  discovery: { mdns: { mode: "minimal" } },
 }
 ```
 
@@ -3186,6 +3326,7 @@ Controls LAN mDNS discovery broadcasts (`_openclaw-gw._tcp`).
 When enabled, the Gateway writes a unicast DNS-SD zone for `_openclaw-gw._tcp` under `~/.openclaw/dns/` using the configured discovery domain (example: `openclaw.internal.`).
 
 To make iOS/Android discover across networks (Vienna ⇄ London), pair this with:
+
 - a DNS server on the gateway host serving your chosen domain (CoreDNS is recommended)
 - Tailscale **split DNS** so clients resolve that domain via the gateway DNS server
 
@@ -3197,7 +3338,7 @@ openclaw dns setup --apply
 
 ```json5
 {
-  discovery: { wideArea: { enabled: true } }
+  discovery: { wideArea: { enabled: true } },
 }
 ```
 
@@ -3205,28 +3346,28 @@ openclaw dns setup --apply
 
 Template placeholders are expanded in `tools.media.*.models[].args` and `tools.media.models[].args` (and any future templated argument fields).
 
-| Variable | Description |
-|----------|-------------|
-| `{{Body}}` | Full inbound message body |
-| `{{RawBody}}` | Raw inbound message body (no history/sender wrappers; best for command parsing) |
-| `{{BodyStripped}}` | Body with group mentions stripped (best default for agents) |
-| `{{From}}` | Sender identifier (E.164 for WhatsApp; may differ per channel) |
-| `{{To}}` | Destination identifier |
-| `{{MessageSid}}` | Channel message id (when available) |
-| `{{SessionId}}` | Current session UUID |
-| `{{IsNewSession}}` | `"true"` when a new session was created |
-| `{{MediaUrl}}` | Inbound media pseudo-URL (if present) |
-| `{{MediaPath}}` | Local media path (if downloaded) |
-| `{{MediaType}}` | Media type (image/audio/document/…) |
-| `{{Transcript}}` | Audio transcript (when enabled) |
-| `{{Prompt}}` | Resolved media prompt for CLI entries |
-| `{{MaxChars}}` | Resolved max output chars for CLI entries |
-| `{{ChatType}}` | `"direct"` or `"group"` |
-| `{{GroupSubject}}` | Group subject (best effort) |
-| `{{GroupMembers}}` | Group members preview (best effort) |
-| `{{SenderName}}` | Sender display name (best effort) |
-| `{{SenderE164}}` | Sender phone number (best effort) |
-| `{{Provider}}` | Provider hint (whatsapp|telegram|discord|googlechat|slack|signal|imessage|msteams|webchat|…) |
+| Variable           | Description                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- | -------- | ------- | ---------- | ----- | ------ | -------- | ------- | ------- | --- |
+| `{{Body}}`         | Full inbound message body                                                       |
+| `{{RawBody}}`      | Raw inbound message body (no history/sender wrappers; best for command parsing) |
+| `{{BodyStripped}}` | Body with group mentions stripped (best default for agents)                     |
+| `{{From}}`         | Sender identifier (E.164 for WhatsApp; may differ per channel)                  |
+| `{{To}}`           | Destination identifier                                                          |
+| `{{MessageSid}}`   | Channel message id (when available)                                             |
+| `{{SessionId}}`    | Current session UUID                                                            |
+| `{{IsNewSession}}` | `"true"` when a new session was created                                         |
+| `{{MediaUrl}}`     | Inbound media pseudo-URL (if present)                                           |
+| `{{MediaPath}}`    | Local media path (if downloaded)                                                |
+| `{{MediaType}}`    | Media type (image/audio/document/…)                                             |
+| `{{Transcript}}`   | Audio transcript (when enabled)                                                 |
+| `{{Prompt}}`       | Resolved media prompt for CLI entries                                           |
+| `{{MaxChars}}`     | Resolved max output chars for CLI entries                                       |
+| `{{ChatType}}`     | `"direct"` or `"group"`                                                         |
+| `{{GroupSubject}}` | Group subject (best effort)                                                     |
+| `{{GroupMembers}}` | Group members preview (best effort)                                             |
+| `{{SenderName}}`   | Sender display name (best effort)                                               |
+| `{{SenderE164}}`   | Sender phone number (best effort)                                               |
+| `{{Provider}}`     | Provider hint (whatsapp                                                         | telegram | discord | googlechat | slack | signal | imessage | msteams | webchat | …)  |
 
 ## Cron (Gateway scheduler)
 
@@ -3236,11 +3377,11 @@ Cron is a Gateway-owned scheduler for wakeups and scheduled jobs. See [Cron jobs
 {
   cron: {
     enabled: true,
-    maxConcurrentRuns: 2
-  }
+    maxConcurrentRuns: 2,
+  },
 }
 ```
 
 ---
 
-*Next: [Agent Runtime](/concepts/agent)* 🦞
+_Next: [Agent Runtime](/concepts/agent)_ 🦞

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -1,93 +1,87 @@
 ---
 name: sag
-description: ElevenLabs text-to-speech with mac-style say UX. Send voice notes via Telegram.
+description: ElevenLabs text-to-speech with mac-style say UX.
 homepage: https://sag.sh
-metadata: {"openclaw":{"emoji":"🗣️","requires":{"bins":["sag"],"env":["ELEVENLABS_API_KEY"]},"primaryEnv":"ELEVENLABS_API_KEY","install":[{"id":"brew","kind":"brew","formula":"steipete/tap/sag","bins":["sag"],"label":"Install sag (brew)"}]}}
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🗣️",
+        "requires": { "bins": ["sag"], "env": ["ELEVENLABS_API_KEY"] },
+        "primaryEnv": "ELEVENLABS_API_KEY",
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "steipete/tap/sag",
+              "bins": ["sag"],
+              "label": "Install sag (brew)",
+            },
+          ],
+      },
+  }
 ---
 
-# SAG - ElevenLabs TTS CLI
+# sag
 
-**The way to send Elie voice notes.** Simple, fast, high quality.
+Use `sag` for ElevenLabs TTS with local playback.
 
-## Quick Start
+API key (required)
 
-```bash
-# Basic voice note (female voice by ID, 1.3x faster)
-sag -v "EXAVITQu4vr4xnSDxMaL" -o /tmp/voice.opus "Hey Elie, quick update on the project."
+- `ELEVENLABS_API_KEY` (preferred)
+- `SAG_API_KEY` also supported by the CLI
 
-# List available voices
-sag voices
-```
+Quick start
 
-## Send to Elie (Telegram)
+- `sag "Hello there"`
+- `sag speak -v "Roger" "Hello"`
+- `sag voices`
+- `sag prompting` (model-specific tips)
 
-```bash
-# Generate voice (1.3x faster = --rate 175)
-# Use VOICE ID for reliable matching (names can fail)
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Your message here"
+Model notes
 
-# Send via message tool
-message action=send media=/tmp/voice.opus target=733180662
-```
+- Default: `eleven_v3` (expressive)
+- Stable: `eleven_multilingual_v2`
+- Fast: `eleven_flash_v2_5`
 
-## Speed Options
+Pronunciation + delivery rules
 
-| Speed | Rate Flag | Use Case |
-|-------|-----------|----------|
-| Normal | `--rate 100` | Default |
-| **1.3x faster** | `--rate 175` | **Elie's preferred** |
-| 2x faster | `--rate 300` | Quick updates |
+- First fix: respell (e.g. "key-note"), add hyphens, adjust casing.
+- Numbers/units/URLs: `--normalize auto` (or `off` if it harms names).
+- Language bias: `--lang en|de|fr|...` to guide normalization.
+- v3: SSML `<break>` not supported; use `[pause]`, `[short pause]`, `[long pause]`.
+- v2/v2.5: SSML `<break time="1.5s" />` supported; `<phoneme>` not exposed in `sag`.
 
-```bash
-# Elie's preferred: Sarah (voice ID), 1.3x faster
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
-```
+v3 audio tags (put at the entrance of a line)
 
-## Available Female Voices (by ID)
+- `[whispers]`, `[shouts]`, `[sings]`
+- `[laughs]`, `[starts laughing]`, `[sighs]`, `[exhales]`
+- `[sarcastic]`, `[curious]`, `[excited]`, `[crying]`, `[mischievously]`
+- Example: `sag "[whispers] keep this quiet. [short pause] ok?"`
 
-| Voice ID | Name | Style |
-|----------|------|-------|
-| `EXAVITQu4vr4xnSDxMaL` | **Sarah** | Mature, Reassuring, Confident ✅ **Default** |
-| `FGY2WhTYpPnrIDTdsKH5` | Laura | Enthusiast, Quirky |
-| `Xb7hH8MSUJpSbSDYk0k2` | Alice | Clear, Engaging Educator |
+Voice defaults
 
-**Always use VOICE ID** — names can fail due to fuzzy matching.
+- `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`
 
-## Audio Tags (v3 only)
+Confirm voice + speaker before long output.
 
-Add at start of lines for expression:
+## Chat voice responses
 
-```
-[whispers]   [shouts]   [sings]
-[laughs]     [sighs]    [excited]
-[sarcastic]  [curious]  [crying]
-[short pause] [long pause]
-```
-
-Example:
-```bash
-sag "[whispers] I found something interesting. [short pause] Look at this data."
-```
-
-## Best Practices
-
-1. **Keep messages under 2 minutes** — longer = longer generation time
-2. **Add pauses** — `[short pause]` for breathing room
-3. **Exaggerate emotion** — ElevenLabs v3 is expressive
-4. **SSML-free** — use `[pause]` tags instead of `<break>`
-
-## Elie's Preferred (1.3x faster, Female voice by ID)
+When Peter asks for a "voice" reply (e.g., "crazy scientist voice", "explain in voice"), generate audio and send it:
 
 ```bash
-# Quick update voice note (Sarah, voice ID, 1.3x faster)
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
+# Generate audio file
+sag -v Clawd -o /tmp/voice-reply.mp3 "Your message here"
 
-# Report style (Laura, female)
-sag -v "FGY2WhTYpPnrIDTdsKH5" --rate 175 -o /tmp/report.opus "Daily report: [short pause] Three critical signals detected."
+# Then include in reply:
+# MEDIA:/tmp/voice-reply.mp3
 ```
 
-## Troubleshooting
+Voice character tips:
 
-- **Slow generation?** Use `--model eleven_flash_v2_5` for speed
-- **Wrong pronunciation?** Add hyphens: "elie-HAB-ib" not "Elie Habib"
-- **Not working?** Check `echo $ELEVENLABS_API_KEY` is set
+- Crazy scientist: Use `[excited]` tags, dramatic pauses `[short pause]`, vary intensity
+- Calm: Use `[whispers]` or slower pacing
+- Dramatic: Use `[sings]` or `[shouts]` sparingly
+
+Default voice for Clawd: `lj2rcrvANS3gaWWnczSX` (or just `-v Clawd`)

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -1,62 +1,93 @@
 ---
 name: sag
-description: ElevenLabs text-to-speech with mac-style say UX.
+description: ElevenLabs text-to-speech with mac-style say UX. Send voice notes via Telegram.
 homepage: https://sag.sh
 metadata: {"openclaw":{"emoji":"🗣️","requires":{"bins":["sag"],"env":["ELEVENLABS_API_KEY"]},"primaryEnv":"ELEVENLABS_API_KEY","install":[{"id":"brew","kind":"brew","formula":"steipete/tap/sag","bins":["sag"],"label":"Install sag (brew)"}]}}
 ---
 
-# sag
+# SAG - ElevenLabs TTS CLI
 
-Use `sag` for ElevenLabs TTS with local playback.
+**The way to send Elie voice notes.** Simple, fast, high quality.
 
-API key (required)
-- `ELEVENLABS_API_KEY` (preferred)
-- `SAG_API_KEY` also supported by the CLI
-
-Quick start
-- `sag "Hello there"`
-- `sag speak -v "Roger" "Hello"`
-- `sag voices`
-- `sag prompting` (model-specific tips)
-
-Model notes
-- Default: `eleven_v3` (expressive)
-- Stable: `eleven_multilingual_v2`
-- Fast: `eleven_flash_v2_5`
-
-Pronunciation + delivery rules
-- First fix: respell (e.g. "key-note"), add hyphens, adjust casing.
-- Numbers/units/URLs: `--normalize auto` (or `off` if it harms names).
-- Language bias: `--lang en|de|fr|...` to guide normalization.
-- v3: SSML `<break>` not supported; use `[pause]`, `[short pause]`, `[long pause]`.
-- v2/v2.5: SSML `<break time="1.5s" />` supported; `<phoneme>` not exposed in `sag`.
-
-v3 audio tags (put at the entrance of a line)
-- `[whispers]`, `[shouts]`, `[sings]`
-- `[laughs]`, `[starts laughing]`, `[sighs]`, `[exhales]`
-- `[sarcastic]`, `[curious]`, `[excited]`, `[crying]`, `[mischievously]`
-- Example: `sag "[whispers] keep this quiet. [short pause] ok?"`
-
-Voice defaults
-- `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`
-
-Confirm voice + speaker before long output.
-
-## Chat voice responses
-
-When Peter asks for a "voice" reply (e.g., "crazy scientist voice", "explain in voice"), generate audio and send it:
+## Quick Start
 
 ```bash
-# Generate audio file
-sag -v Clawd -o /tmp/voice-reply.mp3 "Your message here"
+# Basic voice note (female voice by ID, 1.4x faster)
+sag -v "EXAVITQu4vr4xnSDxMaL" -o /tmp/voice.opus "Hey Elie, quick update on the project."
 
-# Then include in reply:
-# MEDIA:/tmp/voice-reply.mp3
+# List available voices
+sag voices
 ```
 
-Voice character tips:
-- Crazy scientist: Use `[excited]` tags, dramatic pauses `[short pause]`, vary intensity
-- Calm: Use `[whispers]` or slower pacing
-- Dramatic: Use `[sings]` or `[shouts]` sparingly
+## Send to Elie (Telegram)
 
-Default voice for Clawd: `lj2rcrvANS3gaWWnczSX` (or just `-v Clawd`)
+```bash
+# Generate voice (1.4x faster = --rate 200)
+# Use VOICE ID for reliable matching (names can fail)
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Your message here"
+
+# Send via message tool
+message action=send media=/tmp/voice.opus target=733180662
+```
+
+## Speed Options
+
+| Speed | Rate Flag | Use Case |
+|-------|-----------|----------|
+| Normal | `--rate 100` | Default |
+| **1.4x faster** | `--rate 200` | **Elie's preferred** |
+| 2x faster | `--rate 300` | Quick updates |
+
+```bash
+# Elie's preferred: Sarah (voice ID), 1.4x faster
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
+```
+
+## Available Female Voices (by ID)
+
+| Voice ID | Name | Style |
+|----------|------|-------|
+| `EXAVITQu4vr4xnSDxMaL` | **Sarah** | Mature, Reassuring, Confident ✅ **Default** |
+| `FGY2WhTYpPnrIDTdsKH5` | Laura | Enthusiast, Quirky |
+| `Xb7hH8MSUJpSbSDYk0k2` | Alice | Clear, Engaging Educator |
+
+**Always use VOICE ID** — names can fail due to fuzzy matching.
+
+## Audio Tags (v3 only)
+
+Add at start of lines for expression:
+
+```
+[whispers]   [shouts]   [sings]
+[laughs]     [sighs]    [excited]
+[sarcastic]  [curious]  [crying]
+[short pause] [long pause]
+```
+
+Example:
+```bash
+sag "[whispers] I found something interesting. [short pause] Look at this data."
+```
+
+## Best Practices
+
+1. **Keep messages under 2 minutes** — longer = longer generation time
+2. **Add pauses** — `[short pause]` for breathing room
+3. **Exaggerate emotion** — ElevenLabs v3 is expressive
+4. **SSML-free** — use `[pause]` tags instead of `<break>`
+
+## Elie's Preferred (1.4x faster, Female voice by ID)
+
+```bash
+# Quick update voice note (Sarah, voice ID, 1.4x faster)
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
+
+# Report style (Laura, female)
+sag -v "FGY2WhTYpPnrIDTdsKH5" --rate 200 -o /tmp/report.opus "Daily report: [short pause] Three critical signals detected."
+```
+
+## Troubleshooting
+
+- **Slow generation?** Use `--model eleven_flash_v2_5` for speed
+- **Wrong pronunciation?** Add hyphens: "elie-HAB-ib" not "Elie Habib"
+- **Not working?** Check `echo $ELEVENLABS_API_KEY` is set

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -12,7 +12,7 @@ metadata: {"openclaw":{"emoji":"🗣️","requires":{"bins":["sag"],"env":["ELEV
 ## Quick Start
 
 ```bash
-# Basic voice note (female voice by ID, 1.4x faster)
+# Basic voice note (female voice by ID, 1.3x faster)
 sag -v "EXAVITQu4vr4xnSDxMaL" -o /tmp/voice.opus "Hey Elie, quick update on the project."
 
 # List available voices
@@ -22,9 +22,9 @@ sag voices
 ## Send to Elie (Telegram)
 
 ```bash
-# Generate voice (1.4x faster = --rate 200)
+# Generate voice (1.3x faster = --rate 175)
 # Use VOICE ID for reliable matching (names can fail)
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Your message here"
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Your message here"
 
 # Send via message tool
 message action=send media=/tmp/voice.opus target=733180662
@@ -35,12 +35,12 @@ message action=send media=/tmp/voice.opus target=733180662
 | Speed | Rate Flag | Use Case |
 |-------|-----------|----------|
 | Normal | `--rate 100` | Default |
-| **1.4x faster** | `--rate 200` | **Elie's preferred** |
+| **1.3x faster** | `--rate 175` | **Elie's preferred** |
 | 2x faster | `--rate 300` | Quick updates |
 
 ```bash
-# Elie's preferred: Sarah (voice ID), 1.4x faster
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
+# Elie's preferred: Sarah (voice ID), 1.3x faster
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
 ```
 
 ## Available Female Voices (by ID)
@@ -76,14 +76,14 @@ sag "[whispers] I found something interesting. [short pause] Look at this data."
 3. **Exaggerate emotion** — ElevenLabs v3 is expressive
 4. **SSML-free** — use `[pause]` tags instead of `<break>`
 
-## Elie's Preferred (1.4x faster, Female voice by ID)
+## Elie's Preferred (1.3x faster, Female voice by ID)
 
 ```bash
-# Quick update voice note (Sarah, voice ID, 1.4x faster)
-sag -v "EXAVITQu4vr4xnSDxMaL" --rate 200 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
+# Quick update voice note (Sarah, voice ID, 1.3x faster)
+sag -v "EXAVITQu4vr4xnSDxMaL" --rate 175 -o /tmp/voice.opus "Quick update: [short pause] All systems operational."
 
 # Report style (Laura, female)
-sag -v "FGY2WhTYpPnrIDTdsKH5" --rate 200 -o /tmp/report.opus "Daily report: [short pause] Three critical signals detected."
+sag -v "FGY2WhTYpPnrIDTdsKH5" --rate 175 -o /tmp/report.opus "Daily report: [short pause] Three critical signals detected."
 ```
 
 ## Troubleshooting

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -496,12 +496,18 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
+/** Detect JSON parse errors from malformed model tool-call arguments. */
+function isJsonParseError(raw: string): boolean {
+  return /\bis not valid JSON\b|SyntaxError:.*Unexpected token/i.test(raw);
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) return null;
   if (isImageSizeError(raw)) return null;
   if (isRateLimitErrorMessage(raw)) return "rate_limit";
   if (isOverloadedErrorMessage(raw)) return "rate_limit";
   if (isCloudCodeAssistFormatError(raw)) return "format";
+  if (isJsonParseError(raw)) return "format";
   if (isBillingErrorMessage(raw)) return "billing";
   if (isTimeoutErrorMessage(raw)) return "timeout";
   if (isAuthErrorMessage(raw)) return "auth";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -498,7 +498,9 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
 
 /** Detect JSON parse errors from malformed model tool-call arguments. */
 function isJsonParseError(raw: string): boolean {
-  return /\bis not valid JSON\b|SyntaxError:.*Unexpected token/i.test(raw);
+  return /\bis not valid JSON\b|Unexpected token .* in JSON|Unexpected end of JSON input/i.test(
+    raw,
+  );
 }
 
 export function classifyFailoverReason(raw: string): FailoverReason | null {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -198,6 +198,8 @@ export async function launchOpenClawChrome(
       // Best-effort; older Chromes may ignore.
       args.push("--headless=new");
       args.push("--disable-gpu");
+      // Disable automation flags that sites use for headless detection
+      args.push("--disable-blink-features=AutomationControlled");
     }
     if (resolved.noSandbox) {
       args.push("--no-sandbox");

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -88,9 +88,13 @@ async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<Chro
       signal: ctrl.signal,
       headers: getHeadersWithAuth(versionUrl),
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      return null;
+    }
     const data = (await res.json()) as ChromeVersion;
-    if (!data || typeof data !== "object") return null;
+    if (!data || typeof data !== "object") {
+      return null;
+    }
     return data;
   } catch {
     return null;
@@ -105,7 +109,9 @@ export async function getChromeWebSocketUrl(
 ): Promise<string | null> {
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);
   const wsUrl = String(version?.webSocketDebuggerUrl ?? "").trim();
-  if (!wsUrl) return null;
+  if (!wsUrl) {
+    return null;
+  }
   return normalizeCdpWsUrl(wsUrl, cdpUrl);
 }
 
@@ -149,7 +155,9 @@ export async function isChromeCdpReady(
   handshakeTimeoutMs = 800,
 ): Promise<boolean> {
   const wsUrl = await getChromeWebSocketUrl(cdpUrl, timeoutMs);
-  if (!wsUrl) return false;
+  if (!wsUrl) {
+    return false;
+  }
   return await canOpenWebSocket(wsUrl, handshakeTimeoutMs);
 }
 
@@ -198,8 +206,6 @@ export async function launchOpenClawChrome(
       // Best-effort; older Chromes may ignore.
       args.push("--headless=new");
       args.push("--disable-gpu");
-      // Disable automation flags that sites use for headless detection
-      args.push("--disable-blink-features=AutomationControlled");
     }
     if (resolved.noSandbox) {
       args.push("--no-sandbox");
@@ -234,7 +240,9 @@ export async function launchOpenClawChrome(
     const bootstrap = spawnOnce();
     const deadline = Date.now() + 10_000;
     while (Date.now() < deadline) {
-      if (exists(localStatePath) && exists(preferencesPath)) break;
+      if (exists(localStatePath) && exists(preferencesPath)) {
+        break;
+      }
       await new Promise((r) => setTimeout(r, 100));
     }
     try {
@@ -244,7 +252,9 @@ export async function launchOpenClawChrome(
     }
     const exitDeadline = Date.now() + 5000;
     while (Date.now() < exitDeadline) {
-      if (bootstrap.exitCode != null) break;
+      if (bootstrap.exitCode != null) {
+        break;
+      }
       await new Promise((r) => setTimeout(r, 50));
     }
   }
@@ -271,7 +281,9 @@ export async function launchOpenClawChrome(
   // Wait for CDP to come up.
   const readyDeadline = Date.now() + 15_000;
   while (Date.now() < readyDeadline) {
-    if (await isChromeReachable(profile.cdpUrl, 500)) break;
+    if (await isChromeReachable(profile.cdpUrl, 500)) {
+      break;
+    }
     await new Promise((r) => setTimeout(r, 200));
   }
 
@@ -303,7 +315,9 @@ export async function launchOpenClawChrome(
 
 export async function stopOpenClawChrome(running: RunningChrome, timeoutMs = 2500) {
   const proc = running.proc;
-  if (proc.killed) return;
+  if (proc.killed) {
+    return;
+  }
   try {
     proc.kill("SIGTERM");
   } catch {
@@ -312,8 +326,12 @@ export async function stopOpenClawChrome(running: RunningChrome, timeoutMs = 250
 
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (!proc.exitCode && proc.killed) break;
-    if (!(await isChromeReachable(cdpUrlForPort(running.cdpPort), 200))) return;
+    if (!proc.exitCode && proc.killed) {
+      break;
+    }
+    if (!(await isChromeReachable(cdpUrlForPort(running.cdpPort), 200))) {
+      return;
+    }
     await new Promise((r) => setTimeout(r, 100));
   }
 

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -117,7 +117,9 @@ export function rememberRoleRefsForTarget(opts: {
   mode?: NonNullable<PageState["roleRefsMode"]>;
 }): void {
   const targetId = opts.targetId.trim();
-  if (!targetId) return;
+  if (!targetId) {
+    return;
+  }
   roleRefsByTarget.set(roleRefsKey(opts.cdpUrl, targetId), {
     refs: opts.refs,
     ...(opts.frameSelector ? { frameSelector: opts.frameSelector } : {}),
@@ -125,7 +127,9 @@ export function rememberRoleRefsForTarget(opts: {
   });
   while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
     const first = roleRefsByTarget.keys().next();
-    if (first.done) break;
+    if (first.done) {
+      break;
+    }
     roleRefsByTarget.delete(first.value);
   }
 }
@@ -142,7 +146,9 @@ export function storeRoleRefsForTarget(opts: {
   state.roleRefs = opts.refs;
   state.roleRefsFrameSelector = opts.frameSelector;
   state.roleRefsMode = opts.mode;
-  if (!opts.targetId?.trim()) return;
+  if (!opts.targetId?.trim()) {
+    return;
+  }
   rememberRoleRefsForTarget({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -158,11 +164,17 @@ export function restoreRoleRefsForTarget(opts: {
   page: Page;
 }): void {
   const targetId = opts.targetId?.trim() || "";
-  if (!targetId) return;
+  if (!targetId) {
+    return;
+  }
   const cached = roleRefsByTarget.get(roleRefsKey(opts.cdpUrl, targetId));
-  if (!cached) return;
+  if (!cached) {
+    return;
+  }
   const state = ensurePageState(opts.page);
-  if (state.roleRefs) return;
+  if (state.roleRefs) {
+    return;
+  }
   state.roleRefs = cached.refs;
   state.roleRefsFrameSelector = cached.frameSelector;
   state.roleRefsMode = cached.mode;
@@ -170,7 +182,9 @@ export function restoreRoleRefsForTarget(opts: {
 
 export function ensurePageState(page: Page): PageState {
   const existing = pageStates.get(page);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
 
   const state: PageState = {
     console: [],
@@ -194,7 +208,9 @@ export function ensurePageState(page: Page): PageState {
         location: msg.location(),
       };
       state.console.push(entry);
-      if (state.console.length > MAX_CONSOLE_MESSAGES) state.console.shift();
+      if (state.console.length > MAX_CONSOLE_MESSAGES) {
+        state.console.shift();
+      }
     });
     page.on("pageerror", (err: Error) => {
       state.errors.push({
@@ -203,7 +219,9 @@ export function ensurePageState(page: Page): PageState {
         stack: err?.stack ? String(err.stack) : undefined,
         timestamp: new Date().toISOString(),
       });
-      if (state.errors.length > MAX_PAGE_ERRORS) state.errors.shift();
+      if (state.errors.length > MAX_PAGE_ERRORS) {
+        state.errors.shift();
+      }
     });
     page.on("request", (req: Request) => {
       state.nextRequestId += 1;
@@ -216,12 +234,16 @@ export function ensurePageState(page: Page): PageState {
         url: req.url(),
         resourceType: req.resourceType(),
       });
-      if (state.requests.length > MAX_NETWORK_REQUESTS) state.requests.shift();
+      if (state.requests.length > MAX_NETWORK_REQUESTS) {
+        state.requests.shift();
+      }
     });
     page.on("response", (resp: Response) => {
       const req = resp.request();
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (!id) {
+        return;
+      }
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -230,13 +252,17 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) return;
+      if (!rec) {
+        return;
+      }
       rec.status = resp.status();
       rec.ok = resp.ok();
     });
     page.on("requestfailed", (req: Request) => {
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (!id) {
+        return;
+      }
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -245,7 +271,9 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) return;
+      if (!rec) {
+        return;
+      }
       rec.failureText = req.failure()?.errorText;
       rec.ok = false;
     });
@@ -258,71 +286,43 @@ export function ensurePageState(page: Page): PageState {
   return state;
 }
 
-/**
- * Stealth init script: patches common headless-detection signals so sites
- * like Reddit cannot trivially fingerprint the automated browser.
- */
-const STEALTH_INIT_SCRIPT = `
-  // Hide navigator.webdriver
-  Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
-
-  // Spoof chrome.runtime to look like a real Chrome extension environment
-  if (!window.chrome) window.chrome = {};
-  if (!window.chrome.runtime) window.chrome.runtime = { connect: () => {}, sendMessage: () => {} };
-
-  // Spoof plugins (headless Chrome reports 0 plugins)
-  Object.defineProperty(navigator, 'plugins', {
-    get: () => [1, 2, 3, 4, 5],
-  });
-
-  // Spoof languages (some detectors check for empty array)
-  Object.defineProperty(navigator, 'languages', {
-    get: () => ['en-US', 'en'],
-  });
-
-  // Remove "HeadlessChrome" from user-agent exposed to JS
-  Object.defineProperty(navigator, 'userAgent', {
-    get: () => navigator.userAgent.replace(/HeadlessChrome/g, 'Chrome'),
-  });
-
-  // Patch permissions API (headless often throws on query)
-  const origQuery = window.navigator.permissions?.query?.bind(window.navigator.permissions);
-  if (origQuery) {
-    window.navigator.permissions.query = (params) =>
-      params.name === 'notifications'
-        ? Promise.resolve({ state: Notification.permission })
-        : origQuery(params);
-  }
-`;
-
 function observeContext(context: BrowserContext) {
-  if (observedContexts.has(context)) return;
+  if (observedContexts.has(context)) {
+    return;
+  }
   observedContexts.add(context);
   ensureContextState(context);
 
-  // Inject stealth patches before any page script runs
-  context.addInitScript(STEALTH_INIT_SCRIPT).catch(() => {});
-
-  for (const page of context.pages()) ensurePageState(page);
+  for (const page of context.pages()) {
+    ensurePageState(page);
+  }
   context.on("page", (page) => ensurePageState(page));
 }
 
 export function ensureContextState(context: BrowserContext): ContextState {
   const existing = contextStates.get(context);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   const state: ContextState = { traceActive: false };
   contextStates.set(context, state);
   return state;
 }
 
 function observeBrowser(browser: Browser) {
-  for (const context of browser.contexts()) observeContext(context);
+  for (const context of browser.contexts()) {
+    observeContext(context);
+  }
 }
 
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
-  if (cached?.cdpUrl === normalized) return cached;
-  if (connecting) return await connecting;
+  if (cached?.cdpUrl === normalized) {
+    return cached;
+  }
+  if (connecting) {
+    return await connecting;
+  }
 
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
@@ -337,7 +337,9 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
         cached = connected;
         observeBrowser(browser);
         browser.on("disconnected", () => {
-          if (cached?.browser === browser) cached = null;
+          if (cached?.browser === browser) {
+            cached = null;
+          }
         });
         return connected;
       } catch (err) {
@@ -386,7 +388,9 @@ async function findPageByTargetId(
   // First, try the standard CDP session approach
   for (const page of pages) {
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid && tid === targetId) return page;
+    if (tid && tid === targetId) {
+      return page;
+    }
   }
   // If CDP sessions fail (e.g., extension relay blocks Target.attachToBrowserTarget),
   // fall back to URL-based matching using the /json/list endpoint
@@ -436,15 +440,21 @@ export async function getPageForTargetId(opts: {
 }): Promise<Page> {
   const { browser } = await connectBrowser(opts.cdpUrl);
   const pages = await getAllPages(browser);
-  if (!pages.length) throw new Error("No pages available in the connected browser.");
+  if (!pages.length) {
+    throw new Error("No pages available in the connected browser.");
+  }
   const first = pages[0];
-  if (!opts.targetId) return first;
+  if (!opts.targetId) {
+    return first;
+  }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
     // Extension relays can block CDP attachment APIs (e.g. Target.attachToBrowserTarget),
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
-    if (pages.length === 1) return first;
+    if (pages.length === 1) {
+      return first;
+    }
     throw new Error("tab not found");
   }
   return found;
@@ -492,7 +502,9 @@ export function refLocator(page: Page, ref: string) {
 export async function closePlaywrightBrowserConnection(): Promise<void> {
   const cur = cached;
   cached = null;
-  if (!cur) return;
+  if (!cur) {
+    return;
+  }
   await cur.browser.close().catch(() => {});
 }
 


### PR DESCRIPTION
## Summary

When a model returns invalid JSON in tool call arguments (e.g. `{"prompt":}` — missing value), the `JSON.parse` SyntaxError was surfaced as-is to the user as a WhatsApp/Telegram reply like:

> Unexpected token '}', ...","prompt":}" is not valid JSON

This happened because `classifyFailoverReason()` didn't recognize JSON parse errors, so `isFailoverErrorMessage()` returned false and the error was thrown without triggering model fallback.

**Fix:** Add `isJsonParseError()` detection for `"is not valid JSON"` and `SyntaxError: Unexpected token` patterns, classified as `"format"` failover reason. This triggers the existing fallback chain to retry with the next configured model.

Applies to all models — any provider producing malformed tool-call JSON will now failover instead of leaking the raw error to users.

## Test plan
- [x] `pnpm build` passes
- [x] Verified against real MiniMax-M2.1 error: `Unexpected token '}', ...","prompt":}" is not valid JSON`
- [x] Pattern matches both `SyntaxError: Unexpected token` and `is not valid JSON` variants

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

The core functional change is in `src/agents/pi-embedded-helpers/errors.ts`, adding JSON.parse error detection so malformed tool-call argument JSON is classified as a `"format"` failover reason and triggers the existing fallback model chain instead of leaking raw SyntaxErrors to chat users.

However, the diff also includes unrelated updates:
- Docs/skill text updates (`docs/gateway/configuration.md`, `skills/sag/SKILL.md`).
- Browser stealth/headless-detection bypass changes (`src/browser/chrome.ts`, `src/browser/pw-session.ts`) that materially change runtime behavior and don’t match the PR title/description.

Net effect: improved failover behavior for malformed tool-call JSON, but the PR as provided is not focused to that goal due to unrelated browser-stealth changes.

<h3>Confidence Score: 2/5</h3>

- This PR has meaningful behavior changes beyond the stated failover fix, so it’s not safe to merge as-is without follow-up.
- While the failover classification change is small and likely correct in intent, the JSON parse detection may miss common SyntaxError message formats, and the PR also introduces browser “stealth” headless-detection bypass flags/scripts that are unrelated to the title/description and may cause unexpected site behavior or policy concerns.
- src/agents/pi-embedded-helpers/errors.ts, src/browser/chrome.ts, src/browser/pw-session.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->