### PR TITLE
feat(ui): show session label only in dropdown, fall back to key

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -192,7 +192,7 @@ function resolveMainSessionKey(
 
 function resolveSessionDisplayName(key: string, row?: SessionsListResult["sessions"][number]) {
   const label = row?.label?.trim();
-  if (label) return `${label} (${key})`;
+  if (label) return label;
   const displayName = row?.displayName?.trim();
   if (displayName) return displayName;
   return key;


### PR DESCRIPTION
## Summary
When a session has a label, display just the label in the session dropdown instead of 'label (key)'. Falls back to displayName or key when no label is set.

## Changes
- Modified `resolveSessionDisplayName` in `ui/src/ui/app-render.helpers.ts`
- Previously: label would show as `My Label (session-key-123)`  
- Now: label shows as `My Label` (cleaner UI)

## Motivation
Makes the dropdown cleaner and more readable when sessions have custom labels, since the label is the user's preferred identifier for that session.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the UI session display name resolver so that when a session has a custom `label`, the session dropdown shows only the label (instead of `label (key)`), and otherwise falls back to `displayName` or the raw session `key`. The change is localized to `ui/src/ui/app-render.helpers.ts` and affects how session options are rendered in the chat controls dropdown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line adjustment to a pure display-name helper, with no impact on session keys, routing, or state updates; it only affects how labels appear in the dropdown and preserves existing fallback behavior (displayName/key).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->