### PR TITLE
feat: add project workspace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ apps/ios/*.mobileprovision
 # Local untracked files
 .local/
 .vscode/
+!.vscode/settings.json
 IDENTITY.md
 USER.md
 .tgz

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,248 @@
+{
+  // —— Workbench (aligned with project) ——
+  "workbench.list.smoothScrolling": true,
+  "workbench.startupEditor": "newUntitledFile",
+  "workbench.tree.indent": 10,
+  "workbench.editor.highlightModifiedTabs": true,
+  "workbench.editor.closeOnFileDelete": true,
+  "workbench.editor.limit.enabled": true,
+  "workbench.editor.limit.perEditorGroup": true,
+  "workbench.editor.limit.value": 5,
+
+  // —— Editor: TS/JS use oxfmt (2 spaces); Swift uses SwiftFormat (4) ——
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.cursorBlinking": "expand",
+  "editor.largeFileOptimizations": true,
+  "editor.accessibilitySupport": "off",
+  "editor.cursorSmoothCaretAnimation": "on",
+  "editor.guides.bracketPairs": "active",
+  "editor.inlineSuggest.enabled": true,
+  "editor.suggestSelection": "recentlyUsedByPrefix",
+  "editor.acceptSuggestionOnEnter": "smart",
+  "editor.suggest.snippetsPreventQuickSuggestions": false,
+  "editor.stickyScroll.enabled": true,
+  "editor.hover.sticky": true,
+  "editor.suggest.insertMode": "replace",
+  "editor.bracketPairColorization.enabled": true,
+  "editor.autoClosingBrackets": "beforeWhitespace",
+  "editor.autoClosingDelete": "always",
+  "editor.autoClosingOvertype": "always",
+  "editor.autoClosingQuotes": "beforeWhitespace",
+  "editor.wordSeparators": "`~!@#%^&*()=+[{]}\\|;:'\",.<>/?",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "never"
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[swift]": {
+    "editor.defaultFormatter": null,
+    "editor.tabSize": 4
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  // Oxc: enables oxlint (lint). CI/pre-commit use pnpm format (oxfmt) and pnpm lint (oxlint).
+  "oxc.enable": true,
+
+  // —— Extensions ——
+  "extensions.ignoreRecommendations": true,
+
+  // —— Terminal ——
+  "terminal.integrated.cursorBlinking": true,
+  "terminal.integrated.persistentSessionReviveProcess": "never",
+  "terminal.integrated.tabs.enabled": true,
+  "terminal.integrated.scrollback": 10000,
+  "terminal.integrated.stickyScroll.enabled": true,
+
+  // —— Files: EOL and exclusions aligned with .dockerignore / pre-commit ——
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.simpleDialog.enable": true,
+  "files.associations": {
+    "*.ejs": "html",
+    "*.art": "html",
+    "**/tsconfig.json": "jsonc",
+    "**/.oxlintrc.json": "jsonc",
+    "**/.oxfmtrc.jsonc": "jsonc",
+    "*.json": "jsonc",
+    "package.json": "json"
+  },
+  "files.exclude": {
+    "**/.eslintcache": true,
+    "**/bower_components": true,
+    "**/.turbo": true,
+    "**/.idea": true,
+    "**/.vitepress": true,
+    "**/tmp": true,
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.stylelintcache": true,
+    "**/.DS_Store": true,
+    "**/vite.config.mts.*": true,
+    "**/tea.yaml": true,
+    "**/.worktrees": true,
+    "**/.bun-cache": true,
+    "**/.bun": true,
+    "**/coverage": true,
+    "**/dist": true,
+    "**/node_modules": true
+  },
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.vscode/**": true,
+    "**/node_modules/**": true,
+    "**/tmp/**": true,
+    "**/bower_components/**": true,
+    "**/dist/**": true,
+    "**/yarn.lock": true,
+    "**/.worktrees/**": true,
+    "**/.bun-cache/**": true,
+    "**/.pnpm-store/**": true,
+    "**/.next/**": true,
+    "**/.cache/**": true
+  },
+
+  // —— TypeScript: use workspace TS (tsconfig.json) ——
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.tsserver.exclude": ["**/node_modules", "**/dist", "**/.turbo"],
+  "typescript.inlayHints.enumMemberValues.enabled": true,
+  "typescript.preferences.preferTypeOnlyAutoImports": true,
+  "typescript.preferences.includePackageJsonAutoImports": "on",
+
+  // —— Search: exclude build/cache/lockfiles (align with .dockerignore) ——
+  "search.searchEditor.singleClickBehaviour": "peekDefinition",
+  "search.followSymlinks": false,
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/*.log": true,
+    "**/*.log*": true,
+    "**/bower_components": true,
+    "**/dist": true,
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.DS_Store": true,
+    "**/.vitepress/cache": true,
+    "**/.idea": true,
+    "**/.vscode": false,
+    "**/.yarn": true,
+    "**/tmp": true,
+    "**/out": true,
+    "**/coverage": true,
+    "**/.turbo": true,
+    "**/pnpm-lock.yaml": true,
+    "**/yarn.lock": true,
+    "*.xml": true
+  },
+
+  // —— Explorer: file nesting (colocated tests, configs, tooling) ——
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "$(capture).test.ts, $(capture).test.tsx, $(capture).spec.ts, $(capture).spec.tsx, $(capture).e2e.test.ts, $(capture).browser.test.ts, $(capture).integration.test.ts, $(capture).fuzz.test.ts, $(capture).d.ts",
+    "*.tsx": "$(capture).test.ts, $(capture).test.tsx, $(capture).spec.ts, $(capture).spec.tsx, $(capture).e2e.test.ts, $(capture).browser.test.ts, $(capture).d.ts",
+    "*.js": "$(capture).test.js, $(capture).spec.js",
+    "*.mjs": "$(capture).test.mjs",
+    "*.env": "$(capture).env.*",
+    "*.env.example": ".env.*",
+    "README.md": "README*, CHANGELOG*, LICENSE, CNAME, CONTRIBUTING*, SECURITY*, AGENTS*, CLAUDE*",
+    "package.json": "pnpm-lock.yaml, pnpm-workspace.yaml, .gitattributes, .gitignore, .npmrc, .node-version, .nvmrc, openclaw.plugin.json",
+    "tsconfig.json": "tsconfig.*.json",
+    "vitest.config.ts": "vitest.*.config.ts",
+    "vite.config.ts": "vite.config.*.ts",
+    ".oxlintrc.json": ".oxfmtrc.jsonc",
+    ".swiftformat": ".swiftlint.yml",
+    ".swiftlint.yml": ".swiftformat",
+    ".gitignore": ".gitattributes, .editorconfig",
+    "Dockerfile": "Dockerfile.*, .dockerignore",
+    "docker-compose.yml": "Dockerfile, Dockerfile.*, .dockerignore, docker-compose.*",
+    "fly.toml": "fly.private.toml",
+    ".detect-secrets.cfg": ".secrets.baseline",
+    ".pre-commit-config.yaml": ".pre-commit-hooks.yaml",
+    "index.html": "vite.config.ts, vite.config.*.ts, vitest.config.ts"
+  },
+
+  // —— Linting: project uses oxlint (not ESLint in pre-commit); Swift: SwiftLint ——
+  "eslint.validate": ["javascript", "typescript", "javascriptreact", "typescriptreact", "vue", "html", "markdown", "json", "jsonc"],
+  "stylelint.enable": false,
+
+  // —— Error Lens: avoid duplicating oxlint ——
+  "errorLens.enabledDiagnosticLevels": ["warning", "error"],
+  "errorLens.excludeBySource": ["cSpell", "Grammarly", "eslint", "oxlint"],
+
+  // —— Project / package manager ——
+  "npm.packageManager": "pnpm",
+  "debug.onTaskErrors": "debugAnyway",
+  "diffEditor.ignoreTrimWhitespace": false,
+
+  // —— CSS / UI (optional): validate off; cssVariables for ui/ if needed ——
+  "css.validate": false,
+  "less.validate": false,
+  "scss.validate": false,
+  "cssVariables.lookupFiles": ["ui/src/**/*.css"],
+
+  // —— Emmet ——
+  "emmet.showSuggestionsAsSnippets": true,
+  "emmet.triggerExpansionOnTab": false,
+
+  // —— Tailwind (if used in ui/) ——
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ],
+
+  // —— Copilot ——
+  "github.copilot.enable": {
+    "*": true,
+    "markdown": true,
+    "plaintext": false,
+    "yaml": false
+  },
+
+  // —— i18n-ally: disable or point to ui if used ——
+  "i18n-ally.localesPaths": [],
+  "i18n-ally.enabledFrameworks": ["vue", "react"],
+  "i18n-ally.sourceLanguage": "en",
+
+  // —— Vue (ui may use) ——
+  "vue.server.hybridMode": true
+}

