### PR TITLE
fix: custom configured context tokens not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Docs: https://docs.openclaw.ai
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
 - Discord: restore username directory lookup in target resolution. (#3131) Thanks @bonald.
 - Agents: align MiniMax base URL test expectation with default provider config. (#3131) Thanks @bonald.
+- Agents: respect configured context window cap for compaction safeguard. (#6187) Thanks @iamEvanYT.
 - Agents: prevent retries on oversized image errors and surface size limits. (#2871) Thanks @Suksham-sharma.
 - Agents: inherit provider baseUrl/api for inline models. (#2740) Thanks @lploc94.
 - Memory Search: keep auto provider model defaults and only include remote when configured. (#2576) Thanks @papago2355.

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -3,36 +3,30 @@ summary: "Session pruning: tool-result trimming to reduce context bloat"
 read_when:
   - You want to reduce LLM context growth from tool outputs
   - You are tuning agents.defaults.contextPruning
-title: "Session Pruning"
 ---
-
 # Session Pruning
 
 Session pruning trims **old tool results** from the in-memory context right before each LLM call. It does **not** rewrite the on-disk session history (`*.jsonl`).
 
 ## When it runs
-
 - When `mode: "cache-ttl"` is enabled and the last Anthropic call for the session is older than `ttl`.
 - Only affects the messages sent to the model for that request.
-- Only active for Anthropic API calls (and OpenRouter Anthropic models).
-- For best results, match `ttl` to your model `cacheRetention`.
-- After a prune, the TTL window resets so subsequent requests keep cache until `ttl` expires again.
+ - Only active for Anthropic API calls (and OpenRouter Anthropic models).
+ - For best results, match `ttl` to your model `cacheControlTtl`.
+ - After a prune, the TTL window resets so subsequent requests keep cache until `ttl` expires again.
 
 ## Smart defaults (Anthropic)
-
 - **OAuth or setup-token** profiles: enable `cache-ttl` pruning and set heartbeat to `1h`.
-- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention: "short"` on Anthropic models.
+- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheControlTtl` to `1h` on Anthropic models.
 - If you set any of these values explicitly, OpenClaw does **not** override them.
 
 ## What this improves (cost + cache behavior)
-
 - **Why prune:** Anthropic prompt caching only applies within the TTL. If a session goes idle past the TTL, the next request re-caches the full prompt unless you trim it first.
 - **What gets cheaper:** pruning reduces the **cacheWrite** size for that first request after the TTL expires.
 - **Why the TTL reset matters:** once pruning runs, the cache window resets, so follow‑up requests can reuse the freshly cached prompt instead of re-caching the full history again.
 - **What it does not do:** pruning doesn’t add tokens or “double” costs; it only changes what gets cached on that first post‑TTL request.
 
 ## What can be pruned
-
 - Only `toolResult` messages.
 - User + assistant messages are **never** modified.
 - The last `keepLastAssistants` assistant messages are protected; tool results after that cutoff are not pruned.
@@ -40,42 +34,35 @@ Session pruning trims **old tool results** from the in-memory context right befo
 - Tool results containing **image blocks** are skipped (never trimmed/cleared).
 
 ## Context window estimation
+Pruning uses an estimated context window (chars ≈ tokens × 4). The base window is resolved in this order:
+1) `models.providers.*.models[].contextWindow` override.
+2) Model definition `contextWindow` (from the model registry).
+3) Default `200000` tokens.
 
-Pruning uses an estimated context window (chars ≈ tokens × 4). The window size is resolved in this order:
-
-1. Model definition `contextWindow` (from the model registry).
-2. `models.providers.*.models[].contextWindow` override.
-3. `agents.defaults.contextTokens`.
-4. Default `200000` tokens.
+If `agents.defaults.contextTokens` is set, it is treated as a cap (min) on the resolved window.
 
 ## Mode
-
 ### cache-ttl
-
 - Pruning only runs if the last Anthropic call is older than `ttl` (default `5m`).
 - When it runs: same soft-trim + hard-clear behavior as before.
 
 ## Soft vs hard pruning
-
 - **Soft-trim**: only for oversized tool results.
   - Keeps head + tail, inserts `...`, and appends a note with the original size.
   - Skips results with image blocks.
 - **Hard-clear**: replaces the entire tool result with `hardClear.placeholder`.
 
 ## Tool selection
-
 - `tools.allow` / `tools.deny` support `*` wildcards.
 - Deny wins.
 - Matching is case-insensitive.
 - Empty allow list => all tools allowed.
 
 ## Interaction with other limits
-
 - Built-in tools already truncate their own output; session pruning is an extra layer that prevents long-running chats from accumulating too much tool output in the model context.
 - Compaction is separate: compaction summarizes and persists, pruning is transient per request. See [/concepts/compaction](/concepts/compaction).
 
 ## Defaults (when enabled)
-
 - `ttl`: `"5m"`
 - `keepLastAssistants`: `3`
 - `softTrimRatio`: `0.3`
@@ -85,37 +72,33 @@ Pruning uses an estimated context window (chars ≈ tokens × 4). The window siz
 - `hardClear`: `{ enabled: true, placeholder: "[Old tool result content cleared]" }`
 
 ## Examples
-
 Default (off):
-
 ```json5
 {
   agent: {
-    contextPruning: { mode: "off" },
-  },
+    contextPruning: { mode: "off" }
+  }
 }
 ```
 
 Enable TTL-aware pruning:
-
 ```json5
 {
   agent: {
-    contextPruning: { mode: "cache-ttl", ttl: "5m" },
-  },
+    contextPruning: { mode: "cache-ttl", ttl: "5m" }
+  }
 }
 ```
 
 Restrict pruning to specific tools:
-
 ```json5
 {
   agent: {
     contextPruning: {
       mode: "cache-ttl",
-      tools: { allow: ["exec", "read"], deny: ["*image*"] },
-    },
-  },
+      tools: { allow: ["exec", "read"], deny: ["*image*"] }
+    }
+  }
 }
 ```
 

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -11,9 +11,7 @@ export type ContextWindowInfo = {
 };
 
 function normalizePositiveInt(value: unknown): number | null {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return null;
-  }
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
   const int = Math.floor(value);
   return int > 0 ? int : null;
 }
@@ -25,11 +23,6 @@ export function resolveContextWindowInfo(params: {
   modelContextWindow?: number;
   defaultTokens: number;
 }): ContextWindowInfo {
-  const fromModel = normalizePositiveInt(params.modelContextWindow);
-  if (fromModel) {
-    return { tokens: fromModel, source: "model" };
-  }
-
   const fromModelsConfig = (() => {
     const providers = params.cfg?.models?.providers as
       | Record<string, { models?: Array<{ id?: string; contextWindow?: number }> }>
@@ -39,16 +32,19 @@ export function resolveContextWindowInfo(params: {
     const match = models.find((m) => m?.id === params.modelId);
     return normalizePositiveInt(match?.contextWindow);
   })();
-  if (fromModelsConfig) {
-    return { tokens: fromModelsConfig, source: "modelsConfig" };
+  const fromModel = normalizePositiveInt(params.modelContextWindow);
+  const baseInfo = fromModelsConfig
+    ? { tokens: fromModelsConfig, source: "modelsConfig" as const }
+    : fromModel
+      ? { tokens: fromModel, source: "model" as const }
+      : { tokens: Math.floor(params.defaultTokens), source: "default" as const };
+
+  const capTokens = normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);
+  if (capTokens && capTokens < baseInfo.tokens) {
+    return { tokens: capTokens, source: "agentContextTokens" };
   }
 
-  const fromAgentConfig = normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);
-  if (fromAgentConfig) {
-    return { tokens: fromAgentConfig, source: "agentContextTokens" };
-  }
-
-  return { tokens: Math.floor(params.defaultTokens), source: "default" };
+  return baseInfo;
 }
 
 export type ContextWindowGuardResult = ContextWindowInfo & {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -81,8 +81,16 @@ export function buildEmbeddedExtensionPaths(params: {
   const paths: string[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
+    const contextWindowInfo = resolveContextWindowInfo({
+      cfg: params.cfg,
+      provider: params.provider,
+      modelId: params.modelId,
+      modelContextWindow: params.model?.contextWindow,
+      defaultTokens: DEFAULT_CONTEXT_TOKENS,
+    });
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
+      contextWindowTokens: contextWindowInfo.tokens,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,5 +1,6 @@
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
+  contextWindowTokens?: number;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -195,11 +195,15 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     }
 
     try {
-      const contextWindowTokens = resolveContextWindowTokens(model);
+      const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+      const modelContextWindow = resolveContextWindowTokens(model);
+      const contextWindowTokens = Math.min(
+        runtime?.contextWindowTokens ?? modelContextWindow,
+        modelContextWindow,
+      );
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
       let messagesToSummarize = preparation.messagesToSummarize;
 
-      const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
       const maxHistoryShare = runtime?.maxHistoryShare ?? 0.5;
 
       const tokensBefore =

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -197,10 +197,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     try {
       const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
       const modelContextWindow = resolveContextWindowTokens(model);
-      const contextWindowTokens = Math.min(
-        runtime?.contextWindowTokens ?? modelContextWindow,
-        modelContextWindow,
-      );
+      const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
       let messagesToSummarize = preparation.messagesToSummarize;
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -124,7 +124,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           ["openclaw sessions --json", "Machine-readable output."],
           ["openclaw sessions --store ./tmp/sessions.json", "Use a specific session store."],
         ])}\n\n${theme.muted(
-          "Shows token usage per session when the agent reports it; set agents.defaults.contextTokens to see % of your model window.",
+          "Shows token usage per session when the agent reports it; set agents.defaults.contextTokens to cap the window and show %.",
         )}`,
     )
     .addHelpText(

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -122,7 +122,7 @@ export type AgentDefaultsConfig = {
    * Include elapsed time in message envelopes ("on" | "off", default: "on").
    */
   envelopeElapsed?: "on" | "off";
-  /** Optional display-only context window override (used for % in status UIs). */
+  /** Optional context window cap (used for runtime estimates + status %). */
   contextTokens?: number;
   /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
   cliBackends?: Record<string, CliBackendConfig>;


### PR DESCRIPTION
**PR mostly written with OpenCode, has been reviewed and editted by me**

When agents.defaults.contextTokens was configured in openclaw.config.json, the compaction safeguard wasn't respecting it. Users would see status messages like "Context 157k/128k (123%)" even though they had explicitly set a 128k context window limit.

## Root Cause

The compaction safeguard extension (src/agents/pi-extensions/compaction-safeguard.ts) was calling resolveContextWindowTokens(model) which only looked at the model's built-in contextWindow property. It completely bypassed the config resolution that checks agents.defaults.contextTokens (which is handled correctly elsewhere in context-window-guard.ts).

## Solution
Pass the resolved context window through the session-scoped runtime registry, similar to how context-pruning already does it:
1. Added contextWindowTokens to CompactionSafeguardRuntimeValue type
2. Updated extensions.ts to resolve the context window using resolveContextWindowInfo() (which properly checks config → model → fallback chain) before setting the runtime
3. Modified the safeguard extension to prefer the runtime value, falling back to model default only when needed
Testing
- All existing compaction-safeguard tests pass (17 tests)
- Build and lint clean
- The fix follows the established pattern used by context-pruning for runtime-scoped values

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the resolved context window token limit (config → model → default) into the compaction safeguard via the session-scoped runtime registry, so the safeguard uses the same effective context window value as the rest of the agent runtime. It also includes unrelated Antigravity User-Agent changes and a behavioral change to block reply delivery.

Key codepath: `buildEmbeddedExtensionPaths` now computes `resolveContextWindowInfo(...).tokens` and stores it with `setCompactionSafeguardRuntime`, and `compaction-safeguard` prefers that runtime value when computing compaction budgets.

One thing to double-check is the new block reply pipeline logic: the new “fire immediately” comment doesn’t match the continued promise-chaining, and the safeguard now clamps configured context windows to never exceed the model default (which may or may not be desired).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but it contains at least one behavioral change that appears internally inconsistent and should be clarified/fixed first.
- The core fix (passing resolved context window tokens through runtime) is straightforward and aligns with existing patterns, but the block-reply pipeline change appears to claim concurrency while still serializing via `sendChain`, and the context window logic clamps values above the model default which may be an unintended limitation depending on config semantics.
- src/auto-reply/reply/block-reply-pipeline.ts; src/agents/pi-extensions/compaction-safeguard.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->