### PR TITLE
Docs: fix Moonshot MDX comment marker

### DIFF
--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/_ moonshot-kimi-k2-ids:start _/}
+{/* moonshot-kimi-k2-ids:start */}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  {/_ moonshot-kimi-k2-ids:end _/}
+{/* moonshot-kimi-k2-ids:end */}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key


### PR DESCRIPTION
## Summary
- replace HTML comments with MDX comment syntax in `docs/providers/moonshot.md`
- keep Moonshot provider docs rendering on Mintlify

## Testing
- not run (docs change only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/providers/moonshot.md` to use MDX-style comment blocks (`{/* ... */}`) instead of the previous HTML/MDX-incompatible marker syntax. This keeps the Moonshot provider documentation rendering correctly on Mintlify while preserving the start/end comment anchors around the Kimi K2 model ID list.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk (docs-only comment syntax change).
- Change is limited to two comment markers in a single docs file and does not affect runtime code; the new MDX comment syntax is valid and should improve Mintlify rendering.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->