### PR TITLE
feat(hooks): allow webhooks to target specific agents and accounts

### DIFF
--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -66,6 +66,8 @@ Payload:
   "deliver": true,
   "channel": "last",
   "to": "+15551234567",
+  "agentId": "work",
+  "accountId": "acct_abc123",
   "model": "openai/gpt-5.2-mini",
   "thinking": "low",
   "timeoutSeconds": 120
@@ -79,6 +81,8 @@ Payload:
 - `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging channel. Defaults to `true`. Responses that are only heartbeat acknowledgments are automatically skipped.
 - `channel` optional (string): The messaging channel for delivery. One of: `last`, `whatsapp`, `telegram`, `discord`, `slack`, `mattermost` (plugin), `signal`, `imessage`, `msteams`. Defaults to `last`.
 - `to` optional (string): The recipient identifier for the channel (e.g., phone number for WhatsApp/Signal, chat ID for Telegram, channel ID for Discord/Slack/Mattermost (plugin), conversation ID for MS Teams). Defaults to the last recipient in the main session.
+- `agentId` optional (string): Target a specific agent by ID. When set, the hook runs against that agent's configuration and session namespace instead of the default agent.
+- `accountId` optional (string): Target a specific account by ID. When set, the hook uses that account's credentials and settings.
 - `model` optional (string): Model override (e.g., `anthropic/claude-3-5-sonnet` or an alias). Must be in the allowed model list if restricted.
 - `thinking` optional (string): Thinking level override (e.g., `low`, `medium`, `high`).
 - `timeoutSeconds` optional (number): Maximum duration for the agent run in seconds.

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -12,6 +12,7 @@ export type HookMappingConfig = {
   id?: string;
   match?: HookMappingMatch;
   action?: "wake" | "agent";
+  agentId?: string;
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
   sessionKey?: string;
@@ -31,6 +32,7 @@ export type HookMappingConfig = {
     | "imessage"
     | "msteams";
   to?: string;
+  accountId?: string;
   /** Override model for this hook (provider/model or alias). */
   model?: string;
   thinking?: string;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -10,6 +10,7 @@ export const HookMappingSchema = z
       })
       .optional(),
     action: z.union([z.literal("wake"), z.literal("agent")]).optional(),
+    agentId: z.string().optional(),
     wakeMode: z.union([z.literal("now"), z.literal("next-heartbeat")]).optional(),
     name: z.string().optional(),
     sessionKey: z.string().optional(),
@@ -30,6 +31,7 @@ export const HookMappingSchema = z
       ])
       .optional(),
     to: z.string().optional(),
+    accountId: z.string().optional(),
     model: z.string().optional(),
     thinking: z.string().optional(),
     timeoutSeconds: z.number().int().positive().optional(),

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -19,6 +19,7 @@ export async function resolveDeliveryTarget(
   jobPayload: {
     channel?: "last" | ChannelId;
     to?: string;
+    accountId?: string;
   },
 ): Promise<{
   channel: Exclude<OutboundChannel, "none">;
@@ -29,6 +30,8 @@ export async function resolveDeliveryTarget(
 }> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
+  const explicitAccountId =
+    typeof jobPayload.accountId === "string" ? jobPayload.accountId : undefined;
 
   const sessionCfg = cfg.session;
   const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
@@ -67,22 +70,23 @@ export async function resolveDeliveryTarget(
   const channel = resolved.channel ?? fallbackChannel ?? DEFAULT_CHAT_CHANNEL;
   const mode = resolved.mode as "explicit" | "implicit";
   const toCandidate = resolved.to;
+  const accountId = explicitAccountId ?? resolved.accountId;
 
   if (!toCandidate) {
-    return { channel, to: undefined, accountId: resolved.accountId, mode };
+    return { channel, to: undefined, accountId, mode };
   }
 
   const docked = resolveOutboundTarget({
     channel,
     to: toCandidate,
     cfg,
-    accountId: resolved.accountId,
+    accountId,
     mode,
   });
   return {
     channel,
     to: docked.ok ? docked.to : undefined,
-    accountId: resolved.accountId,
+    accountId,
     mode,
     error: docked.ok ? undefined : docked.error,
   };

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -241,6 +241,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
     channel: agentPayload?.channel ?? "last",
     to: agentPayload?.to,
+    accountId: agentPayload?.accountId,
   });
 
   const userTimezone = resolveUserTimezone(params.cfg.agents?.defaults?.userTimezone);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -23,6 +23,7 @@ export type CronPayload =
       deliver?: boolean;
       channel?: CronMessageChannel;
       to?: string;
+      accountId?: string;
       bestEffortDeliver?: boolean;
     };
 
@@ -38,6 +39,7 @@ export type CronPayloadPatch =
       deliver?: boolean;
       channel?: CronMessageChannel;
       to?: string;
+      accountId?: string;
       bestEffortDeliver?: boolean;
     };
 

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -8,6 +8,7 @@ export type HookMappingResolved = {
   matchPath?: string;
   matchSource?: string;
   action: "wake" | "agent";
+  agentId?: string;
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
   sessionKey?: string;
@@ -17,6 +18,7 @@ export type HookMappingResolved = {
   allowUnsafeExternalContent?: boolean;
   channel?: HookMessageChannel;
   to?: string;
+  accountId?: string;
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -51,13 +53,14 @@ export type HookAction =
       allowUnsafeExternalContent?: boolean;
       channel?: HookMessageChannel;
       to?: string;
+      accountId?: string;
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
     };
 
 export type HookMappingResult =
-  | { ok: true; action: HookAction }
+  | ({ ok: true; action: HookAction } & { agentId?: string; accountId?: string })
   | { ok: true; action: null; skipped: true }
   | { ok: false; error: string };
 
@@ -90,6 +93,7 @@ type HookTransformResult = Partial<{
   allowUnsafeExternalContent: boolean;
   channel: HookMessageChannel;
   to: string;
+  accountId: string;
   model: string;
   thinking: string;
   timeoutSeconds: number;
@@ -167,6 +171,8 @@ export async function applyHookMappings(
     if (!merged.ok) {
       return merged;
     }
+    (merged as any).agentId = mapping.agentId;
+    (merged as any).accountId = mapping.accountId;
     return merged;
   }
   return null;
@@ -203,9 +209,11 @@ function normalizeHookMapping(
     allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
     channel: mapping.channel,
     to: mapping.to,
+    accountId: mapping.accountId,
     model: mapping.model,
     thinking: mapping.thinking,
     timeoutSeconds: mapping.timeoutSeconds,
+    agentId: mapping.agentId,
     transform,
   };
 }
@@ -253,6 +261,7 @@ function buildActionFromMapping(
       allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
       channel: mapping.channel,
       to: renderOptional(mapping.to, ctx),
+      accountId: renderOptional(mapping.accountId, ctx),
       model: renderOptional(mapping.model, ctx),
       thinking: renderOptional(mapping.thinking, ctx),
       timeoutSeconds: mapping.timeoutSeconds,
@@ -293,6 +302,7 @@ function mergeAction(
         : baseAgent?.allowUnsafeExternalContent,
     channel: override.channel ?? baseAgent?.channel,
     to: override.to ?? baseAgent?.to,
+    accountId: override.accountId ?? baseAgent?.accountId,
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -59,9 +59,7 @@ export type HookAction =
       timeoutSeconds?: number;
     };
 
-type ActionValidationResult =
-  | { ok: true; action: HookAction }
-  | { ok: false; error: string };
+type ActionValidationResult = { ok: true; action: HookAction } | { ok: false; error: string };
 
 export type HookMappingResult =
   | ({ ok: true; action: HookAction } & { agentId?: string; accountId?: string })

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -152,6 +152,8 @@ export type HookAgentPayload = {
   deliver: boolean;
   channel: HookMessageChannel;
   to?: string;
+  accountId?: string;
+  agentId?: string;
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -210,6 +212,12 @@ export function normalizeAgentPayload(
   }
   const toRaw = payload.to;
   const to = typeof toRaw === "string" && toRaw.trim() ? toRaw.trim() : undefined;
+  const accountIdRaw = payload.accountId;
+  const accountId =
+    typeof accountIdRaw === "string" && accountIdRaw.trim() ? accountIdRaw.trim() : undefined;
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   const modelRaw = payload.model;
   const model = typeof modelRaw === "string" && modelRaw.trim() ? modelRaw.trim() : undefined;
   if (modelRaw !== undefined && !model) {
@@ -234,6 +242,8 @@ export function normalizeAgentPayload(
       deliver,
       channel,
       to,
+      accountId,
+      agentId,
       model,
       thinking,
       timeoutSeconds,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -140,7 +140,7 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      const runId = dispatchAgentHook(normalized.value);
+      const runId = dispatchAgentHook(normalized.value, normalized.value.agentId);
       sendJson(res, 202, { ok: true, runId });
       return true;
     }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -35,19 +35,23 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 type HookDispatchers = {
   dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
-  dispatchAgentHook: (value: {
-    message: string;
-    name: string;
-    wakeMode: "now" | "next-heartbeat";
-    sessionKey: string;
-    deliver: boolean;
-    channel: HookMessageChannel;
-    to?: string;
-    model?: string;
-    thinking?: string;
-    timeoutSeconds?: number;
-    allowUnsafeExternalContent?: boolean;
-  }) => string;
+  dispatchAgentHook: (
+    value: {
+      message: string;
+      name: string;
+      wakeMode: "now" | "next-heartbeat";
+      sessionKey: string;
+      deliver: boolean;
+      channel: HookMessageChannel;
+      to?: string;
+      accountId?: string;
+      model?: string;
+      thinking?: string;
+      timeoutSeconds?: number;
+      allowUnsafeExternalContent?: boolean;
+    },
+    agentId?: string,
+  ) => string;
 };
 
 function sendJson(res: ServerResponse, status: number, body: unknown) {
@@ -172,19 +176,23 @@ export function createHooksRequestHandler(
             sendJson(res, 400, { ok: false, error: getHookChannelError() });
             return true;
           }
-          const runId = dispatchAgentHook({
-            message: mapped.action.message,
-            name: mapped.action.name ?? "Hook",
-            wakeMode: mapped.action.wakeMode,
-            sessionKey: mapped.action.sessionKey ?? "",
-            deliver: resolveHookDeliver(mapped.action.deliver),
-            channel,
-            to: mapped.action.to,
-            model: mapped.action.model,
-            thinking: mapped.action.thinking,
-            timeoutSeconds: mapped.action.timeoutSeconds,
-            allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
-          });
+          const runId = dispatchAgentHook(
+            {
+              message: mapped.action.message,
+              name: mapped.action.name ?? "Hook",
+              wakeMode: mapped.action.wakeMode,
+              sessionKey: mapped.action.sessionKey ?? "",
+              deliver: resolveHookDeliver(mapped.action.deliver),
+              channel,
+              to: mapped.action.to,
+              accountId: mapped.action.accountId ?? mapped.accountId,
+              model: mapped.action.model,
+              thinking: mapped.action.thinking,
+              timeoutSeconds: mapped.action.timeoutSeconds,
+              allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            },
+            mapped.agentId,
+          );
           sendJson(res, 202, { ok: true, runId });
           return true;
         }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -29,19 +29,23 @@ export function createGatewayHooksRequestHandler(params: {
     }
   };
 
-  const dispatchAgentHook = (value: {
-    message: string;
-    name: string;
-    wakeMode: "now" | "next-heartbeat";
-    sessionKey: string;
-    deliver: boolean;
-    channel: HookMessageChannel;
-    to?: string;
-    model?: string;
-    thinking?: string;
-    timeoutSeconds?: number;
-    allowUnsafeExternalContent?: boolean;
-  }) => {
+  const dispatchAgentHook = (
+    value: {
+      message: string;
+      name: string;
+      wakeMode: "now" | "next-heartbeat";
+      sessionKey: string;
+      deliver: boolean;
+      channel: HookMessageChannel;
+      to?: string;
+      accountId?: string;
+      model?: string;
+      thinking?: string;
+      timeoutSeconds?: number;
+      allowUnsafeExternalContent?: boolean;
+    },
+    agentId?: string,
+  ) => {
     const sessionKey = value.sessionKey.trim() ? value.sessionKey.trim() : `hook:${randomUUID()}`;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     const jobId = randomUUID();
@@ -64,6 +68,7 @@ export function createGatewayHooksRequestHandler(params: {
         deliver: value.deliver,
         channel: value.channel,
         to: value.to,
+        accountId: value.accountId,
         allowUnsafeExternalContent: value.allowUnsafeExternalContent,
       },
       state: { nextRunAtMs: now },
@@ -79,6 +84,7 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
+          agentId: agentId,
           lane: "cron",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;


### PR DESCRIPTION
## Summary

- Add `agentId` property to hook mappings, enabling webhooks to route to specific agents
- Add `accountId` property to hook mappings, enabling webhooks to use specific channel account bindings for delivery

This allows multi-agent architectures where different webhooks can be handled by specialized agents with their own session stores and channel bindings.

## Changes

- Add `agentId` and `accountId` to `HookMappingConfig` type and Zod schema
- Flow `agentId` through `dispatchAgentHook` to `runCronIsolatedAgentTurn`
- Flow `accountId` through to delivery target resolution
- Add tests for `agentId` and `accountId` mapping

## Example

```json
{
  "hooks": {
    "mappings": [
      {
        "id": "gmail-to-alt-agent",
        "match": { "path": "gmail" },
        "action": "agent",
        "agentId": "altAgent",
        "accountId": "work",
        "channel": "telegram",
        "to": "<user_id>",
        "messageTemplate": "..."
      }
    ]
  }
}
```

## Test plan

- [x] Added unit tests for `agentId` and `accountId` mapping
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test src/gateway/hooks-mapping.test.ts` passes (10 tests)

Closes #5868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends hook mappings to support routing webhook-triggered agent turns to a specific `agentId` and selecting a specific outbound channel `accountId`, plumbing these fields through gateway hook mapping resolution, cron isolated-agent delivery target resolution, and adding unit tests around mapping behavior.

Main concern: the new routing only applies when requests go through hook *mappings*; the direct `/hooks/agent` endpoint still cannot specify `agentId`/`accountId`, which may be surprising given the feature description. Additionally, `applyHookMappings` attaches `agentId`/`accountId` via `any` mutation, weakening type safety and making the returned shape more fragile during refactors.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but there’s a functional gap in the new routing behavior for the built-in /hooks/agent endpoint.
- Changes are mostly additive and covered by unit tests for mapping behavior, and the agent delivery plumbing looks consistent end-to-end. The main risk is user-visible mismatch between the new `dispatchAgentHook` signature and the code path used by direct `/hooks/agent`, which can lead to confusing behavior if users expect `agentId`/`accountId` to work there too. A smaller maintainability concern is using `(merged as any)` mutations in the mapping result.
- src/gateway/server-http.ts, src/gateway/hooks-mapping.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->