### PR TITLE
security(ui): remove remote mintcdn asset reference

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -132,7 +132,7 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src="https://mintcdn.com/clawhub/4rYvG-uuZrMK_URE/assets/pixel-lobster.svg?fit=max&auto=format&n=4rYvG-uuZrMK_URE&q=85&s=da2032e9eac3b5d9bfe7eb96ca6a8a26" alt="OpenClaw" />
+              <img src="/favicon.svg" alt="OpenClaw" />
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
### Summary
Removes the remote mintcdn.com SVG dependency from the Control UI brand logo and uses the existing local /favicon.svg instead.

### Why
Avoids an external supply-chain dependency in the UI and addresses the concern raised in #5170.

### Testing
- pnpm -C ui build

### Notes
- Pure UI change; no runtime behavior change beyond logo asset source.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes an externally-hosted mintcdn.com SVG reference for the Control UI brand logo and replaces it with a local asset (`/favicon.svg`), reducing supply-chain/external dependency exposure. The change is localized to `ui/src/ui/app-render.ts` within the topbar brand logo render path and should not affect broader UI logic beyond the image source used.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line UI asset source swap from a remote URL to an existing local `/favicon.svg`, with no impact on application logic, state, or security model beyond reducing external dependency surface.
- ui/src/ui/app-render.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->