### PR TITLE
Feature/cron and code intent

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -196,6 +196,8 @@ struct CronRunLogEntry: Codable, Identifiable, Sendable {
     let status: String?
     let error: String?
     let summary: String?
+    let outputText: String?
+    let executionLog: String?
     let runAtMs: Int?
     let durationMs: Int?
     let nextRunAtMs: Int?

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -174,7 +174,9 @@ extension CronSettings {
     }
 
     func runRow(_ entry: CronRunLogEntry) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        let body = entry.executionLog ?? entry.outputText ?? entry.summary ?? ""
+        let hasExpandable = (entry.executionLog != nil) || (entry.outputText != nil && entry.outputText != entry.summary)
+        return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 StatusPill(text: entry.status ?? "unknown", tint: self.statusTint(entry.status))
                 Text(entry.date.formatted(date: .abbreviated, time: .standard))
@@ -193,6 +195,20 @@ extension CronSettings {
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
                     .lineLimit(2)
+            }
+            if hasExpandable, !body.isEmpty {
+                DisclosureGroup("执行记录") {
+                    ScrollView(.vertical, showsIndicators: true) {
+                        Text(body)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(6)
+                    }
+                    .frame(maxHeight: 200)
+                }
+                .font(.caption)
             }
             if let error = entry.error, !error.isEmpty {
                 Text(error)

--- a/apps/macos/Sources/OpenClaw/CronSettings+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Testing.swift
@@ -43,6 +43,8 @@ struct CronSettings_Previews: PreviewProvider {
                 status: "ok",
                 error: nil,
                 summary: "All good.",
+                outputText: nil,
+                executionLog: nil,
                 runAtMs: nil,
                 durationMs: 1234,
                 nextRunAtMs: nil),
@@ -95,6 +97,8 @@ extension CronSettings {
             status: "ok",
             error: nil,
             summary: "done",
+            outputText: nil,
+            executionLog: nil,
             runAtMs: 1_700_000_050_000,
             durationMs: 1200,
             nextRunAtMs: 1_700_000_200_000)

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
@@ -71,6 +71,8 @@ struct SettingsViewSmokeTests {
                 status: "ok",
                 error: nil,
                 summary: "ok",
+                outputText: nil,
+                executionLog: nil,
                 runAtMs: 1_700_000_050_000,
                 durationMs: 123,
                 nextRunAtMs: 1_700_000_200_000),

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -76,3 +76,20 @@ Common choices:
 - Windows: official Node installer, `winget`, or a Windows Node version manager
 
 If you use a version manager (nvm/fnm/asdf/etc), ensure it’s initialized in the shell you use day-to-day (zsh vs bash) so the PATH it sets is present when you run installers.
+
+### nvm: use Node 22+ (command is `nvm use`, not `node use`)
+
+Moltbot requires **Node >= 22**. If your default is older (e.g. 20), switch before running Moltbot:
+
+- **Correct:** `nvm use 22` or `nvm use 24.13.0` — uses nvm to switch the active Node version.
+- **Wrong:** `node use 22` — that runs the Node binary and tries to load a file named `use`; you’ll see `Cannot find module '…/use'`.
+
+To make Node 22 the default in new shells:
+
+```bash
+nvm alias default 22.21.1   # or 24.13.0, etc.
+```
+
+Then open a new terminal (or run `nvm use` again) and run `moltbot onboard --install-daemon` if onboarding failed.
+
+If the install script added Homebrew’s node@22 to your PATH in `~/.zshrc` and you prefer to rely only on nvm, remove that line and use `nvm use 22` (or set default above) when running Moltbot.

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,4 +1,4 @@
-import { getOAuthApiKey, type OAuthCredentials } from "@mariozechner/pi-ai";
+import { getOAuthApiKey, type OAuthCredentials, type OAuthProvider } from "@mariozechner/pi-ai";
 import lockfile from "proper-lockfile";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
@@ -63,7 +63,7 @@ async function refreshOAuthTokenWithLock(params: {
               const newCredentials = await refreshQwenPortalCredentials(cred);
               return { apiKey: newCredentials.access, newCredentials };
             })()
-          : await getOAuthApiKey(cred.provider, oauthCreds);
+          : await getOAuthApiKey(cred.provider as OAuthProvider, oauthCreds);
     if (!result) {
       return null;
     }

--- a/src/agents/code-intent.test.ts
+++ b/src/agents/code-intent.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isCodeIntent } from "./code-intent.js";
+
+describe("isCodeIntent", () => {
+  it("returns false for empty or generic chat", () => {
+    expect(isCodeIntent("")).toBe(false);
+    expect(isCodeIntent("   ")).toBe(false);
+    expect(isCodeIntent("你好")).toBe(false);
+    expect(isCodeIntent("What's the weather?")).toBe(false);
+  });
+
+  it("returns true for Chinese coding phrases", () => {
+    expect(isCodeIntent("写一段代码实现排序")).toBe(true);
+    expect(isCodeIntent("写个函数计算斐波那契")).toBe(true);
+    expect(isCodeIntent("帮我调试一下这个bug")).toBe(true);
+    expect(isCodeIntent("实现一个方法")).toBe(true);
+  });
+
+  it("returns true for English coding phrases", () => {
+    expect(isCodeIntent("write a function to sort")).toBe(true);
+    expect(isCodeIntent("implement the code for login")).toBe(true);
+    expect(isCodeIntent("fix the code in main.py")).toBe(true);
+    expect(isCodeIntent("refactor the function")).toBe(true);
+  });
+
+  it("returns true when message contains code block", () => {
+    expect(isCodeIntent("check this:\n```js\nconst x = 1;\n```")).toBe(true);
+  });
+
+  it("returns true when message mentions file extension", () => {
+    expect(isCodeIntent("open src/main" + ".ts and add a handler")).toBe(true);
+    expect(isCodeIntent("edit foo.py")).toBe(true);
+  });
+});

--- a/src/agents/code-intent.ts
+++ b/src/agents/code-intent.ts
@@ -1,0 +1,42 @@
+/**
+ * Heuristic detection of "programming/coding" intent from user prompt.
+ * Used to optionally switch to a code-focused model (e.g. qwen-portal/coder-model)
+ * when agents.defaults.model.codePrimary is set.
+ */
+
+const CODE_INTENT_PATTERNS = [
+  // Chinese (no \b; word boundary does not work for CJK)
+  /(写|写个|写一段|实现|写一)(段|个)?(代码|程序|脚本|函数|方法)/,
+  /(修|改|调)(bug|错误|代码)/,
+  /(编程|写代码|敲代码|打代码)/,
+  /(代码|程序|脚本)(实现|写|生成|补全)/,
+  /(函数|方法|类)(实现|写|定义)/,
+  /(实现|写)(一个)?(方法|函数)/,
+  /(debug|调试|排错)/,
+  // English / mixed
+  /\b(write|implement|create|add)\s+(a\s+)?(function|method|class|script|code)\b/i,
+  /\b(code|programming|coding)\s+(task|request|help|please)\b/i,
+  /\b(implement|fix|refactor)\s+(the\s+)?(code|function)\b/i,
+  /\b(how\s+to\s+)?(implement|write)\s+.*\s+in\s+(python|js|typescript|java|rust|go)\b/i,
+  // File extensions (strong signal)
+  /\b\w+\.(py|ts|tsx|js|jsx|java|rs|go|rb|php|cpp|c|h|kt|swift)\b/,
+  // Code block or "snippet"
+  /```[\s\S]*?```/,
+  /\b(snippet|snippet of code|code block)\b/i,
+];
+
+/** Max length to scan; avoid scanning huge pastes. */
+const MAX_SCAN_LENGTH = 4000;
+
+/**
+ * Returns true if the prompt likely indicates a programming/coding request.
+ * Used only when codePrimary is configured; does not run when disabled.
+ */
+export function isCodeIntent(prompt: string): boolean {
+  const trimmed = prompt.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const slice = trimmed.length > MAX_SCAN_LENGTH ? trimmed.slice(0, MAX_SCAN_LENGTH) : trimmed;
+  return CODE_INTENT_PATTERNS.some((re) => re.test(slice));
+}

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1,6 +1,5 @@
 import {
   createAgentSession,
-  DefaultResourceLoader,
   estimateTokens,
   SessionManager,
   SettingsManager,
@@ -384,17 +383,6 @@ export async function compactEmbeddedPiSessionDirect(
         sandboxEnabled: !!sandbox?.enabled,
       });
 
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
-        additionalExtensionPaths,
-        noSkills: true,
-        systemPromptOverride: systemPrompt,
-        agentsFilesOverride: () => ({ agentsFiles: [] }),
-      });
-      await resourceLoader.reload();
-
       const { session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -406,7 +394,9 @@ export async function compactEmbeddedPiSessionDirect(
         customTools,
         sessionManager,
         settingsManager,
-        resourceLoader,
+        systemPrompt,
+        skills: [],
+        additionalExtensionPaths,
       });
 
       try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,12 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  SessionManager,
