### PR TITLE
fix(ui): cap exec-approval command height to keep buttons visible

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1463,6 +1463,8 @@
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 120px;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {


### PR DESCRIPTION
Long commands pushed approval buttons off-screen, blocking user workflow. Add max-height and overflow-y to .exec-approval-command so buttons stay visible and users can scroll to see full command.

Fixes #6397

🤖 AI-assisted: Built with Claude Code (claude-opus-4-5) Testing: Fully tested - lint, build, and all tests pass. The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the exec approval modal styling by capping the visible height of `.exec-approval-command` and enabling vertical scrolling. The goal is to prevent long commands from pushing the approval action buttons off-screen, keeping the approval/reject controls accessible while still allowing users to view the full command by scrolling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized CSS adjustment (max-height + overflow-y) on a single selector, with no apparent impact on unrelated UI components and no logic/runtime implications.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->