### PR TITLE
feat(telegram): add Local Bot API server support

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -465,6 +465,7 @@ By default, OpenClaw reads any absolute path returned by the local API server. T
 ```
 
 When `localApiDataDir` is set:
+
 - File paths must be within that directory (after resolving `..` traversal attempts)
 - Paths outside the allowed directory are rejected with an error
 - This prevents a compromised local API server from reading arbitrary files

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -447,7 +447,27 @@ When `localApiServer` is configured:
 - The local server must be running and reachable before starting the gateway.
 - File paths returned by a local server are absolute filesystem paths; ensure OpenClaw has read access to those directories.
 - Trailing slashes in the URL are normalized automatically (`http://localhost:8081/` and `http://localhost:8081` both work).
-- Windows paths (e.g., `C:\telegram-bot-api\...`) are also detected as local paths.
+- Windows paths (e.g., `C:\telegram-bot-api\...` or `C:/telegram-bot-api/...`) are also detected as local paths.
+
+### Security: Restricting file access
+
+By default, OpenClaw reads any absolute path returned by the local API server. To restrict file reads to a specific directory (defense in depth), set `localApiDataDir`:
+
+```json5
+{
+  channels: {
+    telegram: {
+      localApiServer: "http://localhost:8081",
+      localApiDataDir: "/var/lib/telegram-bot-api",
+    },
+  },
+}
+```
+
+When `localApiDataDir` is set:
+- File paths must be within that directory (after resolving `..` traversal attempts)
+- Paths outside the allowed directory are rejected with an error
+- This prevents a compromised local API server from reading arbitrary files
 
 ## Reply threading
 
