### PR TITLE
fix: detect float underflow in duration parsing

### DIFF
--- a/src/cli/parse-duration.ts
+++ b/src/cli/parse-duration.ts
@@ -31,12 +31,13 @@ export function parseDurationMs(raw: string, opts?: DurationMsParseOptions): num
           : unit === "h"
             ? 3_600_000
             : 86_400_000;
-  const ms = Math.round(value * multiplier);
+  const product = value * multiplier;
+  if (product === 0 && value !== 0) {
+    throw new Error(`duration too small: ${raw} (underflow)`);
+  }
+  const ms = Math.round(product);
   if (!Number.isFinite(ms)) {
     throw new Error(`invalid duration: ${raw}`);
-  }
-  if (ms === 0 && value !== 0) {
-    throw new Error(`duration too small: ${raw} (rounds to 0ms)`);
   }
   return ms;
 }

--- a/src/cli/parse-duration.ts
+++ b/src/cli/parse-duration.ts
@@ -35,5 +35,8 @@ export function parseDurationMs(raw: string, opts?: DurationMsParseOptions): num
   if (!Number.isFinite(ms)) {
     throw new Error(`invalid duration: ${raw}`);
   }
+  if (ms === 0 && value !== 0) {
+    throw new Error(`duration too small: ${raw} (rounds to 0ms)`);
+  }
   return ms;
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an additional validation step to `parseDurationMs` (`src/cli/parse-duration.ts`) that throws when the computed duration rounds to `0ms` even though the parsed numeric value is non-zero. The goal is to detect cases where floating-point underflow or precision loss causes an otherwise-valid duration to collapse to zero after conversion and rounding.

The change is localized to the CLI duration parsing helper and impacts all call sites that rely on this shared parsing logic (e.g., agent runtime config validation and various CLI commands that accept duration flags).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge but may introduce unintended rejections of sub-millisecond durations that previously parsed to 0ms.
- The change is small and easy to reason about, but the new `ms === 0 && value !== 0` guard will fire for any value that legitimately rounds to 0ms (not just float underflow), which could be behavior-breaking for callers that allow very small durations.
- src/cli/parse-duration.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->