### PR TITLE
feat(docker): add macOS-specific Docker setup with permission fixes

### DIFF
--- a/Dockerfile.macos
+++ b/Dockerfile.macos
@@ -1,0 +1,80 @@
+# OpenClaw Dockerfile for macOS
+# 
+# This Dockerfile adds fixes for running OpenClaw in Docker on macOS:
+# - Uses gosu for proper permission handling
+# - Creates symlinks for macOS path compatibility
+# - Smart permission fixes that skip .git directories
+#
+# Build: docker build -f Dockerfile.macos -t openclaw:macos .
+# Run: docker compose -f docker-compose.macos.yml up -d
+
+FROM node:22-bookworm
+
+# Install gosu for proper user switching
+# Bun installed via npm for reproducible builds (avoids curl|bash supply chain risk)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    npm install -g bun@1.2.0
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN corepack enable
+
+WORKDIR /app
+
+# Optional extra packages
+ARG OPENCLAW_DOCKER_APT_PACKAGES=""
+RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
+      apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Install dependencies
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+
+RUN pnpm install --frozen-lockfile
+
+# Build
+COPY . .
+RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
+ENV OPENCLAW_PREFER_PNPM=1
+RUN pnpm ui:build
+
+ENV NODE_ENV=production
+
+# Create entrypoint script that handles macOS permission issues
+RUN cat > /app/docker-entrypoint.sh << 'ENTRYPOINT'
+#!/bin/bash
+set -e
+
+# Create symlink for macOS path compatibility
+# Config may have /Users/USERNAME paths that need to resolve inside container
+if [ -n "$OPENCLAW_HOST_USER" ]; then
+  mkdir -p /Users
+  ln -sfn /home/node "/Users/$OPENCLAW_HOST_USER" 2>/dev/null || true
+fi
+
+# Ensure .openclaw directory structure exists
+mkdir -p /home/node/.openclaw/{credentials,sessions,logs,workspace,media,canvas,cron}
+
+# Fix ownership on essential dirs only (skip .git to avoid hanging on pack files)
+for dir in /home/node/.openclaw/credentials /home/node/.openclaw/sessions \
+           /home/node/.openclaw/logs /home/node/.openclaw/media \
+           /home/node/.openclaw/canvas /home/node/.openclaw/cron; do
+  [ -d "$dir" ] && chown -R node:node "$dir" 2>/dev/null || true
+done
+
+# Chown workspace root but not recursively (preserves git object permissions)
+chown node:node /home/node/.openclaw /home/node/.openclaw/workspace 2>/dev/null || true
+
+# Run command as node user
+exec gosu node "$@"
+ENTRYPOINT
+RUN chmod +x /app/docker-entrypoint.sh
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["node", "dist/index.js"]

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,78 @@
+# OpenClaw Docker Compose for macOS
+# 
+# This compose file adds fixes for macOS permission issues and security hardening.
+# Build the image first: docker build -f Dockerfile.macos -t openclaw:macos .
+#
+# Usage:
+#   docker compose -f docker-compose.macos.yml up -d
+#
+# Prerequisites:
+#   - Set gateway.bind: "lan" in ~/.openclaw/openclaw.json (NOT "loopback")
+#   - Set OPENCLAW_GATEWAY_TOKEN in environment or .env file
+#   - Ensure $USER and $HOME are set (create .env file if running from CI/scripts):
+#     echo "USER=$(whoami)" >> .env
+#     echo "HOME=$HOME" >> .env
+
+services:
+  openclaw-gateway:
+    image: ${OPENCLAW_IMAGE:-openclaw:macos}
+    # Note: container_name omitted to allow multiple instances/profiles
+    environment:
+      HOME: /home/node
+      TERM: xterm-256color
+      # macOS username for /Users/<user> symlink
+      OPENCLAW_HOST_USER: ${USER}
+      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
+      # Force lan binding (config may have loopback which won't work)
+      OPENCLAW_GATEWAY_BIND: lan
+      # Optional API keys
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    volumes:
+      # Mount entire .openclaw directory (config + credentials + workspace)
+      - ${HOME}/.openclaw:/home/node/.openclaw:cached
+    ports:
+      # Dashboard/WebSocket
+      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      # Bridge (for providers)
+      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+    init: true
+    restart: unless-stopped
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN      # needed for entrypoint permission fixes
+      - SETUID     # needed for gosu
+      - SETGID     # needed for gosu
+    tmpfs:
+      - /tmp:mode=1777,size=100m
+    command:
+      [
+        "node",
+        "dist/index.js",
+        "gateway",
+        "--bind",
+        "lan",
+        "--port",
+        "18789"
+      ]
+
+  openclaw-cli:
+    image: ${OPENCLAW_IMAGE:-openclaw:macos}
+    # Note: container_name omitted to allow multiple instances
+    environment:
+      HOME: /home/node
+      TERM: xterm-256color
+      BROWSER: echo
+      OPENCLAW_HOST_USER: ${USER}
+    volumes:
+      - ${HOME}/.openclaw:/home/node/.openclaw:cached
+    stdin_open: true
+    tty: true
+    init: true
+    profiles:
+      - cli
+    entrypoint: ["node", "dist/index.js"]

