### PR TITLE
ci(formal): run TLC model suite in formal-conformance workflow

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Checkout formal models
         uses: actions/checkout@v4
         with:
-          repository: vignesh07/clawdbot-formal-models
+          repository: openclaw/clawdbot-formal-models
+          ref: main
           path: clawdbot-formal-models
 
       - name: Setup Node

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout formal models
         uses: actions/checkout@v4
         with:
-          repository: openclaw/clawdbot-formal-models
+          repository: vignesh07/clawdbot-formal-models
           ref: main
           path: clawdbot-formal-models
 

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   formal_conformance:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -35,6 +35,40 @@ jobs:
           export OPENCLAW_REPO_DIR="${GITHUB_WORKSPACE}/openclaw"
           node scripts/extract-tool-groups.mjs
           node scripts/check-tool-group-alias.mjs
+
+      - name: Model check (green suite)
+        run: |
+          set -euo pipefail
+          cd clawdbot-formal-models
+          make \
+            precedence groups elevated nodes-policy \
+            attacker approvals approvals-token nodes-pipeline \
+            gateway-exposure gateway-exposure-v2 gateway-exposure-v2-protected \
+            gateway-auth-conformance gateway-auth-tailscale gateway-auth-proxy \
+            pairing pairing-cap pairing-idempotency pairing-refresh pairing-refresh-race \
+            ingress-gating ingress-idempotency ingress-dedupe-fallback ingress-trace ingress-trace2 \
+            routing-isolation routing-precedence routing-identitylinks routing-identity-transitive routing-identity-symmetry routing-identity-channel-override \
+            routing-thread-parent discord-pluralkit \
+            ingress-retry session-key-stability session-explosion-bound config-normalization \
+            group-alias-check
+
+      - name: Model check (negative suite, expected violations)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          cd clawdbot-formal-models
+          make -k \
+            precedence-negative groups-negative elevated-negative nodes-policy-negative \
+            attacker-negative attacker-nodes-negative attacker-nodes-allowlist-negative attacker-nodes-allowlist-negative \
+            approvals-negative approvals-token-negative nodes-pipeline-negative \
+            gateway-exposure-negative gateway-exposure-v2-negative gateway-exposure-v2-protected-negative \
+            gateway-exposure-v2-unsafe-custom gateway-exposure-v2-unsafe-tailnet gateway-exposure-v2-unsafe-auto \
+            gateway-auth-conformance-negative gateway-auth-tailscale-negative gateway-auth-proxy-negative \
+            pairing-negative pairing-cap-negative pairing-idempotency-negative pairing-refresh-negative pairing-refresh-race-negative \
+            ingress-gating-negative ingress-idempotency-negative ingress-dedupe-fallback-negative ingress-trace-negative ingress-trace2-negative \
+            routing-isolation-negative routing-precedence-negative routing-identitylinks-negative routing-identity-transitive-negative routing-identity-symmetry-negative routing-identity-channel-override-negative \
+            routing-thread-parent-negative discord-pluralkit-negative \
+            ingress-retry-negative session-key-stability-negative config-normalization-negative
 
       - name: Compute drift
         id: drift


### PR DESCRIPTION
Updates .github/workflows/formal-conformance.yml to:

- Increase timeout to 20 minutes
- Run TLC model checking against the clawdbot-formal-models repo:
  - Green suite (blocking)
  - Negative/unsafe suite (continue-on-error; expected invariant violations)

This turns the existing formal conformance workflow into an end-to-end gate for the formal model suite, while keeping negative models informational.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `formal-conformance` GitHub Actions workflow to run the TLC formal model suite end-to-end: it increases the job timeout to 20 minutes, checks out the `clawdbot-formal-models` repo, regenerates extracted constants from the PR’s `openclaw` checkout, and then runs a blocking “green” model-check suite plus a non-blocking “negative/unsafe” suite. It preserves the existing drift detection behavior by uploading a diff artifact and posting an informational PR comment when extracted constants diverge.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the main risks are workflow determinism and signal quality in the negative suite.
- Changes are limited to a CI workflow and are straightforward, but checking out formal models from a user fork without a pinned `ref` can make results non-reproducible and brittle. Also, `continue-on-error` for the negative suite can hide unexpected harness failures alongside expected violations.
- .github/workflows/formal-conformance.yml

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->