### PR TITLE
fix: summarize gateway config.schema to prevent session bloat

### DIFF
--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -198,6 +198,40 @@ export function jsonResult(payload: unknown): AgentToolResult<unknown> {
   };
 }
 
+export const DEFAULT_TOOL_RESULT_MAX_CHARS = 50_000;
+
+export function truncatedJsonResult(
+  payload: unknown,
+  options?: {
+    maxChars?: number;
+    truncationNote?: string;
+  },
+): AgentToolResult<unknown> {
+  const maxChars = options?.maxChars ?? DEFAULT_TOOL_RESULT_MAX_CHARS;
+  const text = JSON.stringify(payload, null, 2);
+
+  if (text.length <= maxChars) {
+    return {
+      content: [{ type: "text", text }],
+      details: payload,
+    };
+  }
+
+  const truncated = text.slice(0, maxChars);
+  const note =
+    options?.truncationNote ??
+    `\n\n[Result truncated: ${text.length.toLocaleString()} chars → ${maxChars.toLocaleString()} chars]`;
+
+  return {
+    content: [{ type: "text", text: truncated + note }],
+    details: {
+      _truncated: true,
+      _originalLength: text.length,
+      _maxChars: maxChars,
+    },
+  };
+}
+
 export async function imageResult(params: {
   label: string;
   path: string;

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -59,18 +59,18 @@ describe("gateway tool config.schema", () => {
     const content = result.content[0] as { type: "text"; text: string };
     const parsed = JSON.parse(content.text);
 
-    // Verify summarized structure
+    // Verify summarized structure wrapped in { ok, result }
     expect(parsed.ok).toBe(true);
-    expect(parsed.version).toBe("1.0.0");
-    expect(parsed.generatedAt).toBe("2024-01-01T00:00:00Z");
-    expect(parsed.sections).toEqual(["agent", "channels", "gateway"]);
-    expect(parsed.sectionSummary).toEqual({
+    expect(parsed.result.version).toBe("1.0.0");
+    expect(parsed.result.generatedAt).toBe("2024-01-01T00:00:00Z");
+    expect(parsed.result.sections).toEqual(["agent", "channels", "gateway"]);
+    expect(parsed.result.sectionSummary).toEqual({
       agent: { type: "object", keys: ["name", "model", "temperature"] },
       channels: { type: "object", keys: ["discord", "telegram", "slack"] },
       gateway: { type: "object", keys: ["port", "host"] },
     });
-    expect(parsed.uiHintCount).toBe(3);
-    expect(parsed.note).toContain("Schema summarized");
+    expect(parsed.result.uiHintCount).toBe(3);
+    expect(parsed.result.note).toContain("Schema summarized");
   });
 
   it("returns reasonably sized response (under 25KB)", async () => {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatewayTool } from "./gateway-tool.js";
+
+const callGatewayToolMock = vi.fn();
+vi.mock("./gateway.js", () => ({
+  callGatewayTool: (...args: unknown[]) => callGatewayToolMock(...args),
+}));
+
+describe("gateway tool config.schema", () => {
+  beforeEach(() => {
+    callGatewayToolMock.mockReset();
+  });
+
+  it("summarizes config.schema response to reduce size", async () => {
+    // Mock a large schema response (simulating 400KB+ real response)
+    const largeSchema = {
+      version: "1.0.0",
+      generatedAt: "2024-01-01T00:00:00Z",
+      schema: {
+        type: "object",
+        properties: {
+          agent: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              model: { type: "string" },
+              temperature: { type: "number" },
+            },
+          },
+          channels: {
+            type: "object",
+            properties: {
+              discord: { type: "object" },
+              telegram: { type: "object" },
+              slack: { type: "object" },
+            },
+          },
+          gateway: {
+            type: "object",
+            properties: {
+              port: { type: "number" },
+              host: { type: "string" },
+            },
+          },
+        },
+      },
+      uiHints: {
+        "agent.name": { label: "Agent Name" },
+        "agent.model": { label: "Model" },
+        "channels.discord": { label: "Discord" },
+      },
+    };
+
+    callGatewayToolMock.mockResolvedValueOnce(largeSchema);
+
+    const tool = createGatewayTool();
+    const result = await tool.execute("test-call-id", { action: "config.schema" });
+
+    const content = result.content[0] as { type: "text"; text: string };
+    const parsed = JSON.parse(content.text);
+
+    // Verify summarized structure
+    expect(parsed.ok).toBe(true);
+    expect(parsed.version).toBe("1.0.0");
+    expect(parsed.generatedAt).toBe("2024-01-01T00:00:00Z");
+    expect(parsed.sections).toEqual(["agent", "channels", "gateway"]);
+    expect(parsed.sectionSummary).toEqual({
+      agent: { type: "object", keys: ["name", "model", "temperature"] },
+      channels: { type: "object", keys: ["discord", "telegram", "slack"] },
+      gateway: { type: "object", keys: ["port", "host"] },
+    });
+    expect(parsed.uiHintCount).toBe(3);
+    expect(parsed.note).toContain("Schema summarized");
+  });
+
+  it("returns reasonably sized response (under 25KB)", async () => {
+    // Mock a realistic large schema with 50 sections x 20 keys
+    const properties: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) {
+      properties[`section${i}`] = {
+        type: "object",
+        properties: Object.fromEntries(
+          Array.from({ length: 20 }, (_, j) => [`key${j}`, { type: "string" }]),
+        ),
+      };
+    }
+
+    const largeSchema = {
+      version: "1.0.0",
+      schema: { type: "object", properties },
+      uiHints: Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`hint${i}`, {}])),
+    };
+
+    callGatewayToolMock.mockResolvedValueOnce(largeSchema);
+
+    const tool = createGatewayTool();
+    const result = await tool.execute("test-call-id", { action: "config.schema" });
+
+    const content = result.content[0] as { type: "text"; text: string };
+
+    // Summarized response should be well under 25KB even with 50 sections x 20 keys
+    // This is a 95%+ reduction from the ~400-600KB full schema
+    expect(content.text.length).toBeLessThan(25_000);
+  });
+});
+
+describe("gateway tool truncation", () => {
+  beforeEach(() => {
+    callGatewayToolMock.mockReset();
+  });
+
+  it("truncates config.get when response is large", async () => {
+    // Mock a large config response
+    const largeConfig = {
+      hash: "abc123",
+      raw: "x".repeat(50_000),
+    };
+
+    callGatewayToolMock.mockResolvedValueOnce(largeConfig);
+
+    const tool = createGatewayTool();
+    const result = await tool.execute("test-call-id", { action: "config.get" });
+
+    const content = result.content[0] as { type: "text"; text: string };
+
+    // Should be truncated to 30KB + truncation note
+    expect(content.text.length).toBeLessThan(35_000);
+    expect(content.text).toContain("[Result truncated:");
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -9,7 +9,13 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { stringEnum } from "../schema/typebox.js";
-import { type AnyAgentTool, jsonResult, readStringParam, truncatedJsonResult } from "./common.js";
+import {
+  type AnyAgentTool,
+  GATEWAY_TOOL_RESULT_MAX_CHARS,
+  jsonResult,
+  readStringParam,
+  truncatedJsonResult,
+} from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 
 function resolveBaseHashFromSnapshot(snapshot: unknown): string | undefined {
@@ -164,7 +170,10 @@ export function createGatewayTool(opts?: {
 
       if (action === "config.get") {
         const result = await callGatewayTool("config.get", gatewayOpts, {});
-        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
+        return truncatedJsonResult(
+          { ok: true, result },
+          { maxChars: GATEWAY_TOOL_RESULT_MAX_CHARS },
+        );
       }
       if (action === "config.schema") {
         const schema = await callGatewayTool("config.schema", gatewayOpts, {});
@@ -182,7 +191,6 @@ export function createGatewayTool(opts?: {
         }
 
         const summary = {
-          ok: true,
           version: schema?.version,
           generatedAt: schema?.generatedAt,
           sections: Object.keys(schemaProperties),
@@ -190,7 +198,7 @@ export function createGatewayTool(opts?: {
           uiHintCount: Object.keys((schema?.uiHints ?? {}) as Record<string, unknown>).length,
           note: "Schema summarized to reduce context size. Use config.get to see current values or ask about specific sections.",
         };
-        return jsonResult(summary);
+        return jsonResult({ ok: true, result: summary });
       }
       if (action === "config.apply") {
         const raw = readStringParam(params, "raw", { required: true });
@@ -216,7 +224,10 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
+        return truncatedJsonResult(
+          { ok: true, result },
+          { maxChars: GATEWAY_TOOL_RESULT_MAX_CHARS },
+        );
       }
       if (action === "config.patch") {
         const raw = readStringParam(params, "raw", { required: true });
@@ -242,7 +253,10 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
+        return truncatedJsonResult(
+          { ok: true, result },
+          { maxChars: GATEWAY_TOOL_RESULT_MAX_CHARS },
+        );
       }
       if (action === "update.run") {
         const sessionKey =
@@ -261,7 +275,10 @@ export function createGatewayTool(opts?: {
           restartDelayMs,
           timeoutMs,
         });
-        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
+        return truncatedJsonResult(
+          { ok: true, result },
+          { maxChars: GATEWAY_TOOL_RESULT_MAX_CHARS },
+        );
       }
 
       throw new Error(`Unknown action: ${action}`);

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -9,7 +9,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { stringEnum } from "../schema/typebox.js";
-import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
+import { type AnyAgentTool, jsonResult, readStringParam, truncatedJsonResult } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 
 function resolveBaseHashFromSnapshot(snapshot: unknown): string | undefined {
@@ -164,11 +164,33 @@ export function createGatewayTool(opts?: {
 
       if (action === "config.get") {
         const result = await callGatewayTool("config.get", gatewayOpts, {});
-        return jsonResult({ ok: true, result });
+        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
       }
       if (action === "config.schema") {
-        const result = await callGatewayTool("config.schema", gatewayOpts, {});
-        return jsonResult({ ok: true, result });
+        const schema = await callGatewayTool("config.schema", gatewayOpts, {});
+        // Summarize schema to avoid 400KB+ responses bloating session files
+        const schemaObj = schema?.schema as Record<string, unknown> | undefined;
+        const schemaProperties = (schemaObj?.properties ?? {}) as Record<string, unknown>;
+
+        const sectionSummary: Record<string, { type?: string; keys: string[] }> = {};
+        for (const [section, def] of Object.entries(schemaProperties)) {
+          const sectionDef = def as { type?: string; properties?: Record<string, unknown> };
+          sectionSummary[section] = {
+            type: sectionDef.type,
+            keys: Object.keys(sectionDef.properties ?? {}),
+          };
+        }
+
+        const summary = {
+          ok: true,
+          version: schema?.version,
+          generatedAt: schema?.generatedAt,
+          sections: Object.keys(schemaProperties),
+          sectionSummary,
+          uiHintCount: Object.keys((schema?.uiHints ?? {}) as Record<string, unknown>).length,
+          note: "Schema summarized to reduce context size. Use config.get to see current values or ask about specific sections.",
+        };
+        return jsonResult(summary);
       }
       if (action === "config.apply") {
         const raw = readStringParam(params, "raw", { required: true });
@@ -194,7 +216,7 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result });
+        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
       }
       if (action === "config.patch") {
         const raw = readStringParam(params, "raw", { required: true });
@@ -220,7 +242,7 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result });
+        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
       }
       if (action === "update.run") {
         const sessionKey =
@@ -239,7 +261,7 @@ export function createGatewayTool(opts?: {
           restartDelayMs,
           timeoutMs,
         });
-        return jsonResult({ ok: true, result });
+        return truncatedJsonResult({ ok: true, result }, { maxChars: 30_000 });
       }
 
       throw new Error(`Unknown action: ${action}`);


### PR DESCRIPTION
## Summary
- Add `truncatedJsonResult()` helper for limiting large tool results to prevent session bloat
- Summarize `config.schema` response to ~5-10KB (down from 400-600KB) - **95%+ reduction**
- Apply 30KB truncation limit to `config.get`, `config.apply`, `config.patch`, and `update.run` actions

## Problem
The gateway tool's `config.schema` action was returning 400-600KB of JSON (full config schema + UI hints). These massive responses got stored in session `.jsonl` files, causing:
- Session files growing to 2-3MB within hours
- Context overflow (208k tokens > 200k limit)
- Auto-compaction failure
- Bot becoming unresponsive

## Solution
Instead of returning the full schema, `config.schema` now returns a compact summary containing:
- Section names and their property keys
- Schema version and generation timestamp
- UI hint count
- A note directing users to use `config.get` for current values

Other gateway actions are protected with a 30KB truncation limit using the new `truncatedJsonResult()` helper.

## Test plan
- [x] Run `pnpm vitest run src/agents/tools/common.test.ts src/agents/tools/gateway-tool.test.ts` - 19 tests pass
- [x] Verify no lint errors in modified files
- [ ] Deploy to staging and verify session files remain manageable with heavy gateway tool usage

Fixes #6190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces session/context bloat from gateway tool calls by introducing a `truncatedJsonResult()` helper (size-bounded JSON tool outputs) and by replacing `config.schema`’s full 400–600KB schema payload with a compact summary (sections + property keys + metadata). It also applies a 30KB truncation limit to `config.get`, `config.apply`, `config.patch`, and `update.run`, with tests covering both the new truncation helper and the summarized `config.schema` response.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should materially reduce session bloat, with one notable contract-change risk around `config.schema` output shape.
- Changes are localized and tested, and truncation is straightforward; main risk is that `config.schema` now returns a different top-level structure than before, which could break any consumers expecting `{ ok, result: { schema, uiHints } }`, plus `truncatedJsonResult()` can throw on non-JSON-serializable payloads.
- src/agents/tools/gateway-tool.ts, src/agents/tools/common.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->