### PR TITLE
CLI: clarify Moonshot AI/Kimi auth option labels based on user feedback

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -56,8 +56,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   },
   {
     value: "moonshot",
-    label: "Moonshot AI",
-    hint: "Kimi K2 + Kimi Coding",
+    label: "Moonshot AI (Kimi K2.5)",
+    hint: "API key + Kimi Code Plan",
     choices: ["moonshot-api-key", "kimi-code-api-key"],
   },
   {
@@ -146,8 +146,8 @@ export function buildAuthChoiceOptions(params: {
     value: "ai-gateway-api-key",
     label: "Vercel AI Gateway API key",
   });
-  options.push({ value: "moonshot-api-key", label: "Moonshot AI API key" });
-  options.push({ value: "kimi-code-api-key", label: "Kimi Coding API key" });
+  options.push({ value: "moonshot-api-key", label: "Kimi API key" });
+  options.push({ value: "kimi-code-api-key", label: "Kimi Code Plan API key" });
   options.push({ value: "synthetic-api-key", label: "Synthetic API key" });
   options.push({
     value: "venice-api-key",


### PR DESCRIPTION
As a Moonshot AI employee, we've received substantial user feedback indicating that the previous hints and labels for selecting Kimi models were confusing. Users had trouble distinguishing between the standard Moonshot API key and the Kimi Code Plan API key.

  This commit updates the labels and hints to be more explicit:
  - "Moonshot AI" → "Moonshot AI (Kimi K2.5)"
  - "Kimi K2 + Kimi Coding" → "API key + Kimi Code Plan"
  - "Moonshot AI API key" → "Kimi API key"
  - "Kimi Coding API key" → "Kimi Code Plan API key"

  These changes should reduce confusion when users configure their Kimi credentials during onboarding.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI onboarding/auth-provider selection copy for Moonshot/Kimi credentials to reduce user confusion. Specifically, it renames the Moonshot group label and hint (to explicitly mention Kimi K2.5 and that it requires an API key plus a Kimi Code Plan), and renames the two underlying options so users can distinguish a standard Kimi API key from a Kimi Code Plan API key. These changes are localized to `src/commands/auth-choice-options.ts`, where auth choice groups and options are assembled for the onboarding UI.

<h3>Confidence Score: 4.5/5</h3>

- This PR is safe to merge; it’s a localized copy change with minimal behavioral impact.
- Only user-facing labels/hints were modified; no identifiers, choice values, or control flow changed. Main risk is copy drift/accuracy over time (e.g., hard-coded model version).
- src/commands/auth-choice-options.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->