### PR TITLE
Docs: add Mintlify language navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Docs: add direct BotFather link and verification reminder in Telegram setup. (#4064) Thanks @shatner.
+- Docs: add Mintlify language navigation for zh-Hans. (#6416) Thanks @joshp123.
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
 
 ### Fixes

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -843,311 +843,340 @@
     }
   ],
   "navigation": {
-    "groups": [
+    "languages": [
       {
-        "group": "Start Here",
-        "pages": [
-          "index",
-          "start/getting-started",
-          "start/wizard",
-          "start/setup",
-          "start/pairing",
-          "start/openclaw",
-          "start/showcase",
-          "start/hubs",
-          "start/onboarding",
-          "start/lore"
+        "language": "en",
+        "default": true,
+        "groups": [
+          {
+            "group": "Start Here",
+            "pages": [
+              "index",
+              "start/getting-started",
+              "start/wizard",
+              "start/setup",
+              "start/pairing",
+              "start/openclaw",
+              "start/showcase",
+              "start/hubs",
+              "start/onboarding",
+              "start/lore"
+            ]
+          },
+          {
+            "group": "Help",
+            "pages": [
+              "help/index",
+              "help/troubleshooting",
+              "help/faq"
+            ]
+          },
+          {
+            "group": "Install & Updates",
+            "pages": [
+              "install/index",
+              "install/installer",
+              "install/updating",
+              "install/development-channels",
+              "install/uninstall",
+              "install/ansible",
+              "install/nix",
+              "install/docker",
+              "railway",
+              "render",
+              "northflank",
+              "install/bun"
+            ]
+          },
+          {
+            "group": "CLI",
+            "pages": [
+              "cli/index",
+              "cli/setup",
+              "cli/onboard",
+              "cli/configure",
+              "cli/doctor",
+              "cli/dashboard",
+              "cli/reset",
+              "cli/uninstall",
+              "cli/browser",
+              "cli/message",
+              "cli/agent",
+              "cli/agents",
+              "cli/status",
+              "cli/health",
+              "cli/sessions",
+              "cli/channels",
+              "cli/directory",
+              "cli/skills",
+              "cli/plugins",
+              "cli/memory",
+              "cli/models",
+              "cli/logs",
+              "cli/system",
+              "cli/nodes",
+              "cli/approvals",
+              "cli/gateway",
+              "cli/tui",
+              "cli/voicecall",
+              "cli/cron",
+              "cli/dns",
+              "cli/docs",
+              "cli/hooks",
+              "cli/pairing",
+              "cli/security",
+              "cli/update",
+              "cli/sandbox"
+            ]
+          },
+          {
+            "group": "Core Concepts",
+            "pages": [
+              "concepts/architecture",
+              "concepts/agent",
+              "concepts/agent-loop",
+              "concepts/system-prompt",
+              "concepts/context",
+              "token-use",
+              "concepts/oauth",
+              "concepts/agent-workspace",
+              "concepts/memory",
+              "concepts/multi-agent",
+              "concepts/compaction",
+              "concepts/session",
+              "concepts/session-pruning",
+              "concepts/sessions",
+              "concepts/session-tool",
+              "concepts/presence",
+              "concepts/channel-routing",
+              "concepts/messages",
+              "concepts/streaming",
+              "concepts/markdown-formatting",
+              "concepts/groups",
+              "concepts/group-messages",
+              "concepts/typing-indicators",
+              "concepts/queue",
+              "concepts/retry",
+              "concepts/model-providers",
+              "concepts/models",
+              "concepts/model-failover",
+              "concepts/usage-tracking",
+              "concepts/timezone",
+              "concepts/typebox"
+            ]
+          },
+          {
+            "group": "Gateway & Ops",
+            "pages": [
+              "gateway/index",
+              "gateway/protocol",
+              "gateway/bridge-protocol",
+              "gateway/pairing",
+              "gateway/gateway-lock",
+              "environment",
+              "gateway/configuration",
+              "gateway/multiple-gateways",
+              "gateway/configuration-examples",
+              "gateway/authentication",
+              "gateway/openai-http-api",
+              "gateway/tools-invoke-http-api",
+              "gateway/cli-backends",
+              "gateway/local-models",
+              "gateway/background-process",
+              "gateway/health",
+              "gateway/heartbeat",
+              "gateway/doctor",
+              "gateway/logging",
+              "gateway/security/index",
+              "security/formal-verification",
+              "gateway/sandbox-vs-tool-policy-vs-elevated",
+              "gateway/sandboxing",
+              "gateway/troubleshooting",
+              "debugging",
+              "gateway/remote",
+              "gateway/remote-gateway-readme",
+              "gateway/discovery",
+              "gateway/bonjour",
+              "gateway/tailscale"
+            ]
+          },
+          {
+            "group": "Web & Interfaces",
+            "pages": [
+              "web/index",
+              "web/control-ui",
+              "web/dashboard",
+              "web/webchat",
+              "tui"
+            ]
+          },
+          {
+            "group": "Channels",
+            "pages": [
+              "channels/index",
+              "channels/whatsapp",
+              "channels/telegram",
+              "channels/grammy",
+              "channels/discord",
+              "channels/slack",
+              "channels/googlechat",
+              "channels/mattermost",
+              "channels/signal",
+              "channels/imessage",
+              "channels/msteams",
+              "channels/line",
+              "channels/matrix",
+              "channels/zalo",
+              "channels/zalouser",
+              "broadcast-groups",
+              "channels/troubleshooting",
+              "channels/location"
+            ]
+          },
+          {
+            "group": "Providers",
+            "pages": [
+              "providers/index",
+              "providers/models",
+              "providers/openai",
+              "providers/anthropic",
+              "bedrock",
+              "providers/moonshot",
+              "providers/minimax",
+              "providers/vercel-ai-gateway",
+              "providers/openrouter",
+              "providers/synthetic",
+              "providers/opencode",
+              "providers/glm",
+              "providers/zai"
+            ]
+          },
+          {
+            "group": "Automation & Hooks",
+            "pages": [
+              "hooks",
+              "hooks/soul-evil",
+              "automation/auth-monitoring",
+              "automation/webhook",
+              "automation/gmail-pubsub",
+              "automation/cron-jobs",
+              "automation/cron-vs-heartbeat",
+              "automation/poll"
+            ]
+          },
+          {
+            "group": "Tools & Skills",
+            "pages": [
+              "tools/index",
+              "tools/lobster",
+              "tools/llm-task",
+              "plugin",
+              "plugins/voice-call",
+              "plugins/zalouser",
+              "tools/exec",
+              "tools/web",
+              "tools/apply-patch",
+              "tools/elevated",
+              "tools/browser",
+              "tools/browser-login",
+              "tools/chrome-extension",
+              "tools/browser-linux-troubleshooting",
+              "tools/slash-commands",
+              "tools/thinking",
+              "tools/agent-send",
+              "tools/subagents",
+              "multi-agent-sandbox-tools",
+              "tools/reactions",
+              "tools/skills",
+              "tools/skills-config",
+              "tools/clawhub"
+            ]
+          },
+          {
+            "group": "Nodes & Media",
+            "pages": [
+              "nodes/index",
+              "nodes/camera",
+              "nodes/images",
+              "nodes/audio",
+              "nodes/location-command",
+              "nodes/voicewake",
+              "nodes/talk"
+            ]
+          },
+          {
+            "group": "Platforms",
+            "pages": [
+              "platforms/index",
+              "platforms/macos",
+              "platforms/macos-vm",
+              "platforms/ios",
+              "platforms/android",
+              "platforms/windows",
+              "platforms/linux",
+              "platforms/fly",
+              "platforms/hetzner",
+              "platforms/gcp",
+              "platforms/exe-dev"
+            ]
+          },
+          {
+            "group": "macOS Companion App",
+            "pages": [
+              "platforms/mac/dev-setup",
+              "platforms/mac/menu-bar",
+              "platforms/mac/voicewake",
+              "platforms/mac/voice-overlay",
+              "platforms/mac/webchat",
+              "platforms/mac/canvas",
+              "platforms/mac/child-process",
+              "platforms/mac/health",
+              "platforms/mac/icon",
+              "platforms/mac/logging",
+              "platforms/mac/permissions",
+              "platforms/mac/remote",
+              "platforms/mac/signing",
+              "platforms/mac/release",
+              "platforms/mac/bundled-gateway",
+              "platforms/mac/xpc",
+              "platforms/mac/skills",
+              "platforms/mac/peekaboo"
+            ]
+          },
+          {
+            "group": "Reference & Templates",
+            "pages": [
+              "testing",
+              "scripts",
+              "reference/session-management-compaction",
+              "reference/rpc",
+              "reference/device-models",
+              "reference/test",
+              "reference/RELEASING",
+              "reference/AGENTS.default",
+              "reference/templates/AGENTS",
+              "reference/templates/BOOT",
+              "reference/templates/BOOTSTRAP",
+              "reference/templates/HEARTBEAT",
+              "reference/templates/IDENTITY",
+              "reference/templates/SOUL",
+              "reference/templates/TOOLS",
+              "reference/templates/USER"
+            ]
+          }
         ]
       },
       {
-        "group": "Help",
-        "pages": ["help/index", "help/troubleshooting", "help/faq"]
-      },
-      {
-        "group": "Install & Updates",
-        "pages": [
-          "install/index",
-          "install/installer",
-          "install/updating",
-          "install/development-channels",
-          "install/uninstall",
-          "install/ansible",
-          "install/nix",
-          "install/docker",
-          "railway",
-          "render",
-          "northflank",
-          "install/bun"
-        ]
-      },
-      {
-        "group": "CLI",
-        "pages": [
-          "cli/index",
-          "cli/setup",
-          "cli/onboard",
-          "cli/configure",
-          "cli/doctor",
-          "cli/dashboard",
-          "cli/reset",
-          "cli/uninstall",
-          "cli/browser",
-          "cli/message",
-          "cli/agent",
-          "cli/agents",
-          "cli/status",
-          "cli/health",
-          "cli/sessions",
-          "cli/channels",
-          "cli/directory",
-          "cli/skills",
-          "cli/plugins",
-          "cli/memory",
-          "cli/models",
-          "cli/logs",
-          "cli/system",
-          "cli/nodes",
-          "cli/approvals",
-          "cli/gateway",
-          "cli/tui",
-          "cli/voicecall",
-          "cli/cron",
-          "cli/dns",
-          "cli/docs",
-          "cli/hooks",
-          "cli/pairing",
-          "cli/security",
-          "cli/update",
-          "cli/sandbox"
-        ]
-      },
-      {
-        "group": "Core Concepts",
-        "pages": [
-          "concepts/architecture",
-          "concepts/agent",
-          "concepts/agent-loop",
-          "concepts/system-prompt",
-          "concepts/context",
-          "token-use",
-          "concepts/oauth",
-          "concepts/agent-workspace",
-          "concepts/memory",
-          "concepts/multi-agent",
-          "concepts/compaction",
-          "concepts/session",
-          "concepts/session-pruning",
-          "concepts/sessions",
-          "concepts/session-tool",
-          "concepts/presence",
-          "concepts/channel-routing",
-          "concepts/messages",
-          "concepts/streaming",
-          "concepts/markdown-formatting",
-          "concepts/groups",
-          "concepts/group-messages",
-          "concepts/typing-indicators",
-          "concepts/queue",
-          "concepts/retry",
-          "concepts/model-providers",
-          "concepts/models",
-          "concepts/model-failover",
-          "concepts/usage-tracking",
-          "concepts/timezone",
-          "concepts/typebox"
-        ]
-      },
-      {
-        "group": "Gateway & Ops",
-        "pages": [
-          "gateway/index",
-          "gateway/protocol",
-          "gateway/bridge-protocol",
-          "gateway/pairing",
-          "gateway/gateway-lock",
-          "environment",
-          "gateway/configuration",
-          "gateway/multiple-gateways",
-          "gateway/configuration-examples",
-          "gateway/authentication",
-          "gateway/openai-http-api",
-          "gateway/tools-invoke-http-api",
-          "gateway/cli-backends",
-          "gateway/local-models",
-          "gateway/background-process",
-          "gateway/health",
-          "gateway/heartbeat",
-          "gateway/doctor",
-          "gateway/logging",
-          "gateway/security/index",
-          "security/formal-verification",
-          "gateway/sandbox-vs-tool-policy-vs-elevated",
-          "gateway/sandboxing",
-          "gateway/troubleshooting",
-          "debugging",
-          "gateway/remote",
-          "gateway/remote-gateway-readme",
-          "gateway/discovery",
-          "gateway/bonjour",
-          "gateway/tailscale"
-        ]
-      },
-      {
-        "group": "Web & Interfaces",
-        "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
-      },
-      {
-        "group": "Channels",
-        "pages": [
-          "channels/index",
-          "channels/whatsapp",
-          "channels/telegram",
-          "channels/grammy",
-          "channels/discord",
-          "channels/slack",
-          "channels/googlechat",
-          "channels/mattermost",
-          "channels/signal",
-          "channels/imessage",
-          "channels/msteams",
-          "channels/line",
-          "channels/matrix",
-          "channels/zalo",
-          "channels/zalouser",
-          "broadcast-groups",
-          "channels/troubleshooting",
-          "channels/location"
-        ]
-      },
-      {
-        "group": "Providers",
-        "pages": [
-          "providers/index",
-          "providers/models",
-          "providers/openai",
-          "providers/anthropic",
-          "bedrock",
-          "providers/moonshot",
-          "providers/minimax",
-          "providers/vercel-ai-gateway",
-          "providers/openrouter",
-          "providers/synthetic",
-          "providers/opencode",
-          "providers/glm",
-          "providers/zai"
-        ]
-      },
-      {
-        "group": "Automation & Hooks",
-        "pages": [
-          "hooks",
-          "hooks/soul-evil",
-          "automation/auth-monitoring",
-          "automation/webhook",
-          "automation/gmail-pubsub",
-          "automation/cron-jobs",
-          "automation/cron-vs-heartbeat",
-          "automation/poll"
-        ]
-      },
-      {
-        "group": "Tools & Skills",
-        "pages": [
-          "tools/index",
-          "tools/lobster",
-          "tools/llm-task",
-          "plugin",
-          "plugins/voice-call",
-          "plugins/zalouser",
-          "tools/exec",
-          "tools/web",
-          "tools/apply-patch",
-          "tools/elevated",
-          "tools/browser",
-          "tools/browser-login",
-          "tools/chrome-extension",
-          "tools/browser-linux-troubleshooting",
-          "tools/slash-commands",
-          "tools/thinking",
-          "tools/agent-send",
-          "tools/subagents",
-          "multi-agent-sandbox-tools",
-          "tools/reactions",
-          "tools/skills",
-          "tools/skills-config",
-          "tools/clawhub"
-        ]
-      },
-      {
-        "group": "Nodes & Media",
-        "pages": [
-          "nodes/index",
-          "nodes/camera",
-          "nodes/images",
-          "nodes/audio",
-          "nodes/location-command",
-          "nodes/voicewake",
-          "nodes/talk"
-        ]
-      },
-      {
-        "group": "Platforms",
-        "pages": [
-          "platforms/index",
-          "platforms/macos",
-          "platforms/macos-vm",
-          "platforms/ios",
-          "platforms/android",
-          "platforms/windows",
-          "platforms/linux",
-          "platforms/fly",
-          "platforms/hetzner",
-          "platforms/gcp",
-          "platforms/exe-dev"
-        ]
-      },
-      {
-        "group": "macOS Companion App",
-        "pages": [
-          "platforms/mac/dev-setup",
-          "platforms/mac/menu-bar",
-          "platforms/mac/voicewake",
-          "platforms/mac/voice-overlay",
-          "platforms/mac/webchat",
-          "platforms/mac/canvas",
-          "platforms/mac/child-process",
-          "platforms/mac/health",
-          "platforms/mac/icon",
-          "platforms/mac/logging",
-          "platforms/mac/permissions",
-          "platforms/mac/remote",
-          "platforms/mac/signing",
-          "platforms/mac/release",
-          "platforms/mac/bundled-gateway",
-          "platforms/mac/xpc",
-          "platforms/mac/skills",
-          "platforms/mac/peekaboo"
-        ]
-      },
-      {
-        "group": "Reference & Templates",
-        "pages": [
-          "testing",
-          "scripts",
-          "reference/session-management-compaction",
-          "reference/rpc",
-          "reference/device-models",
-          "reference/test",
-          "reference/RELEASING",
-          "reference/AGENTS.default",
-          "reference/templates/AGENTS",
-          "reference/templates/BOOT",
-          "reference/templates/BOOTSTRAP",
-          "reference/templates/HEARTBEAT",
-          "reference/templates/IDENTITY",
-          "reference/templates/SOUL",
-          "reference/templates/TOOLS",
-          "reference/templates/USER"
+        "language": "zh-Hans",
+        "groups": [
+          {
+            "group": "开始",
+            "pages": [
+              "zh-CN/index",
+              "zh-CN/start/getting-started",
+              "zh-CN/start/wizard"
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- switch docs navigation to Mintlify languages so zh-CN can render in the native language picker
- keep English nav unchanged and add a zh-Hans nav with the translated entrypoints only

## Testing
- not run (docs config change)

## Notes
- branch rebased on main; PR should now be a single docs.json change
