### PR TITLE
security(gateway): add baseline HTTP security headers

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -62,7 +62,9 @@ function applyBaselineSecurityHeaders(res: ServerResponse) {
   if (!res.hasHeader("X-Content-Type-Options")) res.setHeader("X-Content-Type-Options", "nosniff");
   if (!res.hasHeader("Referrer-Policy"))
     res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
-  if (!res.hasHeader("X-Frame-Options")) res.setHeader("X-Frame-Options", "DENY");
+  // Use SAMEORIGIN instead of DENY to avoid surprising breakage for same-origin embedding
+  // while still preventing third-party framing (clickjacking).
+  if (!res.hasHeader("X-Frame-Options")) res.setHeader("X-Frame-Options", "SAMEORIGIN");
   if (!res.hasHeader("Permissions-Policy")) {
     res.setHeader(
       "Permissions-Policy",

--- a/test/security-headers.e2e.test.ts
+++ b/test/security-headers.e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { startGatewayServer } from "../src/gateway/server.js";
 import { getDeterministicFreePortBlock } from "../src/test-utils/ports.js";
 
@@ -8,18 +8,11 @@ async function getFreeGatewayPort(): Promise<number> {
 
 describe("gateway http security headers", () => {
   it("adds baseline security headers on Control UI responses", async () => {
-    const prev = {
-      token: process.env.OPENCLAW_GATEWAY_TOKEN,
-      skipChannels: process.env.OPENCLAW_SKIP_CHANNELS,
-      skipCron: process.env.OPENCLAW_SKIP_CRON,
-      skipCanvas: process.env.OPENCLAW_SKIP_CANVAS_HOST,
-    };
-
     const token = "test-token-security-headers";
-    process.env.OPENCLAW_GATEWAY_TOKEN = token;
-    process.env.OPENCLAW_SKIP_CHANNELS = "1";
-    process.env.OPENCLAW_SKIP_CRON = "1";
-    process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", token);
+    vi.stubEnv("OPENCLAW_SKIP_CHANNELS", "1");
+    vi.stubEnv("OPENCLAW_SKIP_CRON", "1");
+    vi.stubEnv("OPENCLAW_SKIP_CANVAS_HOST", "1");
 
     const port = await getFreeGatewayPort();
     const server = await startGatewayServer(port, {
@@ -32,21 +25,14 @@ describe("gateway http security headers", () => {
       const res = await fetch(`http://127.0.0.1:${port}/`);
       expect(res.headers.get("x-content-type-options")).toBe("nosniff");
       expect(res.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
-      expect(res.headers.get("x-frame-options")).toBe("DENY");
+      expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
       const permissions = res.headers.get("permissions-policy") ?? "";
       expect(permissions).toContain("camera=()");
       expect(permissions).toContain("microphone=()");
       expect(permissions).toContain("geolocation=()");
     } finally {
       await server.close({ reason: "security headers test complete" });
-      if (prev.token === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
-      else process.env.OPENCLAW_GATEWAY_TOKEN = prev.token;
-      if (prev.skipChannels === undefined) delete process.env.OPENCLAW_SKIP_CHANNELS;
-      else process.env.OPENCLAW_SKIP_CHANNELS = prev.skipChannels;
-      if (prev.skipCron === undefined) delete process.env.OPENCLAW_SKIP_CRON;
-      else process.env.OPENCLAW_SKIP_CRON = prev.skipCron;
-      if (prev.skipCanvas === undefined) delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
-      else process.env.OPENCLAW_SKIP_CANVAS_HOST = prev.skipCanvas;
+      vi.unstubAllEnvs();
     }
   }, 60_000);
 });

--- a/test/security-headers.e2e.test.ts
+++ b/test/security-headers.e2e.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { startGatewayServer } from "../src/gateway/server.js";
+import { getDeterministicFreePortBlock } from "../src/test-utils/ports.js";
+
+async function getFreeGatewayPort(): Promise<number> {
+  return await getDeterministicFreePortBlock();
+}
+
+describe("gateway http security headers", () => {
+  it("adds baseline security headers on Control UI responses", async () => {
+    const prev = {
+      token: process.env.OPENCLAW_GATEWAY_TOKEN,
+      skipChannels: process.env.OPENCLAW_SKIP_CHANNELS,
+      skipCron: process.env.OPENCLAW_SKIP_CRON,
+      skipCanvas: process.env.OPENCLAW_SKIP_CANVAS_HOST,
+    };
+
+    const token = "test-token-security-headers";
+    process.env.OPENCLAW_GATEWAY_TOKEN = token;
+    process.env.OPENCLAW_SKIP_CHANNELS = "1";
+    process.env.OPENCLAW_SKIP_CRON = "1";
+    process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+
+    const port = await getFreeGatewayPort();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: true,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
+      expect(res.headers.get("x-frame-options")).toBe("DENY");
+      const permissions = res.headers.get("permissions-policy") ?? "";
+      expect(permissions).toContain("camera=()");
+      expect(permissions).toContain("microphone=()");
+      expect(permissions).toContain("geolocation=()");
+    } finally {
+      await server.close({ reason: "security headers test complete" });
+      if (prev.token === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      else process.env.OPENCLAW_GATEWAY_TOKEN = prev.token;
+      if (prev.skipChannels === undefined) delete process.env.OPENCLAW_SKIP_CHANNELS;
+      else process.env.OPENCLAW_SKIP_CHANNELS = prev.skipChannels;
+      if (prev.skipCron === undefined) delete process.env.OPENCLAW_SKIP_CRON;
+      else process.env.OPENCLAW_SKIP_CRON = prev.skipCron;
+      if (prev.skipCanvas === undefined) delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
+      else process.env.OPENCLAW_SKIP_CANVAS_HOST = prev.skipCanvas;
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
### Summary
Adds a small set of conservative, baseline HTTP security headers to gateway HTTP responses (Control UI + API).

### Why
These headers reduce common web attack surface (content sniffing, clickjacking, overly-permissive browser features, referrer leakage) in cases where the gateway is exposed on a LAN/tailnet or behind a reverse proxy.

### Changes
- Add baseline headers: X-Content-Type-Options, Referrer-Policy, X-Frame-Options, Permissions-Policy
- Add an e2e test to assert headers are present on Control UI responses
- Intentionally does **not** add CSP yet (to avoid breaking existing UI builds); CSP can be layered in a follow-up PR once validated.

### Testing
- pnpm exec vitest run --config vitest.e2e.config.ts test/security-headers.e2e.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a small set of baseline HTTP response security headers (nosniff, referrer-policy, frame blocking, and a restrictive permissions-policy) to the gateway HTTP server, and adds an e2e test that asserts these headers are present on the Control UI root response.

The header logic is applied at the top of `handleRequest` in `src/gateway/server-http.ts`, before dispatching to the various route handlers (hooks/tools/slack/openai/canvas/control-ui), making it a cross-cutting behavior for most HTTP responses produced by the gateway.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and implements conservative header hardening with minor scoping/testing concerns.
- Changes are straightforward and localized: a new helper applies headers and an e2e test asserts presence. The main risk is behavioral/compat impact from globally applying `X-Frame-Options: DENY` beyond just the Control UI, and potential test flakiness from process-wide env mutation under concurrency.
- src/gateway/server-http.ts (header scoping/intent); test/security-headers.e2e.test.ts (env isolation under parallel tests)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->