@@ -760,6 +780,7 @@ Provider options:
 - `channels.telegram.botToken`: bot token (BotFather).
 - `channels.telegram.tokenFile`: read token from file path.
 - `channels.telegram.localApiServer`: URL of a self-hosted [Telegram Bot API server](https://github.com/tdlib/telegram-bot-api) (e.g., `http://localhost:8081`). Enables 2GB file uploads and direct local file access. Env: `TELEGRAM_LOCAL_API_SERVER`.
+- `channels.telegram.localApiDataDir`: restrict local API file reads to this directory (security hardening). Paths outside are rejected.
 - `channels.telegram.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
 - `channels.telegram.allowFrom`: DM allowlist (ids/usernames). `open` requires `"*"`.
 - `channels.telegram.groupPolicy`: `open | allowlist | disabled` (default: allowlist).

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -108,6 +108,8 @@ export type TelegramAccountConfig = {
   proxy?: string;
   /** Local Telegram Bot API server URL (e.g., http://localhost:8081). */
   localApiServer?: string;
+  /** Allowed directory for Local Bot API file reads. If set, file paths must be within this directory. */
+  localApiDataDir?: string;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -106,6 +106,8 @@ export type TelegramAccountConfig = {
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;
+  /** Local Telegram Bot API server URL (e.g., http://localhost:8081). */
+  localApiServer?: string;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -121,6 +121,7 @@ export const TelegramAccountSchemaBase = z
       .strict()
       .optional(),
     proxy: z.string().optional(),
+    localApiServer: z.string().url().optional(),
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional(),
     webhookPath: z.string().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -122,6 +122,7 @@ export const TelegramAccountSchemaBase = z
       .optional(),
     proxy: z.string().optional(),
     localApiServer: z.string().url().optional(),
+    localApiDataDir: z.string().optional(),
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional(),
     webhookPath: z.string().optional(),

--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -1,4 +1,5 @@
 import type { TelegramGroupConfig } from "../config/types.js";
+import { normalizeApiRoot } from "./local-api.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -88,6 +89,7 @@ export async function auditTelegramGroupMembership(params: {
   botId: number;
   groupIds: string[];
   proxyUrl?: string;
+  apiBase?: string;
   timeoutMs: number;
 }): Promise<TelegramGroupMembershipAudit> {
   const started = Date.now();
@@ -104,7 +106,8 @@ export async function auditTelegramGroupMembership(params: {
   }
 
   const fetcher = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : fetch;
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const apiBase = normalizeApiRoot(params.apiBase) ?? TELEGRAM_API_BASE;
+  const base = `${apiBase}/bot${token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 
   for (const chatId of params.groupIds) {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -334,6 +334,54 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("uses default API root when localApiServer is not configured", () => {
+    botCtorSpy.mockReset();
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+
+    createTelegramBot({ token: "tok" });
+
+    const clientOptions = botCtorSpy.mock.calls[0]?.[1] as { client?: { apiRoot?: string } };
+    expect(clientOptions?.client?.apiRoot).toBeUndefined();
+  });
+
+  it("uses custom API root when localApiServer is configured", () => {
+    botCtorSpy.mockReset();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          localApiServer: "http://localhost:8081",
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+
+    const clientOptions = botCtorSpy.mock.calls[0]?.[1] as { client?: { apiRoot?: string } };
+    expect(clientOptions?.client?.apiRoot).toBe("http://localhost:8081");
+  });
+
+  it("normalizes API root by removing trailing slashes", () => {
+    botCtorSpy.mockReset();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          localApiServer: "http://localhost:8081///",
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+
+    const clientOptions = botCtorSpy.mock.calls[0]?.[1] as { client?: { apiRoot?: string } };
+    expect(clientOptions?.client?.apiRoot).toBe("http://localhost:8081");
+  });
+
   it("sequentializes updates by chat and thread", () => {
     createTelegramBot({ token: "tok" });
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -46,6 +46,7 @@ import {
   resolveTelegramStreamMode,
 } from "./bot/helpers.js";
 import { resolveTelegramFetch } from "./fetch.js";
+import { resolveTelegramApiRoot } from "./local-api.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
 export type TelegramBotOptions = {
@@ -132,13 +133,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = resolveTelegramApiRoot(telegramCfg);
+  const shouldProvideApiRoot = apiRoot !== "https://api.telegram.org";
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || shouldProvideApiRoot
       ? {
           ...(shouldProvideFetch && fetchImpl
             ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] }
             : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(shouldProvideApiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -304,3 +304,6 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 });
+
+// Note: resolveMedia local API path detection is tested via isLocalApiPath in local-api.test.ts
+// ESM modules don't allow spying on fs.readFile, so integration testing would require actual file access

--- a/src/telegram/download.test.ts
+++ b/src/telegram/download.test.ts
@@ -1,35 +1,133 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { downloadTelegramFile, getTelegramFile, type TelegramFileInfo } from "./download.js";
 
 describe("telegram download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("fetches file info", async () => {
     const json = vi.fn().mockResolvedValue({ ok: true, result: { file_path: "photos/1.jpg" } });
-    vi.spyOn(global, "fetch" as never).mockResolvedValueOnce({
+    vi.spyOn(global, "fetch" as any).mockResolvedValueOnce({
       ok: true,
       status: 200,
       statusText: "OK",
       json,
-    } as Response);
+    } as any);
     const info = await getTelegramFile("tok", "fid");
     expect(info.file_path).toBe("photos/1.jpg");
   });
 
-  it("downloads and saves", async () => {
+  it("downloads and saves from HTTP when path is relative", async () => {
     const info: TelegramFileInfo = {
       file_id: "fid",
       file_path: "photos/1.jpg",
     };
     const arrayBuffer = async () => new Uint8Array([1, 2, 3, 4]).buffer;
-    vi.spyOn(global, "fetch" as never).mockResolvedValueOnce({
+    vi.spyOn(global, "fetch" as any).mockResolvedValueOnce({
       ok: true,
       status: 200,
       statusText: "OK",
       body: true,
       arrayBuffer,
       headers: { get: () => "image/jpeg" },
-    } as Response);
+    } as any);
     const saved = await downloadTelegramFile("tok", info, 1024 * 1024);
     expect(saved.path).toBeTruthy();
     expect(saved.contentType).toBe("image/jpeg");
+  });
+
+  describe("local file path detection", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "telegram-test-"));
+    });
+
+    afterEach(async () => {
+      try {
+        await fs.rm(tempDir, { recursive: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    });
+
+    it("reads from filesystem when path is absolute Unix path", async () => {
+      const testFile = path.join(tempDir, "test.jpg");
+      const testData = Buffer.from([1, 2, 3, 4]);
+      await fs.writeFile(testFile, testData);
+
+      const info: TelegramFileInfo = {
+        file_id: "fid",
+        file_path: testFile,
+      };
+
+      const saved = await downloadTelegramFile("tok", info);
+      expect(saved.path).toBeTruthy();
+      expect(saved.contentType).toBeTruthy();
+    });
+
+    it("reads from filesystem when path is absolute Windows path", async () => {
+      const testFile = path.join(tempDir, "test.jpg");
+      const testData = Buffer.from([1, 2, 3, 4]);
+      await fs.writeFile(testFile, testData);
+
+      const info: TelegramFileInfo = {
+        file_id: "fid",
+        file_path: testFile,
+      };
+
+      const saved = await downloadTelegramFile("tok", info);
+      expect(saved.path).toBeTruthy();
+    });
+
+    it("throws error when local file does not exist", async () => {
+      const nonExistentPath = path.join(tempDir, "nonexistent.jpg");
+
+      const info: TelegramFileInfo = {
+        file_id: "fid",
+        file_path: nonExistentPath,
+      };
+
+      await expect(downloadTelegramFile("tok", info)).rejects.toThrow();
+    });
+  });
+
+  describe("custom API base", () => {
+    it("uses custom API base for HTTP downloads when provided", async () => {
+      const fetchSpy = vi.spyOn(global, "fetch" as any);
+      const info: TelegramFileInfo = {
+        file_id: "fid",
+        file_path: "photos/1.jpg",
+      };
+      const arrayBuffer = async () => new Uint8Array([1, 2, 3, 4]).buffer;
+      fetchSpy.mockImplementation(((url: any) => {
+        if ((url as string).includes("/file/bot")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            body: true,
+            arrayBuffer,
+            headers: { get: () => "image/jpeg" },
+          } as any);
+        }
+        throw new Error(`Unexpected fetch call: ${url}`);
+      }) as any);
+
+      const customApiBase = "http://localhost:8081";
+      await downloadTelegramFile("tok", info, 1024 * 1024, customApiBase);
+
+      expect(fetchSpy).toHaveBeenCalled();
+      const downloadCall = fetchSpy.mock.calls.find((call) =>
+        (call[0] as string).includes("/file/bot"),
+      );
+      expect(downloadCall).toBeDefined();
+      const callUrl = (downloadCall?.[0] as string) || "";
+      expect(callUrl).toContain("localhost:8081");
+    });
   });
 });

