### PR TITLE
fix: disable developer role for Moonshot provider

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -41,4 +41,15 @@ describe("normalizeModelCompat", () => {
     const normalized = normalizeModelCompat(model);
     expect(normalized.compat?.supportsDeveloperRole).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for moonshot models", () => {
+    const model = {
+      ...baseModel(),
+      provider: "moonshot",
+      baseUrl: "https://api.moonshot.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -7,7 +7,8 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isMoonshot = model.provider === "moonshot" || baseUrl.includes("api.moonshot.ai");
+  if ((!isZai && !isMoonshot) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,10 +4,18 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
+function hasHostname(baseUrl: string, hostname: string): boolean {
+  try {
+    return new URL(baseUrl).hostname === hostname;
+  } catch {
+    return false;
+  }
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  const isMoonshot = model.provider === "moonshot" || baseUrl.includes("api.moonshot.ai");
+  const isZai = model.provider === "zai" || hasHostname(baseUrl, "api.z.ai");
+  const isMoonshot = model.provider === "moonshot" || hasHostname(baseUrl, "api.moonshot.ai");
   if ((!isZai && !isMoonshot) || !isOpenAiCompletionsModel(model)) {
     return model;
   }


### PR DESCRIPTION
Moonshot API only supports `system`, `user`, `assistant` roles.

[Docs](https://platform.moonshot.ai/docs/api/chat): "The role can only be one of system, user, assistant"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `normalizeModelCompat` to also apply the existing “no developer role” compatibility override to Moonshot models (in addition to z.ai), since Moonshot’s chat API only supports `system`, `user`, and `assistant` roles. It also adds a unit test to ensure Moonshot models are normalized with `supportsDeveloperRole: false` when no compat is set.

The change fits into the existing provider compatibility layer in `src/agents/model-compat.ts`, which conditionally adjusts `Model<Api>.compat` for providers that use the OpenAI-compatible API but have role restrictions.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, well-scoped compatibility tweak with test coverage.
- The code change is minimal and covered by a new test; the main risk is mis-detecting Moonshot via a broad `baseUrl.includes` check and the function’s in-place mutation of the `model` object, which can have side effects depending on caller expectations.
- src/agents/model-compat.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->