### PR TITLE
Fix typo in FAQ regarding model configuration command

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1972,7 +1972,7 @@ Safe options:
 
 - `/model` in chat (quick, per-session)
 - `openclaw models set ...` (updates just model config)
-- `openclaw configure --section models` (interactive)
+- `openclaw configure --section model` (interactive)
 - edit `agents.defaults.model` in `~/.openclaw/openclaw.json`
 
 Avoid `config.apply` with a partial object unless you intend to replace the whole config.


### PR DESCRIPTION
<img width="855" height="86" alt="image" src="https://github.com/user-attachments/assets/c8a2c9ab-39df-4aa7-91d7-17b6ec58c960" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the FAQ entry for switching models by correcting the `openclaw configure` section name (`models` → `model`) so the documented command matches the CLI’s expected configuration section and avoids user confusion when configuring models interactively.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line documentation fix to a CLI command example; it does not affect runtime code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->