### PR TITLE
fix(agents): do not filter fallbacks by models allowlist

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -210,7 +210,9 @@ function resolveFallbackCandidates(params: {
     if (!resolved) {
       continue;
     }
-    addCandidate(resolved.ref, true);
+    // Fallbacks explicitly configured in agents.defaults.model.fallbacks should not
+    // be filtered by the models allowlist - they are intentional user configuration.
+    addCandidate(resolved.ref, false);
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {


### PR DESCRIPTION
## Summary
Fallbacks explicitly configured in `agents.defaults.model.fallbacks` were being incorrectly filtered by the models allowlist (`agents.defaults.models`). This caused fallbacks to be ignored when the user had model aliases configured.

## Problem
When a user has:
```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "anthropic/claude-sonnet-4-20250514",
        "fallbacks": ["openai/gpt-4o", "ollama/glm-4.7:cloud"]
      },
      "models": {
        "anthropic/claude-opus-4-5": { "alias": "opus" }
      }
    }
  }
}
```

The fallbacks (`openai/gpt-4o`, `ollama/glm-4.7:cloud`) were being filtered out because they weren't in the allowlist created by `agents.defaults.models`.

Result: when the primary provider was in cooldown, the error showed `All models failed (1)` instead of trying the configured fallbacks.

## Solution
Changed `enforceAllowlist` to `false` when adding fallbacks from `agents.defaults.model.fallbacks`. These are intentional user configuration and should always be considered, regardless of the models allowlist.

## Testing
- Added regression test for #5763
- All 20 existing model-fallback tests pass

Fixes #5763

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes model fallback resolution so that user-configured `agents.defaults.model.fallbacks` are **not** filtered out by the `agents.defaults.models` allowlist when model aliases are present. Concretely, `resolveFallbackCandidates` now adds candidates from `agents.defaults.model.fallbacks` with `enforceAllowlist=false`, ensuring explicitly configured fallbacks are always considered.

A regression test was added in `src/agents/model-fallback.test.ts` to cover issue #5763 by simulating an allowlist created via `agents.defaults.models` and verifying the fallback list is still attempted after the primary provider fails with a retryable error.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a single boolean controlling allowlist enforcement for explicitly configured fallbacks) and is covered by a targeted regression test; it does not affect allowlist behavior for other candidate sources.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->