### PR TITLE
feat(skills): add timezone/world-clock skill

### DIFF
--- a/skills/timezone/SKILL.md
+++ b/skills/timezone/SKILL.md
@@ -37,11 +37,13 @@ done
 
 To convert 3:00 PM EST to other timezones:
 
+**GNU/Linux:**
+
 ```bash
 # Set the source time in EST
 SOURCE_TIME="2026-02-01 15:00:00"
 
-# Convert to PST
+# Convert to PST (GNU date uses -d)
 TZ="America/Los_Angeles" date -d "TZ=\"America/New_York\" $SOURCE_TIME" "+%H:%M %Z"
 # Output: 12:00 PST
 
@@ -50,28 +52,29 @@ TZ="UTC" date -d "TZ=\"America/New_York\" $SOURCE_TIME" "+%H:%M %Z"
 # Output: 20:00 UTC
 ```
 
-**macOS Note:** Use `-j -f` instead of `-d`:
+**macOS/BSD:**
 
 ```bash
-# macOS: Convert 3pm EST to PST
+# macOS date uses -j -f (incompatible with GNU date)
 TZ="America/Los_Angeles" date -j -f "%Y-%m-%d %H:%M:%S" "2026-02-01 15:00:00" "+%H:%M %Z"
+# Output: 12:00 PST
 ```
 
 ## Common timezone identifiers
 
-| Region | Timezone ID | Common Name |
-|--------|-------------|-------------|
-| US East | `America/New_York` | EST/EDT |
-| US Central | `America/Chicago` | CST/CDT |
-| US Mountain | `America/Denver` | MST/MDT |
-| US Pacific | `America/Los_Angeles` | PST/PDT |
-| UK | `Europe/London` | GMT/BST |
-| Central Europe | `Europe/Paris` | CET/CEST |
-| India | `Asia/Kolkata` | IST |
-| China | `Asia/Shanghai` | CST |
-| Japan | `Asia/Tokyo` | JST |
-| Australia East | `Australia/Sydney` | AEST/AEDT |
-| UTC | `UTC` | UTC |
+| Region         | Timezone ID           | Common Name |
+| -------------- | --------------------- | ----------- |
+| US East        | `America/New_York`    | EST/EDT     |
+| US Central     | `America/Chicago`     | CST/CDT     |
+| US Mountain    | `America/Denver`      | MST/MDT     |
+| US Pacific     | `America/Los_Angeles` | PST/PDT     |
+| UK             | `Europe/London`       | GMT/BST     |
+| Central Europe | `Europe/Paris`        | CET/CEST    |
+| India          | `Asia/Kolkata`        | IST         |
+| China          | `Asia/Shanghai`       | CST         |
+| Japan          | `Asia/Tokyo`          | JST         |
+| Australia East | `Australia/Sydney`    | AEST/AEDT   |
+| UTC            | `UTC`                 | UTC         |
 
 ## List all available timezones
 

--- a/skills/timezone/SKILL.md
+++ b/skills/timezone/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: timezone
+description: Get current time in any timezone and convert between timezones (no API key required).
+metadata: { "openclaw": { "emoji": "🕐", "requires": { "bins": ["date"] } } }
+---
+
+# Timezone / World Clock
+
+Query time in any timezone and convert between timezones using system tools. No API keys needed.
+
+## Get current time in a timezone
+
+```bash
+TZ="America/New_York" date "+%Y-%m-%d %H:%M:%S %Z"
+# Output: 2026-02-01 09:15:30 EST
+```
+
+```bash
+TZ="Asia/Tokyo" date "+%Y-%m-%d %H:%M:%S %Z"
+# Output: 2026-02-01 23:15:30 JST
+```
+
+```bash
+TZ="Europe/London" date "+%Y-%m-%d %H:%M:%S %Z"
+# Output: 2026-02-01 14:15:30 GMT
+```
+
+## Compare multiple timezones at once
+
+```bash
+for tz in "America/New_York" "Europe/London" "Asia/Tokyo"; do
+  echo "$tz: $(TZ=$tz date '+%H:%M %Z')"
+done
+```
+
+## Convert a specific time between timezones
+
+To convert 3:00 PM EST to other timezones:
+
+```bash
+# Set the source time in EST
+SOURCE_TIME="2026-02-01 15:00:00"
+
+# Convert to PST
+TZ="America/Los_Angeles" date -d "TZ=\"America/New_York\" $SOURCE_TIME" "+%H:%M %Z"
+# Output: 12:00 PST
+
+# Convert to UTC
+TZ="UTC" date -d "TZ=\"America/New_York\" $SOURCE_TIME" "+%H:%M %Z"
+# Output: 20:00 UTC
+```
+
+**macOS Note:** Use `-j -f` instead of `-d`:
+
+```bash
+# macOS: Convert 3pm EST to PST
+TZ="America/Los_Angeles" date -j -f "%Y-%m-%d %H:%M:%S" "2026-02-01 15:00:00" "+%H:%M %Z"
+```
+
+## Common timezone identifiers
+
+| Region | Timezone ID | Common Name |
+|--------|-------------|-------------|
+| US East | `America/New_York` | EST/EDT |
+| US Central | `America/Chicago` | CST/CDT |
+| US Mountain | `America/Denver` | MST/MDT |
+| US Pacific | `America/Los_Angeles` | PST/PDT |
+| UK | `Europe/London` | GMT/BST |
+| Central Europe | `Europe/Paris` | CET/CEST |
+| India | `Asia/Kolkata` | IST |
+| China | `Asia/Shanghai` | CST |
+| Japan | `Asia/Tokyo` | JST |
+| Australia East | `Australia/Sydney` | AEST/AEDT |
+| UTC | `UTC` | UTC |
+
+## List all available timezones
+
+```bash
+# List all timezone regions
+ls /usr/share/zoneinfo
+
+# List timezones in America
+ls /usr/share/zoneinfo/America
+
+# Find a timezone by city name
+find /usr/share/zoneinfo -name "*Tokyo*" -o -name "*Paris*" 2>/dev/null
+```
+
+## Get UTC offset for a timezone
+
+```bash
+TZ="America/New_York" date "+%z"
+# Output: -0500 (5 hours behind UTC)
+```
+
+## Tips
+
+- Timezone IDs are case-sensitive: use `America/New_York`, not `america/new_york`
+- DST is handled automatically based on the date
+- Use `UTC` or `Etc/UTC` for coordinated universal time
+- Airport codes don't work—use full timezone IDs


### PR DESCRIPTION
- Get current time in any timezone using TZ environment variable
- Convert times between timezones with examples
- Common timezone identifiers reference table
- No API keys required (uses standard date command)
- Includes macOS-specific notes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `timezone` skill documentation page describing how to:
- print the current time in a given timezone via the `TZ` environment variable and `date`
- convert between timezones using shell examples
- reference common timezone identifiers, plus macOS-specific notes

This fits the skills docs structure by providing a self-contained SKILL.md under `skills/timezone/` that can be surfaced as a built-in capability without requiring external APIs or keys.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; issues are limited to documentation accuracy/portability.
- Only a single markdown file is changed. The main risk is user confusion or broken copy/paste commands on non-macOS platforms due to `date -j` and non-IANA identifiers in the reference table.
- skills/timezone/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->