### PR TITLE
fix(auth): fix Gemini CLI path detection for global npm installs on Windows

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -94,6 +94,48 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
       ),
     ];
 
+    if (process.platform === "win32") {
+      const npmBinDir = dirname(resolvedPath);
+      searchPaths.push(
+        join(
+          npmBinDir,
+          "node_modules",
+          "@google",
+          "gemini-cli",
+          "node_modules",
+          "@google",
+          "gemini-cli-core",
+          "dist",
+          "src",
+          "code_assist",
+          "oauth2.js",
+        ),
+        join(
+          npmBinDir,
+          "node_modules",
+          "@google",
+          "gemini-cli",
+          "node_modules",
+          "@google",
+          "gemini-cli-core",
+          "dist",
+          "code_assist",
+          "oauth2.js",
+        ),
+        join(
+          npmBinDir,
+          "node_modules",
+          "@google",
+          "gemini-cli-core",
+          "dist",
+          "src",
+          "code_assist",
+          "oauth2.js",
+        ),
+        join(npmBinDir, "node_modules", "@google", "gemini-cli-core", "dist", "code_assist", "oauth2.js"),
+      );
+    }
+
     let content: string | null = null;
     for (const p of searchPaths) {
       if (existsSync(p)) {


### PR DESCRIPTION
---

  Description

  Problem:
  OpenClaw fails to detect Gemini CLI on Windows because it cannot correctly resolve the global npm package path
  structure. The relative path between the binary file and node_modules on Windows differs from Linux/macOS, which
  prevents the system from reading oauth2.js to retrieve the OAuth configuration.

  Changes:
  I have modified extensions/google-gemini-cli-auth/oauth.ts to include specific search path logic for Windows
  environments. This allows OpenClaw to correctly locate the Gemini CLI credentials file within the global npm
  directory.

  ---

   - [x] AI-assisted (Vibe-coded)
   - [x] Fully tested on Windows 11

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `extensions/google-gemini-cli-auth/oauth.ts` to better locate the Gemini CLI’s bundled `oauth2.js` on Windows by adding additional Windows-only candidate paths derived from the resolved `gemini` executable path. The intent is to handle global npm install directory layouts that differ from macOS/Linux so OpenClaw can extract the OAuth client config automatically.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but Windows path resolution assumptions may still miss common global npm layouts.
- Change is localized and gated on `process.platform === "win32"`, but the new logic assumes `dirname(resolvedPath)` is a global npm prefix; when `gemini` resolves to a .cmd/.bat shim in `%APPDATA%\npm`, the actual `node_modules` root may be elsewhere, so the fix might not work for all users.
- extensions/google-gemini-cli-auth/oauth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->