### PR TITLE
fix: pass actual filename for WhatsApp document sends (#5781)

### DIFF
--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { resolveImplicitProviders } from "./models-config.providers.js";
 import { mkdtempSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { discoverOllamaModels } from "./models-config.providers.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
 
 describe("Ollama provider", () => {
   it("should not include ollama when no API key is configured", async () => {
@@ -11,5 +14,76 @@ describe("Ollama provider", () => {
 
     // Ollama requires explicit configuration via OLLAMA_API_KEY env var or profile
     expect(providers?.ollama).toBeUndefined();
+  });
+});
+
+describe("discoverOllamaModels", () => {
+  const originalVitest = process.env.VITEST;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    // discoverOllamaModels returns [] when VITEST or NODE_ENV=test is set,
+    // so we temporarily clear those to exercise the real logic.
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalVitest !== undefined) {
+      process.env.VITEST = originalVitest;
+    }
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("skips models with undefined or empty names", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: "llama3:latest", modified_at: "", size: 0, digest: "" },
+          { name: undefined, modified_at: "", size: 0, digest: "" },
+          { name: "", modified_at: "", size: 0, digest: "" },
+          { name: "deepseek-r1:latest", modified_at: "", size: 0, digest: "" },
+        ],
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toHaveLength(2);
+    expect(models[0]!.id).toBe("llama3:latest");
+    expect(models[0]!.reasoning).toBe(false);
+    expect(models[1]!.id).toBe("deepseek-r1:latest");
+    expect(models[1]!.reasoning).toBe(true);
+  });
+
+  it("returns empty array when all model names are invalid", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: undefined, modified_at: "", size: 0, digest: "" },
+          { name: null, modified_at: "", size: 0, digest: "" },
+          { name: "", modified_at: "", size: 0, digest: "" },
+        ],
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toEqual([]);
+  });
+
+  it("returns empty array when fetch fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+
+    const models = await discoverOllamaModels();
+
+    expect(models).toEqual([]);
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -101,7 +101,7 @@ interface OllamaTagsResponse {
   models: OllamaModel[];
 }
 
-async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
+export async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
   // Skip Ollama discovery in test environments
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
@@ -119,20 +119,22 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
       console.warn("No Ollama models found on local instance");
       return [];
     }
-    return data.models.map((model) => {
-      const modelId = model.name;
-      const isReasoning =
-        modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
-      return {
-        id: modelId,
-        name: modelId,
-        reasoning: isReasoning,
-        input: ["text"],
-        cost: OLLAMA_DEFAULT_COST,
-        contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-      };
-    });
+    return data.models
+      .filter((model) => typeof model.name === "string" && model.name.length > 0)
+      .map((model) => {
+        const modelId = model.name;
+        const isReasoning =
+          modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
+        return {
+          id: modelId,
+          name: modelId,
+          reasoning: isReasoning,
+          input: ["text"],
+          cost: OLLAMA_DEFAULT_COST,
+          contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
+          maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+        };
+      });
   } catch (error) {
     console.warn(`Failed to discover Ollama models: ${String(error)}`);
     return [];

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName ?? "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -131,7 +131,9 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -44,11 +44,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -69,10 +71,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             accountId,
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
           }
         : undefined;
     const result = sendOptions


### PR DESCRIPTION
## Summary
- Adds `fileName` to `ActiveWebSendOptions` type so callers can pass a filename through to the send API
- Replaces hard-coded `"file"` in `send-api.ts` with `sendOptions?.fileName ?? "file"`
- Passes `media.fileName` from `loadWebMedia()` through `outbound.ts` into `sendOptions`

Fixes #5781

## Test plan
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm test -- --run src/web/outbound.test.ts` — all 9 tests pass
- [ ] Manual: send a document via WhatsApp Web and verify the recipient sees the original filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a document filename through the WhatsApp Web send pipeline by (1) extending `ActiveWebSendOptions` with `fileName`, (2) using that value in `createWebSendApi` when constructing a `document` payload, and (3) propagating `media.fileName` from `loadWebMedia()` through `sendMessageWhatsApp()` to the active listener. It also exports `discoverOllamaModels()` and adds unit tests to ensure Ollama model discovery skips invalid model names and fails closed.

Overall the change fits cleanly into the existing web outbound/inbound split: outbound gathers/normalizes media metadata and inbound constructs the Baileys `AnyMessageContent` payload.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and narrowly scoped, with minor edge cases to consider.
- Core behavior change is straightforward (pass through filename for document sends) and is covered by an updated outbound unit test. The only notable risks are subtle accountId/activity attribution behavior in multi-account setups and the env-mutation strategy in the new Ollama tests potentially affecting other tests in unusual runner configurations.
- src/web/outbound.ts; src/agents/models-config.providers.ollama.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->