### PR TITLE
refactor: simplify boolean logic using nullish coalescing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -326,8 +326,7 @@ export function formatTerminalLink(
   const esc = "\u001b";
   const safeLabel = label.replaceAll(esc, "");
   const safeUrl = url.replaceAll(esc, "");
-  const allow =
-    opts?.force === true ? true : opts?.force === false ? false : Boolean(process.stdout.isTTY);
+  const allow = opts?.force ?? Boolean(process.stdout.isTTY);
   if (!allow) {
     return opts?.fallback ?? `${safeLabel} (${safeUrl})`;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors `formatTerminalLink` in `src/utils.ts` to simplify the `allow` computation for emitting OSC-8 terminal hyperlinks. The nested ternary that treated `opts.force` as a tri-state override is replaced with nullish coalescing, keeping the default behavior of enabling links only when `process.stdout.isTTY` is truthy and allowing explicit `true`/`false` overrides.

Change is localized to a utility function used for terminal output formatting; no broader control flow or API surface changes are introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small refactor in a single utility function that preserves the intended tri-state behavior of `opts.force` (true/false override, otherwise fall back to TTY detection) via `??`. No behavioral change is apparent for valid inputs, and the modification is unlikely to impact unrelated parts of the codebase.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->