### PR TITLE
docs: document cacheRetention parameter

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -15,13 +15,13 @@ Session pruning trims **old tool results** from the in-memory context right befo
 - When `mode: "cache-ttl"` is enabled and the last Anthropic call for the session is older than `ttl`.
 - Only affects the messages sent to the model for that request.
 - Only active for Anthropic API calls (and OpenRouter Anthropic models).
-- For best results, match `ttl` to your model `cacheControlTtl`.
+- For best results, match `ttl` to your model `cacheRetention`.
 - After a prune, the TTL window resets so subsequent requests keep cache until `ttl` expires again.
 
 ## Smart defaults (Anthropic)
 
 - **OAuth or setup-token** profiles: enable `cache-ttl` pruning and set heartbeat to `1h`.
-- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheControlTtl` to `1h` on Anthropic models.
+- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention` to `"short"` on Anthropic models.
 - If you set any of these values explicitly, OpenClaw does **not** override them.
 
 ## What this improves (cost + cache behavior)

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -21,7 +21,7 @@ Session pruning trims **old tool results** from the in-memory context right befo
 ## Smart defaults (Anthropic)
 
 - **OAuth or setup-token** profiles: enable `cache-ttl` pruning and set heartbeat to `1h`.
-- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention` to `short` on Anthropic models.
+- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention: "short"` on Anthropic models.
 - If you set any of these values explicitly, OpenClaw does **not** override them.
 
 ## What this improves (cost + cache behavior)

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -21,7 +21,7 @@ Session pruning trims **old tool results** from the in-memory context right befo
 ## Smart defaults (Anthropic)
 
 - **OAuth or setup-token** profiles: enable `cache-ttl` pruning and set heartbeat to `1h`.
-- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention` to `"short"` on Anthropic models.
+- **API key** profiles: enable `cache-ttl` pruning, set heartbeat to `30m`, and default `cacheRetention` to `short` on Anthropic models.
 - If you set any of these values explicitly, OpenClaw does **not** override them.
 
 ## What this improves (cost + cache behavior)

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -37,10 +37,17 @@ openclaw onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 
 ## Prompt caching (Anthropic API)
 
-OpenClaw does **not** override Anthropic’s default cache TTL unless you set it.
-This is **API-only**; subscription auth does not honor TTL settings.
+OpenClaw supports Anthropic's prompt caching feature. This is **API-only**; subscription auth does not honor cache settings.
 
-To set the TTL per model, use `cacheControlTtl` in the model `params`:
+### Configuration
+
+Use the `cacheRetention` parameter in your model config:
+
+| Value | Cache Duration | Description |
+|-------|----------------|-------------|
+| `"none"` | No caching | Disable prompt caching |
+| `"short"` | 5 minutes | Default for API Key auth |
+| `"long"` | 1 hour | Extended cache (requires beta flag) |
 
 ```json5
 {
@@ -48,13 +55,25 @@ To set the TTL per model, use `cacheControlTtl` in the model `params`:
     defaults: {
       models: {
         "anthropic/claude-opus-4-5": {
-          params: { cacheControlTtl: "5m" }, // or "1h"
+          params: { cacheRetention: "long" },
         },
       },
     },
   },
 }
 ```
+
+### Defaults
+
+When using Anthropic API Key authentication, OpenClaw automatically applies `cacheRetention: "short"` (5-minute cache) for all Anthropic models. You can override this by explicitly setting `cacheRetention` in your config.
+
+### Legacy parameter
+
+The older `cacheControlTtl` parameter is still supported for backwards compatibility:
+- `"5m"` maps to `"short"`
+- `"1h"` maps to `"long"`
+
+We recommend migrating to the new `cacheRetention` parameter.
 
 OpenClaw includes the `extended-cache-ttl-2025-04-11` beta flag for Anthropic API
 requests; keep it if you override provider headers (see [/gateway/configuration](/gateway/configuration)).

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -45,9 +45,9 @@ Use the `cacheRetention` parameter in your model config:
 
 | Value | Cache Duration | Description |
 |-------|----------------|-------------|
-| `"none"` | No caching | Disable prompt caching |
-| `"short"` | 5 minutes | Default for API Key auth |
-| `"long"` | 1 hour | Extended cache (requires beta flag) |
+| `none` | No caching | Disable prompt caching |
+| `short` | 5 minutes | Default for API Key auth |
+| `long` | 1 hour | Extended cache (requires beta flag) |
 
 ```json5
 {
@@ -70,8 +70,8 @@ When using Anthropic API Key authentication, OpenClaw automatically applies `cac
 ### Legacy parameter
 
 The older `cacheControlTtl` parameter is still supported for backwards compatibility:
-- `"5m"` maps to `"short"`
-- `"1h"` maps to `"long"`
+- `"5m"` maps to `short`
+- `"1h"` maps to `long`
 
 We recommend migrating to the new `cacheRetention` parameter.
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -43,11 +43,11 @@ OpenClaw supports Anthropic's prompt caching feature. This is **API-only**; subs
 
 Use the `cacheRetention` parameter in your model config:
 
-| Value | Cache Duration | Description |
-|-------|----------------|-------------|
-| `none` | No caching | Disable prompt caching |
-| `short` | 5 minutes | Default for API Key auth |
-| `long` | 1 hour | Extended cache (requires beta flag) |
+| Value   | Cache Duration | Description                         |
+| ------- | -------------- | ----------------------------------- |
+| `none`  | No caching     | Disable prompt caching              |
+| `short` | 5 minutes      | Default for API Key auth            |
+| `long`  | 1 hour         | Extended cache (requires beta flag) |
 
 ```json5
 {
@@ -70,6 +70,7 @@ When using Anthropic API Key authentication, OpenClaw automatically applies `cac
 ### Legacy parameter
 
 The older `cacheControlTtl` parameter is still supported for backwards compatibility:
+
 - `"5m"` maps to `short`
 - `"1h"` maps to `long`
 

--- a/docs/token-use.md
+++ b/docs/token-use.md
@@ -97,7 +97,7 @@ agents:
     models:
       "anthropic/claude-opus-4-5":
         params:
-          cacheControlTtl: "1h"
+          cacheRetention: "long"
     heartbeat:
       every: "55m"
 ```


### PR DESCRIPTION
## Summary

- Update documentation to use `cacheRetention` parameter instead of deprecated `cacheControlTtl`
- Add comprehensive table explaining the three cache retention values (`none`, `short`, `long`)
- Document legacy parameter mapping for backwards compatibility

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [ ] Verify docs render correctly on Mintlify (after merge)

Closes #6240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates documentation to prefer the new `cacheRetention` model param over the legacy `cacheControlTtl`, and expands the Anthropic provider docs with a table describing the available retention values (`none`/`short`/`long`) plus a legacy mapping note. It also updates related examples (session pruning + token-use) to reference `cacheRetention` so guidance matches the current configuration defaults/behavior in the codebase.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are limited to documentation with minor consistency nits.
- Reviewed all changed docs and cross-checked against existing code references to `cacheRetention`/`cacheControlTtl`. No functional code changes; only minor formatting/consistency issues likely to confuse copy/paste.
- docs/providers/anthropic.md; docs/concepts/session-pruning.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->