### PR TITLE
fix: add timeout to compaction retry to prevent session lockout

### DIFF
--- a/src/agents/pi-embedded-subscribe.compaction-timeout.test.ts
+++ b/src/agents/pi-embedded-subscribe.compaction-timeout.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+describe("subscribeEmbeddedPiSession compaction timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("times out compaction retry after specified timeout (issue #5784)", async () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-timeout",
+    });
+
+    // Trigger compaction retry (willRetry=true)
+    handler?.({ type: "auto_compaction_start" });
+    handler?.({ type: "auto_compaction_end", willRetry: true });
+
+    // Should be compacting
+    expect(subscription.isCompacting()).toBe(true);
+
+    // Start waiting with a 100ms timeout
+    const waitPromise = subscription.waitForCompactionRetry(100);
+
+    // Advance time past timeout
+    await vi.advanceTimersByTimeAsync(150);
+
+    // Should resolve with timedOut: true
+    const result = await waitPromise;
+    expect(result.timedOut).toBe(true);
+
+    // Compaction state should be cleaned up
+    expect(subscription.isCompacting()).toBe(false);
+  });
+
+  it("resolves normally if compaction completes before timeout", async () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-normal",
+    });
+
+    // Trigger compaction retry
+    handler?.({ type: "auto_compaction_start" });
+    handler?.({ type: "auto_compaction_end", willRetry: true });
+
+    const waitPromise = subscription.waitForCompactionRetry(60_000);
+
+    // Complete compaction normally via agent_end
+    handler?.({ type: "agent_end" });
+
+    const result = await waitPromise;
+    expect(result.timedOut).toBeUndefined();
+    expect(subscription.isCompacting()).toBe(false);
+  });
+
+  it("uses default timeout of 60 seconds when not specified", async () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-default-timeout",
+    });
+
+    handler?.({ type: "auto_compaction_start" });
+    handler?.({ type: "auto_compaction_end", willRetry: true });
+
+    const waitPromise = subscription.waitForCompactionRetry();
+
+    // Advance 59 seconds - should still be waiting
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(subscription.isCompacting()).toBe(true);
+
+    // Advance past 60 seconds
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const result = await waitPromise;
+    expect(result.timedOut).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5784

When auto-compaction fails and triggers a retry (`willRetry=true`), the retry promise in `waitForCompactionRetry()` could hang forever if the SDK's internal retry never completes. This causes:

- Session permanently locked (`active=true`)
- Lock file never released
- Gateway restart is the only recovery

## Solution

This fix adds a configurable timeout (default 60 seconds) to `waitForCompactionRetry()`. When the timeout is reached:

1. Force-resolves the pending promise
2. Cleans up compaction state (`pendingCompactionRetry`, `compactionInFlight`)
3. Logs a warning
4. Returns `{ timedOut: true }` so callers can handle it

The session can then complete normally instead of hanging forever.

## Changes

- `src/agents/pi-embedded-subscribe.ts`: Add timeout parameter and timeout race logic to `waitForCompactionRetry()`
- `src/agents/pi-embedded-runner/run/attempt.ts`: Pass 60s timeout and log warning on timeout
- `src/agents/pi-embedded-subscribe.compaction-timeout.test.ts`: Add tests for timeout behavior

## Testing

Added unit tests that verify:
- Timeout fires after specified duration
- State is properly cleaned up on timeout
- Normal completion still works before timeout
- Default timeout is 60 seconds

## Backward Compatibility

The return type of `waitForCompactionRetry()` changed from `Promise<void>` to `Promise<{ timedOut?: boolean }>`. Existing `.then()` callbacks will still work, but callers may want to check `result.timedOut` to handle the timeout case.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a timeout path to `subscribeEmbeddedPiSession().waitForCompactionRetry()` (default 60s) so embedded runs don’t hang forever if the SDK’s internal compaction retry never completes, and wires the new result into the embedded attempt runner with an extra warning log. Includes new vitest coverage for timeout vs normal completion paths.

Overall this fits cleanly into the existing compaction retry bookkeeping in `pi-embedded-subscribe.ts` (the `pendingCompactionRetry` / `compactionInFlight` gate and shared promise resolver) and addresses the session lockout failure mode described in #5784.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the timeout may not apply in some call timing scenarios due to when waiting begins.
- Core change is localized and covered by tests, but `waitForCompactionRetry()` still resolves immediately if compaction starts after the next microtask, which can bypass both waiting and the new timeout in some real event-orderings.
- src/agents/pi-embedded-subscribe.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->