### PR TITLE
fix(ui): replace unreachable CDN logo with inline SVG

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -132,7 +132,14 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src="https://mintcdn.com/clawhub/4rYvG-uuZrMK_URE/assets/pixel-lobster.svg?fit=max&auto=format&n=4rYvG-uuZrMK_URE&q=85&s=da2032e9eac3b5d9bfe7eb96ca6a8a26" alt="OpenClaw" />
+              <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16" role="img" aria-label="OpenClaw">
+                <rect width="16" height="16" fill="none"/>
+                <g fill="#3a0a0d"><rect x="1" y="5" width="1" height="3"/><rect x="2" y="4" width="1" height="1"/><rect x="2" y="8" width="1" height="1"/><rect x="3" y="3" width="1" height="1"/><rect x="3" y="9" width="1" height="1"/><rect x="4" y="2" width="1" height="1"/><rect x="4" y="10" width="1" height="1"/><rect x="5" y="2" width="6" height="1"/><rect x="11" y="2" width="1" height="1"/><rect x="12" y="3" width="1" height="1"/><rect x="12" y="9" width="1" height="1"/><rect x="13" y="4" width="1" height="1"/><rect x="13" y="8" width="1" height="1"/><rect x="14" y="5" width="1" height="3"/><rect x="5" y="11" width="6" height="1"/><rect x="4" y="12" width="1" height="1"/><rect x="11" y="12" width="1" height="1"/><rect x="3" y="13" width="1" height="1"/><rect x="12" y="13" width="1" height="1"/><rect x="5" y="14" width="6" height="1"/></g>
+                <g fill="#ff4f40"><rect x="5" y="3" width="6" height="1"/><rect x="4" y="4" width="8" height="1"/><rect x="3" y="5" width="10" height="1"/><rect x="3" y="6" width="10" height="1"/><rect x="3" y="7" width="10" height="1"/><rect x="4" y="8" width="8" height="1"/><rect x="5" y="9" width="6" height="1"/><rect x="5" y="12" width="6" height="1"/><rect x="6" y="13" width="4" height="1"/></g>
+                <g fill="#ff775f"><rect x="1" y="6" width="2" height="1"/><rect x="2" y="5" width="1" height="1"/><rect x="2" y="7" width="1" height="1"/><rect x="13" y="6" width="2" height="1"/><rect x="13" y="5" width="1" height="1"/><rect x="13" y="7" width="1" height="1"/></g>
+                <g fill="#081016"><rect x="6" y="5" width="1" height="1"/><rect x="9" y="5" width="1" height="1"/></g>
+                <g fill="#f5fbff"><rect x="6" y="4" width="1" height="1"/><rect x="9" y="4" width="1" height="1"/></g>
+              </svg>
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
## Summary
- Replace external `mintcdn.com` URL with inline SVG for the pixel-lobster logo
- Eliminates external dependency and ensures logo always loads

## Problem
The CDN URL `https://mintcdn.com/clawhub/...` for the logo image was unreachable.

## Solution
Embed the SVG directly in the template. The SVG is the same pixel-lobster asset from `docs/assets/pixel-lobster.svg`.

## Test plan
- [x] Visually verify logo renders correctly in dashboard

Fixes #6394

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces the dashboard brand logo image previously loaded from an external Mint CDN URL with an inline SVG, removing the external dependency and preventing broken logos when the CDN is unreachable. The change is localized to the topbar brand rendering in `ui/src/ui/app-render.ts` and keeps the rest of the UI rendering flow unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a localized UI asset change.
- The change only replaces an `<img>` tag with a static inline SVG and doesn’t alter state, event handlers, or data flow. The main remaining concern is minor accessibility semantics (whether the logo should be announced by screen readers).
- ui/src/ui/app-render.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->