### PR TITLE
feat(channels): add 'confirming' dmPolicy mode for owner-approved responses

### DIFF
--- a/src/cli/confirming-cli.ts
+++ b/src/cli/confirming-cli.ts
@@ -1,0 +1,294 @@
+import type { Command } from "commander";
+import {
+  approvePendingResponse,
+  listPendingResponses,
+  rejectPendingResponse,
+  type ConfirmingChannel,
+  type PendingResponse,
+} from "../confirming/confirming-store.js";
+import { defaultRuntime } from "../runtime.js";
+import { renderTable } from "../terminal/table.js";
+import { theme } from "../terminal/theme.js";
+import { formatCliCommand } from "./command-format.js";
+
+const CONFIRMING_CHANNELS: ConfirmingChannel[] = ["whatsapp", "telegram", "signal", "discord"];
+
+function parseChannel(raw: unknown): ConfirmingChannel {
+  const value = (
+    typeof raw === "string"
+      ? raw
+      : typeof raw === "number" || typeof raw === "boolean"
+        ? String(raw)
+        : ""
+  )
+    .trim()
+    .toLowerCase();
+  if (!value) {
+    throw new Error("Channel required");
+  }
+  if (!CONFIRMING_CHANNELS.includes(value as ConfirmingChannel)) {
+    throw new Error(
+      `Invalid channel: ${value}. Expected one of: ${CONFIRMING_CHANNELS.join(", ")}`,
+    );
+  }
+  return value as ConfirmingChannel;
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength - 3)}...`;
+}
+
+function formatStatus(status: PendingResponse["status"]): string {
+  switch (status) {
+    case "pending":
+      return theme.warn("pending");
+    case "approved":
+      return theme.success("approved");
+    case "rejected":
+      return theme.error("rejected");
+    case "expired":
+      return theme.muted("expired");
+    case "auto-approved":
+      return theme.success("auto-approved");
+    default:
+      return status;
+  }
+}
+
+async function sendApprovedMessage(params: {
+  channel: ConfirmingChannel;
+  response: PendingResponse;
+}): Promise<void> {
+  const { channel, response } = params;
+  const messageToSend = response.editedResponse ?? response.suggestedResponse;
+
+  if (channel === "whatsapp") {
+    // Import dynamically to avoid circular dependencies
+    const { requireActiveWebListener } = await import("../web/active-listener.js");
+    const { listener } = requireActiveWebListener(response.accountId);
+    await listener.sendMessage(response.replyTo, messageToSend);
+  } else {
+    throw new Error(`Sending approved messages not yet implemented for ${channel}`);
+  }
+}
+
+export function registerConfirmingCli(program: Command) {
+  const confirming = program
+    .command("confirming")
+    .description("Manage owner-approved responses (dmPolicy: confirming)");
+
+  confirming
+    .command("list")
+    .description("List pending responses awaiting approval")
+    .option("--channel <channel>", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .argument("[channel]", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .option("--json", "Print JSON", false)
+    .option("--all", "Show all responses (including resolved)", false)
+    .action(async (channelArg, opts) => {
+      const channelRaw = opts.channel ?? channelArg;
+      if (!channelRaw) {
+        throw new Error(
+          `Channel required. Use --channel <channel> or pass it as the first argument (expected one of: ${CONFIRMING_CHANNELS.join(", ")})`,
+        );
+      }
+      const channel = parseChannel(channelRaw);
+      const responses = await listPendingResponses(channel);
+      const filtered = opts.all ? responses : responses.filter((r) => r.status === "pending");
+
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify({ channel, responses: filtered }, null, 2));
+        return;
+      }
+      if (filtered.length === 0) {
+        defaultRuntime.log(theme.muted(`No ${opts.all ? "" : "pending "}${channel} responses.`));
+        return;
+      }
+      const tableWidth = Math.max(80, (process.stdout.columns ?? 120) - 1);
+      defaultRuntime.log(`${theme.heading("Responses")} ${theme.muted(`(${filtered.length})`)}`);
+      defaultRuntime.log(
+        renderTable({
+          width: tableWidth,
+          columns: [
+            { key: "Code", header: "Code", minWidth: 8 },
+            { key: "Status", header: "Status", minWidth: 10 },
+            { key: "From", header: "From", minWidth: 15, flex: true },
+            { key: "Message", header: "Message", minWidth: 20, flex: true },
+            { key: "Created", header: "Created", minWidth: 12 },
+          ],
+          rows: filtered.map((r) => ({
+            Code: r.code,
+            Status: formatStatus(r.status),
+            From: r.senderName ? `${r.senderName} (${r.senderId})` : r.senderId,
+            Message: truncate(r.originalMessage, 30),
+            Created: r.createdAt,
+          })),
+        }).trimEnd(),
+      );
+    });
+
+  confirming
+    .command("show")
+    .description("Show details of a pending response")
+    .option("--channel <channel>", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .argument("<codeOrChannel>", "Response code (or channel when using 2 args)")
+    .argument("[code]", "Response code (when channel is passed as the 1st arg)")
+    .option("--json", "Print JSON", false)
+    .action(async (codeOrChannel, code, opts) => {
+      const channelRaw = opts.channel ?? codeOrChannel;
+      const resolvedCode = opts.channel ? codeOrChannel : code;
+      if (!opts.channel && !code) {
+        throw new Error(`Usage: ${formatCliCommand("openclaw confirming show <channel> <code>")}`);
+      }
+      const channel = parseChannel(channelRaw);
+      const responses = await listPendingResponses(channel);
+      const response = responses.find(
+        (r) => r.code.toUpperCase() === String(resolvedCode).toUpperCase(),
+      );
+      if (!response) {
+        throw new Error(`No response found for code: ${String(resolvedCode)}`);
+      }
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify(response, null, 2));
+        return;
+      }
+      defaultRuntime.log(`${theme.heading("Response")} ${theme.command(response.code)}`);
+      defaultRuntime.log(`${theme.muted("Status:")} ${formatStatus(response.status)}`);
+      defaultRuntime.log(
+        `${theme.muted("From:")} ${response.senderName ? `${response.senderName} (${response.senderId})` : response.senderId}`,
+      );
+      defaultRuntime.log(`${theme.muted("Created:")} ${response.createdAt}`);
+      if (response.resolvedAt) {
+        defaultRuntime.log(`${theme.muted("Resolved:")} ${response.resolvedAt}`);
+      }
+      defaultRuntime.log("");
+      defaultRuntime.log(`${theme.heading("Original Message:")}`);
+      defaultRuntime.log(response.originalMessage);
+      defaultRuntime.log("");
+      defaultRuntime.log(`${theme.heading("Suggested Response:")}`);
+      defaultRuntime.log(response.suggestedResponse);
+      if (response.editedResponse) {
+        defaultRuntime.log("");
+        defaultRuntime.log(`${theme.heading("Edited Response:")}`);
+        defaultRuntime.log(response.editedResponse);
+      }
+    });
+
+  confirming
+    .command("approve")
+    .description("Approve a response and send it to the original sender")
+    .option("--channel <channel>", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .argument("<codeOrChannel>", "Response code (or channel when using 2 args)")
+    .argument("[code]", "Response code (when channel is passed as the 1st arg)")
+    .action(async (codeOrChannel, code, opts) => {
+      const channelRaw = opts.channel ?? codeOrChannel;
+      const resolvedCode = opts.channel ? codeOrChannel : code;
+      if (!opts.channel && !code) {
+        throw new Error(
+          `Usage: ${formatCliCommand("openclaw confirming approve <channel> <code>")}`,
+        );
+      }
+      const channel = parseChannel(channelRaw);
+      const approved = await approvePendingResponse({
+        channel,
+        code: String(resolvedCode),
+      });
+      if (!approved) {
+        throw new Error(`No pending response found for code: ${String(resolvedCode)}`);
+      }
+
+      // Send the approved message to the original sender
+      try {
+        await sendApprovedMessage({ channel, response: approved });
+        defaultRuntime.log(
+          `${theme.success("Approved")} and sent response to ${theme.command(approved.senderId)}.`,
+        );
+      } catch (err) {
+        defaultRuntime.log(`${theme.success("Approved")} but failed to send: ${String(err)}`);
+        defaultRuntime.log(
+          theme.muted(`Response marked as approved. You may need to send manually.`),
+        );
+      }
+    });
+
+  confirming
+    .command("edit")
+    .description("Approve a response with an edited message")
+    .option("--channel <channel>", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .argument("<codeOrChannel>", "Response code (or channel when using 2 args)")
+    .argument("<codeOrMessage>", "Code or edited message")
+    .argument("[message]", "Edited message to send")
+    .action(async (codeOrChannel, codeOrMessage, message, opts) => {
+      let channel: ConfirmingChannel;
+      let resolvedCode: string;
+      let editedMessage: string;
+
+      if (opts.channel) {
+        channel = parseChannel(opts.channel);
+        resolvedCode = codeOrChannel;
+        editedMessage = codeOrMessage;
+      } else if (message) {
+        channel = parseChannel(codeOrChannel);
+        resolvedCode = codeOrMessage;
+        editedMessage = message;
+      } else {
+        throw new Error(
+          `Usage: ${formatCliCommand('openclaw confirming edit <channel> <code> "edited message"')}`,
+        );
+      }
+
+      const approved = await approvePendingResponse({
+        channel,
+        code: resolvedCode,
+        editedResponse: editedMessage,
+      });
+      if (!approved) {
+        throw new Error(`No pending response found for code: ${resolvedCode}`);
+      }
+
+      // Send the edited message to the original sender
+      try {
+        await sendApprovedMessage({ channel, response: approved });
+        defaultRuntime.log(
+          `${theme.success("Approved (edited)")} and sent response to ${theme.command(approved.senderId)}.`,
+        );
+      } catch (err) {
+        defaultRuntime.log(
+          `${theme.success("Approved (edited)")} but failed to send: ${String(err)}`,
+        );
+        defaultRuntime.log(
+          theme.muted(`Response marked as approved. You may need to send manually.`),
+        );
+      }
+    });
+
+  confirming
+    .command("reject")
+    .description("Reject a response (no message will be sent)")
+    .option("--channel <channel>", `Channel (${CONFIRMING_CHANNELS.join(", ")})`)
+    .argument("<codeOrChannel>", "Response code (or channel when using 2 args)")
+    .argument("[code]", "Response code (when channel is passed as the 1st arg)")
+    .action(async (codeOrChannel, code, opts) => {
+      const channelRaw = opts.channel ?? codeOrChannel;
+      const resolvedCode = opts.channel ? codeOrChannel : code;
+      if (!opts.channel && !code) {
+        throw new Error(
+          `Usage: ${formatCliCommand("openclaw confirming reject <channel> <code>")}`,
+        );
+      }
+      const channel = parseChannel(channelRaw);
+      const rejected = await rejectPendingResponse({
+        channel,
+        code: String(resolvedCode),
+      });
+      if (!rejected) {
+        throw new Error(`No pending response found for code: ${String(resolvedCode)}`);
+      }
+
+      defaultRuntime.log(
+        `${theme.error("Rejected")} response for ${theme.command(rejected.senderId)}. No message was sent.`,
+      );
+    });
+}

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -182,6 +182,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "confirming",
+    description: "Owner-approved responses (dmPolicy: confirming)",
+    register: async (program) => {
+      const mod = await import("../confirming-cli.js");
+      mod.registerConfirmingCli(program);
+    },
+  },
+  {
     name: "plugins",
     description: "Plugin management",
     register: async (program) => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -654,7 +654,7 @@ const FIELD_HELP: Record<string, string> = {
   "channels.telegram.timeoutSeconds":
     "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
   "channels.whatsapp.dmPolicy":
-    'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+    'Direct message access control ("pairing" recommended). "confirming" sends agent responses to owner for approval. "open" requires channels.whatsapp.allowFrom=["*"].',
   "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
   "channels.whatsapp.debounceMs":
     "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -6,7 +6,20 @@ export type SessionScope = "per-sender" | "global";
 export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 export type ReplyToMode = "off" | "first" | "all";
 export type GroupPolicy = "open" | "disabled" | "allowlist";
-export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled" | "confirming";
+
+export type ConfirmingTimeoutAction = "queue" | "reject" | "auto-approve";
+
+export type ConfirmingConfig = {
+  /** Chat ID where approval requests are sent (required when dmPolicy is "confirming"). */
+  ownerChat: string;
+  /** Timeout in seconds before onTimeout action is triggered (default: 3600 = 1 hour). */
+  timeout?: number;
+  /** Action when timeout is reached (default: "queue"). */
+  onTimeout?: ConfirmingTimeoutAction;
+  /** Include the original message in the approval request (default: true). */
+  includeMessage?: boolean;
+};
 
 export type OutboundRetryConfig = {
   /** Max retry attempts for outbound requests (default: 3). */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -14,6 +14,24 @@ export type WhatsAppActionConfig = {
   polls?: boolean;
 };
 
+export type WhatsAppPairingConfig = {
+  /**
+   * Notify the owner when a new pairing request is received.
+   * Default: false.
+   */
+  notifyOwner?: boolean;
+  /**
+   * Chat JID to send pairing notifications to (e.g., "554788703000@s.whatsapp.net").
+   * Required when notifyOwner is true.
+   */
+  ownerChat?: string;
+  /**
+   * Include the original message content in the notification.
+   * Default: true.
+   */
+  includeMessage?: boolean;
+};
+
 export type WhatsAppConfig = {
   /** Optional per-account WhatsApp configuration (multi-account). */
   accounts?: Record<string, WhatsAppAccountConfig>;
@@ -32,6 +50,8 @@ export type WhatsAppConfig = {
   messagePrefix?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /** Pairing mode configuration (owner notifications). */
+  pairing?: WhatsAppPairingConfig;
   /**
    * Same-phone setup (bot uses your personal WhatsApp number).
    */
@@ -113,6 +133,8 @@ export type WhatsAppAccountConfig = {
   authDir?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;
+  /** Pairing mode configuration (owner notifications). */
+  pairing?: WhatsAppPairingConfig;
   /** Same-phone setup for this account (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;
   allowFrom?: string[];

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -1,5 +1,6 @@
 import type {
   BlockStreamingCoalesceConfig,
+  ConfirmingConfig,
   DmPolicy,
   GroupPolicy,
   MarkdownConfig,
@@ -52,6 +53,8 @@ export type WhatsAppConfig = {
   dmPolicy?: DmPolicy;
   /** Pairing mode configuration (owner notifications). */
   pairing?: WhatsAppPairingConfig;
+  /** Confirming mode configuration (owner-approved responses). */
+  confirming?: ConfirmingConfig;
   /**
    * Same-phone setup (bot uses your personal WhatsApp number).
    */
@@ -135,6 +138,8 @@ export type WhatsAppAccountConfig = {
   dmPolicy?: DmPolicy;
   /** Pairing mode configuration (owner notifications). */
   pairing?: WhatsAppPairingConfig;
+  /** Confirming mode configuration (owner-approved responses). */
+  confirming?: ConfirmingConfig;
   /** Same-phone setup for this account (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;
   allowFrom?: string[];

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -126,7 +126,18 @@ export const ReplyToModeSchema = z.union([z.literal("off"), z.literal("first"), 
 //   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
 export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
 
-export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
+export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled", "confirming"]);
+
+export const ConfirmingTimeoutActionSchema = z.enum(["queue", "reject", "auto-approve"]);
+
+export const ConfirmingConfigSchema = z
+  .object({
+    ownerChat: z.string().min(1),
+    timeout: z.number().int().positive().optional().default(3600),
+    onTimeout: ConfirmingTimeoutActionSchema.optional().default("queue"),
+    includeMessage: z.boolean().optional().default(true),
+  })
+  .strict();
 
 export const BlockStreamingCoalesceSchema = z
   .object({

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -11,6 +11,26 @@ import {
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+const WhatsAppPairingConfigSchema = z
+  .object({
+    /** Notify the owner when a new pairing request is received. Default: false. */
+    notifyOwner: z.boolean().optional().default(false),
+    /** Chat JID to send pairing notifications to (e.g., "554788703000@s.whatsapp.net"). */
+    ownerChat: z.string().optional(),
+    /** Include the original message content in the notification. Default: true. */
+    includeMessage: z.boolean().optional().default(true),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.notifyOwner && !value.ownerChat) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["ownerChat"],
+        message: "ownerChat is required when notifyOwner is true",
+      });
+    }
+  });
+
 export const WhatsAppAccountSchema = z
   .object({
     name: z.string().optional(),
@@ -23,6 +43,7 @@ export const WhatsAppAccountSchema = z
     /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
     authDir: z.string().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    pairing: WhatsAppPairingConfigSchema.optional(),
     selfChatMode: z.boolean().optional(),
     allowFrom: z.array(z.string()).optional(),
     groupAllowFrom: z.array(z.string()).optional(),
@@ -83,6 +104,7 @@ export const WhatsAppConfigSchema = z
     configWrites: z.boolean().optional(),
     sendReadReceipts: z.boolean().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    pairing: WhatsAppPairingConfigSchema.optional(),
     messagePrefix: z.string().optional(),
     selfChatMode: z.boolean().optional(),
     allowFrom: z.array(z.string()).optional(),

--- a/src/confirming/confirming-messages.ts
+++ b/src/confirming/confirming-messages.ts
@@ -1,0 +1,100 @@
+import type { PendingResponse } from "./confirming-store.js";
+
+export function buildConfirmingNotification(params: {
+  code: string;
+  senderId: string;
+  senderName?: string;
+  originalMessage: string;
+  suggestedResponse: string;
+  includeMessage?: boolean;
+}): string {
+  const senderDisplay = params.senderName
+    ? `${params.senderName} (${params.senderId})`
+    : params.senderId;
+
+  const includeMessage = params.includeMessage !== false;
+  const messageSection = includeMessage ? `\n📝 *Message:*\n"${params.originalMessage}"\n` : "";
+
+  return [
+    `📩 *New message awaiting approval*`,
+    ``,
+    `From: ${senderDisplay}`,
+    `Code: \`${params.code}\``,
+    messageSection,
+    `💬 *Suggested response:*`,
+    `"${params.suggestedResponse}"`,
+    ``,
+    `✅ Approve: \`openclaw confirming approve whatsapp ${params.code}\``,
+    `✏️ Edit: \`openclaw confirming edit whatsapp ${params.code} "your edited response"\``,
+    `❌ Reject: \`openclaw confirming reject whatsapp ${params.code}\``,
+  ].join("\n");
+}
+
+export function buildConfirmingApprovedNotification(params: {
+  code: string;
+  senderId: string;
+  senderName?: string;
+  editedResponse?: string;
+}): string {
+  const senderDisplay = params.senderName
+    ? `${params.senderName} (${params.senderId})`
+    : params.senderId;
+
+  const editNote = params.editedResponse ? " (edited)" : "";
+
+  return [
+    `✅ *Response approved${editNote}*`,
+    ``,
+    `To: ${senderDisplay}`,
+    `Code: \`${params.code}\``,
+    ``,
+    `Message has been sent.`,
+  ].join("\n");
+}
+
+export function buildConfirmingRejectedNotification(params: {
+  code: string;
+  senderId: string;
+  senderName?: string;
+}): string {
+  const senderDisplay = params.senderName
+    ? `${params.senderName} (${params.senderId})`
+    : params.senderId;
+
+  return [
+    `❌ *Response rejected*`,
+    ``,
+    `To: ${senderDisplay}`,
+    `Code: \`${params.code}\``,
+    ``,
+    `No message was sent to the sender.`,
+  ].join("\n");
+}
+
+export function buildConfirmingAckReply(): string {
+  return [
+    `Thanks for your message! 📨`,
+    ``,
+    `I've received it and will get back to you shortly.`,
+  ].join("\n");
+}
+
+export function formatPendingResponsesList(responses: PendingResponse[]): string {
+  if (responses.length === 0) {
+    return "No pending responses.";
+  }
+
+  const pending = responses.filter((r) => r.status === "pending");
+  if (pending.length === 0) {
+    return "No pending responses.";
+  }
+
+  const lines = pending.map((r) => {
+    const senderDisplay = r.senderName ? `${r.senderName} (${r.senderId})` : r.senderId;
+    const preview =
+      r.originalMessage.length > 50 ? `${r.originalMessage.slice(0, 50)}...` : r.originalMessage;
+    return `• \`${r.code}\` from ${senderDisplay}: "${preview}"`;
+  });
+
+  return [`*Pending responses (${pending.length}):*`, "", ...lines].join("\n");
+}

