### PR TITLE
fix(browser): add CORS headers for chrome-extension:// origins

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -263,6 +263,38 @@ describe("chrome extension relay server", () => {
     ext.close();
   }, 15_000);
 
+  it("returns CORS headers for chrome-extension:// origins", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    // Test HEAD / with chrome-extension origin
+    const headRes = await fetch(`${cdpUrl}/`, {
+      method: "HEAD",
+      headers: { Origin: "chrome-extension://hgbmgodgmoepcniaoidlifjekhjkkckl" },
+    });
+    expect(headRes.status).toBe(200);
+    expect(headRes.headers.get("Access-Control-Allow-Origin")).toBe(
+      "chrome-extension://hgbmgodgmoepcniaoidlifjekhjkkckl",
+    );
+    expect(headRes.headers.get("Access-Control-Allow-Methods")).toContain("HEAD");
+
+    // Test OPTIONS preflight
+    const optionsRes = await fetch(`${cdpUrl}/`, {
+      method: "OPTIONS",
+      headers: { Origin: "chrome-extension://hgbmgodgmoepcniaoidlifjekhjkkckl" },
+    });
+    expect(optionsRes.status).toBe(204);
+    expect(optionsRes.headers.get("Access-Control-Allow-Origin")).toBe(
+      "chrome-extension://hgbmgodgmoepcniaoidlifjekhjkkckl",
+    );
+
+    // Test without extension origin - no CORS headers
+    const noOriginRes = await fetch(`${cdpUrl}/`, { method: "HEAD" });
+    expect(noOriginRes.status).toBe(200);
+    expect(noOriginRes.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
   it("rebroadcasts attach when a session id is reused for a new target", async () => {
     const port = await getFreePort();
     cdpUrl = `http://127.0.0.1:${port}`;

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -115,6 +115,20 @@ function isLoopbackAddress(ip: string | undefined): boolean {
   return false;
 }
 
+function getCorsHeaders(origin: string | undefined): Record<string, string> {
+  if (!origin) {
+    return {};
+  }
+  if (origin.startsWith("chrome-extension://") || origin.startsWith("moz-extension://")) {
+    return {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Methods": "GET, HEAD, PUT, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    };
+  }
+  return {};
+}
+
 function parseBaseUrl(raw: string): {
   host: string;
   port: number;
@@ -312,21 +326,28 @@ export async function ensureChromeExtensionRelayServer(opts: {
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", info.baseUrl);
     const path = url.pathname;
+    const corsHeaders = getCorsHeaders(req.headers.origin);
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, corsHeaders);
+      res.end();
+      return;
+    }
 
     if (req.method === "HEAD" && path === "/") {
-      res.writeHead(200);
+      res.writeHead(200, corsHeaders);
       res.end();
       return;
     }
 
     if (path === "/") {
-      res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+      res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", ...corsHeaders });
       res.end("OK");
       return;
     }
 
     if (path === "/extension/status") {
-      res.writeHead(200, { "Content-Type": "application/json" });
+      res.writeHead(200, { "Content-Type": "application/json", ...corsHeaders });
       res.end(JSON.stringify({ connected: Boolean(extensionWs) }));
       return;
     }
@@ -347,7 +368,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
       if (extensionWs) {
         payload.webSocketDebuggerUrl = cdpWsUrl;
       }
-      res.writeHead(200, { "Content-Type": "application/json" });
+      res.writeHead(200, { "Content-Type": "application/json", ...corsHeaders });
       res.end(JSON.stringify(payload));
       return;
     }
@@ -363,7 +384,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
         webSocketDebuggerUrl: cdpWsUrl,
         devtoolsFrontendUrl: `/devtools/inspector.html?ws=${cdpWsUrl.replace("ws://", "")}`,
       }));
-      res.writeHead(200, { "Content-Type": "application/json" });
+      res.writeHead(200, { "Content-Type": "application/json", ...corsHeaders });
       res.end(JSON.stringify(list));
       return;
     }
@@ -372,7 +393,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     if (activateMatch && (req.method === "GET" || req.method === "PUT")) {
       const targetId = decodeURIComponent(activateMatch[1] ?? "").trim();
       if (!targetId) {
-        res.writeHead(400);
+        res.writeHead(400, corsHeaders);
         res.end("targetId required");
         return;
       }
@@ -387,7 +408,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
           // ignore
         }
       })();
-      res.writeHead(200);
+      res.writeHead(200, corsHeaders);
       res.end("OK");
       return;
     }
@@ -396,7 +417,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     if (closeMatch && (req.method === "GET" || req.method === "PUT")) {
       const targetId = decodeURIComponent(closeMatch[1] ?? "").trim();
       if (!targetId) {
-        res.writeHead(400);
+        res.writeHead(400, corsHeaders);
         res.end("targetId required");
         return;
       }
@@ -411,12 +432,12 @@ export async function ensureChromeExtensionRelayServer(opts: {
           // ignore
         }
       })();
-      res.writeHead(200);
+      res.writeHead(200, corsHeaders);
       res.end("OK");
       return;
     }
 
-    res.writeHead(404);
+    res.writeHead(404, corsHeaders);
     res.end("not found");
   });
 


### PR DESCRIPTION
## Summary

Fixes #5856

The extension relay server was missing CORS headers, causing the Chrome extension's preflight `fetch()` check to fail.

## Root Cause

The HTTP server handlers didn't set any CORS headers for `chrome-extension://` origins:

```javascript
if (req.method === "HEAD" && path === "/") {
    res.writeHead(200);  // No CORS headers
    res.end();
    return;
}
```

## Changes

- Add `getCorsHeaders()` helper to detect `chrome-extension://` and `moz-extension://` origins
- Handle `OPTIONS` preflight requests with 204 response
- Include CORS headers in all HTTP responses when origin matches
- Add test case for CORS header behavior

## Testing

- Added new test: "returns CORS headers for chrome-extension:// origins"
- All 4 extension-relay tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds CORS handling to the extension relay HTTP server by detecting `chrome-extension://` and `moz-extension://` origins, responding to `OPTIONS` preflight requests with 204, and attaching CORS headers to all relevant HTTP responses. It also adds a Vitest case to validate that extension origins receive the expected CORS headers.

The change fits into the relay’s local HTTP control plane (`/`, `/json/*`, `/extension/status`), ensuring the Chrome extension can perform fetch() preflights against the relay without being blocked by missing CORS headers.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the main remaining risk is incomplete preflight header handling for non-trivial requests.
- Changes are localized to HTTP response headers and include a new test; however, the preflight handler currently allows only `Content-Type`, which may not cover the extension’s actual requested headers and could leave the original issue partially unfixed in some environments.
- src/browser/extension-relay.ts (preflight/header handling), src/browser/extension-relay.test.ts (coverage for requested headers).

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->