### PR TITLE
fix(agent): trigger fallback chain on unknown model errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -208,7 +208,11 @@ export async function runEmbeddedPiAgent(
         params.config,
       );
       if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+          reason: "unknown",
+          provider,
+          model: modelId,
+        });
       }
 
       const ctxInfo = resolveContextWindowInfo({


### PR DESCRIPTION
## Summary

When the primary model cannot be resolved (e.g., model ID not recognized by provider), the agent now throws `FailoverError` instead of plain `Error`. This allows the configured fallback chain to be attempted instead of hard-failing.

## Problem

Previously, "Unknown model" errors threw plain `Error` which bypassed the fallback logic entirely:

```typescript
// Before: hard-fails, no fallback attempted
throw new Error(error ?? \`Unknown model: \${provider}/\${modelId}\`);
```

This left the agent broken until the primary model was manually changed, even when fallback models were properly configured.

## Solution

```diff
- throw new Error(error ?? \`Unknown model: \${provider}/\${modelId}\`);
+ throw new FailoverError(error ?? \`Unknown model: \${provider}/\${modelId}\`, {
+   reason: "unknown",
+   provider,
+   model: modelId,
+ });
```

This matches the existing behavior for context window errors (line 134) which already use `FailoverError` to trigger fallbacks.

## Testing

- [x] `pi-embedded-runner.test.ts` - 7/7 tests pass (including existing "Unknown model" test)
- [x] TypeScript compilation passes
- [x] Lint passes (0 warnings, 0 errors)

## Related

Also mentioned in #6203 (same root cause, different report)

Fixes #6224

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the embedded Pi agent runner so that when `resolveModel()` cannot resolve the configured provider/model ID, it throws a `FailoverError` instead of a plain `Error`, allowing the agent’s existing fallback-chain logic to kick in (consistent with how context-window blocking already triggers failover). The change is localized to model-resolution in `src/agents/pi-embedded-runner/run.ts` and aims to prevent hard-failures when a primary model is unknown but fallbacks are configured.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted swap from `Error` to `FailoverError` at the model-resolution boundary, aligning behavior with existing failover pathways (e.g., context-window blocking) and not altering downstream request execution paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->