### PR TITLE
feat(discord): Add forum channel support for thread-create

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
-        "18789"
+        "18789",
       ]
 
   openclaw-cli:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -10,6 +10,7 @@ title: "Telegram"
 Status: production-ready for bot DMs + groups via grammY. Long-polling by default; webhook optional.
 
 ## Quick setup (beginner)
+
 1. Create a bot with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`, then copy the token.
 2. Set the token:
    - Env: `TELEGRAM_BOT_TOKEN=...`
@@ -41,6 +42,7 @@ Minimal config:
 ## Setup (fast path)
 
 ### 1) Create a bot token (BotFather)
+
 1. Open Telegram and chat with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`.
 2. Run `/newbot`, then follow the prompts (name + username ending in `bot`).
 3. Copy the token and store it safely.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -865,11 +865,7 @@
           },
           {
             "group": "Help",
-            "pages": [
-              "help/index",
-              "help/troubleshooting",
-              "help/faq"
-            ]
+            "pages": ["help/index", "help/troubleshooting", "help/faq"]
           },
           {
             "group": "Install & Updates",
@@ -1002,13 +998,7 @@
           },
           {
             "group": "Web & Interfaces",
-            "pages": [
-              "web/index",
-              "web/control-ui",
-              "web/dashboard",
-              "web/webchat",
-              "tui"
-            ]
+            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
           },
           {
             "group": "Channels",
@@ -1171,11 +1161,7 @@
         "groups": [
           {
             "group": "开始",
-            "pages": [
-              "zh-CN/index",
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard"
-            ]
+            "pages": ["zh-CN/index", "zh-CN/start/getting-started", "zh-CN/start/wizard"]
           }
         ]
       }

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -24,6 +24,7 @@ wizard, and let the agent bootstrap itself.
 8. Ready
 
 ## 1) Welcome + security notice
+
 Read the security notice displayed and decide accordingly.
 
 ## 2) Local vs Remote

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -54,6 +54,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 [Devices CLI](/cli/devices) for token rotation and revocation.
 
 **Notes:**
+
 - Local connections (`127.0.0.1`) are auto-approved.
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -110,6 +110,7 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
+
 - **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
 - **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -281,6 +281,7 @@ export async function handleDiscordMessagingAction(
       const channelId = resolveChannelId();
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
+      const content = readStringParam(params, "content");
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
@@ -289,10 +290,10 @@ export async function handleDiscordMessagingAction(
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes },
+            { name, messageId, autoArchiveMinutes, content },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes });
+        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes, content });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -184,7 +184,7 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
-    const content = readStringParam(params, "message");
+    const content = readStringParam(params, "content") ?? readStringParam(params, "message");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -184,6 +184,7 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    const content = readStringParam(params, "message");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -195,6 +196,7 @@ export async function handleDiscordMessageAction(
         name,
         messageId,
         autoArchiveMinutes,
+        content,
       },
       cfg,
     );

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -106,7 +106,7 @@ export async function createThreadDiscord(
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
   // Support for forum channels (type 15): requires message.content to create a post
-  if (payload.content) {
+  if (payload.content !== undefined) {
     body.message = { content: payload.content };
   }
   const route = Routes.threads(channelId, payload.messageId);

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -105,6 +105,10 @@ export async function createThreadDiscord(
   if (payload.autoArchiveMinutes) {
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
+  // Support for forum channels (type 15): requires message.content to create a post
+  if (payload.content) {
+    body.message = { content: payload.content };
+  }
   const route = Routes.threads(channelId, payload.messageId);
   return await rest.post(route, { body });
 }

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -71,6 +71,8 @@ export type DiscordThreadCreate = {
   messageId?: string;
   name: string;
   autoArchiveMinutes?: number;
+  /** Initial message content (required for forum channel posts). */
+  content?: string;
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

This PR adds support for creating threads/posts in Discord forum channels (type 15).

## The Bug

`thread-create` action fails on Discord forum channels because the Discord API requires a `message.content` field to create a post in a forum, but this wasn't being sent.

Error from Discord API: 
```
Cannot start a thread in a forum channel without an initial message.
```

## The Fix

When `content` is provided in the thread creation request, include it as `message: { content }` in the API request body. This matches Discord's [Start Thread in Forum or Media Channel](https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel) endpoint requirements.

### Changes:
- **`src/discord/send.types.ts`**: Added `content?: string` to `DiscordThreadCreate` type
- **`src/discord/send.messages.ts`**: Added `body.message = { content }` when content is provided in `createThreadDiscord()`
- **`src/agents/tools/discord-actions-messaging.ts`**: Read and pass `content` param in `threadCreate` action
- **`src/channels/plugins/actions/discord/handle-action.ts`**: Read `message` param and pass as `content` in `thread-create` action

## Testing

✅ Tested in production on Discord forum channels - posts are created successfully.

## AI-Assisted

This PR was created with AI assistance (Claude/Anthropic). The fix was identified and verified through production testing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `content` field to Discord thread creation requests and forwards it through the action layers so forum-channel thread/post creation can include `message.content` in the Discord API payload.

The changes touch the Discord send layer (`createThreadDiscord`), the agent tool action handler (`threadCreate`), and the channel plugin adapter for the `thread-create` message action to pass user-provided content down to the REST call.

<h3>Confidence Score: 3/5</h3>

- This PR is generally safe to merge, but has a couple of parameter/edge-case issues that can prevent the intended forum-thread creation behavior in some inputs.
- Core change (adding `body.message.content`) is small and localized, but there are two correctness gaps: empty-string content is dropped due to truthiness checks, and the high-level `thread-create` adapter reads `message` rather than `content`, which can cause callers to miss the new functionality unless they know the exact param name.
- src/discord/send.messages.ts, src/channels/plugins/actions/discord/handle-action.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->