### PR TITLE
Chore/openclaw issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ What actually happened?
 - OpenClaw version (or commit SHA):
 - OS:
 - Install method (pnpm/npx/docker/etc):
-- Messaging channel (if relevant: telegram/discord/slack/signal/imessage/web/…):
+- Messaging channel (if relevant: telegram/discord/slack/signal/imessage/web/...):
 
 ## Logs or screenshots
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem or unexpected behavior in Clawdbot.
+about: Report a problem or unexpected behavior in OpenClaw.
 title: "[Bug]: "
 labels: bug
 ---
@@ -25,9 +25,10 @@ What actually happened?
 
 ## Environment
 
-- Clawdbot version:
+- OpenClaw version (or commit SHA):
 - OS:
 - Install method (pnpm/npx/docker/etc):
+- Messaging channel (if relevant: telegram/discord/slack/signal/imessage/web/…):
 
 ## Logs or screenshots
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Onboarding
     url: https://discord.gg/clawd
-    about: New to Clawdbot? Join Discord for setup guidance from Krill in #help.
+    about: New to OpenClaw? Join Discord for setup guidance in #help.
   - name: Support
     url: https://discord.gg/clawd
-    about: Get help from Krill and the community on Discord in #help.
+    about: Get help from the community on Discord in #help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,35 @@
 ---
 name: Feature request
-about: Suggest an idea or improvement for Clawdbot.
+about: Suggest an idea or improvement for OpenClaw.
 title: "[Feature]: "
 labels: enhancement
 ---
 
 ## Summary
 
-Describe the problem you are trying to solve or the opportunity you see.
+Describe the problem you are trying to solve and who it affects.
+
+## Motivation / context
+
+Why is this important now? What current workflow is painful or missing?
 
 ## Proposed solution
 
-What would you like Clawdbot to do?
+What would you like OpenClaw to do? Include as much implementation detail as you can:
+
+- Expected behavior
+- CLI/API shape (commands, flags, config)
+- Where it fits in the codebase (core vs extension/plugin)
+
+## Scope
+
+What is in scope for this request? What is explicitly out of scope?
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+- [ ]
 
 ## Alternatives considered
 
@@ -19,4 +37,4 @@ Any other approaches you have considered?
 
 ## Additional context
 
-Links, screenshots, or related issues.
+Links, screenshots, logs, or related issues.


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates GitHub issue templates to reflect the OpenClaw naming and to collect more actionable info: the bug template now asks for OpenClaw version/commit plus an optional messaging channel, and the feature request template adds motivation/context, scope, and a more detailed proposed-solution prompt. The issue template config also updates Discord contact-link descriptions to remove Clawdbot/Krill references.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are limited to issue-template text with minor UX nits.
- Only GitHub issue template markdown/YAML is modified. No runtime code changes; the only actionable issues are template UX/clarity (empty checkboxes and redundant contact links).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->