### PR TITLE
WhatsApp: add HTTP/HTTPS proxy support via environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- WhatsApp: add HTTP/HTTPS proxy support via `HTTPS_PROXY`/`HTTP_PROXY` environment variables.
+
 ### Fixes
 
 - Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "express": "^5.2.1",
     "file-type": "^21.3.0",
     "grammy": "^1.39.3",
+    "https-proxy-agent": "^7.0.5",
     "jiti": "^2.6.1",
     "json5": "^2.2.3",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       grammy:
         specifier: ^1.39.3
         version: 1.39.3
+      https-proxy-agent:
+        specifier: ^7.0.5
+        version: 7.0.6
       jiti:
         specifier: ^2.6.1
         version: 2.6.1

--- a/src/web/session.proxy.test.ts
+++ b/src/web/session.proxy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+describe("WhatsApp proxy support", () => {
+  it("reads HTTPS_PROXY environment variable", () => {
+    const originalProxy = process.env.HTTPS_PROXY;
+    try {
+      process.env.HTTPS_PROXY = "http://127.0.0.1:8080";
+      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      expect(proxyUrl).toBe("http://127.0.0.1:8080");
+    } finally {
+      if (originalProxy) {
+        process.env.HTTPS_PROXY = originalProxy;
+      } else {
+        delete process.env.HTTPS_PROXY;
+      }
+    }
+  });
+
+  it("reads HTTP_PROXY environment variable when HTTPS_PROXY is not set", () => {
+    const originalHttpsProxy = process.env.HTTPS_PROXY;
+    const originalHttpProxy = process.env.HTTP_PROXY;
+    try {
+      delete process.env.HTTPS_PROXY;
+      process.env.HTTP_PROXY = "http://127.0.0.1:1080";
+      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      expect(proxyUrl).toBe("http://127.0.0.1:1080");
+    } finally {
+      if (originalHttpsProxy) {
+        process.env.HTTPS_PROXY = originalHttpsProxy;
+      }
+      if (originalHttpProxy) {
+        process.env.HTTP_PROXY = originalHttpProxy;
+      } else {
+        delete process.env.HTTP_PROXY;
+      }
+    }
+  });
+
+  it("returns undefined when no proxy environment variables are set", () => {
+    const originalHttpsProxy = process.env.HTTPS_PROXY;
+    const originalHttpProxy = process.env.HTTP_PROXY;
+    try {
+      delete process.env.HTTPS_PROXY;
+      delete process.env.HTTP_PROXY;
+      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      expect(proxyUrl).toBeUndefined();
+    } finally {
+      if (originalHttpsProxy) {
+        process.env.HTTPS_PROXY = originalHttpsProxy;
+      }
+      if (originalHttpProxy) {
+        process.env.HTTP_PROXY = originalHttpProxy;
+      }
+    }
+  });
+});

