### PR TITLE
fix: pass fileName to WhatsApp document messages

### DIFF
--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -43,8 +43,10 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
+      mediaFileName = media.fileName;
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -68,9 +68,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
## Summary
Fixes #5781 - WhatsApp document filename always shows "file" instead of actual filename.

## Problem
When sending documents (PDFs, etc.) via WhatsApp, the filename was hardcoded to "file" in `send-api.ts`, ignoring the actual filename from the media source.

## Solution
Two changes:

### 1. `src/web/outbound.ts`
Include `mediaFileName` in the condition for creating `sendOptions`, and pass it through:

```diff
- const sendOptions = options.gifPlayback || accountId
+ const sendOptions = options.gifPlayback || accountId || mediaFileName
    ? {
        ...(options.gifPlayback ? { gifPlayback: true } : {}),
+       ...(mediaFileName ? { fileName: mediaFileName } : {}),
        accountId,
    }
    : undefined;
```

### 2. `src/web/inbound/send-api.ts`
Use `sendOptions?.fileName` instead of hardcoded "file":

```diff
payload = {
    document: mediaBuffer,
-   fileName: "file",
+   fileName: sendOptions?.fileName || "file",
    caption: text || undefined,
    mimetype: mediaType,
};
```

## Testing
- Sent PDF via WhatsApp message tool
- Verified filename displays correctly on recipient's device
- Tested with various file types (PDF, DOCX)

## Checklist
- [x] Fixes reported issue
- [x] No breaking changes
- [x] Backwards compatible (falls back to "file" if no filename provided)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires a document `fileName` through the WhatsApp web send path: outbound now attempts to include a filename in `sendOptions`, and inbound/send-api now prefers `sendOptions?.fileName` when building the Baileys document payload, falling back to `"file"`.

Main concern: `src/web/outbound.ts` references `mediaFileName` but never defines it, which will break compilation/runtime and prevents the filename from being passed at all.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge as-is due to an undefined identifier in the outbound WhatsApp send path.
- `mediaFileName` is used in `src/web/outbound.ts` without being declared, which should cause a build/typecheck failure or runtime ReferenceError; the intended fix can’t work until this is corrected.
- src/web/outbound.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->