### PR TITLE
refactor: add explicit type assertion in resolveOptionFromCommand

### DIFF
--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -57,7 +57,7 @@ export function resolveOptionFromCommand<T>(
   while (current) {
     const opts = current.opts?.() ?? {};
     if (opts[key] !== undefined) {
-      return opts[key];
+      return opts[key] as T;
     }
     current = current.parent ?? undefined;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveOptionFromCommand` (`src/cli/cli-utils.ts`) to explicitly assert the option value type (`opts[key] as T`) when walking up the commander `Command` parent chain. The behavior at runtime is unchanged; the change is purely for TypeScript typing to align the generic return type `T | undefined` with commander’s untyped `opts()` return shape.

I didn’t find any new functional issues introduced by this change. In current call sites (e.g. `src/cli/models-cli.ts`), callers already treat the returned value as a string/undefined, so the assertion matches existing usage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow TypeScript-only type assertion in a helper that reads commander options; it does not alter runtime control flow or values, and current usage aligns with the asserted types.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->