--- a/src/confirming/confirming-store.ts
+++ b/src/confirming/confirming-store.ts
@@ -1,0 +1,481 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import lockfile from "proper-lockfile";
+import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
+
+const CONFIRMING_CODE_LENGTH = 6;
+const CONFIRMING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const CONFIRMING_PENDING_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CONFIRMING_PENDING_MAX = 50;
+const CONFIRMING_STORE_LOCK_OPTIONS = {
+  retries: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 100,
+    maxTimeout: 10_000,
+    randomize: true,
+  },
+  stale: 30_000,
+} as const;
+
+export type ConfirmingChannel = "whatsapp" | "telegram" | "signal" | "discord";
+
+export type PendingResponseStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "expired"
+  | "auto-approved";
+
+export type PendingResponse = {
+  /** Unique request ID (short code for user reference). */
+  code: string;
+  /** Sender identifier (e.g., phone number, user ID). */
+  senderId: string;
+  /** Sender display name. */
+  senderName?: string;
+  /** The JID/chat ID to reply to. */
+  replyTo: string;
+  /** Original message from the sender. */
+  originalMessage: string;
+  /** AI-generated suggested response. */
+  suggestedResponse: string;
+  /** Current status. */
+  status: PendingResponseStatus;
+  /** ISO timestamp when created. */
+  createdAt: string;
+  /** ISO timestamp when resolved (approved/rejected). */
+  resolvedAt?: string;
+  /** Edited response (if owner edited before approving). */
+  editedResponse?: string;
+  /** Account ID for multi-account setups. */
+  accountId?: string;
+};
+
+type ConfirmingStore = {
+  version: 1;
+  responses: PendingResponse[];
+};
+
+function resolveCredentialsDir(env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveStateDir(env, os.homedir);
+  return resolveOAuthDir(env, stateDir);
+}
+
+function safeChannelKey(channel: ConfirmingChannel): string {
+  const raw = String(channel).trim().toLowerCase();
+  if (!raw) {
+    throw new Error("invalid confirming channel");
+  }
+  const safe = raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
+  if (!safe || safe === "_") {
+    throw new Error("invalid confirming channel");
+  }
+  return safe;
+}
+
+function resolveConfirmingPath(
+  channel: ConfirmingChannel,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(resolveCredentialsDir(env), `${safeChannelKey(channel)}-confirming.json`);
+}
+
+function safeParseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function readJsonFile<T>(
+  filePath: string,
+  fallback: T,
+): Promise<{ value: T; exists: boolean }> {
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const parsed = safeParseJson<T>(raw);
+    if (parsed == null) {
+      return { value: fallback, exists: true };
+    }
+    return { value: parsed, exists: true };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return { value: fallback, exists: false };
+    }
+    return { value: fallback, exists: false };
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+  const tmp = path.join(dir, `${path.basename(filePath)}.${crypto.randomUUID()}.tmp`);
+  await fs.promises.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf-8",
+  });
+  await fs.promises.chmod(tmp, 0o600);
+  await fs.promises.rename(tmp, filePath);
+}
+
+async function ensureJsonFile(filePath: string, fallback: unknown) {
+  try {
+    await fs.promises.access(filePath);
+  } catch {
+    await writeJsonFile(filePath, fallback);
+  }
+}
+
+async function withFileLock<T>(
+  filePath: string,
+  fallback: unknown,
+  fn: () => Promise<T>,
+): Promise<T> {
+  await ensureJsonFile(filePath, fallback);
+  let release: (() => Promise<void>) | undefined;
+  try {
+    release = await lockfile.lock(filePath, CONFIRMING_STORE_LOCK_OPTIONS);
+    return await fn();
+  } finally {
+    if (release) {
+      try {
+        await release();
+      } catch {
+        // ignore unlock errors
+      }
+    }
+  }
+}
+
+function parseTimestamp(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function isExpired(entry: PendingResponse, nowMs: number): boolean {
+  const createdAt = parseTimestamp(entry.createdAt);
+  if (!createdAt) {
+    return true;
+  }
+  return nowMs - createdAt > CONFIRMING_PENDING_TTL_MS;
+}
+
+function pruneExpiredResponses(responses: PendingResponse[], nowMs: number) {
+  const kept: PendingResponse[] = [];
+  let removed = false;
+  for (const resp of responses) {
+    // Keep resolved responses for a shorter time (1 hour) for history
+    if (resp.status !== "pending") {
+      const resolvedAt = parseTimestamp(resp.resolvedAt);
+      if (resolvedAt && nowMs - resolvedAt > 60 * 60 * 1000) {
+        removed = true;
+        continue;
+      }
+    }
+    if (isExpired(resp, nowMs)) {
+      removed = true;
+      continue;
+    }
+    kept.push(resp);
+  }
+  return { responses: kept, removed };
+}
+
+function pruneExcessResponses(responses: PendingResponse[], maxPending: number) {
+  const pending = responses.filter((r) => r.status === "pending");
+  const resolved = responses.filter((r) => r.status !== "pending");
+
+  if (maxPending <= 0 || pending.length <= maxPending) {
+    return { responses, removed: false };
+  }
+
+  // Sort by createdAt and keep only the most recent
+  const sorted = pending.toSorted((a, b) => {
+    const aTime = parseTimestamp(a.createdAt) ?? 0;
+    const bTime = parseTimestamp(b.createdAt) ?? 0;
+    return aTime - bTime;
+  });
+
+  return {
+    responses: [...sorted.slice(-maxPending), ...resolved],
+    removed: true,
+  };
+}
+
+function randomCode(): string {
+  let out = "";
+  for (let i = 0; i < CONFIRMING_CODE_LENGTH; i++) {
+    const idx = crypto.randomInt(0, CONFIRMING_CODE_ALPHABET.length);
+    out += CONFIRMING_CODE_ALPHABET[idx];
+  }
+  return out;
+}
+
+function generateUniqueCode(existing: Set<string>): string {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const code = randomCode();
+    if (!existing.has(code)) {
+      return code;
+    }
+  }
+  throw new Error("failed to generate unique confirming code");
+}
+
+export async function listPendingResponses(
+  channel: ConfirmingChannel,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<PendingResponse[]> {
+  const filePath = resolveConfirmingPath(channel, env);
+  return await withFileLock(
+    filePath,
+    { version: 1, responses: [] } satisfies ConfirmingStore,
+    async () => {
+      const { value } = await readJsonFile<ConfirmingStore>(filePath, {
+        version: 1,
+        responses: [],
+      });
+      const responses = Array.isArray(value.responses) ? value.responses : [];
+      const nowMs = Date.now();
+      const { responses: prunedExpired, removed: expiredRemoved } = pruneExpiredResponses(
+        responses,
+        nowMs,
+      );
+      const { responses: pruned, removed: cappedRemoved } = pruneExcessResponses(
+        prunedExpired,
+        CONFIRMING_PENDING_MAX,
+      );
+      if (expiredRemoved || cappedRemoved) {
+        await writeJsonFile(filePath, {
+          version: 1,
+          responses: pruned,
+        } satisfies ConfirmingStore);
+      }
+      return pruned
+        .filter((r) => r && typeof r.code === "string" && typeof r.senderId === "string")
+        .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt));
+    },
+  );
+}
+
+export async function createPendingResponse(params: {
+  channel: ConfirmingChannel;
+  senderId: string;
+  senderName?: string;
+  replyTo: string;
+  originalMessage: string;
+  suggestedResponse: string;
+  accountId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ code: string; created: boolean }> {
+  const env = params.env ?? process.env;
+  const filePath = resolveConfirmingPath(params.channel, env);
+  return await withFileLock(
+    filePath,
+    { version: 1, responses: [] } satisfies ConfirmingStore,
+    async () => {
+      const { value } = await readJsonFile<ConfirmingStore>(filePath, {
+        version: 1,
+        responses: [],
+      });
+      const now = new Date().toISOString();
+      const nowMs = Date.now();
+
+      let responses = Array.isArray(value.responses) ? value.responses : [];
+      const { responses: prunedExpired, removed: expiredRemoved } = pruneExpiredResponses(
+        responses,
+        nowMs,
+      );
+      responses = prunedExpired;
+
+      const existingCodes = new Set(
+        responses.map((r) =>
+          String(r.code ?? "")
+            .trim()
+            .toUpperCase(),
+        ),
+      );
+
+      const { responses: capped, removed: cappedRemoved } = pruneExcessResponses(
+        responses,
+        CONFIRMING_PENDING_MAX,
+      );
+      responses = capped;
+
+      const pendingCount = responses.filter((r) => r.status === "pending").length;
+      if (CONFIRMING_PENDING_MAX > 0 && pendingCount >= CONFIRMING_PENDING_MAX) {
+        if (expiredRemoved || cappedRemoved) {
+          await writeJsonFile(filePath, {
+            version: 1,
+            responses,
+          } satisfies ConfirmingStore);
+        }
+        return { code: "", created: false };
+      }
+
+      const code = generateUniqueCode(existingCodes);
+      const newResponse: PendingResponse = {
+        code,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        replyTo: params.replyTo,
+        originalMessage: params.originalMessage,
+        suggestedResponse: params.suggestedResponse,
+        status: "pending",
+        createdAt: now,
+        accountId: params.accountId,
+      };
+
+      await writeJsonFile(filePath, {
+        version: 1,
+        responses: [...responses, newResponse],
+      } satisfies ConfirmingStore);
+
+      return { code, created: true };
+    },
+  );
+}
+
+export async function approvePendingResponse(params: {
+  channel: ConfirmingChannel;
+  code: string;
+  editedResponse?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<PendingResponse | null> {
+  const env = params.env ?? process.env;
+  const code = params.code.trim().toUpperCase();
+  if (!code) {
+    return null;
+  }
+
+  const filePath = resolveConfirmingPath(params.channel, env);
+  return await withFileLock(
+    filePath,
+    { version: 1, responses: [] } satisfies ConfirmingStore,
+    async () => {
+      const { value } = await readJsonFile<ConfirmingStore>(filePath, {
+        version: 1,
+        responses: [],
+      });
+      const responses = Array.isArray(value.responses) ? value.responses : [];
+      const nowMs = Date.now();
+      const { responses: pruned, removed } = pruneExpiredResponses(responses, nowMs);
+
+      const idx = pruned.findIndex(
+        (r) => String(r.code ?? "").toUpperCase() === code && r.status === "pending",
+      );
+      if (idx < 0) {
+        if (removed) {
+          await writeJsonFile(filePath, {
+            version: 1,
+            responses: pruned,
+          } satisfies ConfirmingStore);
+        }
+        return null;
+      }
+
+      const entry = pruned[idx];
+      if (!entry) {
+        return null;
+      }
+
+      const updated: PendingResponse = {
+        ...entry,
+        status: "approved",
+        resolvedAt: new Date().toISOString(),
+        ...(params.editedResponse ? { editedResponse: params.editedResponse } : {}),
+      };
+      pruned[idx] = updated;
+
+      await writeJsonFile(filePath, {
+        version: 1,
+        responses: pruned,
+      } satisfies ConfirmingStore);
+
+      return updated;
+    },
+  );
+}
+
+export async function rejectPendingResponse(params: {
+  channel: ConfirmingChannel;
+  code: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<PendingResponse | null> {
+  const env = params.env ?? process.env;
+  const code = params.code.trim().toUpperCase();
+  if (!code) {
+    return null;
+  }
+
+  const filePath = resolveConfirmingPath(params.channel, env);
+  return await withFileLock(
+    filePath,
+    { version: 1, responses: [] } satisfies ConfirmingStore,
+    async () => {
+      const { value } = await readJsonFile<ConfirmingStore>(filePath, {
+        version: 1,
+        responses: [],
+      });
+      const responses = Array.isArray(value.responses) ? value.responses : [];
+      const nowMs = Date.now();
+      const { responses: pruned, removed } = pruneExpiredResponses(responses, nowMs);
+
+      const idx = pruned.findIndex(
+        (r) => String(r.code ?? "").toUpperCase() === code && r.status === "pending",
+      );
+      if (idx < 0) {
+        if (removed) {
+          await writeJsonFile(filePath, {
+            version: 1,
+            responses: pruned,
+          } satisfies ConfirmingStore);
+        }
+        return null;
+      }
+
+      const entry = pruned[idx];
+      if (!entry) {
+        return null;
+      }
+
+      const updated: PendingResponse = {
+        ...entry,
+        status: "rejected",
+        resolvedAt: new Date().toISOString(),
+      };
+      pruned[idx] = updated;
+
+      await writeJsonFile(filePath, {
+        version: 1,
+        responses: pruned,
+      } satisfies ConfirmingStore);
+
+      return updated;
+    },
+  );
+}
+
+export async function getPendingResponseByCode(params: {
+  channel: ConfirmingChannel;
+  code: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<PendingResponse | null> {
+  const env = params.env ?? process.env;
+  const code = params.code.trim().toUpperCase();
+  if (!code) {
+    return null;
+  }
+
+  const responses = await listPendingResponses(params.channel, env);
+  return responses.find((r) => String(r.code ?? "").toUpperCase() === code) ?? null;
+}

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
-import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
+import type {
+  DmPolicy,
+  GroupPolicy,
+  WhatsAppAccountConfig,
+  WhatsAppPairingConfig,
+} from "../config/types.js";
 import { resolveOAuthDir } from "../config/paths.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
@@ -20,6 +25,7 @@ export type ResolvedWhatsAppAccount = {
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
+  pairing?: WhatsAppPairingConfig;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
@@ -156,6 +162,7 @@ export function resolveWhatsAppAccount(params: {
     isLegacyAuthDir: isLegacy,
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
+    pairing: accountCfg?.pairing ?? rootCfg?.pairing,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
+  ConfirmingConfig,
   DmPolicy,
   GroupPolicy,
   WhatsAppAccountConfig,
@@ -26,6 +27,7 @@ export type ResolvedWhatsAppAccount = {
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
   pairing?: WhatsAppPairingConfig;
+  confirming?: ConfirmingConfig;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
@@ -163,6 +165,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     pairing: accountCfg?.pairing ?? rootCfg?.pairing,
+    confirming: accountCfg?.confirming ?? rootCfg?.confirming,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -40,7 +40,7 @@ export async function checkInboundAccessControl(params: {
     cfg,
     accountId: params.accountId,
   });
-  const dmPolicy = cfg.channels?.whatsapp?.dmPolicy ?? "pairing";
+  const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
   const storeAllowFrom = await readChannelAllowFromStore("whatsapp").catch(() => []);
   // Without user config, default to self-only DM access so the owner can talk to themselves.

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -199,6 +199,9 @@ export async function monitorWebInbox(options: {
         ? Number(msg.messageTimestamp) * 1000
         : undefined;
 
+      // Extract message body early for pairing notifications
+      const earlyBody = extractText(msg.message ?? undefined);
+
       const access = await checkInboundAccessControl({
         accountId: options.accountId,
         from,
@@ -211,6 +214,7 @@ export async function monitorWebInbox(options: {
         connectedAtMs,
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
         remoteJid,
+        messageBody: earlyBody ?? undefined,
       });
       if (!access.allowed) {
         continue;

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -3,6 +3,11 @@ import { DisconnectReason, isJidGroup } from "@whiskeysockets/baileys";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 import { createInboundDebouncer } from "../../auto-reply/inbound-debounce.js";
 import { formatLocationText } from "../../channels/location.js";
+import {
+  buildConfirmingAckReply,
+  buildConfirmingNotification,
+} from "../../confirming/confirming-messages.js";
+import { createPendingResponse } from "../../confirming/confirming-store.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
 import { getChildLogger } from "../../logging/logger.js";
@@ -286,10 +291,69 @@ export async function monitorWebInbox(options: {
           logVerbose(`Presence update failed: ${String(err)}`);
         }
       };
+
+      // In confirming mode, intercept replies and send to owner for approval
+      let confirmingReplySent = false;
       const reply = async (text: string) => {
-        await sock.sendMessage(chatJid, { text });
+        if (access.confirmingMode && access.confirmingConfig?.ownerChat && !confirmingReplySent) {
+          confirmingReplySent = true;
+          const senderDisplay = from;
+          const pushNameDisplay = (msg.pushName ?? "").trim() || undefined;
+
+          // Create pending response in store
+          const { code, created } = await createPendingResponse({
+            channel: "whatsapp",
+            senderId: senderDisplay,
+            senderName: pushNameDisplay,
+            replyTo: chatJid,
+            originalMessage: earlyBody ?? "",
+            suggestedResponse: text,
+            accountId: access.resolvedAccountId,
+          });
+
+          if (created && code) {
+            // Send notification to owner
+            const includeMessage = access.confirmingConfig.includeMessage !== false;
+            const notification = buildConfirmingNotification({
+              code,
+              senderId: senderDisplay,
+              senderName: pushNameDisplay,
+              originalMessage: earlyBody ?? "",
+              suggestedResponse: text,
+              includeMessage,
+            });
+            try {
+              await sock.sendMessage(access.confirmingConfig.ownerChat, { text: notification });
+              logVerbose(
+                `Confirming notification sent to owner ${access.confirmingConfig.ownerChat}`,
+              );
+            } catch (err) {
+              logVerbose(`Failed to send confirming notification: ${String(err)}`);
+            }
+
+            // Send ack to sender
+            try {
+              await sock.sendMessage(chatJid, { text: buildConfirmingAckReply() });
+              logVerbose(`Confirming ack sent to ${chatJid}`);
+            } catch (err) {
+              logVerbose(`Failed to send confirming ack: ${String(err)}`);
+            }
+          } else {
+            logVerbose(`Failed to create pending response for ${senderDisplay}`);
+            // Fall back to direct reply
+            await sock.sendMessage(chatJid, { text });
+          }
+        } else {
+          await sock.sendMessage(chatJid, { text });
+        }
       };
+
       const sendMedia = async (payload: AnyMessageContent) => {
+        // In confirming mode, block media sends (only text approval supported for now)
+        if (access.confirmingMode && access.confirmingConfig?.ownerChat) {
+          logVerbose(`Confirming mode: blocking media send to ${chatJid}`);
+          return;
+        }
         await sock.sendMessage(chatJid, payload);
       };
       const timestamp = messageTimestampMs;


### PR DESCRIPTION
## Summary
Adds a new `dmPolicy: "confirming"` mode that sits between `open` and `pairing`. In this mode:
- The agent **receives and processes** the message
- The agent **generates a suggested response**
- The response is **sent to the owner for approval** instead of directly to the sender
- Only after owner approval is the response sent

## Configuration
```json
{
  "channels": {
    "whatsapp": {
      "dmPolicy": "confirming",
      "confirming": {
        "ownerChat": "554788703000@s.whatsapp.net",
        "timeout": 3600,
        "onTimeout": "queue"
      }
    }
  }
}
```

## CLI Commands
- `openclaw confirming list whatsapp` - List pending responses
- `openclaw confirming approve whatsapp <code>` - Approve and send
- `openclaw confirming edit whatsapp <code> "message"` - Approve with edit
- `openclaw confirming reject whatsapp <code>` - Reject (no message sent)

## Use Case
Essential for:
- Personal assistants managing client communications
- Small businesses wanting AI help but needing final approval
- Anyone who wants to leverage AI suggestions without losing control

Fixes #6262

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new WhatsApp DM access mode, `dmPolicy: "confirming"`, that lets the agent process inbound DMs and generate a suggested reply, but routes that reply to an owner chat for approval via a new `openclaw confirming ...` CLI. It also adds persistent storage for pending approvals, config schema/types for `confirming` (and pairing owner notifications), and wires the web inbound monitor to enqueue suggested replies and send an acknowledgement back to the sender.

The changes fit into the existing channel policy flow by extending `checkInboundAccessControl` to flag “confirming mode” and adding a reply interceptor in the WhatsApp inbound monitor that stores a pending response and notifies the owner with approve/edit/reject commands.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there are a couple of policy-bypass/runtime-compat issues that should be addressed first.
- Core feature wiring is straightforward, but there are two correctness risks: confirming mode can be bypassed for allowlisted senders due to where it’s checked, and multiple replies can leak past approval due to the one-shot intercept. Additionally, `toSorted()` may break in environments on older Node runtimes.
- src/web/inbound/access-control.ts, src/web/inbound/monitor.ts, src/confirming/confirming-store.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->