### PR TITLE
fix(gateway): prevent restart on meta.lastTouchedAt changes

### DIFF
--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -47,6 +47,7 @@ const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  { prefix: "meta", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {


### PR DESCRIPTION
## Summary

Changes to `meta.lastTouchedAt` in the config were falling through to the default restart behavior because no reload rule matched the `meta` prefix.

This adds a `none` rule for the `meta` prefix so metadata-only changes are treated as no-ops rather than triggering unnecessary gateway restarts.

## Changes

```diff
const BASE_RELOAD_RULES: ReloadRule[] = [
  { prefix: "gateway.remote", kind: "none" },
  { prefix: "gateway.reload", kind: "none" },
+ { prefix: "meta", kind: "none" },
```

## Testing

- [x] `config-reload.test.ts` - 8/8 tests pass
- [x] TypeScript compilation passes
- [x] Lint passes (0 warnings, 0 errors)

Fixes #6149

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway config reload rules so that changes under the `meta` config prefix (e.g., `meta.lastTouchedAt`) are treated as no-ops (`kind: "none"`) instead of falling back to the default restart behavior. This fits into the existing `BASE_RELOAD_RULES` mechanism in `src/gateway/config-reload.ts`, where prefixes map config diffs to reload actions, preventing unnecessary restarts for metadata-only changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to adding a `meta` prefix reload rule set to `none`, aligning with existing rule patterns and addressing a specific unwanted restart behavior; no functional complexity or broad surface area changes are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->