### PR TITLE
adding framework for 1Password integration

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -10,6 +10,39 @@ title: "config"
 Config helpers: get/set/unset values by path. Run without a subcommand to open
 the configure wizard (same as `openclaw configure`).
 
+## Secrets
+
+Use the secrets helper to migrate sensitive values in `openclaw.json` to
+`${ENV_VAR}` references. This keeps secrets out of the config file and lets
+you source them from 1Password or another password manager.
+
+```bash
+openclaw config secrets plan
+openclaw config secrets apply
+```
+
+### 1Password setup
+
+Store the env vars in 1Password and inject them at runtime. Example workflow:
+
+```bash
+openclaw config secrets plan --prefix OPENCLAW_SECRET_
+# Create a template with 1Password references (example values).
+cat > ~/.openclaw/openclaw.env.tpl <<'EOF'
+OPENCLAW_GATEWAY_TOKEN=op://Vault/OpenClaw/Gateway Token
+TELEGRAM_BOT_TOKEN=op://Vault/OpenClaw/Telegram Bot Token
+OPENCLAW_SECRET_TOOLS_WEB_SEARCH_APIKEY=op://Vault/OpenClaw/Brave Search
+EOF
+
+op inject -i ~/.openclaw/openclaw.env.tpl -o ~/.openclaw/openclaw.env
+set -a
+source ~/.openclaw/openclaw.env
+set +a
+openclaw config secrets apply
+```
+
+Restart the gateway after updating secrets.
+
 ## Examples
 
 ```bash

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -351,6 +351,8 @@ Subcommands:
 - `config get <path>`: print a config value (dot/bracket path).
 - `config set <path> <value>`: set a value (JSON5 or raw string).
 - `config unset <path>`: remove a value.
+- `config secrets plan`: list sensitive config values and suggested env vars.
+- `config secrets apply`: replace sensitive config values with `${ENV_VAR}`.
 
 ### `doctor`
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -14,6 +14,53 @@ function isIndexSegment(raw: string): boolean {
   return /^[0-9]+$/.test(raw);
 }
 
+type SecretMatch = {
+  path: string;
+  segments: PathSegment[];
+  value: string;
+  envVar: string;
+  source: "mapped" | "generated";
+  status: "static" | "env";
+};
+
+const SECRET_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SECRET_KEY_EXACT = new Set(["serviceAccount"]);
+const SECRET_KEY_SKIP_SUFFIXES = ["file", "path", "dir"];
+const SECRET_ENV_OVERRIDES: Record<string, string> = {
+  "gateway.auth.token": "OPENCLAW_GATEWAY_TOKEN",
+  "gateway.auth.password": "OPENCLAW_GATEWAY_PASSWORD",
+  "channels.telegram.botToken": "TELEGRAM_BOT_TOKEN",
+  "channels.discord.token": "DISCORD_BOT_TOKEN",
+  "channels.slack.botToken": "SLACK_BOT_TOKEN",
+  "channels.slack.appToken": "SLACK_APP_TOKEN",
+  "channels.line.channelAccessToken": "LINE_CHANNEL_ACCESS_TOKEN",
+  "channels.line.channelSecret": "LINE_CHANNEL_SECRET",
+  "tools.web.search.apiKey": "BRAVE_API_KEY",
+  "tools.web.search.perplexity.apiKey": "PERPLEXITY_API_KEY",
+  "tools.web.fetch.firecrawl.apiKey": "FIRECRAWL_API_KEY",
+  "talk.apiKey": "ELEVENLABS_API_KEY",
+  "messages.tts.elevenlabs.apiKey": "ELEVENLABS_API_KEY",
+  "messages.tts.openai.apiKey": "OPENAI_API_KEY",
+};
+const PROVIDER_ENV_OVERRIDES: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GEMINI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  synthetic: "SYNTHETIC_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  moonshot: "MOONSHOT_API_KEY",
+  venice: "VENICE_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+};
+
 function parsePath(raw: string): PathSegment[] {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -66,6 +113,18 @@ function parsePath(raw: string): PathSegment[] {
   return parts.map((part) => part.trim()).filter(Boolean);
 }
 
+function formatPath(segments: PathSegment[]): string {
+  let out = "";
+  for (const segment of segments) {
+    if (isIndexSegment(segment)) {
+      out += `[${segment}]`;
+      continue;
+    }
+    out = out ? `${out}.${segment}` : segment;
+  }
+  return out;
+}
+
 function parseValue(raw: string, opts: { json?: boolean }): unknown {
   const trimmed = raw.trim();
   if (opts.json) {
@@ -107,6 +166,181 @@ function getAtPath(root: unknown, path: PathSegment[]): { found: boolean; value?
     current = record[segment];
   }
   return { found: true, value: current };
+}
+
+function normalizeEnvPrefix(raw: string | undefined): string {
+  const cleaned = (raw ?? "").trim() || "OPENCLAW_SECRET_";
+  const withUnderscore = cleaned.endsWith("_") ? cleaned : `${cleaned}_`;
+  return withUnderscore.replace(/[^A-Za-z0-9_]/g, "_").toUpperCase();
+}
+
+function sanitizeEnvSegment(segment: string): string {
+  if (!segment) {
+    return "";
+  }
+  return segment
+    .replace(/[^A-Za-z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .toUpperCase();
+}
+
+function generateEnvVar(segments: PathSegment[], prefix: string): string {
+  const tokens = segments.map((segment) => sanitizeEnvSegment(segment)).filter(Boolean);
+  return `${prefix}${tokens.join("_")}`.replace(/_+/g, "_");
+}
+
+function parseEnvReference(value: string): string | null {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^\$\{([A-Z_][A-Z0-9_]*)\}$/);
+  return match ? match[1] : null;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const trimmed = key.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  if (SECRET_KEY_SKIP_SUFFIXES.some((suffix) => lower.endsWith(suffix))) {
+    return false;
+  }
+  if (SECRET_KEY_EXACT.has(trimmed)) {
+    return true;
+  }
+  return SECRET_KEY_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function resolveEnvVarForPath(
+  segments: PathSegment[],
+  prefix: string,
+): { envVar: string; source: "mapped" | "generated" } {
+  const path = formatPath(segments);
+  const direct = SECRET_ENV_OVERRIDES[path];
+  if (direct) {
+    return { envVar: direct, source: "mapped" };
+  }
+  if (
+    segments.length >= 4 &&
+    segments[0] === "models" &&
+    segments[1] === "providers" &&
+    segments[3] === "apiKey"
+  ) {
+    const providerId = segments[2]?.toLowerCase() ?? "";
+    const providerEnv = PROVIDER_ENV_OVERRIDES[providerId];
+    if (providerEnv) {
+      return { envVar: providerEnv, source: "mapped" };
+    }
+  }
+  return { envVar: generateEnvVar(segments, prefix), source: "generated" };
+}
+
+function maskSecret(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "<empty>";
+  }
+  if (trimmed.length <= 6) {
+    return "***";
+  }
+  return `${trimmed.slice(0, 3)}...${trimmed.slice(-2)}`;
+}
+
+function collectSecretMatches(params: {
+  root: unknown;
+  prefix: string;
+  includeEnvRefs?: boolean;
+}): SecretMatch[] {
+  const matches: SecretMatch[] = [];
+  const visit = (value: unknown, segments: PathSegment[]) => {
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => visit(entry, [...segments, String(index)]));
+      return;
+    }
+    if (!value || typeof value !== "object") {
+      return;
+    }
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      const nextSegments = [...segments, key];
+      if (isSensitiveKey(key)) {
+        const rawValue =
+          typeof entry === "string"
+            ? entry
+            : SECRET_KEY_EXACT.has(key) && entry && typeof entry === "object"
+              ? (() => {
+                  try {
+                    return JSON.stringify(entry);
+                  } catch {
+                    return "";
+                  }
+                })()
+              : null;
+        if (typeof rawValue === "string") {
+          const envRef = parseEnvReference(rawValue);
+          if (envRef && !params.includeEnvRefs) {
+            continue;
+          }
+          const resolved = envRef
+            ? { envVar: envRef, source: "mapped" as const }
+            : resolveEnvVarForPath(nextSegments, params.prefix);
+          matches.push({
+            path: formatPath(nextSegments),
+            segments: nextSegments,
+            value: rawValue,
+            envVar: resolved.envVar,
+            source: resolved.source,
+            status: envRef ? "env" : "static",
+          });
+          continue;
+        }
+      }
+      visit(entry, nextSegments);
+    }
+  };
+  visit(params.root, []);
+  matches.sort((a, b) => a.path.localeCompare(b.path));
+  const reserved = new Set(matches.filter((match) => match.status === "env").map((m) => m.envVar));
+  const used = new Set<string>(reserved);
+  const seenValueByEnv = new Map<string, string>();
+  for (const match of matches) {
+    if (match.status !== "static") {
+      continue;
+    }
+    if (reserved.has(match.envVar)) {
+      const base = generateEnvVar(match.segments, params.prefix);
+      let candidate = base;
+      let suffix = 2;
+      while (used.has(candidate)) {
+        candidate = `${base}_${suffix}`;
+        suffix += 1;
+      }
+      match.envVar = candidate;
+      match.source = "generated";
+      used.add(candidate);
+      seenValueByEnv.set(candidate, match.value);
+      continue;
+    }
+    const existing = seenValueByEnv.get(match.envVar);
+    if (!existing) {
+      used.add(match.envVar);
+      seenValueByEnv.set(match.envVar, match.value);
+      continue;
+    }
+    if (existing === match.value) {
+      continue;
+    }
+    const base = generateEnvVar(match.segments, params.prefix);
+    let candidate = base;
+    let suffix = 2;
+    while (used.has(candidate) && seenValueByEnv.get(candidate) !== match.value) {
+      candidate = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    match.envVar = candidate;
+    match.source = "generated";
+    used.add(candidate);
+    seenValueByEnv.set(candidate, match.value);
+  }
+  return matches;
 }
 
 function setAtPath(root: Record<string, unknown>, path: PathSegment[], value: unknown): void {
@@ -336,6 +570,92 @@ export function registerConfigCli(program: Command) {
         }
         await writeConfigFile(next);
         defaultRuntime.log(info(`Removed ${path}. Restart the gateway to apply.`));
+      } catch (err) {
+        defaultRuntime.error(danger(String(err)));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  const secrets = cmd
+    .command("secrets")
+    .description("Plan/apply env var migrations for sensitive config values");
+
+  secrets
+    .command("plan")
+    .description("List secrets in config and suggested env vars")
+    .option("--prefix <prefix>", "Env var prefix for generated names", "OPENCLAW_SECRET_")
+    .action(async (opts) => {
+      try {
+        const snapshot = await loadValidConfig();
+        const prefix = normalizeEnvPrefix(opts.prefix);
+        const matches = collectSecretMatches({
+          root: snapshot.config,
+          prefix,
+          includeEnvRefs: true,
+        });
+        if (matches.length === 0) {
+          defaultRuntime.log(info("No secret values found in config."));
+          return;
+        }
+        const pending = matches.filter((match) => match.status === "static");
+        const existing = matches.filter((match) => match.status === "env");
+        defaultRuntime.log(
+          info(
+            `Found ${matches.length} secret value(s) in ${shortenHomePath(
+              snapshot.path,
+            )} (${pending.length} to migrate).`,
+          ),
+        );
+        for (const match of matches) {
+          const status =
+            match.status === "env" ? "already env" : `value ${maskSecret(match.value)}`;
+          const source = match.source === "mapped" ? "mapped" : "generated";
+          defaultRuntime.log(`- ${match.path} -> ${match.envVar} (${status}; ${source})`);
+        }
+        if (pending.length > 0) {
+          defaultRuntime.log(
+            info(
+              `Store these env vars in 1Password (op run / op inject) or another manager, then run "${formatCliCommand(
+                "openclaw config secrets apply",
+              )}".`,
+            ),
+          );
+        } else if (existing.length > 0) {
+          defaultRuntime.log(info("All detected secrets already use env references."));
+        }
+      } catch (err) {
+        defaultRuntime.error(danger(String(err)));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  secrets
+    .command("apply")
+    .description("Replace secret values with ${ENV_VAR} references")
+    .option("--prefix <prefix>", "Env var prefix for generated names", "OPENCLAW_SECRET_")
+    .action(async (opts) => {
+      try {
+        const snapshot = await loadValidConfig();
+        const prefix = normalizeEnvPrefix(opts.prefix);
+        const matches = collectSecretMatches({
+          root: snapshot.config,
+          prefix,
+          includeEnvRefs: false,
+        });
+        if (matches.length === 0) {
+          defaultRuntime.log(info("No secret values found to migrate."));
+          return;
+        }
+        const next = snapshot.config as Record<string, unknown>;
+        for (const match of matches) {
+          setAtPath(next, match.segments, `\${${match.envVar}}`);
+        }
+        await writeConfigFile(next);
+        defaultRuntime.log(
+          info(
+            `Updated ${matches.length} secret value(s). Set the env vars before restarting the gateway.`,
+          ),
+        );
       } catch (err) {
         defaultRuntime.error(danger(String(err)));
         defaultRuntime.exit(1);


### PR DESCRIPTION
This creates the framework necessary to add in the ability to store secrets in a password manager such as 1Password. More validation is needed. This implementation was done with ChatGPT Codex.

Signed-off-by: Matthew A. Davis <mdavis@fhrp.org>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `openclaw config secrets` command group with `plan` and `apply` subcommands to help migrate sensitive values in `openclaw.json` into `${ENV_VAR}` references, along with CLI docs describing the workflow (including a 1Password-based example).

In the codebase, the new logic lives in `src/cli/config-cli.ts` alongside existing `config get/set/unset` commands, using a heuristic scanner to find likely secret fields and generate/match environment variable names (with some explicit per-path/provider overrides). Docs are updated in `docs/cli/config.md` and the command tree summary in `docs/cli/index.md`.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a bug that writes incorrect `${ENV_VAR}` placeholders during secret migration.
- Main functionality is straightforward, but `config secrets apply` currently emits `\${ENV}` instead of `${ENV}`, which breaks the core promise of the feature and will confuse users; remaining items are mostly doc portability and heuristic coverage concerns.
- src/cli/config-cli.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->