### PR TITLE
fix(cli): escape brackets in zsh completion option descriptions

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -142,7 +142,12 @@ function generateZshArgs(cmd: Command): string {
       const flags = opt.flags.split(/[ ,|]+/);
       const name = flags.find((f) => f.startsWith("--")) || flags[0];
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
-      const desc = opt.description.replace(/'/g, "'\\''");
+      const desc = opt.description
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/'/g, "'\\''")
+        .replace(/\[/g, "\\[")
+        .replace(/\]/g, "\\]");
       if (short) {
         return `"(${name} ${short})"{${name},${short}}"[${desc}]"`;
       }


### PR DESCRIPTION
## Summary

Fixes zsh completion parser error when tab-completing commands with options that have quotes or special characters in their descriptions.

## Problem

When running `openclaw gateway res<TAB>`, zsh reports:
```
_arguments:comparguments:327: invalid option definition: --compact[Alias for --ws-log
```

**Root Cause:** The `generateZshArgs` function was not escaping special characters in option descriptions. Options like `--ws-log` with descriptions containing quotes like `("auto"|"full"|"compact")` broke zsh's `_arguments` parser when embedded in double-quoted strings.

Example of broken output:
```zsh
"--ws-log[WebSocket log style ("auto"|"full"|"compact")]"
                                 ↑ unescaped quotes break parsing
```

## Solution

Added proper escaping for all special characters in option descriptions:

```typescript
const desc = opt.description
  .replace(/\\/g, "\\\\")      // Backslashes (must be first!)
  .replace(/"/g, "\\\"")       // Double quotes (main issue)
  .replace(/'/g, "'\\''")      // Single quotes
  .replace(/\[/g, "\\[")       // Square brackets
  .replace(/\]/g, "\\]");
```

**Key insight:** Escaping order matters - backslash must be escaped first to avoid double-escaping other characters.

Now generates correctly escaped output:
```zsh
"--ws-log[WebSocket log style (\"auto\"|\"full\"|\"compact\")]"
```

## Testing

1. ✅ Built and verified the generated completion script properly escapes all special chars
2. ✅ Manual test: `source <(openclaw completion --shell zsh)` loads without errors
3. ✅ Tab completion now works: `openclaw gateway res<TAB>` completes successfully
4. ✅ Existing tests pass

## Related

- Fixes completion errors for any option with special characters in descriptions
- Aligns with proper zsh `_arguments` escaping requirements
- Follows similar pattern to `generateZshSubcmdList` but adds quote escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)