### PR TITLE
fix(ui): use local favicon instead of CDN URL with expired signature

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -132,7 +132,7 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src="https://mintcdn.com/clawhub/4rYvG-uuZrMK_URE/assets/pixel-lobster.svg?fit=max&auto=format&n=4rYvG-uuZrMK_URE&q=85&s=da2032e9eac3b5d9bfe7eb96ca6a8a26" alt="OpenClaw" />
+              <img src="/favicon.svg" alt="OpenClaw" />
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
## Problem

The sidebar logo in the Control UI fails to load with a 403 Forbidden error. The CDN URL `mintcdn.com/clawhub/...` has an expired or domain-locked signature that fails for self-hosted and Docker deployments.

## Solution

Replace the external CDN URL with the local `/favicon.svg` (absolute path) which is already bundled in the UI public assets.

## Changes

- `ui/src/ui/app-render.ts`: Replace CDN URL with `/favicon.svg`

## Testing

- Tested on local Docker deployment
- Logo now loads correctly from local assets
- Used absolute path per Greptile feedback (relative `./` would break on nested routes)

Fixes #6135
Fixes #6365