### PR TITLE
docs: add Shellfish skill split

### DIFF
--- a/skills/shellfish-canvas/SKILL.md
+++ b/skills/shellfish-canvas/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: shellfish-canvas
+description: Render Shellfish dashboard and shopping canvases.
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"🖼️","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-canvas
+
+Render the Shellfish dashboard canvas.
+
+Quick start
+
+- Load dashboard HTML from your Shellfish repo (skills/shellfish/canvas/dashboard.html)
+- Render via your canvas tool with live data once wired
+
+Notes
+
+- The current dashboard HTML is static (mock data) until wired to memory/*.json.
+- Use this skill to standardize where the Shellfish UI lives for Clawdbot.

--- a/skills/shellfish-core/SKILL.md
+++ b/skills/shellfish-core/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: shellfish-core
+description: Core Shellfish shopping commands: search, details, cart, checkout, discover.
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"🦪","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-core
+
+Core Shellfish CLI commands for shopping discovery and checkout.
+
+Quick start
+
+- `shellfish search "running shoes" --limit 5 --ships-to GB --currency GBP`
+- `shellfish details <lookupUrl>`
+- `shellfish cart add <checkoutUrl|variantId> --qty 1 --shop <domain>`
+- `shellfish checkout <checkoutUrl> --mode handoff`
+- `shellfish discover <domain>`
+
+Search
+
+- Basic: `shellfish search "gymshark vest" --limit 5`
+- Direct store (no auth): `shellfish search "wool runners" --store allbirds.com`
+- Cards JSON: `shellfish search "headphones" --format cards --output json`
+- With context: `shellfish search "running shoes" --context "UK buyer under £120"`
+
+Details
+
+- `shellfish details <lookupUrl> [--ships-to GB] [--shop-id <id>] [--variant-id <id>]`
+
+Cart
+
+- Add: `shellfish cart add <checkoutUrl|variantId> [--qty N] [--title text] [--price N] [--currency CODE] [--shop domain]`
+- Show: `shellfish cart show`
+- Remove: `shellfish cart remove <index>`
+- Checkout URLs: `shellfish cart checkout`
+
+Checkout
+
+- Handoff: `shellfish checkout <checkoutUrl> --mode handoff`
+- Browser steps: `shellfish checkout <checkoutUrl> --mode browser`
+- Shop Pay: `shellfish checkout <checkoutUrl> --mode shoppay`
+- Shop Pay QR: `shellfish checkout <checkoutUrl> --mode shoppay-qr`
+- MCP checkout: `shellfish checkout <checkoutUrl> --mode mcp`
+
+Discovery
+
+- `shellfish discover <domain>`
+
+Notes
+
+- `--store <domain>` uses Storefront MCP and does not require Shopify API keys.
+- Preferences are loaded from `memory/preferences.json` when available.
+
+Environment
+
+Required for catalog search (non-Storefront MCP):
+- `SHOPIFY_CLIENT_ID`
+- `SHOPIFY_CLIENT_SECRET`
+
+Optional for browser checkout:
+- `SHELLFISH_SHIPPING_*` (address fields)
+- `SHELLFISH_PAYMENT_TYPE` (`shop_pay` | `card` | `auto`)
+- `SHELLFISH_CARD_*`

--- a/skills/shellfish-merchant-intel/SKILL.md
+++ b/skills/shellfish-merchant-intel/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: shellfish-merchant-intel
+description: Merchant discovery and registry intel for Shellfish.
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"🏪","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-merchant-intel
+
+Merchant discovery and reputation lookups.
+
+Quick start
+
+- Search merchants: `shellfish merchant-intel "running"`
+- Fetch by domain: `shellfish merchant-intel --domain allbirds.com`
+- Browse category: `shellfish merchant-intel --category footwear`
+
+Commands
+
+- `shellfish merchant-intel <query>`
+- `shellfish merchant-intel --domain <domain> [--json]`
+- `shellfish merchant-intel --category <category>`
+
+Notes
+
+- Uses the Shellfish registry (default http://localhost:3333).
+- Override with `--registry <url>` or `SHELLFISH_REGISTRY_URL`.

--- a/skills/shellfish-orders/SKILL.md
+++ b/skills/shellfish-orders/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shellfish-orders
+description: Purchase ledger commands for Shellfish (orders list/add/show/update).
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"🧾","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-orders
+
+Manage the local purchase ledger (memory/purchases.json).
+
+Quick start
+
+- List: `shellfish orders list`
+- Add: `shellfish orders add --merchant allbirds.com --item "Tree Runner" --price 99.00 --currency GBP`
+- Show: `shellfish orders show <orderId>`
+- Update: `shellfish orders update <orderId> --status shipped --tracking RM123 --carrier "Royal Mail"`
+
+Commands
+
+- `shellfish orders list [--status <status>] [--merchant <domain>] [--since <YYYY-MM-DD>] [--limit N] [--json]`
+- `shellfish orders add --merchant <domain> --item <title> --price <amount> [--currency GBP] [--qty N] [--order-id id]`
+- `shellfish orders show <orderId>`
+- `shellfish orders update <orderId> [--status <status>] [--tracking <num>] [--carrier <name>]`
+
+Statuses
+
+- `pending`, `confirmed`, `shipped`, `delivered`, `returned`, `cancelled`
+
+Notes
+
+- Orders are stored at `memory/purchases.json`.
+- MCP checkouts auto-record orders when an order ID is returned.

--- a/skills/shellfish-prices/SKILL.md
+++ b/skills/shellfish-prices/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: shellfish-prices
+description: Price watch commands for Shellfish (add/list/remove/check).
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"📉","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-prices
+
+Track product prices and get alerts.
+
+Quick start
+
+- Add watch: `shellfish watch add <lookupUrl> --target £49.99`
+- List watches: `shellfish watch list`
+- Remove: `shellfish watch remove 1`
+- Check now: `shellfish watch check`
+- Check with JSON output: `shellfish watch check --notify`
+
+Commands
+
+- `shellfish watch add <lookupUrl> --target <price> [--currency GBP] [--auto-buy]`
+- `shellfish watch list`
+- `shellfish watch remove <index|id>`
+- `shellfish watch check [--notify]`
+
+Notes
+
+- Watches are stored at `memory/watches.json`.
+- `--notify` prints JSON so Clawdbot can send alerts.
+- Auto-buy will attempt checkout when target price is met.
+
+Environment
+
+- Requires `SHOPIFY_CLIENT_ID` and `SHOPIFY_CLIENT_SECRET` for catalog lookups.

--- a/skills/shellfish-reviews/SKILL.md
+++ b/skills/shellfish-reviews/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: shellfish-reviews
+description: Submit and browse agent reviews for merchants.
+homepage: https://shellfish.store
+metadata:
+  {"openclaw":{"emoji":"⭐","requires":{"bins":["shellfish"]}}}
+---
+
+# shellfish-reviews
+
+Submit agent reviews and pull merchant reputation data.
+
+Quick start
+
+- Review a merchant: `shellfish review <merchant-domain> --rating 5 --tip "Fast checkout"`
+- Fetch merchant profile: `shellfish merchant-intel --domain allbirds.com`
+
+Commands
+
+- `shellfish review <merchant-domain> --rating <1-5> [--tip text] [--notes text] [--delivery-days N]`
+- `shellfish merchant-intel --domain <domain> [--json]`
+
+Notes
+
+- Reviews are submitted to the Shellfish registry.
+- Set `SHELLFISH_REGISTRY_URL` to point at your registry.


### PR DESCRIPTION
## Summary
- add Shellfish skill split (core, orders, prices, merchant intel, reviews, canvas)
- document shellfish CLI usage in per-skill SKILL.md files

## Notes
- Requires `shellfish` bin available on agents
- Canvas skill references existing Shellfish dashboard HTML

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds six new Shellfish skill documentation files (`skills/shellfish-*/SKILL.md`) that split Shellfish functionality into focused areas (core shopping commands, orders ledger, price watches, merchant intel, reviews submission, and a canvas/dashboard renderer). Each file defines skill metadata (name/description/homepage + openclaw metadata) and provides quick-start CLI examples plus notes on expected environment variables and local `memory/*.json` files.


<h3>Confidence Score: 4/5</h3>

- This PR is low risk to merge since it only adds documentation, with minor risk of user confusion from drifting defaults.
- All changes are new markdown docs; there are no code-path changes or runtime-impacting modifications. The only notable risk is correctness/consistency of documented defaults and flags relative to the actual `shellfish` CLI behavior.
- skills/shellfish-merchant-intel/SKILL.md (hardcoded default registry URL statement)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->