### PR TITLE
feat: create a SKILL.md to bridge the gap from the application renaming

### DIFF
--- a/skills/openclaw-migration/SKILL.md
+++ b/skills/openclaw-migration/SKILL.md
@@ -1,0 +1,34 @@
+# SKILL.md - OpenClaw Migration
+
+## Purpose
+When the workspace is in the middle of renaming the Clawd project to OpenClaw, this skill lives in the repo so everyone—human or helper—can follow the same migration playbook. It outlines what gets moved, renamed, and tested as we align the codebase, docs, and tooling with the new brand.
+
+## When to use
+- The human asks for a migration status, plan, or checklist (e.g., “How do we move Clawd to OpenClaw?”).
+- You are about to rename directories, update config files, or explain where the old artifacts live.
+- A new contributor needs consistent steps so renaming doesn’t break builds or automation.
+
+## Migration playbook
+1. **Inventory current layout**: `clawdbot/` is the existing application root, containing `src/`, `apps/`, `docs/`, `skills/`, `package.json`, tests, and tooling. The repo root also hosts the agent metadata (`AGENTS.md`), personality files (`SOUL.md`, `MEMORY.md`, etc.), and artifacts like `skills.json`.
+2. **Create the OpenClaw root**: either rename `clawdbot/` → `openclaw/` or copy its contents into a new `openclaw/` branch. Preserve hidden files (`.github`, `.agent`, `.ox` configs, etc.) and ensure `package.json`, `pnpm-workspace.yaml`, and lockfile stay in sync.
+3. **Update references**: search for “Clawd” (case-sensitive) inside docs, READMEs, skill definitions, config files, CI workflows, and rename it to “OpenClaw.”
+   - Pay special attention to `README-header.png`, `docs/*.md`, `AGENTS.md`, and `SOUL.md` (the persona description may mention Clawd by name).
+   - Update any CLI/`npm run` scripts that reference `clawdbot` paths.
+4. **Move common metadata**: decide where `AGENTS.md`, `SOUL.md`, `MEMORY.md`, `skills.json`, `skills/` should live relative to the new app root. Keep human-facing files at the repo root if they drive onboarding (the main persona, heartbeat, identity, etc.).
+5. **Verify tooling**: rerun `pnpm test`, `pnpm lint`, and any `docs` building scripts from within `openclaw/` so the new layout works with existing CI.
+6. **Update documentation**: mention the migration in `README.md` (root and inside the app) so contributors know the repo now houses OpenClaw. Document how to run the app from the new directory.
+7. **Clean up artifacts**: remove or archive the old `clawdbot/` directory once the new structure is stable, or keep a reference README explaining the archive for traceability.
+
+## Validation
+- `package.json` scripts (`dev`, `build`, `bootstrap`) still resolve to the right folders.
+- `pnpm` workspace references and `tsconfig` paths point to `openclaw/` (if renamed).
+- `skills.json` still lists the correct skill directories and versions.
+- CI/CD workflows (GitHub Actions, Fly, Render) use the new name in their config.
+
+## Communication
+- Share this SKILL.md with reviewers during the migration review, so they can confirm each step.
+- When sending summaries to Ivan, include a list of moved files and new `openclaw/` entrypoints.
+
+## Triggers
+- Any “migration”, “rename”, or “Clawd → OpenClaw” question from user.
+- When prepping a release that should ship under the OpenClaw brand.

--- a/skills/openclaw-migration/SKILL.md
+++ b/skills/openclaw-migration/SKILL.md
@@ -1,4 +1,9 @@
-# SKILL.md - OpenClaw Migration
+---
+name: OpenClaw Migration
+description: Migration playbook and validation steps for renaming Clawd to OpenClaw across code, docs, and tooling.
+homepage: https://www.clawhub.ai/chenyuan99/openclaw-migration
+---
+# SKILL.md OpenClaw Migration
 
 ## Purpose
 When the workspace is in the middle of renaming the Clawd project to OpenClaw, this skill lives in the repo so everyone—human or helper—can follow the same migration playbook. It outlines what gets moved, renamed, and tested as we align the codebase, docs, and tooling with the new brand.


### PR DESCRIPTION
Like manyone else, I face a similar issue around the openclaw migration, https://github.com/openclaw/openclaw/issues/5103, the way i fixit is setup the openclaw as new and use the migration skill reset up everything, I think we can consider add the skill to openclaw as a default skill https://www.clawhub.ai/chenyuan99/openclaw-migration,

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `skills/openclaw-migration/SKILL.md` playbook describing how to rename/migrate a Clawd workspace to OpenClaw, including validation checks and suggested communication triggers.

<h3>Confidence Score: 3/5</h3>

- Safe to merge, but the new skill doc likely won’t integrate cleanly without metadata and has some misleading/stale assumptions.
- Change is isolated to a single markdown file and won’t affect runtime behavior, but it deviates from established `SKILL.md` frontmatter conventions and contains repo-layout assumptions (e.g., `clawdbot/`, repo-root persona files) that could confuse users.
- skills/openclaw-migration/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->