### PR TITLE
feat(tools): add category-based lazy loading to reduce tokens

### DIFF
--- a/src/agents/tool-categories.test.ts
+++ b/src/agents/tool-categories.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "./tools/common.js";
+import {
+  categorizeTool,
+  detectToolCategoriesFromMessage,
+  filterToolsByCategories,
+  TOOL_CATEGORIES,
+} from "./tool-categories.js";
+
+// Mock tools for testing
+const createMockTool = (name: string): AnyAgentTool =>
+  ({
+    name,
+    label: name,
+    description: `Mock tool ${name}`,
+    parameters: {},
+    execute: async () => ({ success: true }),
+  }) as AnyAgentTool;
+
+describe("categorizeTool", () => {
+  it("categorizes core tools correctly", () => {
+    expect(categorizeTool("read")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("write")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("edit")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("grep")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("find")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("ls")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("exec")).toBe(TOOL_CATEGORIES.CORE);
+    expect(categorizeTool("process")).toBe(TOOL_CATEGORIES.CORE);
+  });
+
+  it("categorizes web tools correctly", () => {
+    expect(categorizeTool("web_search")).toBe(TOOL_CATEGORIES.WEB);
+    expect(categorizeTool("web_fetch")).toBe(TOOL_CATEGORIES.WEB);
+    expect(categorizeTool("browser")).toBe(TOOL_CATEGORIES.WEB);
+  });
+
+  it("categorizes channel tools correctly", () => {
+    expect(categorizeTool("message")).toBe(TOOL_CATEGORIES.CHANNELS);
+    expect(categorizeTool("cron")).toBe(TOOL_CATEGORIES.CHANNELS);
+    expect(categorizeTool("tts")).toBe(TOOL_CATEGORIES.CHANNELS);
+  });
+
+  it("categorizes session tools correctly", () => {
+    expect(categorizeTool("sessions_list")).toBe(TOOL_CATEGORIES.SESSIONS);
+    expect(categorizeTool("sessions_send")).toBe(TOOL_CATEGORIES.SESSIONS);
+    expect(categorizeTool("sessions_spawn")).toBe(TOOL_CATEGORIES.SESSIONS);
+    expect(categorizeTool("sessions_history")).toBe(TOOL_CATEGORIES.SESSIONS);
+    expect(categorizeTool("session_status")).toBe(TOOL_CATEGORIES.SESSIONS);
+    expect(categorizeTool("agents_list")).toBe(TOOL_CATEGORIES.SESSIONS);
+  });
+
+  it("categorizes infra tools correctly", () => {
+    expect(categorizeTool("gateway")).toBe(TOOL_CATEGORIES.INFRA);
+    expect(categorizeTool("nodes")).toBe(TOOL_CATEGORIES.INFRA);
+    expect(categorizeTool("canvas")).toBe(TOOL_CATEGORIES.INFRA);
+  });
+
+  it("categorizes vision tools correctly", () => {
+    expect(categorizeTool("image")).toBe(TOOL_CATEGORIES.VISION);
+  });
+
+  it("returns UNKNOWN for unrecognized tools", () => {
+    expect(categorizeTool("unknown_tool")).toBe(TOOL_CATEGORIES.UNKNOWN);
+    expect(categorizeTool("custom_plugin")).toBe(TOOL_CATEGORIES.UNKNOWN);
+  });
+});
+
+describe("detectToolCategoriesFromMessage", () => {
+  it("always includes CORE category", () => {
+    const result = detectToolCategoriesFromMessage("hello world");
+    expect(result).toContain(TOOL_CATEGORIES.CORE);
+  });
+
+  it("detects web category from keywords", () => {
+    const webKeywords = [
+      "search",
+      "google",
+      "website",
+      "http",
+      "url",
+      "browser",
+      "web",
+      "internet",
+      "site",
+    ];
+
+    for (const keyword of webKeywords) {
+      const result = detectToolCategoriesFromMessage(`Please ${keyword} something`);
+      expect(result).toContain(TOOL_CATEGORIES.WEB);
+    }
+  });
+
+  it("detects channels category from keywords", () => {
+    const channelKeywords = [
+      "telegram",
+      "discord",
+      "slack",
+      "whatsapp",
+      "signal",
+      "message",
+      "send",
+      "channel",
+      "remind",
+      "schedule",
+    ];
+
+    for (const keyword of channelKeywords) {
+      const result = detectToolCategoriesFromMessage(`Send a ${keyword} please`);
+      expect(result).toContain(TOOL_CATEGORIES.CHANNELS);
+    }
+  });
+
+  it("detects sessions category from keywords", () => {
+    const sessionKeywords = ["session", "agent", "spawn", "subagent", "history"];
+
+    for (const keyword of sessionKeywords) {
+      const result = detectToolCategoriesFromMessage(`Check ${keyword}`);
+      expect(result).toContain(TOOL_CATEGORIES.SESSIONS);
+    }
+  });
+
+  it("detects infra category from keywords", () => {
+    const infraKeywords = ["gateway", "restart", "config", "node", "camera", "screen"];
+
+    for (const keyword of infraKeywords) {
+      const result = detectToolCategoriesFromMessage(`Use ${keyword}`);
+      expect(result).toContain(TOOL_CATEGORIES.INFRA);
+    }
+  });
+
+  it("detects vision category from image mentions", () => {
+    const visionKeywords = ["image", "picture", "photo", "analyze image", "vision"];
+
+    for (const keyword of visionKeywords) {
+      const result = detectToolCategoriesFromMessage(`Analyze this ${keyword}`);
+      expect(result).toContain(TOOL_CATEGORIES.VISION);
+    }
+  });
+
+  it("detects multiple categories", () => {
+    const result = detectToolCategoriesFromMessage("Search the web and send a message to telegram");
+
+    expect(result).toContain(TOOL_CATEGORIES.CORE);
+    expect(result).toContain(TOOL_CATEGORIES.WEB);
+    expect(result).toContain(TOOL_CATEGORIES.CHANNELS);
+    expect(result).not.toContain(TOOL_CATEGORIES.SESSIONS);
+    expect(result).not.toContain(TOOL_CATEGORIES.INFRA);
+  });
+
+  it("returns only CORE for generic messages", () => {
+    const genericMessages = [
+      "Hello",
+      "How are you?",
+      "Create a file",
+      "Run this command",
+      "Edit the code",
+    ];
+
+    for (const message of genericMessages) {
+      const result = detectToolCategoriesFromMessage(message);
+      expect(result).toEqual([TOOL_CATEGORIES.CORE]);
+    }
+  });
+});
+
+describe("filterToolsByCategories", () => {
+  const mockTools: AnyAgentTool[] = [
+    createMockTool("read"),
+    createMockTool("write"),
+    createMockTool("web_search"),
+    createMockTool("browser"),
+    createMockTool("message"),
+    createMockTool("cron"),
+    createMockTool("sessions_list"),
+    createMockTool("gateway"),
+    createMockTool("image"),
+    createMockTool("custom_plugin"),
+  ];
+
+  it("filters tools by single category", () => {
+    const result = filterToolsByCategories(mockTools, [TOOL_CATEGORIES.CORE]);
+
+    expect(result.map((t) => t.name)).toContain("read");
+    expect(result.map((t) => t.name)).toContain("write");
+    expect(result.map((t) => t.name)).not.toContain("web_search");
+    expect(result.map((t) => t.name)).not.toContain("message");
+  });
+
+  it("filters tools by multiple categories", () => {
+    const result = filterToolsByCategories(mockTools, [TOOL_CATEGORIES.CORE, TOOL_CATEGORIES.WEB]);
+
+    expect(result.map((t) => t.name)).toContain("read");
+    expect(result.map((t) => t.name)).toContain("web_search");
+    expect(result.map((t) => t.name)).toContain("browser");
+    expect(result.map((t) => t.name)).not.toContain("message");
+    expect(result.map((t) => t.name)).not.toContain("gateway");
+  });
+
+  it("includes UNKNOWN category tools", () => {
+    const result = filterToolsByCategories(mockTools, [TOOL_CATEGORIES.CORE]);
+
+    // Unknown/plugin tools should always be included
+    expect(result.map((t) => t.name)).toContain("custom_plugin");
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = filterToolsByCategories([], [TOOL_CATEGORIES.CORE]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns all tools when all categories specified", () => {
+    const allCategories = Object.values(TOOL_CATEGORIES);
+    const result = filterToolsByCategories(mockTools, allCategories);
+
+    expect(result).toHaveLength(mockTools.length);
+  });
+});
+
+describe("Integration: message to filtered tools", () => {
+  const allTools: AnyAgentTool[] = [
+    createMockTool("read"),
+    createMockTool("write"),
+    createMockTool("edit"),
+    createMockTool("web_search"),
+    createMockTool("web_fetch"),
+    createMockTool("browser"),
+    createMockTool("message"),
+    createMockTool("cron"),
+    createMockTool("sessions_list"),
+    createMockTool("sessions_spawn"),
+    createMockTool("gateway"),
+    createMockTool("nodes"),
+    createMockTool("image"),
+  ];
+
+  it("reduces tools for generic message", () => {
+    const categories = detectToolCategoriesFromMessage("Create a file");
+    const filtered = filterToolsByCategories(allTools, categories);
+
+    // Should only have core tools
+    expect(filtered.map((t) => t.name)).toContain("read");
+    expect(filtered.map((t) => t.name)).toContain("write");
+    expect(filtered.map((t) => t.name)).not.toContain("web_search");
+    expect(filtered.map((t) => t.name)).not.toContain("message");
+    expect(filtered.map((t) => t.name)).not.toContain("gateway");
+
+    // Should reduce from 13 to ~4 tools
+    expect(filtered.length).toBeLessThan(allTools.length);
+  });
+
+  it("includes web tools for web-related message", () => {
+    const categories = detectToolCategoriesFromMessage("Search on Google");
+    const filtered = filterToolsByCategories(allTools, categories);
+
+    expect(filtered.map((t) => t.name)).toContain("web_search");
+    expect(filtered.map((t) => t.name)).toContain("web_fetch");
+    expect(filtered.map((t) => t.name)).toContain("browser");
+  });
+
+  it("includes channel tools for messaging request", () => {
+    const categories = detectToolCategoriesFromMessage("Send telegram message");
+    const filtered = filterToolsByCategories(allTools, categories);
+
+    expect(filtered.map((t) => t.name)).toContain("message");
+    expect(filtered.map((t) => t.name)).toContain("cron");
+  });
+
+  it("estimates token reduction", () => {
+    const genericMessage = "Edit this file";
+    const categories = detectToolCategoriesFromMessage(genericMessage);
+    const filtered = filterToolsByCategories(allTools, categories);
+
+    const reduction = allTools.length - filtered.length;
+    const reductionPercent = (reduction / allTools.length) * 100;
+
+    // Should reduce by at least 50% for generic messages
+    expect(reductionPercent).toBeGreaterThan(50);
+  });
+});

--- a/src/agents/tool-categories.ts
+++ b/src/agents/tool-categories.ts
@@ -1,0 +1,262 @@
+import type { AnyAgentTool } from "./tools/common.js";
+
+/**
+ * Tool categories for lazy loading optimization.
+ * Reduces token usage by only sending relevant tools based on message context.
+ */
+export enum TOOL_CATEGORIES {
+  /** Core file and shell operations - always active */
+  CORE = "core",
+  /** Web search, fetch, browser operations */
+  WEB = "web",
+  /** Messaging channels and scheduling */
+  CHANNELS = "channels",
+  /** Session and agent management */
+  SESSIONS = "sessions",
+  /** Infrastructure: gateway, nodes, canvas */
+  INFRA = "infra",
+  /** Image/vision analysis */
+  VISION = "vision",
+  /** Unknown/plugin tools - always included */
+  UNKNOWN = "unknown",
+}
+
+export type ToolCategory = TOOL_CATEGORIES;
+
+/**
+ * Tool to category mapping
+ */
+const TOOL_CATEGORY_MAP: Record<string, TOOL_CATEGORIES> = {
+  // Core tools - always available
+  read: TOOL_CATEGORIES.CORE,
+  write: TOOL_CATEGORIES.CORE,
+  edit: TOOL_CATEGORIES.CORE,
+  apply_patch: TOOL_CATEGORIES.CORE,
+  grep: TOOL_CATEGORIES.CORE,
+  find: TOOL_CATEGORIES.CORE,
+  ls: TOOL_CATEGORIES.CORE,
+  exec: TOOL_CATEGORIES.CORE,
+  process: TOOL_CATEGORIES.CORE,
+
+  // Web tools
+  web_search: TOOL_CATEGORIES.WEB,
+  web_fetch: TOOL_CATEGORIES.WEB,
+  browser: TOOL_CATEGORIES.WEB,
+
+  // Channel tools
+  message: TOOL_CATEGORIES.CHANNELS,
+  cron: TOOL_CATEGORIES.CHANNELS,
+  tts: TOOL_CATEGORIES.CHANNELS,
+
+  // Session tools
+  sessions_list: TOOL_CATEGORIES.SESSIONS,
+  sessions_history: TOOL_CATEGORIES.SESSIONS,
+  sessions_send: TOOL_CATEGORIES.SESSIONS,
+  sessions_spawn: TOOL_CATEGORIES.SESSIONS,
+  session_status: TOOL_CATEGORIES.SESSIONS,
+  agents_list: TOOL_CATEGORIES.SESSIONS,
+
+  // Infra tools
+  gateway: TOOL_CATEGORIES.INFRA,
+  nodes: TOOL_CATEGORIES.INFRA,
+  canvas: TOOL_CATEGORIES.INFRA,
+
+  // Vision tools
+  image: TOOL_CATEGORIES.VISION,
+};
+
+/**
+ * Keywords that trigger each category
+ */
+const CATEGORY_KEYWORDS: Record<TOOL_CATEGORIES, string[]> = {
+  [TOOL_CATEGORIES.CORE]: [], // Always included
+  [TOOL_CATEGORIES.WEB]: [
+    "search",
+    "google",
+    "website",
+    "http",
+    "https",
+    "url",
+    "browse",
+    "browser",
+    "web",
+    "internet",
+    "site",
+    "page",
+    "scrape",
+    "fetch",
+    "download",
+    "online",
+  ],
+  [TOOL_CATEGORIES.CHANNELS]: [
+    "telegram",
+    "discord",
+    "slack",
+    "whatsapp",
+    "signal",
+    "imessage",
+    "message",
+    "send",
+    "notify",
+    "channel",
+    "remind",
+    "schedule",
+    "cron",
+    "voice",
+    "audio",
+  ],
+  [TOOL_CATEGORIES.SESSIONS]: [
+    "session",
+    "sessions",
+    "agent",
+    "agents",
+    "spawn",
+    "subagent",
+    "history",
+    "context",
+  ],
+  [TOOL_CATEGORIES.INFRA]: [
+    "gateway",
+    "restart",
+    "config",
+    "node",
+    "nodes",
+    "camera",
+    "screen",
+    "canvas",
+    "infrastructure",
+  ],
+  [TOOL_CATEGORIES.VISION]: [
+    "image",
+    "picture",
+    "photo",
+    "analyze image",
+    "vision",
+    "see",
+    "look",
+    "visual",
+  ],
+  [TOOL_CATEGORIES.UNKNOWN]: [], // Plugin tools - always included
+};
+
+/**
+ * Get the category for a tool by name.
+ * Returns UNKNOWN for unrecognized/plugin tools.
+ * Normalizes names to lowercase for case-insensitive matching.
+ */
+export function categorizeTool(toolName: string): TOOL_CATEGORIES {
+  // Normalize tool names to lowercase for case-insensitive matching
+  // Handles namespaced tools like "tools.memory_search" or "bash"
+  const normalizedName = toolName.toLowerCase();
+
+  // Try exact match first
+  if (TOOL_CATEGORY_MAP[normalizedName]) {
+    return TOOL_CATEGORY_MAP[normalizedName];
+  }
+
+  // Try matching without namespace (e.g., "tools.read" -> "read")
+  const withoutNamespace = normalizedName.split(".").pop() ?? normalizedName;
+  return TOOL_CATEGORY_MAP[withoutNamespace] ?? TOOL_CATEGORIES.UNKNOWN;
+}
+
+/**
+ * Detect which tool categories are needed based on message content.
+ * Always includes CORE category.
+ */
+export function detectToolCategoriesFromMessage(message: string): TOOL_CATEGORIES[] {
+  const normalizedMessage = " " + message.toLowerCase() + " ";
+  const categories: Set<TOOL_CATEGORIES> = new Set([TOOL_CATEGORIES.CORE]);
+
+  // Check each category's keywords using word boundaries to avoid false positives
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (category === TOOL_CATEGORIES.CORE || category === TOOL_CATEGORIES.UNKNOWN) {
+      continue;
+    }
+
+    for (const keyword of keywords) {
+      const lowerKeyword = keyword.toLowerCase();
+      // Use word boundary matching: space + keyword + space/punctuation
+      // This prevents "web" matching "webhook" or "message" matching "messaging"
+      if (
+        normalizedMessage.includes(" " + lowerKeyword + " ") ||
+        normalizedMessage.includes(" " + lowerKeyword + ".") ||
+        normalizedMessage.includes(" " + lowerKeyword + ",") ||
+        normalizedMessage.includes(" " + lowerKeyword + "!") ||
+        normalizedMessage.includes(" " + lowerKeyword + "?")
+      ) {
+        categories.add(category as TOOL_CATEGORIES);
+        break; // Found a match for this category, move to next
+      }
+    }
+  }
+
+  return Array.from(categories);
+}
+
+/**
+ * Filter tools to only include those from specified categories.
+ * Unknown/plugin tools are always included.
+ */
+export function filterToolsByCategories(
+  tools: AnyAgentTool[],
+  categories: TOOL_CATEGORIES[],
+): AnyAgentTool[] {
+  const categorySet = new Set(categories);
+
+  return tools.filter((tool) => {
+    const toolCategory = categorizeTool(tool.name);
+
+    // Always include unknown/plugin tools
+    if (toolCategory === TOOL_CATEGORIES.UNKNOWN) {
+      return true;
+    }
+
+    return categorySet.has(toolCategory);
+  });
+}
+
+/**
+ * Filter tool names to only include those from specified categories.
+ * Unknown/plugin tools are always included.
+ */
+export function filterToolNamesByCategories(
+  toolNames: string[],
+  categories: TOOL_CATEGORIES[],
+): string[] {
+  const categorySet = new Set(categories);
+
+  return toolNames.filter((name) => {
+    const toolCategory = categorizeTool(name);
+
+    // Always include unknown/plugin tools
+    if (toolCategory === TOOL_CATEGORIES.UNKNOWN) {
+      return true;
+    }
+
+    return categorySet.has(toolCategory);
+  });
+}
+
+/**
+ * Get recommended categories for a message.
+ * Convenience function that combines detection and returns array.
+ */
+export function getRecommendedCategoriesForMessage(message: string): TOOL_CATEGORIES[] {
+  return detectToolCategoriesFromMessage(message);
+}
+
+/**
+ * Estimate token savings from filtering.
+ * Rough estimate: ~300 tokens per tool (schema + description)
+ */
+export function estimateTokenSavings(
+  totalTools: number,
+  filteredTools: number,
+): { saved: number; percent: number } {
+  const tokensPerTool = 300;
+  const savedTools = totalTools - filteredTools;
+  const saved = savedTools * tokensPerTool;
+  const percent = totalTools > 0 ? (savedTools / totalTools) * 100 : 0;
+
+  return { saved, percent };
+}


