### PR TITLE
Wire up after_tool_call hook in agent execution loop

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -43,6 +43,7 @@ import {
   resolveCompactionReserveTokensFloor,
 } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
+import { wrapToolsWithHooks, wrapToolDefinitionsWithHooks } from "../../pi-tools.hooks.js";
 import { createOpenClawCodingTools } from "../../pi-tools.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
@@ -441,6 +442,10 @@ export async function runEmbeddedAttempt(
         model: params.model,
       });
 
+      // Get hook runner once for tool-call hooks, before_agent_start, and agent_end
+      const hookRunner = getGlobalHookRunner();
+      const hookAgentId = params.sessionKey?.split(":")[0] ?? "main";
+
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
@@ -463,6 +468,15 @@ export async function runEmbeddedAttempt(
 
       const allCustomTools = [...customTools, ...clientToolDefs];
 
+      // Wrap tools with before_tool_call / after_tool_call plugin hooks
+      const hookCtx = { agentId: hookAgentId, sessionKey: params.sessionKey };
+      const hookedBuiltInTools = hookRunner
+        ? wrapToolsWithHooks(builtInTools, hookRunner, hookCtx)
+        : builtInTools;
+      const hookedCustomTools = hookRunner
+        ? wrapToolDefinitionsWithHooks(allCustomTools, hookRunner, hookCtx)
+        : allCustomTools;
+
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -470,8 +484,8 @@ export async function runEmbeddedAttempt(
         modelRegistry: params.modelRegistry,
         model: params.model,
         thinkingLevel: mapThinkingLevel(params.thinkLevel),
-        tools: builtInTools,
-        customTools: allCustomTools,
+        tools: hookedBuiltInTools,
+        customTools: hookedCustomTools,
         sessionManager,
         settingsManager,
       }));
@@ -693,9 +707,6 @@ export async function runEmbeddedAttempt(
         }
       }
 
