### PR TITLE
fix(memory): add ignore patterns to chokidar file watcher

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,6 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
+  ignorePaths: string[];
   provider: "openai" | "local" | "gemini" | "auto";
   remote?: {
     baseUrl?: string;
@@ -174,6 +175,26 @@ function mergeConfig(
     .map((value) => value.trim())
     .filter(Boolean);
   const extraPaths = Array.from(new Set(rawPaths));
+  // Default ignore patterns for common non-document directories
+  const defaultIgnorePaths = [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "**/.env/**",
+    "**/__pycache__/**",
+    "**/.tox/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.nuxt/**",
+    "**/target/**",
+    "**/.cargo/**",
+  ];
+  const userIgnorePaths = [...(defaults?.ignorePaths ?? []), ...(overrides?.ignorePaths ?? [])]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const ignorePaths = Array.from(new Set([...defaultIgnorePaths, ...userIgnorePaths]));
   const vector = {
     enabled: overrides?.store?.vector?.enabled ?? defaults?.store?.vector?.enabled ?? true,
     extensionPath:
@@ -249,6 +270,7 @@ function mergeConfig(
     enabled,
     sources,
     extraPaths,
+    ignorePaths,
     provider,
     remote,
     experimental: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -223,6 +223,7 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.enabled": "Enable Memory Search",
   "agents.defaults.memorySearch.sources": "Memory Search Sources",
   "agents.defaults.memorySearch.extraPaths": "Extra Memory Paths",
+  "agents.defaults.memorySearch.ignorePaths": "Ignore Paths (Glob Patterns)",
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Memory Search Session Index (Experimental)",
   "agents.defaults.memorySearch.provider": "Memory Search Provider",
@@ -504,6 +505,8 @@ const FIELD_HELP: Record<string, string> = {
     'Sources to index for memory search (default: ["memory"]; add "sessions" to include session transcripts).',
   "agents.defaults.memorySearch.extraPaths":
     "Extra paths to include in memory search (directories or .md files; relative paths resolved from workspace).",
+  "agents.defaults.memorySearch.ignorePaths":
+    "Glob patterns to exclude from memory search (merged with defaults: node_modules, .git, .venv, etc).",
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Enable experimental session transcript indexing for memory search (default: false).",
   "agents.defaults.memorySearch.provider": 'Embedding provider ("openai", "gemini", or "local").',

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -228,6 +228,8 @@ export type MemorySearchConfig = {
   sources?: Array<"memory" | "sessions">;
   /** Extra paths to include in memory search (directories or .md files). */
   extraPaths?: string[];
+  /** Glob patterns to ignore when watching extraPaths (merged with defaults like node_modules, .git, .venv). */
+  ignorePaths?: string[];
   /** Experimental memory search settings. */
   experimental?: {
     /** Enable session transcript indexing (experimental, default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -310,6 +310,8 @@ export const MemorySearchSchema = z
     enabled: z.boolean().optional(),
     sources: z.array(z.union([z.literal("memory"), z.literal("sessions")])).optional(),
     extraPaths: z.array(z.string()).optional(),
+    /** Glob patterns to ignore when watching extraPaths (merged with defaults). */
+    ignorePaths: z.array(z.string()).optional(),
     experimental: z
       .object({
         sessionMemory: z.boolean().optional(),

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -109,6 +109,30 @@ describe("listMemoryFiles", () => {
       expect(files.some((file) => file.endsWith("nested.md"))).toBe(false);
     }
   });
+
+  it("respects ignorePaths glob patterns", async () => {
+    await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
+    const extraDir = path.join(tmpDir, "extra");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "note.md"), "# Note");
+
+    // Create node_modules with a .md file inside
+    const nodeModules = path.join(extraDir, "node_modules");
+    await fs.mkdir(nodeModules, { recursive: true });
+    await fs.writeFile(path.join(nodeModules, "readme.md"), "# Should be ignored");
+
+    // Create .venv with a .md file inside
+    const venv = path.join(extraDir, ".venv");
+    await fs.mkdir(venv, { recursive: true });
+    await fs.writeFile(path.join(venv, "docs.md"), "# Should also be ignored");
+
+    const files = await listMemoryFiles(tmpDir, [extraDir], ["**/node_modules/**", "**/.venv/**"]);
+    expect(files).toHaveLength(2); // MEMORY.md + note.md
+    expect(files.some((file) => file.endsWith("MEMORY.md"))).toBe(true);
+    expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
+    expect(files.some((file) => file.includes("node_modules"))).toBe(false);
+    expect(files.some((file) => file.includes(".venv"))).toBe(false);
+  });
 });
 
 describe("chunkMarkdown", () => {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -54,7 +54,23 @@ export function isMemoryPath(relPath: string): boolean {
   return normalized.startsWith("memory/");
 }
 
-async function walkDir(dir: string, files: string[]) {
+/**
+ * Extract literal directory names from glob patterns like `**​/node_modules/**`.
+ * Returns a Set of directory names to ignore.
+ */
+function extractIgnoredDirNames(patterns: string[]): Set<string> {
+  const names = new Set<string>();
+  for (const pattern of patterns) {
+    // Match patterns like **/dirname/** or **/dirname
+    const match = pattern.match(/^\*\*\/([^/*]+)(?:\/\*\*)?$/);
+    if (match?.[1]) {
+      names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+async function walkDir(dir: string, files: string[], ignoredDirNames?: Set<string>) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
@@ -62,7 +78,11 @@ async function walkDir(dir: string, files: string[]) {
       continue;
     }
     if (entry.isDirectory()) {
-      await walkDir(full, files);
+      // Skip ignored directories
+      if (ignoredDirNames?.has(entry.name)) {
+        continue;
+      }
+      await walkDir(full, files, ignoredDirNames);
       continue;
     }
     if (!entry.isFile()) {
@@ -78,11 +98,13 @@ async function walkDir(dir: string, files: string[]) {
 export async function listMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
+  ignorePaths?: string[],
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
   const altMemoryFile = path.join(workspaceDir, "memory.md");
   const memoryDir = path.join(workspaceDir, "memory");
+  const ignoredDirNames = ignorePaths ? extractIgnoredDirNames(ignorePaths) : undefined;
 
   const addMarkdownFile = async (absPath: string) => {
     try {
@@ -102,7 +124,7 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await walkDir(memoryDir, result);
+      await walkDir(memoryDir, result, ignoredDirNames);
     }
   } catch {}
 
@@ -115,7 +137,7 @@ export async function listMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
-          await walkDir(inputPath, result);
+          await walkDir(inputPath, result, ignoredDirNames);
           continue;
         }
         if (stat.isFile() && inputPath.endsWith(".md")) {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -867,6 +867,7 @@ export class MemoryIndexManager {
     ]);
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
+      ignored: this.settings.ignorePaths,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,
@@ -1107,7 +1108,11 @@ export class MemoryIndexManager {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);
+    const files = await listMemoryFiles(
+      this.workspaceDir,
+      this.settings.extraPaths,
+      this.settings.ignorePaths,
+    );
     const fileEntries = await Promise.all(
       files.map(async (file) => buildFileEntry(file, this.workspaceDir)),
     );

--- a/src/memory/sync-memory-files.ts
+++ b/src/memory/sync-memory-files.ts
@@ -14,6 +14,7 @@ type ProgressState = {
 export async function syncMemoryFiles(params: {
   workspaceDir: string;
   extraPaths?: string[];
+  ignorePaths?: string[];
   db: DatabaseSync;
   needsFullReindex: boolean;
   progress?: ProgressState;
@@ -27,7 +28,7 @@ export async function syncMemoryFiles(params: {
   ftsAvailable: boolean;
   model: string;
 }) {
-  const files = await listMemoryFiles(params.workspaceDir, params.extraPaths);
+  const files = await listMemoryFiles(params.workspaceDir, params.extraPaths, params.ignorePaths);
   const fileEntries = await Promise.all(
     files.map(async (file) => buildFileEntry(file, params.workspaceDir)),
   );


### PR DESCRIPTION
## Summary

Add default ignore patterns to `chokidar.watch()` to prevent file descriptor exhaustion when `memorySearch.extraPaths` includes directories with large non-document subtrees.

## Problem

When `memorySearch.extraPaths` points to a directory containing large non-document subtrees (e.g., Python `.venv` with PyTorch, `node_modules`, `.git`), chokidar opens a file descriptor for **every file and directory** in the tree — even though only `.md` files are ever indexed.

This causes the gateway process to exhaust its file descriptor limit and produce `spawn EBADF` errors.

Example: A `.venv` containing PyTorch (~22,000 files) caused **24,308 open file descriptors** on the gateway process. The macOS LaunchAgent soft limit is 256 by default.

## Solution

Add `ignored` option to chokidar.watch() with sensible defaults:

```javascript
this.watcher = chokidar.watch(Array.from(watchPaths), {
  ignoreInitial: true,
  ignored: this.settings.ignorePaths,  // NEW
  awaitWriteFinish: { ... },
});
```

### Default ignored patterns:
- `**/node_modules/**`
- `**/.git/**`
- `**/.venv/**` / `**/venv/**`
- `**/.env/**`
- `**/__pycache__/**`
- `**/.tox/**`
- `**/dist/**` / `**/build/**`
- `**/.next/**` / `**/.nuxt/**`
- `**/target/**` / `**/.cargo/**`

### User-configurable

Also adds `memorySearch.ignorePaths` config option for custom patterns:

```json
{
  "memorySearch": {
    "extraPaths": ["/path/to/obsidian-vault"],
    "ignorePaths": ["**/my-custom-ignore/**"]
  }
}
```

User patterns are merged with defaults.

Fixes #5827

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `memorySearch.ignorePaths` config option and threads it through config resolution so `MemoryIndexManager` passes it as `ignored` to `chokidar.watch()`. The intent is to avoid file descriptor exhaustion when `memorySearch.extraPaths` points at large non-document trees (e.g., `.venv`, `node_modules`, `.git`).

The change fits cleanly into the existing memory-search config pipeline (`src/agents/memory-search.ts` resolves agent defaults/overrides; `src/memory/manager.ts` consumes the resolved settings to set up watchers).

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and should reduce chokidar watcher load, with minor UX/behavior edge cases to confirm.
- Changes are localized to config plumbing + watcher options, with no schema-breaking changes and no risky side effects identified beyond potential over-broad ignores and missing UI help text.
- src/memory/manager.ts (watcher behavior vs ignore patterns), src/config/schema.ts (UI help text for new setting)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->