### PR TITLE
fix: use 400K context window instead of 200K if the model allows (gpt-5.2)

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -4,6 +4,7 @@
 import { loadConfig } from "../config/config.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
+import { MODEL_CONTEXT_WINDOWS as OPENCODE_ZEN_CONTEXT_WINDOWS } from "./opencode-zen-models.js";
 
 type ModelEntry = { id: string; contextWindow?: number };
 
@@ -36,5 +37,17 @@ export function lookupContextTokens(modelId?: string): number | undefined {
   }
   // Best-effort: kick off loading, but don't block.
   void loadPromise;
-  return MODEL_CACHE.get(modelId);
+
+  // Dynamic cache first
+  const cached = MODEL_CACHE.get(modelId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // Static fallback for known models (handles prefixed model IDs like "openai-codex/gpt-5.2")
+  const bareModelId = modelId.includes("/") ? modelId.split("/").pop() : modelId;
+  if (!bareModelId) {
+    return undefined;
+  }
+  return OPENCODE_ZEN_CONTEXT_WINDOWS[bareModelId];
 }

--- a/src/agents/opencode-zen-models.ts
+++ b/src/agents/opencode-zen-models.ts
@@ -141,7 +141,7 @@ const MODEL_COSTS: Record<
 
 const DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 
-const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gpt-5.1-codex": 400000,
   "claude-opus-4-5": 200000,
   "gemini-3-pro": 1048576,

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
 ] as const;


### PR DESCRIPTION
## Summary
- OpenAI Codex models (`openai-codex/gpt-5.2`) have 400k context windows
- Sessions were auto-clearing at ~200k because `lookupContextTokens()` returned `undefined` for prefixed model IDs
- Added static fallback lookup using `MODEL_CONTEXT_WINDOWS` from `opencode-zen-models.ts`

## Changes
- Export `MODEL_CONTEXT_WINDOWS` from `opencode-zen-models.ts`
- Add static fallback in `lookupContextTokens()` for cache misses
- Handle prefixed model IDs by extracting bare model ID (e.g., `openai-codex/gpt-5.2` → `gpt-5.2`)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (4924 tests)
- [x] `pnpm lint` passes for changed files
- [ ] Manual: verify `openai-codex/gpt-5.2` sessions don't clear at 200k

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes incorrect context window inference for OpenAI Codex model refs like `openai-codex/gpt-5.2` by adding a static fallback lookup in `lookupContextTokens()` when the dynamic models cache misses. It also exports `MODEL_CONTEXT_WINDOWS` from the OpenCode Zen model catalog so that context window defaults can be reused, and updates the xhigh-thinking allowlist to include the new `openai-codex/gpt-5.2` ref.

Overall, the change is consistent with the existing “best-effort cache, then fallback” approach used in model discovery, and should prevent sessions from auto-clearing early when the configured model id includes a provider prefix.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge, with a minor normalization edge case to consider.
- Changes are small, covered by existing test suite per the PR description, and primarily add a fallback read path. The main residual risk is that model IDs may include more complex prefixes/suffixes than a single `/` segment, in which case the fallback may still miss.
- src/agents/context.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->