### PR TITLE
fix(skills): ignore Python directories in skills watcher

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,13 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  // Python virtual environments and caches
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])\.pytest_cache([\\/]|$)/,
+  // General caches
+  /(^|[\\/])\.cache([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
## Summary
- Add `.venv`, `venv`, `__pycache__`, `.pytest_cache`, and `.cache` to `DEFAULT_SKILLS_WATCH_IGNORED`
- Prevents EMFILE (too many open files) errors when Python-based skills have large virtual environments

## Test plan
- [x] Existing test passes (`src/agents/skills/refresh.test.ts`)
- [ ] Manual test with Python skill containing `.venv`

Fixes #6429

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the default `chokidar` ignore list used by the skills directory watcher (`ensureSkillsWatcher` in `src/agents/skills/refresh.ts`) to exclude common Python virtual environment and cache directories (`.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.cache`). This reduces the watcher’s file descriptor usage and helps avoid `EMFILE` errors when a skills workspace contains large Python dependency trees, while keeping the existing behavior of watching the skills-related paths and debouncing snapshot version bumps.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to adding additional ignore regexes for a file watcher; it doesn’t affect core logic beyond reducing watched paths. No behavior-breaking changes were found in the modified code.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->