### PR TITLE
fix(media-understanding): support legacy {file} placeholder in CLI audio args

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -10,6 +10,7 @@ title: "Telegram"
 Status: production-ready for bot DMs + groups via grammY. Long-polling by default; webhook optional.
 
 ## Quick setup (beginner)
+
 1. Create a bot with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`, then copy the token.
 2. Set the token:
    - Env: `TELEGRAM_BOT_TOKEN=...`
@@ -41,6 +42,7 @@ Minimal config:
 ## Setup (fast path)
 
 ### 1) Create a bot token (BotFather)
+
 1. Open Telegram and chat with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`.
 2. Run `/newbot`, then follow the prompts (name + username ending in `bot`).
 3. Copy the token and store it safely.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -24,6 +24,7 @@ wizard, and let the agent bootstrap itself.
 8. Ready
 
 ## 1) Welcome + security notice
+
 Read the security notice displayed and decide accordingly.
 
 ## 2) Local vs Remote

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -110,6 +110,7 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
+
 - **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
 - **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizePlaceholders } from "./runner.js";
+
+describe("normalizePlaceholders", () => {
+  it("converts {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("converts {input} and {media} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{media}")).toBe("{{MediaPath}}");
+  });
+
+  it("converts output placeholders", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+    expect(normalizePlaceholders("{output_base}")).toBe("{{OutputBase}}");
+  });
+
+  it("converts {prompt} and {media_dir}", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+    expect(normalizePlaceholders("{media_dir}")).toBe("{{MediaDir}}");
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+    expect(normalizePlaceholders("{OUTPUT_DIR}")).toBe("{{OutputDir}}");
+  });
+
+  it("handles multiple placeholders in one string", () => {
+    expect(normalizePlaceholders("{file} --output {output_dir}")).toBe(
+      "{{MediaPath}} --output {{OutputDir}}",
+    );
+  });
+
+  it("leaves unknown placeholders unchanged", () => {
+    expect(normalizePlaceholders("{unknown}")).toBe("{unknown}");
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("leaves regular text unchanged", () => {
+    expect(normalizePlaceholders("--model large-v3")).toBe("--model large-v3");
+  });
+});

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -58,6 +58,34 @@ const DEFAULT_IMAGE_MODELS: Record<string, string> = {
   minimax: "MiniMax-VL-01",
 };
 
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+export function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
 export type ActiveMediaModel = {
   provider: string;
   model?: string;
@@ -1036,7 +1064,7 @@ async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {


### PR DESCRIPTION
## Summary
Adds `normalizePlaceholders()` function that converts intuitive single-brace placeholders to the standard double-brace format before template expansion.

## Problem
When using `tools.media.audio.models` with `type: "cli"`, the `{file}` placeholder in the `args` array is passed literally instead of being substituted with the actual audio file path.

Example config that doesn't work:
```json
{
  "tools": {
    "media": {
      "audio": {
        "models": [{
          "type": "cli",
          "command": "whisper",
          "args": ["{file}", "--model", "large-v3-turbo"]
        }]
      }
    }
  }
}
```

## Solution
Normalize legacy placeholders before template expansion:
- `{file}`, `{input}`, `{media}` → `{{MediaPath}}`
- `{output}`, `{output_dir}` → `{{OutputDir}}`
- `{output_base}` → `{{OutputBase}}`
- `{prompt}` → `{{Prompt}}`
- `{media_dir}` → `{{MediaDir}}`

## Testing
Added comprehensive test suite for normalizePlaceholders().

Closes #5845
Re-opens fix from #6178 (incorrectly closed by triage bot)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes CLI audio model template expansion by normalizing legacy single-brace placeholders (e.g. `{file}`, `{output_dir}`) into the existing double-brace template variables (e.g. `{{MediaPath}}`, `{{OutputDir}}`) before calling `applyTemplate()` in `src/media-understanding/runner.ts`.

It also adds a focused Vitest suite covering placeholder normalization behavior (case-insensitivity, multiple replacements, unknown placeholders) and includes a few small docs formatting/marker updates in the docs pages.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported CLI placeholder substitution bug with low risk.
- The core change is narrow (pre-processing CLI args before existing template expansion) and is covered by a dedicated unit test suite. Main remaining risk is around the docs marker syntax change potentially breaking whatever tooling maintains those auto-generated sections, plus minor performance considerations in the placeholder normalization implementation.
- docs/concepts/model-providers.md, docs/providers/moonshot.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->