### PR TITLE
CLI/TUI: add feedback levels for agent status

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -27,6 +27,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
+    .option("--feedback <level>", "Feedback level: silent | info | debug")
     .option(
       "--channel <channel>",
       `Delivery channel: ${args.agentChannelOptions} (default: ${DEFAULT_CHAT_CHANNEL})`,

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -15,6 +15,7 @@ export function registerTuiCli(program: Command) {
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
     .option("--deliver", "Deliver assistant replies", false)
     .option("--thinking <level>", "Thinking level override")
+    .option("--feedback <level>", "Feedback level: silent | info | debug")
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")
     .option("--history-limit <n>", "History entries to load", "200")
@@ -38,6 +39,7 @@ export function registerTuiCli(program: Command) {
           session: opts.session as string | undefined,
           deliver: Boolean(opts.deliver),
           thinking: opts.thinking as string | undefined,
+          feedback: opts.feedback as string | undefined,
           message: opts.message as string | undefined,
           timeoutMs,
           historyLimit: Number.isNaN(historyLimit) ? undefined : historyLimit,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -55,6 +55,7 @@ import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
+import { normalizeFeedbackLevel } from "../infra/feedback.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
@@ -121,6 +122,10 @@ export async function agentCommand(
   if (opts.verbose && !verboseOverride) {
     throw new Error('Invalid verbose level. Use "on", "full", or "off".');
   }
+  const feedbackOverride = normalizeFeedbackLevel(opts.feedback);
+  if (opts.feedback && !feedbackOverride) {
+    throw new Error('Invalid feedback level. Use "silent", "info", or "debug".');
+  }
 
   const timeoutSecondsRaw =
     opts.timeout !== undefined ? Number.parseInt(String(opts.timeout), 10) : undefined;
@@ -182,6 +187,7 @@ export async function agentCommand(
       registerAgentRunContext(runId, {
         sessionKey,
         verboseLevel: resolvedVerboseLevel,
+        ...(feedbackOverride ? { feedbackLevel: feedbackOverride } : {}),
       });
     }
 

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -40,6 +40,8 @@ export type AgentCommandOpts = {
   thinking?: string;
   thinkingOnce?: string;
   verbose?: string;
+  /** UI feedback verbosity (silent|info|debug). */
+  feedback?: string;
   json?: boolean;
   timeout?: string;
   deliver?: boolean;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -278,6 +278,7 @@ const FIELD_LABELS: Record<string, string> = {
   "commands.restart": "Allow Restart",
   "commands.useAccessGroups": "Use Access Groups",
   "ui.seamColor": "Accent Color",
+  "ui.feedback": "Feedback Level",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
   "browser.evaluateEnabled": "Browser Evaluate Enabled",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -67,6 +67,8 @@ export type OpenClawConfig = {
   ui?: {
     /** Accent color for OpenClaw UI chrome (hex). */
     seamColor?: string;
+    /** Feedback level for CLI/TUI status updates. */
+    feedback?: "silent" | "info" | "debug";
     assistant?: {
       /** Assistant display name for UI surfaces. */
       name?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -169,6 +169,7 @@ export const OpenClawSchema = z
     ui: z
       .object({
         seamColor: HexColorSchema.optional(),
+        feedback: z.union([z.literal("silent"), z.literal("info"), z.literal("debug")]).optional(),
         assistant: z
           .object({
             name: z.string().max(50).optional(),

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -16,6 +16,7 @@ import {
   type GatewayClientName,
 } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
+import type { GatewayClientOptions } from "./client.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 export type CallGatewayOptions = {
@@ -41,6 +42,7 @@ export type CallGatewayOptions = {
    * Does not affect config loading; callers still control auth via opts.token/password/env/config.
    */
   configPath?: string;
+  onEvent?: GatewayClientOptions["onEvent"];
 };
 
 export type GatewayConnectionDetails = {
@@ -220,6 +222,7 @@ export async function callGateway<T = Record<string, unknown>>(
       deviceIdentity: loadOrCreateDeviceIdentity(),
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
+      onEvent: opts.onEvent,
       onHelloOk: async () => {
         try {
           const result = await client.request<T>(opts.method, opts.params, {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -51,6 +51,7 @@ export const AgentParamsSchema = Type.Object(
     sessionId: Type.Optional(Type.String()),
     sessionKey: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
+    feedback: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     channel: Type.Optional(Type.String()),

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -36,6 +36,7 @@ export const ChatSendParamsSchema = Type.Object(
     sessionKey: NonEmptyString,
     message: Type.String(),
     thinking: Type.Optional(Type.String()),
+    feedback: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,6 +1,7 @@
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
+import { normalizeFeedbackLevel } from "../infra/feedback.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
@@ -215,6 +216,10 @@ export function createAgentEventHandler({
 
   const shouldEmitToolEvents = (runId: string, sessionKey?: string) => {
     const runContext = getAgentRunContext(runId);
+    const runFeedback = normalizeFeedbackLevel(runContext?.feedbackLevel);
+    if (runFeedback && runFeedback !== "silent") {
+      return true;
+    }
     const runVerbose = normalizeVerboseLevel(runContext?.verboseLevel);
     if (runVerbose) {
       return runVerbose === "on";

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,4 +1,5 @@
 import type { VerboseLevel } from "../auto-reply/thinking.js";
+import type { FeedbackLevel } from "./feedback.js";
 
 export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
 
@@ -14,6 +15,7 @@ export type AgentEventPayload = {
 export type AgentRunContext = {
   sessionKey?: string;
   verboseLevel?: VerboseLevel;
+  feedbackLevel?: FeedbackLevel;
   isHeartbeat?: boolean;
 };
 
@@ -36,6 +38,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
   if (context.verboseLevel && existing.verboseLevel !== context.verboseLevel) {
     existing.verboseLevel = context.verboseLevel;
+  }
+  if (context.feedbackLevel && existing.feedbackLevel !== context.feedbackLevel) {
+    existing.feedbackLevel = context.feedbackLevel;
   }
   if (context.isHeartbeat !== undefined && existing.isHeartbeat !== context.isHeartbeat) {
     existing.isHeartbeat = context.isHeartbeat;

--- a/src/infra/agent-feedback.ts
+++ b/src/infra/agent-feedback.ts
@@ -1,0 +1,115 @@
+import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
+import type { FeedbackLevel } from "./feedback.js";
+
+type FeedbackFormatOptions = {
+  includeLifecycle?: boolean;
+  includeAssistant?: boolean;
+  includeTool?: boolean;
+  includeCompaction?: boolean;
+};
+
+export type AgentFeedbackEvent = {
+  stream?: string;
+  data?: Record<string, unknown>;
+};
+
+const DEFAULT_FORMAT_OPTIONS: Required<FeedbackFormatOptions> = {
+  includeLifecycle: true,
+  includeAssistant: true,
+  includeTool: true,
+  includeCompaction: true,
+};
+
+const MAX_LABEL_LENGTH = 120;
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function clampLabel(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= MAX_LABEL_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MAX_LABEL_LENGTH - 3)}...`;
+}
+
+export function formatAgentFeedbackLabel(
+  event: AgentFeedbackEvent,
+  level: FeedbackLevel,
+  options: FeedbackFormatOptions = {},
+): string | undefined {
+  if (level === "silent") {
+    return undefined;
+  }
+  const opts = { ...DEFAULT_FORMAT_OPTIONS, ...options };
+  const stream = normalizeString(event.stream);
+  const data = event.data ?? {};
+
+  if (stream === "lifecycle" && opts.includeLifecycle) {
+    const phase = normalizeString(data.phase);
+    if (phase === "start") {
+      return "thinking";
+    }
+    if (phase === "end") {
+      return "finalizing";
+    }
+    if (phase === "error") {
+      return "error";
+    }
+  }
+
+  if (stream === "assistant" && opts.includeAssistant) {
+    return "streaming reply";
+  }
+
+  if (stream === "compaction" && opts.includeCompaction) {
+    const phase = normalizeString(data.phase);
+    if (phase === "start") {
+      return "compacting";
+    }
+    if (phase === "end") {
+      return data.willRetry === true ? "compaction retrying" : "compaction complete";
+    }
+  }
+
+  if (stream === "tool" && opts.includeTool) {
+    const phase = normalizeString(data.phase);
+    if (phase && phase !== "start" && phase !== "result" && phase !== "update") {
+      return undefined;
+    }
+    if (phase === "update" && level !== "debug") {
+      return undefined;
+    }
+
+    const name = normalizeString(data.name) || "tool";
+    const args = data.args;
+    const meta = normalizeString(data.meta);
+    const display = resolveToolDisplay({
+      name,
+      args,
+      meta: meta || undefined,
+    });
+    const detail = level === "debug" ? formatToolDetail(display) : undefined;
+    let label = `tool: ${display.label}`;
+    if (detail) {
+      label = `${label} - ${detail}`;
+    }
+    if (data.isError === true) {
+      label = `${label} (error)`;
+    }
+    return clampLabel(label);
+  }
+
+  if (stream === "error") {
+    return "error";
+  }
+
+  return undefined;
+}

--- a/src/infra/feedback.ts
+++ b/src/infra/feedback.ts
@@ -1,0 +1,32 @@
+export type FeedbackLevel = "silent" | "info" | "debug";
+
+const FEEDBACK_ORDER: Record<FeedbackLevel, number> = {
+  silent: 0,
+  info: 1,
+  debug: 2,
+};
+
+export function normalizeFeedbackLevel(raw?: string | null): FeedbackLevel | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const key = raw.trim().toLowerCase();
+  if (["silent", "off", "false", "no", "none", "0"].includes(key)) {
+    return "silent";
+  }
+  if (["info", "on", "true", "yes", "1", "default"].includes(key)) {
+    return "info";
+  }
+  if (["debug", "verbose", "full", "trace", "2"].includes(key)) {
+    return "debug";
+  }
+  return undefined;
+}
+
+export function resolveFeedbackLevel(raw?: string | null, fallback?: FeedbackLevel): FeedbackLevel {
+  return normalizeFeedbackLevel(raw) ?? fallback ?? "info";
+}
+
+export function isFeedbackLevelAtLeast(level: FeedbackLevel, min: FeedbackLevel): boolean {
+  return FEEDBACK_ORDER[level] >= FEEDBACK_ORDER[min];
+}

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -20,6 +20,7 @@ export type ChatSendOptions = {
   sessionKey: string;
   message: string;
   thinking?: string;
+  feedback?: string;
   deliver?: boolean;
   timeoutMs?: number;
 };
@@ -158,6 +159,7 @@ export class GatewayChatClient {
       sessionKey: opts.sessionKey,
       message: opts.message,
       thinking: opts.thinking,
+      feedback: opts.feedback,
       deliver: opts.deliver,
       timeoutMs: opts.timeoutMs,
       idempotencyKey: runId,

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -20,6 +20,7 @@ describe("tui command handlers", () => {
         sessionInfo: {},
       } as never,
       deliverDefault: false,
+      feedbackLevel: "info",
       openOverlay: vi.fn(),
       closeOverlay: vi.fn(),
       refreshSessionInfo: vi.fn(),

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -21,6 +21,7 @@ import {
   createSettingsList,
 } from "./components/selectors.js";
 import { formatStatusSummary } from "./tui-status-summary.js";
+import type { FeedbackLevel } from "../infra/feedback.js";
 
 type CommandHandlerContext = {
   client: GatewayChatClient;
@@ -29,6 +30,7 @@ type CommandHandlerContext = {
   opts: TuiOptions;
   state: TuiStateAccess;
   deliverDefault: boolean;
+  feedbackLevel: FeedbackLevel;
   openOverlay: (component: Component) => void;
   closeOverlay: () => void;
   refreshSessionInfo: () => Promise<void>;
@@ -48,6 +50,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     opts,
     state,
     deliverDefault,
+    feedbackLevel,
     openOverlay,
     closeOverlay,
     refreshSessionInfo,
@@ -453,6 +456,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         sessionKey: state.currentSessionKey,
         message: text,
         thinking: opts.thinking,
+        feedback: feedbackLevel === "silent" ? undefined : feedbackLevel,
         deliver: deliverDefault,
         timeoutMs: opts.timeoutMs,
       });

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -44,19 +44,22 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     };
     const tui = { requestRender: vi.fn() };
     const setActivityStatus = vi.fn();
+    const setStatusDetail = vi.fn();
 
-    return { chatLog, tui, state, setActivityStatus };
+    return { chatLog, tui, state, setActivityStatus, setStatusDetail };
   };
 
   it("processes tool events when runId matches activeChatRunId (even if sessionId differs)", () => {
     const state = makeState({ currentSessionId: "session-xyz", activeChatRunId: "run-123" });
-    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { chatLog, tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleAgentEvent } = createEventHandlers({
       // Casts are fine here: TUI runtime shape is larger than we need in unit tests.
       chatLog: chatLog as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     const evt: AgentEvent = {
@@ -78,12 +81,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
   it("ignores tool events when runId does not match activeChatRunId", () => {
     const state = makeState({ activeChatRunId: "run-1" });
-    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { chatLog, tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleAgentEvent } = createEventHandlers({
       chatLog: chatLog as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     const evt: AgentEvent = {
@@ -101,12 +106,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
   it("processes lifecycle events when runId matches activeChatRunId", () => {
     const state = makeState({ activeChatRunId: "run-9" });
-    const { tui, setActivityStatus } = makeContext(state);
+    const { tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleAgentEvent } = createEventHandlers({
       chatLog: { startTool: vi.fn(), updateToolResult: vi.fn() } as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     const evt: AgentEvent = {
@@ -123,12 +130,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
   it("captures runId from chat events when activeChatRunId is unset", () => {
     const state = makeState({ activeChatRunId: null });
-    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { chatLog, tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleChatEvent, handleAgentEvent } = createEventHandlers({
       chatLog: chatLog as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     const chatEvt: ChatEvent = {
@@ -155,12 +164,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
   it("clears run mapping when the session changes", () => {
     const state = makeState({ activeChatRunId: null });
-    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { chatLog, tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleChatEvent, handleAgentEvent } = createEventHandlers({
       chatLog: chatLog as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     handleChatEvent({
@@ -186,12 +197,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
   it("ignores lifecycle updates for non-active runs in the same session", () => {
     const state = makeState({ activeChatRunId: "run-active" });
-    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { chatLog, tui, setActivityStatus, setStatusDetail } = makeContext(state);
     const { handleChatEvent, handleAgentEvent } = createEventHandlers({
       chatLog: chatLog as any,
       tui: tui as any,
       state,
       setActivityStatus,
+      setStatusDetail,
+      feedbackLevel: "info",
     });
 
     handleChatEvent({

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -5,6 +5,7 @@ export type TuiOptions = {
   session?: string;
   deliver?: boolean;
   thinking?: string;
+  feedback?: string;
   timeoutMs?: number;
   historyLimit?: number;
   message?: string;


### PR DESCRIPTION
## Summary
This PR adds a configurable “Verbose Feedback” feature to the CLI/TUI so users can see real-time agent status beyond a ticking timer. It introduces feedback levels (`silent`, `info`, `debug`), wires agent lifecycle + tool events into CLI progress labels and TUI status details, and propagates feedback preferences through gateway requests.

## Why
When the agent is running, the current UI only shows a timer, making it hard to tell if the agent is actively working or stuck. This change provides clear, incremental feedback without overwhelming the UI, while keeping the default experience minimal.

## What’s Included

### 1) Feedback levels + helpers
- **New helpers** to normalize and compare feedback levels:
  - `src/infra/feedback.ts`
- **New mapping** from agent events to concise status labels:
  - `src/infra/agent-feedback.ts`

### 2) CLI + TUI configuration
- **CLI flag** for agent runs:
  - `openclaw agent --feedback <silent|info|debug>`
  - `src/cli/program/register.agent.ts`
- **CLI flag** for TUI runs:
  - `openclaw tui --feedback <silent|info|debug>`
  - `src/cli/tui-cli.ts`
- **Config setting**:
  - `ui.feedback` in `src/config/types.openclaw.ts`, `src/config/zod-schema.ts`, `src/config/schema.ts`

### 3) Agent execution + gateway wiring
- **Agent command** validates/propagates feedback preference:
  - `src/commands/agent.ts`
  - `src/commands/agent/types.ts`
- **Gateway agent runner** resolves config + CLI override, updates progress labels from agent events, and sends feedback preference when invoking the gateway:
  - `src/commands/agent-via-gateway.ts`
- **Gateway protocol + server support**:
  - Optional `feedback` in protocol schemas:
    - `src/gateway/protocol/schema/agent.ts`
    - `src/gateway/protocol/schema/logs-chat.ts`
  - Validation + run-context wiring:
    - `src/gateway/server-methods/agent.ts`
    - `src/gateway/server-methods/chat.ts`
  - Tool event emission enabled when feedback is non-silent:
    - `src/gateway/server-chat.ts`
  - Optional `onEvent` passthrough for gateway calls:
    - `src/gateway/call.ts`

### 4) TUI status detail UI
- **Status detail** added next to the timer and updated in real time:
  - `src/tui/tui.ts`
- **Event handling** for tool + compaction updates:
  - `src/tui/tui-event-handlers.ts`
- **Feedback preference passed on TUI send**:
  - `src/tui/tui-command-handlers.ts`
  - `src/tui/gateway-chat.ts`
- **Tests updated**:
  - `src/tui/tui-event-handlers.test.ts`
  - `src/tui/tui-command-handlers.test.ts`

## Behavior Changes
- Default remains minimal, only showing extra details when feedback is enabled.
- `--feedback info` shows high-level phase / tool status (e.g., “Tool: FileSystem”).
- `--feedback debug` includes finer-grained events where available.
- `--feedback silent` keeps the current timer-only view.

## Testing
- `corepack pnpm vitest run --config vitest.unit.config.ts src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts`

## Notes
- A broader `pnpm test --filter …` attempt timed out (full suite ran due to repo test runner behavior). Focused unit tests above are green.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new UI “feedback level” concept (`silent`/`info`/`debug`) and threads it through CLI flags, config (`ui.feedback`), gateway protocol params, gateway server handlers, and the TUI status line. It also introduces helpers to normalize/compare feedback levels and to format concise status labels from agent/tool/lifecycle events.

Main things to double-check before merge:
- The effective default currently resolves to `info` when neither CLI nor config sets feedback, which may conflict with the stated “default minimal” behavior.
- The `agentCliCommand`/gateway fallback path has multiple runId sources (generated vs provided) that can cause progress/event filtering mismatches during fallback.
- TUI status detail updates can become stale because detail is set opportunistically but not consistently cleared on non-lifecycle transitions.

Overall, the wiring is cohesive: the gateway can now accept/pass `feedback` and optionally emit additional events to drive richer UI surfaces.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a few behavior/UX edge cases worth addressing.
- Most changes are additive and well-scoped (new flag/config plumbed through gateway + TUI), but there are a couple of correctness/behavior mismatches (default feedback level vs stated default; runId/event filtering mismatch in fallback path) and a likely stale-status UI edge case. None appear like security regressions, but they can cause confusing UX.
- src/infra/feedback.ts, src/commands/agent-via-gateway.ts, src/tui/tui-event-handlers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->