### PR TITLE
fix(skills): deduplicate skill commands

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -106,7 +106,7 @@ describe("listSkillCommandsForAgents", () => {
       const bundledDir = path.join(tempDir, "bundled-skills");
       await fs.mkdir(bundledDir);
       await writeSkill({
-        dir: bundledDir,
+        workspaceDir: bundledDir,
         dirName: "bundled-1",
         name: "bundled-skill",
         description: "A bundled skill",

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -40,6 +40,7 @@ export function listSkillCommandsForAgents(params: {
   agentIds?: string[];
 }): SkillCommandSpec[] {
   const used = resolveReservedCommandNames();
+  const registeredSkills = new Set<string>();
   const entries: SkillCommandSpec[] = [];
   const agentIds = params.agentIds ?? listAgentIds(params.cfg);
   for (const agentId of agentIds) {
@@ -53,6 +54,10 @@ export function listSkillCommandsForAgents(params: {
       reservedNames: used,
     });
     for (const command of commands) {
+      if (registeredSkills.has(command.skillName)) {
+        continue;
+      }
+      registeredSkills.add(command.skillName);
       used.add(command.name.toLowerCase());
       entries.push(command);
     }


### PR DESCRIPTION
Re-submission of ghosted PR #5671. Deduplicates skill commands by skill name across agents.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `listSkillCommandsForAgents` to deduplicate skill command specs by `skillName` across agents (preventing the same skill from being registered multiple times), and adjusts/adds tests to assert the new behavior, including for bundled skills via `OPENCLAW_BUNDLED_SKILLS_DIR`.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the new test has a runtime-throw bug.
- Core deduplication logic is small and looks correct, but the added test calls `writeSkill` with the wrong parameter name (`dir` instead of `workspaceDir`), which will crash when building the path and cause CI failures. Also unable to run tests locally due to missing npm in this environment, so relying on static review for other issues.
- src/auto-reply/skill-commands.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->