### PR TITLE
fix: JSON parse failover - add test coverage

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -38,4 +38,20 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+
+  it("classifies JSON parse errors as format for model failover", () => {
+    // OpenAI-style
+    expect(classifyFailoverReason("is not valid JSON")).toBe("format");
+    expect(classifyFailoverReason("The value is not valid JSON")).toBe("format");
+
+    // Node JSON.parse style
+    expect(classifyFailoverReason("Unexpected token < in JSON at position 0")).toBe("format");
+    expect(classifyFailoverReason("SyntaxError: Unexpected token } in JSON")).toBe("format");
+
+    // Truncated JSON
+    expect(classifyFailoverReason("Unexpected end of JSON input")).toBe("format");
+
+    // Should not match unrelated errors
+    expect(classifyFailoverReason("JSON file not found")).toBeNull();
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -584,6 +584,13 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
+/** Detect JSON parse errors from malformed model tool-call arguments. */
+function isJsonParseError(raw: string): boolean {
+  return /\bis not valid JSON\b|Unexpected token .* in JSON|Unexpected end of JSON input/i.test(
+    raw,
+  );
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;
@@ -598,6 +605,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "rate_limit";
   }
   if (isCloudCodeAssistFormatError(raw)) {
+    return "format";
+  }
+  if (isJsonParseError(raw)) {
     return "format";
   }
   if (isBillingErrorMessage(raw)) {


### PR DESCRIPTION
## Summary
Follow-up to PR #6001 by @koala73 - adds test coverage for the new isJsonParseError() function.

## Changes
- `src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts` - Added tests for JSON parse error patterns:
  - OpenAI-style: "is not valid JSON"
  - Node JSON.parse: "Unexpected token ... in JSON"
  - Truncated: "Unexpected end of JSON input"
  - Negative case: "JSON file not found" returns null

## Testing
- All failover classification tests pass (3/3)
- Linting passes

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds coverage for JSON parse-related failover classification by extending `classifyFailoverReason` to treat common malformed-JSON messages (OpenAI-style and Node `JSON.parse` errors, including truncated input) as `format`, and adds a new test case exercising several representative strings.

The change fits into the existing error-classification flow in `src/agents/pi-embedded-helpers/errors.ts`, which maps raw provider/model error text into normalized `FailoverReason` values used to decide when to trigger model failover.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and covered by tests.
- The PR adds a narrow regex-based classifier and corresponding unit tests. Main risk is minor: the regex can be made less backtracking-prone on very long error strings, but functional behavior is otherwise straightforward and covered by the added tests.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->