### PR TITLE
fix: Add timeouts to prevent indefinite hangs (issues #4954, #4956, #5122)

### DIFF
--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -106,5 +106,8 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  // ThrottleInterval: Cap restart delay at 5 seconds to prevent hours of downtime
+  // after crashes. Without this, launchd applies exponential backoff that can
+  // leave the service down for 10+ hours. (Fixes #4632)
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>5</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -16,6 +16,7 @@ import {
 } from "./launchd-plist.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
+import { safeWrite, safeWriteLine } from "./safe-write.js";
 
 const execFileAsync = promisify(execFile);
 const toPosixPath = (value: string) => value.replace(/\\/g, "/");
@@ -313,9 +314,9 @@ export async function uninstallLegacyLaunchAgents({
     const dest = path.join(trashDir, `${agent.label}.plist`);
     try {
       await fs.rename(agent.plistPath, dest);
-      stdout.write(`${formatLine("Moved legacy LaunchAgent to Trash", dest)}\n`);
+      safeWriteLine(stdout, formatLine("Moved legacy LaunchAgent to Trash", dest));
     } catch {
-      stdout.write(`Legacy LaunchAgent remains at ${agent.plistPath} (could not move)\n`);
+      safeWriteLine(stdout, `Legacy LaunchAgent remains at ${agent.plistPath} (could not move)`);
     }
   }
 
@@ -338,7 +339,7 @@ export async function uninstallLaunchAgent({
   try {
     await fs.access(plistPath);
   } catch {
-    stdout.write(`LaunchAgent not found at ${plistPath}\n`);
+    safeWriteLine(stdout, `LaunchAgent not found at ${plistPath}`);
     return;
   }
 
@@ -348,9 +349,9 @@ export async function uninstallLaunchAgent({
   try {
     await fs.mkdir(trashDir, { recursive: true });
     await fs.rename(plistPath, dest);
-    stdout.write(`${formatLine("Moved LaunchAgent to Trash", dest)}\n`);
+    safeWriteLine(stdout, formatLine("Moved LaunchAgent to Trash", dest));
   } catch {
-    stdout.write(`LaunchAgent remains at ${plistPath} (could not move)\n`);
+    safeWriteLine(stdout, `LaunchAgent remains at ${plistPath} (could not move)`);
   }
 }
 
@@ -376,7 +377,7 @@ export async function stopLaunchAgent({
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
     throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  safeWriteLine(stdout, formatLine("Stopped LaunchAgent", `${domain}/${label}`));
 }
 
 export async function installLaunchAgent({
@@ -441,9 +442,9 @@ export async function installLaunchAgent({
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
-  stdout.write("\n");
-  stdout.write(`${formatLine("Installed LaunchAgent", plistPath)}\n`);
-  stdout.write(`${formatLine("Logs", stdoutPath)}\n`);
+  safeWrite(stdout, "\n");
+  safeWriteLine(stdout, formatLine("Installed LaunchAgent", plistPath));
+  safeWriteLine(stdout, formatLine("Logs", stdoutPath));
   return { plistPath };
 }
 
@@ -460,5 +461,5 @@ export async function restartLaunchAgent({
   if (res.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  safeWriteLine(stdout, formatLine("Restarted LaunchAgent", `${domain}/${label}`));
 }

--- a/src/daemon/safe-write.test.ts
+++ b/src/daemon/safe-write.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { safeWrite, safeWriteLine } from "./safe-write.js";
+
+describe("safe-write", () => {
+  describe("safeWrite", () => {
+    it("writes to stream successfully", () => {
+      const mockWrite = vi.fn();
+      const stream = { write: mockWrite } as unknown as NodeJS.WritableStream;
+
+      const result = safeWrite(stream, "hello");
+
+      expect(result).toBe(true);
+      expect(mockWrite).toHaveBeenCalledWith("hello");
+    });
+
+    it("returns false and suppresses EPIPE errors", () => {
+      const epipeError = new Error("write EPIPE") as NodeJS.ErrnoException;
+      epipeError.code = "EPIPE";
+
+      const stream = {
+        write: vi.fn().mockImplementation(() => {
+          throw epipeError;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      const result = safeWrite(stream, "hello");
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false and suppresses EIO errors", () => {
+      const eioError = new Error("write EIO") as NodeJS.ErrnoException;
+      eioError.code = "EIO";
+
+      const stream = {
+        write: vi.fn().mockImplementation(() => {
+          throw eioError;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      const result = safeWrite(stream, "hello");
+
+      expect(result).toBe(false);
+    });
+
+    it("rethrows non-pipe errors", () => {
+      const otherError = new Error("something else") as NodeJS.ErrnoException;
+      otherError.code = "ENOENT";
+
+      const stream = {
+        write: vi.fn().mockImplementation(() => {
+          throw otherError;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      expect(() => safeWrite(stream, "hello")).toThrow("something else");
+    });
+  });
+
+  describe("safeWriteLine", () => {
+    it("appends newline if not present", () => {
+      const mockWrite = vi.fn();
+      const stream = { write: mockWrite } as unknown as NodeJS.WritableStream;
+
+      safeWriteLine(stream, "hello");
+
+      expect(mockWrite).toHaveBeenCalledWith("hello\n");
+    });
+
+    it("does not double newline", () => {
+      const mockWrite = vi.fn();
+      const stream = { write: mockWrite } as unknown as NodeJS.WritableStream;
+
+      safeWriteLine(stream, "hello\n");
+
+      expect(mockWrite).toHaveBeenCalledWith("hello\n");
+    });
+
+    it("handles EPIPE gracefully", () => {
+      const epipeError = new Error("write EPIPE") as NodeJS.ErrnoException;
+      epipeError.code = "EPIPE";
+
+      const stream = {
+        write: vi.fn().mockImplementation(() => {
+          throw epipeError;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      const result = safeWriteLine(stream, "hello");
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/daemon/safe-write.ts
+++ b/src/daemon/safe-write.ts
@@ -1,0 +1,43 @@
+/**
+ * Safe stream write utilities that handle EPIPE/EIO errors gracefully.
+ *
+ * When writing to stdout/stderr during process shutdown or restart,
+ * the pipe may already be closed, causing EPIPE errors. These utilities
+ * catch and suppress such errors to prevent crashes.
+ *
+ * Fixes: #5345, #4632
+ */
+
+/**
+ * Check if an error is a broken pipe error (EPIPE or EIO).
+ */
+function isBrokenPipeError(err: unknown): boolean {
+  const code = (err as { code?: string })?.code;
+  return code === "EPIPE" || code === "EIO";
+}
+
+/**
+ * Write to a stream, gracefully handling EPIPE/EIO errors.
+ * Returns true if the write succeeded, false if it was suppressed due to broken pipe.
+ */
+export function safeWrite(stream: NodeJS.WritableStream, data: string): boolean {
+  try {
+    stream.write(data);
+    return true;
+  } catch (err) {
+    if (isBrokenPipeError(err)) {
+      // Pipe closed during shutdown - suppress error
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Write a line to a stream, gracefully handling EPIPE/EIO errors.
+ * Appends a newline if not already present.
+ */
+export function safeWriteLine(stream: NodeJS.WritableStream, line: string): boolean {
+  const data = line.endsWith("\n") ? line : `${line}\n`;
+  return safeWrite(stream, data);
+}

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -74,17 +74,28 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
 export async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
+  timeoutMs = 30_000,
 ): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
   return await new Promise((resolve) => {
     let done = false;
     let total = 0;
     const chunks: Buffer[] = [];
+
+    const timeout = setTimeout(() => {
+      if (!done) {
+        done = true;
+        req.destroy();
+        resolve({ ok: false, error: "Request body read timeout" });
+      }
+    }, timeoutMs);
+
     req.on("data", (chunk: Buffer) => {
       if (done) {
         return;
       }
       total += chunk.length;
       if (total > maxBytes) {
+        clearTimeout(timeout);
         done = true;
         resolve({ ok: false, error: "payload too large" });
         req.destroy();
@@ -96,6 +107,7 @@ export async function readJsonBody(
       if (done) {
         return;
       }
+      clearTimeout(timeout);
       done = true;
       const raw = Buffer.concat(chunks).toString("utf-8").trim();
       if (!raw) {
@@ -113,6 +125,7 @@ export async function readJsonBody(
       if (done) {
         return;
       }
+      clearTimeout(timeout);
       done = true;
       resolve({ ok: false, error: String(err) });
     });


### PR DESCRIPTION
Adds timeout mechanisms to three critical functions that could hang forever:

## Changes

### 1. waitForWaConnection() (#4956)
- Added 60s timeout (configurable)
- Prevents WhatsApp channel from hanging on connection issues
- Rejects with clear error message on timeout

### 2. readJsonBody() (#5122) - P0 Security
- Added 30s read timeout (configurable)
- Prevents Slowloris DoS attacks on webhook endpoint
- Cleans up request on timeout

### 3. GatewayClient.request() (#4954)
- Added 30s default timeout (configurable via opts.timeoutMs)
- Prevents memory leak in pending Map on unresponsive gateway
- Cleans up pending entry on timeout

## Pattern

All follow the same pattern:
- Add optional timeoutMs parameter with sensible defaults
- Use setTimeout to race against operation
- Clean up resources (pending entries, event listeners) on timeout
- Return clear error messages

## Impact

These fixes prevent resource exhaustion and improve availability when network conditions are poor or gateway is unresponsive.

Closes #4954, closes #4956, closes #5122

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds timeout protection to several I/O paths to avoid indefinite hangs: WhatsApp Web connection wait, webhook JSON body reads, and gateway RPC requests. It also includes a small daemon-output hardening change (safe writes for EPIPE/EIO) and launchd plist throttling.

The general direction is solid (timeouts + cleanup), but there are a couple of correctness gaps: the gateway request timeout is not actually configurable per call (despite the PR description) and the timeout handle is stored via an untyped escape hatch, which makes it easy to leak timers (notably when flushing pending requests). The webhook body read timeout is also not cleared on all connection termination paths (e.g. `close`).

<h3>Confidence Score: 3/5</h3>

- This PR is directionally good but has a couple of real correctness/cleanup bugs around timeouts that should be fixed before merge.
- Main risk is in `GatewayClient.request()` where timeouts are implemented via an untyped field and not cleared during bulk rejection; this can keep timers alive and cause late rejects. `readJsonBody()` also doesn’t clear timeout on all termination events.
- src/gateway/client.ts, src/gateway/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->