### PR TITLE
fix(media): skip audio files regardless of text-like byte content

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -256,7 +256,7 @@ async function extractFileBlocks(params: {
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
     const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
-    if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
+    if (!forcedTextMimeResolved && kind === "audio") {
       continue;
     }
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;


### PR DESCRIPTION
Remove the && !textLike condition from the audio skip logic in extractFileBlocks(). OGG/Opus files often contain printable headers that cause looksLikeUtf8Text() to return true, leading to incorrect MIME type detection (e.g., text/csv) and binary garbage being included as file blocks.

If the attachment kind is audio, skip it unconditionally rather than checking byte content.

Fixes #6069

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `extractFileBlocks()` in `src/media-understanding/apply.ts` so attachments classified as `audio` are skipped unconditionally (unless a forced text MIME is already resolved). This prevents OGG/Opus files with text-like headers from being misdetected as text (e.g., `text/csv`) and included as binary garbage in extracted file blocks.

The change is localized to the media-understanding pipeline and narrows behavior only for `audio` kinds, reducing false-positive text classification.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line logic change that directly addresses the reported misclassification; no new APIs or broader refactors involved, and control flow remains straightforward.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->