### PR TITLE
feat: add native Azure OpenAI support

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -256,6 +256,32 @@ ollama pull llama3.3
 
 Ollama is automatically detected when running locally at `http://127.0.0.1:11434/v1`. See [/providers/ollama](/providers/ollama) for model recommendations and custom configuration.
 
+### Azure OpenAI
+
+Azure OpenAI provides enterprise-grade access to GPT models with Azure security and compliance.
+
+- Provider: `azure-openai`
+- Auth: `AZURE_OPENAI_API_KEY`
+- API: `azure-openai-responses`
+- Example model: `azure-openai/your-deployment-name`
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-openai": {
+        baseUrl: "https://your-resource.openai.azure.com/openai/v1",
+        apiKey: "${AZURE_OPENAI_API_KEY}",
+        api: "azure-openai-responses",
+        models: [{ id: "your-deployment-name", name: "GPT-5.2 Codex" }],
+      },
+    },
+  },
+}
+```
+
+See [/providers/azure-openai](/providers/azure-openai) for complete setup guide.
+
 ### Local proxies (LM Studio, vLLM, LiteLLM, etc.)
 
 Example (OpenAI‑compatible):

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -1,0 +1,114 @@
+---
+summary: "Use Azure OpenAI models (GPT-4o, GPT-5, etc.) natively in OpenClaw"
+read_when:
+  - You want to use Azure OpenAI models
+  - You have Azure credits or an Azure OpenAI deployment
+  - You need enterprise-grade Azure compliance
+title: "Azure OpenAI"
+---
+
+# Azure OpenAI
+
+Azure OpenAI Service provides enterprise-grade access to OpenAI models (GPT-4o, GPT-5, etc.) with Azure security and compliance features.
+
+## Why Azure OpenAI
+
+- **Enterprise compliance**: SOC 2, HIPAA, and other certifications
+- **Azure credits**: Use existing Azure Sponsorship, Enterprise Agreements, or MSDN subscriptions
+- **Regional deployment**: Deploy models in specific Azure regions
+- **Private networking**: VNet integration and private endpoints
+
+## Setup
+
+OpenClaw supports Azure OpenAI natively using the `azure-openai-responses` API.
+
+### Step 1: Set Environment Variables
+
+```bash
+export AZURE_OPENAI_API_KEY="your-azure-api-key"
+```
+
+### Step 2: Configure OpenClaw
+
+Add to `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      "azure-openai": {
+        baseUrl: "https://your-resource.openai.azure.com/openai/v1",
+        apiKey: "${AZURE_OPENAI_API_KEY}",
+        api: "azure-openai-responses",
+        models: [
+          {
+            id: "your-deployment-name",
+            name: "GPT-5.2 Codex (Azure)",
+            reasoning: false,
+            input: ["text", "image"],
+            contextWindow: 200000,
+            maxTokens: 16384,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "azure-openai/your-deployment-name" },
+    },
+  },
+}
+```
+
+### Key Configuration
+
+| Field     | Description                                     |
+| --------- | ----------------------------------------------- |
+| `baseUrl` | Your Azure endpoint + `/openai/v1`              |
+| `api`     | Must be `"azure-openai-responses"`              |
+| `id`      | Your Azure deployment name (not the model name) |
+
+## Environment Variables
+
+The pi-ai library also supports these environment variables:
+
+| Variable                           | Description                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| `AZURE_OPENAI_API_KEY`             | Your Azure API key                                                     |
+| `AZURE_OPENAI_BASE_URL`            | Full base URL (alternative to config)                                  |
+| `AZURE_OPENAI_RESOURCE_NAME`       | Resource name (builds URL automatically)                               |
+| `AZURE_OPENAI_API_VERSION`         | API version (default: v1)                                              |
+| `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` | Map model IDs to deployments (format: `model1=deploy1,model2=deploy2`) |
+
+## Finding Your Azure Configuration
+
+1. **Resource Endpoint**: Azure Portal > Your OpenAI Resource > Overview > Endpoint
+2. **Deployment Name**: Azure Portal > Your OpenAI Resource > Model Deployments
+3. **API Key**: Azure Portal > Your OpenAI Resource > Keys and Endpoint
+
+## Troubleshooting
+
+### "Azure OpenAI base URL is required" error
+
+Ensure your config includes the full base URL:
+
+```json5
+{
+  baseUrl: "https://your-resource.openai.azure.com/openai/v1",
+}
+```
+
+### "No API key" error
+
+Set the `AZURE_OPENAI_API_KEY` environment variable or include `apiKey` in config.
+
+### Model not found
+
+The model `id` in config must match your **Azure deployment name**, not the OpenAI model name.
+
+## See Also
+
+- [Model Providers](/concepts/model-providers) - Overview of all providers
+- [Model Failover](/concepts/model-failover) - Configure fallback models

--- a/src/agents/models-config.azure-openai.test.ts
+++ b/src/agents/models-config.azure-openai.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildAzureOpenAIProvider } from "./models-config.providers.js";
+
+describe("Azure OpenAI provider", () => {
+  describe("buildAzureOpenAIProvider", () => {
+    it("generates native Azure provider config", () => {
+      const provider = buildAzureOpenAIProvider({
+        endpoint: "https://my-resource.openai.azure.com",
+        apiKey: "test-key",
+        deployments: {
+          "gpt-4o-mini": "my-gpt4o-deployment",
+          "gpt-5.2-codex": "my-gpt5-deployment",
+        },
+      });
+
+      expect(provider.baseUrl).toBe("https://my-resource.openai.azure.com/openai/v1");
+      expect(provider.apiKey).toBe("test-key");
+      expect(provider.api).toBe("azure-openai-responses");
+      expect(provider.models).toHaveLength(2);
+
+      const gpt4Model = provider.models.find((m) => m.id === "my-gpt4o-deployment");
+      expect(gpt4Model).toBeDefined();
+      expect(gpt4Model?.name).toBe("gpt-4o-mini");
+
+      const gpt5Model = provider.models.find((m) => m.id === "my-gpt5-deployment");
+      expect(gpt5Model).toBeDefined();
+      expect(gpt5Model?.contextWindow).toBe(200000);
+    });
+
+    it("strips trailing slash from endpoint", () => {
+      const provider = buildAzureOpenAIProvider({
+        endpoint: "https://my-resource.openai.azure.com/",
+        deployments: { "gpt-4o": "deploy" },
+      });
+
+      expect(provider.baseUrl).toBe("https://my-resource.openai.azure.com/openai/v1");
+    });
+
+    it("detects reasoning models (o1, o3)", () => {
+      const provider = buildAzureOpenAIProvider({
+        endpoint: "https://test.openai.azure.com",
+        deployments: {
+          "o1-preview": "o1-deploy",
+          "o3-mini": "o3-deploy",
+          "gpt-4o": "gpt4-deploy",
+        },
+      });
+
+      const o1Model = provider.models.find((m) => m.id === "o1-deploy");
+      expect(o1Model?.reasoning).toBe(true);
+
+      const o3Model = provider.models.find((m) => m.id === "o3-deploy");
+      expect(o3Model?.reasoning).toBe(true);
+
+      const gptModel = provider.models.find((m) => m.id === "gpt4-deploy");
+      expect(gptModel?.reasoning).toBe(false);
+    });
+
+    it("sets supportsStore to false for Azure models", () => {
+      const provider = buildAzureOpenAIProvider({
+        endpoint: "https://test.openai.azure.com",
+        deployments: { "gpt-4o": "deploy" },
+      });
+
+      expect(provider.models[0]?.compat?.supportsStore).toBe(false);
+    });
+  });
+});

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -4,7 +4,8 @@ export type ModelApi =
   | "anthropic-messages"
   | "google-generative-ai"
   | "github-copilot"
-  | "bedrock-converse-stream";
+  | "bedrock-converse-stream"
+  | "azure-openai-responses";
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -8,6 +8,7 @@ export const ModelApiSchema = z.union([
   z.literal("google-generative-ai"),
   z.literal("github-copilot"),
   z.literal("bedrock-converse-stream"),
+  z.literal("azure-openai-responses"),
 ]);
 
 export const ModelCompatSchema = z


### PR DESCRIPTION
## Summary

Add native support for Azure OpenAI models using pi-ai's built-in `azure-openai-responses` API. No external proxy required.

## Changes

- Add `azure-openai-responses` to `ModelApi` type and Zod schema
- Add `buildAzureOpenAIProvider()` helper function
- Add documentation at `/providers/azure-openai`
- Add unit tests (4 passing)

## Configuration Example

```json5
{
  models: {
    providers: {
      "azure-openai": {
        baseUrl: "https://your-resource.openai.azure.com/openai/v1",
        apiKey: "${AZURE_OPENAI_API_KEY}",
        api: "azure-openai-responses",
        models: [{ id: "your-deployment-name", name: "GPT-5.2 Codex" }]
      }
    }
  }
}
```

## Test Plan

- [x] Unit tests pass (4 tests)
- [x] TypeScript compilation passes
- [x] Linting/formatting passes
- [x] Tested with real Azure OpenAI deployment

Closes #6056

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds native Azure OpenAI support by introducing a new `ModelApi` variant (`azure-openai-responses`), wiring it into the Zod config schema, and providing a helper (`buildAzureOpenAIProvider`) that generates an Azure provider config (baseUrl, api, apiKey, and model definitions). It also adds dedicated docs under `/providers/azure-openai` and unit tests covering baseUrl normalization, reasoning-model detection, and store-compat defaults.

The change fits into the existing model/provider configuration system by extending the shared `ModelApi` union + schema and by following the existing pattern of provider-building helpers in `src/agents/models-config.providers.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one likely footgun around Azure endpoint/baseUrl formatting.
- Schema/type changes are straightforward and tests cover the helper behavior, but the baseUrl builder will produce an invalid URL if users supply an endpoint that already includes an `/openai/...` suffix (a common copy/paste path from the Azure Portal).
- src/agents/models-config.providers.ts (Azure baseUrl construction) and the Azure provider docs for clarity on expected endpoint format.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->