### PR TITLE
gateway: auto-approve device pairing for Tailscale users

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -637,7 +637,7 @@ export function attachGatewayWsMessageHandler(params: {
               role,
               scopes,
               remoteIp: reportedClientIp,
-              silent: isLocalClient,
+              silent: isLocalClient || authMethod === "tailscale",
             });
             const context = buildRequestContext();
             if (pairing.request.silent === true) {


### PR DESCRIPTION
Tailscale Serve users had to manually approve device pairing on each new browser, even though their identity was already verified via Tailscale. This auto-approves pairing for Tailscale-authenticated users.

Funnel traffic from the public internet is unaffected - Tailscale strips identity headers from Funnel requests, so auth fails before reaching pairing logic.