### PR TITLE
feat(telegram): Add message content filtering

### DIFF
--- a/extensions/telegram/src/message-filter.ts
+++ b/extensions/telegram/src/message-filter.ts
@@ -1,0 +1,281 @@
+/**
+ * Message Content Filter for Telegram Plugin
+ * 
+ * Filters messages based on regex patterns before they reach the agent.
+ * Supports blockPatterns (denylist) and allowPatterns (allowlist) modes.
+ */
+
+export interface MessageFilterConfig {
+  // Regex patterns to block (denylist)
+  blockPatterns?: string[];
+
+  // Regex patterns to allow (allowlist)
+  allowPatterns?: string[];
+
+  // Evaluation mode: "block-first" (default) or "allowlist-first"
+  mode?: "block-first" | "allowlist-first";
+
+  // Case sensitivity (default: false)
+  caseSensitive?: boolean;
+
+  // Apply to text content only, not captions (default: true)
+  textOnly?: boolean;
+
+  // Log filtered messages for debugging (default: true)
+  logFiltered?: boolean;
+
+  // Patterns to exclude from filtering (bypass)
+  excludePatterns?: string[];
+}
+
+interface FilterResult {
+  shouldFilter: boolean;
+  reason?: string;
+  matchedPattern?: string;
+  matchedSource?: 'block' | 'allow' | 'exclude';
+}
+
+export class MessageFilter {
+  private blockRegexes: RegExp[] = [];
+  private allowRegexes: RegExp[] = [];
+  private excludeRegexes: RegExp[] = [];
+  private config: MessageFilterConfig;
+  private readonly DEFAULT_FLAGS = 'i'; // Case-insensitive by default
+
+  constructor(config: MessageFilterConfig = {}) {
+    this.config = {
+      mode: 'block-first',
+      caseSensitive: false,
+      textOnly: true,
+      logFiltered: true,
+      ...config,
+    };
+
+    this.compilePatterns();
+  }
+
+  private getFlags(): string {
+    return this.config.caseSensitive ? '' : this.DEFAULT_FLAGS;
+  }
+
+  private compilePatterns(): void {
+    const flags = this.getFlags();
+
+    if (this.config.blockPatterns) {
+      this.blockRegexes = this.config.blockPatterns.map(pattern => {
+        try {
+          return new RegExp(pattern, flags);
+        } catch (err) {
+          console.error(`[MessageFilter] Invalid block pattern: ${pattern}`, err);
+          return null;
+        }
+      }).filter((r): r is RegExp => r !== null);
+    }
+
+    if (this.config.allowPatterns) {
+      this.allowRegexes = this.config.allowPatterns.map(pattern => {
+        try {
+          return new RegExp(pattern, flags);
+        } catch (err) {
+          console.error(`[MessageFilter] Invalid allow pattern: ${pattern}`, err);
+          return null;
+        }
+      }).filter((r): r is RegExp => r !== null);
+    }
+
+    if (this.config.excludePatterns) {
+      this.excludeRegexes = this.config.excludePatterns.map(pattern => {
+        try {
+          return new RegExp(pattern, flags);
+        } catch (err) {
+          console.error(`[MessageFilter] Invalid exclude pattern: ${pattern}`, err);
+          return null;
+        }
+      }).filter((r): r is RegExp => r !== null);
+    }
+  }
+
+  /**
+   * Check if message should be filtered
+   * @param text - Message text
+   * @param caption - Message caption (for media)
+   * @returns Filter result
+   */
+  shouldFilter(text?: string | null, caption?: string | null): FilterResult {
+    // Skip if no patterns configured
+    if (this.blockRegexes.length === 0 && this.allowRegexes.length === 0) {
+      return { shouldFilter: false };
+    }
+
+    // Determine text to filter
+    const content = this.config.textOnly ? (text ?? '') : ((text ?? '') + ' ' + (caption ?? '')).trim();
+    const isEmpty = !content || content.trim().length === 0;
+
+    if (isEmpty) {
+      // Empty messages pass through (let agent handle them)
+      return { shouldFilter: false };
+    }
+
+    // Check exclude patterns first (bypass list)
+    if (this.excludeRegexes.length > 0) {
+      for (const regex of this.excludeRegexes) {
+        if (regex.test(content)) {
+          // Excluded from filtering, allow through
+          return { 
+            shouldFilter: false, 
+            matchedSource: 'exclude',
+            matchedPattern: regex.source 
+          };
+        }
+      }
+    }
+
+    const mode = this.config.mode ?? 'block-first';
+
+    if (mode === 'allowlist-first') {
+      return this.checkAllowlistFirst(content);
+    } else {
+      return this.checkBlockFirst(content);
+    }
+  }
+
+  private checkAllowlistFirst(content: string): FilterResult {
+    // If allow patterns exist, message must match one
+    if (this.allowRegexes.length > 0) {
+      for (const regex of this.allowRegexes) {
+        if (regex.test(content)) {
+          // Matched allowlist, also check block patterns
+          if (this.blockRegexes.length > 0) {
+            for (const blockRegex of this.blockRegexes) {
+              if (blockRegex.test(content)) {
+                return this.logFilter(content, blockRegex.source, 'block', 'Matched allowlist but also blocked');
+              }
+            }
+          }
+          // Matched allowlist and not blocked
+          return { 
+            shouldFilter: false, 
+            matchedSource: 'allow',
+            matchedPattern: regex.source 
+          };
+        }
+      }
+      // Didn't match any allow pattern
+      return this.logFilter(content, null, 'allow', 'No allowlist match');
+    }
+
+    // No allow patterns, proceed to block check
+    if (this.blockRegexes.length > 0) {
+      for (const regex of this.blockRegexes) {
+        if (regex.test(content)) {
+          return this.logFilter(content, regex.source, 'block');
+        }
+      }
+    }
+
+    // No matches, allow through
+    return { shouldFilter: false };
+  }
+
+  private checkBlockFirst(content: string): FilterResult {
+    // Check block patterns first
+    if (this.blockRegexes.length > 0) {
+      for (const regex of this.blockRegexes) {
+        if (regex.test(content)) {
+          // Also check if it's in allowlist
+          if (this.allowRegexes.length > 0) {
+            for (const allowRegex of this.allowRegexes) {
+              if (allowRegex.test(content)) {
+                // In allowlist, bypass block
+                return { 
+                  shouldFilter: false,
+                  matchedSource: 'allow',
+                  matchedPattern: allowRegex.source 
+                };
+              }
+            }
+          }
+          // Not in allowlist, block it
+          return this.logFilter(content, regex.source, 'block');
+        }
+      }
+    }
+
+    // Check allow patterns if they exist
+    if (this.allowRegexes.length > 0) {
+      for (const regex of this.allowRegexes) {
+        if (regex.test(content)) {
+          return { 
+            shouldFilter: false,
+            matchedSource: 'allow',
+            matchedPattern: regex.source 
+          };
+        }
+      }
+      // Didn't match any allow pattern
+      return this.logFilter(content, null, 'allow', 'No allowlist match');
+    }
+
+    // No matches, allow through
+    return { shouldFilter: false };
+  }
+
+  private logFilter(content: string, pattern: string | null, source: 'block' | 'allow', customReason?: string): FilterResult {
+    if (!this.config.logFiltered) {
+      return { shouldFilter: true };
+    }
+
+    const reason = customReason || `Matched ${source} pattern`;
+    const patternInfo = pattern ? ` (${pattern})` : '';
+    const preview = content.length > 50 ? content.substring(0, 50) + '...' : content;
+
+    console.log(`[MessageFilter] Blocked: ${preview}${patternInfo} - ${reason}`);
+
+    return { shouldFilter: true, reason, matchedPattern: pattern, matchedSource: source };
+  }
+
+  /**
+   * Update filter configuration at runtime
+   */
+  updateConfig(newConfig: Partial<MessageFilterConfig>): void {
+    this.config = { ...this.config, ...newConfig };
+    this.compilePatterns();
+  }
+
+  /**
+   * Get current filter statistics
+   */
+  getStats(): { blockPatterns: number; allowPatterns: number; excludePatterns: number } {
+    return {
+      blockPatterns: this.blockRegexes.length,
+      allowPatterns: this.allowRegexes.length,
+      excludePatterns: this.excludeRegexes.length,
+    };
+  }
+}
+
+/**
+ * Factory function to create a message filter from config
+ */
+export function createMessageFilter(config?: MessageFilterConfig): MessageFilter {
+  return new MessageFilter(config);
+}
+
+/**
+ * Check if a group config has message filtering enabled
+ */
+export function hasMessageFilterEnabled(groupConfig?: { messageFilter?: MessageFilterConfig }): boolean {
+  return Boolean(groupConfig?.messageFilter && (
+    groupConfig.messageFilter.blockPatterns?.length > 0 ||
+    groupConfig.messageFilter.allowPatterns?.length > 0
+  ));
+}
+
+/**
+ * Extract message filter config from group config
+ */
+export function resolveMessageFilterConfig(
+  groupConfig?: { messageFilter?: MessageFilterConfig }
+): MessageFilterConfig | undefined {
+  return groupConfig?.messageFilter;
+}


### PR DESCRIPTION
Add MessageFilter class for content-based message filtering:
- Block patterns (denylist) for spam/noise
- Allow patterns (allowlist) for trigger-only mode
- Hybrid modes with exclude patterns (bypass list)
- Two evaluation modes: block-first or allowlist-first

Use cases:
- DD bots: Trigger-only mode (allow specific patterns)
- Support groups: FAQ/Help mode
- Hybrid: Block spam but allow commands

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `MessageFilter` utility for the Telegram extension that compiles configurable allow/block/exclude regex patterns and evaluates incoming message text/captions in either "block-first" or "allowlist-first" mode. Also includes small helpers to construct the filter and detect/resolve per-group filter config.

The file is self-contained under `extensions/telegram/src/` and is intended to be called by the Telegram message handling pipeline before forwarding content to an agent.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but has a correctness bug around runtime config updates and a couple of behavior/logging surprises.
- The implementation is straightforward and isolated, but `compilePatterns()` can preserve old compiled regexes after `updateConfig()` changes, leading to incorrect filtering behavior. The other findings are lower severity but would likely confuse operators or callers.
- extensions/telegram/src/message-filter.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->