### PR TITLE
fix(ux): update gateway token error message UI location

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1409,7 +1409,7 @@ Notes:
 
 ### Why do I need a token on localhost now
 
-OpenClaw enforces token auth by default, including loopback. If no token is configured, gateway startup auto-generates one and saves it to `gateway.auth.token`, so **local WS clients must authenticate**. This blocks other local processes from calling the Gateway.
+OpenClaw enforces token auth by default, including loopback. If no token is configured, gateway startup auto-generates one and saves it to `gateway.auth.token`, so **local WS clients must authenticate**. This blocks other local processes from calling the Gateway. Paste the token into the Overview → Gateway Access (or your client config) to connect.
 
 If you **really** want open loopback, set `gateway.auth.mode: "none"` explicitly in your config. Doctor can generate a token for you any time: `openclaw doctor --generate-gateway-token`.
 
@@ -2444,7 +2444,7 @@ Fix:
 - If you don't have a token yet: `openclaw doctor --generate-gateway-token`.
 - If remote, tunnel first: `ssh -N -L 18789:127.0.0.1:18789 user@host` then open `http://127.0.0.1:18789/`.
 - Set `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`) on the gateway host.
-- In the Control UI settings, paste the same token.
+- In the Overview → Gateway Access, paste the same token (or refresh with a one-time `?token=...` link).
 - Still stuck? Run `openclaw status --all` and follow [Troubleshooting](/gateway/troubleshooting). See [Dashboard](/web/dashboard) for auth details.
 
 ### I set gatewaybind tailnet but it can't bind nothing listens

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -681,7 +681,7 @@ describe("gateway server auth/connect", () => {
         },
       });
       expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("Control UI settings");
+      expect(res.error?.message ?? "").toContain("Overview → Gateway Access");
       ws.close();
     });
 

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -14,7 +14,7 @@ export function formatGatewayAuthFailureMessage(params: {
   const isCli = isGatewayCliClient(client);
   const isControlUi = client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
   const isWebchat = isWebchatClient(client);
-  const uiHint = "open the dashboard URL and paste the token in Control UI settings";
+  const uiHint = "open a tokenized dashboard URL or paste token in Overview → Gateway Access";
   const tokenHint = isCli
     ? "set gateway.remote.token to match gateway.auth.token"
     : isControlUi || isWebchat
@@ -23,7 +23,7 @@ export function formatGatewayAuthFailureMessage(params: {
   const passwordHint = isCli
     ? "set gateway.remote.password to match gateway.auth.password"
     : isControlUi || isWebchat
-      ? "enter the password in Control UI settings"
+      ? "enter the password in Overview → Gateway Access"
       : "provide gateway auth password";
   switch (reason) {
     case "token_missing":


### PR DESCRIPTION
## Summary
Updates error messages to point users to 'Overview → Gateway Access' instead of the old 'Control UI settings' which no longer exists.

## Changes
- `src/gateway/server/ws-connection/message-handler.ts`: Updated `uiHint` and `passwordHint` messages
- `src/gateway/server.auth.e2e.test.ts`: Updated test assertion
- `docs/help/faq.md`: Updated FAQ references
- `docs/start/getting-started.md`: Updated getting started guide

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] Test assertion updated to match new message

Closes #2032

Supersedes #2063

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates user-facing gateway auth error hints (token/password) to direct users to the new UI location **Overview → Gateway Access** instead of the removed “Control UI settings”. It also updates the corresponding E2E assertion and refreshes two docs pages (FAQ + Getting Started) to reference the new location, keeping guidance consistent with the server error messaging and current dashboard UX.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to user-facing strings in one server helper, a single test assertion, and corresponding docs updates; no control flow or protocol behavior is altered.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->