### PR TITLE
fix(agent-runner): drain followup queue on exception

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,12 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -520,5 +525,10 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Ensure followup queue is drained even if an exception was thrown.
+    // Normal return paths call finalizeWithFollowup which drains the queue,
+    // but exceptions skip that - this ensures queued messages aren't lost.
+    // (Fix for #5951)
+    scheduleFollowupDrain(queueKey, runFollowupTurn);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5951 — Queued followup messages are lost when an agent run throws an exception.

## The Problem

When `runAgentTurnWithFallback` throws an exception, control jumps to the `finally` block which only cleans up the typing indicator and block reply pipeline. The followup queue is never drained because all normal return paths go through `finalizeWithFollowup`, which exceptions bypass.

This causes messages queued via `enqueueFollowupRun()` during the run to be orphaned in `FOLLOWUP_QUEUES` forever (until process restart).

## The Fix

Call `scheduleFollowupDrain(queueKey, runFollowupTurn)` in the `finally` block. This ensures the followup queue is processed even when the run fails with an exception.

This is safe because:
- `scheduleFollowupDrain` checks if the queue exists and isn't already draining before doing anything
- If the queue was already drained via `finalizeWithFollowup`, this is a no-op
- The `queueKey` and `runFollowupTurn` are defined before the `try` block, so they're always available

## Testing

- Verified that followup queue is drained after run throws exception
- Confirmed normal (non-exception) flow still works correctly
- No duplicate draining due to idempotent check in `scheduleFollowupDrain`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `runReplyAgent` (`src/auto-reply/reply/agent-runner.ts`) to ensure the followup queue is drained even when `runAgentTurnWithFallback` throws. It does this by importing `scheduleFollowupDrain` and calling it from the `finally` block; normal return paths already go through `finalizeWithFollowup`, which schedules the same drain on successful completion. The change aligns with the existing followup-queue design (idempotent drain guard) and addresses the reported orphaned-queue behavior in #5951.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped: it adds a followup-drain call in a `finally` block, and the drain function is explicitly guarded (`!queue || queue.draining`) so it becomes a no-op when a drain is already in progress or the queue is empty. No behavior changes occur outside exception paths beyond an extra guarded call.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->