### PR TITLE
feat(memory): add Bun sqlite compatibility

### DIFF
--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -3,7 +3,86 @@ import { installProcessWarningFilter } from "../infra/warnings.js";
 
 const require = createRequire(import.meta.url);
 
+// Detect Bun runtime
+const isBun = typeof globalThis.Bun !== "undefined";
+
+/**
+ * Provides a unified SQLite interface for both Node.js and Bun runtimes.
+ * - Node.js: uses built-in `node:sqlite` (requires --experimental-sqlite flag)
+ * - Bun: uses built-in `bun:sqlite` with a compatibility wrapper
+ */
 export function requireNodeSqlite(): typeof import("node:sqlite") {
+  if (isBun) {
+    return requireBunSqlite();
+  }
   installProcessWarningFilter();
   return require("node:sqlite") as typeof import("node:sqlite");
+}
+
+/**
+ * Wraps Bun's sqlite to match node:sqlite's DatabaseSync API.
+ */
+function requireBunSqlite(): typeof import("node:sqlite") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const bunSqlite = require("bun:sqlite") as typeof import("bun:sqlite");
+  const BunDatabase = bunSqlite.Database;
+
+  // Create a wrapper class that matches node:sqlite's DatabaseSync interface
+  class DatabaseSync {
+    private db: InstanceType<typeof BunDatabase>;
+    private extensionsEnabled = false;
+
+    constructor(path: string, options?: { allowExtension?: boolean }) {
+      this.db = new BunDatabase(path);
+      // Bun doesn't need allowExtension in constructor, extensions are always loadable
+      if (options?.allowExtension) {
+        this.extensionsEnabled = true;
+      }
+    }
+
+    exec(sql: string): void {
+      this.db.exec(sql);
+    }
+
+    prepare<T = unknown>(sql: string) {
+      return this.db.prepare<T, []>(sql);
+    }
+
+    close(): void {
+      this.db.close();
+    }
+
+    enableLoadExtension(enable: boolean): void {
+      // Bun doesn't have this method - extensions are always loadable
+      this.extensionsEnabled = enable;
+    }
+
+    loadExtension(path: string): void {
+      if (!this.extensionsEnabled) {
+        throw new Error("Extensions are not enabled. Call enableLoadExtension(true) first.");
+      }
+      this.db.loadExtension(path);
+    }
+  }
+
+  // Return an object matching node:sqlite's export structure
+  // Use `as unknown as` to bypass strict type checking since Bun's API is compatible at runtime
+  return {
+    DatabaseSync,
+    StatementSync: bunSqlite.Statement,
+    constants: {
+      SQLITE_CHANGESET_OMIT: 0,
+      SQLITE_CHANGESET_REPLACE: 1,
+      SQLITE_CHANGESET_ABORT: 2,
+      SQLITE_CHANGESET_DATA: 1,
+      SQLITE_CHANGESET_NOTFOUND: 2,
+      SQLITE_CHANGESET_CONFLICT: 3,
+      SQLITE_CHANGESET_CONSTRAINT: 4,
+      SQLITE_CHANGESET_FOREIGN_KEY: 5,
+    },
+    // Stub for backup function (not used in memory module)
+    backup: () => {
+      throw new Error("backup() is not supported in Bun runtime");
+    },
+  } as unknown as typeof import("node:sqlite");
 }


### PR DESCRIPTION
## Summary
Add runtime detection and compatibility wrapper for Bun's `bun:sqlite` to work with the existing `node:sqlite` API used in memory search.

## Changes
- Detect Bun runtime via `globalThis.Bun`
- Wrap `bun:sqlite` Database class to match `node:sqlite` DatabaseSync API
- Handle extension loading differences between runtimes

## Why
When running the gateway under Bun, memory search fails with:
```
No such built-in module: node:sqlite
```

Bun has its own `bun:sqlite` with a slightly different API. This patch provides a compatibility layer so memory search works on both Node.js and Bun.

## Testing
- Tested on Bun 1.3.5
- Memory search with custom embeddings endpoint works
- Extension loading (sqlite-vec) compatibility preserved

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds runtime detection for Bun (`globalThis.Bun`) and a compatibility shim that returns a `node:sqlite`-shaped module under Bun by wrapping `bun:sqlite`’s `Database` into a `DatabaseSync`-like class, plus a small stubbed export surface (`StatementSync`, `constants`, `backup`). This allows the memory module (e.g. `src/memory/manager.ts` opening the DB and `src/memory/sqlite-vec.ts` loading extensions) to run when `node:sqlite` is unavailable under Bun.


<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the Bun wrapper still has some behavior mismatches that can change runtime semantics in edge cases.
- Change is isolated to the sqlite loader and is straightforward, but the Bun compatibility layer is intentionally type-erased and may diverge from `node:sqlite` semantics; one concrete mismatch is in-memory database path handling. Previous review threads also indicate potential Statement API/constant-value mismatches that could surface at runtime under Bun.
- src/memory/sqlite.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->