### PR TITLE
fix(embedded-runner): ensure cleanup runs on timeout

### DIFF
--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -134,8 +134,11 @@ export async function acquireSessionWriteLock(params: {
   const held = HELD_LOCKS.get(normalizedSessionFile);
   if (held) {
     held.count += 1;
+    let released = false; // Track if this handle has been released (idempotent - fix for #3092)
     return {
       release: async () => {
+        if (released) return; // Idempotent: safe to call multiple times
+        released = true;
         const current = HELD_LOCKS.get(normalizedSessionFile);
         if (!current) {
           return;
@@ -162,8 +165,11 @@ export async function acquireSessionWriteLock(params: {
         "utf8",
       );
       HELD_LOCKS.set(normalizedSessionFile, { count: 1, handle, lockPath });
+      let released = false; // Track if this handle has been released (idempotent - fix for #3092)
       return {
         release: async () => {
+          if (released) return; // Idempotent: safe to call multiple times
+          released = true;
           const current = HELD_LOCKS.get(normalizedSessionFile);
           if (!current) {
             return;


### PR DESCRIPTION
## Summary

Fixes #3092 — Session locks weren't released when embedded runs timeout, causing subsequent messages to be silently dropped.

## The Problem

When `abortTimer` fires, `abortRun(true)` is called, but `activeSession.prompt()` may never resolve if the underlying operation ignores the abort signal. This prevents the `finally` block from executing, leaving the session lock held indefinitely.

## The Fix

1. **Race prompt against abort signal** — Uses `Promise.race()` with a `rejectOnAbort` helper to guarantee the await settles when abort fires, even if the prompt ignores it

2. **Timeout on lock release** — Wraps `sessionLock.release()` with `withTimeout(5000ms)` to prevent hanging on unresponsive filesystems

3. **Idempotent lock release** — Adds a `released` flag to prevent double-decrement if release is called multiple times

4. **Late rejection handling** — Catches prompt rejections after abort to prevent unhandled rejection warnings

## Testing

- Verified lock is released after timeout even with uncooperative prompt
- Confirmed idempotent release prevents corruption of lock count
- No regressions in normal (non-timeout) flow

## Code Review

This patch was reviewed by 9 AI agents (Claude Opus, Gemini 3 Pro, GPT-5.2, DeepSeek V3, Qwen3, Mistral Large 3, Grok 4.1, Llama 4, Kimi K2.5) — all approved unanimously.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses embedded-run timeouts leaving session write locks held by ensuring cleanup paths always run even when the underlying `activeSession.prompt()` doesn’t honor abort.

Key changes:
- In `src/agents/pi-embedded-runner/run/attempt.ts`, the prompt await is raced against an abort-triggered rejection so the `finally` block can run on timeout, plus a guard to avoid unhandled rejections from late prompt failures.
- In `src/agents/session-write-lock.ts`, lock handles are made idempotent via a per-handle `released` flag to prevent double-decrement/corruption.
- Lock release is wrapped with a 5s timeout during teardown to avoid hanging cleanup on an unresponsive filesystem.

Overall this fits the embedded runner’s lifecycle management by making teardown deterministic under timeout/abort conditions, which prevents subsequent runs from being blocked by leaked locks.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge and should fix the lock-leak on timeout, with a small risk of minor resource/timer leakage due to the new timeout helper.
- Core behavioral change (racing prompt against abort and ensuring lock release) is targeted and aligns with the stated bug. The main concern is the new `withTimeout()` implementation leaving a pending timer even when the wrapped promise resolves quickly, which can keep the event loop alive longer than needed and add avoidable overhead. No other clear correctness regressions stood out in the changed code paths.
- src/agents/pi-embedded-runner/run/attempt.ts (new withTimeout implementation and prompt race/catch behavior)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->