### PR TITLE
feat(skills): update coding-agent to use sub-agent execution strategy

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -7,21 +7,49 @@ metadata:
   }
 ---
 
-# Coding Agent (bash-first)
+# Coding Agent
 
-Use **bash** (with optional background mode) for all coding agent work. Simple and effective.
+This skill manages interactive coding agents (Claude Code, Codex, Pi).
+**Core Rule:** Main Agent orchestrates via **Sub-Agents** (`sessions_spawn`); Sub-Agents execute via **Bash** (`pty:true`).
 
-## ⚠️ PTY Mode Required!
+## Execution Strategy: Sub-Agents (Non-Blocking)
 
-Coding agents (Codex, Claude Code, Pi) are **interactive terminal applications** that need a pseudo-terminal (PTY) to work correctly. Without PTY, you'll get broken output, missing colors, or the agent may hang.
+**CRITICAL:** Coding agents are slow and interactive.
+**NEVER** run them directly in the main session.
+**ALWAYS** use `sessions_spawn` to delegate the work to a background sub-agent.
 
-**Always use `pty:true`** when running coding agents:
+**Main Agent's Job:**
+1.  Define the task clearly.
+2.  Spawn a sub-agent.
+3.  Instruct the sub-agent to use `bash` with `pty:true`.
+
+**Example:**
+```javascript
+sessions_spawn({
+  task: "Navigate to ~/project. Use bash with pty:true to run: claude -p 'Build a landing page...'",
+  label: "coding-task"
+})
+```
+
+---
+
+## Implementation: Bash-First (PTY Required)
+
+**This section applies to the Sub-Agent (or manual one-shot tasks).**
+
+Use **bash** (with optional background mode) for all coding agent work.
+
+### PTY Is Mandatory!
+
+Coding agents are **interactive terminal applications**. They need a pseudo-terminal (PTY) to render progress bars, colors, and handle input correctly.
+
+**Always use `pty:true`**:
 
 ```bash
-# ✅ Correct - with PTY
+# ✅ Correct
 bash pty:true command:"codex exec 'Your prompt'"
 
-# ❌ Wrong - no PTY, agent may break
+# ❌ Wrong (agent will hang or break)
 bash command:"codex exec 'Your prompt'"
 ```
 
@@ -220,7 +248,7 @@ git worktree remove /tmp/issue-99
 
 ---
 
-## ⚠️ Rules
+## Rules
 
 1. **Always use pty:true** - coding agents need a terminal!
 2. **Respect tool choice** - if user asks for Codex, use Codex.


### PR DESCRIPTION
Updates the coding-agent skill documentation to explicitly recommend using Sub-Agents (sessions_spawn) for execution. This prevents blocking the main agent loop during long-running coding tasks. Also clarifies the internal usage of bash with pty:true within the sub-agent.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `skills/coding-agent/SKILL.md` to recommend a non-blocking execution model where the main agent orchestrates work by spawning sub-agents (`sessions_spawn`) and those sub-agents run interactive coding CLIs via `bash` with `pty:true`. It reframes the doc from “bash-first” to an explicit orchestration/execution split and adds a concrete `sessions_spawn` example alongside the existing PTY guidance for running Codex/Claude Code/Pi.


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a documentation-only change with minor consistency risks.
- Changes are confined to a single markdown doc and don’t affect runtime behavior. The main risk is documentation correctness/usability (e.g., headings/anchors and copy-pastable examples).
- skills/coding-agent/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->