### PR TITLE
fix: respect allowAny flag for model overrides and improve Ollama provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+package-lock.json

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -58,7 +58,7 @@ function resolveProviderAuthOverride(
 ): ModelProviderAuthMode | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   const auth = entry?.auth;
-  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token") {
+  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token" || auth === "none") {
     return auth;
   }
   return undefined;
@@ -162,6 +162,12 @@ export async function resolveApiKeyForProvider(params: {
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
     return resolveAwsSdkAuthInfo();
+  }
+
+  // Providers with auth: "none" don't require an API key (e.g., local Ollama).
+  // Return a placeholder key so the OpenAI client doesn't reject the request.
+  if (authOverride === "none") {
+    return { apiKey: "ollama", source: "auth:none", mode: "api-key" };
   }
 
   const order = resolveAuthProfileOrder({

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -58,7 +58,13 @@ function resolveProviderAuthOverride(
 ): ModelProviderAuthMode | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   const auth = entry?.auth;
-  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token" || auth === "none") {
+  if (
+    auth === "api-key" ||
+    auth === "aws-sdk" ||
+    auth === "oauth" ||
+    auth === "token" ||
+    auth === "none"
+  ) {
     return auth;
   }
   return undefined;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -173,7 +173,7 @@ export async function resolveApiKeyForProvider(params: {
   // Providers with auth: "none" don't require an API key (e.g., local Ollama).
   // Return a placeholder key so the OpenAI client doesn't reject the request.
   if (authOverride === "none") {
-    return { apiKey: "ollama", source: "auth:none", mode: "api-key" };
+    return { apiKey: "no-key", source: "auth:none", mode: "api-key" };
   }
 
   const order = resolveAuthProfileOrder({

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -7,6 +7,7 @@ import {
 import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
 import { resolveAwsSdkEnvVarName, resolveEnvApiKey } from "./model-auth.js";
+import { normalizeProviderId } from "./model-selection.js";
 import {
   buildSyntheticModelDefinition,
   SYNTHETIC_BASE_URL,
@@ -461,8 +462,11 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("ollama") ??
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
-    // Use the explicit config's base URL for discovery if available
-    const explicitOllama = params.explicitProviders?.ollama;
+    // Use the explicit config's base URL for discovery if available.
+    // Resolve by normalized provider id so keys like "ollama-local" are matched too.
+    const explicitOllama = Object.entries(params.explicitProviders ?? {}).find(
+      ([key]) => normalizeProviderId(key) === "ollama",
+    )?.[1];
     const ollamaApiBaseUrl = explicitOllama?.baseUrl
       ? explicitOllama.baseUrl.replace(/\/v1\/?$/, "")
       : undefined;

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -89,7 +89,7 @@ export async function ensureOpenClawModelsJson(
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
 
   const explicitProviders = cfg.models?.providers ?? {};
-  const implicitProviders = await resolveImplicitProviders({ agentDir });
+  const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -49,6 +49,11 @@ export type EmbeddedPiSubscribeState = {
   suppressBlockChunks: boolean;
   lastReasoningSent?: string;
 
+  /** Set to true when the provider sends native thinking blocks (via API-level reasoning field).
+   *  When detected, enforceFinalTag is dynamically disabled since the provider handles
+   *  reasoning separation natively and tag-based enforcement is unnecessary. */
+  nativeReasoningDetected: boolean;
+
   compactionInFlight: boolean;
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -266,6 +266,7 @@ export async function agentCommand(
     let allowedModelKeys = new Set<string>();
     let allowedModelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
     let modelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | null = null;
+    let allowAnyModel = false;
 
     if (needsModelCatalog) {
       modelCatalog = await loadModelCatalog({ config: cfg });
@@ -277,6 +278,7 @@ export async function agentCommand(
       });
       allowedModelKeys = allowed.allowedKeys;
       allowedModelCatalog = allowed.allowedCatalog;
+      allowAnyModel = allowed.allowAny;
     }
 
     if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
@@ -287,6 +289,7 @@ export async function agentCommand(
         const key = modelKey(overrideProvider, overrideModel);
         if (
           !isCliProvider(overrideProvider, cfg) &&
+          !allowAnyModel &&
           allowedModelKeys.size > 0 &&
           !allowedModelKeys.has(key)
         ) {
@@ -311,6 +314,7 @@ export async function agentCommand(
       const key = modelKey(candidateProvider, storedModelOverride);
       if (
         isCliProvider(candidateProvider, cfg) ||
+        allowAnyModel ||
         allowedModelKeys.size === 0 ||
         allowedModelKeys.has(key)
       ) {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -13,7 +13,7 @@ export type ModelCompatConfig = {
   maxTokensField?: "max_completion_tokens" | "max_tokens";
 };
 
-export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";
+export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token" | "none";
 
 export type ModelDefinitionConfig = {
   id: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -50,7 +50,7 @@ export const ModelProviderSchema = z
     baseUrl: z.string().min(1),
     apiKey: z.string().optional(),
     auth: z
-      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
+      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token"), z.literal("none")])
       .optional(),
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -50,7 +50,13 @@ export const ModelProviderSchema = z
     baseUrl: z.string().min(1),
     apiKey: z.string().optional(),
     auth: z
-      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token"), z.literal("none")])
+      .union([
+        z.literal("api-key"),
+        z.literal("aws-sdk"),
+        z.literal("oauth"),
+        z.literal("token"),
+        z.literal("none"),
+      ])
       .optional(),
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -13,12 +13,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   }
   const normalized = provider.trim().toLowerCase();
 
-  // Check for exact matches or known prefixes/substrings for reasoning providers
-  if (
-    normalized === "ollama" ||
-    normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
-  ) {
+  // Check for exact matches or known prefixes/substrings for reasoning providers.
+  // Note: Ollama is intentionally excluded — its OpenAI-compatible endpoint
+  // already separates reasoning via the native `reasoning` field in streaming
+  // chunks, so tag-based enforcement is unnecessary and causes empty output.
+  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
     return true;
   }
 

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -14,10 +14,15 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   const normalized = provider.trim().toLowerCase();
 
   // Check for exact matches or known prefixes/substrings for reasoning providers.
-  // Note: Ollama is intentionally excluded — its OpenAI-compatible endpoint
-  // already separates reasoning via the native `reasoning` field in streaming
-  // chunks, so tag-based enforcement is unnecessary and causes empty output.
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  // Note: For providers listed here that also support native API-level reasoning
+  // (e.g. Ollama via the `reasoning` field), enforceFinalTag is dynamically
+  // disabled at runtime when native thinking blocks are detected in the response.
+  // See nativeReasoningDetected in pi-embedded-subscribe.
+  if (
+    normalized === "ollama" ||
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai"
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## Purpose

Ollama models are broken in two independent ways: (1) model overrides via `sessions_spawn` are silently cleared, falling back to the default Anthropic model, and (2) all Ollama responses return empty output because `enforceFinalTag` is statically applied based on provider name, even when the provider handles reasoning natively via the API. This PR fixes both issues with a runtime detection approach and improves Ollama provider configuration.

---

### 1. Model override silently cleared
In `agentCommand`, `buildAllowedModelSet` returns `allowAny: true` when no explicit model allowlist is configured, but the validation code ignored this flag. It only checked `allowedModelKeys.has(key)`, which only contains models from the curated catalog. Custom provider models (Ollama, etc.) not in the catalog were silently rejected, clearing the session's model override back to the default — even though `sessions.patch` reported success.

Now tracks `allowAny` and skips the allowlist check when true.

### 2. Dynamic native reasoning detection (replaces static provider check)
`isReasoningTagProvider()` returns `true` for Ollama, which sets `enforceFinalTag: true` — this strips ALL output not wrapped in `<final>` tags. Ollama models don't emit these tags; they separate reasoning via the native `reasoning` field in their OpenAI-compatible API.

Rather than simply removing Ollama from the list (which would break models that genuinely need tag enforcement), this PR adds **runtime detection**: a `nativeReasoningDetected` flag in the subscribe state that is set when the provider sends native thinking blocks via the API. When detected, `enforceFinalTag` is automatically bypassed — the provider already handles reasoning separation natively.

This approach is **provider-agnostic**: any provider that sends native thinking blocks gets automatic bypass, regardless of whether it's in the `isReasoningTagProvider()` list. Providers that rely purely on `<think>/<final>` tags (like Google Gemini CLI) continue to work with enforcement enabled.

### 3. Ollama auto-discovery uses hardcoded localhost URL
`discoverOllamaModels()` always queried `http://127.0.0.1:11434` regardless of the user's configured `baseUrl`. Now accepts an optional base URL parameter, resolved via `normalizeProviderId()` so keys like `ollama-local` are matched too.

### 4. API key handling for keyless providers
Added `auth: "none"` mode for providers that don't require authentication (like local Ollama). Returns a provider-agnostic placeholder key so the OpenAI client doesn't reject the request. Updated the zod schema and type definitions.

---

### Files changed
- `src/commands/agent.ts` — respect `allowAny` flag for model overrides
- `src/agents/pi-embedded-subscribe.ts` — bypass `enforceFinalTag` when `nativeReasoningDetected`
- `src/agents/pi-embedded-subscribe.handlers.messages.ts` — detect native thinking blocks early in `handleMessageEnd`
- `src/agents/pi-embedded-subscribe.handlers.types.ts` — add `nativeReasoningDetected` state field
- `src/utils/provider-utils.ts` — updated comments explaining runtime detection
- `src/agents/model-auth.ts` — `auth: "none"` with provider-agnostic placeholder
- `src/agents/models-config.providers.ts` — Ollama URL discovery with normalized provider ID
- `src/agents/models-config.ts` — pass explicit providers for URL resolution
- `src/config/types.models.ts` + `src/config/zod-schema.core.ts` — `"none"` auth mode

Fixes #2474, fixes #2279, relates to #2838