### PR TITLE
fix: enable reasoning flag for Kimi K2.5 in Moonshot provider (#6451)

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -313,7 +313,7 @@ function buildMoonshotProvider(): ProviderConfig {
       {
         id: MOONSHOT_DEFAULT_MODEL_ID,
         name: "Kimi K2.5",
-        reasoning: false,
+        reasoning: true,
         input: ["text"],
         cost: MOONSHOT_DEFAULT_COST,
         contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## Problem
Kimi K2.5 outputs reasoning tokens but was configured with `reasoning: false` in the Moonshot provider config. This caused reasoning content to leak into user-visible output instead of being properly stripped.

## Root Cause
In `models-config.providers.ts`, the Moonshot provider had:
```typescript
{
  id: MOONSHOT_DEFAULT_MODEL_ID,
  name: "Kimi K2.5",
  reasoning: false,  // Wrong - model outputs reasoning
  ...
}
```

Meanwhile, the synthetic model catalog already correctly had `reasoning: true` for `hf:moonshotai/Kimi-K2.5`.

## Fix
Changed `reasoning: false` → `reasoning: true` for Kimi K2.5 in Moonshot provider config.

## Impact
- Enables reasoning tag stripping for Kimi K2.5 via Moonshot provider
- Prevents reasoning leaks in user-visible output
- Makes Moonshot config consistent with synthetic model config

## Testing
This is a configuration change that enables existing reasoning tag stripping infrastructure. The `reasoning-tags.ts` module will now be applied to Kimi K2.5 output.

Fixes #6451

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Moonshot provider’s default model definition for **Kimi K2.5** to set `reasoning: true` (was `false`) in `src/agents/models-config.providers.ts`. This aligns the Moonshot provider config with the synthetic model catalog and ensures the existing “reasoning tag stripping” pipeline is applied to Kimi K2.5 outputs, preventing model reasoning tokens from leaking into user-visible text.

Change is localized to the provider model metadata and fits the codebase’s pattern of per-provider static model catalogs used by `resolveImplicitProviders` and other config normalization utilities.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line config correction (enabling `reasoning` for a model known to emit reasoning tokens) and does not alter control flow, APIs, or data formats beyond selecting existing output-stripping behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->