### PR TITLE
fix(telegram): improve timeout handling - test and lint fixes

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -136,7 +136,7 @@ describe("monitorTelegramProvider (grammY)", () => {
         sink: { concurrency: 3 },
         runner: expect.objectContaining({
           silent: true,
-          maxRetryTime: 5 * 60 * 1000,
+          maxRetryTime: 2 * 60 * 1000, // Reduced from 5 min to 2 min for faster recovery
           retryInterval: "exponential",
         }),
       }),

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -117,10 +117,12 @@ const isTimeoutAbortError = (err: unknown): boolean => {
   const stack = error.stack?.toLowerCase() || "";
 
   // Look for timeout-related indicators in the error
-  return message.includes("timeout") ||
+  return (
+    message.includes("timeout") ||
     stack.includes("timeout") ||
     stack.includes("undici") ||
-    stack.includes("getupdates");
+    stack.includes("getupdates")
+  );
 };
 
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
@@ -236,8 +238,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
 
       let reason = "network error";
-      if (isConflict) reason = "getUpdates conflict";
-      else if (isTimeout) reason = "request timeout";
+      if (isConflict) {
+        reason = "getUpdates conflict";
+      } else if (isTimeout) {
+        reason = "request timeout";
+      }
 
       const errMsg = formatErrorMessage(err);
       const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);


### PR DESCRIPTION
## Summary
Follow-up fixes for PR #5971 by @rmacias12

- Update test expectation from 5min to 2min maxRetryTime to match the PR changes
- Add curly braces to if/else statements per linting rules
- Fix formatting in isTimeoutAbortError return statement

## Changes
- `src/telegram/monitor.test.ts` - Updated test expectation
- `src/telegram/monitor.ts` - Fixed linting and formatting issues

## Testing
- All telegram monitor tests pass (5/5)
- Linting passes
- Formatting passes

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

PR makes follow-up fixes to the Telegram monitor: adjusts the `maxRetryTime` expectation in `src/telegram/monitor.test.ts` from 5 minutes to 2 minutes to match prior behavior changes, and applies lint/formatting updates in `src/telegram/monitor.ts` (curly braces on conditionals and a reformatted `isTimeoutAbortError` return). These changes align the test suite and code style with the updated timeout logic introduced in the earlier PR.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge as it only adjusts a test expectation and applies lint/formatting fixes without changing core runtime behavior.
- Changes described are narrowly scoped (test update + style/formatting) and are unlikely to affect production logic; no functional regressions are evident from the stated modifications.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->