### PR DESCRIPTION
## Summary
Implements lazy loading of tools based on categories, automatically filtering irrelevant tools for each message.

## Problem
- All ~24 tools (~29k tokens) sent every message
- Many tools irrelevant for simple tasks

## Solution
- 6 categories: CORE (always), WEB, CHANNELS, SESSIONS, INFRA, VISION
- Automatic detection via keywords in user message
- ~76% tool reduction for generic messages

## Changes
- src/agents/tool-categories.ts - Category system
- src/agents/tool-categories.test.ts - 24 TDD tests  
- src/agents/pi-embedded-runner/run/attempt.ts - Integration (4 lines)
- src/agents/system-prompt.ts - Helper function

## Testing
✅ 24 tests passing
✅ Build passing

## Token Savings
~4,800 tokens saved for generic messages.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds category-based tool filtering to reduce per-message tool schema tokens by detecting needed categories from the (hook-adjusted) user prompt and only enabling relevant tools for the embedded runner.

Main changes:
- New `src/agents/tool-categories.ts` implements category definitions, keyword-based detection, and tool filtering.
- `src/agents/pi-embedded-runner/run/attempt.ts` integrates the filtering so the SDK session is created with the filtered tool list.
- `src/agents/system-prompt.ts` adds a helper for filtering tool names (currently unused).
- New vitest suite `src/agents/tool-categories.test.ts` covers categorization, detection, and filtering behavior.

Key risk area is ensuring the *same* filtered tool set is reflected both in the model-facing tool definitions and in the system prompt/tooling section, otherwise the model may be told tools exist that aren’t actually callable (or vice versa).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but there are a couple integration mismatches that can reduce the intended token savings and confuse tool availability.
- Core idea and unit tests look straightforward, and the runner now filters tools after hooks. However, the system prompt/tool reporting paths still appear to use the unfiltered tool list, and the filtering relies on exact tool-name matches with UNKNOWN tools always included, both of which can undermine effectiveness or create confusing behavior.
- src/agents/pi-embedded-runner/run/attempt.ts; src/agents/tool-categories.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->