### PR TITLE
fix(gateway): add handshake timeout and connection error handling

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -242,6 +242,14 @@ export async function callGateway<T = Record<string, unknown>>(
         client.stop();
         stop(new Error(formatCloseError(code, reason)));
       },
+      onConnectError: (err) => {
+        if (settled || ignoreClose) {
+          return;
+        }
+        ignoreClose = true;
+        client.stop();
+        stop(new Error(`gateway connection failed: ${err.message}\n${connectionDetails.message}`));
+      },
     });
 
     const timer = setTimeout(() => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -248,7 +248,10 @@ export async function callGateway<T = Record<string, unknown>>(
         }
         ignoreClose = true;
         client.stop();
-        stop(new Error(`gateway connection failed: ${err.message}\n${connectionDetails.message}`));
+        stop(
+          new Error(`gateway connection failed: ${err.message}
+${connectionDetails.message}`),
+        );
       },
     });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -110,6 +110,7 @@ export class GatewayClient {
     // Allow node screen snapshots and other large responses.
     const wsOptions: ClientOptions = {
       maxPayload: 25 * 1024 * 1024,
+      handshakeTimeout: 10_000, // Fail fast if connection can't be established
     };
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
       wsOptions.rejectUnauthorized = false;


### PR DESCRIPTION
Adds timeout handling for agent CLI connections to prevent hanging when the gateway is unreachable or slow to respond.

## Changes
- Added handshake timeout for connection establishment
- Improved error handling for connection failures
- Clearer error messages when connection times out

## Testing
Tested locally with various network conditions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds faster failure behavior for gateway CLI connections by:
- Setting a WebSocket `handshakeTimeout` in `GatewayClient` to prevent hanging during connection establishment.
- Plumbing a new `onConnectError` path through `callGateway` so connection failures surface as clearer CLI errors with connection details.

These changes fit into the existing gateway client lifecycle (`GatewayClient.start()` wiring and `callGateway`’s promise-based connect/request flow) and should improve operator UX when the gateway is unreachable or slow.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge and is a focused improvement to connection failure behavior.
- Changes are small and localized to gateway connection setup and error plumbing; the new `handshakeTimeout` is a standard ws option and the new callback is guarded to avoid double-settle. The main concern is message formatting consistency (literal `\\n`), not runtime correctness.
- src/gateway/call.ts (error message formatting), src/gateway/client.ts (ensure handshakeTimeout aligns with desired CLI timeout behavior)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->