### PR TITLE
signal: resolve mentions in inbound messages

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -1,4 +1,5 @@
-import type { SignalEventHandlerDeps, SignalReceivePayload } from "./event-handler.types.js";
+import type { SignalEventHandlerDeps, SignalMention, SignalReceivePayload } from "./event-handler.types.js";
+import { signalRpcRequest } from "../client.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
@@ -43,6 +44,91 @@ import {
   resolveSignalSender,
 } from "../identity.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
+
+// ---------------------------------------------------------------------------
+// Signal mention resolution
+// ---------------------------------------------------------------------------
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isUuid(s: string | null | undefined): boolean {
+  return UUID_RE.test(s?.trim() ?? "");
+}
+
+/**
+ * Cache of Signal UUID → display name.
+ *
+ * Seeded once from signal-cli `listContacts` (profile names) and then
+ * continuously updated from `envelope.sourceName` on every inbound SSE event.
+ * Used to resolve mentions whose `name` field is just the UUID (signal-cli
+ * does this for users not in the local address book).
+ */
+const signalNameCache = new Map<string, string>();
+let signalNameCacheSeeded = false;
+
+function nameCachePut(uuid: string | null | undefined, name: string | null | undefined): void {
+  if (!uuid || !name || isUuid(name)) return;
+  signalNameCache.set(uuid.toLowerCase(), name);
+}
+
+function nameCacheGet(uuid: string | null | undefined): string | undefined {
+  return uuid ? signalNameCache.get(uuid.toLowerCase()) : undefined;
+}
+
+async function seedSignalNameCache(baseUrl: string, account: string | undefined): Promise<void> {
+  if (signalNameCacheSeeded) return;
+  signalNameCacheSeeded = true;
+  try {
+    type Contact = {
+      uuid?: string;
+      profile?: { givenName?: string; familyName?: string };
+    };
+    const contacts = await signalRpcRequest<Contact[]>("listContacts", { account }, { baseUrl, timeoutMs: 5000 });
+    if (Array.isArray(contacts)) {
+      for (const c of contacts) {
+        const displayName = [c.profile?.givenName, c.profile?.familyName].filter(Boolean).join(" ").trim();
+        if (c.uuid && displayName) nameCachePut(c.uuid, displayName);
+      }
+    }
+  } catch {
+    // Non-fatal — cache will still be populated from SSE events.
+  }
+}
+
+/**
+ * Replace U+FFFC (Object Replacement Character) placeholders with `@name`
+ * using the mention metadata array from signal-cli.
+ *
+ * signal-cli represents Signal mentions as:
+ *   - `dataMessage.message` contains U+FFFC at the mention position
+ *   - `dataMessage.mentions[]` contains `{name, number, uuid, start, length}`
+ *
+ * The `name` field is sometimes set to the UUID rather than the display name
+ * (especially for users not in the local address book), so we fall back to
+ * the name cache, then number, then UUID.
+ */
+function resolveSignalMentions(text: string, mentions: SignalMention[] | null | undefined): string {
+  if (!mentions || mentions.length === 0) return text;
+
+  // Process from end to start so replacements don't shift earlier indices.
+  const sorted = [...mentions].sort((a, b) => (b.start ?? 0) - (a.start ?? 0));
+  let result = text;
+  for (const mention of sorted) {
+    const start = mention.start ?? 0;
+    const length = mention.length ?? 1;
+
+    let label = mention.name?.trim();
+    if (!label || isUuid(label)) {
+      label =
+        nameCacheGet(mention.uuid) ||
+        mention.number?.trim() ||
+        mention.uuid?.trim() ||
+        "someone";
+    }
+
+    result = result.slice(0, start) + `@${label}` + result.slice(start + length);
+  }
+  return result;
+}
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const inboundDebounceMs = resolveInboundDebounceMs({ cfg: deps.cfg, channel: "signal" });
@@ -296,6 +382,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   });
 
   return async (event: { event?: string; data?: string }) => {
+    // Seed the mention name cache from contacts on first event.
+    void seedSignalNameCache(deps.baseUrl, deps.account);
+
     if (event.event !== "receive" || !event.data) {
       return;
     }
@@ -322,6 +411,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (!sender) {
       return;
     }
+
+    // Populate mention name cache from every inbound envelope.
+    const senderUuid = envelope.sourceUuid ?? (sender.kind === "uuid" ? sender.raw : undefined);
+    if (senderUuid && envelope.sourceName) {
+      nameCachePut(senderUuid, envelope.sourceName);
+    }
+
     if (deps.account && sender.kind === "phone") {
       if (sender.e164 === normalizeE164(deps.account)) {
         return;
@@ -334,7 +430,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       : deps.isSignalReactionMessage(dataMessage?.reaction)
         ? dataMessage?.reaction
         : null;
-    const messageText = (dataMessage?.message ?? "").trim();
+    const messageText = resolveSignalMentions(dataMessage?.message ?? "", dataMessage?.mentions).trim();
     const quoteText = dataMessage?.quote?.text?.trim() ?? "";
     const hasBodyContent =
       Boolean(messageText || quoteText) || Boolean(!reaction && dataMessage?.attachments?.length);

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -16,9 +16,18 @@ export type SignalEnvelope = {
   reactionMessage?: SignalReactionMessage | null;
 };
 
+export type SignalMention = {
+  name?: string | null;
+  number?: string | null;
+  uuid?: string | null;
+  start?: number;
+  length?: number;
+};
+
 export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
+  mentions?: SignalMention[] | null;
   attachments?: Array<SignalAttachment>;
   groupInfo?: {
     groupId?: string | null;


### PR DESCRIPTION
fixes #1926

Signal messages with mentions embed `U+FFFC` (Object Replacement Character) as a placeholder in the message body, with the actual mention data (name, UUID, start position, length) in a separate dataMessage.mentions array. OpenClaw was passing the raw message text through without resolving these placeholders, so mentions appeared as invisible/broken characters to the agent.

This adds resolveSignalMentions() which replaces each U+FFFC placeholder with @name using the mention metadata. Since signal-cli sometimes puts the UUID as the name field (for users not in the local address book), a name cache is seeded from listContacts profile data at startup and continuously updated from envelope.sourceName on every inbound SSE event, with fallbacks to phone number then UUID.

Tested in a live Signal group with mentions of both contacts (resolved via profile name from listContacts) and non-contacts/bots (resolved via the SSE sourceName cache). Also includes a new SignalMention type and mentions field on SignalDataMessage.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Signal mention support by introducing a `SignalMention` type on inbound `SignalDataMessage`, seeding a UUID→display-name cache from `listContacts`, updating it opportunistically from `envelope.sourceName`, and replacing U+FFFC placeholders in `dataMessage.message` with `@name` based on the `mentions` metadata.

The change is localized to the Signal SSE receive path (`src/signal/monitor/event-handler.ts`) and the associated payload typings (`src/signal/monitor/event-handler.types.ts`), improving how inbound messages are rendered for downstream routing/command detection/agent prompts.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple edge-case correctness issues around mention seeding and offset handling.
- Core logic is straightforward and scoped, but mention index handling currently trusts external offsets (can corrupt text on malformed/inconsistent payloads) and the cache seeding guard can permanently disable seeding after a transient failure and may still allow overlapping calls early on.
- src/signal/monitor/event-handler.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->