### PR TITLE
android: allow manual gateway password auth in UI

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -128,6 +128,18 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.refreshGatewayConnection()
   }
 
+  fun setGatewayToken(token: String?) {
+    runtime.setGatewayToken(token)
+  }
+
+  fun setGatewayPassword(password: String?) {
+    runtime.setGatewayPassword(password)
+  }
+
+  fun clearGatewayAuth() {
+    runtime.clearGatewayAuth()
+  }
+
   fun connect(endpoint: GatewayEndpoint) {
     runtime.connect(endpoint)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -557,6 +557,29 @@ class NodeRuntime(context: Context) {
     nodeSession.reconnect()
   }
 
+  fun setGatewayToken(token: String?) {
+    val trimmed = token?.trim().orEmpty()
+    if (trimmed.isEmpty()) {
+      prefs.clearGatewayToken()
+    } else {
+      prefs.saveGatewayToken(trimmed)
+    }
+  }
+
+  fun setGatewayPassword(password: String?) {
+    val trimmed = password?.trim().orEmpty()
+    if (trimmed.isEmpty()) {
+      prefs.clearGatewayPassword()
+    } else {
+      prefs.saveGatewayPassword(trimmed)
+    }
+  }
+
+  fun clearGatewayAuth() {
+    prefs.clearGatewayToken()
+    prefs.clearGatewayPassword()
+  }
+
   fun connect(endpoint: GatewayEndpoint) {
     connectedEndpoint = endpoint
     operatorStatusText = "Connecting…"

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -159,6 +159,11 @@ class SecurePrefs(context: Context) {
     prefs.edit { putString(key, token.trim()) }
   }
 
+  fun clearGatewayToken() {
+    val key = "gateway.token.${_instanceId.value}"
+    prefs.edit { remove(key) }
+  }
+
   fun loadGatewayPassword(): String? {
     val key = "gateway.password.${_instanceId.value}"
     val stored = prefs.getString(key, null)?.trim()
@@ -168,6 +173,11 @@ class SecurePrefs(context: Context) {
   fun saveGatewayPassword(password: String) {
     val key = "gateway.password.${_instanceId.value}"
     prefs.edit { putString(key, password.trim()) }
+  }
+
+  fun clearGatewayPassword() {
+    val key = "gateway.password.${_instanceId.value}"
+    prefs.edit { remove(key) }
   }
 
   fun loadGatewayTlsFingerprint(stableId: String): String? {


### PR DESCRIPTION
Adds manual gateway auth controls (none/token/password) to the Android Settings → Advanced → Manual gateway connection sheet.\n\n- Stores credentials in EncryptedSharedPreferences via SecurePrefs\n- Clears the opposite credential to avoid ambiguity (token takes precedence in protocol)\n\nThis enables password-mode gateways to be used from Android companion app.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds manual gateway authentication controls (none/token/password) to the Android Settings → Advanced → Manual gateway connection UI, and wires those settings through `MainViewModel`/`NodeRuntime` into `SecurePrefs` (EncryptedSharedPreferences) so credentials can be persisted and used during `connect()`/`refreshGatewayConnection()`.

The changes fit the existing architecture by keeping storage in `SecurePrefs`, transport wiring in `NodeRuntime` (which already loads token/password and passes them into `GatewaySession.connect()`), and exposing view-model methods for the Compose UI.

Main issue spotted: the Compose state for auth mode/token/password is not initialized from persisted values, so reopening Settings shows “None” and a manual connect can unintentionally clear previously saved credentials.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but has a user-facing state bug around persisted manual auth.
- The storage and runtime wiring are straightforward and localized, but the Settings UI currently doesn’t reflect existing stored credentials and can clear them on connect, which is a behavioral regression for users relying on saved token/password.
- apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->