### PR TITLE
feat: add Azure OpenAI provider support via LiteLLM proxy

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -256,6 +256,19 @@ ollama pull llama3.3
 
 Ollama is automatically detected when running locally at `http://127.0.0.1:11434/v1`. See [/providers/ollama](/providers/ollama) for model recommendations and custom configuration.
 
+### Azure OpenAI
+
+Azure OpenAI provides enterprise-grade access to GPT models with Azure security and compliance.
+
+- Provider: `azure-openai` (via LiteLLM proxy)
+- Auth: Azure API key + LiteLLM proxy
+- Example model: `azure-openai/gpt-5.2-codex`
+
+Azure OpenAI requires a LiteLLM proxy because its API differs from standard OpenAI
+(different auth header, URL format, and unsupported params).
+
+See [/providers/azure-openai](/providers/azure-openai) for complete setup guide.
+
 ### Local proxies (LM Studio, vLLM, LiteLLM, etc.)
 
 Example (OpenAI‑compatible):

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -1,0 +1,178 @@
+---
+summary: "Use Azure OpenAI models (GPT-4o, GPT-5, etc.) in OpenClaw via LiteLLM proxy"
+read_when:
+  - You want to use Azure OpenAI models
+  - You have Azure credits or an Azure OpenAI deployment
+  - You need enterprise-grade Azure compliance
+title: "Azure OpenAI"
+---
+
+# Azure OpenAI
+
+Azure OpenAI Service provides enterprise-grade access to OpenAI models (GPT-4o, GPT-5, etc.) with Azure security and compliance features.
+
+## Why Azure OpenAI
+
+- **Enterprise compliance**: SOC 2, HIPAA, and other certifications
+- **Azure credits**: Use existing Azure Sponsorship, Enterprise Agreements, or MSDN subscriptions
+- **Regional deployment**: Deploy models in specific Azure regions
+- **Private networking**: VNet integration and private endpoints
+
+## Setup with LiteLLM Proxy
+
+Azure OpenAI requires a LiteLLM proxy because its API differs from standard OpenAI:
+- Uses `api-key` header instead of `Authorization: Bearer`
+- Different URL format with deployment names in the path
+- Doesn't support some OpenAI params (like `store`)
+
+### Step 1: Install LiteLLM
+
+```bash
+pip install litellm[proxy]
+```
+
+### Step 2: Create LiteLLM Config
+
+Create `litellm_config.yaml`:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: azure/your-gpt4o-mini-deployment
+      api_base: https://your-resource.openai.azure.com
+      api_key: ${AZURE_OPENAI_API_KEY}
+      api_version: "2024-10-21"
+
+  - model_name: gpt-5.2-codex
+    litellm_params:
+      model: azure/your-gpt5-codex-deployment
+      api_base: https://your-resource.openai.azure.com
+      api_key: ${AZURE_OPENAI_API_KEY}
+      api_version: "2024-10-21"
+
+litellm_settings:
+  drop_params: true  # Required: OpenClaw sends params Azure doesn't support
+```
+
+Replace:
+- `your-resource` with your Azure OpenAI resource name
+- `your-gpt4o-mini-deployment` and `your-gpt5-codex-deployment` with your deployment names
+- Set `AZURE_OPENAI_API_KEY` environment variable with your Azure API key
+
+### Step 3: Start LiteLLM Proxy
+
+```bash
+litellm --config litellm_config.yaml --port 4000
+```
+
+### Step 4: Configure OpenClaw
+
+Add to `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      "azure-openai": {
+        baseUrl: "http://localhost:4000/v1",
+        apiKey: "your-litellm-key",
+        api: "openai-completions",
+        models: [
+          {
+            id: "gpt-4o-mini",
+            name: "GPT-4o Mini (Azure)",
+            reasoning: false,
+            input: ["text", "image"],
+            contextWindow: 128000,
+            maxTokens: 16384,
+            compat: { supportsStore: false },
+          },
+          {
+            id: "gpt-5.2-codex",
+            name: "GPT-5.2 Codex (Azure)",
+            reasoning: false,
+            input: ["text", "image"],
+            contextWindow: 200000,
+            maxTokens: 16384,
+            compat: { supportsStore: false },
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "azure-openai/gpt-5.2-codex" },
+    },
+  },
+}
+```
+
+## Key Configuration Notes
+
+### Required Settings
+
+- `api: "openai-completions"` - Tells OpenClaw to use OpenAI-compatible format
+- `mode: "merge"` - Preserves built-in providers while adding Azure
+- `compat: { supportsStore: false }` - Azure doesn't support the `store` parameter
+
+### LiteLLM `drop_params: true`
+
+This setting is critical. Without it, you'll get errors like:
+```
+azure does not support parameters: ['store']
+```
+
+### API Version
+
+Use a recent API version. Recommended: `2024-10-21` or later.
+
+## Finding Your Azure Configuration
+
+1. **Resource Endpoint**: Azure Portal > Your OpenAI Resource > Overview > Endpoint
+2. **Deployment Name**: Azure Portal > Your OpenAI Resource > Model Deployments
+3. **API Key**: Azure Portal > Your OpenAI Resource > Keys and Endpoint
+
+## Troubleshooting
+
+### "No API provider registered" error
+
+Ensure your provider config includes `"api": "openai-completions"`.
+
+### Empty responses
+
+- Check LiteLLM logs for errors
+- Verify deployment name matches exactly
+- Confirm API key has access to the deployment
+
+### Rate limiting
+
+Azure OpenAI has per-deployment rate limits. Consider:
+- Increasing TPM (tokens per minute) quota in Azure Portal
+- Using multiple deployments with model failover
+
+## Docker Deployment
+
+For production, run LiteLLM in Docker:
+
+```yaml
+# docker-compose.yml
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./litellm_config.yaml:/app/config.yaml
+    environment:
+      - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY}
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+```
+
+## See Also
+
+- [Model Providers](/concepts/model-providers) - Overview of all providers
+- [Model Failover](/concepts/model-failover) - Configure fallback models
+- [LiteLLM Documentation](https://docs.litellm.ai/docs/providers/azure)

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -21,6 +21,7 @@ Azure OpenAI Service provides enterprise-grade access to OpenAI models (GPT-4o, 
 ## Setup with LiteLLM Proxy
 
 Azure OpenAI requires a LiteLLM proxy because its API differs from standard OpenAI:
+
 - Uses `api-key` header instead of `Authorization: Bearer`
 - Different URL format with deployment names in the path
 - Doesn't support some OpenAI params (like `store`)
@@ -52,10 +53,11 @@ model_list:
       api_version: "2024-10-21"
 
 litellm_settings:
-  drop_params: true  # Required: OpenClaw sends params Azure doesn't support
+  drop_params: true # Required: OpenClaw sends params Azure doesn't support
 ```
 
 Replace:
