### PR TITLE
fix(memory): add ignore patterns to chokidar file watcher

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,6 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
+  ignorePaths: string[];
   provider: "openai" | "local" | "gemini" | "voyage" | "auto";
   remote?: {
     baseUrl?: string;
@@ -193,6 +194,26 @@ function mergeConfig(
     .map((value) => value.trim())
     .filter(Boolean);
   const extraPaths = Array.from(new Set(rawPaths));
+  // Default ignore patterns for common non-document directories
+  const defaultIgnorePaths = [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "**/.env/**",
+    "**/__pycache__/**",
+    "**/.tox/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.nuxt/**",
+    "**/target/**",
+    "**/.cargo/**",
+  ];
+  const userIgnorePaths = [...(defaults?.ignorePaths ?? []), ...(overrides?.ignorePaths ?? [])]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const ignorePaths = Array.from(new Set([...defaultIgnorePaths, ...userIgnorePaths]));
   const vector = {
     enabled: overrides?.store?.vector?.enabled ?? defaults?.store?.vector?.enabled ?? true,
     extensionPath:
@@ -296,6 +317,7 @@ function mergeConfig(
     enabled,
     sources,
     extraPaths,
+    ignorePaths,
     provider,
     remote,
     experimental: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -267,6 +267,8 @@ export type MemorySearchConfig = {
   sources?: Array<"memory" | "sessions">;
   /** Extra paths to include in memory search (directories or .md files). */
   extraPaths?: string[];
+  /** Glob patterns to ignore when watching extraPaths (merged with defaults like node_modules, .git, .venv). */
+  ignorePaths?: string[];
   /** Experimental memory search settings. */
   experimental?: {
     /** Enable session transcript indexing (experimental, default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -469,6 +469,8 @@ export const MemorySearchSchema = z
     enabled: z.boolean().optional(),
     sources: z.array(z.union([z.literal("memory"), z.literal("sessions")])).optional(),
     extraPaths: z.array(z.string()).optional(),
+    /** Glob patterns to ignore when watching extraPaths (merged with defaults). */
+    ignorePaths: z.array(z.string()).optional(),
     experimental: z
       .object({
         sessionMemory: z.boolean().optional(),

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -131,6 +131,30 @@ describe("listMemoryFiles", () => {
     const memoryMatches = files.filter((file) => file.endsWith("MEMORY.md"));
     expect(memoryMatches).toHaveLength(1);
   });
+
+  it("respects ignorePaths glob patterns", async () => {
+    await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
+    const extraDir = path.join(tmpDir, "extra");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "note.md"), "# Note");
+
+    // Create node_modules with a .md file inside
+    const nodeModules = path.join(extraDir, "node_modules");
+    await fs.mkdir(nodeModules, { recursive: true });
+    await fs.writeFile(path.join(nodeModules, "readme.md"), "# Should be ignored");
+
+    // Create .venv with a .md file inside
+    const venv = path.join(extraDir, ".venv");
+    await fs.mkdir(venv, { recursive: true });
+    await fs.writeFile(path.join(venv, "docs.md"), "# Should also be ignored");
+
+    const files = await listMemoryFiles(tmpDir, [extraDir], ["**/node_modules/**", "**/.venv/**"]);
+    expect(files).toHaveLength(2); // MEMORY.md + note.md
+    expect(files.some((file) => file.endsWith("MEMORY.md"))).toBe(true);
+    expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
+    expect(files.some((file) => file.includes("node_modules"))).toBe(false);
+    expect(files.some((file) => file.includes(".venv"))).toBe(false);
+  });
 });
 
 describe("buildFileEntry", () => {

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -155,6 +155,21 @@ describe("listMemoryFiles", () => {
     expect(files.some((file) => file.includes("node_modules"))).toBe(false);
     expect(files.some((file) => file.includes(".venv"))).toBe(false);
   });
+
+  it("supports wildcard glob patterns in ignorePaths", async () => {
+    await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
+    const extraDir = path.join(tmpDir, "extra");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "note.md"), "# Note");
+
+    const generatedDir = path.join(extraDir, "generated-build-cache");
+    await fs.mkdir(generatedDir, { recursive: true });
+    await fs.writeFile(path.join(generatedDir, "skip.md"), "# Should be ignored");
+
+    const files = await listMemoryFiles(tmpDir, [extraDir], ["**/generated-*/**"]);
+    expect(files).toHaveLength(2); // MEMORY.md + note.md
+    expect(files.some((file) => file.endsWith("skip.md"))).toBe(false);
+  });
 });
 
 describe("buildFileEntry", () => {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -56,7 +56,23 @@ export function isMemoryPath(relPath: string): boolean {
   return normalized.startsWith("memory/");
 }
 
-async function walkDir(dir: string, files: string[]) {
+/**
+ * Extract literal directory names from glob patterns like "**\/node_modules\/**".
+ * Returns a Set of directory names to ignore.
+ */
+function extractIgnoredDirNames(patterns: string[]): Set<string> {
+  const names = new Set<string>();
+  for (const pattern of patterns) {
+    // Match patterns like **/dirname/** or **/dirname
+    const match = pattern.match(/^\*\*\/([^/*]+)(?:\/\*\*)?$/);
+    if (match?.[1]) {
+      names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+async function walkDir(dir: string, files: string[], ignoredDirNames?: Set<string>) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
@@ -64,7 +80,11 @@ async function walkDir(dir: string, files: string[]) {
       continue;
     }
     if (entry.isDirectory()) {
-      await walkDir(full, files);
+      // Skip ignored directories
+      if (ignoredDirNames?.has(entry.name)) {
+        continue;
+      }
+      await walkDir(full, files, ignoredDirNames);
       continue;
     }
     if (!entry.isFile()) {
@@ -80,11 +100,13 @@ async function walkDir(dir: string, files: string[]) {
 export async function listMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
+  ignorePaths?: string[],
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
   const altMemoryFile = path.join(workspaceDir, "memory.md");
   const memoryDir = path.join(workspaceDir, "memory");
+  const ignoredDirNames = ignorePaths ? extractIgnoredDirNames(ignorePaths) : undefined;
 
   const addMarkdownFile = async (absPath: string) => {
     try {
@@ -104,7 +126,7 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await walkDir(memoryDir, result);
+      await walkDir(memoryDir, result, ignoredDirNames);
     }
   } catch {}
 
@@ -117,7 +139,7 @@ export async function listMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
-          await walkDir(inputPath, result);
+          await walkDir(inputPath, result, ignoredDirNames);
           continue;
         }
         if (stat.isFile() && inputPath.endsWith(".md")) {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -57,22 +57,49 @@ export function isMemoryPath(relPath: string): boolean {
 }
 
 /**
- * Extract literal directory names from glob patterns like "**\/node_modules\/**".
- * Returns a Set of directory names to ignore.
+ * Normalize paths for glob matching across platforms.
  */
-function extractIgnoredDirNames(patterns: string[]): Set<string> {
-  const names = new Set<string>();
-  for (const pattern of patterns) {
-    // Match patterns like **/dirname/** or **/dirname
-    const match = pattern.match(/^\*\*\/([^/*]+)(?:\/\*\*)?$/);
-    if (match?.[1]) {
-      names.add(match[1]);
-    }
-  }
-  return names;
+function toPosixPath(value: string): string {
+  return value.replace(/\\/g, "/");
 }
 
-async function walkDir(dir: string, files: string[], ignoredDirNames?: Set<string>) {
+function shouldIgnorePath(params: {
+  absPath: string;
+  workspaceDir: string;
+  rootDir: string;
+  ignorePaths: string[];
+  isDirectory?: boolean;
+}): boolean {
+  const absPathPosix = toPosixPath(path.resolve(params.absPath));
+  const rootRelPosix = toPosixPath(path.relative(params.rootDir, params.absPath));
+  const workspaceRelPosix = toPosixPath(path.relative(params.workspaceDir, params.absPath));
+  const candidates = [absPathPosix, rootRelPosix, workspaceRelPosix]
+    .filter((value) => value.length > 0 && value !== ".")
+    .map((value) => (params.isDirectory ? `${value.replace(/\/+$/g, "")}/` : value));
+
+  for (const rawPattern of params.ignorePaths) {
+    const pattern = rawPattern.trim();
+    if (!pattern) {
+      continue;
+    }
+    const posixPattern = toPosixPath(pattern);
+    for (const candidate of candidates) {
+      if (path.posix.matchesGlob(candidate, posixPattern)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+async function walkDir(params: {
+  dir: string;
+  files: string[];
+  workspaceDir: string;
+  rootDir: string;
+  ignorePaths: string[];
+}) {
+  const { dir, files, workspaceDir, rootDir, ignorePaths } = params;
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
@@ -80,14 +107,33 @@ async function walkDir(dir: string, files: string[], ignoredDirNames?: Set<strin
       continue;
     }
     if (entry.isDirectory()) {
-      // Skip ignored directories
-      if (ignoredDirNames?.has(entry.name)) {
+      if (
+        ignorePaths.length > 0 &&
+        shouldIgnorePath({
+          absPath: full,
+          workspaceDir,
+          rootDir,
+          ignorePaths,
+          isDirectory: true,
+        })
+      ) {
         continue;
       }
-      await walkDir(full, files, ignoredDirNames);
+      await walkDir({ dir: full, files, workspaceDir, rootDir, ignorePaths });
       continue;
     }
     if (!entry.isFile()) {
+      continue;
+    }
+    if (
+      ignorePaths.length > 0 &&
+      shouldIgnorePath({
+        absPath: full,
+        workspaceDir,
+        rootDir,
+        ignorePaths,
+      })
+    ) {
       continue;
     }
     if (!entry.name.endsWith(".md")) {
@@ -106,7 +152,7 @@ export async function listMemoryFiles(
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
   const altMemoryFile = path.join(workspaceDir, "memory.md");
   const memoryDir = path.join(workspaceDir, "memory");
-  const ignoredDirNames = ignorePaths ? extractIgnoredDirNames(ignorePaths) : undefined;
+  const normalizedIgnorePaths = (ignorePaths ?? []).map((value) => value.trim()).filter(Boolean);
 
   const addMarkdownFile = async (absPath: string) => {
     try {
@@ -126,7 +172,13 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await walkDir(memoryDir, result, ignoredDirNames);
+      await walkDir({
+        dir: memoryDir,
+        files: result,
+        workspaceDir,
+        rootDir: memoryDir,
+        ignorePaths: normalizedIgnorePaths,
+      });
     }
   } catch {}
 
@@ -139,7 +191,13 @@ export async function listMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
-          await walkDir(inputPath, result, ignoredDirNames);
+          await walkDir({
+            dir: inputPath,
+            files: result,
+            workspaceDir,
+            rootDir: inputPath,
+            ignorePaths: normalizedIgnorePaths,
+          });
           continue;
         }
         if (stat.isFile() && inputPath.endsWith(".md")) {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -73,9 +73,14 @@ function shouldIgnorePath(params: {
   const absPathPosix = toPosixPath(path.resolve(params.absPath));
   const rootRelPosix = toPosixPath(path.relative(params.rootDir, params.absPath));
   const workspaceRelPosix = toPosixPath(path.relative(params.workspaceDir, params.absPath));
-  const candidates = [absPathPosix, rootRelPosix, workspaceRelPosix]
+  const baseCandidates = [absPathPosix, rootRelPosix, workspaceRelPosix]
     .filter((value) => value.length > 0 && value !== ".")
-    .map((value) => (params.isDirectory ? `${value.replace(/\/+$/g, "")}/` : value));
+    .map((value) => value.replace(/\/+$/g, ""));
+  const candidates = Array.from(
+    new Set(
+      params.isDirectory ? baseCandidates.flatMap((value) => [value, `${value}/`]) : baseCandidates,
+    ),
+  );
 
   for (const rawPattern of params.ignorePaths) {
     const pattern = rawPattern.trim();

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -378,7 +378,7 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
-      ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
+      ignored: this.settings.ignorePaths,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,
@@ -633,7 +633,11 @@ export abstract class MemoryManagerSyncOps {
       return;
     }
 
-    const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);
+    const files = await listMemoryFiles(
+      this.workspaceDir,
+      this.settings.extraPaths,
+      this.settings.ignorePaths,
+    );
     const fileEntries = (
       await Promise.all(files.map(async (file) => buildFileEntry(file, this.workspaceDir)))
     ).filter((entry): entry is MemoryFileEntry => entry !== null);

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -98,12 +98,8 @@ describe("memory watcher config", () => {
     expect(options.ignoreInitial).toBe(true);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
-    const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;
-    expect(ignored).toBeTypeOf("function");
-    expect(ignored?.(path.join(workspaceDir, "memory", "node_modules", "pkg", "index.md"))).toBe(
-      true,
-    );
-    expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
+    const ignored = options.ignored as string[];
+    expect(Array.isArray(ignored)).toBe(true);
+    expect(ignored).toEqual(expect.arrayContaining(["**/node_modules/**", "**/.venv/**"]));
   });
 });


### PR DESCRIPTION
## Summary
Adds `ignorePaths` config option to memorySearch that prevents chokidar from watching non-document directories.

## Problem
When `memorySearch.extraPaths` points to a directory containing large non-document subtrees (e.g., Python `.venv` with PyTorch, `node_modules`, `.git`), chokidar opens a file descriptor for **every file and directory** in the tree — even though only `.md` files are ever indexed.

This causes the gateway process to exhaust its file descriptor limit and produce:
```
spawn EBADF
Error: EMFILE: too many open files
```

## Solution
1. Add `ignorePaths` array to memorySearch config (zod schema, types, etc)
2. Add default ignore patterns: `node_modules`, `.git`, `.venv`, `venv`, `.env`, `__pycache__`, `.tox`, `dist`, `build`, `.next`, `.nuxt`, `target`, `.cargo`
3. Pass `ignored` option to chokidar.watch()
4. Update `listMemoryFiles()` and `walkDir()` to respect ignore patterns

## Config Example
```json
{
  "agents": {
    "defaults": {
      "memorySearch": {
        "extraPaths": ["/large/project"],
        "ignorePaths": ["**/custom_ignore/**"]
      }
    }
  }
}
```

## Testing
Added test for `listMemoryFiles()` with ignorePaths.

Closes #5827
Re-opens fix from #6146 (incorrectly closed by triage bot)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `ignorePaths` option to `memorySearch` and wires it through config/schema/types, then uses it to reduce file watcher scope (via chokidar’s `ignored` option) and to skip ignored directories when enumerating memory markdown files.

Main concern: `ignorePaths` is documented and surfaced as “glob patterns”, but `listMemoryFiles()` only implements a narrow subset (extracting literal dir names from patterns like `**/dirname/**`). Since chokidar applies full glob semantics, certain ignore patterns can lead to watch/index mismatches or silently not be honored during indexing.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the ignorePaths behavior is inconsistent and may surprise users.
- The change is localized and addresses a real resource issue, but the new ignorePaths setting is described as glob patterns while indexing only supports a narrow pattern shape, and chokidar uses full glob semantics—creating potential watch/index divergence and confusing configs.
- src/memory/internal.ts, src/memory/manager.ts, src/agents/memory-search.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->