### PR TITLE
feat(telegram): add sticker and custom emoji vision support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+.idea/

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -3,7 +3,7 @@ import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
 } from "../media-understanding/types.js";
-import type { StickerMetadata } from "../telegram/bot/types.js";
+import type { CustomEmojiMetadata, StickerMetadata } from "../telegram/bot/types.js";
 import type { InternalMessageChannel } from "../utils/message-channel.js";
 import type { CommandArgs } from "./commands-registry.types.js";
 
@@ -68,6 +68,8 @@ export type MsgContext = {
   MediaTypes?: string[];
   /** Telegram sticker metadata (emoji, set name, file IDs, cached description). */
   Sticker?: StickerMetadata;
+  /** Telegram custom emoji metadata (from messages containing custom emoji). */
+  CustomEmojis?: CustomEmojiMetadata[];
   OutputDir?: string;
   OutputBase?: string;
   /** Remote host for SCP when media lives on a different machine (e.g., openclaw@192.168.64.3). */

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -130,6 +130,10 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /** Enable vision AI analysis for stickers. Default: false. */
+  stickerVision?: boolean;
+  /** Enable vision AI analysis for custom emoji in messages. Default: false (expensive). */
+  customEmojiVision?: boolean;
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -137,6 +137,8 @@ export const TelegramAccountSchemaBase = z
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
+    stickerVision: z.boolean().optional(),
+    customEmojiVision: z.boolean().optional(),
   })
   .strict();
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,6 +1,5 @@
 import type { TelegramMessage } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-// @ts-nocheck
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,

--- a/src/telegram/bot/helpers.expand-entities.test.ts
+++ b/src/telegram/bot/helpers.expand-entities.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { expandEntities } from "./helpers.js";
+
+describe("expandEntities", () => {
+  it("returns text unchanged when no entities are provided", () => {
+    expect(expandEntities("Hello world")).toBe("Hello world");
+    expect(expandEntities("Hello world", null)).toBe("Hello world");
+    expect(expandEntities("Hello world", [])).toBe("Hello world");
+  });
+
+  it("returns text unchanged when there are no expandable entities", () => {
+    const entities = [
+      { type: "mention", offset: 0, length: 5 },
+      { type: "bold", offset: 6, length: 5 },
+    ];
+    expect(expandEntities("@user hello", entities)).toBe("@user hello");
+  });
+
+  describe("text_link expansion", () => {
+    it("expands a single text_link entity", () => {
+      const text = "Check this link for details";
+      const entities = [{ type: "text_link", offset: 11, length: 4, url: "https://example.com" }];
+      expect(expandEntities(text, entities)).toBe(
+        "Check this [link](https://example.com) for details",
+      );
+    });
+
+    it("expands multiple text_link entities", () => {
+      const text = "Visit Google or GitHub for more";
+      const entities = [
+        { type: "text_link", offset: 6, length: 6, url: "https://google.com" },
+        { type: "text_link", offset: 16, length: 6, url: "https://github.com" },
+      ];
+      expect(expandEntities(text, entities)).toBe(
+        "Visit [Google](https://google.com) or [GitHub](https://github.com) for more",
+      );
+    });
+  });
+
+  describe("custom_emoji expansion", () => {
+    it("expands a single custom_emoji with resolved info", () => {
+      const text = "Hello X world";
+      const entities = [
+        { type: "custom_emoji", offset: 6, length: 1, custom_emoji_id: "emoji123" },
+      ];
+      const resolved = new Map([["emoji123", { emoji: "😂", setName: "FunPack" }]]);
+
+      expect(expandEntities(text, entities, resolved)).toBe("Hello [😂:FunPack] world");
+    });
+
+    it("expands custom_emoji without set name", () => {
+      const text = "Hi X!";
+      const entities = [{ type: "custom_emoji", offset: 3, length: 1, custom_emoji_id: "e1" }];
+      const resolved = new Map([["e1", { emoji: "🎉" }]]);
+
+      expect(expandEntities(text, entities, resolved)).toBe("Hi [🎉]!");
+    });
+
+    it("ignores custom_emoji when no resolved map provided", () => {
+      const text = "Hello X world";
+      const entities = [
+        { type: "custom_emoji", offset: 6, length: 1, custom_emoji_id: "emoji123" },
+      ];
+
+      expect(expandEntities(text, entities)).toBe("Hello X world");
+    });
+
+    it("ignores unresolved custom_emoji", () => {
+      const text = "A B";
+      const entities = [
+        { type: "custom_emoji", offset: 0, length: 1, custom_emoji_id: "resolved" },
+        { type: "custom_emoji", offset: 2, length: 1, custom_emoji_id: "unknown" },
+      ];
+      const resolved = new Map([["resolved", { emoji: "✅" }]]);
+
+      expect(expandEntities(text, entities, resolved)).toBe("[✅] B");
+    });
+  });
+
+  describe("combined text_link and custom_emoji expansion", () => {
+    it("expands both entity types in a single pass", () => {
+      const text = "Check link and emoji X here";
+      const entities = [
+        { type: "text_link", offset: 6, length: 4, url: "https://example.com" },
+        { type: "custom_emoji", offset: 21, length: 1, custom_emoji_id: "e1" },
+      ];
+      const resolved = new Map([["e1", { emoji: "🎯", setName: "Targets" }]]);
+
+      expect(expandEntities(text, entities, resolved)).toBe(
+        "Check [link](https://example.com) and emoji [🎯:Targets] here",
+      );
+    });
+
+    it("handles adjacent text_link and custom_emoji", () => {
+      const text = "linkX";
+      const entities = [
+        { type: "text_link", offset: 0, length: 4, url: "https://a.com" },
+        { type: "custom_emoji", offset: 4, length: 1, custom_emoji_id: "e1" },
+      ];
+      const resolved = new Map([["e1", { emoji: "⭐" }]]);
+
+      expect(expandEntities(text, entities, resolved)).toBe("[link](https://a.com)[⭐]");
+    });
+
+    it("preserves entity order when expanding both types", () => {
+      const text = "A B C D E";
+      const entities = [
+        { type: "custom_emoji", offset: 0, length: 1, custom_emoji_id: "e1" },
+        { type: "text_link", offset: 2, length: 1, url: "https://b.com" },
+        { type: "custom_emoji", offset: 4, length: 1, custom_emoji_id: "e2" },
+        { type: "text_link", offset: 6, length: 1, url: "https://d.com" },
+        { type: "custom_emoji", offset: 8, length: 1, custom_emoji_id: "e3" },
+      ];
+      const resolved = new Map([
+        ["e1", { emoji: "1️⃣" }],
+        ["e2", { emoji: "3️⃣" }],
+        ["e3", { emoji: "5️⃣" }],
+      ]);
+
+      expect(expandEntities(text, entities, resolved)).toBe(
+        "[1️⃣] [B](https://b.com) [3️⃣] [D](https://d.com) [5️⃣]",
+      );
+    });
+
+    it("handles multiple overlapping-position entities correctly", () => {
+      // Real-world case: message with links and emoji interspersed
+      const text = "See docs here emoji1 and emoji2 links";
+      const entities = [
+        { type: "text_link", offset: 4, length: 4, url: "https://docs.example.com" },
+        { type: "custom_emoji", offset: 14, length: 6, custom_emoji_id: "smile" },
+        { type: "custom_emoji", offset: 25, length: 6, custom_emoji_id: "wave" },
+      ];
+      const resolved = new Map([
+        ["smile", { emoji: "😊", setName: "Faces" }],
+        ["wave", { emoji: "👋" }],
+      ]);
+
+      expect(expandEntities(text, entities, resolved)).toBe(
+        "See [docs](https://docs.example.com) here [😊:Faces] and [👋] links",
+      );
+    });
+  });
+});

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -87,3 +87,19 @@ export interface StickerMetadata {
   /** Cached description from previous vision processing (skip re-processing if present). */
   cachedDescription?: string;
 }