+
 - `your-resource` with your Azure OpenAI resource name
 - `your-gpt4o-mini-deployment` and `your-gpt5-codex-deployment` with your deployment names
 - Set `AZURE_OPENAI_API_KEY` environment variable with your Azure API key
@@ -121,6 +123,7 @@ Add to `~/.openclaw/openclaw.json`:
 ### LiteLLM `drop_params: true`
 
 This setting is critical. Without it, you'll get errors like:
+
 ```
 azure does not support parameters: ['store']
 ```
@@ -150,6 +153,7 @@ Ensure your provider config includes `"api": "openai-completions"`.
 ### Rate limiting
 
 Azure OpenAI has per-deployment rate limits. Consider:
+
 - Increasing TPM (tokens per minute) quota in Azure Portal
 - Using multiple deployments with model failover
 

--- a/src/agents/models-config.azure-openai.test.ts
+++ b/src/agents/models-config.azure-openai.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAzureOpenAILiteLLMProvider,
+  generateAzureLiteLLMConfig,
+} from "./models-config.providers.js";
+
+describe("Azure OpenAI provider helpers", () => {
+  describe("buildAzureOpenAILiteLLMProvider", () => {
+    it("generates provider config for LiteLLM proxy", () => {
+      const provider = buildAzureOpenAILiteLLMProvider({
+        litellmBaseUrl: "http://localhost:4000/v1",
+        litellmApiKey: "test-key",
+        deployments: {
+          "gpt-4o-mini": "my-gpt4o-deployment",
+          "gpt-5.2-codex": "my-gpt5-deployment",
+        },
+      });
+
+      expect(provider.baseUrl).toBe("http://localhost:4000/v1");
+      expect(provider.apiKey).toBe("test-key");
+      expect(provider.api).toBe("openai-completions");
+      expect(provider.models).toHaveLength(2);
+
+      const gpt4Model = provider.models.find((m) => m.id === "gpt-4o-mini");
+      expect(gpt4Model).toBeDefined();
+      expect(gpt4Model?.name).toBe("gpt-4o-mini");
+      expect(gpt4Model?.compat?.supportsStore).toBe(false);
+
+      const gpt5Model = provider.models.find((m) => m.id === "gpt-5.2-codex");
+      expect(gpt5Model).toBeDefined();
+      expect(gpt5Model?.contextWindow).toBe(200000);
+    });
+
+    it("strips trailing slash from baseUrl", () => {
+      const provider = buildAzureOpenAILiteLLMProvider({
+        litellmBaseUrl: "http://localhost:4000/v1/",
+        deployments: { "gpt-4o": "deploy" },
+      });
+
+      expect(provider.baseUrl).toBe("http://localhost:4000/v1");
+    });
+
+    it("detects reasoning models (o1, o3)", () => {
+      const provider = buildAzureOpenAILiteLLMProvider({
+        litellmBaseUrl: "http://localhost:4000/v1",
+        deployments: {
+          "o1-preview": "o1-deploy",
+          "o3-mini": "o3-deploy",
+          "gpt-4o": "gpt4-deploy",
+        },
+      });
+
+      const o1Model = provider.models.find((m) => m.id === "o1-preview");
+      expect(o1Model?.reasoning).toBe(true);
+
+      const o3Model = provider.models.find((m) => m.id === "o3-mini");
+      expect(o3Model?.reasoning).toBe(true);
+
+      const gptModel = provider.models.find((m) => m.id === "gpt-4o");
+      expect(gptModel?.reasoning).toBe(false);
+    });
+  });
+
+  describe("generateAzureLiteLLMConfig", () => {
+    it("generates valid LiteLLM config YAML", () => {
+      const yaml = generateAzureLiteLLMConfig({
+        endpoint: "https://my-resource.openai.azure.com",
+        apiVersion: "2024-10-21",
+        deployments: {
+          "gpt-4o-mini": "my-gpt4o-mini-deployment",
+        },
+      });
+
+      expect(yaml).toContain("model_list:");
+      expect(yaml).toContain("model_name: gpt-4o-mini");
+      expect(yaml).toContain("model: azure/my-gpt4o-mini-deployment");
+      expect(yaml).toContain("api_base: https://my-resource.openai.azure.com");
+      expect(yaml).toContain('api_version: "2024-10-21"');
+      expect(yaml).toContain("drop_params: true");
+    });
+
+    it("uses default API version when not specified", () => {
+      const yaml = generateAzureLiteLLMConfig({
+        endpoint: "https://test.openai.azure.com",
+        deployments: { "gpt-4o": "deploy" },
+      });
+
+      expect(yaml).toContain('api_version: "2024-10-21"');
+    });
+
+    it("generates config for multiple deployments", () => {
+      const yaml = generateAzureLiteLLMConfig({
+        endpoint: "https://test.openai.azure.com",
+        deployments: {
+          "gpt-4o-mini": "deploy-1",
+          "gpt-5.2-codex": "deploy-2",
+        },
+      });
+
+      expect(yaml).toContain("model_name: gpt-4o-mini");
+      expect(yaml).toContain("model_name: gpt-5.2-codex");
+      expect(yaml).toContain("model: azure/deploy-1");
+      expect(yaml).toContain("model: azure/deploy-2");
+    });
+  });
+});

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -43,6 +43,17 @@ export type ModelProviderConfig = {
   models: ModelDefinitionConfig[];
 };
 
