### PR TITLE
support ipv6

### DIFF
--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -175,7 +175,8 @@ export async function gatherDaemonStatus(
     | "lan"
     | "loopback"
     | "custom"
-    | "tailnet";
+    | "tailnet"
+    | "dualstack";
   const customBindHost = daemonCfg.gateway?.customBindHost;
   const bindHost = await resolveGatewayBindHost(bindMode, customBindHost);
   const tailnetIPv4 = pickPrimaryTailnetIPv4();

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -180,11 +180,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     bindRaw === "lan" ||
     bindRaw === "auto" ||
     bindRaw === "custom" ||
-    bindRaw === "tailnet"
+    bindRaw === "tailnet" ||
+    bindRaw === "dualstack"
       ? bindRaw
       : null;
   if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", "custom", or "dualstack")');
     defaultRuntime.exit(1);
     return;
   }
@@ -313,7 +314,7 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option("--port <port>", "Port for the gateway WebSocket")
     .option(
       "--bind <mode>",
-      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
+      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"|"dualstack"). Defaults to config gateway.bind (or loopback).',
     )
     .option(
       "--token <token>",

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -20,7 +20,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
 
   const gatewayBind = (cfg.gateway?.bind ?? "loopback") as string;
   const customBindHost = cfg.gateway?.customBindHost?.trim();
-  const bindModes: GatewayBindMode[] = ["auto", "lan", "loopback", "custom", "tailnet"];
+  const bindModes: GatewayBindMode[] = ["auto", "lan", "loopback", "custom", "tailnet", "dualstack"];
   const bindMode = bindModes.includes(gatewayBind as GatewayBindMode)
     ? (gatewayBind as GatewayBindMode)
     : undefined;

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -434,7 +434,7 @@ export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;
 
 export function resolveControlUiLinks(params: {
   port: number;
-  bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";
+  bind?: import("../config/types.gateway.js").GatewayBindMode;
   customBindHost?: string;
   basePath?: string;
 }): { httpUrl: string; wsUrl: string } {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -95,7 +95,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
   const daemonRuntimeRaw = opts.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
   if (!opts.skipHealth) {
     const links = resolveControlUiLinks({
-      bind: gatewayResult.bind as "auto" | "lan" | "loopback" | "custom" | "tailnet",
+      bind: gatewayResult.bind,
       port: gatewayResult.port,
       customBindHost: nextConfig.gateway?.customBindHost,
       basePath: undefined,

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { GatewayBindMode } from "../../../config/types.gateway.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 import { randomToken } from "../../onboard-helpers.js";
@@ -11,7 +12,7 @@ export function applyNonInteractiveGatewayConfig(params: {
 }): {
   nextConfig: OpenClawConfig;
   port: number;
-  bind: string;
+  bind: GatewayBindMode;
   authMode: string;
   tailscaleMode: string;
   tailscaleResetOnExit: boolean;

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -1,3 +1,4 @@
+import type { GatewayBindMode } from "../../../config/types.gateway.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
@@ -9,7 +10,7 @@ export function logNonInteractiveOnboardingJson(params: {
   authChoice?: string;
   gateway?: {
     port: number;
-    bind: string;
+    bind: GatewayBindMode;
     authMode: string;
     tailscaleMode: string;
   };

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -36,7 +36,7 @@ export type AuthChoice =
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
-export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet";
+export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet" | "dualstack";
 export type TailscaleMode = "off" | "serve" | "funnel";
 export type NodeManagerChoice = "npm" | "pnpm" | "bun";
 export type ChannelChoice = ChannelId;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,4 +1,4 @@
-export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
+export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet" | "dualstack";
 
 export type GatewayTlsConfig = {
   /** Enable TLS for the gateway server. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -312,6 +312,7 @@ export const OpenClawSchema = z
             z.literal("loopback"),
             z.literal("custom"),
             z.literal("tailnet"),
+            z.literal("dualstack"),
           ])
           .optional(),
         controlUi: z

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -155,6 +155,10 @@ export async function resolveGatewayBindHost(
     return "0.0.0.0";
   }
 
+  if (mode === "dualstack") {
+    return "::";
+  }
+
   if (mode === "custom") {
     const host = customHost?.trim();
     if (!host) {

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -211,7 +211,7 @@ export const testState = {
   allowFrom: undefined as string[] | undefined,
   cronStorePath: undefined as string | undefined,
   cronEnabled: false as boolean | undefined,
-  gatewayBind: undefined as "auto" | "lan" | "tailnet" | "loopback" | undefined,
+  gatewayBind: undefined as "auto" | "lan" | "tailnet" | "loopback" | "custom" | "dualstack" | undefined,
   gatewayAuth: undefined as Record<string, unknown> | undefined,
   gatewayControlUi: undefined as Record<string, unknown> | undefined,
   hooksConfig: undefined as HooksConfig | undefined,

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -96,11 +96,12 @@ async function main() {
     bindRaw === "lan" ||
     bindRaw === "auto" ||
     bindRaw === "custom" ||
-    bindRaw === "tailnet"
+    bindRaw === "tailnet" ||
+    bindRaw === "dualstack"
       ? bindRaw
       : null;
   if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", "custom", or "dualstack")');
     process.exit(1);
   }
 

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -5,6 +5,7 @@ import type {
   ResetScope,
 } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { GatewayBindMode } from "../config/types.gateway.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
@@ -239,7 +240,7 @@ export async function runOnboardingWizard(
   })();
 
   if (flow === "quickstart") {
-    const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet") => {
+    const formatBind = (value: GatewayBindMode) => {
       if (value === "loopback") {
         return "Loopback (127.0.0.1)";
       }
@@ -251,6 +252,9 @@ export async function runOnboardingWizard(
       }
       if (value === "tailnet") {
         return "Tailnet (Tailscale IP)";
+      }
+      if (value === "dualstack") {
+        return "Dualstack (IPv4+IPv6)";
       }
       return "Auto";
     };

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -204,7 +204,8 @@ export async function runOnboardingWizard(
       bindRaw === "lan" ||
       bindRaw === "auto" ||
       bindRaw === "custom" ||
-      bindRaw === "tailnet"
+      bindRaw === "tailnet" ||
+      bindRaw === "dualstack"
         ? bindRaw
         : "loopback";
 

--- a/src/wizard/onboarding.types.ts
+++ b/src/wizard/onboarding.types.ts
@@ -1,11 +1,12 @@
 import type { GatewayAuthChoice } from "../commands/onboard-types.js";
+import type { GatewayBindMode } from "../config/types.gateway.js";
 
 export type WizardFlow = "quickstart" | "advanced";
 
 export type QuickstartGatewayDefaults = {
   hasExisting: boolean;
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: GatewayBindMode;
   authMode: GatewayAuthChoice;
   tailscaleMode: "off" | "serve" | "funnel";
   token?: string;
@@ -16,7 +17,7 @@ export type QuickstartGatewayDefaults = {
 
 export type GatewayWizardSettings = {
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: GatewayBindMode;
   customBindHost?: string;
   authMode: GatewayAuthChoice;
   gatewayToken?: string;


### PR DESCRIPTION
only ipv6 machine not run

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `gateway.bind` mode (`dualstack`) intended to improve IPv6 support by allowing the gateway to bind to an IPv6 wildcard address, and threads the new enum value through the CLI, onboarding flows, config schema, and related type definitions.

Main concerns are around correctness of “dualstack” semantics: in `src/gateway/net.ts` the mode currently resolves to `::`, which can still be IPv6-only on common Linux configurations, and several caller surfaces (daemon status probing and onboarding/control-UI link generation) still assume IPv4 loopback/IPv4 tailnet, which can lead to false “gateway unreachable” reports or unusable URLs on IPv6-only hosts.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has functional gaps around IPv6-only vs true dual-stack behavior and a few UX surfaces that may misreport reachability.
- Most changes are enum/threading updates and should be low risk, but the core behavior change (`dualstack` -> `::`) does not guarantee IPv4 reachability on common Linux setups and some related features (status probing, Control UI link generation) still assume IPv4, which can cause real user-facing failures in the targeted IPv6 scenarios.
- src/gateway/net.ts, src/cli/daemon-cli/shared.ts, src/commands/onboard-helpers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->