### PR TITLE
security(message-tool): validate filePath/path against sandbox root

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -92,6 +92,7 @@ export function createOpenClawTools(options?: {
       currentThreadTs: options?.currentThreadTs,
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
+      sandboxRoot: options?.sandboxRoot,
     }),
     createTtsTool({
       agentChannel: options?.agentChannel,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
@@ -159,5 +162,108 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("leaveGroup");
 
     setActivePluginRegistry(createTestRegistry([]));
+  });
+});
+
+describe("message tool sandbox path validation", () => {
+  it("rejects filePath that escapes sandbox root", async () => {
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await expect(
+        tool.execute("1", {
+          action: "send",
+          target: "telegram:123",
+          filePath: "/etc/passwd",
+          message: "",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects path param with traversal sequence", async () => {
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await expect(
+        tool.execute("1", {
+          action: "send",
+          target: "telegram:123",
+          path: "../../../etc/shadow",
+          message: "",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows filePath inside sandbox root", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "telegram",
+      to: "telegram:123",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await tool.execute("1", {
+        action: "send",
+        target: "telegram:123",
+        filePath: "./data/file.txt",
+        message: "",
+      });
+
+      expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips validation when no sandboxRoot is set", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "telegram",
+      to: "telegram:123",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "telegram:123",
+      filePath: "/etc/passwd",
+      message: "",
+    });
+
+    // Bez sandboxRoot walidacja nie blokuje - niesandboxowane sesje dzialaja normalnie.
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -263,7 +263,7 @@ describe("message tool sandbox path validation", () => {
       message: "",
     });
 
-    // Bez sandboxRoot walidacja nie blokuje - niesandboxowane sesje dzialaja normalnie.
+    // Without sandboxRoot the validation is skipped — unsandboxed sessions work normally.
     expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -19,6 +19,7 @@ import { normalizeAccountId } from "../../routing/session-key.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
+import { assertSandboxPath } from "../sandbox-paths.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 
@@ -252,6 +253,7 @@ type MessageToolOptions = {
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
+  sandboxRoot?: string;
 };
 
 function buildMessageToolSchema(cfg: OpenClawConfig) {
@@ -361,6 +363,17 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;
+
+      // Walidacja sciezek plikow wzgledem sandbox root (zapobiega odczytowi plikow hosta).
+      const sandboxRoot = options?.sandboxRoot;
+      if (sandboxRoot) {
+        for (const key of ["filePath", "path"] as const) {
+          const raw = readStringParam(params, key, { trim: false });
+          if (raw) {
+            await assertSandboxPath({ filePath: raw, cwd: sandboxRoot, root: sandboxRoot });
+          }
+        }
+      }
 
       const accountId = readStringParam(params, "accountId") ?? agentAccountId;
       if (accountId) {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -364,7 +364,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         required: true,
       }) as ChannelMessageActionName;
 
-      // Walidacja sciezek plikow wzgledem sandbox root (zapobiega odczytowi plikow hosta).
+      // Validate file paths against sandbox root to prevent host file access.
       const sandboxRoot = options?.sandboxRoot;
       if (sandboxRoot) {
         for (const key of ["filePath", "path"] as const) {


### PR DESCRIPTION
## Summary

Fixes #3805 (CRITICAL sandbox escape via message tool `filePath`/`path` params).

The `message` tool accepted arbitrary file paths (`filePath`, `path`) without validating them against the sandbox root directory. A sandboxed agent could read or exfiltrate host files (e.g. `/etc/passwd`, `~/.ssh/id_rsa`) by passing absolute or traversal paths through the message tool's send action.

### Changes

- **`src/agents/tools/message-tool.ts`**: Added `sandboxRoot` option to `MessageToolOptions`. When set, both `filePath` and `path` params are validated via `assertSandboxPath()` before `runMessageAction()` is called. This mirrors the pattern already used in `image-tool.ts` and `read/write/edit` tools.
- **`src/agents/openclaw-tools.ts`**: Pass `sandboxRoot` from tool creation options to `createMessageTool()`.
- **`src/agents/tools/message-tool.test.ts`**: Added 4 tests covering sandbox path validation (reject absolute escape, reject traversal, allow valid relative path, skip validation when no sandbox).

### Security Impact

Without this fix, any sandboxed agent session could bypass the sandbox boundary via the message tool to access arbitrary host filesystem paths. This is a critical privilege escalation vector.

### Test Plan

- [x] `pnpm vitest run src/agents/tools/message-tool.test.ts` (8/8 pass)
- [x] `npx oxlint --type-aware --tsconfig tsconfig.oxlint.json` (0 errors)
- [x] `npx oxfmt --check` (all files formatted)
- [x] Build errors are pre-existing on `main` (unrelated `pi-coding-agent` type issues)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR closes a critical sandbox escape in the `message` tool by adding an optional `sandboxRoot` to `createMessageTool` and validating `filePath`/`path` against that root via `assertSandboxPath()` before invoking `runMessageAction()`. It wires `sandboxRoot` through `createOpenClawTools`, and adds new unit tests to ensure absolute paths and traversal are rejected when sandboxing is enabled, while preserving existing behavior when `sandboxRoot` is unset.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and meaningfully improves sandbox security with minimal behavioral risk.
- The change is narrowly scoped: it gates validation on an explicit `sandboxRoot`, uses the existing shared `assertSandboxPath` helper (including symlink checks), and adds focused tests for escape/traversal/allow cases. Main residual risk is limited to edge cases in path semantics or non-send actions that also accept file paths, but the code validates both `filePath` and `path` for all actions when sandboxing is enabled.
- src/agents/tools/message-tool.ts (ensure no other file-path-like params exist beyond `filePath`/`path` that should also be sandbox-validated).

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->