### PR TITLE
fix(telegram): include threadId in OriginatingTo for DM topics

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -628,7 +628,8 @@ export const buildTelegramMessageContext = async ({
     IsForum: isForum,
     // Originating channel for reply routing.
     OriginatingChannel: "telegram" as const,
-    OriginatingTo: `telegram:${chatId}`,
+    OriginatingTo:
+      dmThreadId != null ? `telegram:${chatId}:topic:${dmThreadId}` : `telegram:${chatId}`,
   });
 
   await recordInboundSession({

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -532,7 +532,10 @@ export const registerTelegramNativeCommands = ({
             IsForum: isForum,
             // Originating context for sub-agent announce routing
             OriginatingChannel: "telegram" as const,
-            OriginatingTo: `telegram:${chatId}`,
+            OriginatingTo:
+              !isGroup && messageThreadId != null
+                ? `telegram:${chatId}:topic:${messageThreadId}`
+                : `telegram:${chatId}`,
           });
 
           const disableBlockStreaming =


### PR DESCRIPTION
## Summary
- Include `dmThreadId` in `OriginatingTo` when present for Telegram DM topics
- Format: `telegram:{chatId}:topic:{threadId}` instead of just `telegram:{chatId}`

## Problem
When a user sends a message in a Telegram DM topic (threaded mode enabled via BotFather), the auto-reply was being sent to the main chat instead of the topic.

## Solution
Modified `OriginatingTo` to include the topic ID for DM threads, so reply routing sends responses to the correct topic.

## Test plan
- [ ] Enable threaded mode for a bot in BotFather
- [ ] Create a topic in DM
- [ ] Send a message in the topic
- [ ] Verify reply appears in the topic, not main chat

Fixes #6417

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram inbound context construction so `OriginatingTo` includes a DM topic/thread id when `message_thread_id` is present, intending to route auto-replies back into the correct DM topic instead of the main chat.

Key integration point: queued/templated reply routing relies on `OriginatingChannel` + `OriginatingTo` and (for Telegram) ultimately goes through `parseTelegramTarget()` to derive `message_thread_id` for outbound sends. The new `OriginatingTo` format should match what the Telegram target parser understands (`<chatId>:topic:<threadId>`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe but may not actually fix DM-topic routing end-to-end due to target format/parser mismatch.
- The change is small and localized, but reply routing depends on `OriginatingTo` being parseable into a Telegram chatId + thread id; the introduced `telegram:${chatId}:topic:${dmThreadId}` format does not appear to align with `parseTelegramTarget()`’s expectations and may still route replies to the main chat.
- src/telegram/bot-message-context.ts; also verify downstream parsing in src/telegram/targets.ts and any `OriginatingTo` consumers.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->