### PR TITLE
feat: add /spawn command for fire-and-forget subagent spawning

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -274,6 +274,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       argsMenu: "auto",
     }),
     defineChatCommand({
+      key: "spawn",
+      nativeName: "spawn",
+      description: "Spawn a subagent immediately (fire-and-forget).",
+      textAliases: ["/spawn", "/subagent"],
+      category: "management",
+      args: [
+        {
+          name: "task",
+          description: "Task for the subagent",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "config",
       nativeName: "config",
       description: "Show or set config values.",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -29,6 +29,7 @@ import {
   handleStopCommand,
   handleUsageCommand,
 } from "./commands-session.js";
+import { handleSpawnCommand } from "./commands-spawn.js";
 import { handleSubagentsCommand } from "./commands-subagents.js";
 import { handleTtsCommands } from "./commands-tts.js";
 import { routeReply } from "./route-reply.js";
@@ -53,6 +54,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleApproveCommand,
       handleContextCommand,
       handleWhoamiCommand,
+      handleSpawnCommand,
       handleSubagentsCommand,
       handleConfigCommand,
       handleDebugCommand,

--- a/src/auto-reply/reply/commands-spawn.ts
+++ b/src/auto-reply/reply/commands-spawn.ts
@@ -1,0 +1,241 @@
+import crypto from "node:crypto";
+import type { CommandHandler } from "./commands-types.js";
+import { AGENT_LANE_SUBAGENT } from "../../agents/lanes.js";
+import { buildSubagentSystemPrompt } from "../../agents/subagent-announce.js";
+import { registerSubagentRun } from "../../agents/subagent-registry.js";
+import {
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "../../agents/tools/sessions-helpers.js";
+import { callGateway } from "../../gateway/call.js";
+import { logVerbose } from "../../globals.js";
+import {
+  isSubagentSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
+
+const SPAWN_COMMAND = "/spawn";
+const SUBAGENT_ALIAS = "/subagent";
+
+type SpawnOptions = {
+  task: string;
+  model?: string;
+  label?: string;
+  deliver?: boolean;
+};
+
+function parseSpawnArgs(argsRaw: string): SpawnOptions | { error: string } {
+  const tokens: string[] = [];
+  let remaining = argsRaw.trim();
+
+  const options: Partial<SpawnOptions> = {};
+
+  // Parse flags before the task
+  while (remaining.length > 0) {
+    // Check for --model flag
+    const modelMatch = remaining.match(/^--model\s+(\S+)\s*/);
+    if (modelMatch) {
+      options.model = modelMatch[1];
+      remaining = remaining.slice(modelMatch[0].length);
+      continue;
+    }
+
+    // Check for --label flag
+    const labelMatch = remaining.match(/^--label\s+(\S+)\s*/);
+    if (labelMatch) {
+      options.label = labelMatch[1];
+      remaining = remaining.slice(labelMatch[0].length);
+      continue;
+    }
+
+    // Check for --deliver flag
+    if (remaining.startsWith("--deliver")) {
+      options.deliver = true;
+      remaining = remaining.slice("--deliver".length).trimStart();
+      continue;
+    }
+
+    // If no more flags, the rest is the task
+    break;
+  }
+
+  const task = remaining.trim();
+  if (!task) {
+    return { error: "Missing task. Usage: /spawn <task>" };
+  }
+
+  return { task, ...options };
+}
+
+function buildSpawnHelp(): string {
+  return [
+    "🚀 Spawn a subagent",
+    "",
+    "Usage:",
+    "  /spawn <task>",
+    "  /spawn --model <model> <task>",
+    "  /spawn --label <label> <task>",
+    "  /spawn --deliver <task>",
+    "",
+    "Options:",
+    "  --model    Model override (e.g., anthropic/claude-sonnet-4-20250514)",
+    "  --label    Label for the subagent",
+    "  --deliver  Enable delivery of subagent responses",
+    "",
+    "Alias: /subagent",
+  ].join("\n");
+}
+
+export const handleSpawnCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+
+  const normalized = params.command.commandBodyNormalized.toLowerCase();
+  if (!normalized.startsWith(SPAWN_COMMAND) && !normalized.startsWith(SUBAGENT_ALIAS)) {
+    return null;
+  }
+
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /spawn from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  // Extract the command part and args
+  const commandBody = params.command.commandBodyNormalized;
+  const commandEnd = commandBody.indexOf(" ");
+  const argsRaw = commandEnd === -1 ? "" : commandBody.slice(commandEnd + 1).trim();
+
+  // Show help if no args or --help
+  if (!argsRaw || argsRaw === "--help" || argsRaw === "-h" || argsRaw === "help") {
+    return { shouldContinue: false, reply: { text: buildSpawnHelp() } };
+  }
+
+  const parsed = parseSpawnArgs(argsRaw);
+  if ("error" in parsed) {
+    return { shouldContinue: false, reply: { text: `⚠️ ${parsed.error}` } };
+  }
+
+  const { task, model, label, deliver } = parsed;
+
+  // Resolve session context
+  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
+  const requesterSessionKey = params.sessionKey;
+
+  // Don't allow spawning from subagent sessions
+  if (typeof requesterSessionKey === "string" && isSubagentSessionKey(requesterSessionKey)) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚠️ Cannot spawn subagents from subagent sessions." },
+    };
+  }
+
+  const requesterInternalKey = requesterSessionKey
+    ? resolveInternalSessionKey({
+        key: requesterSessionKey,
+        alias,
+        mainKey,
+      })
+    : alias;
+
+  const requesterAgentId = normalizeAgentId(parseAgentSessionKey(requesterInternalKey)?.agentId);
+
+  // Create child session key
+  const childSessionKey = `agent:${requesterAgentId}:subagent:${crypto.randomUUID()}`;
+  const spawnedByKey = requesterInternalKey;
+
+  // Resolve delivery context from the originating message
+  const requesterOrigin = normalizeDeliveryContext({
+    channel: params.ctx.OriginatingChannel ?? params.command.channel,
+    accountId: params.ctx.AccountId,
+    to: params.ctx.OriginatingTo ?? params.command.from,
+    threadId: params.ctx.MessageThreadId,
+  });
+
+  // Build subagent system prompt
+  const childSystemPrompt = buildSubagentSystemPrompt({
+    requesterSessionKey,
+    requesterOrigin,
+    childSessionKey,
+    label: label || undefined,
+    task,
+  });
+
+  // Apply model override if specified
+  if (model) {
+    try {
+      await callGateway({
+        method: "sessions.patch",
+        params: { key: childSessionKey, model },
+        timeoutMs: 10_000,
+      });
+    } catch (err) {
+      const messageText =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+      // Only fail on non-recoverable errors
+      const recoverable =
+        messageText.includes("invalid model") || messageText.includes("model not allowed");
+      if (!recoverable) {
+        return {
+          shouldContinue: false,
+          reply: { text: `⚠️ Failed to apply model: ${messageText}` },
+        };
+      }
+      // Log warning but continue
+      logVerbose(`/spawn model warning: ${messageText}`);
+    }
+  }
+
+  // Spawn the subagent via gateway
+  const childIdem = crypto.randomUUID();
+  let childRunId: string = childIdem;
+
+  try {
+    const response = await callGateway<{ runId: string }>({
+      method: "agent",
+      params: {
+        message: task,
+        sessionKey: childSessionKey,
+        channel: requesterOrigin?.channel,
+        idempotencyKey: childIdem,
+        deliver: deliver ?? false,
+        lane: AGENT_LANE_SUBAGENT,
+        extraSystemPrompt: childSystemPrompt,
+        label: label || undefined,
+        spawnedBy: spawnedByKey,
+      },
+      timeoutMs: 10_000,
+    });
+    if (typeof response?.runId === "string" && response.runId) {
+      childRunId = response.runId;
+    }
+  } catch (err) {
+    const messageText =
+      err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+    return {
+      shouldContinue: false,
+      reply: { text: `⚠️ Failed to spawn subagent: ${messageText}` },
+    };
+  }
+
+  // Register the subagent run for tracking
+  registerSubagentRun({
+    runId: childRunId,
+    childSessionKey,
+    requesterSessionKey: requesterInternalKey,
+    requesterOrigin,
+    requesterDisplayKey: requesterInternalKey === mainKey ? alias : requesterInternalKey,
+    task,
+    cleanup: "keep",
+    label: label || undefined,
+    runTimeoutSeconds: 0,
+  });
+
+  // Fire-and-forget: return with no reply (subagent will announce when done)
+  // This is the key difference from asking the model to spawn - no confirmation message
+  return { shouldContinue: false };
+};

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -50,6 +50,8 @@ const RESERVED_COMMANDS = new Set([
   "activation",
   // Agent control
   "skill",
+  "spawn",
+  "subagent",
   "subagents",
   "model",
   "models",


### PR DESCRIPTION
## Summary

Adds the `/spawn` command (alias `/subagent`) that immediately spawns a subagent without a model response. This provides a fast-path alternative to asking the agent to spawn subagents.

## Changes

- **`src/auto-reply/commands-registry.data.ts`**: Add command definition for `/spawn` with alias `/subagent`
- **`src/auto-reply/reply/commands-spawn.ts`**: New command handler implementing fire-and-forget spawn
- **`src/auto-reply/reply/commands-core.ts`**: Register the spawn command handler
- **`src/plugins/commands.ts`**: Add `spawn` and `subagent` to reserved commands list

## Features

- **Fire-and-forget**: No "Ok, spawning..." response, just immediately starts the subagent
- **Subagent announces when done**: Uses existing announce behavior to ping user with results  
- **Fast-path execution**: Bypasses LLM entirely, like `/status` and `/help`
- **Optional flags**:
  - `--model <provider/model>`: Override model for subagent
  - `--label <label>`: Set subagent label
  - `--deliver`: Enable delivery of subagent responses

## Usage

```
/spawn <task>
/spawn --model anthropic/claude-sonnet-4-20250514 <task>
/spawn --label research-task <task>  
/spawn --deliver <task>
/subagent <task>  # alias
```

## Implementation Notes

- Reuses existing `sessions_spawn` tool logic internally via gateway call
- Follows the pattern of other fast-path commands (`handleStatusCommand`, `handleSubagentsCommand`, etc.)
- Returns `{ shouldContinue: false }` with no reply to achieve fire-and-forget behavior

Closes #6162

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new fast-path auto-reply command `/spawn` (alias `/subagent`) that spawns a subagent via gateway calls without producing an immediate model response. It registers the command in the chat command registry, hooks the handler into the core command pipeline, and updates the plugin command registry’s reserved command list to prevent name collisions.

The handler builds a child subagent session key, optionally applies a model override via `sessions.patch`, calls the gateway `agent` method to start the run, and registers the run for existing subagent announcement/tracking behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one correctness edge case around command prefix matching and a small dead-code cleanup.
- Changes are localized and largely reuse existing spawn/tool patterns; the main functional risk is the `startsWith` command detection which can mis-handle similarly-prefixed commands, plus an unused variable that may trip linting depending on project settings.
- src/auto-reply/reply/commands-spawn.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->