### PR TITLE
fix(infra): strip absolute paths from sessionId

### DIFF
--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -181,10 +181,11 @@ function pickLatestLegacyDirectEntry(
 }
 
 function normalizeSessionEntry(entry: SessionEntryLike): SessionEntry | null {
-  const sessionId = typeof entry.sessionId === "string" ? entry.sessionId : null;
-  if (!sessionId) {
+  const rawSessionId = typeof entry.sessionId === "string" ? entry.sessionId : null;
+  if (!rawSessionId) {
     return null;
   }
+  const sessionId = path.basename(rawSessionId, ".jsonl");
   const updatedAt =
     typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
       ? entry.updatedAt
@@ -195,6 +196,7 @@ function normalizeSessionEntry(entry: SessionEntryLike): SessionEntry | null {
     rec.groupChannel = rec.room;
   }
   delete rec.room;
+  delete rec.sessionFile;
   return normalized;
 }
 

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -185,7 +185,11 @@ function normalizeSessionEntry(entry: SessionEntryLike): SessionEntry | null {
   if (!rawSessionId) {
     return null;
   }
-  const sessionId = path.basename(rawSessionId, ".jsonl");
+  // Only strip .jsonl extension if the rawSessionId is actually a file path (contains directory separators)
+  // Otherwise, preserve bare IDs unchanged to avoid breaking legacy stores that used bare IDs
+  const sessionId = rawSessionId.includes('/') || rawSessionId.includes('\\') 
+    ? path.basename(rawSessionId, ".jsonl")
+    : rawSessionId;
   const updatedAt =
     typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
       ? entry.updatedAt


### PR DESCRIPTION
Re-submission of ghosted PR #5672. Strips absolute paths from sessionId during state migration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts legacy state migration to avoid persisting machine-specific absolute paths in session metadata. In `src/infra/state-migrations.ts`, `normalizeSessionEntry` now derives `sessionId` from the basename of a path-like `sessionId` (and strips a `.jsonl` extension), and also drops the legacy `sessionFile` field. A new Vitest case in `src/commands/doctor-state-migrations.test.ts` validates that migrating a legacy sessions store containing absolute `sessionId`/`sessionFile` values produces an extension-less id and removes `sessionFile` in the migrated target store.

Overall, this fits into the existing doctor/state-migrations flow by normalizing legacy session entry shapes before writing to the new per-agent `sessions.json` store.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the sessionId normalization heuristic may miss some legacy formats.
- The change is small and covered by a focused test, but the new “strip only when separators exist” heuristic can under-normalize relative `.jsonl` values and may also transform non-path identifiers that happen to contain separators, depending on what legacy stores contained.
- src/infra/state-migrations.ts (normalizeSessionEntry)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->