### PR TITLE
feat: wire before_tool_call and after_tool_call hooks into tool execution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
-        "18789"
+        "18789",
       ]
 
   openclaw-cli:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -10,6 +10,7 @@ title: "Telegram"
 Status: production-ready for bot DMs + groups via grammY. Long-polling by default; webhook optional.
 
 ## Quick setup (beginner)
+
 1. Create a bot with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`, then copy the token.
 2. Set the token:
    - Env: `TELEGRAM_BOT_TOKEN=...`
@@ -41,6 +42,7 @@ Minimal config:
 ## Setup (fast path)
 
 ### 1) Create a bot token (BotFather)
+
 1. Open Telegram and chat with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`.
 2. Run `/newbot`, then follow the prompts (name + username ending in `bot`).
 3. Copy the token and store it safely.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -865,11 +865,7 @@
           },
           {
             "group": "Help",
-            "pages": [
-              "help/index",
-              "help/troubleshooting",
-              "help/faq"
-            ]
+            "pages": ["help/index", "help/troubleshooting", "help/faq"]
           },
           {
             "group": "Install & Updates",
@@ -1002,13 +998,7 @@
           },
           {
             "group": "Web & Interfaces",
-            "pages": [
-              "web/index",
-              "web/control-ui",
-              "web/dashboard",
-              "web/webchat",
-              "tui"
-            ]
+            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
           },
           {
             "group": "Channels",
@@ -1171,11 +1161,7 @@
         "groups": [
           {
             "group": "开始",
-            "pages": [
-              "zh-CN/index",
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard"
-            ]
+            "pages": ["zh-CN/index", "zh-CN/start/getting-started", "zh-CN/start/wizard"]
           }
         ]
       }

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -24,6 +24,7 @@ wizard, and let the agent bootstrap itself.
 8. Ready
 
 ## 1) Welcome + security notice
+
 Read the security notice displayed and decide accordingly.
 
 ## 2) Local vs Remote

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -54,6 +54,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 [Devices CLI](/cli/devices) for token rotation and revocation.
 
 **Notes:**
