### PR TITLE
fix(daemon): prefer bundled node from install-cli.sh over system node

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -11,6 +11,8 @@ vi.mock("node:fs/promises", () => ({
 
 import {
   renderSystemNodeWarning,
+  resolveBundledNodeInfo,
+  resolveBundledNodePath,
   resolvePreferredNodePath,
   resolveSystemNodeInfo,
 } from "./runtime-paths.js";
@@ -19,10 +21,137 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
+describe("resolveBundledNodePath", () => {
+  it("returns bundled node path for darwin", () => {
+    const result = resolveBundledNodePath({ HOME: "/Users/test" }, "darwin");
+    expect(result).toBe("/Users/test/.openclaw/tools/node/bin/node");
+  });
+
+  it("returns bundled node path for linux", () => {
+    const result = resolveBundledNodePath({ HOME: "/home/test" }, "linux");
+    expect(result).toBe("/home/test/.openclaw/tools/node/bin/node");
+  });
+
+  it("returns bundled node path for win32", () => {
+    const result = resolveBundledNodePath({ USERPROFILE: "C:\\Users\\test" }, "win32");
+    expect(result).toBe("C:\\Users\\test\\.openclaw\\tools\\node\\bin\\node.exe");
+  });
+});
+
+describe("resolveBundledNodeInfo", () => {
+  it("returns bundled node info when it exists and is supported", async () => {
+    const bundledPath = "/Users/test/.openclaw/tools/node/bin/node";
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === bundledPath) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.22.0\n", stderr: "" });
+
+    const result = await resolveBundledNodeInfo({
+      env: { HOME: "/Users/test" },
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toEqual({
+      path: bundledPath,
+      version: "22.22.0",
+      supported: true,
+    });
+  });
+
+  it("returns null when bundled node does not exist", async () => {
+    fsMocks.access.mockRejectedValue(new Error("missing"));
+
+    const execFile = vi.fn();
+
+    const result = await resolveBundledNodeInfo({
+      env: { HOME: "/Users/test" },
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toBeNull();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+});
+
 describe("resolvePreferredNodePath", () => {
   const darwinNode = "/opt/homebrew/bin/node";
+  const bundledNode = "/Users/test/.openclaw/tools/node/bin/node";
 
-  it("uses system node when it meets the minimum version", async () => {
+  it("prefers bundled node over system node", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === bundledNode || target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.1.0\n", stderr: "" });
+
+    const result = await resolvePreferredNodePath({
+      env: { HOME: "/Users/test" },
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toBe(bundledNode);
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to system node when bundled node is missing", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.1.0\n", stderr: "" });
+
+    const result = await resolvePreferredNodePath({
+      env: { HOME: "/Users/test" },
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toBe(darwinNode);
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to system node when bundled node is too old", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === bundledNode || target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (nodePath: string) => {
+      if (nodePath === bundledNode) {
+        return { stdout: "18.0.0\n", stderr: "" };
+      }
+      return { stdout: "22.1.0\n", stderr: "" };
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: { HOME: "/Users/test" },
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toBe(darwinNode);
+    expect(execFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses system node when it meets the minimum version (no bundled)", async () => {
     fsMocks.access.mockImplementation(async (target: string) => {
       if (target === darwinNode) {
         return;


### PR DESCRIPTION
## Summary

The gateway install command now checks for bundled Node.js at `~/.openclaw/tools/node/bin/node` (installed by `install-cli.sh`) before falling back to system node paths like `/opt/homebrew/bin/node`.

## Problem

There was a disconnect between different components:

| Component | Knows about bundled node? |
|-----------|---------------------------|
| `install-cli.sh` | ✅ Installs and uses it |
| macOS app (`CommandResolver.swift:109`) | ✅ Adds to PATH |
| CLI `resolvePreferredNodePath()` | ❌ Only checked system paths |

This caused `openclaw gateway install` to generate LaunchAgent with Homebrew node instead of the bundled node that `install-cli.sh` installed.

## Changes

- Added `resolveBundledNodePath()` to resolve `~/.openclaw/tools/node/bin/node`
- Added `resolveBundledNodeInfo()` to check if bundled node exists and is supported
- Modified `resolvePreferredNodePath()` to check bundled node first, then fall back to system node
- Added tests for all new functionality

## Testing

- [x] All existing tests pass
- [x] New tests for bundled node resolution
- [x] `pnpm tsgo && pnpm format && pnpm lint && pnpm build && pnpm test` passes

## AI Disclosure

🤖 AI-assisted (Claude Code). Fully tested locally. Changes are understood.

Fixes #6061

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the daemon’s Node runtime selection (`src/daemon/runtime-paths.ts`) to prefer a bundled Node installed by `install-cli.sh` at `~/.openclaw/tools/node/bin/node` before falling back to system Node locations, and adds coverage in `src/daemon/runtime-paths.test.ts` for the new bundled-resolution behavior.

Net effect: `openclaw gateway install` should now generate launch configuration that targets the bundled Node (when present + supported), aligning CLI behavior with the installer and macOS app PATH handling.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and matches the intended behavior change, with a small platform edge case to consider.
- The changes are localized to runtime path resolution, are covered by new tests, and preserve the existing system-node fallback behavior. The main remaining concern is a win32 edge case where `os.homedir()` may not match win32 path semantics when env vars are missing, potentially producing an invalid bundled-node candidate path.
- src/daemon/runtime-paths.ts (win32 home directory fallback behavior)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->