### PR TITLE
fix(tts): add WhatsApp support for Opus audio output

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -474,7 +474,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
+  if (channelId === "telegram" || channelId === "whatsapp") {
     return TELEGRAM_OUTPUT;
   }
   return DEFAULT_OUTPUT;
@@ -1543,7 +1543,8 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = channelId === "telegram" && result.voiceCompatible === true;
+    const shouldVoice =
+      (channelId === "telegram" || channelId === "whatsapp") && result.voiceCompatible === true;
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,


### PR DESCRIPTION
## Summary
WhatsApp voice messages require OGG/Opus format to play correctly. Previously, only Telegram received Opus output while WhatsApp got MP3, causing "something is wrong with the audio" errors on playback.

## Changes
- `resolveOutputFormat()`: Include `whatsapp` in Opus output channels  
- `shouldVoice`: Include `whatsapp` for voice message delivery

## Testing
Tested locally with ElevenLabs TTS → WhatsApp. Voice messages now play correctly.

Fixes #6491

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates TTS channel handling so WhatsApp receives Opus output (matching Telegram’s voice-note-friendly settings) and marks WhatsApp TTS media as `audioAsVoice` when the produced audio is voice-compatible.

The change is localized to `src/tts/tts.ts` by extending `resolveOutputFormat()` and the `shouldVoice` decision in `maybeApplyTtsToPayload()`, aligning the media format/flagging with WhatsApp’s voice-message playback requirements.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and narrowly scoped, with minor format/compatibility risk depending on WhatsApp’s expected container/MIME handling.
- Changes are small and confined to channel-specific branching for output format selection and voice-message delivery. Main uncertainty is whether reusing Telegram’s `.opus` container/extension is sufficient for WhatsApp, which may require OGG/Opus semantics beyond just using an Opus codec.
- src/tts/tts.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->