### PR TITLE
agents: add tool policy conformance snapshot (no runtime behavior change)

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Regenerate extracted constants from openclaw
         run: |

--- a/src/agents/tool-policy.conformance.test.ts
+++ b/src/agents/tool-policy.conformance.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import { TOOL_GROUPS } from "./tool-policy";
+import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance";
+
+describe("TOOL_POLICY_CONFORMANCE", () => {
+  test("matches exported TOOL_GROUPS exactly", () => {
+    expect(TOOL_POLICY_CONFORMANCE.toolGroups).toEqual(TOOL_GROUPS);
+  });
+
+  test("is JSON-serializable", () => {
+    expect(() => JSON.stringify(TOOL_POLICY_CONFORMANCE)).not.toThrow();
+  });
+});

--- a/src/agents/tool-policy.conformance.test.ts
+++ b/src/agents/tool-policy.conformance.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { TOOL_GROUPS } from "./tool-policy.js";
-import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance";
+import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance.js";
 
 describe("TOOL_POLICY_CONFORMANCE", () => {
   test("matches exported TOOL_GROUPS exactly", () => {

--- a/src/agents/tool-policy.conformance.test.ts
+++ b/src/agents/tool-policy.conformance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { TOOL_GROUPS } from "./tool-policy";
+import { TOOL_GROUPS } from "./tool-policy.js";
 import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance";
 
 describe("TOOL_POLICY_CONFORMANCE", () => {

--- a/src/agents/tool-policy.conformance.test.ts
+++ b/src/agents/tool-policy.conformance.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
-
-import { TOOL_GROUPS } from "./tool-policy.js";
 import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance.js";
+import { TOOL_GROUPS } from "./tool-policy.js";
 
 describe("TOOL_POLICY_CONFORMANCE", () => {
   test("matches exported TOOL_GROUPS exactly", () => {

--- a/src/agents/tool-policy.conformance.ts
+++ b/src/agents/tool-policy.conformance.ts
@@ -1,0 +1,17 @@
+/**
+ * Conformance snapshot for tool policy.
+ *
+ * Security note:
+ * - This is static, build-time information (no runtime I/O, no network exposure).
+ * - Intended for CI/tools to detect drift between the implementation policy and
+ *   the formal models/extractors.
+ */
+
+import { TOOL_GROUPS } from "./tool-policy";
+
+// Tool name aliases are intentionally not exported from tool-policy today.
+// Keep the conformance snapshot focused on exported policy constants.
+
+export const TOOL_POLICY_CONFORMANCE = {
+  toolGroups: TOOL_GROUPS,
+} as const;

--- a/src/agents/tool-policy.conformance.ts
+++ b/src/agents/tool-policy.conformance.ts
@@ -7,7 +7,7 @@
  *   the formal models/extractors.
  */
 
-import { TOOL_GROUPS } from "./tool-policy";
+import { TOOL_GROUPS } from "./tool-policy.js";
 
 // Tool name aliases are intentionally not exported from tool-policy today.
 // Keep the conformance snapshot focused on exported policy constants.


### PR DESCRIPTION
## What
Adds a tiny, POJO-style **static conformance snapshot** for the tool policy:
- `src/agents/tool-policy.conformance.ts` exports `TOOL_POLICY_CONFORMANCE` (currently `{ toolGroups: TOOL_GROUPS }`).
- `src/agents/tool-policy.conformance.test.ts` asserts the snapshot matches `TOOL_GROUPS` exactly and is JSON-serializable.

## Why
We maintain external tooling/formal models that need a **stable, easy-to-extract source of truth** for the implemented tool policy (e.g. tool group names -> tool lists).

Without this, extractors end up scraping multiple internal modules/exports and are more likely to drift when code is reorganized.

This module provides a single, intentional “contract surface” that CI/tools can consume to detect drift.

## What this is NOT
- **Not a feature / not user-facing functionality.**
- **Not runtime introspection.** It does not read live config/state.
- **Not a network/API endpoint.** Nothing is exposed over HTTP.

## Security considerations
- Contains only already-public, static policy constants.
- No secrets, allowlists, tokens, host paths, or environment-derived values.
- Additive export only; no behavior change unless an external tool chooses to import it.

## Tests
- Verifies `TOOL_POLICY_CONFORMANCE.toolGroups` === `TOOL_GROUPS`.
- Verifies JSON serialization (so CI can safely consume it as data).