### PR TITLE
fix: always sanitize tool call IDs for cross-provider compatibility

### DIFF
--- a/src/agents/pi-embedded-runner.google-sanitize-thinking.test.ts
+++ b/src/agents/pi-embedded-runner.google-sanitize-thinking.test.ts
@@ -223,13 +223,13 @@ describe("sanitizeSessionHistory (google thinking)", () => {
       { type: "thinking", thinking: "ok", thought_signature: "c2ln" },
       {
         type: "toolCall",
-        id: "call_1",
+        id: "call1",
         name: "read",
         arguments: { path: "/tmp/foo" },
       },
       {
         type: "toolCall",
-        id: "call_2",
+        id: "call2",
         name: "read",
         arguments: { path: "/tmp/bar" },
         thoughtSignature: "c2ln",

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -76,7 +76,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for non-Google APIs", async () => {
+  it("sanitizes tool call ids for Anthropic APIs", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -90,7 +90,7 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: false }),
+      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: true }),
     );
   });
 

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,12 +95,13 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral;
-  const toolCallIdMode: ToolCallIdMode | undefined = isMistral
-    ? "strict9"
-    : sanitizeToolCallIds
-      ? "strict"
-      : undefined;
+  // Always sanitize tool call IDs to ensure cross-provider compatibility.
+  // Source models (e.g., Ollama/Qwen3) may generate IDs with characters like "|"
+  // that are invalid for other providers (Anthropic, Google, etc.).
+  // Using "strict" mode (alphanumeric only) works universally.
+  // Exception: Mistral requires exactly 9 characters.
+  const sanitizeToolCallIds = true;
+  const toolCallIdMode: ToolCallIdMode | undefined = isMistral ? "strict9" : "strict";
   const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,12 +95,11 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  // Always sanitize tool call IDs to ensure cross-provider compatibility.
+  // Always sanitize tool call IDs (except OpenAI) to ensure cross-provider compatibility.
   // Source models (e.g., Ollama/Qwen3) may generate IDs with characters like "|"
   // that are invalid for other providers (Anthropic, Google, etc.).
   // Using "strict" mode (alphanumeric only) works universally.
   // Exception: Mistral requires exactly 9 characters.
-  const sanitizeToolCallIds = true;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral ? "strict9" : "strict";
   const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures = isOpenRouterGemini
@@ -110,7 +109,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds: !isOpenAi,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
     preserveSignatures: isAntigravityClaudeModel,


### PR DESCRIPTION
When sessions involve multiple LLM providers (e.g., Ollama/Qwen3 for heartbeat + OpenRouter/Claude for main chat), tool call IDs generated by one provider can be rejected by another due to incompatible ID format requirements.

For example, Ollama/Qwen3 generates IDs like "call_dqgnzb73|fc_705868_0" which contain pipe characters that Anthropic's API rejects with: "tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'"

This change enables universal sanitization using "strict" mode (alphanumeric only) which works as the lowest common denominator for all providers:
- Anthropic: accepts [a-zA-Z0-9_-], strict [a-zA-Z0-9] is valid subset
- Google: accepts [a-zA-Z0-9], exact match
- Mistral: uses strict9 mode (9 char alphanumeric)
- OpenAI: accepts anything, sanitization skipped
- DeepSeek/Kimi/others: typically accept [a-zA-Z0-9_-], subset works

This future-proofs the solution - no code changes needed when adding new providers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveTranscriptPolicy` to always apply tool-call ID sanitization (using `strict` mode by default and `strict9` for Mistral) so session transcripts remain compatible when switching between providers with different tool ID constraints (e.g., IDs containing `|` from one provider being rejected by Anthropic/Google). The change keeps OpenAI APIs opting out of sanitization via the existing `!isOpenAi` gating.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it makes a narrowly-scoped behavior change to tool-call ID sanitization logic.
- Change is localized to transcript policy selection and aligns with existing sanitization implementation (`strict`/`strict9`). Main risk is behavioral/compatibility impact on any downstream code that expects unsanitized IDs in non-OpenAI providers, but the mapping logic is transcript-wide and collision-aware.
- src/agents/transcript-policy.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->