+export type AzureOpenAIDeploymentConfig = {
+  /** Azure OpenAI resource endpoint (e.g., https://my-resource.openai.azure.com) */
+  endpoint: string;
+  /** Azure OpenAI API key */
+  apiKey?: string;
+  /** API version (e.g., 2024-10-21) */
+  apiVersion?: string;
+  /** Map model IDs to Azure deployment names */
+  deployments?: Record<string, string>;
+};
+
 export type BedrockDiscoveryConfig = {
   enabled?: boolean;
   region?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -59,6 +59,16 @@ export const ModelProviderSchema = z
   })
   .strict();
 
+export const AzureOpenAIDeploymentSchema = z
+  .object({
+    endpoint: z.string().min(1),
+    apiKey: z.string().optional(),
+    apiVersion: z.string().optional(),
+    deployments: z.record(z.string(), z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const BedrockDiscoverySchema = z
   .object({
     enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Add support for Azure OpenAI models (GPT-4o, GPT-5.2-codex, etc.) via LiteLLM proxy
- Add helper functions to generate provider config and LiteLLM YAML
- Add comprehensive documentation at `/providers/azure-openai`

## Why LiteLLM proxy?

Azure OpenAI requires a proxy because:
- Uses `api-key` header instead of `Authorization: Bearer`
- Different URL format: `https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>`
- Doesn't support some OpenAI params (like `store`)

## Changes

- `src/agents/models-config.providers.ts` - Add `buildAzureOpenAILiteLLMProvider()` and `generateAzureLiteLLMConfig()` helpers
- `src/config/types.models.ts` - Add `AzureOpenAIDeploymentConfig` type
- `src/config/zod-schema.core.ts` - Add `AzureOpenAIDeploymentSchema` validation
- `docs/providers/azure-openai.md` - Complete setup guide with LiteLLM config
- `docs/concepts/model-providers.md` - Add Azure OpenAI section
- `src/agents/models-config.azure-openai.test.ts` - Unit tests (6 passing)

## Test plan

- [x] Unit tests pass (6 tests)
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] `openclaw models list` shows Azure model correctly
- [x] Helper functions generate valid config

## Example usage

```json5
{
  models: {
    providers: {
      "azure-openai": {
        baseUrl: "http://localhost:4000/v1",
        apiKey: "litellm-key",
        api: "openai-completions",
        models: [{ id: "gpt-5.2-codex", name: "GPT-5.2 Codex (Azure)" }]
      }
    }
  }
}
```

Closes #6056

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an Azure OpenAI setup path by documenting a LiteLLM proxy workflow and introducing helper functions to generate an OpenClaw provider config and a LiteLLM YAML snippet. It also introduces new config types/schemas and unit tests around the helpers.

Main issues spotted are around config/schema wiring: the newly added `AzureOpenAIDeploymentSchema` isn’t currently used by any top-level schema, and the YAML generator accepts an `apiKey` field but ignores it while hardcoding an environment-variable-based `api_key` entry. There’s also some type duplication (`AzureOpenAIConfig` vs `AzureOpenAIDeploymentConfig`) that increases drift risk.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a couple of wiring/expectation mismatches that could confuse users.
- Core changes are additive (docs + helper functions + tests) and don’t appear to alter existing provider behavior, but the new Azure schema is currently unused and the LiteLLM YAML generator ignores its `apiKey` input, which can lead to confusing or broken generated configs.
- src/agents/models-config.providers.ts, src/config/zod-schema.core.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->