### PR TITLE
feat(whatsapp): add pairing owner notification

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -14,6 +14,24 @@ export type WhatsAppActionConfig = {
   polls?: boolean;
 };
 
+export type WhatsAppPairingConfig = {
+  /**
+   * Notify the owner when a new pairing request is received.
+   * Default: false.
+   */
+  notifyOwner?: boolean;
+  /**
+   * Chat JID to send pairing notifications to (e.g., "554788703000@s.whatsapp.net").
+   * Required when notifyOwner is true.
+   */
+  ownerChat?: string;
+  /**
+   * Include the original message content in the notification.
+   * Default: true.
+   */
+  includeMessage?: boolean;
+};
+
 export type WhatsAppGroupConfig = {
   requireMention?: boolean;
   tools?: GroupToolPolicyConfig;
@@ -40,6 +58,8 @@ type WhatsAppSharedConfig = {
   enabled?: boolean;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /** Pairing mode configuration (owner notifications). */
+  pairing?: WhatsAppPairingConfig;
   /** Same-phone setup (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -11,6 +11,26 @@ import {
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+const WhatsAppPairingConfigSchema = z
+  .object({
+    /** Notify the owner when a new pairing request is received. Default: false. */
+    notifyOwner: z.boolean().optional().default(false),
+    /** Chat JID to send pairing notifications to (e.g., "554788703000@s.whatsapp.net"). */
+    ownerChat: z.string().optional(),
+    /** Include the original message content in the notification. Default: true. */
+    includeMessage: z.boolean().optional().default(true),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.notifyOwner && !value.ownerChat) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["ownerChat"],
+        message: "ownerChat is required when notifyOwner is true",
+      });
+    }
+  });
+
 const WhatsAppGroupEntrySchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -40,6 +60,7 @@ const WhatsAppSharedSchema = z.object({
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
   dmPolicy: DmPolicySchema.optional().default("pairing"),
+  pairing: WhatsAppPairingConfigSchema.optional(),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveOAuthDir } from "../config/paths.js";
-import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
+import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig, WhatsAppPairingConfig } from "../config/types.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
@@ -22,6 +22,7 @@ export type ResolvedWhatsAppAccount = {
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
+  pairing?: WhatsAppPairingConfig;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
@@ -134,6 +135,7 @@ export function resolveWhatsAppAccount(params: {
     isLegacyAuthDir: isLegacy,
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
+    pairing: accountCfg?.pairing ?? rootCfg?.pairing,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -53,6 +53,8 @@ export async function checkInboundAccessControl(params: {
     sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
   };
   remoteJid: string;
+  /** Original message body for pairing notifications (optional). */
+  messageBody?: string;
 }): Promise<InboundAccessControlResult> {
   const cfg = loadConfig();
   const account = resolveWhatsAppAccount({
@@ -191,6 +193,35 @@ export async function checkInboundAccessControl(params: {
             });
           } catch (err) {
             logVerbose(`whatsapp pairing reply failed for ${candidate}: ${String(err)}`);
+          }
+
+          // Notify owner if configured
+          const pairingConfig = account.pairing ?? cfg.channels?.whatsapp?.pairing;
+          if (pairingConfig?.notifyOwner && pairingConfig.ownerChat) {
+            const senderName = (params.pushName ?? "").trim() || "Unknown";
+            const includeMessage = pairingConfig.includeMessage !== false;
+            const messagePreview =
+              includeMessage && params.messageBody
+                ? `\n\n📝 Message:\n"${params.messageBody}"`
+                : "";
+            const notificationText = [
+              `📩 *New pairing request*`,
+              ``,
+              `From: ${senderName} (${candidate})`,
+              `Code: \`${code}\``,
+              messagePreview,
+              ``,
+              `To approve: \`openclaw pairing approve whatsapp ${code}\``,
+            ].join("\n");
+
+            try {
+              await params.sock.sendMessage(pairingConfig.ownerChat, {
+                text: notificationText,
+              });
+              logVerbose(`Pairing notification sent to owner ${pairingConfig.ownerChat}`);
+            } catch (err) {
+              logVerbose(`Failed to notify owner of pairing request: ${String(err)}`);
+            }
           }
         }
       }

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -200,10 +200,14 @@ export async function checkInboundAccessControl(params: {
           if (pairingConfig?.notifyOwner && pairingConfig.ownerChat) {
             const senderName = (params.pushName ?? "").trim() || "Unknown";
             const includeMessage = pairingConfig.includeMessage !== false;
+            const MAX_PREVIEW_LENGTH = 500;
+            const rawBody = params.messageBody ?? "";
+            const sanitizedBody = rawBody
+              .replace(/[*_`~]/g, "")
+              .slice(0, MAX_PREVIEW_LENGTH)
+              .concat(rawBody.length > MAX_PREVIEW_LENGTH ? "…" : "");
             const messagePreview =
-              includeMessage && params.messageBody
-                ? `\n\n📝 Message:\n"${params.messageBody}"`
-                : "";
+              includeMessage && sanitizedBody ? `\n\n📝 Message:\n"${sanitizedBody}"` : "";
             const notificationText = [
               `📩 *New pairing request*`,
               ``,

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -205,6 +205,9 @@ export async function monitorWebInbox(options: {
       ? Number(msg.messageTimestamp) * 1000
       : undefined;
 
+    // Extract message body early for pairing notifications
+    const earlyBody = extractText(msg.message ?? undefined);
+
     const access = await checkInboundAccessControl({
       accountId: options.accountId,
       from,
@@ -217,6 +220,7 @@ export async function monitorWebInbox(options: {
       connectedAtMs,
       sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
       remoteJid,
+      messageBody: earlyBody ?? undefined,
     });
     if (!access.allowed) {
       return null;


### PR DESCRIPTION
## Summary
When `dmPolicy` is `pairing`, owners can now be notified when someone requests to pair with the bot. This allows owners to be aware of incoming requests without having to manually check the CLI.

## Configuration
```json
{
  "channels": {
    "whatsapp": {
      "dmPolicy": "pairing",
      "pairing": {
        "notifyOwner": true,
        "ownerChat": "554788703000@s.whatsapp.net",
        "includeMessage": true
      }
    }
  }
}
```

## Notification Format
```
📩 *New pairing request*

From: João (+5547999999999)
Code: `ABC123`

📝 Message:
"Oi, quanto custa a consultoria?"

To approve: `openclaw pairing approve whatsapp ABC123`
```

## Changes
- Added `WhatsAppPairingConfig` type with `notifyOwner`, `ownerChat`, and `includeMessage` options
- Added Zod schema validation (ownerChat required when notifyOwner is true)
- Modified `checkInboundAccessControl` to send notifications when pairing requests are created
- Added `messageBody` parameter to include original message in notifications

## Testing
- Existing access-control tests pass
- TypeScript compiles without errors

Fixes #6261

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a WhatsApp pairing owner-notification feature gated by new `channels.whatsapp.pairing` config (and per-account overrides), validates it via Zod, threads message text into inbound access control, and sends a formatted notification to an owner chat when a new pairing request is created.

The changes integrate into the existing WhatsApp web inbound pipeline by extracting the inbound text early in `monitorWebInbox()` and passing it into `checkInboundAccessControl()`, which already creates pairing requests and replies to the requester when `dmPolicy` is `pairing`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but has a functional config bug affecting multi-account dmPolicy behavior.
- The feature is self-contained and guarded by config, and notification send failures are handled. However, `checkInboundAccessControl` currently ignores per-account dmPolicy despite resolving it, which can lead to incorrect access behavior in multi-account setups (and makes the new per-account pairing config feel inconsistent).
- src/web/inbound/access-control.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->