### PR TITLE
feat: add openai-codex/gpt-5.2 to xhigh thinking models

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
 ] as const;


### PR DESCRIPTION
## Summary
- Add `openai-codex/gpt-5.2` to XHIGH_MODEL_REFS list
- Enables xhigh thinking level for the model variant without `-codex` suffix

## Test plan
- [ ] Verify `openai-codex/gpt-5.2` now shows xhigh as available thinking level
- [ ] Confirm existing models (`openai/gpt-5.2`, `openai-codex/gpt-5.2-codex`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `openai-codex/gpt-5.2` to the `XHIGH_MODEL_REFS` allowlist used by `supportsXHighThinking()` / `listThinkingLevels()` so the xhigh thinking level becomes available for that provider/model pair (in addition to the existing `openai/gpt-5.2` and codex-suffixed variants).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line change adding a new model ref to an existing allowlist; no control-flow changes and all comparisons are case-normalized via existing sets.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->