### PR TITLE
fix(control-ui): include base path in default WebSocket URL

### DIFF
--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -1,6 +1,7 @@
 const KEY = "openclaw.control.settings.v1";
 
 import type { ThemeMode } from "./theme";
+import { inferBasePathFromPathname } from "./navigation";
 
 export type UiSettings = {
   gatewayUrl: string;
@@ -16,9 +17,12 @@ export type UiSettings = {
 };
 
 export function loadSettings(): UiSettings {
+  // Include inferred base path in WebSocket URL to support reverse proxies
+  // that serve the Control UI under a subpath (e.g., /app/control-ui/)
   const defaultUrl = (() => {
     const proto = location.protocol === "https:" ? "wss" : "ws";
-    return `${proto}://${location.host}`;
+    const basePath = inferBasePathFromPathname(location.pathname);
+    return `${proto}://${location.host}${basePath}`;
   })();
 
   const defaults: UiSettings = {


### PR DESCRIPTION
## Summary

Include the inferred base path in the default gateway WebSocket URL to support reverse proxy scenarios where the Control UI is served under a subpath.

## Problem

When accessing the Control UI through a reverse proxy that serves it under a subpath (e.g., Home Assistant Ingress at `/api/hassio_ingress/<token>/`), the WebSocket connection fails because:

- Browser location: `https://host/api/hassio_ingress/<token>/chat`
- Expected WebSocket URL: `wss://host/api/hassio_ingress/<token>/`
- Actual WebSocket URL: `wss://host/` ❌

The current implementation in `storage.ts` only uses `location.host`:
```typescript
const defaultUrl = (() => {
  const proto = location.protocol === "https:" ? "wss" : "ws";
  return `${proto}://${location.host}`;
})();
```

## Solution

Reuse the existing `inferBasePathFromPathname()` function from `navigation.ts` to extract the base path from the current URL and include it in the default WebSocket URL:

```typescript
const defaultUrl = (() => {
  const proto = location.protocol === "https:" ? "wss" : "ws";
  const basePath = inferBasePathFromPathname(location.pathname);
  return `${proto}://${location.host}${basePath}`;
})();
```

## Test Plan

- [ ] Verify Control UI still works when served at root path (`/`)
- [ ] Verify Control UI works when served through reverse proxy with subpath
- [ ] Run existing UI tests to ensure no regressions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Control UI’s persisted settings defaults to build the gateway WebSocket URL from `location.protocol`/`location.host` **and** an inferred base path (via `inferBasePathFromPathname(location.pathname)`), improving compatibility when the UI is served behind a reverse proxy under a subpath.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, targeted change with low behavioral surface area in browser environments.
- The change only affects the default construction of `settings.gatewayUrl` and reuses an existing base-path inference helper. Primary risk is non-browser execution contexts where `location`/`localStorage` may not exist, but that concern already exists and is only marginally expanded here.
- ui/src/ui/storage.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->