### PR TITLE
fix(cron): persist isolated sessions to enable message delivery

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -195,7 +195,7 @@ export async function runCronIsolatedAgentTurn(params: {
     model = resolvedOverride.ref.model;
   }
   const now = Date.now();
-  const cronSession = resolveCronSession({
+  const cronSession = await resolveCronSession({
     cfg: params.cfg,
     sessionKey: agentSessionKey,
     agentId,

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -36,10 +36,11 @@ export async function resolveCronSession(params: {
     skillsSnapshot: entry?.skillsSnapshot,
   };
 
-  store[params.sessionKey] = sessionEntry;
   await updateSessionStore(storePath, (currentStore) => {
     currentStore[params.sessionKey] = sessionEntry;
   });
 
-  return { storePath, store, sessionEntry, systemSent, isNewSession: true };
+  const updatedStore = loadSessionStore(storePath);
+
+  return { storePath, store: updatedStore, sessionEntry, systemSent, isNewSession: true };
 }

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -1,8 +1,13 @@
 import crypto from "node:crypto";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadSessionStore, resolveStorePath, type SessionEntry } from "../../config/sessions.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  type SessionEntry,
+  updateSessionStore,
+} from "../../config/sessions.js";
 
-export function resolveCronSession(params: {
+export async function resolveCronSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   nowMs: number;
@@ -30,5 +35,11 @@ export function resolveCronSession(params: {
     lastAccountId: entry?.lastAccountId,
     skillsSnapshot: entry?.skillsSnapshot,
   };
+
+  store[params.sessionKey] = sessionEntry;
+  await updateSessionStore(storePath, (currentStore) => {
+    currentStore[params.sessionKey] = sessionEntry;
+  });
+
   return { storePath, store, sessionEntry, systemSent, isNewSession: true };
 }


### PR DESCRIPTION
## Fix: Cron Jobs with Isolated Sessions Not Delivering Messages

### Root Cause
The issue was located in src/cron/isolated-agent/session.ts.
The resolveCronSession function acted as a factory that created a session object in memory but never persisted it to the disk store.
* Consequence: The scheduler assumed the session existed, but subsequent lookups (like sessions_list or the delivery agent) failed silently because the ID was missing from the persistent store.

### Changes Made
1. Persistence in src/cron/isolated-agent/session.ts
* Changed resolveCronSession from synchronous to async.
* Imported updateSessionStore from ../../config/sessions.js.
* Added immediate persistence logic:
    ```typescript
    // Now persists immediately upon creation
    await updateSessionStore(storePath, (currentStore) => {
      currentStore[params.sessionKey] = sessionEntry;
    });
    ```

2. Async Propagation in src/cron/isolated-agent/run.ts
* Updated the call site to handle the new async nature of the session resolver:
    ```typescript
    // Added await
    const cronSession = await resolveCronSession({ ... });
    ```

### Impact
| Feature | Before | After |
| :--- | :--- | :--- |
| Session Creation | In-memory only (lost on exit) | Persisted to disk |
| Visibility | Invisible in sessions_list | Visible |
| Message Delivery | Silent Failure | Delivered |

### Testing
Validated using the reproduction case:
```json
{
  "sessionTarget": "isolated",
  "payload": {
    "kind": "agentTurn",
    "deliver": true,
    "to": "telegram:287312345"
  }
}

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron isolated-agent message delivery by ensuring cron sessions are persisted to the on-disk session store. `resolveCronSession` is converted to `async` and now writes the created `SessionEntry` via `updateSessionStore`, and the isolated cron runner is updated to `await` the resolver so downstream delivery/session lookups can find the session key.

Overall this fits into the existing session-store architecture (`src/config/sessions/store.ts`) which uses a lock + re-read to serialize writers and keep the persisted sessions.json as the shared source of truth.

<h3>Confidence Score: 3/5</h3>

- This PR is likely correct, but there are a couple of behavior/regression risks around session identity and store overwrites that should be addressed before merging.
- The persistence change addresses the described root cause, and uses the repository’s locked `updateSessionStore` API. However, the new write path assigns a newly generated sessionId on every run and writes a partial SessionEntry back to the store, which can rotate transcript IDs and potentially clobber previously persisted session metadata for the same key.
- src/cron/isolated-agent/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->