### PR TITLE
Fix signal-cli installation on ARM64 architectures

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -42,6 +42,22 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
     withName.find((asset) => pattern.test(asset.name.toLowerCase()));
 
   if (platform === "linux") {
+    const arch = os.arch();
+    const isArm = arch === "arm64" || arch === "aarch64" || arch === "arm";
+
+    // On ARM architectures, prefer the JAR version (no native binaries available)
+    if (isArm) {
+      return (
+        withName.find((asset) =>
+          !asset.name.toLowerCase().includes("native") &&
+          looksLikeArchive(asset.name.toLowerCase())
+        ) ||
+        byName(/linux/) ||
+        withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
+      );
+    }
+
+    // On x86_64, prefer native binaries for better performance
     return (
       byName(/linux-native/) ||
       byName(/linux/) ||

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -43,7 +43,7 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
 
   if (platform === "linux") {
     const arch = os.arch();
-    const isArm = arch === "arm64" || arch === "aarch64" || arch === "arm";
+    const isArm = arch === "arm64" || arch === "arm" || arch.startsWith("arm");
 
     // On ARM architectures, prefer the JAR version (no native binaries available)
     if (isArm) {

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -43,8 +43,7 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
 
   if (platform === "linux") {
     const arch = os.arch();
-    const isArm =
-      arch === "arm64" || arch === "aarch64" || arch === "arm" || arch.startsWith("arm");
+    const isArm = arch === "arm64" || arch === "arm" || arch.startsWith("arm");
 
     // On ARM architectures, prefer the JAR version (no native binaries available)
     if (isArm) {

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -43,14 +43,16 @@ function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
 
   if (platform === "linux") {
     const arch = os.arch();
-    const isArm = arch === "arm64" || arch === "arm" || arch.startsWith("arm");
+    const isArm =
+      arch === "arm64" || arch === "aarch64" || arch === "arm" || arch.startsWith("arm");
 
     // On ARM architectures, prefer the JAR version (no native binaries available)
     if (isArm) {
       return (
-        withName.find((asset) =>
-          !asset.name.toLowerCase().includes("native") &&
-          looksLikeArchive(asset.name.toLowerCase())
+        withName.find(
+          (asset) =>
+            !asset.name.toLowerCase().includes("native") &&
+            looksLikeArchive(asset.name.toLowerCase()),
         ) ||
         byName(/linux/) ||
         withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))


### PR DESCRIPTION
## Problem

The signal-cli installer was downloading and attempting to use x86-64 native binaries on all Linux systems, causing "exec format error" on ARM64 platforms like Raspberry Pi.

## Solution

This PR adds architecture detection to select the appropriate signal-cli release:
- **ARM64/aarch64/arm**: Downloads the JAR version (platform-independent)
- **x86_64**: Continues using native binaries for optimal performance

## Technical Details

The JAR version includes all necessary native libraries (libsignal-client) and works reliably across all architectures when paired with the system's Java runtime.

## Testing

Tested on:
- Raspberry Pi (aarch64) - Successfully downloads and runs JAR version
- Should maintain existing behavior on x86_64 systems

## Related Issues

Fixes installation issues on Raspberry Pi and other ARM64 Linux systems where users encountered:
```
zsh: exec format error: ./signal-cli
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the signal-cli installer to select different release assets on Linux based on CPU architecture: ARM platforms prefer the platform-independent archive (avoiding x86_64 native binaries), while x86_64 continues to prefer `linux-native` for performance. The selection happens in `pickAsset` and feeds into the existing download/extract/install flow used by Signal onboarding.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one correctness concern in the ARM architecture detection logic.
- The change is localized to asset selection and keeps existing Linux/x86 behavior, but the `os.arch()` check includes a non-returned value (`"aarch64"`) and may not cover all ARM variants, which could still lead to selecting native binaries on some ARM systems.
- src/commands/signal-install.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->