-  SettingsManager,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -455,17 +450,6 @@ export async function runEmbeddedAttempt(
 
       const allCustomTools = [...customTools, ...clientToolDefs];
 
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
-        additionalExtensionPaths,
-        noSkills: true,
-        systemPromptOverride: systemPrompt,
-        agentsFilesOverride: () => ({ agentsFiles: [] }),
-      });
-      await resourceLoader.reload();
-
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -477,7 +461,9 @@ export async function runEmbeddedAttempt(
         customTools: allCustomTools,
         sessionManager,
         settingsManager,
-        resourceLoader,
+        systemPrompt,
+        skills: [],
+        additionalExtensionPaths,
       }));
       if (!session) {
         throw new Error("Embedded agent session missing");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -261,6 +261,7 @@ const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",
+  "agents.defaults.model.codePrimary": "Code Model (auto when coding intent)",
   "agents.defaults.model.fallbacks": "Model Fallbacks",
   "agents.defaults.imageModel.primary": "Image Model",
   "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
@@ -573,6 +574,8 @@ const FIELD_HELP: Record<string, string> = {
   "agents.list.*.identity.avatar":
     "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
   "agents.defaults.model.primary": "Primary model (provider/model).",
+  "agents.defaults.model.codePrimary":
+    "Optional model (provider/model) used when the user message looks like a coding request; otherwise primary is used.",
   "agents.defaults.model.fallbacks":
     "Ordered fallback models (provider/model). Used when the primary model fails.",
   "agents.defaults.imageModel.primary":

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -39,6 +39,22 @@ export function pickLastNonEmptyTextFromPayloads(payloads: Array<{ text?: string
   return undefined;
 }
 
+/** Build execution log from all payload texts (tool outputs, thinking, answer). */
+export function buildExecutionLogFromPayloads(
+  payloads: Array<{ text?: string | undefined }>,
+  maxChars = 8000,
+): string | undefined {
+  const parts: string[] = [];
+  for (const p of payloads) {
+    const clean = (p.text ?? "").trim();
+    if (clean) parts.push(clean);
+  }
+  if (parts.length === 0) return undefined;
+  const joined = parts.join("\n\n---\n\n");
+  if (joined.length <= maxChars) return joined;
+  return `${joined.slice(0, maxChars)}…`;
+}
+
 /**
  * Check if all payloads are just heartbeat ack responses (HEARTBEAT_OK).
  * Returns true if delivery should be skipped because there's no real content.

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -74,7 +74,7 @@ describe("cron run log", () => {
       limit: 10,
       jobId: "a",
     });
-    expect(onlyA.map((e) => e.ts)).toEqual([1, 3]);
+    expect(onlyA.map((e) => e.ts)).toEqual([3, 1]); // newest first
 
     const lastOne = await readCronRunLogEntries(logPathA, { limit: 1 });
     expect(lastOne.map((e) => e.ts)).toEqual([3]);

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -8,6 +8,10 @@ export type CronRunLogEntry = {
   status?: "ok" | "error" | "skipped";
   error?: string;
   summary?: string;
+  /** Full agent output (isolated jobs only). */
+  outputText?: string;
+  /** Execution log: tool outputs, thinking, answer (isolated jobs only). */
+  executionLog?: string;
   runAtMs?: number;
   durationMs?: number;
   nextRunAtMs?: number;
@@ -98,5 +102,6 @@ export async function readCronRunLogEntries(
       // ignore invalid lines
     }
   }
-  return parsed.toReversed();
+  // Return newest-first (descending) so UIs show latest run at top
+  return parsed;
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -9,6 +9,10 @@ export type CronEvent = {
   status?: "ok" | "error" | "skipped";
   error?: string;
   summary?: string;
+  /** Full agent output (isolated jobs only). */
+  outputText?: string;
+  /** Execution log: tool outputs, thinking, answer (isolated jobs only). */
+  executionLog?: string;
   nextRunAtMs?: number;
 };
 
@@ -32,6 +36,8 @@ export type CronServiceDeps = {
     summary?: string;
     /** Last non-empty agent text output (not truncated). */
     outputText?: string;
+    /** Full execution log: tool outputs, thinking, answer (truncated). */
+    executionLog?: string;
     error?: string;
   }>;
   onEvent?: (evt: CronEvent) => void;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -236,6 +236,8 @@ export const CronRunLogEntrySchema = Type.Object(
     ),
     error: Type.Optional(Type.String()),
     summary: Type.Optional(Type.String()),
+    outputText: Type.Optional(Type.String()),
+    executionLog: Type.Optional(Type.String()),
     runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
     nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -90,6 +90,8 @@ export function buildGatewayCronService(params: {
           status: evt.status,
           error: evt.error,
           summary: evt.summary,
+          outputText: evt.outputText,
+          executionLog: evt.executionLog,
           runAtMs: evt.runAtMs,
           durationMs: evt.durationMs,
           nextRunAtMs: evt.nextRunAtMs,

--- a/src/gateway/server.cron.e2e.test.ts
+++ b/src/gateway/server.cron.e2e.test.ts
@@ -316,8 +316,9 @@ describe("gateway server cron", () => {
       expect(runsRes.ok).toBe(true);
       const entries = (runsRes.payload as { entries?: unknown } | null)?.entries;
       expect(Array.isArray(entries)).toBe(true);
-      expect((entries as Array<{ jobId?: unknown }>).at(-1)?.jobId).toBe(jobId);
-      expect((entries as Array<{ summary?: unknown }>).at(-1)?.summary).toBe("hello");
+      // entries are newest-first
+      expect((entries as Array<{ jobId?: unknown }>).at(0)?.jobId).toBe(jobId);
+      expect((entries as Array<{ summary?: unknown }>).at(0)?.summary).toBe("hello");
 
       const statusRes = await rpcReq(ws, "cron.status", {});
       expect(statusRes.ok).toBe(true);
@@ -347,7 +348,7 @@ describe("gateway server cron", () => {
         | undefined;
       expect(Array.isArray(autoEntries?.entries)).toBe(true);
       const runs = autoEntries?.entries ?? [];
-      expect(runs.at(-1)?.jobId).toBe(autoJobId);
+      expect(runs.at(0)?.jobId).toBe(autoJobId); // newest-first
     } finally {
       ws.close();
       await server.close();

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -459,6 +459,8 @@ export type CronRunLogEntry = {
   durationMs?: number;
   error?: string;
   summary?: string;
+  outputText?: string;
+  executionLog?: string;
 };
 
 export type SkillsStatusConfigCheck = {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -444,11 +444,38 @@ function renderJob(job: CronJob, props: CronProps) {
 }
 
 function renderRun(entry: CronRunLogEntry) {
+  const body = entry.executionLog ?? entry.outputText ?? entry.summary ?? "";
+  const hasExpandable = Boolean(
+    entry.executionLog || (entry.outputText && entry.outputText !== (entry.summary ?? "")),
+  );
   return html`
     <div class="list-item">
       <div class="list-main">
         <div class="list-title">${entry.status}</div>
-        <div class="list-sub">${entry.summary ?? ""}</div>
+        <div class="list-sub">${entry.summary ?? entry.outputText ?? ""}</div>
+        ${
+          hasExpandable && body
+            ? html`
+              <details class="cron-run-details" style="margin-top: 8px;">
+                <summary class="muted" style="cursor: pointer;">执行记录</summary>
+                <pre
+                  class="muted"
+                  style="
+                    margin-top: 6px;
+                    padding: 8px;
+                    background: var(--color-bg-muted, #f5f5f5);
+                    border-radius: 6px;
+                    font-size: 12px;
+                    white-space: pre-wrap;
+                    word-break: break-word;
+                    max-height: 300px;
+                    overflow-y: auto;
+                  "
+                >${body}</pre>
+              </details>
+            `
+            : nothing
+        }
       </div>
       <div class="list-meta">
         <div>${formatMs(entry.ts)}</div>


### PR DESCRIPTION
- Add code intent detection for model selection (codePrimary)
   - Add cron execution log and testing support
   - Add macOS cron testing UI
   - Minor agent/oauth/compact refactors
   - AI-assisted PR

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a heuristic “code intent” detector (`src/agents/code-intent.ts`) and wires it into both CLI agent runs (`src/commands/agent.ts`) and auto-reply routing (`src/auto-reply/reply/get-reply-directives.ts`) to optionally switch to a configured `agents.defaults.model.codePrimary` model when the user message looks like a coding request. It also extends cron run logging across the cron service, gateway protocol, and UIs to include `outputText` and a truncated `executionLog`, and changes run-log ordering to be newest-first to match UI expectations. Additionally, it refactors embedded runner session creation to pass prompts/skills directly instead of using `DefaultResourceLoader`, and includes macOS/UI changes and tests around the new cron run log fields.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with minor UX/API edge cases to address.
- Changes are mostly additive (new optional fields and model-selection heuristics) and tests were updated for the new newest-first ordering; the main remaining concerns are a small API behavior edge case in `readCronRunLogEntries` (cannot request limit=0) and hard-coded non-localized UI strings.
- src/cron/run-log.ts, apps/macos/Sources/OpenClaw/CronSettings+Rows.swift, ui/src/ui/views/cron.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->