### PR TITLE
fix: trigger model failover on malformed tool-call JSON

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -584,6 +584,13 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
+/** Detect malformed model requests: JSON parse errors, invalid tool-call params, etc. */
+function isMalformedRequestError(raw: string): boolean {
+  return /\bis not valid JSON\b|Unexpected token .* in JSON|Unexpected end of JSON input|tool result's tool id.*not found|invalid params.*tool/i.test(
+    raw,
+  );
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;
@@ -598,6 +605,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "rate_limit";
   }
   if (isCloudCodeAssistFormatError(raw)) {
+    return "format";
+  }
+  if (isMalformedRequestError(raw)) {
     return "format";
   }
   if (isBillingErrorMessage(raw)) {


### PR DESCRIPTION
## Summary

When a model (e.g. MiniMax-M2.1) produces syntactically invalid JSON in tool-call arguments, the raw `SyntaxError` was forwarded to the end user instead of triggering failover to the next model in the chain.

- Add `isJsonParseError()` helper matching common JSON parse error patterns:
  - `"is not valid JSON"` (OpenAI-style)
  - `"Unexpected token ... in JSON"` (Node `JSON.parse`, with or without `SyntaxError:` prefix)
  - `"Unexpected end of JSON input"` (truncated JSON)
- Classify matches as `"format"` failover reason so the runner retries with the fallback model

## Test plan

- [x] Verified locally: malformed tool-call JSON from MiniMax-M2.1 now triggers failover instead of surfacing the raw error
- [ ] `pnpm test` passes (single file change in `errors.ts`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a small helper (`isJsonParseError`) to detect common malformed JSON parse errors coming from model tool-call argument parsing, and wires it into `classifyFailoverReason` to classify these cases as a `"format"` failover reason. This prevents raw `SyntaxError`-style JSON parsing failures from being surfaced directly to end users, and instead triggers the existing model fallback/retry behavior used for other request-format issues.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a narrow change to failover classification.
- Change is localized to error classification and uses a simple regex-based detection; main risk is overmatching and triggering failover on unrelated errors, but impact is limited to retry behavior.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->