### PR TITLE
Telegram: fix DM Topics thread routing

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -158,11 +158,15 @@ export const buildTelegramMessageContext = async ({
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
   const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
-  const resolvedThreadId = resolveTelegramForumThreadId({
-    isForum,
-    messageThreadId,
-  });
-  const replyThreadId = isGroup ? resolvedThreadId : messageThreadId;
+
+  // Thread routing:
+  // - Forum groups: resolve forum topic id (defaults to General topic=1 when missing)
+  // - Private chats with topics: use raw message_thread_id
+  const resolvedThreadId = isGroup
+    ? resolveTelegramForumThreadId({ isForum, messageThreadId })
+    : messageThreadId;
+
+  const replyThreadId = resolvedThreadId;
   const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, resolvedThreadId);
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const route = resolveAgentRoute({


### PR DESCRIPTION
### What
Fix thread routing for Telegram *private chats with Topics enabled* by using the raw `message_thread_id` instead of applying forum-group thread resolution.

### Why
`resolveTelegramForumThreadId(...)` is intended for forum groups; in private chats it can cause replies/typing to fall back to the main thread.

### Change
- In groups/supergroups: keep using `resolveTelegramForumThreadId({ isForum, messageThreadId })`
- In private chats: set `resolvedThreadId = messageThreadId`
- Make `replyThreadId` follow `resolvedThreadId`

### Notes
This matches observed behavior when DM Topics are enabled and `message_thread_id` is present.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram thread routing in `buildTelegramMessageContext` to treat DMs differently from groups: groups/supergroups still derive a `resolvedThreadId` via `resolveTelegramForumThreadId`, while private chats use the raw `message_thread_id`, and replies/typing now consistently use `replyThreadId = resolvedThreadId`.

Overall this aligns the DM behavior with Telegram “Topics in private chats”, but the new `replyThreadId` assignment can change behavior for *non-forum* groups by routing replies/typing into the default forum topic id (often `1`) rather than the main thread when `message_thread_id` is absent.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but may misroute replies/typing in non-forum groups due to default topic resolution.
- The change is small and targeted, but it modifies group reply routing by always using `resolvedThreadId`, which can differ from the previous behavior when `isForum` is false and `message_thread_id` is missing.
- src/telegram/bot-message-context.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->