### PR TITLE
feat(memory): add short-term memory to survive context compaction

### DIFF
--- a/src/agents/short-term-memory.ts
+++ b/src/agents/short-term-memory.ts
@@ -1,0 +1,291 @@
+/**
+ * Short-term memory: loads recent messages from session transcript
+ * and injects them into context to survive compaction.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+
+export type ShortTermMemoryConfig = {
+  /** Enable short-term memory injection. Default: false. */
+  enabled?: boolean;
+  /** Number of recent messages to include (user + assistant). Default: 30. */
+  messageCount?: number;
+  /** Custom path for short-term memory file. If set, reads from this instead of session. */
+  path?: string;
+};
+
+export function resolveShortTermMemoryConfig(
+  config?: OpenClawConfig,
+): ShortTermMemoryConfig | undefined {
+  const stm = (config?.session as Record<string, unknown> | undefined)?.shortTermMemory;
+  if (!stm || typeof stm !== "object") {
+    return undefined;
+  }
+  return stm as ShortTermMemoryConfig;
+}
+
+export function isShortTermMemoryEnabled(config?: OpenClawConfig): boolean {
+  const stmConfig = resolveShortTermMemoryConfig(config);
+  return stmConfig?.enabled === true;
+}
+
+export function resolveShortTermMessageCount(config?: OpenClawConfig): number {
+  const stmConfig = resolveShortTermMemoryConfig(config);
+  const count = stmConfig?.messageCount;
+  if (typeof count === "number" && count > 0 && count <= 100) {
+    return count;
+  }
+  return 30; // Default
+}
+
+type SessionMessageEntry = {
+  type: "message";
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+  };
+  timestamp?: number;
+};
+
+function extractMessageText(
+  content: string | Array<{ type: string; text?: string }> | undefined,
+): string | null {
+  if (!content) {
+    return null;
+  }
+  if (typeof content === "string") {
+    return content.trim() || null;
+  }
+  if (Array.isArray(content)) {
+    const textPart = content.find((c) => c.type === "text" && c.text);
+    return textPart?.text?.trim() || null;
+  }
+  return null;
+}
+
+function formatTimestamp(ts?: number): string {
+  if (!ts) {
+    return "";
+  }
+  try {
+    const date = new Date(ts);
+    return date.toISOString().replace("T", " ").split(".")[0] + " UTC";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Load recent messages from session JSONL file.
+ */
+async function loadRecentMessagesFromSession(
+  sessionFile: string,
+  messageCount: number,
+): Promise<Array<{ role: string; text: string; timestamp?: string }>> {
+  try {
+    const content = await fs.readFile(sessionFile, "utf-8");
+    const lines = content.trim().split("\n");
+
+    const messages: Array<{ role: string; text: string; timestamp?: string }> = [];
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as SessionMessageEntry;
+        if (entry.type === "message" && entry.message) {
+          const role = entry.message.role;
+          if (role === "user" || role === "assistant") {
+            const text = extractMessageText(entry.message.content);
+            if (text && !text.startsWith("/")) {
+              // Skip command messages
+              messages.push({
+                role,
+                text,
+                timestamp: formatTimestamp(entry.timestamp),
+              });
+            }
+          }
+        }
+      } catch {
+        // Skip invalid JSON lines
+      }
+    }
+
+    // Return last N messages
+    return messages.slice(-messageCount);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Load recent messages from a custom short-term memory file (plain text or JSONL).
+ */
+async function loadRecentMessagesFromFile(
+  filePath: string,
+  messageCount: number,
+): Promise<Array<{ role: string; text: string; timestamp?: string }>> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+
+    // Try JSONL format first
+    if (content.trim().startsWith("{")) {
+      const lines = content.trim().split("\n");
+      const messages: Array<{ role: string; text: string; timestamp?: string }> = [];
+
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line);
+          if (entry.role && entry.text) {
+            messages.push({
+              role: entry.role,
+              text: entry.text,
+              timestamp: entry.timestamp,
+            });
+          }
+        } catch {
+          // Skip invalid lines
+        }
+      }
+      return messages.slice(-messageCount);
+    }
+
+    // Fall back to plain text format (one message per line with role prefix)
+    const lines = content.trim().split("\n");
+    const messages: Array<{ role: string; text: string }> = [];
+
+    for (const line of lines) {
+      const match = line.match(/^(user|assistant):\s*(.+)/i);
+      if (match) {
+        messages.push({
+          role: match[1].toLowerCase(),
+          text: match[2].trim(),
+        });
+      }
+    }
+    return messages.slice(-messageCount);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Format messages as markdown for context injection.
+ */
+function formatMessagesAsMarkdown(
+  messages: Array<{ role: string; text: string; timestamp?: string }>,
+): string {
+  if (messages.length === 0) {
+    return "No recent messages in this session.";
+  }
+
+  const lines: string[] = ["Recent conversation history (for context continuity):", ""];
+
+  for (const msg of messages) {
+    const roleLabel = msg.role === "user" ? "**User**" : "**Assistant**";
+    const timestampSuffix = msg.timestamp ? ` _(${msg.timestamp})_` : "";
+
+    // Truncate very long messages
+    let text = msg.text;
+    if (text.length > 500) {
+      text = text.slice(0, 500) + "...";
+    }
+
+    lines.push(`${roleLabel}${timestampSuffix}: ${text}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build short-term memory context file from session or custom file.
+ */
+export async function buildShortTermMemoryContextFile(params: {
+  config?: OpenClawConfig;
+  sessionFile?: string;
+  workspaceDir?: string;
+}): Promise<EmbeddedContextFile | null> {
+  if (!isShortTermMemoryEnabled(params.config)) {
+    return null;
+  }
+
+  const stmConfig = resolveShortTermMemoryConfig(params.config);
+  const messageCount = resolveShortTermMessageCount(params.config);
+
+  let messages: Array<{ role: string; text: string; timestamp?: string }> = [];
+
+  // Check for custom path first
+  if (stmConfig?.path) {
+    const customPath = params.workspaceDir
+      ? path.resolve(params.workspaceDir, stmConfig.path)
+      : stmConfig.path;
+    messages = await loadRecentMessagesFromFile(customPath, messageCount);
+  } else if (params.sessionFile) {
+    // Load from session transcript
+    messages = await loadRecentMessagesFromSession(params.sessionFile, messageCount);
+  }
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  const content = formatMessagesAsMarkdown(messages);
+
+  return {
+    path: "SHORT_TERM_MEMORY",
+    content,
+  };
+}
+
+/**
+ * Append a message to the short-term memory file (for custom path mode).
+ */
+export async function appendToShortTermMemory(params: {
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  role: "user" | "assistant";
+  text: string;
+  timestamp?: number;
+}): Promise<void> {
+  const stmConfig = resolveShortTermMemoryConfig(params.config);
+  if (!stmConfig?.enabled || !stmConfig.path) {
+    return; // Only append when using custom path mode
+  }
+
+  const filePath = path.resolve(params.workspaceDir, stmConfig.path);
+  const messageCount = resolveShortTermMessageCount(params.config);
+
+  // Ensure directory exists
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  // Append new message
+  const entry = {
+    role: params.role,
+    text: params.text,
+    timestamp: params.timestamp
+      ? new Date(params.timestamp).toISOString()
+      : new Date().toISOString(),
+  };
+
+  try {
+    await fs.appendFile(filePath, JSON.stringify(entry) + "\n", "utf-8");
+  } catch {
+    // Write fresh if append fails
+    await fs.writeFile(filePath, JSON.stringify(entry) + "\n", "utf-8");
+  }
+
+  // Trim to messageCount
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.trim().split("\n");
+    if (lines.length > messageCount) {
+      const trimmed = lines.slice(-messageCount).join("\n") + "\n";
+      await fs.writeFile(filePath, trimmed, "utf-8");
+    }
+  } catch {
+    // Ignore trim errors
+  }
+}

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -76,6 +76,15 @@ export type SessionResetByTypeConfig = {
   thread?: SessionResetConfig;
 };
 
+export type ShortTermMemoryConfig = {
+  /** Enable short-term memory injection. Default: false. */
+  enabled?: boolean;
+  /** Number of recent messages to include (user + assistant). Default: 30. */
+  messageCount?: number;
+  /** Custom path for short-term memory file. If set, reads from this instead of session. */
+  path?: string;
+};
+
 export type SessionConfig = {
   scope?: SessionScope;
   /** DM session scoping (default: "main"). */
@@ -97,6 +106,8 @@ export type SessionConfig = {
     /** Max ping-pong turns between requester/target (0–5). Default: 5. */
     maxPingPongTurns?: number;
   };
+  /** Short-term memory: inject recent messages into context to survive compaction. */
+  shortTermMemory?: ShortTermMemoryConfig;
 };
 
 export type LoggingConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -82,6 +82,14 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    shortTermMemory: z
+      .object({
+        enabled: z.boolean().optional(),
+        messageCount: z.number().int().min(1).max(100).optional(),
+        path: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Adds `session.shortTermMemory` config option that injects recent messages into the context to help the agent maintain continuity after context compaction.

## Problem

When context gets too long and is compacted/truncated, the agent loses track of what was being discussed. The summary is often unhelpful ("Summary unavailable due to context limits"), and the agent has to guess from modified files what was happening.

## Solution

Add a configurable short-term memory feature that:
1. Reads recent user/assistant messages from the session transcript
2. Formats them as markdown
3. Injects them into the Project Context section as `SHORT_TERM_MEMORY`

## Config Options

```yaml
session:
  shortTermMemory:
    enabled: true          # Enable the feature (default: false)
    messageCount: 30       # Number of recent messages (default: 30)
    path: memory/stm.jsonl # Optional custom file path
```

## How It Works

- When `enabled: true`, the last N messages from the session transcript are extracted
- Messages are formatted as markdown with role labels and timestamps
- This content is injected as an additional context file
- Survives compaction because it's regenerated fresh each turn from the session file

## Files Changed

- `src/config/types.base.ts` - Added `ShortTermMemoryConfig` type
- `src/agents/short-term-memory.ts` - New module with core logic
- `src/agents/pi-embedded-runner/compact.ts` - Integration point
- `src/agents/pi-embedded-runner/run/attempt.ts` - Integration point

## Testing

Manual testing with config enabled. Would appreciate guidance on test file conventions for this codebase.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an optional `session.shortTermMemory` config that extracts the last N user/assistant messages from the session transcript (or an optional custom file), formats them as markdown, and injects them into the embedded runner’s `contextFiles` as `SHORT_TERM_MEMORY` so the agent retains recent conversational continuity after compaction.

Integration is done at both run (`src/agents/pi-embedded-runner/run/attempt.ts`) and compaction (`src/agents/pi-embedded-runner/compact.ts`) entry points by appending the generated context file to the bootstrap-derived context file list when enabled.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but may have performance and footgun risks in long-running sessions.
- Core behavior is additive and gated behind a config flag, but the implementation currently reads whole transcript/custom files into memory each turn and duplicates config typing across modules, which could cause scalability and maintainability issues.
- src/agents/short-term-memory.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->