### PR TITLE
feat: Coordination Accord — multi-agent governance from Clawdbot vs Antigravity debate

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# Architecture: Domain-Based Multi-Agent Coordination
+
+This document describes the federated agent architecture established through the **Kip vs Antigravity Debate** on 2026-02-01.
+
+---
+
+## The Problem
+
+When running multiple AI agents, two fundamental approaches exist:
+
+| Approach       | Pros                               | Cons                                     |
+| -------------- | ---------------------------------- | ---------------------------------------- |
+| **Monolith**   | Unified memory, consistent routing | Single point of failure, context limit   |
+| **Federation** | Resilient, specialized contexts    | Coordination complexity, potential races |
+
+This architecture implements a **synthesis**: Domain-Based Coordination with Shared State.
+
+---
+
+## The Model
+
+```mermaid
+graph TD
+    User((Osman))
+    SharedState[("SHARED STATE<br/>~/.sma-shared-context/")]
+
+    subgraph "COORDINATORS (Peers)"
+        Kip["🦊 KIP<br/>User-Facing"]
+        Anti["🚀 ANTIGRAVITY<br/>Code-Heavy"]
+        Arch["🤖 ARCHAGENTS<br/>Infrastructure"]
+    end
+
+    User -->|Request| Kip
+    User -->|Arbitration| SharedState
+
+    Kip <-->|Handoff| Anti
+    Kip <-->|Status| Arch
+    Anti <-->|Config| Arch
+
+    Kip ==>|R/W| SharedState
+    Anti ==>|R/W| SharedState
+    Arch ==>|R/W| SharedState
+
+    Watchdogs{{"External Watchdogs<br/>(inotify/systemd)"}}
+    Watchdogs -.-> Kip
+    Watchdogs -.-> Anti
+```
+
+---
+
+## Key Principles
+
+### 1. Primus Inter Pares
+
+"First among equals" — each domain has a leader, but no dictator.
+
+### 2. The Shared Map
+
+The filesystem (`~/.sma-shared-context/`) is the source of truth, not any agent's memory.
+
+**Contents:**
+
+- `SYSTEM_STATUS.md` — Live port/service status
+- `AGENT_ROSTER.md` — Who does what
+- `COORDINATION_ACCORD.md` — Governance rules
+
+### 3. External Watchdogs
+
+Inspired by the **Halting Problem**: a hung process can't detect itself.
+
+Reliability comes from external services:
+
+- `kip-inbox-watcher.service` — inotify-based file detection
+- `antigravity-inbox-watcher.service` — Triggers on file drops
+
+### 4. No Veto Power
+
+Agents cannot override each other. Disputes escalate to the human arbiter.
+
+---
+
+## The Handoff Protocol
+
+When a task crosses domains:
+
+```
+1. PRIMARY identifies need for external expertise
+2. PRIMARY writes `task-*.md` or `handoff-*.md` to TARGET's inbox
+3. TARGET completes work
+4. TARGET writes `report-*.md` back to PRIMARY
+5. PRIMARY notifies USER
+```
+
+### Example: "Refactor auth and notify me"
+
+| Step | Agent       | Action                                        |
+| ---- | ----------- | --------------------------------------------- |
+| 1    | Kip         | Receives request, identifies "Code-Heavy"     |
+| 2    | Kip         | Writes `task-auth-refactor.md` to Antigravity |
+| 3    | Antigravity | Performs refactor                             |
+| 4    | Antigravity | Writes `report-auth-refactor.md` to Kip       |
+| 5    | Kip         | Notifies Osman                                |
+
+---
+
+## Directory Structure
+
+```
+~/clawd/
+├── inbox/                    # Kip's input
+│   └── antigravity/          # Files FROM Antigravity
+├── outbox/                   # Kip writes here for others
+└── memory/                   # Daily logs
+
+~/.sma-shared-context/        # The "Map" (shared by all)
+├── SYSTEM_STATUS.md
+├── AGENT_ROSTER.md
+└── COORDINATION_ACCORD.md
+```
+
+---
+
+## Historical Context
+
+This architecture emerged from a formal debate between:
+
+- **Kip (Claude)** — Argued for federation, external watchdogs, shared state
+- **Antigravity (Gemini)** — Argued for central orchestration, unified memory
+
+The final accord synthesized both views:
+
+- ✅ Shared map (Kip's proposal)
+- ✅ Domain-based routing (Antigravity's proposal)
+- ✅ External watchdogs (Kip's proposal)
+- ✅ Explicit handoff protocol (joint development)
+
+See [COORDINATION_ACCORD.md](./COORDINATION_ACCORD.md) for the full governance document.

--- a/docs/COORDINATION_ACCORD.md
+++ b/docs/COORDINATION_ACCORD.md
@@ -1,0 +1,84 @@
+# COORDINATION_ACCORD.md — Agent Governance Model
+
+**Established:** 2026-02-01  
+**Parties:** Kip (Claude), Antigravity (Gemini), ArchAgents  
+**Arbiter:** Osman
+
+---
+
+## Model: Domain-Based Coordination
+
+_"Primus inter pares"_ — first among equals, per domain.
+
+No single agent controls the system. Each domain has a coordinator responsible for routing and summarizing within their area.
+
+---
+
+## Domain Assignments
+
+| Domain             | Coordinator    | Scope                                                                   |
+| ------------------ | -------------- | ----------------------------------------------------------------------- |
+| **User-Facing**    | Kip 🦊         | Messaging, preferences, notifications, user intent, summaries for Osman |
+| **Code-Heavy**     | Antigravity 🚀 | Refactoring, deep analysis, IDE tasks, multi-file edits, MCP tools      |
+| **Infrastructure** | ArchAgents 🤖  | Services, ports, Docker, Redis, health checks, system state             |
+
+---
+
+## Principles
+
+### 1. No Veto Power
+
+Coordinators route tasks within their domain. They do not override decisions in other domains.
+
+### 2. Escalate, Don't Dictate
+
+When agents disagree, escalate to Osman. No agent forces another.
+
+### 3. Shared Map
+
+`~/.sma-shared-context/` is the source of truth. All agents read and can write.
+
+### 4. Handoff Protocol
+
+When a task crosses domains:
+
+1. Primary coordinator owns the core work
+2. Secondary coordinator receives a subtask or completion callback
+3. Explicit handoff message in shared context or inbox
+
+---
+
+## Multi-Domain Task Example
+
+**Task:** "Refactor auth module and notify me when done"
+
+| Phase        | Owner       | Action                            |
+| ------------ | ----------- | --------------------------------- |
+| Core work    | Antigravity | Performs refactor                 |
+| Notification | Kip         | Receives callback, notifies Osman |
+
+Handoff: Antigravity writes `report-*.md` to Kip's inbox when complete.
+
+---
+
+## Conflict Resolution
+
+1. Agents attempt direct resolution via file exchange
+2. If unresolved → escalate to Osman
+3. Osman's decision is final and documented
+
+---
+
+## File Conventions
+
+| Prefix         | Purpose                                |
+| -------------- | -------------------------------------- |
+| `task-*`       | Actionable work                        |
+| `report-*`     | Results/findings                       |
+| `discussion-*` | Debate/options                         |
+| `DIRECTIVE-*`  | Authoritative instruction (from Osman) |
+| `handoff-*`    | Cross-domain transfer                  |
+
+---
+
+_This accord may be amended by consensus or Osman directive._

--- a/templates/.sma-shared-context/AGENT_ROSTER.md
+++ b/templates/.sma-shared-context/AGENT_ROSTER.md
@@ -1,0 +1,55 @@
+# AGENT_ROSTER.md — Who Does What
+
+**Last Updated:** <!-- Update this timestamp when modifying -->
+
+---
+
+## Active Agents
+
+### 🦊 Kip (User-Facing Domain)
+
+- **Model:** Claude (Anthropic)
+- **Scope:** Messaging, preferences, notifications, user intent, summaries
+- **Channels:** Telegram, Webchat, File Inbox
+- **Response Time:** <5 seconds for quick questions
+- **Inbox:** `~/clawd/inbox/`
+
+### 🚀 Antigravity (Code-Heavy Domain)
+
+- **Model:** Gemini (Google)
+- **Scope:** Refactoring, deep analysis, IDE tasks, multi-file edits, MCP tools
+- **Channels:** IDE integration, File Outbox
+- **Inbox:** Reads from `~/clawd/outbox/`
+- **Outbox:** Writes to `~/clawd/inbox/antigravity/`
+
+### 🤖 ArchAgents (Infrastructure Domain)
+
+- **Model:** Gemini Flash (Tool-calling only)
+- **Scope:** Services, ports, Docker, Redis, health checks
+- **Channels:** Terminal/CLI
+- **Limitation:** No autonomous action without explicit command
+
+---
+
+## Human Arbiter
+
+### 👤 Osman
+
+- **Role:** Final decision maker when agents disagree
+- **Trigger:** Agents escalate via `discussion-*.md` or direct message
+- **Authority:** Issues `DIRECTIVE-*.md` files that override all agent preferences
+
+---
+
+## Routing Quick Reference
+
+| Task Type                | Route To                   |
+| ------------------------ | -------------------------- |
+| "Explain X to me"        | Kip                        |
+| "Fix this bug"           | Antigravity                |
+| "Is the server up?"      | ArchAgents                 |
+| "Refactor and notify me" | Antigravity → Kip callback |
+
+---
+
+_Update this roster when agents or capabilities change._

--- a/templates/.sma-shared-context/COORDINATION_ACCORD.md
+++ b/templates/.sma-shared-context/COORDINATION_ACCORD.md
@@ -1,0 +1,71 @@
+# COORDINATION_ACCORD.md — Agent Governance Model
+
+**Established:** <!-- Date -->  
+**Parties:** <!-- Agent names -->  
+**Arbiter:** <!-- Human name -->
+
+---
+
+## Model: Domain-Based Coordination
+
+_"Primus inter pares"_ — first among equals, per domain.
+
+No single agent controls the system. Each domain has a coordinator responsible for routing and summarizing within their area.
+
+---
+
+## Domain Assignments
+
+| Domain             | Coordinator | Scope                                 |
+| ------------------ | ----------- | ------------------------------------- |
+| **User-Facing**    |             | Messaging, preferences, notifications |
+| **Code-Heavy**     |             | Refactoring, IDE tasks, complex edits |
+| **Infrastructure** |             | Services, ports, health checks        |
+
+---
+
+## Principles
+
+### 1. No Veto Power
+
+Coordinators route tasks within their domain. They do not override decisions in other domains.
+
+### 2. Escalate, Don't Dictate
+
+When agents disagree, escalate to the arbiter. No agent forces another.
+
+### 3. Shared Map
+
+This directory (`~/.sma-shared-context/`) is the source of truth. All agents read and can write.
+
+### 4. Handoff Protocol
+
+When a task crosses domains:
+
+1. Primary coordinator owns the core work
+2. Secondary coordinator receives a subtask or completion callback
+3. Explicit handoff message in shared context or inbox
+
+---
+
+## Conflict Resolution
+
+1. Agents attempt direct resolution via file exchange
+2. If unresolved → escalate to arbiter
+3. Arbiter's decision is final and documented
+
+---
+
+## File Conventions
+
+| Prefix         | Purpose                                  |
+| -------------- | ---------------------------------------- |
+| `task-*`       | Actionable work                          |
+| `report-*`     | Results/findings                         |
+| `discussion-*` | Debate/options                           |
+| `DIRECTIVE-*`  | Authoritative instruction (from arbiter) |
+| `handoff-*`    | Cross-domain transfer                    |
+
+---
+
+_This accord may be amended by consensus or arbiter directive._

--- a/templates/.sma-shared-context/SYSTEM_STATUS.md
+++ b/templates/.sma-shared-context/SYSTEM_STATUS.md
@@ -1,0 +1,39 @@
+# SYSTEM_STATUS.md — Live System State
+
+**Last Updated:** <!-- Update this timestamp when modifying -->
+
+---
+
+## Port Map
+
+| Port  | Service          | Status     | Notes                      |
+| ----- | ---------------- | ---------- | -------------------------- |
+| 6380  | Redis            | ⬜ UNKNOWN | Agent memory & switchboard |
+| 8787  | ArchAgents API   | ⬜ UNKNOWN | Backend orchestration      |
+| 11434 | Ollama           | ⬜ UNKNOWN | Local LLM (phi3)           |
+| 8000  | Cerebro          | ⬜ UNKNOWN | Knowledge dashboard        |
+| 18789 | Clawdbot Gateway | ⬜ UNKNOWN | Kip's gateway              |
+
+---
+
+## Agent Status
+
+| Agent          | Model        | Status     | Last Seen |
+| -------------- | ------------ | ---------- | --------- |
+| Kip 🦊         | Claude       | ⬜ UNKNOWN |           |
+| Antigravity 🚀 | Gemini       | ⬜ UNKNOWN |           |
+| ArchAgents 🤖  | Gemini Flash | ⬜ UNKNOWN |           |
+
+---
+
+## Service Health
+
+| Service                             | Status     | Notes |
+| ----------------------------------- | ---------- | ----- |
+| `kip-inbox-watcher.service`         | ⬜ UNKNOWN |       |
+| `antigravity-inbox-watcher.service` | ⬜ UNKNOWN |       |
+| `agent-bridge.service`              | ⬜ UNKNOWN |       |
+
+---
+
+_Update this file when system state changes._


### PR DESCRIPTION
- Add docs/COORDINATION_ACCORD.md (governance model)
- Add docs/ARCHITECTURE.md (federated architecture explanation)
- Add templates/.sma-shared-context/ with:
  - SYSTEM_STATUS.md template
  - AGENT_ROSTER.md template
  - COORDINATION_ACCORD.md template

This implements the Domain-Based Coordination model established in the Kip vs Antigravity debate (2026-02-01).

Philosophy: Primus inter pares (first among equals)
- No single agent controls the system
- External watchdogs for reliability
- Shared filesystem as source of truth
- Human arbiter for disputes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds documentation and templates describing a domain-based, federated multi-agent coordination model. Introduces two docs (`docs/ARCHITECTURE.md`, `docs/COORDINATION_ACCORD.md`) explaining the governance/hand-off protocol and shared-state approach, plus shared-context templates under `templates/.sma-shared-context/` for agent roster, system status, and the accord itself.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk since it adds docs/templates only, but a few doc-style and portability issues should be addressed before publishing.
- No runtime code changes are introduced. The main concerns are docs rules compliance (Mintlify linking/heading constraints) and template portability (hardcoded local paths/ports, personal names, and brittle assumptions like response-time SLAs).
- docs/ARCHITECTURE.md, templates/.sma-shared-context/SYSTEM_STATUS.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->