--- a/src/web/session.proxy.test.ts
+++ b/src/web/session.proxy.test.ts
@@ -2,55 +2,97 @@ import { describe, expect, it } from "vitest";
 
 describe("WhatsApp proxy support", () => {
   it("reads HTTPS_PROXY environment variable", () => {
-    const originalProxy = process.env.HTTPS_PROXY;
+    const saved = saveProxyEnv();
     try {
       process.env.HTTPS_PROXY = "http://127.0.0.1:8080";
-      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      const proxyUrl = resolveProxyUrl();
       expect(proxyUrl).toBe("http://127.0.0.1:8080");
     } finally {
-      if (originalProxy) {
-        process.env.HTTPS_PROXY = originalProxy;
-      } else {
-        delete process.env.HTTPS_PROXY;
-      }
+      restoreProxyEnv(saved);
     }
   });
 
-  it("reads HTTP_PROXY environment variable when HTTPS_PROXY is not set", () => {
-    const originalHttpsProxy = process.env.HTTPS_PROXY;
-    const originalHttpProxy = process.env.HTTP_PROXY;
+  it("reads https_proxy (lowercase) when HTTPS_PROXY is not set", () => {
+    const saved = saveProxyEnv();
     try {
-      delete process.env.HTTPS_PROXY;
+      process.env.https_proxy = "http://127.0.0.1:8080";
+      const proxyUrl = resolveProxyUrl();
+      expect(proxyUrl).toBe("http://127.0.0.1:8080");
+    } finally {
+      restoreProxyEnv(saved);
+    }
+  });
+
+  it("reads HTTP_PROXY when HTTPS_PROXY variants are not set", () => {
+    const saved = saveProxyEnv();
+    try {
       process.env.HTTP_PROXY = "http://127.0.0.1:1080";
-      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      const proxyUrl = resolveProxyUrl();
       expect(proxyUrl).toBe("http://127.0.0.1:1080");
     } finally {
-      if (originalHttpsProxy) {
-        process.env.HTTPS_PROXY = originalHttpsProxy;
-      }
-      if (originalHttpProxy) {
-        process.env.HTTP_PROXY = originalHttpProxy;
-      } else {
-        delete process.env.HTTP_PROXY;
-      }
+      restoreProxyEnv(saved);
+    }
+  });
+
+  it("reads http_proxy (lowercase) as last fallback", () => {
+    const saved = saveProxyEnv();
+    try {
+      process.env.http_proxy = "http://127.0.0.1:1080";
+      const proxyUrl = resolveProxyUrl();
+      expect(proxyUrl).toBe("http://127.0.0.1:1080");
+    } finally {
+      restoreProxyEnv(saved);
+    }
+  });
+
+  it("prefers HTTPS_PROXY over lowercase variants", () => {
+    const saved = saveProxyEnv();
+    try {
+      process.env.HTTPS_PROXY = "http://127.0.0.1:8080";
+      process.env.https_proxy = "http://127.0.0.1:9090";
+      const proxyUrl = resolveProxyUrl();
+      expect(proxyUrl).toBe("http://127.0.0.1:8080");
+    } finally {
+      restoreProxyEnv(saved);
     }
   });
 
   it("returns undefined when no proxy environment variables are set", () => {
-    const originalHttpsProxy = process.env.HTTPS_PROXY;
-    const originalHttpProxy = process.env.HTTP_PROXY;
+    const saved = saveProxyEnv();
     try {
-      delete process.env.HTTPS_PROXY;
-      delete process.env.HTTP_PROXY;
-      const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      const proxyUrl = resolveProxyUrl();
       expect(proxyUrl).toBeUndefined();
     } finally {
-      if (originalHttpsProxy) {
-        process.env.HTTPS_PROXY = originalHttpsProxy;
-      }
-      if (originalHttpProxy) {
-        process.env.HTTP_PROXY = originalHttpProxy;
-      }
+      restoreProxyEnv(saved);
     }
   });
 });
+
+function resolveProxyUrl() {
+  return (
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy
+  );
+}
+
+function saveProxyEnv() {
+  return {
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    https_proxy: process.env.https_proxy,
+    HTTP_PROXY: process.env.HTTP_PROXY,
+    http_proxy: process.env.http_proxy,
+  };
+}
+
+function restoreProxyEnv(saved: ReturnType<typeof saveProxyEnv>) {
+  delete process.env.HTTPS_PROXY;
+  delete process.env.https_proxy;
+  delete process.env.HTTP_PROXY;
+  delete process.env.http_proxy;
+  if (saved.HTTPS_PROXY) process.env.HTTPS_PROXY = saved.HTTPS_PROXY;
+  if (saved.https_proxy) process.env.https_proxy = saved.https_proxy;
+  if (saved.HTTP_PROXY) process.env.HTTP_PROXY = saved.HTTP_PROXY;
+  if (saved.http_proxy) process.env.http_proxy = saved.http_proxy;
+}

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -5,6 +5,7 @@ import {
   makeWASocket,
   useMultiFileAuthState,
 } from "@whiskeysockets/baileys";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import qrcode from "qrcode-terminal";
@@ -109,6 +110,8 @@ export async function createWaSocket(
   maybeRestoreCredsFromBackup(authDir);
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
   const sock = makeWASocket({
     auth: {
       creds: state.creds,
@@ -117,6 +120,8 @@ export async function createWaSocket(
     version,
     logger,
     printQRInTerminal: false,
+    agent: proxyAgent,
+    fetchAgent: proxyAgent,
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
     markOnlineOnConnect: false,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -110,7 +110,11 @@ export async function createWaSocket(
   maybeRestoreCredsFromBackup(authDir);
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
-  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
   const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
   const sock = makeWASocket({
     auth: {


### PR DESCRIPTION
# Add HTTP/HTTPS Proxy Support for WhatsApp Channel

## Summary

This PR adds HTTP/HTTPS proxy support to OpenClaw's WhatsApp channel via standard environment variables (`HTTPS_PROXY`/`HTTP_PROXY`), enabling users behind corporate firewalls or in restricted regions to connect to WhatsApp Web.

## Motivation

OpenClaw's WhatsApp channel (powered by Baileys) currently does not respect proxy environment variables, causing connection failures for users who require proxy access:

```
WhatsApp Web connection ended before fully opening. 
status=408 Request Time-out WebSocket Error (Opening handshake has timed out)
```

While Baileys supports proxy configuration via `agent` and `fetchAgent` options in `makeWASocket()`, OpenClaw was not utilizing these parameters, making proxy usage impossible without source code modifications.

## Changes

### Modified Files
- `src/web/session.ts` - Added proxy detection and agent configuration
- `package.json` - Added `https-proxy-agent` dependency
- `CHANGELOG.md` - Documented the feature

### New Files
- `src/web/session.proxy.test.ts` - Unit tests for proxy environment variable detection

### Implementation Details

The implementation reads proxy configuration from environment variables and passes it to Baileys:

```typescript
import { HttpsProxyAgent } from "https-proxy-agent";

// Detect proxy from environment
const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;

// Configure Baileys socket with proxy support
const sock = makeWASocket({
    auth: { /* ... */ },
    version,
    logger,
    printQRInTerminal: false,
    agent: proxyAgent,        // WebSocket connections
    fetchAgent: proxyAgent,   // Media upload/download
    browser: ["openclaw", "cli", VERSION],
    // ...
});
```

## Usage

Set proxy environment variables before running OpenClaw:

```bash
# Temporary (current session)
export HTTPS_PROXY=http://127.0.0.1:8080
openclaw channels login

# Persistent (add to shell profile)
echo 'export HTTPS_PROXY=http://127.0.0.1:8080' >> ~/.zshrc
source ~/.zshrc
```

## Testing

**Verified scenarios:**
- ✅ HTTP proxy connection (tested with ClashX Pro on port 1080)
- ✅ WhatsApp Web WebSocket handshake through proxy
- ✅ QR code generation and device pairing
- ✅ Session establishment and message delivery
- ✅ Backward compatibility (no proxy environment variables set)
- ✅ Unit tests for environment variable detection logic

**Test commands:**
```bash
pnpm lint    # ✅ Passed (0 errors)
pnpm build   # ✅ Successful
pnpm test    # ✅ New tests passing
```

## Benefits

- **Standards-compliant**: Uses Node.js standard `HTTP_PROXY`/`HTTPS_PROXY` conventions
- **Zero breaking changes**: Fully backward compatible—no impact on existing users
- **Minimal footprint**: Only ~10 lines of code added
- **Broad compatibility**: Works with any HTTP/HTTPS proxy (Clash, V2Ray, Surge, corporate proxies)
- **Enterprise-ready**: Enables deployment in corporate networks with mandatory proxies

## Use Cases

This feature enables OpenClaw usage in:
- Corporate networks with mandatory HTTP proxies
- Regions with restricted access to WhatsApp Web infrastructure
- Development environments with network security policies
- VPN/proxy-based network configurations

## Checklist

- [x] Code follows project style guidelines (oxlint passed)
- [x] Changes are backward compatible
- [x] Tested with proxy enabled
- [x] Tested without proxy (backward compatibility verified)
- [x] Unit tests added and passing
- [x] Build successful (`pnpm build`)
- [x] Changelog updated
- [x] No breaking changes

## Additional Notes

- The `https-proxy-agent` package (v7.0.6) is added as a direct dependency
- Both `agent` (WebSocket) and `fetchAgent` (HTTP requests) are configured to ensure complete proxy coverage
- Proxy detection follows standard Node.js environment variable precedence: `HTTPS_PROXY` → `HTTP_PROXY`
- No configuration file changes required—purely environment-based

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds WhatsApp proxy support by reading standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY` plus lowercase variants) in `src/web/session.ts` and wiring a `HttpsProxyAgent` into Baileys via `agent` and `fetchAgent`. Includes a small vitest suite verifying env var precedence, and records the change in the changelog while adding `https-proxy-agent` to dependencies.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and scoped to WhatsApp session setup.
- The runtime change is a straightforward env-var lookup and optional proxy agent injection; no broad refactors. Main concern is test reliability: current tests validate a local helper rather than the actual production resolver, so regressions in `createWaSocket` could slip through without failing CI.
- src/web/session.proxy.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->