+
 - Local connections (`127.0.0.1`) are auto-approved.
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -110,6 +110,7 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
+
 - **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
 - **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -444,7 +444,7 @@ export async function runEmbeddedAttempt(
         tools,
         sandboxEnabled: !!sandbox?.enabled,
         hookCtx: {
-          agentId: params.sessionKey?.split(":")[0] ?? "main",
+          agentId: params.sessionKey?.split(":")[0] || "main",
           sessionKey: params.sessionKey,
         },
       });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -443,6 +443,10 @@ export async function runEmbeddedAttempt(
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookCtx: {
+          agentId: params.sessionKey?.split(":")[0] ?? "main",
+          sessionKey: params.sessionKey,
+        },
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,17 +1,24 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
+import {
+  toToolDefinitions,
+  type ToolDefinitionHookContext,
+} from "../pi-tool-definition-adapter.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  hookCtx?: ToolDefinitionHookContext;
+}): {
   builtInTools: AnyAgentTool[];
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
-  const { tools } = options;
+  const { tools, hookCtx } = options;
   return {
     builtInTools: [],
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, hookCtx),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -1,8 +1,34 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
 
+// Mock the global hook runner
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function makeTool(
+  overrides: Partial<AgentTool<unknown, unknown>> = {},
+): AgentTool<unknown, unknown> {
+  return {
+    name: "test-tool",
+    label: "Test",
+    description: "test",
+    parameters: {},
+    execute: async () => ({ details: { ok: true }, resultForAssistant: "ok" }),
+    ...overrides,
+  };
+}
+
 describe("pi tool definition adapter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("wraps tool errors into a tool result", async () => {
     const tool = {
       name: "boom",
@@ -43,6 +69,190 @@ describe("pi tool definition adapter", () => {
       status: "error",
       tool: "exec",
       error: "nope",
+    });
+  });
+
+  // =========================================================================
+  // before_tool_call hook tests
+  // =========================================================================
+
+  describe("before_tool_call hook", () => {
+    it("blocks tool execution when hook returns block: true", async () => {
+      const executeSpy = vi.fn(async () => ({ details: { ok: true }, resultForAssistant: "ok" }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "before_tool_call",
+        runBeforeToolCall: vi.fn(async () => ({
+          block: true,
+          blockReason: "Security policy: blocked",
+        })),
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main", sessionKey: "main:abc" });
+      const result = await defs[0].execute("call1", { command: "gog inbox" }, undefined, undefined);
+
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(result.details).toMatchObject({
+        status: "blocked",
+        tool: "exec",
+        error: "Security policy: blocked",
+      });
+    });
+
+    it("allows tool execution when hook does not block", async () => {
+      const executeSpy = vi.fn(async () => ({
+        details: { ran: true },
+        resultForAssistant: "done",
+      }));
+      const tool = makeTool({ name: "read", execute: executeSpy });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "before_tool_call",
+        runBeforeToolCall: vi.fn(async () => undefined),
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      const result = await defs[0].execute("call1", { path: "/tmp/f" }, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalled();
+      expect(result.details).toMatchObject({ ran: true });
+    });
+
+    it("passes modified params from hook to tool.execute", async () => {
+      const executeSpy = vi.fn(async (_id: string, params: unknown) => ({
+        details: { params },
+        resultForAssistant: "ok",
+      }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "before_tool_call",
+        runBeforeToolCall: vi.fn(async () => ({
+          params: { command: "echo safe" },
+        })),
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "rm -rf /" }, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalledWith(
+        "call1",
+        { command: "echo safe" },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("provides correct context to before_tool_call hook", async () => {
+      const runBeforeToolCall = vi.fn(async () => undefined);
+      const tool = makeTool({ name: "exec" });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "before_tool_call",
+        runBeforeToolCall,
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "reader", sessionKey: "reader:xyz" });
+      await defs[0].execute("call1", { command: "ls" }, undefined, undefined);
+
+      expect(runBeforeToolCall).toHaveBeenCalledWith(
+        { toolName: "exec", params: { command: "ls" } },
+        { agentId: "reader", sessionKey: "reader:xyz", toolName: "exec" },
+      );
+    });
+  });
+
+  // =========================================================================
+  // after_tool_call hook tests
+  // =========================================================================
+
+  describe("after_tool_call hook", () => {
+    it("fires after_tool_call on successful execution", async () => {
+      const runAfterToolCall = vi.fn(async () => {});
+      const tool = makeTool({
+        name: "read",
+        execute: async () => ({ details: { content: "hello" }, resultForAssistant: "hello" }),
+      });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "after_tool_call",
+        runBeforeToolCall: vi.fn(async () => undefined),
+        runAfterToolCall,
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { path: "/tmp/f" }, undefined, undefined);
+
+      // Wait for the fire-and-forget promise
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(runAfterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "read",
+          params: { path: "/tmp/f" },
+          result: { content: "hello" },
+        }),
+        expect.objectContaining({ agentId: "main", toolName: "read" }),
+      );
+      expect(runAfterToolCall.mock.calls[0][0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("fires after_tool_call on error path with error message", async () => {
+      const runAfterToolCall = vi.fn(async () => {});
+      const tool = makeTool({
+        name: "exec",
+        execute: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === "after_tool_call",
+        runBeforeToolCall: vi.fn(async () => undefined),
+        runAfterToolCall,
+      } as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "fail" }, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(runAfterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          error: "boom",
+        }),
+        expect.objectContaining({ agentId: "main", toolName: "exec" }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // No hook runner (null) — backwards compatibility
+  // =========================================================================
+
+  describe("without hook runner", () => {
+    it("executes normally when no hook runner is available", async () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      const tool = makeTool({
+        name: "read",
+        execute: async () => ({ details: { ok: true }, resultForAssistant: "ok" }),
+      });
+
+      const defs = toToolDefinitions([tool]);
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+      expect(result.details).toMatchObject({ ok: true });
+    });
+
+    it("executes normally when hookCtx is not provided", async () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      const tool = makeTool();
+      const defs = toToolDefinitions([tool]);
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+      expect(result.details).toMatchObject({ ok: true });
     });
   });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -5,12 +5,18 @@ import type {
 } from "@mariozechner/pi-agent-core";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
-import { logDebug, logError } from "../logger.js";
+import { logDebug, logError, logWarn } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { jsonResult } from "./tools/common.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: TypeBox schema type from pi-agent-core uses a different module instance.
 type AnyAgentTool = AgentTool<any, unknown>;
+
+export type ToolDefinitionHookContext = {
+  agentId?: string;
+  sessionKey?: string;
+};
 
 function describeToolExecutionError(err: unknown): {
   message: string;
@@ -23,7 +29,10 @@ function describeToolExecutionError(err: unknown): {
   return { message: String(err) };
 }
 
-export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
+export function toToolDefinitions(
+  tools: AnyAgentTool[],
+  hookCtx?: ToolDefinitionHookContext,
+): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -42,8 +51,62 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       ): Promise<AgentToolResult<unknown>> => {
         // KNOWN: pi-coding-agent `ToolDefinition.execute` has a different signature/order
         // than pi-agent-core `AgentTool.execute`. This adapter keeps our existing tools intact.
+        const startMs = Date.now();
+        let effectiveParams = params;
+
+        // Run before_tool_call plugin hooks — may modify params or block execution.
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("before_tool_call")) {
+          try {
+            const hookResult = await hookRunner.runBeforeToolCall(
+              { toolName: normalizedName, params: params as Record<string, unknown> },
+              {
+                agentId: hookCtx?.agentId,
+                sessionKey: hookCtx?.sessionKey,
+                toolName: normalizedName,
+              },
+            );
+            if (hookResult?.block) {
+              const reason = hookResult.blockReason ?? "Blocked by plugin hook";
+              logWarn(`[tools] ${normalizedName} blocked by before_tool_call hook: ${reason}`);
+              return jsonResult({ status: "blocked", tool: normalizedName, error: reason });
+            }
+            if (hookResult?.params) {
+              effectiveParams = hookResult.params;
+            }
+          } catch (hookErr) {
+            logWarn(
+              `[tools] before_tool_call hook error for ${normalizedName}: ${String(hookErr)}`,
+            );
+          }
+        }
+
         try {
-          return await tool.execute(toolCallId, params, signal, onUpdate);
+          const result = await tool.execute(toolCallId, effectiveParams, signal, onUpdate);
+
+          // Fire after_tool_call hooks (best-effort, non-blocking).
+          if (hookRunner?.hasHooks("after_tool_call")) {
+            const durationMs = Date.now() - startMs;
+            hookRunner
+              .runAfterToolCall(
+                {
+                  toolName: normalizedName,
+                  params: effectiveParams as Record<string, unknown>,
+                  result: result?.details,
+                  durationMs,
+                },
+                {
+                  agentId: hookCtx?.agentId,
+                  sessionKey: hookCtx?.sessionKey,
+                  toolName: normalizedName,
+                },
+              )
+              .catch((err) =>
+                logWarn(`[tools] after_tool_call hook error for ${normalizedName}: ${String(err)}`),
+              );
+          }
+
+          return result;
         } catch (err) {
           if (signal?.aborted) {
             throw err;
@@ -60,6 +123,29 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
           }
           logError(`[tools] ${normalizedName} failed: ${described.message}`);
+
+          // Fire after_tool_call hooks on error path too.
+          if (hookRunner?.hasHooks("after_tool_call")) {
+            const durationMs = Date.now() - startMs;
+            hookRunner
+              .runAfterToolCall(
+                {
+                  toolName: normalizedName,
+                  params: effectiveParams as Record<string, unknown>,
+                  error: described.message,
+                  durationMs,
+                },
+                {
+                  agentId: hookCtx?.agentId,
+                  sessionKey: hookCtx?.sessionKey,
+                  toolName: normalizedName,
+                },
+              )
+              .catch((e) =>
+                logWarn(`[tools] after_tool_call hook error for ${normalizedName}: ${String(e)}`),
+              );
+          }
+
           return jsonResult({
             status: "error",
             tool: normalizedName,


### PR DESCRIPTION
## Summary

- Wires the existing `before_tool_call` and `after_tool_call` plugin hooks into the tool execution pipeline
- The hook types, runner functions, and `api.on()` registration were already implemented but **never invoked** — this connects the last mile
- Plugins can now **block** tool calls, **modify** params, and **observe** results/errors via these hooks

## Problem

The `before_tool_call` and `after_tool_call` hooks are documented, have full type definitions (`PluginHookBeforeToolCallEvent`, `PluginHookBeforeToolCallResult`, etc.), runner functions in `hooks.ts`, and registration via `api.on("before_tool_call", handler)` — but `runBeforeToolCall()` and `runAfterToolCall()` were never called from the tool execution path. Plugins registering these hooks were silently ignored.

## Changes

- **`pi-tool-definition-adapter.ts`**: Calls `runBeforeToolCall()` before `tool.execute()` and `runAfterToolCall()` after (both success and error paths). Supports blocking (`{ block: true, blockReason }`) and param modification (`{ params }`). The `after_tool_call` hook is fire-and-forget (non-blocking).
- **`tool-split.ts`**: Passes through `hookCtx` (agentId, sessionKey) to `toToolDefinitions()`
- **`attempt.ts`**: Provides agentId (derived from sessionKey with truthy fallback) and sessionKey as context
- **`pi-tool-definition-adapter.test.ts`**: 10 tests covering blocking, param modification, context passing, after_tool_call on success/error, and backwards compatibility (null hook runner)

## Design Decisions

- **Adapter layer** was chosen over the event handler layer because `tool_execution_start` events from pi-agent-core are observational (fire after execution begins) — the adapter wraps `tool.execute()` directly and can intercept before execution
- **`hookCtx` is optional** — zero breaking changes; callers without context still work
- **Hook errors are caught and logged** — a misbehaving plugin won't break tool execution
- **`getGlobalHookRunner()` is called per-execution** (not cached at definition time) so hooks registered after tool setup are still picked up
- **Truthy fallback (`||`)** used for agentId derivation so empty strings from split also fall back to "main"

## AI Disclosure

- [x] AI-assisted (Claude Code / Claude Opus 4.5)
- [x] Fully tested — 10 unit tests + TypeScript type check + local vitest run
- [x] I understand what the code does

## Test plan

- [x] All 10 unit tests pass (`vitest run pi-tool-definition-adapter.test.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] `pnpm format && pnpm lint` pass
- [ ] Manual test: register a `before_tool_call` plugin that blocks exec calls and verify the tool returns `{ status: "blocked" }` instead of executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)