-      // Get hook runner once for both before_agent_start and agent_end hooks
-      const hookRunner = getGlobalHookRunner();
-
       let promptError: unknown = null;
       try {
         const promptStartedAt = Date.now();
@@ -710,7 +721,7 @@ export async function runEmbeddedAttempt(
                 messages: activeSession.messages,
               },
               {
-                agentId: params.sessionKey?.split(":")[0] ?? "main",
+                agentId: hookAgentId,
                 sessionKey: params.sessionKey,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
@@ -840,7 +851,7 @@ export async function runEmbeddedAttempt(
                 durationMs: Date.now() - promptStartedAt,
               },
               {
-                agentId: params.sessionKey?.split(":")[0] ?? "main",
+                agentId: hookAgentId,
                 sessionKey: params.sessionKey,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,

--- a/src/agents/pi-tools.hooks.ts
+++ b/src/agents/pi-tools.hooks.ts
@@ -1,0 +1,163 @@
+/**
+ * Tool Hook Wrappers
+ *
+ * Wraps tool execute methods to fire after_tool_call plugin hooks.
+ * Note: before_tool_call is handled separately in handleToolExecutionStart (#6570)
+ */
+
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { HookRunner } from "../plugins/hooks.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("tools/hooks");
+
+/**
+ * Wrap a single AgentTool's execute method to fire after_tool_call hooks.
+ */
+export function wrapToolWithHooks(
+  tool: AnyAgentTool,
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): AnyAgentTool {
+  const originalExecute = tool.execute;
+  if (!originalExecute) {
+    return tool;
+  }
+
+  const toolName = tool.name;
+
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate): Promise<AgentToolResult<unknown>> => {
+      const hookCtx = {
+        agentId: ctx.agentId,
+        sessionKey: ctx.sessionKey,
+        toolName,
+      };
+
+      const startMs = Date.now();
+      let result: AgentToolResult<unknown> | undefined;
+      let error: string | undefined;
+      try {
+        result = await originalExecute(toolCallId, params, signal, onUpdate);
+        return result;
+      } catch (err) {
+        error = String(err);
+        throw err;
+      } finally {
+        // --- after_tool_call (fire-and-forget) ---
+        if (hookRunner.hasHooks("after_tool_call")) {
+          hookRunner
+            .runAfterToolCall(
+              {
+                toolName,
+                params: (params ?? {}) as Record<string, unknown>,
+                result,
+                error,
+                durationMs: Date.now() - startMs,
+              },
+              hookCtx,
+            )
+            .catch((hookErr) => {
+              log.debug(`after_tool_call hook error for ${toolName}: ${String(hookErr)}`);
+            });
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Wrap a single ToolDefinition's execute method to fire after_tool_call hooks.
+ * ToolDefinition uses a different execute signature: (toolCallId, params, onUpdate, ctx, signal)
+ */
+export function wrapToolDefinitionWithHooks<T extends ToolDefinition>(
+  tool: T,
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): T {
+  if (!tool.execute) {
+    return tool;
+  }
+  // Bind to preserve context in case execute uses `this`
+  const originalExecute = tool.execute.bind(tool);
+  const toolName = tool.name;
+
+  return {
+    ...tool,
+    execute: async (
+      toolCallId,
+      params,
+      onUpdate,
+      extCtx,
+      signal,
+    ): Promise<AgentToolResult<unknown>> => {
+      const hookCtx = {
+        agentId: ctx.agentId,
+        sessionKey: ctx.sessionKey,
+        toolName,
+      };
+
+      const startMs = Date.now();
+      let result: AgentToolResult<unknown> | undefined;
+      let error: string | undefined;
+      try {
+        result = await originalExecute(toolCallId, params, onUpdate, extCtx, signal);
+        return result;
+      } catch (err) {
+        error = String(err);
+        throw err;
+      } finally {
+        // --- after_tool_call (fire-and-forget) ---
+        if (hookRunner.hasHooks("after_tool_call")) {
+          hookRunner
+            .runAfterToolCall(
+              {
+                toolName,
+                params: (params ?? {}) as Record<string, unknown>,
+                result,
+                error,
+                durationMs: Date.now() - startMs,
+              },
+              hookCtx,
+            )
+            .catch((hookErr) => {
+              log.debug(`after_tool_call hook error for ${toolName}: ${String(hookErr)}`);
+            });
+        }
+      }
+    },
+  } as T;
+}
+
+/**
+ * Wrap all AgentTools in an array with after_tool_call hooks.
+ * Returns the original array unchanged if no after_tool_call hooks are registered.
+ */
+export function wrapToolsWithHooks(
+  tools: AnyAgentTool[],
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): AnyAgentTool[] {
+  if (!hookRunner.hasHooks("after_tool_call")) {
+    return tools;
+  }
+  return tools.map((tool) => wrapToolWithHooks(tool, hookRunner, ctx));
+}
+
+/**
+ * Wrap all ToolDefinitions in an array with after_tool_call hooks.
+ * Returns the original array unchanged if no after_tool_call hooks are registered.
+ */
+export function wrapToolDefinitionsWithHooks<T extends ToolDefinition>(
+  tools: T[],
+  hookRunner: HookRunner,
+  ctx: { agentId?: string; sessionKey?: string },
+): T[] {
+  if (!hookRunner.hasHooks("after_tool_call")) {
+    return tools;
+  }
+  return tools.map((tool) => wrapToolDefinitionWithHooks(tool, hookRunner, ctx));
+}


### PR DESCRIPTION
## Summary

Now that `before_tool_call` is implemented (#6570), this PR adds the complementary `after_tool_call` hook for post-execution telemetry.

### Changes

- Add `pi-tools.hooks.ts`: wraps tool execute methods to fire `after_tool_call`
- Hook fires as fire-and-forget after tool returns
- Provides: `toolName`, `params`, `result`, `error`, `durationMs`
- Hook context includes `agentId` and `sessionKey` for correlation
- Hook errors are caught and logged, never breaking tool execution
- Tools are only wrapped when hooks are registered (zero overhead otherwise)

### API Usage

Plugins can register `after_tool_call` handlers:

```typescript
api.on("after_tool_call", (event, ctx) => {
  console.log(`Tool ${event.toolName} completed in ${event.durationMs}ms`);
  if (event.error) {
    console.error(`Tool failed: ${event.error}`);
  }
});
```

### Related

- Builds on #6570 (before_tool_call)
- Addresses #6535 (2 of 8 unimplemented hooks now working)