### PR TITLE
fix(media-understanding): support legacy {file} placeholder in CLI audio args

### DIFF
--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizePlaceholders } from "./runner.js";
+
+describe("normalizePlaceholders", () => {
+  it("converts {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("converts {input} and {media} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{media}")).toBe("{{MediaPath}}");
+  });
+
+  it("converts output placeholders", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+    expect(normalizePlaceholders("{output_base}")).toBe("{{OutputBase}}");
+  });
+
+  it("converts {prompt} and {media_dir}", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+    expect(normalizePlaceholders("{media_dir}")).toBe("{{MediaDir}}");
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{OUTPUT_DIR}")).toBe("{{OutputDir}}");
+  });
+
+  it("handles multiple placeholders in one string", () => {
+    expect(normalizePlaceholders("{file} --output {output_dir}")).toBe(
+      "{{MediaPath}} --output {{OutputDir}}",
+    );
+  });
+
+  it("leaves unknown placeholders unchanged", () => {
+    expect(normalizePlaceholders("{unknown}")).toBe("{unknown}");
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("leaves regular text unchanged", () => {
+    expect(normalizePlaceholders("--model large-v3")).toBe("--model large-v3");
+  });
+});

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -58,6 +58,34 @@ const DEFAULT_IMAGE_MODELS: Record<string, string> = {
   minimax: "MiniMax-VL-01",
 };
 
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+export function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
 export type ActiveMediaModel = {
   provider: string;
   model?: string;
@@ -1036,7 +1064,7 @@ async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {


### PR DESCRIPTION
## Summary

Adds `normalizePlaceholders()` to convert intuitive single-brace placeholders to the standard double-brace format before template substitution.

## Problem

When using `tools.media.audio.models` with `type: "cli"`, the `{file}` placeholder in the `args` array was passed literally instead of being substituted with the actual audio file path.

```json
{
  "tools": {
    "media": {
      "audio": {
        "models": [{
          "type": "cli",
          "command": "whisper",
          "args": ["{file}", "--model", "large-v3-turbo"]
        }]
      }
    }
  }
}
```

Error: `Error opening input file {file}.`

## Solution

Add legacy placeholder normalization that converts intuitive single-brace placeholders before `applyTemplate()` is called.

### Supported aliases:
- `{file}`, `{input}`, `{media}` → `{{MediaPath}}`
- `{output}`, `{output_dir}` → `{{OutputDir}}`
- `{output_base}` → `{{OutputBase}}`
- `{prompt}` → `{{Prompt}}`
- `{media_dir}` → `{{MediaDir}}`

Case-insensitive matching for user convenience.

## Testing

- Added 8 unit tests for `normalizePlaceholders()`
- All tests pass

Fixes #5845

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes legacy single-brace placeholders in `tools.media.audio.models` CLI configs by normalizing values like `{file}` / `{output_dir}` into the existing double-brace templating format (e.g., `{{MediaPath}}`) before `applyTemplate()` runs. It introduces a small mapping + `normalizePlaceholders()` helper in `src/media-understanding/runner.ts` and adds focused Vitest coverage for the new normalization behavior in `src/media-understanding/runner.placeholders.test.ts`.

The change integrates cleanly with the current CLI execution path (`runCliEntry`), which already builds a `templCtx` containing `MediaPath`, `OutputDir`, etc., and now ensures legacy placeholders resolve via the same `applyTemplate()` mechanism used elsewhere.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, well-scoped behavior fix with tests, with only minor potential performance polish needed.
- The change is localized to the CLI arg templating path and adds unit tests for the new normalization behavior. No risky IO or security-sensitive parsing was introduced. Main residual concern is minor inefficiency from per-call regex compilation, not correctness.
- src/media-understanding/runner.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->