### PR TITLE
Add Baseten Model-APIs as a model provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
-        "18789"
+        "18789",
       ]
 
   openclaw-cli:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -10,6 +10,7 @@ title: "Telegram"
 Status: production-ready for bot DMs + groups via grammY. Long-polling by default; webhook optional.
 
 ## Quick setup (beginner)
+
 1. Create a bot with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`, then copy the token.
 2. Set the token:
    - Env: `TELEGRAM_BOT_TOKEN=...`
@@ -41,6 +42,7 @@ Minimal config:
 ## Setup (fast path)
 
 ### 1) Create a bot token (BotFather)
+
 1. Open Telegram and chat with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`.
 2. Run `/newbot`, then follow the prompts (name + username ending in `bot`).
 3. Copy the token and store it safely.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -138,13 +138,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -120,6 +120,10 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
   - OpenAI-compatible base URL: `https://api.cerebras.ai/v1`.
 - Mistral: `mistral` (`MISTRAL_API_KEY`)
 - GitHub Copilot: `github-copilot` (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`)
+- Baseten: `baseten` (`BASETEN_API_KEY`)
+  - Supports open source models: DeepSeek, GLM, Kimi
+  - Example model: `baseten/deepseek-ai/DeepSeek-V3.1`
+  - CLI: `openclaw onboard --auth-choice baseten-api-key`
 
 ## Providers via `models.providers` (custom/base URL)
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -865,11 +865,7 @@
           },
           {
             "group": "Help",
-            "pages": [
-              "help/index",
-              "help/troubleshooting",
-              "help/faq"
-            ]
+            "pages": ["help/index", "help/troubleshooting", "help/faq"]
           },
           {
             "group": "Install & Updates",
@@ -1002,13 +998,7 @@
           },
           {
             "group": "Web & Interfaces",
-            "pages": [
-              "web/index",
-              "web/control-ui",
-              "web/dashboard",
-              "web/webchat",
-              "tui"
-            ]
+            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
           },
           {
             "group": "Channels",
@@ -1172,11 +1162,7 @@
         "groups": [
           {
             "group": "开始",
-            "pages": [
-              "zh-CN/index",
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard"
-            ]
+            "pages": ["zh-CN/index", "zh-CN/start/getting-started", "zh-CN/start/wizard"]
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1046,6 +1046,7 @@
               "providers/vercel-ai-gateway",
               "providers/openrouter",
               "providers/synthetic",
+              "providers/baseten",
               "providers/opencode",
               "providers/glm",
               "providers/zai"

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -82,23 +82,23 @@ config is needed when `BASETEN_API_KEY` is set.
 All models use OpenAI-compatible endpoints. Pricing varies by model; check
 [baseten.co/pricing](https://www.baseten.co/pricing) for current rates.
 
-| Model ID                        | Name              | Context Window | Max Tokens | Reasoning |
-| ------------------------------- | ----------------- | -------------- | ---------- | --------- |
-| `zai-org/GLM-4.6`               | GLM 4.6           | 200k           | 8192       | false     |
-| `zai-org/GLM-4.7`               | GLM 4.7           | 200k           | 8192       | false     |
-| `deepseek-ai/DeepSeek-V3-0324`  | DeepSeek V3 0324  | 128k           | 8192       | true      |
-| `deepseek-ai/DeepSeek-V3.1`     | DeepSeek V3.1     | 128k           | 8192       | true      |
-| `moonshotai/Kimi-K2-0905`       | Kimi K2 0905      | 128k           | 8192       | false     |
-| `moonshotai/Kimi-K2-Thinking`   | Kimi K2 Thinking  | 128k           | 8192       | true      |
+| Model ID                       | Name             | Context Window | Max Tokens | Reasoning |
+| ------------------------------ | ---------------- | -------------- | ---------- | --------- |
+| `zai-org/GLM-4.6`              | GLM 4.6          | 200k           | 8192       | false     |
+| `zai-org/GLM-4.7`              | GLM 4.7          | 200k           | 8192       | false     |
+| `deepseek-ai/DeepSeek-V3-0324` | DeepSeek V3 0324 | 128k           | 8192       | true      |
+| `deepseek-ai/DeepSeek-V3.1`    | DeepSeek V3.1    | 128k           | 8192       | true      |
+| `moonshotai/Kimi-K2-0905`      | Kimi K2 0905     | 128k           | 8192       | false     |
+| `moonshotai/Kimi-K2-Thinking`  | Kimi K2 Thinking | 128k           | 8192       | true      |
 
 ## Which model should I use
 
-| Use Case              | Recommended Model                    | Why                          |
-| --------------------- | ------------------------------------ | ---------------------------- |
-| **General tasks**     | `deepseek-ai/DeepSeek-V3.1`          | Strong reasoning, versatile  |
-| **Coding**            | `deepseek-ai/DeepSeek-V3.1`          | Code-optimized reasoning     |
-| **Multilingual**      | `zai-org/GLM-4.7`                    | Strong multilingual support  |
-| **Complex reasoning** | `moonshotai/Kimi-K2-Thinking`        | Thinking/reasoning model     |
+| Use Case              | Recommended Model             | Why                         |
+| --------------------- | ----------------------------- | --------------------------- |
+| **General tasks**     | `deepseek-ai/DeepSeek-V3.1`   | Strong reasoning, versatile |
+| **Coding**            | `deepseek-ai/DeepSeek-V3.1`   | Code-optimized reasoning    |
+| **Multilingual**      | `zai-org/GLM-4.7`             | Strong multilingual support |
+| **Complex reasoning** | `moonshotai/Kimi-K2-Thinking` | Thinking/reasoning model    |
 
 ## Change default model
 
@@ -115,11 +115,11 @@ openclaw models list | grep baseten
 
 ## Features
 
-| Feature              | Support           |
-| -------------------- | ----------------- |
-| **Streaming**        | Yes               |
-| **Function calling** | Model-dependent   |
-| **Vision**           | No (text only)    |
+| Feature              | Support         |
+| -------------------- | --------------- |
+| **Streaming**        | Yes             |
+| **Function calling** | Model-dependent |
+| **Vision**           | No (text only)  |
 
 ## Troubleshooting
 

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -1,0 +1,147 @@
+---
+summary: "Use Baseten Model-APIs for open source models in OpenClaw"
+read_when:
+  - You want to use Baseten as a model provider
+  - You need Baseten API key setup for DeepSeek, GLM, or Kimi models
+title: "Baseten"
+---
+
+# Baseten
+
+Baseten provides inference for open source models like DeepSeek, GLM, and Kimi
+via an OpenAI-compatible API. OpenClaw registers it as the `baseten` provider.
+
+## Quick setup
+
+1. Set `BASETEN_API_KEY` (or run the wizard below).
+2. Run onboarding:
+
+```bash
+openclaw onboard --auth-choice baseten-api-key
+```
+
+The default model is set to:
+
+```
+baseten/deepseek-ai/DeepSeek-V3.1
+```
+
+## Get your API key
+
+1. Sign up at [baseten.co](https://baseten.co)
+2. Go to **Settings > API Keys** at [app.baseten.co/settings/api-keys](https://app.baseten.co/settings/api-keys)
+3. Create a new API key
+
+## Configuration options
+
+**Option A: Environment Variable**
+
+```bash
+export BASETEN_API_KEY="your-api-key"
+```
+
+**Option B: Interactive Setup (Recommended)**
+
+```bash
+openclaw onboard --auth-choice baseten-api-key
+```
+
+**Option C: Non-interactive**
+
+```bash
+openclaw onboard --non-interactive \
+  --auth-choice baseten-api-key \
+  --baseten-api-key "your-api-key"
+```
+
+## Verify setup
+
+```bash
+openclaw chat --model baseten/deepseek-ai/DeepSeek-V3.1 "Hello, are you working?"
+```
+
+## Config example
+
+```json5
+{
+  env: { BASETEN_API_KEY: "..." },
+  agents: {
+    defaults: {
+      model: { primary: "baseten/deepseek-ai/DeepSeek-V3.1" },
+      models: { "baseten/deepseek-ai/DeepSeek-V3.1": { alias: "DeepSeek V3.1" } },
+    },
+  },
+}
+```
+
+Baseten uses implicit provider discovery, so no explicit `models.providers`
+config is needed when `BASETEN_API_KEY` is set.
+
+## Model catalog
+
+All models use OpenAI-compatible endpoints. Pricing varies by model; check
+[baseten.co/pricing](https://www.baseten.co/pricing) for current rates.
+
+| Model ID                        | Name              | Context Window | Max Tokens | Reasoning |
+| ------------------------------- | ----------------- | -------------- | ---------- | --------- |
+| `zai-org/GLM-4.6`               | GLM 4.6           | 200k           | 8192       | false     |
+| `zai-org/GLM-4.7`               | GLM 4.7           | 200k           | 8192       | false     |
+| `deepseek-ai/DeepSeek-V3-0324`  | DeepSeek V3 0324  | 128k           | 8192       | true      |
+| `deepseek-ai/DeepSeek-V3.1`     | DeepSeek V3.1     | 128k           | 8192       | true      |
+| `moonshotai/Kimi-K2-0905`       | Kimi K2 0905      | 128k           | 8192       | false     |
+| `moonshotai/Kimi-K2-Thinking`   | Kimi K2 Thinking  | 128k           | 8192       | true      |
+
+## Which model should I use
+
+| Use Case              | Recommended Model                    | Why                          |
+| --------------------- | ------------------------------------ | ---------------------------- |
+| **General tasks**     | `deepseek-ai/DeepSeek-V3.1`          | Strong reasoning, versatile  |
+| **Coding**            | `deepseek-ai/DeepSeek-V3.1`          | Code-optimized reasoning     |
+| **Multilingual**      | `zai-org/GLM-4.7`                    | Strong multilingual support  |
+| **Complex reasoning** | `moonshotai/Kimi-K2-Thinking`        | Thinking/reasoning model     |
+
+## Change default model
+
+```bash
+openclaw models set baseten/deepseek-ai/DeepSeek-V3.1
+openclaw models set baseten/zai-org/GLM-4.7
+```
+
+List available models:
+
+```bash
+openclaw models list | grep baseten
+```
+
+## Features
+
+| Feature              | Support           |
+| -------------------- | ----------------- |
+| **Streaming**        | Yes               |
+| **Function calling** | Model-dependent   |
+| **Vision**           | No (text only)    |
+
+## Troubleshooting
+
+### API key not recognized
+
+```bash
+echo $BASETEN_API_KEY
+openclaw models list | grep baseten
+```
+
+### Model not available
+
+Baseten model availability may change. Run `openclaw models list` to see
+currently available models.
+
+### Connection issues
+
+Baseten API is at `https://inference.baseten.co/v1`. Ensure your network allows
+HTTPS connections.
+
+## Links
+
+- [Baseten](https://baseten.co)
+- [API Documentation](https://docs.baseten.co)
+- [Pricing](https://www.baseten.co/pricing)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -47,6 +47,7 @@ See [Venice AI](/providers/venice).
 - [Xiaomi](/providers/xiaomi)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
+- [Baseten (Fast GLM, Kimi, Deepseek)](/providers/baseten)
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Ollama (local models)](/providers/ollama)
 

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -24,6 +24,7 @@ wizard, and let the agent bootstrap itself.
 8. Ready
 
 ## 1) Welcome + security notice
+
 Read the security notice displayed and decide accordingly.
 
 ## 2) Local vs Remote

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -54,6 +54,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 [Devices CLI](/cli/devices) for token rotation and revocation.
 
 **Notes:**
+
 - Local connections (`127.0.0.1`) are auto-approved.
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -110,6 +110,7 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
+
 - **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
 - **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -300,6 +300,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    baseten: "BASETEN_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -134,6 +134,7 @@ export function registerOnboardCommand(program: Command) {
             minimaxApiKey: opts.minimaxApiKey as string | undefined,
             syntheticApiKey: opts.syntheticApiKey as string | undefined,
             veniceApiKey: opts.veniceApiKey as string | undefined,
+            basetenApiKey: opts.basetenApiKey as string | undefined,
             opencodeZenApiKey: opts.opencodeZenApiKey as string | undefined,
             gatewayPort:
               typeof gatewayPort === "number" && Number.isFinite(gatewayPort)

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -82,6 +82,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--minimax-api-key <key>", "MiniMax API key")
     .option("--synthetic-api-key <key>", "Synthetic API key")
     .option("--venice-api-key <key>", "Venice API key")
+    .option("--baseten-api-key <key>", "Baseten API key")
     .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -21,6 +21,7 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
+  | "baseten"
   | "qwen";
 
 export type AuthChoiceGroup = {
@@ -120,6 +121,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "Privacy-focused (uncensored models)",
     choices: ["venice-api-key"],
   },
+  {
+    value: "baseten",
+    label: "Baseten",
+    hint: "Open source models (DeepSeek, GLM, Kimi)",
+    choices: ["baseten-api-key"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -153,6 +160,11 @@ export function buildAuthChoiceOptions(params: {
     value: "venice-api-key",
     label: "Venice AI API key",
     hint: "Privacy-focused inference (uncensored models)",
+  });
+  options.push({
+    value: "baseten-api-key",
+    label: "Baseten API key",
+    hint: "Open source models (DeepSeek, GLM, Kimi)",
   });
   options.push({
     value: "github-copilot",

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -98,6 +98,8 @@ export async function applyAuthChoiceApiProviders(
       authChoice = "synthetic-api-key";
     } else if (params.opts.tokenProvider === "venice") {
       authChoice = "venice-api-key";
+    } else if (params.opts.tokenProvider === "baseten") {
+      authChoice = "baseten-api-key";
     } else if (params.opts.tokenProvider === "opencode") {
       authChoice = "opencode-zen";
     }

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -187,6 +187,59 @@ describe("applyAuthChoice", () => {
     expect(parsed.profiles?.["synthetic:default"]?.key).toBe("sk-synthetic-test");
   });
 
+  it("prompts and writes Baseten API key when selecting baseten-api-key", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    process.env.OPENCLAW_AGENT_DIR = path.join(tempStateDir, "agent");
+    process.env.PI_CODING_AGENT_DIR = process.env.OPENCLAW_AGENT_DIR;
+
+    const text = vi.fn().mockResolvedValue("sk-baseten-test");
+    const select: WizardPrompter["select"] = vi.fn(
+      async (params) => params.options[0]?.value as never,
+    );
+    const multiselect: WizardPrompter["multiselect"] = vi.fn(async () => []);
+    const prompter: WizardPrompter = {
+      intro: vi.fn(noopAsync),
+      outro: vi.fn(noopAsync),
+      note: vi.fn(noopAsync),
+      select,
+      multiselect,
+      text,
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: noop, stop: noop })),
+    };
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    const result = await applyAuthChoice({
+      authChoice: "baseten-api-key",
+      config: {},
+      prompter,
+      runtime,
+      setDefaultModel: true,
+    });
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Enter Baseten API key" }),
+    );
+    expect(result.config.auth?.profiles?.["baseten:default"]).toMatchObject({
+      provider: "baseten",
+      mode: "api_key",
+    });
+
+    const authProfilePath = authProfilePathFor(requireAgentDir());
+    const raw = await fs.readFile(authProfilePath, "utf8");
+    const parsed = JSON.parse(raw) as {
+      profiles?: Record<string, { key?: string }>;
+    };
+    expect(parsed.profiles?.["baseten:default"]?.key).toBe("sk-baseten-test");
+  });
+
   it("sets default model when selecting github-copilot", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -113,6 +113,20 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
+export async function setBasetenApiKey(key: string, agentDir?: string) {
+  // Write to resolved agent dir so gateway finds credentials on startup.
+  upsertAuthProfile({
+    profileId: "baseten:default",
+    credential: {
+      type: "api_key",
+      provider: "baseten",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export const BASETEN_DEFAULT_MODEL_REF = "baseten/deepseek-ai/DeepSeek-V3.1";
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyBasetenConfig,
+  applyBasetenProviderConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
@@ -35,8 +37,10 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  BASETEN_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
+  setBasetenApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
   setMinimaxApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -10,6 +10,7 @@ import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-tok
 import { applyGoogleGeminiModelDefault } from "../../google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyBasetenConfig,
   applyKimiCodeConfig,
   applyMinimaxApiConfig,
   applyMinimaxConfig,
@@ -22,6 +23,7 @@ import {
   applyXiaomiConfig,
   applyZaiConfig,
   setAnthropicApiKey,
+  setBasetenApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
   setMinimaxApiKey,
@@ -370,6 +372,29 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyVeniceConfig(nextConfig);
+  }
+
+  if (authChoice === "baseten-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "baseten",
+      cfg: baseConfig,
+      flagValue: opts.basetenApiKey,
+      flagName: "--baseten-api-key",
+      envVar: "BASETEN_API_KEY",
+      runtime,
+    });
+    if (!resolved) {
+      return null;
+    }
+    if (resolved.source !== "profile") {
+      await setBasetenApiKey(resolved.key);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "baseten:default",
+      provider: "baseten",
+      mode: "api_key",
+    });
+    return applyBasetenConfig(nextConfig);
   }
 
   if (

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -17,6 +17,7 @@ export type AuthChoice =
   | "kimi-code-api-key"
   | "synthetic-api-key"
   | "venice-api-key"
+  | "baseten-api-key"
   | "codex-cli"
   | "apiKey"
   | "gemini-api-key"
@@ -73,6 +74,7 @@ export type OnboardOptions = {
   minimaxApiKey?: string;
   syntheticApiKey?: string;
   veniceApiKey?: string;
+  basetenApiKey?: string;
   opencodeZenApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;


### PR DESCRIPTION
## Summary

- Add Baseten Model-APIs as a new inference provider supporting open source models (DeepSeek, GLM, Kimi)
- Add documentation page for Baseten provider setup and configuration
- Add unit test for the `baseten-api-key` auth choice flow

## Changes

### Code (first commit)
- `src/agents/model-auth.ts` - Add `BASETEN_API_KEY` env var mapping
- `src/agents/models-config.providers.ts` - Add provider config with 6 models (GLM 4.6/4.7, DeepSeek V3, Kimi K2)
- `src/cli/program/register.onboard.ts` - Add `--baseten-api-key` CLI option
- `src/commands/auth-choice-options.ts` - Add auth choice group
- `src/commands/auth-choice.apply.api-providers.ts` - Add full onboarding flow
- `src/commands/onboard-auth.config-core.ts` - Add config functions
- `src/commands/onboard-auth.credentials.ts` - Add credential setter
- `src/commands/onboard-auth.ts` - Add exports
- `src/commands/onboard-types.ts` - Add types

### Docs (second commit)
- `docs/providers/baseten.md` - New documentation page
- `docs/docs.json` - Add to navigation
- `docs/providers/index.md` - Add to provider list
- `docs/concepts/model-providers.md` - Add Baseten section

### Tests (second commit)
- `src/commands/auth-choice.test.ts` - Add test for baseten-api-key auth flow

## Test plan

- [x] `pnpm lint` - passes (0 warnings, 0 errors)
- [x] `pnpm test src/commands/auth-choice.test.ts` - all 13 tests pass
- [x] Manual test with real Baseten API key

## User-facing changes

- New `--auth-choice baseten-api-key` option in `openclaw onboard`
- New `--baseten-api-key` CLI flag for non-interactive setup
- New provider `baseten` with models like `baseten/deepseek-ai/DeepSeek-V3.1`
- New docs page at https://docs.openclaw.ai/providers/baseten

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Baseten as a first-class inference provider: it wires `BASETEN_API_KEY` into env auth resolution, adds a Baseten provider definition (OpenAI-compatible base URL + a curated model list), integrates Baseten into the onboarding auth-choice flow (interactive + non-interactive with `--baseten-api-key`), and documents setup and usage.

The main integration points are:
- `src/agents/models-config.providers.ts` for implicit provider discovery and Baseten’s model catalog
- `src/commands/auth-choice.apply.api-providers.ts` and `src/commands/onboard-non-interactive/local/auth-choice.ts` for onboarding flows and credential persistence
- docs navigation + a new provider page for user guidance

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a couple of auth/help-text edge cases that could break Baseten onboarding or confuse users.
- Core changes are additive and follow existing provider patterns, and there is test coverage for the interactive auth-choice flow. However, Baseten’s implicit provider discovery currently stores an env-var *name* in `apiKey` while also defining a non-empty models list, which can cause runtime auth/availability issues depending on downstream expectations. Also, the CLI help string omits the new auth-choice value, increasing user confusion.
- src/agents/models-config.providers.ts, src/cli/program/register.onboard.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->