### PR TITLE
refactor: add early return for invalid Authorization headers

### DIFF
--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -15,7 +15,7 @@ export function getHeader(req: IncomingMessage, name: string): string | undefine
 
 export function getBearerToken(req: IncomingMessage): string | undefined {
   const raw = getHeader(req, "authorization")?.trim();
-  if (!raw || raw.length < 8) {
+  if (!raw) {
     return undefined;
   }
   if (!raw.toLowerCase().startsWith("bearer ")) {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -14,7 +14,10 @@ export function getHeader(req: IncomingMessage, name: string): string | undefine
 }
 
 export function getBearerToken(req: IncomingMessage): string | undefined {
-  const raw = getHeader(req, "authorization")?.trim() ?? "";
+  const raw = getHeader(req, "authorization")?.trim();
+  if (!raw || raw.length < 8) {
+    return undefined;
+  }
   if (!raw.toLowerCase().startsWith("bearer ")) {
     return undefined;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tweaks `getBearerToken` in `src/gateway/http-utils.ts` to return early when the `Authorization` header is missing/empty (after trimming) rather than defaulting to an empty string, while keeping the existing `Bearer …` prefix parsing.

The change sits in the gateway request parsing helpers used to normalize headers and resolve auth/session routing inputs.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and narrowly scoped to bearer-token parsing.
- The change is small and localized, with no obvious behavioral regressions for valid headers; main concern is a minor readability/perceived intent issue around the added length check.
- src/gateway/http-utils.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->