### PR TITLE
feat(matrix): add inbound message debouncing

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -15,6 +15,8 @@ import { createDirectRoomTracker } from "./direct.js";
 import { registerMatrixMonitorEvents } from "./events.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
 import { createMatrixRoomInfoResolver } from "./room-info.js";
+import type { MatrixRawEvent, RoomMessageEventContent } from "./types.js";
+import { EventType } from "./types.js";
 
 export type MonitorMatrixOpts = {
   runtime?: RuntimeEnv;
@@ -234,6 +236,108 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     getMemberDisplayName,
   });
 
+  // Set up inbound message debouncing to batch rapid messages from the same sender
+  const debounceMs = core.channel.debounce.resolveInboundDebounceMs({ cfg, channel: "matrix" });
+
+  type MatrixDebounceEntry = {
+    roomId: string;
+    event: MatrixRawEvent;
+    debounceKey: string | null;
+  };
+
+  const inboundDebouncer = core.channel.debounce.createInboundDebouncer<MatrixDebounceEntry>({
+    debounceMs,
+    buildKey: (entry) => entry.debounceKey,
+    shouldDebounce: (entry) => {
+      const event = entry.event;
+      // Don't debounce non-message events
+      if (event.type !== EventType.RoomMessage) {
+        return false;
+      }
+      // Don't debounce if no text content (media-only)
+      const content = event.content as RoomMessageEventContent | undefined;
+      const text = typeof content?.body === "string" ? content.body.trim() : "";
+      if (!text) {
+        return false;
+      }
+      // Don't debounce control commands - process immediately
+      if (core.channel.text.hasControlCommand(text, cfg)) {
+        return false;
+      }
+      return true;
+    },
+    onFlush: async (entries) => {
+      if (entries.length === 0) {
+        return;
+      }
+
+      // Single message - process directly
+      if (entries.length === 1) {
+        const entry = entries[0];
+        if (entry) {
+          await handleRoomMessage(entry.roomId, entry.event);
+        }
+        return;
+      }
+
+      // Multiple messages - combine text and process as one
+      const first = entries[0];
+      const last = entries.at(-1);
+      if (!first || !last) {
+        return;
+      }
+
+      // Combine body text from all events
+      const combinedText = entries
+        .map((entry) => {
+          const content = entry.event.content as RoomMessageEventContent | undefined;
+          return typeof content?.body === "string" ? content.body : "";
+        })
+        .filter(Boolean)
+        .join("\n");
+
+      if (!combinedText.trim()) {
+        // No text to combine, just process the first event
+        await handleRoomMessage(first.roomId, first.event);
+        return;
+      }
+
+      // Create synthetic event with combined text, using last event's ID for reply targeting
+      const syntheticEvent: MatrixRawEvent = {
+        ...first.event,
+        event_id: last.event.event_id,
+        origin_server_ts: last.event.origin_server_ts ?? first.event.origin_server_ts,
+        content: {
+          ...first.event.content,
+          body: combinedText,
+        },
+      };
+
+      logVerboseMessage(
+        `matrix: debounced ${entries.length} messages from ${first.event.sender ?? "unknown"} in ${first.roomId}`,
+      );
+
+      await handleRoomMessage(first.roomId, syntheticEvent);
+    },
+    onError: (err) => {
+      runtime.error?.(`matrix debounce flush failed: ${String(err)}`);
+    },
+  });
+
+  // Wrapper that enqueues events to the debouncer
+  const debouncedRoomMessageHandler = async (roomId: string, event: MatrixRawEvent) => {
+    const senderId = event.sender;
+    // Build debounce key: channel:accountId:room:sender
+    const accountId = opts.accountId ?? "default";
+    const debounceKey = senderId ? `matrix:${accountId}:${roomId}:${senderId}` : null;
+
+    await inboundDebouncer.enqueue({
+      roomId,
+      event,
+      debounceKey,
+    });
+  };
+
   registerMatrixMonitorEvents({
     client,
     auth,
@@ -242,7 +346,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     warnedCryptoMissingRooms,
     logger,
     formatNativeDependencyHint: core.system.formatNativeDependencyHint,
-    onRoomMessage: handleRoomMessage,
+    onRoomMessage: debouncedRoomMessageHandler,
   });
 
   logVerboseMessage("matrix: starting client");


### PR DESCRIPTION
## Summary

Add inbound debouncer to Matrix monitor to batch rapid messages from the same sender, matching Telegram's behavior.

## Problem

Matrix events are processed immediately without debouncing (issue #6507). When users send multiple rapid messages, each one triggers a separate agent turn, unlike Telegram which batches them together.

## Solution

Wrap the Matrix message handler with `createInboundDebouncer` (the same system Telegram uses):

- **Debounce key**: `matrix:accountId:roomId:senderId`
- **Combines text**: Multiple messages joined with newlines
- **Uses last event ID**: For reply targeting
- **Skips debouncing for**: Media-only messages and control commands

## Changes

- `extensions/matrix/src/matrix/monitor/index.ts`:
  - Import `MatrixRawEvent`, `RoomMessageEventContent`, and `EventType` from types
  - Create debouncer using `core.channel.debounce.createInboundDebouncer`
  - Wrap handler with debouncer before passing to `registerMatrixMonitorEvents`
  - On flush: combine text, use last event ID, call handler once

## Testing

Tested by examining the code structure against Telegram's working implementation. The debouncer pattern is identical to what Telegram and other channels use.

## Related

Fixes #6507

---

*Co-authored-by: Klowalski <klowalski@semmy.dev>*
*Guided-by: SeMmy <semmy@semmy.dev>*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds inbound message debouncing to the Matrix monitor by wrapping the existing `handleRoomMessage` callback with a `core.channel.debounce.createInboundDebouncer` instance. The debouncer groups rapid `m.room.message` events from the same sender in the same room, concatenates their text bodies with newlines, and then invokes the Matrix room message handler once using a synthetic combined event (with the last event’s `event_id` for reply targeting).

Overall this aligns Matrix behavior with other channels (Telegram/MSTeams/Mattermost) that use the shared inbound debounce infrastructure, reducing excess agent turns for message bursts.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but debouncing correctness depends on the exact `createInboundDebouncer.enqueue()` semantics and Matrix event metadata handling.
- The change is localized and follows existing channel patterns, but the wrapper currently enqueues every event (including ones intended to bypass debouncing) which could introduce unintended delays if non-debounced entries aren’t flushed immediately. Also, the synthetic event combines only `body` while mixing first/last event metadata, which can cause reply/thread mismatches in some Matrix message bursts.
- extensions/matrix/src/matrix/monitor/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->