### PR TITLE
fix(matrix): pass accountId through outbound chain to resolveMatrixClient

### DIFF
--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -45,6 +45,7 @@ export async function sendMessageMatrix(
   const { client, stopOnDone } = await resolveMatrixClient({
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
   try {
     const roomId = await resolveMatrixRoomId(client, to);
@@ -166,6 +167,7 @@ export async function sendPollMatrix(
   const { client, stopOnDone } = await resolveMatrixClient({
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
 
   try {

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -28,6 +28,7 @@ export function resolveMediaMaxBytes(): number | undefined {
 export async function resolveMatrixClient(opts: {
   client?: MatrixClient;
   timeoutMs?: number;
+  accountId?: string | null;
 }): Promise<{ client: MatrixClient; stopOnDone: boolean }> {
   ensureNodeRuntime();
   if (opts.client) {
@@ -41,6 +42,7 @@ export async function resolveMatrixClient(opts: {
   if (shouldShareClient) {
     const client = await resolveSharedMatrixClient({
       timeoutMs: opts.timeoutMs,
+      accountId: opts.accountId,
     });
     return { client, stopOnDone: false };
   }
@@ -51,6 +53,7 @@ export async function resolveMatrixClient(opts: {
     accessToken: auth.accessToken,
     encryption: auth.encryption,
     localTimeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
   if (auth.encryption && client.crypto) {
     try {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -7,13 +7,14 @@ export const matrixOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getMatrixRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ to, text, deps, replyToId, threadId }) => {
+  sendText: async ({ to, text, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
     const result = await send(to, text, {
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
+      accountId: accountId ?? undefined,
     });
     return {
       channel: "matrix",
@@ -21,7 +22,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId }) => {
+  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
@@ -29,6 +30,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
+      accountId: accountId ?? undefined,
     });
     return {
       channel: "matrix",


### PR DESCRIPTION
## Bug Description

When using the `message` tool without specifying `accountId`, messages were sent from the wrong Matrix account. Instead of using the accountId from the session context, it would default to the last-started Matrix account (which ends up being alphabetically last).

## How to Reproduce

1. Configure multiple Matrix accounts (e.g., `sam` and `yessica`)
2. Start the gateway (accounts start in alphabetical order)
3. Send a message via the Matrix channel as agent `sam` without specifying accountId
4. Message is sent from `yessica` instead of `sam`

## Root Cause

The `accountId` parameter was not being passed through the chain:
- `outbound.ts` → `send.ts` → `send/client.ts` → `resolveMatrixClient()`

When `resolveMatrixClient()` doesn't receive an `accountId`, it falls back to `getActiveMatrixClient()` which returns whichever client was set last (typically the last account to start, alphabetically).

## The Fix

Three files updated to pass `accountId` through the chain:

1. **`extensions/matrix/src/outbound.ts`** — Extract `accountId` from outbound context and pass to `sendMessageMatrix`
2. **`extensions/matrix/src/matrix/send.ts`** — Pass `opts.accountId` to `resolveMatrixClient` calls
3. **`extensions/matrix/src/matrix/send/client.ts`** — Accept `accountId` parameter and pass to `resolveSharedMatrixClient` and `createMatrixClient`

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`)
- Changes are minimal and follow the existing pattern used by other channels (Telegram, Discord, etc.)
- The `accountId` field already existed in `MatrixSendOpts` and `ChannelOutboundContext` types, it just wasn't being threaded through

## Related

This matches how other multi-account channels handle routing. The session context already contains the correct `accountId` from `resolveAgentRoute()`, it just wasn't being used during outbound message delivery.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads `accountId` through Matrix outbound message sending so `resolveMatrixClient()` can select the right Matrix client instead of implicitly using whichever client was last started.

Changes are localized to the Matrix extension: the outbound adapter now forwards `accountId` into `sendMessageMatrix`, and `sendMessageMatrix`/`sendPollMatrix` forward it into `resolveMatrixClient`, which in turn passes it to shared/per-send client creation.

<h3>Confidence Score: 3/5</h3>

- Mergeable, but there are a couple of correctness gaps that can still cause wrong-account sends in multi-account setups.
- The intent is correct and changes are small, but `resolveMatrixClient()` still returns `getActiveMatrixClient()` before considering `accountId`, and `sendPoll` doesn’t forward `accountId`, so the reported bug may persist in some paths.
- extensions/matrix/src/matrix/send/client.ts, extensions/matrix/src/outbound.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->