### PR TITLE
feat(tts): add Chatterbox TTS as first-class provider

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "chatterbox";
 
 export type TtsMode = "final" | "all";
 
@@ -72,6 +72,27 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** Chatterbox TTS configuration (local or self-hosted). */
+  chatterbox?: {
+    /** Explicitly enable Chatterbox TTS. */
+    enabled?: boolean;
+    /** Base URL for Chatterbox API (default: http://localhost:4123). */
+    baseUrl?: string;
+    /** Optional API key if your Chatterbox instance requires auth. */
+    apiKey?: string;
+    /** Voice name from voice library (e.g., "default", "sarah"). */
+    voice?: string;
+    /** Model variant: "chatterbox" | "chatterbox-turbo" | "chatterbox-multilingual". */
+    model?: string;
+    /** Language code for multilingual model (e.g., "en", "ar", "fr"). */
+    language?: string;
+    /** Exaggeration parameter (0.0-1.0, default 0.5). */
+    exaggeration?: number;
+    /** CFG weight parameter (0.0-1.0, default 0.5). */
+    cfgWeight?: number;
+    /** Speed multiplier (0.5-2.0, default 1.0). */
+    speed?: number;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;


### PR DESCRIPTION
## Summary

Adds [Chatterbox TTS](https://github.com/resemble-ai/chatterbox) as a first-class TTS provider in OpenClaw.

Chatterbox is a state-of-the-art open-source text-to-speech system by Resemble AI that runs entirely locally with GPU acceleration.

## Features

- **OpenAI-compatible API**: Works with [chatterbox-tts-api](https://github.com/travisvn/chatterbox-tts-api) or similar wrappers
- **Voice cloning**: Use custom voice samples via voice library
- **Multilingual**: 23+ languages supported with Chatterbox-Multilingual
- **Expressive speech**: Paralinguistic tags (`[laugh]`, `[chuckle]`, etc.) with Chatterbox-Turbo
- **Configurable parameters**: exaggeration, CFG weight, speed

## Configuration

```yaml
messages:
  tts:
    provider: chatterbox
    chatterbox:
      enabled: true
      baseUrl: http://localhost:4123  # Chatterbox API server
      voice: default                   # Voice from library
      model: chatterbox-turbo          # or chatterbox, chatterbox-multilingual
      language: en                     # For multilingual model
      exaggeration: 0.5               # 0.0-1.0
      cfgWeight: 0.5                  # 0.0-1.0
      speed: 1.0                      # 0.5-2.0
```

## Changes

- `src/config/types.tts.ts`: Added `chatterbox` to `TtsProvider` type and config schema
- `src/tts/tts.ts`: 
  - Added `chatterboxTTS()` function with OpenAI-compatible API calls
  - Added Chatterbox to provider fallback chain
  - Added config resolution for Chatterbox settings

## Testing

Tested with:
- `travisvn/chatterbox-tts-api` running on RTX 5080
- Voice cloning with custom samples
- Arabic and English transcription via Chatterbox-Multilingual

## Related

- Chatterbox: https://github.com/resemble-ai/chatterbox
- Chatterbox API: https://github.com/travisvn/chatterbox-tts-api

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new TTS provider (`chatterbox`) to the config types and implements a Chatterbox/OpenAI-compatible `/v1/audio/speech` call path in `src/tts/tts.ts`, wiring it into provider fallback and config resolution alongside existing `openai`, `elevenlabs`, and `edge` providers.

Main issue: the runtime code supports `chatterbox`, but the config validation and user-facing control surfaces don’t. `src/config/zod-schema.core.ts` still restricts `TtsProviderSchema` to `openai|elevenlabs|edge`, so `messages.tts.provider: chatterbox` will fail schema validation and block use. Related: `[[tts:provider=...]]` directive parsing and the `/tts provider` command only recognize the old provider set, preventing users from selecting Chatterbox even when configured.

Beyond that, Chatterbox’s output-format selection is currently handled in a provider-specific way rather than reusing the existing `resolveOutputFormat()` mapping, which may cause drift for Telegram/voice compatibility behavior over time.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable but will likely break or block Chatterbox configuration in validated setups.
- The core implementation is straightforward and follows existing TTS patterns, but config/schema and command/directive surfaces weren’t updated to recognize the new provider, which will prevent users from selecting or validating `chatterbox` in common flows.
- src/config/zod-schema.core.ts and any user-facing provider selection surfaces (commands/directives)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->