### PR TITLE
Reply: avoid typing before text in message mode

### DIFF
--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -117,6 +117,9 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
+    if (mode === "message" && !hasRenderableText) {
+      return;
+    }
     // Start typing as soon as tools begin executing, even before the first text delta.
     if (!typing.isActive()) {
       await typing.startTypingLoop();

--- a/src/auto-reply/reply/typing.test.ts
+++ b/src/auto-reply/reply/typing.test.ts
@@ -230,7 +230,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("starts typing on tool start before text", async () => {
+  it("does not start typing on tool start before text in message mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -240,8 +240,8 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- skip typing indicator on tool start when typingMode=message until real text appears
- adjust typing-mode unit test to match new behavior

## Testing
- pnpm test src/auto-reply/reply/typing.test.ts (fails: vitest not installed; node_modules missing)


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tweaks the typing indicator behavior for `typingMode="message"`: tool execution no longer triggers typing until the reply has produced the first renderable text, and the associated unit test was updated to assert the new behavior. The change is localized to the auto-reply typing signaler logic (`src/auto-reply/reply/typing-mode.ts`), which coordinates when `TypingController` starts/refreshes the typing loop based on run/message/text/tool events.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge, with one behavioral edge case worth double-checking.
- The change is small and covered by a targeted unit test, but it alters when typing is shown during tool execution and may leave cases where the typing indicator never appears if output is tool-only (no text deltas). That may be intended, but it’s a user-visible behavioral change that depends on runtime event ordering.
- src/auto-reply/reply/typing-mode.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->