--- a/clawdbot.code-workspace
+++ b/clawdbot.code-workspace
@@ -1,0 +1,181 @@
+{
+  "folders": [
+    {
+      "name": "OpenClaw",
+      "path": "."
+    },
+    {
+      "name": "Apps · Android",
+      "path": "apps/android"
+    },
+    {
+      "name": "Apps · iOS",
+      "path": "apps/ios"
+    },
+    {
+      "name": "Apps · macOS",
+      "path": "apps/macos"
+    },
+    {
+      "name": "Apps · Shared",
+      "path": "apps/shared"
+    },
+    {
+      "name": "Docs",
+      "path": "docs"
+    },
+    {
+      "name": "Extensions · bluebubbles",
+      "path": "extensions/bluebubbles"
+    },
+    {
+      "name": "Extensions · copilot-proxy",
+      "path": "extensions/copilot-proxy"
+    },
+    {
+      "name": "Extensions · diagnostics-otel",
+      "path": "extensions/diagnostics-otel"
+    },
+    {
+      "name": "Extensions · discord",
+      "path": "extensions/discord"
+    },
+    {
+      "name": "Extensions · google-antigravity-auth",
+      "path": "extensions/google-antigravity-auth"
+    },
+    {
+      "name": "Extensions · google-gemini-cli-auth",
+      "path": "extensions/google-gemini-cli-auth"
+    },
+    {
+      "name": "Extensions · googlechat",
+      "path": "extensions/googlechat"
+    },
+    {
+      "name": "Extensions · imessage",
+      "path": "extensions/imessage"
+    },
+    {
+      "name": "Extensions · line",
+      "path": "extensions/line"
+    },
+    {
+      "name": "Extensions · llm-task",
+      "path": "extensions/llm-task"
+    },
+    {
+      "name": "Extensions · lobster",
+      "path": "extensions/lobster"
+    },
+    {
+      "name": "Extensions · matrix",
+      "path": "extensions/matrix"
+    },
+    {
+      "name": "Extensions · mattermost",
+      "path": "extensions/mattermost"
+    },
+    {
+      "name": "Extensions · memory-core",
+      "path": "extensions/memory-core"
+    },
+    {
+      "name": "Extensions · memory-lancedb",
+      "path": "extensions/memory-lancedb"
+    },
+    {
+      "name": "Extensions · minimax-portal-auth",
+      "path": "extensions/minimax-portal-auth"
+    },
+    {
+      "name": "Extensions · msteams",
+      "path": "extensions/msteams"
+    },
+    {
+      "name": "Extensions · nextcloud-talk",
+      "path": "extensions/nextcloud-talk"
+    },
+    {
+      "name": "Extensions · nostr",
+      "path": "extensions/nostr"
+    },
+    {
+      "name": "Extensions · open-prose",
+      "path": "extensions/open-prose"
+    },
+    {
+      "name": "Extensions · qwen-portal-auth",
+      "path": "extensions/qwen-portal-auth"
+    },
+    {
+      "name": "Extensions · signal",
+      "path": "extensions/signal"
+    },
+    {
+      "name": "Extensions · slack",
+      "path": "extensions/slack"
+    },
+    {
+      "name": "Extensions · telegram",
+      "path": "extensions/telegram"
+    },
+    {
+      "name": "Extensions · tlon",
+      "path": "extensions/tlon"
+    },
+    {
+      "name": "Extensions · twitch",
+      "path": "extensions/twitch"
+    },
+    {
+      "name": "Extensions · voice-call",
+      "path": "extensions/voice-call"
+    },
+    {
+      "name": "Extensions · whatsapp",
+      "path": "extensions/whatsapp"
+    },
+    {
+      "name": "Extensions · zalo",
+      "path": "extensions/zalo"
+    },
+    {
+      "name": "Extensions · zalouser",
+      "path": "extensions/zalouser"
+    },
+    {
+      "name": "Packages · clawdbot",
+      "path": "packages/clawdbot"
+    },
+    {
+      "name": "Packages · moltbot",
+      "path": "packages/moltbot"
+    },
+    {
+      "name": "Scripts",
+      "path": "scripts"
+    },
+    {
+      "name": "Skills",
+      "path": "skills"
+    },
+    {
+      "name": "Source",
+      "path": "src"
+    },
+    {
+      "name": "Swabble",
+      "path": "Swabble"
+    },
+    {
+      "name": "UI",
+      "path": "ui"
+    },
+    {
+      "name": "Vendor",
+      "path": "vendor"
+    }
+  ],
+  "settings": {}
+}


### PR DESCRIPTION
feat: add project workspace. for clearly development path of module.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a VS Code workspace file (`clawdbot.code-workspace`) that defines a multi-folder view of the OpenClaw repo, enumerating many apps/extensions/packages directories for easier navigation during development.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk because it only adds an editor workspace file, but it may add unwanted repo noise/maintenance burden.
- No runtime code changes are introduced, so there’s little chance of breaking builds/tests. Main concern is repo hygiene: committing an IDE-specific workspace file can be contentious and can drift as the directory structure evolves.
- clawdbot.code-workspace

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->