### PR TITLE
fix(agents): cast streamParams to allow cacheRetention property assignment

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -74,7 +74,7 @@ function createStreamFnWithExtraParams(
   }
   const cacheRetention = resolveCacheRetention(extraParams, provider);
   if (cacheRetention) {
-    streamParams.cacheRetention = cacheRetention;
+    (streamParams as Record<string, unknown>).cacheRetention = cacheRetention;
   }
 
   if (Object.keys(streamParams).length === 0) {


### PR DESCRIPTION
The `cacheRetention` property may not be in the `SimpleStreamOptions` type definition yet, but it's supported by pi-ai 0.50.9. Cast to `Record<string, unknown>` to allow the assignment while maintaining type safety for other properties.

This fixes the TypeScript compilation error that was blocking all OpenClaw commands:
```
error TS2339: Property 'cacheRetention' does not exist on type 'Partial<SimpleStreamOptions>'.
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a TypeScript build break in the Pi embedded runner by allowing the `cacheRetention` stream option to be passed through even though the current `@mariozechner/pi-ai` `SimpleStreamOptions` type doesn’t include it yet. Concretely, it changes the assignment of `streamParams.cacheRetention` to a casted write (`(streamParams as Record<string, unknown>).cacheRetention = ...`) inside `createStreamFnWithExtraParams`, so the wrapper can still forward the option to `streamSimple` at runtime.

This fits into the existing design of `src/agents/pi-embedded-runner/extra-params.ts`, which merges model-config `extraParams` with overrides and constructs a wrapper `streamFn` that spreads these resolved stream parameters into the underlying Pi stream call.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it’s a narrow type-level workaround that matches the intended runtime behavior.
- Only a single line changes, and it addresses a concrete TS compile error without altering the runtime logic of how stream params are built or passed through. The cast is localized to the one property that is missing from the upstream type, so other properties remain type-checked as before.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->