### PR TITLE
fix(agents): detect Anthropic 'exceed context limit' error for auto-compaction

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -185,6 +185,19 @@ describe("isContextOverflowError", () => {
     expect(isContextOverflowError("We're debugging context overflow issues")).toBe(false);
     expect(isContextOverflowError("Something is causing context overflow messages")).toBe(false);
   });
+
+  it("matches Anthropic 'exceed context limit' error from extended thinking", () => {
+    // When using extended thinking with large contexts, Anthropic returns this error:
+    // "input length and max_tokens exceed context limit: 156321 + 48384 > 200000"
+    const samples = [
+      "input length and max_tokens exceed context limit: 156321 + 48384 > 200000",
+      '{"type":"error","error":{"type":"invalid_request_error","message":"input length and max_tokens exceed context limit: 100000 + 16000 > 100000"}}',
+      "exceed context limit: 50000 + 10000 > 50000",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
 });
 
 describe("error classifiers", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -53,7 +53,8 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow:") ||
-    (lower.includes("413") && lower.includes("too large"))
+    (lower.includes("413") && lower.includes("too large")) ||
+    lower.includes("exceed context limit")
   );
 }
 


### PR DESCRIPTION
## Summary
Detect Anthropic's 'input length and max_tokens exceed context limit' error to trigger auto-compaction.

## Problem
When using extended thinking with large contexts, Anthropic returns this specific error:
```
input length and max_tokens exceed context limit: 156321 + 48384 > 200000
```

Without detection, auto-compaction is not triggered and the request fails.

## Solution
Add 'exceed context limit' pattern matching in `isContextOverflowError()`.

## Testing
Added test cases for the new error format.

Supersedes #4266

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `isContextOverflowError()` to recognize Anthropic’s extended-thinking context overflow error string ("…exceed context limit…"), and adds Vitest coverage for the new format. There are also small docs formatting tweaks in provider docs/onboarding/canvas docs.

The main behavior change is in `src/agents/pi-embedded-helpers/errors.ts`, where additional substring matching allows auto-compaction logic to treat the new Anthropic error as a context overflow and retry accordingly.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it adds a narrow error-pattern match and corresponding tests.
- The code change is a simple additional substring check in a well-scoped helper, and tests cover representative raw/plain-text variants. Primary risk is around the doc marker syntax change potentially rendering unintended text in docs builds.
- docs/concepts/model-providers.md, docs/providers/moonshot.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->