### PR TITLE
fix(cli): silence Powerlevel10k Zsh warning from completion script

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 
+const warningFilterKey = Symbol.for("openclaw.warning-filter");
+if (!globalThis[warningFilterKey]?.installed) {
+  globalThis[warningFilterKey] = { installed: true };
+  // Remove Node.js default warning handler to prevent it from printing before we filter
+  process.removeAllListeners("warning");
+  process.on("warning", (warning) => {
+    if (warning.code === "DEP0040" && warning.message?.includes("punycode")) return;
+    if (warning.code === "DEP0060" && warning.message?.includes("util._extend")) return;
+    if (warning.name === "ExperimentalWarning" && warning.message?.includes("SQLite")) return;
+    process.stderr.write(`${warning.stack ?? warning.toString()}\n`);
+  });
+}
+
 import module from "node:module";
 
 // https://nodejs.org/api/module.html#module-compile-cache

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -54,7 +54,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 
   if (shell === "zsh") {
     profilePath = path.join(home, ".zshrc");
-    sourceLine = `source <(${binName} completion --shell zsh)`;
+    sourceLine = `source <(${binName} completion --shell zsh 2>/dev/null)`;
   } else if (shell === "bash") {
     // Try .bashrc first, then .bash_profile
     profilePath = path.join(home, ".bashrc");

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -54,7 +54,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 
   if (shell === "zsh") {
     profilePath = path.join(home, ".zshrc");
-    sourceLine = `source <(${binName} completion --shell zsh 2>/dev/null)`;
+    sourceLine = `source <(${binName} completion --shell zsh)`;
   } else if (shell === "bash") {
     // Try .bashrc first, then .bash_profile
     profilePath = path.join(home, ".bashrc");


### PR DESCRIPTION
Fix issue #6357

Suppress stderr when using openclaw completion.

The stderr output:
```
(node:291720) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the zsh installation snippet written into `~/.zshrc` to redirect stderr for the `openclaw completion --shell zsh` process substitution, suppressing Node’s `DEP0040` deprecation warning during shell startup/completion loading. The change is localized to `src/cli/completion-cli.ts` where the install command assembles the `source <(...)` line for zsh profiles.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge, with the main concern being reduced debuggability due to blanket stderr suppression.
- The change is a one-line modification to the zsh completion install command; it doesn’t affect runtime CLI behavior outside of the installed shell snippet. The primary trade-off is that redirecting all stderr may hide legitimate errors when generating completion.
- src/cli/completion-cli.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->