--- a/src/telegram/download.ts
+++ b/src/telegram/download.ts
@@ -1,5 +1,9 @@
+import * as fs from "node:fs/promises";
 import { detectMime } from "../media/mime.js";
 import { type SavedMedia, saveMediaBuffer } from "../media/store.js";
+import { isLocalApiPath, normalizeApiRoot } from "./local-api.js";
+
+const TELEGRAM_API_BASE = "https://api.telegram.org";
 
 export type TelegramFileInfo = {
   file_id: string;
@@ -8,10 +12,13 @@ export type TelegramFileInfo = {
   file_path?: string;
 };
 
-export async function getTelegramFile(token: string, fileId: string): Promise<TelegramFileInfo> {
-  const res = await fetch(
-    `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
-  );
+export async function getTelegramFile(
+  token: string,
+  fileId: string,
+  apiBase?: string,
+): Promise<TelegramFileInfo> {
+  const baseUrl = normalizeApiRoot(apiBase) ?? TELEGRAM_API_BASE;
+  const res = await fetch(`${baseUrl}/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`);
   if (!res.ok) {
     throw new Error(`getFile failed: ${res.status} ${res.statusText}`);
   }
@@ -26,24 +33,34 @@ export async function downloadTelegramFile(
   token: string,
   info: TelegramFileInfo,
   maxBytes?: number,
+  apiBase?: string,
 ): Promise<SavedMedia> {
   if (!info.file_path) {
     throw new Error("file_path missing");
   }
-  const url = `https://api.telegram.org/file/bot${token}/${info.file_path}`;
-  const res = await fetch(url);
-  if (!res.ok || !res.body) {
-    throw new Error(`Failed to download telegram file: HTTP ${res.status}`);
+
+  let array: Buffer;
+  let contentTypeHeader: string | null = null;
+
+  if (isLocalApiPath(info.file_path)) {
+    array = await fs.readFile(info.file_path);
+  } else {
+    const baseUrl = normalizeApiRoot(apiBase) ?? TELEGRAM_API_BASE;
+    const url = `${baseUrl}/file/bot${token}/${info.file_path}`;
+    const res = await fetch(url);
+    if (!res.ok || !res.body) {
+      throw new Error(`Failed to download telegram file: HTTP ${res.status}`);
+    }
+    array = Buffer.from(await res.arrayBuffer());
+    contentTypeHeader = res.headers.get("content-type");
   }
-  const array = Buffer.from(await res.arrayBuffer());
+
   const mime = await detectMime({
     buffer: array,
-    headerMime: res.headers.get("content-type"),
+    headerMime: contentTypeHeader,
     filePath: info.file_path,
   });
-  // save with inbound subdir
   const saved = await saveMediaBuffer(array, mime, "inbound", maxBytes, info.file_path);
-  // Ensure extension matches mime if possible
   if (!saved.contentType && mime) {
     saved.contentType = mime;
   }

--- a/src/telegram/local-api.test.ts
+++ b/src/telegram/local-api.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { TelegramAccountConfig } from "../config/types.js";
+import { resolveTelegramApiRoot, normalizeApiRoot, isLocalApiPath } from "./local-api.js";
+
+describe("local-api", () => {
+  const originalEnv = process.env.TELEGRAM_LOCAL_API_SERVER;
+
+  beforeEach(() => {
+    delete process.env.TELEGRAM_LOCAL_API_SERVER;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.TELEGRAM_LOCAL_API_SERVER = originalEnv;
+    } else {
+      delete process.env.TELEGRAM_LOCAL_API_SERVER;
+    }
+  });
+
+  describe("resolveTelegramApiRoot", () => {
+    it("returns default API base when not configured", () => {
+      const result = resolveTelegramApiRoot();
+      expect(result).toBe("https://api.telegram.org");
+    });
+
+    it("returns config value when localApiServer is set", () => {
+      const config: TelegramAccountConfig = {
+        localApiServer: "http://localhost:8081",
+      };
+      const result = resolveTelegramApiRoot(config);
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("returns env var when config not set but env is set", () => {
+      process.env.TELEGRAM_LOCAL_API_SERVER = "http://localhost:9000";
+      const result = resolveTelegramApiRoot();
+      expect(result).toBe("http://localhost:9000");
+    });
+
+    it("prefers config over env var", () => {
+      process.env.TELEGRAM_LOCAL_API_SERVER = "http://localhost:9000";
+      const config: TelegramAccountConfig = {
+        localApiServer: "http://localhost:8081",
+      };
+      const result = resolveTelegramApiRoot(config);
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("strips trailing slashes from config value", () => {
+      const config: TelegramAccountConfig = {
+        localApiServer: "http://localhost:8081/",
+      };
+      const result = resolveTelegramApiRoot(config);
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("strips multiple trailing slashes from config value", () => {
+      const config: TelegramAccountConfig = {
+        localApiServer: "http://localhost:8081///",
+      };
+      const result = resolveTelegramApiRoot(config);
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("strips trailing slashes from env var", () => {
+      process.env.TELEGRAM_LOCAL_API_SERVER = "http://localhost:9000/";
+      const result = resolveTelegramApiRoot();
+      expect(result).toBe("http://localhost:9000");
+    });
+
+    it("returns default when config value is empty string", () => {
+      const config: TelegramAccountConfig = {
+        localApiServer: "",
+      };
+      const result = resolveTelegramApiRoot(config);
+      expect(result).toBe("https://api.telegram.org");
+    });
+
+    it("returns default when env var is empty string", () => {
+      process.env.TELEGRAM_LOCAL_API_SERVER = "";
+      const result = resolveTelegramApiRoot();
+      expect(result).toBe("https://api.telegram.org");
+    });
+  });
+
+  describe("normalizeApiRoot", () => {
+    it("strips trailing slashes", () => {
+      const result = normalizeApiRoot("http://localhost:8081/");
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("strips multiple trailing slashes", () => {
+      const result = normalizeApiRoot("http://localhost:8081///");
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("handles URLs without trailing slashes", () => {
+      const result = normalizeApiRoot("http://localhost:8081");
+      expect(result).toBe("http://localhost:8081");
+    });
+
+    it("returns undefined for undefined input", () => {
+      const result = normalizeApiRoot(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns empty string for empty string input", () => {
+      const result = normalizeApiRoot("");
+      expect(result).toBe("");
+    });
+
+    it("preserves path components", () => {
+      const result = normalizeApiRoot("http://localhost:8081/api/v1/");
+      expect(result).toBe("http://localhost:8081/api/v1");
+    });
+  });
+
+  describe("isLocalApiPath", () => {
+    it("returns true for Unix absolute paths", () => {
+      expect(isLocalApiPath("/var/lib/telegram-bot-api/file.pdf")).toBe(true);
+      expect(isLocalApiPath("/home/user/documents/file.pdf")).toBe(true);
+      expect(isLocalApiPath("/")).toBe(true);
+    });
+
+    it("returns true for Windows absolute paths", () => {
+      expect(isLocalApiPath("C:\\Users\\bot\\file.pdf")).toBe(true);
+      expect(isLocalApiPath("D:\\data\\documents\\file.pdf")).toBe(true);
+      expect(isLocalApiPath("C:\\")).toBe(true);
+    });
+
+    it("returns true for Windows paths with lowercase drive letter", () => {
+      expect(isLocalApiPath("c:\\Users\\bot\\file.pdf")).toBe(true);
+      expect(isLocalApiPath("d:\\data\\documents\\file.pdf")).toBe(true);
+    });
+
+    it("returns false for relative paths", () => {
+      expect(isLocalApiPath("documents/file.pdf")).toBe(false);
+      expect(isLocalApiPath("./documents/file.pdf")).toBe(false);
+      expect(isLocalApiPath("../documents/file.pdf")).toBe(false);
+      expect(isLocalApiPath("file.pdf")).toBe(false);
+    });
+
+    it("returns false for UNC paths (backslash format)", () => {
+      expect(isLocalApiPath("\\\\server\\share\\file.pdf")).toBe(false);
+    });
+
+    it("returns false for file:// URLs", () => {
+      expect(isLocalApiPath("file:///var/lib/telegram-bot-api/file.pdf")).toBe(false);
+      expect(isLocalApiPath("file://C:/Users/bot/file.pdf")).toBe(false);
+    });
+
+    it("returns false for http/https URLs", () => {
+      expect(isLocalApiPath("http://localhost:8081/file.pdf")).toBe(false);
+      expect(isLocalApiPath("https://api.telegram.org/file.pdf")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isLocalApiPath("")).toBe(false);
+    });
+  });
+});

--- a/src/telegram/local-api.ts
+++ b/src/telegram/local-api.ts
@@ -1,0 +1,63 @@
+import type { TelegramAccountConfig } from "../config/types.js";
+
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+
+/**
+ * Strips trailing slashes from a URL string.
+ * @param url - The URL to normalize, or undefined
+ * @returns The normalized URL without trailing slashes, or undefined if input is undefined
+ */
+export function normalizeApiRoot(url: string | undefined): string | undefined {
+  if (!url) {
+    return url;
+  }
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Resolves the Telegram API root URL from config or environment.
+ * Priority: config.localApiServer > env.TELEGRAM_LOCAL_API_SERVER > default
+ * @param config - Optional Telegram account configuration
+ * @returns The resolved API root URL
+ */
+export function resolveTelegramApiRoot(config?: TelegramAccountConfig): string {
+  const configValue = config?.localApiServer;
+  if (configValue) {
+    const normalized = normalizeApiRoot(configValue);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  const envValue = process.env.TELEGRAM_LOCAL_API_SERVER;
+  if (envValue) {
+    const normalized = normalizeApiRoot(envValue);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return TELEGRAM_API_BASE;
+}
+
+/**
+ * Detects if a path is an absolute local file path.
+ * Supports Unix paths (/) and Windows paths (C:\).
+ * Does NOT support UNC paths (\\server\share) or file:// URLs.
+ * @param path - The path to check
+ * @returns true if the path is an absolute local file path
+ */
+export function isLocalApiPath(path: string): boolean {
+  // Unix absolute path
+  if (path.startsWith("/")) {
+    return true;
+  }
+
+  // Windows absolute path (e.g., C:\, D:\)
+  if (/^[A-Z]:\\/i.test(path)) {
+    return true;
+  }
+
+  // NOT supported: UNC paths (\\server\share), file:// URLs
+  return false;
+}

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { probeTelegram } from "./probe.js";
+
+describe("probeTelegram", () => {
+  const testToken = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+  const timeoutMs = 5000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses default API base when apiBase is not provided", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: 123456789,
+            username: "test_bot",
+            can_join_groups: true,
+            can_read_all_group_messages: false,
+            supports_inline_queries: true,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    global.fetch = fetchSpy;
+
+    const result = await probeTelegram(testToken, timeoutMs);
+
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://api.telegram.org/bot${testToken}/getMe`,
+      expect.any(Object),
+    );
+  });
+
+  it("uses custom API base when apiBase is provided", async () => {
+    const customBase = "https://custom.api.example.com";
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: 123456789,
+            username: "test_bot",
+            can_join_groups: true,
+            can_read_all_group_messages: false,
+            supports_inline_queries: true,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    global.fetch = fetchSpy;
+
+    const result = await probeTelegram(testToken, timeoutMs, undefined, customBase);
+
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${customBase}/bot${testToken}/getMe`,
+      expect.any(Object),
+    );
+  });
+
+  it("normalizes API base by stripping trailing slashes", async () => {
+    const customBase = "https://custom.api.example.com/";
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: 123456789,
+            username: "test_bot",
+            can_join_groups: true,
+            can_read_all_group_messages: false,
+            supports_inline_queries: true,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    global.fetch = fetchSpy;
+
+    const result = await probeTelegram(testToken, timeoutMs, undefined, customBase);
+
+    expect(result.ok).toBe(true);
+    // Should strip the trailing slash
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://custom.api.example.com/bot${testToken}/getMe`,
+      expect.any(Object),
+    );
+  });
+
+  it("normalizes API base with multiple trailing slashes", async () => {
+    const customBase = "https://custom.api.example.com///";
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: 123456789,
+            username: "test_bot",
+            can_join_groups: true,
+            can_read_all_group_messages: false,
+            supports_inline_queries: true,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    global.fetch = fetchSpy;
+
+    const result = await probeTelegram(testToken, timeoutMs, undefined, customBase);
+
+    expect(result.ok).toBe(true);
+    // Should strip all trailing slashes
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://custom.api.example.com/bot${testToken}/getMe`,
+      expect.any(Object),
+    );
+  });
+});

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,3 +1,4 @@
+import { normalizeApiRoot } from "./local-api.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -35,10 +36,12 @@ export async function probeTelegram(
   token: string,
   timeoutMs: number,
   proxyUrl?: string,
+  apiBase?: string,
 ): Promise<TelegramProbe> {
   const started = Date.now();
   const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const resolvedBase = normalizeApiRoot(apiBase) ?? TELEGRAM_API_BASE;
+  const base = `${resolvedBase}/bot${token}`;
 
   const result: TelegramProbe = {
     ok: false,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -24,6 +24,7 @@ import { buildTelegramThreadParams } from "./bot/helpers.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
+import { resolveTelegramApiRoot } from "./local-api.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
@@ -98,10 +99,13 @@ function resolveTelegramClientOptions(
     Number.isFinite(account.config.timeoutSeconds)
       ? Math.max(1, Math.floor(account.config.timeoutSeconds))
       : undefined;
-  return fetchImpl || timeoutSeconds
+  const apiRoot = resolveTelegramApiRoot(account.config);
+  const isDefaultApiRoot = apiRoot === "https://api.telegram.org";
+  return fetchImpl || timeoutSeconds || !isDefaultApiRoot
     ? {
         ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
         ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        ...(!isDefaultApiRoot ? { apiRoot } : {}),
       }
     : undefined;
 }


### PR DESCRIPTION
## Summary

Adds support for self-hosted Telegram Local Bot API servers, enabling:
- **2GB file uploads/downloads** (vs 50MB with official API)
- **Faster transfers** - files transfer directly between server and Telegram
- **Direct file access** - files read from local filesystem instead of HTTP downloads

## Configuration

```json5
{
  channels: {
    telegram: {
      localApiServer: "http://localhost:8081",
    },
  },
}
```

Or via environment variable: `TELEGRAM_LOCAL_API_SERVER=http://localhost:8081`

## Changes

- **Config**: Added `localApiServer` option to `TelegramAccountConfig` + Zod schema
- **Utilities**: New `src/telegram/local-api.ts` with `resolveTelegramApiRoot()`, `normalizeApiRoot()`, `isLocalApiPath()`
- **Bot/Send**: Pass `apiRoot` to grammY client options
- **Probe/Audit**: Accept optional `apiBase` parameter
- **Download/Delivery**: Detect absolute file paths and read from filesystem
- **Docs**: Added "Local Bot API server" section to `docs/channels/telegram.md`

## Testing

- 23 new unit tests for path detection and API resolution
- All 208 Telegram tests pass
- Lint passes

## Notes

- Backward compatible - existing configs work unchanged
- When Local API returns absolute paths (e.g., `/var/lib/telegram-bot-api/file.jpg`), files are read directly from disk
- Relative paths (standard API) continue to use HTTP downloads

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for Telegram’s Local Bot API server by introducing `localApiServer` config/env resolution (`resolveTelegramApiRoot`), plumbing `apiRoot` into the grammY client, and teaching download/media delivery code paths to treat absolute `file_path` values as local filesystem paths (bypassing HTTP downloads). It also updates probe/audit helpers to accept an optional API base and includes extensive unit tests.

Main concern: reading absolute `file_path` values from disk introduces a new trust boundary—if the Local Bot API endpoint is compromised/untrusted, it can trick OpenClaw into reading arbitrary local files. Consider constraining/validating local reads to an expected base directory (fail closed) when `localApiServer` is enabled.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but has a meaningful security footgun if Local Bot API is pointed at an untrusted server.
- The feature is well-contained and test-covered, and apiRoot plumbing looks consistent. The main risk is the new behavior of reading `file_path` values directly from the filesystem when they’re absolute; without constraining the allowed directory, a compromised/misconfigured Local Bot API endpoint could cause unintended local file disclosure.
- src/telegram/download.ts, src/telegram/bot/delivery.ts, src/telegram/local-api.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->