+
+/** Telegram custom emoji metadata for context enrichment. */
+export interface CustomEmojiMetadata {
+  /** Unique identifier for the custom emoji. */
+  customEmojiId: string;
+  /** Emoji character associated with the custom emoji. */
+  emoji: string;
+  /** Name of the sticker set the custom emoji belongs to. */
+  setName?: string;
+  /** Telegram file_id for the custom emoji sticker. */
+  fileId?: string;
+  /** Stable file_unique_id for cache deduplication. */
+  fileUniqueId?: string;
+  /** Cached description from previous vision processing (skip re-processing if present). */
+  cachedDescription?: string;
+}

--- a/src/telegram/custom-emoji-cache.test.ts
+++ b/src/telegram/custom-emoji-cache.test.ts
@@ -1,0 +1,263 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheCustomEmoji,
+  cacheCustomEmojiAsync,
+  getAllCachedCustomEmojis,
+  getCachedCustomEmoji,
+  getCustomEmojiCacheStats,
+} from "./custom-emoji-cache.js";
+
+// Mock the state directory to use a temp location
+vi.mock("../config/paths.js", () => ({
+  STATE_DIR: "/tmp/openclaw-test-custom-emoji-cache",
+}));
+
+const TEST_CACHE_DIR = "/tmp/openclaw-test-custom-emoji-cache/telegram";
+const TEST_CACHE_FILE = path.join(TEST_CACHE_DIR, "custom-emoji-cache.json");
+
+describe("custom-emoji-cache", () => {
+  beforeEach(() => {
+    // Clean up before each test
+    if (fs.existsSync(TEST_CACHE_FILE)) {
+      fs.unlinkSync(TEST_CACHE_FILE);
+    }
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    if (fs.existsSync(TEST_CACHE_FILE)) {
+      fs.unlinkSync(TEST_CACHE_FILE);
+    }
+  });
+
+  describe("getCachedCustomEmoji", () => {
+    it("returns null for unknown ID", () => {
+      const result = getCachedCustomEmoji("unknown-id");
+      expect(result).toBeNull();
+    });
+
+    it("returns cached emoji after cacheCustomEmoji", () => {
+      const emoji = {
+        customEmojiId: "emoji123",
+        fileId: "file123",
+        fileUniqueId: "unique123",
+        emoji: "🎉",
+        setName: "TestPack",
+        description: "A party popper emoji",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+
+      cacheCustomEmoji(emoji);
+      const result = getCachedCustomEmoji("emoji123");
+
+      expect(result).toEqual(emoji);
+    });
+
+    it("returns null after cache is cleared", () => {
+      const emoji = {
+        customEmojiId: "emoji123",
+        emoji: "🎉",
+        description: "test",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+
+      cacheCustomEmoji(emoji);
+      expect(getCachedCustomEmoji("emoji123")).not.toBeNull();
+
+      // Manually clear the cache file
+      fs.unlinkSync(TEST_CACHE_FILE);
+
+      expect(getCachedCustomEmoji("emoji123")).toBeNull();
+    });
+  });
+
+  describe("cacheCustomEmoji", () => {
+    it("adds entry to cache", () => {
+      const emoji = {
+        customEmojiId: "emoji456",
+        emoji: "🦊",
+        description: "A cute fox",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+
+      cacheCustomEmoji(emoji);
+
+      const all = getAllCachedCustomEmojis();
+      expect(all).toHaveLength(1);
+      expect(all[0]).toEqual(emoji);
+    });
+
+    it("updates existing entry", () => {
+      const original = {
+        customEmojiId: "emoji789",
+        emoji: "🐱",
+        description: "Original description",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+      const updated = {
+        customEmojiId: "emoji789",
+        emoji: "🐱",
+        description: "Updated description",
+        cachedAt: "2026-01-26T13:00:00.000Z",
+      };
+
+      cacheCustomEmoji(original);
+      cacheCustomEmoji(updated);
+
+      const result = getCachedCustomEmoji("emoji789");
+      expect(result?.description).toBe("Updated description");
+    });
+  });
+
+  describe("cacheCustomEmojiAsync", () => {
+    it("adds entry to cache with locking", async () => {
+      const emoji = {
+        customEmojiId: "async-emoji",
+        emoji: "🔥",
+        description: "A fire emoji",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+
+      await cacheCustomEmojiAsync(emoji);
+
+      const result = getCachedCustomEmoji("async-emoji");
+      expect(result).toEqual(emoji);
+    });
+
+    it("handles concurrent writes without data loss", async () => {
+      const emojis = Array.from({ length: 10 }, (_, i) => ({
+        customEmojiId: `concurrent-${i}`,
+        emoji: String.fromCodePoint(0x1f600 + i),
+        description: `Emoji ${i}`,
+        cachedAt: new Date().toISOString(),
+      }));
+
+      // Write all emojis concurrently
+      await Promise.all(emojis.map((e) => cacheCustomEmojiAsync(e)));
+
+      // Verify all emojis were saved
+      const all = getAllCachedCustomEmojis();
+      expect(all).toHaveLength(10);
+
+      for (const emoji of emojis) {
+        const cached = getCachedCustomEmoji(emoji.customEmojiId);
+        expect(cached).not.toBeNull();
+        expect(cached?.description).toBe(emoji.description);
+      }
+    });
+  });
+
+  describe("getAllCachedCustomEmojis", () => {
+    it("returns empty array when cache is empty", () => {
+      const result = getAllCachedCustomEmojis();
+      expect(result).toEqual([]);
+    });
+
+    it("returns all cached emojis", () => {
+      cacheCustomEmoji({
+        customEmojiId: "a",
+        emoji: "🅰️",
+        description: "Letter A",
+        cachedAt: "2026-01-26T10:00:00.000Z",
+      });
+      cacheCustomEmoji({
+        customEmojiId: "b",
+        emoji: "🅱️",
+        description: "Letter B",
+        cachedAt: "2026-01-26T11:00:00.000Z",
+      });
+
+      const result = getAllCachedCustomEmojis();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("getCustomEmojiCacheStats", () => {
+    it("returns count 0 when cache is empty", () => {
+      const stats = getCustomEmojiCacheStats();
+      expect(stats.count).toBe(0);
+      expect(stats.oldestAt).toBeUndefined();
+      expect(stats.newestAt).toBeUndefined();
+    });
+
+    it("returns correct stats with cached emojis", () => {
+      cacheCustomEmoji({
+        customEmojiId: "old",
+        emoji: "👴",
+        description: "Old emoji",
+        cachedAt: "2026-01-20T10:00:00.000Z",
+      });
+      cacheCustomEmoji({
+        customEmojiId: "new",
+        emoji: "👶",
+        description: "New emoji",
+        cachedAt: "2026-01-26T10:00:00.000Z",
+      });
+      cacheCustomEmoji({
+        customEmojiId: "mid",
+        emoji: "🧑",
+        description: "Middle emoji",
+        cachedAt: "2026-01-23T10:00:00.000Z",
+      });
+
+      const stats = getCustomEmojiCacheStats();
+      expect(stats.count).toBe(3);
+      expect(stats.oldestAt).toBe("2026-01-20T10:00:00.000Z");
+      expect(stats.newestAt).toBe("2026-01-26T10:00:00.000Z");
+    });
+  });
+
+  describe("cache validation", () => {
+    it("handles malformed cache gracefully", () => {
+      // Write invalid JSON structure
+      if (!fs.existsSync(TEST_CACHE_DIR)) {
+        fs.mkdirSync(TEST_CACHE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(TEST_CACHE_FILE, '{"version": 1, "emojis": "not-an-object"}');
+
+      // Should return empty cache without throwing
+      const result = getCachedCustomEmoji("any-id");
+      expect(result).toBeNull();
+    });
+
+    it("handles version mismatch gracefully", () => {
+      // Write cache with wrong version
+      if (!fs.existsSync(TEST_CACHE_DIR)) {
+        fs.mkdirSync(TEST_CACHE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(
+        TEST_CACHE_FILE,
+        JSON.stringify({
+          version: 999,
+          emojis: {
+            test: { customEmojiId: "test", emoji: "🎉", description: "test", cachedAt: "" },
+          },
+        }),
+      );
+
+      // Should return empty cache
+      const result = getCachedCustomEmoji("test");
+      expect(result).toBeNull();
+    });
+
+    it("handles missing required fields gracefully", () => {
+      // Write cache with missing required fields
+      if (!fs.existsSync(TEST_CACHE_DIR)) {
+        fs.mkdirSync(TEST_CACHE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(
+        TEST_CACHE_FILE,
+        JSON.stringify({
+          version: 1,
+          emojis: { test: { customEmojiId: "test" } }, // Missing required fields
+        }),
+      );
+
+      // Should return empty cache without throwing
+      const result = getCachedCustomEmoji("test");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/telegram/custom-emoji-cache.ts
+++ b/src/telegram/custom-emoji-cache.ts
@@ -1,0 +1,166 @@
+import path from "node:path";
+import { z } from "zod";
+import type { OpenClawConfig } from "../config/config.js";
+import { STATE_DIR } from "../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+import { describeImageWithVision } from "./vision-describe.js";
+
+const CACHE_FILE = path.join(STATE_DIR, "telegram", "custom-emoji-cache.json");
+const CACHE_VERSION = 1;
+
+export interface CachedCustomEmoji {
+  customEmojiId: string;
+  fileId?: string;
+  fileUniqueId?: string;
+  emoji: string;
+  setName?: string;
+  description: string;
+  cachedAt: string;
+}
+
+// Zod schema for runtime validation of cache structure
+const CachedCustomEmojiSchema = z.object({
+  customEmojiId: z.string(),
+  fileId: z.string().optional(),
+  fileUniqueId: z.string().optional(),
+  emoji: z.string(),
+  setName: z.string().optional(),
+  description: z.string(),
+  cachedAt: z.string(),
+});
+
+const CustomEmojiCacheSchema = z.object({
+  version: z.number(),
+  emojis: z.record(z.string(), CachedCustomEmojiSchema),
+});
+
+type CustomEmojiCache = z.infer<typeof CustomEmojiCacheSchema>;
+
+// Simple in-memory lock for cache operations to prevent race conditions
+let cacheLock: Promise<void> = Promise.resolve();
+
+async function withCacheLock<T>(fn: () => T | Promise<T>): Promise<T> {
+  const previousLock = cacheLock;
+  let resolve: () => void;
+  cacheLock = new Promise((r) => {
+    resolve = r;
+  });
+  try {
+    await previousLock;
+    return await fn();
+  } finally {
+    resolve!();
+  }
+}
+
+function loadCache(): CustomEmojiCache {
+  const data = loadJsonFile(CACHE_FILE);
+  if (!data || typeof data !== "object") {
+    return { version: CACHE_VERSION, emojis: {} };
+  }
+
+  // Validate cache structure with Zod
+  const result = CustomEmojiCacheSchema.safeParse(data);
+  if (!result.success) {
+    return { version: CACHE_VERSION, emojis: {} };
+  }
+
+  if (result.data.version !== CACHE_VERSION) {
+    return { version: CACHE_VERSION, emojis: {} };
+  }
+
+  return result.data;
+}
+
+function saveCache(cache: CustomEmojiCache): void {
+  saveJsonFile(CACHE_FILE, cache);
+}
+
+/**
+ * Get a cached custom emoji by its ID.
+ */
+export function getCachedCustomEmoji(customEmojiId: string): CachedCustomEmoji | null {
+  const cache = loadCache();
+  return cache.emojis[customEmojiId] ?? null;
+}
+
+/**
+ * Add or update a custom emoji in the cache.
+ */
+export function cacheCustomEmoji(emoji: CachedCustomEmoji): void {
+  const cache = loadCache();
+  cache.emojis[emoji.customEmojiId] = emoji;
+  saveCache(cache);
+}
+
+/**
+ * Add or update a custom emoji in the cache with locking.
+ * Prevents race conditions during concurrent writes.
+ */
+export async function cacheCustomEmojiAsync(emoji: CachedCustomEmoji): Promise<void> {
+  await withCacheLock(() => {
+    const cache = loadCache();
+    cache.emojis[emoji.customEmojiId] = emoji;
+    saveCache(cache);
+  });
+}
+
+/**
+ * Get all cached custom emojis.
+ */
+export function getAllCachedCustomEmojis(): CachedCustomEmoji[] {
+  const cache = loadCache();
+  return Object.values(cache.emojis);
+}
+
+/**
+ * Get cache statistics.
+ */
+export function getCustomEmojiCacheStats(): {
+  count: number;
+  oldestAt?: string;
+  newestAt?: string;
+} {
+  const cache = loadCache();
+  const emojis = Object.values(cache.emojis);
+  if (emojis.length === 0) {
+    return { count: 0 };
+  }
+  const sorted = [...emojis].toSorted(
+    (a, b) => new Date(a.cachedAt).getTime() - new Date(b.cachedAt).getTime(),
+  );
+  return {
+    count: emojis.length,
+    oldestAt: sorted[0]?.cachedAt,
+    newestAt: sorted[sorted.length - 1]?.cachedAt,
+  };
+}
+
+const CUSTOM_EMOJI_DESCRIPTION_PROMPT =
+  "Describe this custom emoji/sticker image in 1-2 sentences. Focus on what it depicts (character, object, action, emotion). Be concise.";
+
+export interface DescribeCustomEmojiParams {
+  imagePath: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  agentId?: string;
+}
+
+/**
+ * Describe a custom emoji image using vision API.
+ * Auto-detects an available vision provider based on configured API keys.
+ * Returns null if no vision provider is available.
+ */
+export async function describeCustomEmojiImage(
+  params: DescribeCustomEmojiParams,
+): Promise<string | null> {
+  return describeImageWithVision({
+    imagePath: params.imagePath,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    agentId: params.agentId,
+    prompt: CUSTOM_EMOJI_DESCRIPTION_PROMPT,
+    fileName: "custom-emoji.webp",
+    logPrefix: "telegram",
+  });
+}

--- a/src/telegram/custom-emoji-cache.ts
+++ b/src/telegram/custom-emoji-cache.ts
@@ -144,6 +144,7 @@ export interface DescribeCustomEmojiParams {
   cfg: OpenClawConfig;
   agentDir?: string;
   agentId?: string;
+  contentType?: string;
 }
 
 /**
@@ -162,5 +163,6 @@ export async function describeCustomEmojiImage(
     prompt: CUSTOM_EMOJI_DESCRIPTION_PROMPT,
     fileName: "custom-emoji.webp",
     logPrefix: "telegram",
+    contentType: params.contentType,
   });
 }

--- a/src/telegram/custom-emoji.test.ts
+++ b/src/telegram/custom-emoji.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  downloadCustomEmojiFiles,
+  extractCustomEmojiEntities,
+  expandCustomEmojisInText,
+  processCustomEmojis,
+  resolveCustomEmojis,
+} from "./custom-emoji.js";
+
+describe("extractCustomEmojiEntities", () => {
+  it("returns empty array when entities is undefined", () => {
+    expect(extractCustomEmojiEntities(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when entities is empty", () => {
+    expect(extractCustomEmojiEntities([])).toEqual([]);
+  });
+
+  it("returns empty array when no custom_emoji entities exist", () => {
+    const entities = [
+      { type: "mention", offset: 0, length: 5 },
+      { type: "bold", offset: 6, length: 5 },
+      { type: "text_link", offset: 12, length: 4, url: "https://example.com" },
+    ];
+    expect(extractCustomEmojiEntities(entities)).toEqual([]);
+  });
+
+  it("extracts custom_emoji entities", () => {
+    const entities = [
+      { type: "mention", offset: 0, length: 5 },
+      { type: "custom_emoji", offset: 6, length: 2, custom_emoji_id: "emoji123" },
+      { type: "bold", offset: 9, length: 5 },
+      { type: "custom_emoji", offset: 15, length: 2, custom_emoji_id: "emoji456" },
+    ];
+    const result = extractCustomEmojiEntities(entities);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      type: "custom_emoji",
+      offset: 6,
+      length: 2,
+      custom_emoji_id: "emoji123",
+    });
+    expect(result[1]).toEqual({
+      type: "custom_emoji",
+      offset: 15,
+      length: 2,
+      custom_emoji_id: "emoji456",
+    });
+  });
+
+  it("skips custom_emoji without custom_emoji_id", () => {
+    const entities = [
+      { type: "custom_emoji", offset: 0, length: 2, custom_emoji_id: "valid123" },
+      { type: "custom_emoji", offset: 3, length: 2 }, // missing custom_emoji_id
+      { type: "custom_emoji", offset: 6, length: 2, custom_emoji_id: "" }, // empty string
+    ];
+    const result = extractCustomEmojiEntities(entities);
+    expect(result).toHaveLength(1);
+    expect(result[0].custom_emoji_id).toBe("valid123");
+  });
+});
+
+describe("expandCustomEmojisInText", () => {
+  it("returns text unchanged when entities is empty", () => {
+    const resolved = new Map([["emoji123", { emoji: "😂", setName: "TestPack" }]]);
+    expect(expandCustomEmojisInText("Hello world", [], resolved)).toBe("Hello world");
+  });
+
+  it("returns text unchanged when resolved map is empty", () => {
+    const entities = [
+      { type: "custom_emoji" as const, offset: 6, length: 1, custom_emoji_id: "emoji123" },
+    ];
+    expect(expandCustomEmojisInText("Hello X world", entities, new Map())).toBe("Hello X world");
+  });
+
+  it("expands a single custom emoji with set name", () => {
+    const text = "Hello X world";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 6, length: 1, custom_emoji_id: "emoji123" },
+    ];
+    const resolved = new Map([["emoji123", { emoji: "😂", setName: "FunnyPack" }]]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe("Hello [😂:FunnyPack] world");
+  });
+
+  it("expands a single custom emoji without set name", () => {
+    const text = "Hello X world";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 6, length: 1, custom_emoji_id: "emoji123" },
+    ];
+    const resolved = new Map([["emoji123", { emoji: "🎉" }]]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe("Hello [🎉] world");
+  });
+
+  it("expands multiple custom emojis", () => {
+    const text = "A B C";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 0, length: 1, custom_emoji_id: "e1" },
+      { type: "custom_emoji" as const, offset: 2, length: 1, custom_emoji_id: "e2" },
+      { type: "custom_emoji" as const, offset: 4, length: 1, custom_emoji_id: "e3" },
+    ];
+    const resolved = new Map([
+      ["e1", { emoji: "🅰️", setName: "Letters" }],
+      ["e2", { emoji: "🅱️", setName: "Letters" }],
+      ["e3", { emoji: "©️" }],
+    ]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe(
+      "[🅰️:Letters] [🅱️:Letters] [©️]",
+    );
+  });
+
+  it("handles adjacent custom emojis", () => {
+    const text = "XY";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 0, length: 1, custom_emoji_id: "e1" },
+      { type: "custom_emoji" as const, offset: 1, length: 1, custom_emoji_id: "e2" },
+    ];
+    const resolved = new Map([
+      ["e1", { emoji: "🔥" }],
+      ["e2", { emoji: "💧" }],
+    ]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe("[🔥][💧]");
+  });
+
+  it("skips unresolved custom emoji", () => {
+    const text = "A B C";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 0, length: 1, custom_emoji_id: "e1" },
+      { type: "custom_emoji" as const, offset: 2, length: 1, custom_emoji_id: "unknown" },
+      { type: "custom_emoji" as const, offset: 4, length: 1, custom_emoji_id: "e3" },
+    ];
+    const resolved = new Map([
+      ["e1", { emoji: "🔴" }],
+      ["e3", { emoji: "🔵" }],
+    ]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe("[🔴] B [🔵]");
+  });
+
+  it("handles multi-byte emoji placeholder", () => {
+    // Custom emoji in Telegram can occupy 2 UTF-16 code units (surrogate pair)
+    const text = "Hi 👋 there";
+    const entities = [
+      { type: "custom_emoji" as const, offset: 3, length: 2, custom_emoji_id: "wave" },
+    ];
+    const resolved = new Map([["wave", { emoji: "👋", setName: "Hands" }]]);
+
+    expect(expandCustomEmojisInText(text, entities, resolved)).toBe("Hi [👋:Hands] there");
+  });
+});
+
+describe("resolveCustomEmojis", () => {
+  it("returns empty map for empty array", async () => {
+    const mockBot = { api: { getCustomEmojiStickers: vi.fn() } };
+    const result = await resolveCustomEmojis(mockBot as never, []);
+    expect(result.size).toBe(0);
+    expect(mockBot.api.getCustomEmojiStickers).not.toHaveBeenCalled();
+  });
+
+  it("resolves emoji info from API", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockResolvedValue([
+          {
+            custom_emoji_id: "emoji1",
+            emoji: "🎉",
+            set_name: "PartyPack",
+            file_id: "file1",
+            file_unique_id: "unique1",
+          },
+          {
+            custom_emoji_id: "emoji2",
+            emoji: "🔥",
+            set_name: "FireSet",
+            file_id: "file2",
+            file_unique_id: "unique2",
+          },
+        ]),
+      },
+    };
+
+    const result = await resolveCustomEmojis(mockBot as never, ["emoji1", "emoji2"]);
+
+    expect(result.size).toBe(2);
+    expect(result.get("emoji1")).toEqual({
+      emoji: "🎉",
+      setName: "PartyPack",
+      fileId: "file1",
+      fileUniqueId: "unique1",
+    });
+    expect(result.get("emoji2")).toEqual({
+      emoji: "🔥",
+      setName: "FireSet",
+      fileId: "file2",
+      fileUniqueId: "unique2",
+    });
+  });
+
+  it("uses fallback emoji when emoji is undefined", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockResolvedValue([
+          {
+            custom_emoji_id: "emoji1",
+            // emoji is undefined
+            set_name: "TestPack",
+            file_id: "file1",
+            file_unique_id: "unique1",
+          },
+        ]),
+      },
+    };
+
+    const result = await resolveCustomEmojis(mockBot as never, ["emoji1"]);
+
+    expect(result.get("emoji1")?.emoji).toBe("❓");
+  });
+
+  it("returns empty map on API error", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockRejectedValue(new Error("API error")),
+      },
+    };
+
+    const result = await resolveCustomEmojis(mockBot as never, ["emoji1"]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("skips stickers without custom_emoji_id", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockResolvedValue([
+          {
+            custom_emoji_id: "emoji1",
+            emoji: "🎉",
+          },
+          {
+            // no custom_emoji_id
+            emoji: "🔥",
+          },
+        ]),
+      },
+    };
+
+    const result = await resolveCustomEmojis(mockBot as never, ["emoji1", "emoji2"]);
+
+    expect(result.size).toBe(1);
+    expect(result.has("emoji1")).toBe(true);
+  });
+});
+
+describe("downloadCustomEmojiFiles", () => {
+  it("returns empty array for empty map", async () => {
+    const mockBot = { api: { getFile: vi.fn() } };
+    const result = await downloadCustomEmojiFiles(mockBot as never, "token", new Map(), 1000000);
+    expect(result).toEqual([]);
+  });
+
+  it("handles emoji without fileId", async () => {
+    const mockBot = { api: { getFile: vi.fn() } };
+    const emojiInfo = new Map([["e1", { emoji: "🎉", setName: "Pack" }]]);
+
+    const result = await downloadCustomEmojiFiles(mockBot as never, "token", emojiInfo, 1000000);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "e1",
+      emoji: "🎉",
+      setName: "Pack",
+    });
+    expect(mockBot.api.getFile).not.toHaveBeenCalled();
+  });
+
+  it("handles getFile returning no file_path", async () => {
+    const mockBot = {
+      api: {
+        getFile: vi.fn().mockResolvedValue({
+          // no file_path
+        }),
+      },
+    };
+    const emojiInfo = new Map([
+      ["e1", { emoji: "🎉", setName: "Pack", fileId: "f1", fileUniqueId: "u1" }],
+    ]);
+
+    const result = await downloadCustomEmojiFiles(mockBot as never, "token", emojiInfo, 1000000);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "e1",
+      emoji: "🎉",
+      setName: "Pack",
+      fileId: "f1",
+      fileUniqueId: "u1",
+    });
+  });
+
+  it("handles download failure gracefully", async () => {
+    const mockBot = {
+      api: {
+        getFile: vi.fn().mockRejectedValue(new Error("Download failed")),
+      },
+    };
+    const emojiInfo = new Map([
+      ["e1", { emoji: "🎉", setName: "Pack", fileId: "f1", fileUniqueId: "u1" }],
+    ]);
+
+    const result = await downloadCustomEmojiFiles(mockBot as never, "token", emojiInfo, 1000000);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "e1",
+      emoji: "🎉",
+      setName: "Pack",
+      fileId: "f1",
+      fileUniqueId: "u1",
+    });
+  });
+});
+
+describe("processCustomEmojis", () => {
+  it("returns original text when no custom emojis", async () => {
+    const mockBot = { api: { getCustomEmojiStickers: vi.fn() } };
+    const result = await processCustomEmojis({
+      text: "Hello world",
+      entities: [{ type: "bold", offset: 0, length: 5 }],
+      bot: mockBot as never,
+      token: "token",
+      maxBytes: 1000000,
+    });
+
+    expect(result.expandedText).toBe("Hello world");
+    expect(result.customEmojis).toEqual([]);
+    expect(mockBot.api.getCustomEmojiStickers).not.toHaveBeenCalled();
+  });
+
+  it("returns original text when entities is undefined", async () => {
+    const mockBot = { api: { getCustomEmojiStickers: vi.fn() } };
+    const result = await processCustomEmojis({
+      text: "Hello world",
+      entities: undefined,
+      bot: mockBot as never,
+      token: "token",
+      maxBytes: 1000000,
+    });
+
+    expect(result.expandedText).toBe("Hello world");
+    expect(result.customEmojis).toEqual([]);
+  });
+
+  it("resolves and expands custom emojis without downloading", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockResolvedValue([
+          {
+            custom_emoji_id: "emoji1",
+            emoji: "🎉",
+            set_name: "PartyPack",
+          },
+        ]),
+      },
+    };
+
+    const result = await processCustomEmojis({
+      text: "Hello X world",
+      entities: [{ type: "custom_emoji", offset: 6, length: 1, custom_emoji_id: "emoji1" }],
+      bot: mockBot as never,
+      token: "token",
+      maxBytes: 1000000,
+      downloadFiles: false,
+    });
+
+    expect(result.expandedText).toBe("Hello [🎉:PartyPack] world");
+    expect(result.customEmojis).toHaveLength(1);
+    expect(result.customEmojis[0]).toEqual({
+      id: "emoji1",
+      emoji: "🎉",
+      setName: "PartyPack",
+    });
+  });
+
+  it("handles multiple emojis in correct order", async () => {
+    const mockBot = {
+      api: {
+        getCustomEmojiStickers: vi.fn().mockResolvedValue([
+          { custom_emoji_id: "e1", emoji: "🔴" },
+          { custom_emoji_id: "e2", emoji: "🟢" },
+          { custom_emoji_id: "e3", emoji: "🔵" },
+        ]),
+      },
+    };
+
+    const result = await processCustomEmojis({
+      text: "A B C",
+      entities: [
+        { type: "custom_emoji", offset: 0, length: 1, custom_emoji_id: "e1" },
+        { type: "custom_emoji", offset: 2, length: 1, custom_emoji_id: "e2" },
+        { type: "custom_emoji", offset: 4, length: 1, custom_emoji_id: "e3" },
+      ],
+      bot: mockBot as never,
+      token: "token",
+      maxBytes: 1000000,
+    });
+
+    expect(result.expandedText).toBe("[🔴] [🟢] [🔵]");
+    expect(result.customEmojis).toHaveLength(3);
+  });
+});

--- a/src/telegram/custom-emoji.ts
+++ b/src/telegram/custom-emoji.ts
@@ -1,0 +1,274 @@
+import type { Bot } from "grammy";
+import { logVerbose } from "../globals.js";
+import { fetchRemoteMedia } from "../media/fetch.js";
+import { saveMediaBuffer } from "../media/store.js";
+
+/** Maximum concurrent downloads for custom emoji files */
+const MAX_CONCURRENT_DOWNLOADS = 3;
+
+export interface CustomEmojiEntity {
+  type: "custom_emoji";
+  offset: number;
+  length: number;
+  custom_emoji_id: string;
+}
+
+export interface ResolvedCustomEmoji {
+  id: string;
+  emoji: string;
+  setName?: string;
+  fileId?: string;
+  fileUniqueId?: string;
+  filePath?: string;
+  contentType?: string;
+  cachedDescription?: string;
+}
+
+/**
+ * Extract custom_emoji entities from message entities.
+ * @param entities - Array of Telegram message entities
+ * @returns Array of custom emoji entities with their IDs and positions
+ */
+export function extractCustomEmojiEntities(
+  entities?: Array<{ type: string; offset: number; length: number; custom_emoji_id?: string }>,
+): CustomEmojiEntity[] {
+  if (!entities) {
+    return [];
+  }
+  return entities.filter(
+    (e): e is CustomEmojiEntity => e.type === "custom_emoji" && Boolean(e.custom_emoji_id),
+  );
+}
+
+/**
+ * Resolve custom emoji info by calling Telegram API.
+ * Returns sticker info including emoji character and set name.
+ * @param bot - Grammy bot instance
+ * @param emojiIds - Array of custom emoji IDs to resolve
+ * @returns Map of emoji ID to resolved info (emoji character, set name, file IDs)
+ */
+export async function resolveCustomEmojis(
+  bot: Bot,
+  emojiIds: string[],
+): Promise<
+  Map<string, { emoji: string; setName?: string; fileId?: string; fileUniqueId?: string }>
+> {
+  if (emojiIds.length === 0) {
+    return new Map();
+  }
+
+  try {
+    const stickers = await bot.api.getCustomEmojiStickers(emojiIds);
+    const result = new Map<
+      string,
+      { emoji: string; setName?: string; fileId?: string; fileUniqueId?: string }
+    >();
+
+    for (const sticker of stickers) {
+      if (sticker.custom_emoji_id) {
+        result.set(sticker.custom_emoji_id, {
+          emoji: sticker.emoji ?? "❓",
+          setName: sticker.set_name,
+          fileId: sticker.file_id,
+          fileUniqueId: sticker.file_unique_id,
+        });
+      }
+    }
+
+    return result;
+  } catch (err) {
+    // If API fails, return empty map - we'll fall back to placeholder text
+    logVerbose(`Failed to resolve custom emojis: ${String(err)}`);
+    return new Map();
+  }
+}
+
+/**
+ * Download a single custom emoji file.
+ * @internal
+ */
+async function downloadSingleCustomEmoji(params: {
+  id: string;
+  info: { emoji: string; setName?: string; fileId?: string; fileUniqueId?: string };
+  bot: Bot;
+  token: string;
+  maxBytes: number;
+  fetchImpl: typeof fetch;
+}): Promise<ResolvedCustomEmoji> {
+  const { id, info, bot, token, maxBytes, fetchImpl } = params;
+
+  if (!info.fileId) {
+    return { id, emoji: info.emoji, setName: info.setName };
+  }
+
+  try {
+    const file = await bot.api.getFile(info.fileId);
+    if (!file.file_path) {
+      return {
+        id,
+        emoji: info.emoji,
+        setName: info.setName,
+        fileId: info.fileId,
+        fileUniqueId: info.fileUniqueId,
+      };
+    }
+
+    const url = `https://api.telegram.org/file/bot${token}/${file.file_path}`;
+    const fetched = await fetchRemoteMedia({
+      url,
+      fetchImpl,
+      filePathHint: file.file_path,
+    });
+    const saved = await saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes);
+
+    return {
+      id,
+      emoji: info.emoji,
+      setName: info.setName,
+      fileId: info.fileId,
+      fileUniqueId: info.fileUniqueId,
+      filePath: saved.path,
+      contentType: saved.contentType,
+    };
+  } catch (err) {
+    // If download fails, just include the emoji info without file
+    logVerbose(`Failed to download custom emoji ${id}: ${String(err)}`);
+    return {
+      id,
+      emoji: info.emoji,
+      setName: info.setName,
+      fileId: info.fileId,
+      fileUniqueId: info.fileUniqueId,
+    };
+  }
+}
+
+/**
+ * Download custom emoji sticker files with concurrency limit.
+ * @param bot - Grammy bot instance
+ * @param token - Telegram bot token for file downloads
+ * @param emojiInfo - Map of emoji IDs to their resolved info
+ * @param maxBytes - Maximum file size in bytes
+ * @param proxyFetch - Optional custom fetch implementation
+ * @returns Array of resolved emojis with file paths where available
+ */
+export async function downloadCustomEmojiFiles(
+  bot: Bot,
+  token: string,
+  emojiInfo: Map<
+    string,
+    { emoji: string; setName?: string; fileId?: string; fileUniqueId?: string }
+  >,
+  maxBytes: number,
+  proxyFetch?: typeof fetch,
+): Promise<ResolvedCustomEmoji[]> {
+  const fetchImpl = proxyFetch ?? globalThis.fetch;
+  const entries = Array.from(emojiInfo.entries());
+
+  if (entries.length === 0) {
+    return [];
+  }
+
+  // Process in batches with concurrency limit
+  const results: ResolvedCustomEmoji[] = [];
+  for (let i = 0; i < entries.length; i += MAX_CONCURRENT_DOWNLOADS) {
+    const batch = entries.slice(i, i + MAX_CONCURRENT_DOWNLOADS);
+    const batchResults = await Promise.all(
+      batch.map(([id, info]) =>
+        downloadSingleCustomEmoji({ id, info, bot, token, maxBytes, fetchImpl }),
+      ),
+    );
+    results.push(...batchResults);
+  }
+
+  return results;
+}
+
+/**
+ * Expand custom emoji in text by replacing placeholders with descriptive text.
+ * Returns the expanded text and list of resolved emojis.
+ * @param text - Original message text
+ * @param entities - Array of custom emoji entities with offsets
+ * @param resolved - Map of emoji IDs to resolved info
+ * @returns Text with custom emoji placeholders replaced by annotations
+ */
+export function expandCustomEmojisInText(
+  text: string,
+  entities: CustomEmojiEntity[],
+  resolved: Map<string, { emoji: string; setName?: string }>,
+): string {
+  if (entities.length === 0) {
+    return text;
+  }
+
+  // Sort by offset descending to replace from end to start (preserves offsets)
+  const sorted = [...entities].toSorted((a, b) => b.offset - a.offset);
+
+  let result = text;
+  for (const entity of sorted) {
+    const info = resolved.get(entity.custom_emoji_id);
+    if (!info) {
+      continue;
+    }
+
+    // Replace the placeholder character with emoji + annotation
+    const annotation = info.setName ? `[${info.emoji}:${info.setName}]` : `[${info.emoji}]`;
+    result =
+      result.slice(0, entity.offset) + annotation + result.slice(entity.offset + entity.length);
+  }
+
+  return result;
+}
+
+/**
+ * Process custom emoji in a message: resolve, optionally download, and expand text.
+ * @param params - Processing parameters
+ * @param params.text - Original message text
+ * @param params.entities - Message entities from Telegram
+ * @param params.bot - Grammy bot instance
+ * @param params.token - Telegram bot token
+ * @param params.maxBytes - Maximum file size for downloads
+ * @param params.downloadFiles - Whether to download emoji images
+ * @param params.proxyFetch - Optional custom fetch implementation
+ * @returns Object containing expanded text and array of resolved emojis
+ */
+export async function processCustomEmojis(params: {
+  text: string;
+  entities?: Array<{ type: string; offset: number; length: number; custom_emoji_id?: string }>;
+  bot: Bot;
+  token: string;
+  maxBytes: number;
+  downloadFiles?: boolean;
+  proxyFetch?: typeof fetch;
+}): Promise<{
+  expandedText: string;
+  customEmojis: ResolvedCustomEmoji[];
+}> {
+  const customEmojiEntities = extractCustomEmojiEntities(params.entities);
+  if (customEmojiEntities.length === 0) {
+    return { expandedText: params.text, customEmojis: [] };
+  }
+
+  const emojiIds = customEmojiEntities.map((e) => e.custom_emoji_id);
+  const resolved = await resolveCustomEmojis(params.bot, emojiIds);
+
+  const expandedText = expandCustomEmojisInText(params.text, customEmojiEntities, resolved);
+
+  let customEmojis: ResolvedCustomEmoji[] = [];
+  if (params.downloadFiles) {
+    customEmojis = await downloadCustomEmojiFiles(
+      params.bot,
+      params.token,
+      resolved,
+      params.maxBytes,
+      params.proxyFetch,
+    );
+  } else {
+    // Just return resolved info without files
+    for (const [id, info] of resolved) {
+      customEmojis.push({ id, emoji: info.emoji, setName: info.setName });
+    }
+  }
+
+  return { expandedText, customEmojis };
+}

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -189,6 +189,7 @@ export interface DescribeStickerParams {
   cfg: OpenClawConfig;
   agentDir?: string;
   agentId?: string;
+  contentType?: string;
 }
 
 /**
@@ -205,5 +206,6 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
     prompt: STICKER_DESCRIPTION_PROMPT,
     fileName: "sticker.webp",
     logPrefix: "telegram",
+    contentType: params.contentType,
   });
 }

--- a/src/telegram/vision-describe.ts
+++ b/src/telegram/vision-describe.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import {
+  findModelInCatalog,
+  loadModelCatalog,
+  modelSupportsVision,
+} from "../agents/model-catalog.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { logVerbose } from "../globals.js";
+import { resolveAutoImageModel } from "../media-understanding/runner.js";
+
+const VISION_PROVIDERS = ["openai", "anthropic", "google", "minimax"] as const;
+
+export interface DescribeImageParams {
+  imagePath: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  agentId?: string;
+  prompt: string;
+  fileName: string;
+  logPrefix: string;
+}
+
+/**
+ * Shared helper to describe an image using vision API.
+ * Auto-detects an available vision provider based on configured API keys.
+ * Returns null if no vision provider is available.
+ */
+export async function describeImageWithVision(params: DescribeImageParams): Promise<string | null> {
+  const { imagePath, cfg, agentDir, agentId, prompt, fileName, logPrefix } = params;
+
+  const defaultModel = resolveDefaultModelForAgent({ cfg, agentId });
+  let activeModel = undefined as { provider: string; model: string } | undefined;
+  let catalog: ModelCatalogEntry[] = [];
+  try {
+    catalog = await loadModelCatalog({ config: cfg });
+    const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
+    const supportsVision = modelSupportsVision(entry);
+    if (supportsVision) {
+      activeModel = { provider: defaultModel.provider, model: defaultModel.model };
+    }
+  } catch {
+    // Ignore catalog failures; fall back to auto selection.
+  }
+
+  const hasProviderKey = async (provider: string) => {
+    try {
+      await resolveApiKeyForProvider({ provider, cfg, agentDir });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const selectCatalogModel = (provider: string) => {
+    const entries = catalog.filter(
+      (entry) =>
+        entry.provider.toLowerCase() === provider.toLowerCase() && modelSupportsVision(entry),
+    );
+    if (entries.length === 0) {
+      return undefined;
+    }
+    const defaultId =
+      provider === "openai"
+        ? "gpt-5-mini"
+        : provider === "anthropic"
+          ? "claude-opus-4-5"
+          : provider === "google"
+            ? "gemini-3-flash-preview"
+            : "MiniMax-VL-01";
+    const preferred = entries.find((entry) => entry.id === defaultId);
+    return preferred ?? entries[0];
+  };
+
+  let resolved = null as { provider: string; model?: string } | null;
+  if (
+    activeModel &&
+    VISION_PROVIDERS.includes(activeModel.provider as (typeof VISION_PROVIDERS)[number]) &&
+    (await hasProviderKey(activeModel.provider))
+  ) {
+    resolved = activeModel;
+  }
+
+  if (!resolved) {
+    for (const provider of VISION_PROVIDERS) {
+      if (!(await hasProviderKey(provider))) {
+        continue;
+      }
+      const entry = selectCatalogModel(provider);
+      if (entry) {
+        resolved = { provider, model: entry.id };
+        break;
+      }
+    }
+  }
+
+  if (!resolved) {
+    resolved = await resolveAutoImageModel({
+      cfg,
+      agentDir,
+      activeModel,
+    });
+  }
+
+  if (!resolved?.model) {
+    logVerbose(`${logPrefix}: no vision provider available for image description`);
+    return null;
+  }
+
+  const { provider, model } = resolved;
+  logVerbose(`${logPrefix}: describing image with ${provider}/${model}`);
+
+  try {
+    const buffer = await fs.readFile(imagePath);
+    const { describeImageWithModel } = await import("../media-understanding/providers/image.js");
+    const result = await describeImageWithModel({
+      buffer,
+      fileName,
+      mime: "image/webp",
+      prompt,
+      cfg,
+      agentDir: agentDir ?? "",
+      provider,
+      model,
+      maxTokens: 150,
+      timeoutMs: 30000,
+    });
+    return result.text;
+  } catch (err) {
+    logVerbose(`${logPrefix}: failed to describe image: ${String(err)}`);
+    return null;
+  }
+}


### PR DESCRIPTION
Adds AI-powered vision support for Telegram stickers and custom emoji

## Why?

Cause it’s fun and makes OpenClaw understand the nuances of your and your friends' chronically online writing

## What does this PR do?

* adds 2 new configs: `telegramCfg.stickerVision` and `telegramCfg.customEmojiVision` to control if the user wants to burn tokens for getting more context to OpenClaw
* adds a cache layer to store text descriptions of stickers and custom emojis (also, Telegram allows bots to send stickers, and it’s a good base to teach bots funny stickers, but I can’t consistently make my OpenClaw not spam me stickers after each message, so not now)

---
Code was mostly written with Claude Code and run for a week in a few chats, so it’s kinda battle-tested

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Telegram “vision” enrichment for stickers and custom emojis, gated by two new config flags (`stickerVision`, `customEmojiVision`). It introduces small cache layers (JSON in `STATE_DIR/telegram/…`) to store 1–2 sentence descriptions, expands Telegram message entity processing to annotate custom emojis in text, and adds a shared vision helper to select a suitable vision-capable model/provider based on configured API keys.

Main codepaths affected are inbound Telegram message handling (collecting media/custom emoji metadata and cache hits) and outbound dispatch (optionally describing/caching the media and injecting descriptions into the prompt instead of sending the image).

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there are a couple of correctness/maintainability issues worth fixing first.
- The feature is conceptually well-scoped and includes tests for entity expansion and caching, but file-level `@ts-nocheck` in core Telegram paths can hide real runtime errors, and `describeImageWithVision` currently hardcodes a WebP MIME type which can be wrong depending on downloaded media.
- src/telegram/bot-message-dispatch.ts, src/telegram/bot-handlers.ts, src/telegram/vision-describe.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->