### PR TITLE
docs: add Mistral AI provider setup guide

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -119,6 +119,8 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
   - GLM models on Cerebras use ids `zai-glm-4.7` and `zai-glm-4.6`.
   - OpenAI-compatible base URL: `https://api.cerebras.ai/v1`.
 - Mistral: `mistral` (`MISTRAL_API_KEY`)
+  - CLI: `openclaw models auth paste-token --provider mistral`
+  - See [/providers/mistral](/providers/mistral) for setup details.
 - GitHub Copilot: `github-copilot` (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`)
 
 ## Providers via `models.providers` (custom/base URL)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -47,6 +47,7 @@ See [Venice AI](/providers/venice).
 - [Xiaomi](/providers/xiaomi)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
+- [Mistral AI](/providers/mistral)
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Ollama (local models)](/providers/ollama)
 

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -18,7 +18,7 @@ If you have an API key from the [Mistral Console](https://console.mistral.ai/api
 
 ```bash
 openclaw models auth paste-token --provider mistral
-# Paste your MISTRAL_API_KEY when prompted
+# Paste your Mistral API key when prompted
 ```
 
 ### Option B: Environment variable
@@ -52,13 +52,13 @@ Or add it to your `openclaw.json`:
 
 Mistral offers several model tiers:
 
-| Model ID | Description | Use case |
-|----------|-------------|----------|
-| `mistral-large-latest` | Most capable model | Complex reasoning, coding |
-| `mistral-medium-latest` | Balanced performance | General tasks |
-| `mistral-small-latest` | Fast and efficient | Simple tasks, high throughput |
-| `codestral-latest` | Code-specialized | Code generation, completion |
-| `mistral-embed` | Embeddings | Semantic search, RAG |
+| Model ID                | Description          | Use case                      |
+| ----------------------- | -------------------- | ----------------------------- |
+| `mistral-large-latest`  | Most capable model   | Complex reasoning, coding     |
+| `mistral-medium-latest` | Balanced performance | General tasks                 |
+| `mistral-small-latest`  | Fast and efficient   | Simple tasks, high throughput |
+| `codestral-latest`      | Code-specialized     | Code generation, completion   |
+| `mistral-embed`         | Embeddings           | Semantic search, RAG          |
 
 Example with a specific model:
 

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -1,0 +1,114 @@
+---
+summary: "Use Mistral AI models in OpenClaw with API key authentication"
+read_when:
+  - You want to use Mistral models in OpenClaw
+  - You need to configure Mistral API credentials
+title: "Mistral AI"
+---
+
+# Mistral AI
+
+Mistral AI provides powerful open-weight and commercial language models. OpenClaw supports Mistral as a built-in provider with API key authentication.
+
+## Quick start
+
+### Option A: CLI paste-token (recommended)
+
+If you have an API key from the [Mistral Console](https://console.mistral.ai/api-keys/):
+
+```bash
+openclaw models auth paste-token --provider mistral
+# Paste your MISTRAL_API_KEY when prompted
+```
+
+### Option B: Environment variable
+
+Set the `MISTRAL_API_KEY` environment variable:
+
+```bash
+export MISTRAL_API_KEY="your-api-key-here"
+```
+
+Or add it to your `openclaw.json`:
+
+```json5
+{
+  env: { MISTRAL_API_KEY: "your-api-key-here" },
+  agents: { defaults: { model: { primary: "mistral/mistral-large-latest" } } },
+}
+```
+
+## Configuration
+
+### Config snippet
+
+```json5
+{
+  agents: { defaults: { model: { primary: "mistral/mistral-large-latest" } } },
+}
+```
+
+### Available models
+
+Mistral offers several model tiers:
+
+| Model ID | Description | Use case |
+|----------|-------------|----------|
+| `mistral-large-latest` | Most capable model | Complex reasoning, coding |
+| `mistral-medium-latest` | Balanced performance | General tasks |
+| `mistral-small-latest` | Fast and efficient | Simple tasks, high throughput |
+| `codestral-latest` | Code-specialized | Code generation, completion |
+| `mistral-embed` | Embeddings | Semantic search, RAG |
+
+Example with a specific model:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "mistral/codestral-latest" },
+    },
+  },
+}
+```
+
+## CLI commands
+
+```bash
+# Set Mistral as default model
+openclaw models set mistral/mistral-large-latest
+
+# Check authentication status
+openclaw models status
+
+# List available models
+openclaw models list --provider mistral
+```
+
+## Getting an API key
+
+1. Create an account at [console.mistral.ai](https://console.mistral.ai)
+2. Navigate to **API Keys** in the left sidebar
+3. Click **Create new key**
+4. Copy the key and use one of the setup methods above
+
+## Troubleshooting
+
+**No API key found for provider "mistral"**
+
+- Ensure you've configured auth using one of the methods above.
+- Run `openclaw models status` to verify authentication.
+- Check that `MISTRAL_API_KEY` is set if using environment variables.
+
+**401 Unauthorized errors**
+
+- Verify your API key is correct and not expired.
+- Check your Mistral account has available credits.
+- Re-run `openclaw models auth paste-token --provider mistral`.
+
+**Model not found**
+
+- Run `openclaw models list --provider mistral` to see available models.
+- Ensure you're using the correct model ID format: `mistral/<model-id>`.
+
+More: [Model providers](/concepts/model-providers) and [/help/faq](/help/faq).


### PR DESCRIPTION
Fixes #6170

### Summary
Adds comprehensive documentation for setting up Mistral AI credentials in OpenClaw, addressing user confusion reported in the issue.

### Changes
- **New**: [docs/providers/mistral.md](cci:7://file:///home/akram/openclaw/docs/providers/mistral.md:0:0-0:0) - Complete Mistral provider setup guide
- **Updated**: [docs/concepts/model-providers.md](cci:7://file:///home/akram/openclaw/docs/concepts/model-providers.md:0:0-0:0) - Added CLI example and link to Mistral docs
- **Updated**: [docs/providers/index.md](cci:7://file:///home/akram/openclaw/docs/providers/index.md:0:0-0:0) - Added Mistral to provider list

### Documentation includes
- Quick start with `openclaw models auth paste-token --provider mistral`
- Environment variable (`MISTRAL_API_KEY`) configuration
- Available models table (mistral-large, codestral, etc.)
- Configuration snippets with JSON5 examples
- Troubleshooting section for common errors

### Testing
- Verified CLI command exists in [models-cli.ts](cci:7://file:///home/akram/openclaw/src/cli/models-cli.ts:0:0-0:0)
- Confirmed model IDs match Mistral API documentation
- Verified `MISTRAL_API_KEY` env var in `model-auth.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Mistral AI provider documentation, links it from the provider index, and adds a quick CLI/setup pointer under the built-in providers section. This fits into the existing Mintlify docs structure by giving Mistral its own `/providers/mistral` page while keeping `/concepts/model-providers` as the cross-provider overview.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and mainly adds documentation, with only minor accuracy/clarity nits to verify.
- Changes are doc-only and follow existing docs structure; main risk is small CLI/example inaccuracies that could confuse users if the command syntax differs from the actual CLI.
- docs/providers/mistral.md (verify CLI examples match current `openclaw models` behavior)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->