### PR TITLE
feat(hooks): add systemPrompt and tools to before_agent_start event

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -300,7 +300,9 @@ export function wrapStreamFnTrimToolCallNames(baseFn: StreamFn): StreamFn {
 
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
-  messages: unknown[];
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  tools?: Array<{ name: string; description?: string; parameters?: Record<string, unknown> }>;
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -327,6 +329,8 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
+              systemPrompt: params.systemPrompt,
+              tools: params.tools,
             },
             params.hookCtx,
           )
@@ -1194,6 +1198,23 @@ export async function runEmbeddedAttempt(
       try {
         const promptStartedAt = Date.now();
 
+        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
+        // Must happen before hooks so plugins see the exact messages sent to the LLM.
+        const leafEntry = sessionManager.getLeafEntry();
+        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+          if (leafEntry.parentId) {
+            sessionManager.branch(leafEntry.parentId);
+          } else {
+            sessionManager.resetLeaf();
+          }
+          const sessionContext = sessionManager.buildSessionContext();
+          activeSession.agent.replaceMessages(sessionContext.messages);
+          log.warn(
+            `Removed orphaned user message to prevent consecutive user turns. ` +
+              `runId=${params.runId} sessionId=${params.sessionId}`,
+          );
+        }
+
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
@@ -1207,6 +1228,12 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          systemPrompt: systemPromptText,
+          tools: tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          })),
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
@@ -1232,22 +1259,6 @@ export async function runEmbeddedAttempt(
           prompt: effectivePrompt,
           messages: activeSession.messages,
         });
-
-        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
-          if (leafEntry.parentId) {
-            sessionManager.branch(leafEntry.parentId);
-          } else {
-            sessionManager.resetLeaf();
-          }
-          const sessionContext = sessionManager.buildSessionContext();
-          activeSession.agent.replaceMessages(sessionContext.messages);
-          log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
-              `runId=${params.runId} sessionId=${params.sessionId}`,
-          );
-        }
 
         try {
           // Idempotent cleanup for legacy sessions with persisted image payloads.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -360,7 +360,14 @@ export type PluginHookBeforePromptBuildResult = {
 export type PluginHookBeforeAgentStartEvent = {
   prompt: string;
   /** Optional because legacy hook can run in pre-session phase. */
-  messages?: unknown[];
+  messages?: AgentMessage[];
+  // Expose full context for monitoring/capture plugins
+  systemPrompt?: string;
+  tools?: Array<{
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  }>;
 };
 
 export type PluginHookBeforeAgentStartResult = PluginHookBeforePromptBuildResult &


### PR DESCRIPTION
Exposes the full assembled system prompt and available tools array in the `before_agent_start` plugin hook event. This enables monitoring and capture plugins to see the complete context sent to LLMs.

## Changes
- Add optional `systemPrompt` field (full prompt with injected files)
- Add optional `tools` field (sanitized tools array)  
- No breaking changes (fields are optional)

## Use case
LLM monitoring plugins need to see the full context being sent to providers for observability, debugging, and capture purposes.

## Testing
- ✅ `pnpm tsgo` - TypeScript passes
- ✅ `pnpm format` - Formatting passes
- ✅ `pnpm lint` - No new errors
- ✅ `pnpm build` - Build passes
- ✅ `pnpm test` - 4922 tests passed

## AI Disclosure
- [x] AI-assisted contribution (Claude)
- [x] Fully tested locally (all checks pass)
- [x] We understand the changes: passing two existing variables (`appendPrompt` and `tools`) to the hook that already exists ~50 lines earlier in the same function

---
AI-assisted contribution 🤖
---

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `before_agent_start` plugin hook payload to include the fully assembled `systemPrompt` (with injected files) and a sanitized `tools` array (name/description/parameters) from the embedded runner. This enables monitoring/capture plugins to observe the full LLM invocation context without changing existing plugins, since the new fields are optional.

The change is localized to the embedded attempt runner where hooks are invoked and to the plugin type definitions that describe the event payload.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it adds optional observability fields with minimal behavioral impact.
- Changes are additive and type-safe, but the current hook payload can include a messages snapshot that is later mutated (orphan user-message repair), which can mislead monitoring/capture plugins about the exact context actually sent to the provider.
- src/agents/pi-embedded-runner/run/attempt.ts (hook call ordering vs message repair)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->