### PR TITLE
fix(tui): skip empty text for tool-only assistant turns

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -115,7 +115,9 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
-      chatLog.finalizeAssistant(finalText, evt.runId);
+      if (finalText) {
+        chatLog.finalizeAssistant(finalText, evt.runId);
+      }
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus(stopReason === "error" ? "error" : "idle");

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -13,7 +13,7 @@ export function resolveFinalAssistantText(params: {
   if (streamedText.trim()) {
     return streamedText;
   }
-  return "(no output)";
+  return "";
 }
 
 export function composeThinkingAndContent(params: {


### PR DESCRIPTION
Tool-only turns showed "(no output)" in the TUI, confusing users during multi-step operations. Return empty string from resolveFinalAssistantText and guard finalizeAssistant with if(finalText), matching the pattern in tui-session-actions.ts.

Fixes #3361

🤖 AI-assisted: Built with Claude Code (claude-opus-4-5) Testing: Fully tested - lint, build, and all tests pass The contributor understands and has reviewed all code changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts TUI rendering for assistant turns that contain no user-visible text (e.g., tool-only runs). `resolveFinalAssistantText` now returns an empty string instead of the literal "(no output)", and the chat event handler skips calling `chatLog.finalizeAssistant` when the finalized text is empty, preventing confusing placeholder output during multi-step operations.

These changes fit into the existing TUI streaming/finalization flow (`TuiStreamAssembler` → `ChatLog` updates) by treating “no content” as “render nothing”, consistent with other guards in the TUI that already skip empty delta updates.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to TUI formatting/finalization, and aligns with existing patterns (skipping empty delta updates). It should only suppress a placeholder string and avoid finalizing empty assistant messages; no behavioral changes to tool streaming or error handling were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->