### PR TITLE
fix(ui): add tick monitoring to browser WebSocket client

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -71,6 +71,11 @@ export class GatewayBrowserClient {
   private connectSent = false;
   private connectTimer: number | null = null;
   private backoffMs = 800;
+  // Track last tick to detect silent stalls (Issue #6087)
+  private lastTick: number | null = null;
+  private tickIntervalMs = 30_000;
+  private tickTimer: number | null = null;
+  private visibilityHandler: (() => void) | null = null;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
 
@@ -81,6 +86,8 @@ export class GatewayBrowserClient {
 
   stop() {
     this.closed = true;
+    this.stopTickWatch();
+    this.removeVisibilityHandler();
     this.ws?.close();
     this.ws = null;
     this.flushPending(new Error("gateway client stopped"));
@@ -217,6 +224,14 @@ export class GatewayBrowserClient {
           });
         }
         this.backoffMs = 800;
+        // Initialize tick monitoring (Issue #6087)
+        this.tickIntervalMs =
+          typeof hello?.policy?.tickIntervalMs === "number"
+            ? hello.policy.tickIntervalMs
+            : 30_000;
+        this.lastTick = Date.now();
+        this.startTickWatch();
+        this.addVisibilityHandler();
         this.opts.onHello?.(hello);
       })
       .catch(() => {
@@ -253,6 +268,10 @@ export class GatewayBrowserClient {
           this.opts.onGap?.({ expected: this.lastSeq + 1, received: seq });
         }
         this.lastSeq = seq;
+      }
+      // Update lastTick on tick events (Issue #6087)
+      if (evt.event === "tick") {
+        this.lastTick = Date.now();
       }
       try {
         this.opts.onEvent?.(evt);
@@ -293,5 +312,59 @@ export class GatewayBrowserClient {
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
     }, 750);
+  }
+
+  // Tick monitoring methods (Issue #6087)
+  private startTickWatch() {
+    this.stopTickWatch();
+    const interval = Math.max(this.tickIntervalMs, 1000);
+    this.tickTimer = window.setInterval(() => {
+      if (this.closed) {
+        return;
+      }
+      if (!this.lastTick) {
+        return;
+      }
+      const gap = Date.now() - this.lastTick;
+      if (gap > this.tickIntervalMs * 2) {
+        this.ws?.close(4000, "tick timeout");
+      }
+    }, interval);
+  }
+
+  private stopTickWatch() {
+    if (this.tickTimer !== null) {
+      window.clearInterval(this.tickTimer);
+      this.tickTimer = null;
+    }
+  }
+
+  // Visibility change handling (Issue #6087)
+  private addVisibilityHandler() {
+    this.removeVisibilityHandler();
+    this.visibilityHandler = () => this.handleVisibilityChange();
+    document.addEventListener("visibilitychange", this.visibilityHandler);
+  }
+
+  private removeVisibilityHandler() {
+    if (this.visibilityHandler) {
+      document.removeEventListener("visibilitychange", this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
+  }
+
+  private handleVisibilityChange() {
+    if (document.visibilityState !== "visible") {
+      return;
+    }
+    // Tab became visible - check if connection is stale
+    if (!this.lastTick) {
+      return;
+    }
+    const gap = Date.now() - this.lastTick;
+    if (gap > this.tickIntervalMs * 2) {
+      // Connection is stale, force reconnect
+      this.ws?.close(4000, "tick timeout on visibility");
+    }
   }
 }


### PR DESCRIPTION
Fixes #6087

## Problem
The browser WebSocket client in the webchat dashboard was missing tick/keepalive monitoring that the Node.js client has. This caused silent disconnections that manifested as the agent appearing to "hang" indefinitely.

**Symptoms:**
- Browser client continues to think it's connected after silent disconnect
- Misses all incoming messages
- Shows agent as "thinking" forever
- User has to manually refresh to see actual responses

## Root Cause
The Node.js client (`gateway/client.ts`) monitors for `tick` events and closes/reconnects if 2x the tick interval passes without receiving one. The browser client had NO tick handling - it only relied on `onclose`/`onerror` events which may not fire reliably on silent disconnects.

## Solution
Added tick monitoring to `GatewayBrowserClient` matching the Node.js implementation:

1. **Tick monitoring properties:**
   - `lastTick`: timestamp of last received tick
   - `tickIntervalMs`: interval from server policy (default 30s)
   - `tickTimer`: interval timer for checking tick staleness

2. **Tick event handling:**
   - Update `lastTick` when receiving tick events
   - Initialize monitoring after successful hello handshake

3. **Stale connection detection:**
   - `startTickWatch()`: starts interval to check if 2x tick interval passed
   - Closes connection with code 4000 ("tick timeout") when stale
   - Triggers automatic reconnect via existing `scheduleReconnect()`

4. **Visibility change handling:**
   - Listen for `visibilitychange` events
   - Check connection health when tab becomes visible
   - Force reconnect if connection is stale

## Testing
- TypeScript type check passes
- Lint passes
- Manual testing: tab backgrounding now triggers reconnect when returning

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds tick/keepalive monitoring to the browser `GatewayBrowserClient` to mirror the Node gateway client: tracks `lastTick`, reads `tickIntervalMs` from the hello policy, starts an interval that closes the socket on tick timeout, and adds a `visibilitychange` hook to trigger a reconnect when returning to a stale tab.

Main concern is lifecycle/cleanup: unlike the Node client, the browser client doesn’t stop tick monitoring/listeners on reconnect paths, and its `onclose` always schedules a reconnect even if the client was intentionally stopped, which can lead to multiple reconnect timers/sockets once tick timeouts start closing the connection.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but has reconnection lifecycle edge cases that can create duplicate sockets/timers.
- The tick timeout logic itself matches the Node implementation, but the browser client currently doesn’t clear tick timers/listeners during reconnect and always schedules reconnect on `onclose`, which can cause overlapping reconnect attempts and stale timers acting on newer sockets.
- ui/src/ui/gateway.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->