### PR TITLE
fix(gateway): pass accountId in restart sentinel for correct bot routing

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -92,6 +92,7 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
         sessionKey,
         to: resolved.to,
         channel,
+        accountId: origin?.accountId,
         deliver: true,
         bestEffortDeliver: true,
         messageChannel: channel,


### PR DESCRIPTION
## Summary
- Pass `accountId: origin?.accountId` to `agentCommand` in restart sentinel wake

## Problem
When multiple Telegram bot accounts are configured, message delivery after a gateway restart was routed through whichever bot connected first (alphabetically), not the bot associated with the originating session.

This is a **data isolation / privacy issue** in multi-agent setups.

## Root Cause
The `accountId` was already correctly resolved via `mergeDeliveryContext` but was never forwarded to the `agentCommand` call.

## Solution
Add `accountId: origin?.accountId` to the agentCommand parameters.

## Test plan
- [ ] Configure 2+ Telegram bot accounts bound to different agents
- [ ] Start a session on one account
- [ ] Trigger a gateway restart (config patch)
- [ ] Verify queued response is delivered through the correct bot

Fixes #6402

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-account channel routing after a gateway restart by forwarding the resolved `accountId` from the merged delivery context into the restart sentinel’s `agentCommand` call (`src/gateway/server-restart-sentinel.ts`). That aligns the wake-up delivery path with the existing `resolveOutboundTarget({ accountId })` resolution and prevents responses from being sent via the first-connected bot in multi-bot Telegram setups.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line parameter pass-through that matches the existing delivery context resolution; it’s consistent with how `accountId` is already supplied to `resolveOutboundTarget` and how `agentCommand` consumes `accountId` via `runContext.accountId` for embedded routing.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->