--- a/docs/platforms/macos-docker.md
+++ b/docs/platforms/macos-docker.md
@@ -1,0 +1,135 @@
+# Running OpenClaw in Docker on macOS
+
+This guide covers running OpenClaw in Docker on macOS, which requires special handling due to permission differences between macOS and Linux containers.
+
+## The Problem
+
+When running Docker on macOS:
+- macOS users have uid 501 (typically)
+- Docker containers run with uid 1000 (node user)
+- Volume-mounted files keep host permissions
+- Config paths like `/Users/username/...` don't exist in the container
+- Result: Permission errors, "invalid credentials", path resolution failures
+
+## Quick Solution
+
+Use the macOS-specific Dockerfile and compose file:
+
+```bash
+# Clone the repo
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+
+# Build with macOS Dockerfile
+docker build -f Dockerfile.macos -t openclaw:macos .
+
+# Start with macOS compose
+docker compose -f docker-compose.macos.yml up -d
+```
+
+## Prerequisites
+
+Before starting, ensure your `~/.openclaw/openclaw.json` has:
+
+```json
+{
+  "gateway": {
+    "bind": "lan"
+  }
+}
+```
+
+> **Important:** The default `"bind": "loopback"` won't work in Docker - the web UI will be unreachable from outside the container.
+
+## What the macOS Setup Does
+
+1. **Symlink for path compatibility**: Creates `/Users/<username>` → `/home/node` so macOS paths in your config resolve correctly
+2. **Smart permission fixes**: Only chowns essential directories (skips `.git` to avoid hanging)
+3. **Security hardening**: 
+   - `no-new-privileges` - prevents privilege escalation
+   - `cap_drop: ALL` - drops all Linux capabilities
+   - Minimal `cap_add` for only what's needed
+4. **gosu for user switching**: Properly switches from root to node user after fixing permissions
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCLAW_HOST_USER` | `$USER` | Your macOS username (for symlink) |
+| `OPENCLAW_GATEWAY_TOKEN` | (required) | Gateway auth token |
+| `OPENCLAW_GATEWAY_BIND` | `lan` | Network binding mode |
+
+### Security Recommendations
+
+1. **Command Allowlist**: Create `~/.openclaw/exec-approvals.json`:
+   ```json
+   {
+     "version": 1,
+     "defaults": {
+       "security": "allowlist",
+       "ask": "on-miss"
+     },
+     "agents": {
+       "main": {
+         "allowlist": [
+           { "pattern": "git *" },
+           { "pattern": "npm *" },
+           { "pattern": "node *" }
+         ]
+       }
+     }
+   }
+   ```
+
+2. **Lock credentials**:
+   ```bash
+   chmod 600 ~/.openclaw/credentials/*.json
+   ```
+
+## Troubleshooting
+
+### "pairing required" error
+Approve your device:
+```bash
+openclaw devices list
+openclaw devices approve <request-id>
+```
+
+### Can't access web UI
+1. Verify `bind: "lan"` in config (not `loopback`)
+2. Restart container after config changes
+3. Check logs: `docker logs openclaw`
+
+### Permission errors on startup
+The entrypoint skips `.git` directories. If issues persist:
+```bash
+# On host
+chmod -R a+r ~/.openclaw/workspace
+```
+
+### Path errors mentioning `/Users`
+Ensure `OPENCLAW_HOST_USER` is set correctly in your environment or compose file.
+
+## Accessing the Dashboard
+
+- **URL**: http://localhost:18789
+- **Token**: Found in `~/.openclaw/openclaw.json` under `gateway.auth.token`
+
+## Browser Access from Docker
+
+If you need browser automation from inside Docker, the host browser can be reached at `host.docker.internal:9222`, but requires a Host header workaround.
+
+**Run this on your Mac (not inside the container):**
+```bash
+curl -H "Host: localhost:9222" http://host.docker.internal:9222/json/version
+```
+
+Note: The container itself uses this address internally for browser automation when configured.
+
+## Files Reference
+
+- `Dockerfile.macos` - macOS-compatible Dockerfile
+- `docker-compose.macos.yml` - macOS-specific compose file
+- `~/.openclaw/exec-approvals.json` - Command allowlist


### PR DESCRIPTION
## Problem

Running OpenClaw in Docker on macOS fails due to permission and path issues:

- macOS users have uid 501, Docker node user has uid 1000
- Volume-mounted files keep host permissions → permission errors
- Config paths like `/Users/username/...` do not exist in the container
- `gateway.bind: loopback` (default) makes the web UI unreachable

Related issues: #2781, #3407, #4076, #2434

## Solution

Add dedicated macOS Docker files:

### Dockerfile.macos
- Uses `gosu` for proper user switching
- **Installs Bun via npm with pinned version** (`npm install -g bun@1.2.0`) - avoids curl|bash supply chain risk
- Smart entrypoint that:
  - Creates `/Users/<user>` → `/home/node` symlink for path compatibility
  - Only chowns essential dirs (skips `.git` to avoid hanging on pack files)
  - Properly drops to node user after permission fixes

### docker-compose.macos.yml
- Security hardening:
  - `no-new-privileges: true`
  - `cap_drop: ALL` with minimal `cap_add`
  - `tmpfs` for `/tmp`
- `OPENCLAW_HOST_USER` env var for symlink creation
- Forces `bind: lan` (overrides loopback default)
- **Documents `$USER`/`$HOME` requirements** with .env file instructions
- **Removed explicit `container_name`** to allow multiple instances

### docs/platforms/macos-docker.md
- Complete setup guide
- Troubleshooting section
- Security recommendations (exec allowlist, credential permissions)
- **Clarified browser curl command is for host**, not container

## Testing

- Tested on macOS Sonoma with Docker Desktop
- Web UI accessible at http://localhost:18789
- Telegram provider connects successfully
- Exec commands work with allowlist

## Usage

```bash
# Build
docker build -f Dockerfile.macos -t openclaw:macos .

# Run
docker compose -f docker-compose.macos.yml up -d
```

## Greptile Feedback Addressed

- ✅ [P0] Replaced `curl | bash` with pinned npm install
- ✅ [P0] Fixed trailing comma in YAML
- ✅ [P1] Removed explicit container_name
- ✅ [P2] Added USER/HOME documentation
- ✅ [P2] Clarified curl command is for host