### PR TITLE
fix(whatsapp): use actual filename for document sends instead of hardcoded 'file'

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.test.ts
+++ b/src/web/inbound/send-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWebSendApi } from "./send-api.js";
+
+describe("createWebSendApi", () => {
+  function makeApi() {
+    const sendMessage = vi.fn(async () => ({ key: { id: "m1" } }));
+    const sendPresenceUpdate = vi.fn(async () => {});
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "default",
+    });
+    return { api, sendMessage };
+  }
+
+  it("uses provided fileName for document payloads", async () => {
+    const { api, sendMessage } = makeApi();
+    await api.sendMessage("+1555", "report", Buffer.from("pdf"), "application/pdf", {
+      fileName: "report.pdf",
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "report.pdf",
+      }),
+    );
+  });
+
+  it("falls back to 'file' when fileName is not provided", async () => {
+    const { api, sendMessage } = makeApi();
+    await api.sendMessage("+1555", "blob", Buffer.from("bin"), "application/octet-stream");
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "file",
+      }),
+    );
+  });
+});

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName ?? "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -130,7 +130,23 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
+  });
+
+  it("falls back to 'file' when loadWebMedia returns no fileName", async () => {
+    const buf = Buffer.from("bin");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/octet-stream",
+      kind: "document",
+    });
+    await sendMessageWhatsApp("+1555", "blob", {
+      verbose: false,
+      mediaUrl: "/tmp/data.bin",
+    });
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "blob", buf, "application/octet-stream");
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -43,11 +43,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -68,10 +70,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             accountId,
+            fileName: mediaFileName,
           }
         : undefined;
     const result = sendOptions


### PR DESCRIPTION
## Summary

Fixes #6455 — WhatsApp document sends always used the hardcoded filename `"file"` regardless of the actual source filename. Recipients see every document named "file" instead of the real name (e.g. "report.pdf").

## Root Cause

`loadWebMedia()` already extracts and returns `fileName` from the media source, but it was never threaded through to the Baileys payload:

1. `sendMessageWhatsApp()` in `web/outbound.ts` called `loadWebMedia()`, captured `media.buffer` and `media.contentType`, but **dropped `media.fileName`**
2. `createWebSendApi().sendMessage()` in `web/inbound/send-api.ts` **hardcoded `fileName: "file"`** for all document payloads

## Fix

Thread the existing `fileName` through via `ActiveWebSendOptions` (3 lines of plumbing):

- **`active-listener.ts`**: Add `fileName?: string` to `ActiveWebSendOptions`
- **`outbound.ts`**: Capture `media.fileName` from `loadWebMedia()` result, include in `sendOptions`
- **`send-api.ts`**: Use `sendOptions?.fileName ?? "file"` instead of hardcoded `"file"`

Falls back to `"file"` when no filename is available (zero behavior change for existing callers).

## What's NOT changed

- No other channels affected (WhatsApp-only code path)
- No changes to `message-action-runner.ts` or `inferAttachmentFilename()`
- No new dependencies

## Testing

- [x] Updated existing test `"maps other kinds to document with filename"` to verify filename flows through
- [x] Added new test `"falls back to 'file' when loadWebMedia returns no fileName"` for the fallback
- [x] `pnpm tsgo` — no type errors
- [x] `pnpm format` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm build` — clean
- [x] `pnpm test` — all passing (10/10 in outbound suite, 880/880 full suite)

## AI Disclosure

Built with Claude (AI-assisted). Fully tested locally. I understand what the code does. 

**Diff: 4 files, +23 / -3 lines.**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a `fileName` value extracted by `loadWebMedia()` through the WhatsApp Web outbound/send pipeline so document messages display the original filename instead of a hardcoded `"file"`. Concretely:
- `ActiveWebSendOptions` adds an optional `fileName` field (`src/web/active-listener.ts`).
- `sendMessageWhatsApp` captures `media.fileName` and passes it via `sendOptions` (`src/web/outbound.ts`).
- The Baileys document payload now uses `sendOptions?.fileName ?? "file"` (`src/web/inbound/send-api.ts`).
- Tests were updated to cover filename propagation and intended fallback (`src/web/outbound.test.ts`).

The change is localized to the WhatsApp web channel and fits the existing pattern of threading per-send options through `ActiveWebSendOptions` to the Baileys payload builder.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and should be safe to merge after tightening the fallback test to actually cover the send-api defaulting behavior.
- Behavioral change is small and localized (adds an optional option field and uses it when constructing document payloads). The only real concern is test coverage: the newly added fallback test doesn’t exercise the `send-api` defaulting path, so a future regression there could slip through.
- src/web/outbound.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->