### PR TITLE
security(message-tool): validate filePath/path against sandbox root

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -92,6 +92,7 @@ export function createOpenClawTools(options?: {
       currentThreadTs: options?.currentThreadTs,
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
+      sandboxRoot: options?.sandboxRoot,
     }),
     createTtsTool({
       agentChannel: options?.agentChannel,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
@@ -159,5 +162,108 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("leaveGroup");
 
     setActivePluginRegistry(createTestRegistry([]));
+  });
+});
+
+describe("message tool sandbox path validation", () => {
+  it("rejects filePath that escapes sandbox root", async () => {
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await expect(
+        tool.execute("1", {
+          action: "send",
+          target: "telegram:123",
+          filePath: "/etc/passwd",
+          message: "",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects path param with traversal sequence", async () => {
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await expect(
+        tool.execute("1", {
+          action: "send",
+          target: "telegram:123",
+          path: "../../../etc/shadow",
+          message: "",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows filePath inside sandbox root", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "telegram",
+      to: "telegram:123",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
+    try {
+      const tool = createMessageTool({
+        config: {} as never,
+        sandboxRoot: sandboxDir,
+      });
+
+      await tool.execute("1", {
+        action: "send",
+        target: "telegram:123",
+        filePath: "./data/file.txt",
+        message: "",
+      });
+
+      expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips validation when no sandboxRoot is set", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "telegram",
+      to: "telegram:123",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "telegram:123",
+      filePath: "/etc/passwd",
+      message: "",
+    });
+
+    // Bez sandboxRoot walidacja nie blokuje - niesandboxowane sesje dzialaja normalnie.
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -263,7 +263,7 @@ describe("message tool sandbox path validation", () => {
       message: "",
     });
 
-    // Bez sandboxRoot walidacja nie blokuje - niesandboxowane sesje dzialaja normalnie.
+    // Without sandboxRoot the validation is skipped — unsandboxed sessions work normally.
     expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -19,6 +19,7 @@ import { normalizeAccountId } from "../../routing/session-key.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
+import { assertSandboxPath } from "../sandbox-paths.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 
@@ -252,6 +253,7 @@ type MessageToolOptions = {
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
+  sandboxRoot?: string;
 };
 
 function buildMessageToolSchema(cfg: OpenClawConfig) {
@@ -361,6 +363,17 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;
+
+      // Walidacja sciezek plikow wzgledem sandbox root (zapobiega odczytowi plikow hosta).
+      const sandboxRoot = options?.sandboxRoot;
+      if (sandboxRoot) {
+        for (const key of ["filePath", "path"] as const) {
+          const raw = readStringParam(params, key, { trim: false });
+          if (raw) {
+            await assertSandboxPath({ filePath: raw, cwd: sandboxRoot, root: sandboxRoot });
+          }
+        }
+      }
 
       const accountId = readStringParam(params, "accountId") ?? agentAccountId;
       if (accountId) {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -364,7 +364,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         required: true,
       }) as ChannelMessageActionName;
 
-      // Walidacja sciezek plikow wzgledem sandbox root (zapobiega odczytowi plikow hosta).
+      // Validate file paths against sandbox root to prevent host file access.
       const sandboxRoot = options?.sandboxRoot;
       if (sandboxRoot) {
         for (const key of ["filePath", "path"] as const) {


### PR DESCRIPTION
## Summary

Fixes #3805 (CRITICAL sandbox escape via message tool `filePath`/`path` params).

> **Note:** Previous PR #6181 was auto-closed by CLAWDINATOR triage bot. This is a **critical security fix** for an existing open issue, not a feature or improvement. Issue #3805 documents a confirmed sandbox escape with PoC.

The `message` tool accepted arbitrary file paths (`filePath`, `path`) without validating them against the sandbox root directory. A sandboxed agent could read or exfiltrate host files (e.g. `/etc/passwd`, `~/.ssh/id_rsa`) by passing absolute or traversal paths through the message tool's send action.

### Changes

- **`src/agents/tools/message-tool.ts`**: Added `sandboxRoot` option to `MessageToolOptions`. When set, both `filePath` and `path` params are validated via `assertSandboxPath()` before `runMessageAction()` is called. This mirrors the pattern already used in `image-tool.ts` and `read/write/edit` tools.
- **`src/agents/openclaw-tools.ts`**: Pass `sandboxRoot` from tool creation options to `createMessageTool()`.
- **`src/agents/tools/message-tool.test.ts`**: Added 4 tests covering sandbox path validation (reject absolute escape, reject traversal, allow valid relative path, skip validation when no sandbox).

### Security Impact

Without this fix, any sandboxed agent session could bypass the sandbox boundary via the message tool to access arbitrary host filesystem paths. This is a critical privilege escalation vector.

### AI Disclosure

This PR was developed with AI assistance (Claude Code). The code was reviewed, tested, and verified by the author. All tests pass, linting is clean, and the fix follows existing patterns in the codebase (`image-tool.ts`, `read`/`write` tools).

### Test Plan

- [x] `pnpm vitest run src/agents/tools/message-tool.test.ts` (8/8 pass)
- [x] `npx oxlint --type-aware --tsconfig tsconfig.oxlint.json` (0 errors)
- [x] `npx oxfmt --check` (all files formatted)
- [x] Build errors are pre-existing on `main` (unrelated `pi-coding-agent` type issues)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a `sandboxRoot` option into the `message` agent tool and uses the existing `assertSandboxPath()` helper to validate `filePath`/`path` parameters before dispatching to `runMessageAction()`, closing a sandbox escape vector where a sandboxed agent could reference arbitrary host paths. `createOpenClawTools()` now forwards `sandboxRoot` into `createMessageTool()`, and new Vitest cases exercise absolute-path and traversal rejection, as well as the “no sandboxRoot” passthrough.

The approach aligns with other sandbox-aware tools (e.g. `image-tool.ts` and the read/write/edit tools) by enforcing a single sandbox boundary at the tool surface before any plugin/channel code sees the path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and meaningfully improves sandbox safety, with a couple of edge cases to confirm.
- The change is localized and reuses the existing `assertSandboxPath()` sandbox boundary check, and tests cover key escape inputs. Remaining uncertainty is around how `path` is interpreted across different message actions/channels and whether an untrimmed `sandboxRoot` could lead to unexpected behavior in misconfigured callers.
- src/agents/tools/message-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->