### PR TITLE
feat: add light theme support for terminal UI

### DIFF
--- a/src/terminal/palette.ts
+++ b/src/terminal/palette.ts
@@ -1,6 +1,8 @@
 // Lobster palette tokens for CLI/UI theming. "lobster seam" == use this palette.
 // Keep in sync with docs/cli/index.md (CLI palette section).
-export const LOBSTER_PALETTE = {
+
+// Dark theme palette (default) - bright colors for dark backgrounds
+const LOBSTER_PALETTE_DARK = {
   accent: "#FF5A2D",
   accentBright: "#FF7A3D",
   accentDim: "#D14A22",
@@ -10,3 +12,19 @@ export const LOBSTER_PALETTE = {
   error: "#E23D2D",
   muted: "#8B7F77",
 } as const;
+
+// Light theme palette - darker colors for light backgrounds
+const LOBSTER_PALETTE_LIGHT = {
+  accent: "#C43D1A",
+  accentBright: "#D14A22",
+  accentDim: "#A03015",
+  info: "#B35C2A",
+  success: "#1A8A4A",
+  warn: "#B37A00",
+  error: "#B32020",
+  muted: "#5A534D",
+} as const;
+
+// Select palette based on OPENCLAW_THEME env var
+const isLightTheme = process.env.OPENCLAW_THEME?.toLowerCase() === "light";
+export const LOBSTER_PALETTE = isLightTheme ? LOBSTER_PALETTE_LIGHT : LOBSTER_PALETTE_DARK;

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -9,7 +9,8 @@ import { highlight, supportsLanguage } from "cli-highlight";
 import type { SearchableSelectListTheme } from "../components/searchable-select-list.js";
 import { createSyntaxTheme } from "./syntax-theme.js";
 
-const palette = {
+// Dark theme palette (default)
+const darkPalette = {
   text: "#E8E3D5",
   dim: "#7B7F87",
   accent: "#F6C453",
@@ -32,6 +33,35 @@ const palette = {
   error: "#F97066",
   success: "#7DD3A5",
 };
+
+// Light theme palette (for light terminal backgrounds)
+const lightPalette = {
+  text: "#1A1A1A",
+  dim: "#666666",
+  accent: "#B8860B",
+  accentSoft: "#CD853F",
+  border: "#CCCCCC",
+  userBg: "#F0F0F0",
+  userText: "#1A1A1A",
+  systemText: "#555555",
+  toolPendingBg: "#E8F4F8",
+  toolSuccessBg: "#E8F5E9",
+  toolErrorBg: "#FFEBEE",
+  toolTitle: "#B8860B",
+  toolOutput: "#333333",
+  quote: "#0066CC",
+  quoteBorder: "#99CCFF",
+  code: "#8B4513",
+  codeBlock: "#F5F5F5",
+  codeBorder: "#DDDDDD",
+  link: "#228B22",
+  error: "#CC0000",
+  success: "#228B22",
+};
+
+// Select palette based on OPENCLAW_THEME env var
+const isLightTheme = process.env.OPENCLAW_THEME?.toLowerCase() === "light";
+const palette = isLightTheme ? lightPalette : darkPalette;
 
 const fg = (hex: string) => (text: string) => chalk.hex(hex)(text);
 const bg = (hex: string) => (text: string) => chalk.bgHex(hex)(text);


### PR DESCRIPTION
## Summary

- Add `OPENCLAW_THEME=light` environment variable support for light terminal backgrounds
- Add light-friendly color palettes for both TUI and CLI components

## Problem

Users with light terminal backgrounds (e.g., white bg in macOS Terminal) have difficulty reading OpenClaw's output because the default colors are optimized for dark backgrounds.

## Solution

- Added `lightPalette` in `src/tui/theme/theme.ts` with darker colors suitable for light backgrounds
- Added `LOBSTER_PALETTE_LIGHT` in `src/terminal/palette.ts` with adjusted CLI colors
- Both palettes check `process.env.OPENCLAW_THEME` at startup

## Usage

```bash
export OPENCLAW_THEME=light
openclaw ...
```

## Test plan

- [x] Verify `OPENCLAW_THEME=light bun src/entry.ts help` shows readable colors
- [x] Verify default (dark) theme unchanged when env var not set
- [x] Lint passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds light-theme support for terminal output by introducing separate dark/light color palettes for both CLI (`src/terminal/palette.ts`) and TUI (`src/tui/theme/theme.ts`). The active palette is selected at startup via `OPENCLAW_THEME=light`, improving readability on light terminal backgrounds while keeping the default dark theme unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should improve readability, with minor behavior caveats around when the env var is read.
- Changes are localized to palette selection and color constants. Main risk is that `OPENCLAW_THEME` is read only at module initialization, which can be surprising for runtime switching and can affect test isolation in long-lived processes; otherwise the logic is straightforward.
- src/terminal/palette.ts, src/tui/theme/theme.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->