### PR TITLE
fix: from source development command

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -175,7 +175,7 @@ cd openclaw
 pnpm install
 pnpm ui:build # auto-installs UI deps on first run
 pnpm build
-openclaw onboard --install-daemon
+pnpm openclaw onboard --install-daemon
 ```
 
 If you don’t have a global install yet, run the onboarding step via `pnpm openclaw ...` from the repo.
@@ -184,7 +184,7 @@ If you don’t have a global install yet, run the onboarding step via `pnpm open
 Gateway (from this repo):
 
 ```bash
-node openclaw.mjs gateway --port 18789 --verbose
+pnpm openclaw gateway --port 18789 --verbose
 ```
 
 ## 7) Verify end-to-end


### PR DESCRIPTION
Since pnpm build only compiles the project files into the dist/ directory but does not install the openclaw binary to your system's global PATH, the command openclaw explicitly will not be found in your terminal.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the “From source (development)” instructions to run onboarding via `pnpm openclaw ...` instead of relying on a globally installed `openclaw` binary, aligning the docs with the fact that `pnpm build` produces `dist/` output but doesn’t put `openclaw` on PATH.

Change is localized to `docs/start/getting-started.md` and improves the out-of-the-box developer experience when building/running OpenClaw directly from the repo.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and only adjusts documentation guidance.
- The change is a small docs-only update that makes source-development instructions more accurate; the only risk is minor user confusion if adjacent examples use different invocation styles.
- docs/start/getting-started.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->