### PR TITLE
fix: prevent Telegram voice .ogg from being misclassified as text

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -147,7 +147,8 @@ function isKnownBinaryMedia(buffer?: Buffer): boolean {
   if (hasMagic(buffer, "fLaC")) {
     return true;
   }
-  if (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0) {
+  // MP3 frame sync: 0xFF followed by 0xE2..0xFB, but exclude UTF-16 BOM (0xFF 0xFE)
+  if (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0 && buffer[1] !== 0xfe) {
     return true;
   }
   return false;

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -289,15 +289,15 @@ async function extractFileBlocks(params: {
       }
       continue;
     }
-    const buf = bufferResult?.buffer;
-    if (isKnownBinaryMedia(buf)) {
-      continue;
-    }
     const nameHint = bufferResult?.fileName ?? attachment.path ?? attachment.url;
     const forcedTextMimeResolved = forcedTextMime ?? resolveTextMimeFromName(nameHint ?? "");
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
     const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
+    // Skip binary audio that would otherwise be misclassified as text by heuristics
+    if (!forcedTextMimeResolved && kind === "audio" && isKnownBinaryMedia(bufferResult?.buffer)) {
+      continue;
+    }
     if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
       continue;
     }

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -120,20 +120,36 @@ function appendFileBlocks(body: string | undefined, blocks: string[]): string {
 
 /** Detect known binary media via magic bytes to prevent text-heuristic misclassification. */
 function hasMagic(buffer: Buffer, ascii: string): boolean {
-  if (buffer.length < ascii.length) return false;
+  if (buffer.length < ascii.length) {
+    return false;
+  }
   for (let i = 0; i < ascii.length; i++) {
-    if (buffer[i] !== ascii.charCodeAt(i)) return false;
+    if (buffer[i] !== ascii.charCodeAt(i)) {
+      return false;
+    }
   }
   return true;
 }
 
 function isKnownBinaryMedia(buffer?: Buffer): boolean {
-  if (!buffer || buffer.length < 4) return false;
-  if (hasMagic(buffer, "OggS")) return true; // OGG/Opus (Telegram voice)
-  if (hasMagic(buffer, "RIFF")) return true; // WAV/AVI
-  if (hasMagic(buffer, "ID3")) return true; // MP3 with ID3 tag
-  if (hasMagic(buffer, "fLaC")) return true; // FLAC
-  if (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0) return true; // MP3 sync
+  if (!buffer || buffer.length < 4) {
+    return false;
+  }
+  if (hasMagic(buffer, "OggS")) {
+    return true;
+  }
+  if (hasMagic(buffer, "RIFF")) {
+    return true;
+  }
+  if (hasMagic(buffer, "ID3")) {
+    return true;
+  }
+  if (hasMagic(buffer, "fLaC")) {
+    return true;
+  }
+  if (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0) {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary

Fixes #6081

- Add magic-byte detection (`isKnownBinaryMedia()`) for known binary audio formats (OGG/Opus, RIFF/WAV, MP3/ID3, FLAC)
- Guard `resolveUtf16Charset()` to bail early on binary media buffers
- Guard `extractFileBlocks()` to skip binary media before text heuristics run

This prevents Telegram voice messages (`.ogg`) from being misclassified as `text/tab-separated-values`, which caused raw binary garbage to be injected into session history and contaminate the context window.

## Test plan

- [ ] Send a Telegram voice message and verify Whisper transcription still works
- [ ] Reopen the session and confirm no `<file>` blocks with binary garbage appear
- [ ] Send actual text/CSV/TSV files and verify they are still extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds lightweight “magic byte” detection for common binary audio formats (OGG/Opus, RIFF/WAV, MP3/ID3, FLAC) and uses it to short-circuit text heuristics (`resolveUtf16Charset`, `extractFileBlocks`). The intent is to prevent Telegram voice `.ogg` payloads from being treated as `text/tab-separated-values` and injected into `<file>` blocks, contaminating session history/context.

The changes are localized to `src/media-understanding/apply.ts` and sit in the file-extraction path that runs before media capability processing (audio transcription/image/video).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but the new binary-magic guard may unintentionally skip legitimate file attachments.
- The change is small and addresses a real misclassification path, but the `isKnownBinaryMedia()` check is applied unconditionally in `extractFileBlocks()`, which can change behavior for normal audio file uploads that users expect to appear as `<file>` blocks.
- src/media-understanding/apply.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->