### PR TITLE
fix: remove whitespace in MEDIA token for auto-attachment

### DIFF
--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -170,7 +170,7 @@ def main():
             full_path = output_path.resolve()
             print(f"\nImage saved: {full_path}")
             # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
-            print(f"MEDIA: {full_path}")
+            print(f"MEDIA:{full_path}")
         else:
             print("Error: No image was generated in the response.", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
# Summary

This PR fixes an issue where generated images from the nano-banana-pro skill are not automatically attached/uploaded to chat channels like Discord or Telegram.
# Technical Details

* Bug: The image generation script was outputting the media token with a trailing space after the colon (e.g., MEDIA: /path/to/file).

* Constraint: According to OpenClaw's official media handling documentation, the MEDIA:<path-or-url> token must be provided on its own line with no spaces between the prefix and the path.

* Fix: Modified the print statement in generate_image.py to remove the extra whitespace, ensuring the OpenClaw parser can correctly identify and extract the media path for auto-attachment.

# Impact

* Restores the automatic image upload functionality for the nano-banana-pro skill.

* Ensures compliance with the OpenClaw media output specification.

* Fixes the "text-only" fallback issue where only the file path string was displayed instead of the actual image in Discord.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes auto-attachment for the `nano-banana-pro` skill by removing the extra whitespace after the `MEDIA:` prefix in `generate_image.py`, aligning the script’s output with OpenClaw’s media token parsing expectations (`MEDIA:<path-or-url>`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line output formatting fix that aligns with documented `MEDIA:<path-or-url>` requirements and existing parser behavior; it does not affect control flow or external API usage.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->