### PR TITLE
fix(cli): add --thread-id option to message read command

### DIFF
--- a/src/cli/program/message/register.read-edit-delete.ts
+++ b/src/cli/program/message/register.read-edit-delete.ts
@@ -15,6 +15,7 @@ export function registerMessageReadEditDeleteCommands(
     .option("--before <id>", "Read/search before id")
     .option("--after <id>", "Read/search after id")
     .option("--around <id>", "Read around id")
+    .option("--thread-id <id>", "Thread id (Slack/Telegram thread parent timestamp)")
     .option("--include-thread", "Include thread replies (Discord)", false)
     .action(async (opts) => {
       await helpers.runMessageAction("read", opts);


### PR DESCRIPTION
## Summary

Adds the `--thread-id` option to the `openclaw message read` CLI command to enable reading thread replies on Slack and Telegram.

## Problem

When trying to read Slack thread replies using the message tool or CLI, the `threadId` parameter wasn't being passed through. The CLI `read` command was missing the `--thread-id` option entirely.

## Investigation

Traced through the codebase and found:

1. ✅ `slack.actions.ts` correctly reads `threadId` from params and passes it to `handleSlackAction`
2. ✅ `handleSlackAction` correctly passes `threadId` to `readSlackMessages`
3. ✅ `readSlackMessages` correctly uses `conversations.replies` when `threadId` is set
4. ✅ The message tool schema includes `threadId` (from `buildSendSchema`)
5. ✅ Existing test `slack.actions.test.ts` confirms threadId forwarding works
6. ❌ CLI `read` command was missing `--thread-id` option

## Changes

- Added `--thread-id <id>` option to the `message read` CLI command

## Testing

- [x] Code follows existing patterns
- [x] Existing test `slack.actions.test.ts` verifies the action handler works correctly
- [ ] Manual e2e testing pending

## AI Disclosure

🤖 This PR was AI-assisted (created with Claude). The investigation and fix were done by tracing through the codebase to identify where `threadId` support was missing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a missing `--thread-id <id>` option to the `openclaw message read` CLI command so the CLI can forward `threadId` into the existing message action pipeline (which already supports reading Slack thread replies / Telegram thread context).

This change is localized to the CLI command registration alongside the existing message read flags (limit/before/after/around/include-thread).

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge.
- The change is a single CLI option addition that forwards an existing parameter; no behavioral changes occur unless the new flag is used. The only concern is user-facing clarity/consistency of the flag’s description across platforms.
- src/cli/program/message/register.read-edit-delete.ts (help text wording/consistency)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->