### PR TITLE
ci(security): add actionlint + zizmor workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,21 @@
+name: actionlint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+        with:
+          # Use repo config when present
+          config-file: .github/actionlint.yaml

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.7
         with:
           # Use repo config when present
           config-file: .github/actionlint.yaml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor@v1.11.0
+        uses: zizmorcore/zizmor-action@v0.4.1
         with:
           config: zizmor.yml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,20 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor@v0
+        with:
+          config: zizmor.yml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor@v0
+        uses: zizmorcore/zizmor@v1.11.0
         with:
           config: zizmor.yml


### PR DESCRIPTION
### Summary
Adds CI jobs to lint GitHub Actions workflows with actionlint and to scan workflow security posture with zizmor.

### Why
The repo already has `actionlint.yaml` and `zizmor.yml`, but no workflows were actually running these tools. Wiring them up catches workflow bugs and reduces supply-chain risk.

### Notes
- Read-only permissions
- Runs on PRs and main

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new GitHub Actions workflows under `.github/workflows/` that run on `pull_request` and pushes to `main`: one runs `rhysd/actionlint` using the repo’s `.github/actionlint.yaml` config, and the other runs `zizmorcore/zizmor` using `zizmor.yml`.

These checks complement the existing workflow/tool configuration by actually enforcing it in CI, helping catch workflow syntax/logic issues and providing automated security posture scanning for workflows.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and limited blast radius (CI-only changes).
- Changes are isolated to two new workflows and don’t affect runtime code. Main consideration is supply-chain hardening of the workflows themselves (pinning action refs / checkout credential handling) rather than functional correctness.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->