### PR TITLE
feat(chrome-extension): auto-reattach debugger after page navigation

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -291,7 +291,7 @@ async function detachTab(tabId, reason, opts = {}) {
 
   // NEW: If this was a navigation-triggered detach and auto-reattach is enabled,
   // schedule reattachment
-  if (shouldAutoReattach && (reason === 'target_closed' || reason === 'canceled_by_user' || !reason)) {
+  if (shouldAutoReattach && (reason === 'target_closed' || !reason)) {
     console.log(`[OpenClaw] Tab ${tabId} detached (${reason}), scheduling auto-reattach...`)
     setBadge(tabId, 'reattaching')
     void chrome.action.setTitle({


### PR DESCRIPTION
Chrome debugger disconnects on navigation, requiring manual reattach. This adds auto-reconnection with retry logic.

## Changes
- Add reattaching badge state with visual feedback
- Track tabs for auto-reconnect
- Debounce reattachment (500ms)
- Retry logic (3 attempts)
- Handle SPA navigation via tabs.onUpdated
- Clean up on tab removal

## Test plan
- Attach to tab, navigate → should auto-reattach
- Click to detach → should NOT auto-reattach
- Close attached tab → no errors

Relates to #1160, #1674, #1935

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Chrome extension background script to automatically reattach `chrome.debugger` after navigations. It introduces a new badge state (`reattaching`), tracks tabs eligible for auto-reattach via `autoReattachTabs`, debounces reattach attempts, and adds retry logic. It also hooks `chrome.tabs.onUpdated` to catch SPA-style navigations and `chrome.tabs.onRemoved` for cleanup, so the extension can recover from debugger detaches without requiring the user to manually click attach again.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of behavioral edge cases that could cause unexpected auto-reattach loops or duplicate attaches.
- Core changes are localized to the extension background script and implement straightforward debounce/retry logic, but the current detach reason gating includes `canceled_by_user` (risking reattaching after an intentional user detach), and there are potential races between multiple reattach triggers and retries.
- assets/chrome-extension/background.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->