### PR TITLE
fix: set correct mode for Anthropic OAuth auth (#2697)

### DIFF
--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -53,7 +53,7 @@ export async function applyAuthChoiceAnthropic(
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: namedProfileId,
       provider,
-      mode: "token",
+      mode: params.authChoice === "oauth" ? "oauth" : "token",
     });
     return { config: nextConfig };
   }


### PR DESCRIPTION
## Problem
When using Anthropic OAuth (Claude CLI) authentication via `clawdbot configure`, the wizard was incorrectly setting `mode: "token"` instead of `mode: "oauth"`. This caused authentication failures with 401 "Invalid bearer token" errors.

## Root Cause
In `auth-choice.apply.anthropic.ts`, the code handled `authChoice === "oauth"` the same as `authChoice === "token"`, always setting `mode: "token"` regardless of the actual auth type.

## Fix
Changed the mode assignment to check if `authChoice` is "oauth" and set the appropriate mode:
```typescript
mode: params.authChoice === "oauth" ? "oauth" : "token"
```

## Testing
- OAuth mode now correctly set when selecting "Anthropic token (Claude Code CLI)"
- Token mode still works for traditional token auth

Fixes #2697

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Anthropic auth-choice application so that selecting OAuth persists `mode: "oauth"` instead of always forcing `mode: "token"`. This aligns the `clawdbot configure` wizard’s saved config with the user’s selection and prevents 401 “Invalid bearer token” failures when OAuth is chosen.

No additional PR-introduced issues were found in `src/commands/auth-choice.apply.anthropic.ts`; the change is a narrow conditional assignment consistent with the stated root cause.

<h3>Confidence Score: 4/5</h3>

This PR is safe to merge and narrowly fixes a clear mode-selection bug.

Single-line conditional change with low blast radius that directly addresses the described failure mode (wrong config mode for OAuth). Residual risk is limited to downstream assumptions about mode/credential pairing, but that pairing behavior is pre-existing; this PR only corrects mode assignment.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/commands/auth-choice.apply.anthropic.ts | Sets auth profile config mode based on `authChoice` (oauth => oauth, else token). No other behavior changes; fix addresses incorrect mode written for OAuth choice. |

</details>


</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->