### PR TITLE
feat(slack): expose thread-reply action

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
-        "18789"
+        "18789",
       ]
 
   openclaw-cli:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -10,6 +10,7 @@ title: "Telegram"
 Status: production-ready for bot DMs + groups via grammY. Long-polling by default; webhook optional.
 
 ## Quick setup (beginner)
+
 1. Create a bot with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`, then copy the token.
 2. Set the token:
    - Env: `TELEGRAM_BOT_TOKEN=...`
@@ -41,6 +42,7 @@ Minimal config:
 ## Setup (fast path)
 
 ### 1) Create a bot token (BotFather)
+
 1. Open Telegram and chat with **@BotFather** ([direct link](https://t.me/BotFather)). Confirm the handle is exactly `@BotFather`.
 2. Run `/newbot`, then follow the prompts (name + username ending in `bot`).
 3. Copy the token and store it safely.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
+  {/_ moonshot-kimi-k2-model-refs:start _/}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+    {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -865,11 +865,7 @@
           },
           {
             "group": "Help",
-            "pages": [
-              "help/index",
-              "help/troubleshooting",
-              "help/faq"
-            ]
+            "pages": ["help/index", "help/troubleshooting", "help/faq"]
           },
           {
             "group": "Install & Updates",
@@ -1002,13 +998,7 @@
           },
           {
             "group": "Web & Interfaces",
-            "pages": [
-              "web/index",
-              "web/control-ui",
-              "web/dashboard",
-              "web/webchat",
-              "tui"
-            ]
+            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
           },
           {
             "group": "Channels",
@@ -1171,11 +1161,7 @@
         "groups": [
           {
             "group": "开始",
-            "pages": [
-              "zh-CN/index",
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard"
-            ]
+            "pages": ["zh-CN/index", "zh-CN/start/getting-started", "zh-CN/start/wizard"]
           }
         ]
       }

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,14 +14,14 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
-{/* moonshot-kimi-k2-ids:start */}
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -24,6 +24,7 @@ wizard, and let the agent bootstrap itself.
 8. Ready
 
 ## 1) Welcome + security notice
+
 Read the security notice displayed and decide accordingly.
 
 ## 2) Local vs Remote

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -54,6 +54,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 [Devices CLI](/cli/devices) for token rotation and revocation.
 
 **Notes:**
+
 - Local connections (`127.0.0.1`) are auto-approved.
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -110,6 +110,7 @@ cat ~/.openclaw/openclaw.json | jq '.gateway.bind'
 ```
 
 Then construct the URL:
+
 - **loopback**: `http://127.0.0.1:18793/__openclaw__/canvas/<file>.html`
 - **lan/tailnet/auto**: `http://<hostname>:18793/__openclaw__/canvas/<file>.html`
 

--- a/src/channels/plugins/slack.actions.test.ts
+++ b/src/channels/plugins/slack.actions.test.ts
@@ -30,4 +30,62 @@ describe("slack actions adapter", () => {
       threadId: "171234.567",
     });
   });
+
+  it("lists thread-reply in actions when messages enabled", () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    const actions = createSlackActions("slack");
+    const listed = actions.listActions?.({ cfg }) ?? [];
+    expect(listed).toContain("thread-reply");
+  });
+
+  it("does not list thread-reply when messages disabled", () => {
+    const cfg = {
+      channels: { slack: { botToken: "tok", actions: { messages: false } } },
+    } as OpenClawConfig;
+    const actions = createSlackActions("slack");
+    const listed = actions.listActions?.({ cfg }) ?? [];
+    expect(listed).not.toContain("thread-reply");
+  });
+
+  it("handles thread-reply action", async () => {
+    handleSlackAction.mockClear();
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    const actions = createSlackActions("slack");
+
+    await actions.handleAction?.({
+      channel: "slack",
+      action: "thread-reply",
+      cfg,
+      params: {
+        channelId: "C123",
+        threadId: "1712345.678",
+        message: "Thread reply content",
+      },
+    });
+
+    const [params] = handleSlackAction.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      action: "sendMessage",
+      to: "channel:C123",
+      content: "Thread reply content",
+      threadTs: "1712345.678",
+    });
+  });
+
+  it("thread-reply throws without threadId", async () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    const actions = createSlackActions("slack");
+
+    await expect(
+      actions.handleAction?.({
+        channel: "slack",
+        action: "thread-reply",
+        cfg,
+        params: {
+          channelId: "C123",
+          message: "Missing thread",
+        },
+      }),
+    ).rejects.toThrow(/threadId/);
+  });
 });

--- a/src/channels/plugins/slack.actions.test.ts
+++ b/src/channels/plugins/slack.actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSlackActions } from "./slack.actions.js";
 
@@ -9,6 +9,10 @@ vi.mock("../../agents/tools/slack-actions.js", () => ({
 }));
 
 describe("slack actions adapter", () => {
+  beforeEach(() => {
+    handleSlackAction.mockClear();
+  });
+
   it("forwards threadId for read", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     const actions = createSlackActions("slack");
@@ -48,7 +52,6 @@ describe("slack actions adapter", () => {
   });
 
   it("handles thread-reply action", async () => {
-    handleSlackAction.mockClear();
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     const actions = createSlackActions("slack");
 
@@ -72,7 +75,7 @@ describe("slack actions adapter", () => {
     });
   });
 
-  it("thread-reply throws without threadId", async () => {
+  it("thread-reply throws without thread identifier", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     const actions = createSlackActions("slack");
 
@@ -86,6 +89,6 @@ describe("slack actions adapter", () => {
           message: "Missing thread",
         },
       }),
-    ).rejects.toThrow(/threadId/);
+    ).rejects.toThrow(/thread-reply requires/);
   });
 });

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -230,9 +230,12 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         if (!threadTs) {
           throw new Error("thread-reply requires threadId or replyTo parameter");
         }
-        // Resolve channel: prefer to/channelId param as-is, only prefix context fallback
-        const toParam = readStringParam(params, "to") ?? readStringParam(params, "channelId");
-        const channelId = toParam ?? (toolContext?.currentChannelId ? `channel:${toolContext.currentChannelId}` : undefined);
+        // Resolve channel: to is used as-is, channelId and context need prefix
+        const toParam = readStringParam(params, "to");
+        const channelIdParam = readStringParam(params, "channelId");
+        const channelId = toParam
+          ?? (channelIdParam ? `channel:${channelIdParam}` : undefined)
+          ?? (toolContext?.currentChannelId ? `channel:${toolContext.currentChannelId}` : undefined);
         if (!channelId) {
           throw new Error("thread-reply requires channelId or to parameter");
         }

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -228,7 +228,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         const replyTo = readStringParam(params, "replyTo");
         const threadTs = threadId ?? replyTo ?? toolContext?.currentThreadTs;
         if (!threadTs) {
-          throw new Error("thread-reply requires threadId or replyTo parameter");
+          throw new Error("thread-reply requires threadId, replyTo, or thread context");
         }
         // Resolve channel: to is used as-is, channelId and context need prefix
         const toParam = readStringParam(params, "to");

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -233,10 +233,8 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         // Resolve channel: prefer channelId param, then to param, then context
         const channelIdParam = readStringParam(params, "channelId");
         const toParam = readStringParam(params, "to");
-        const channelId =
-          channelIdParam ?? toParam ?? toolContext?.currentChannelId
-            ? `channel:${channelIdParam ?? toParam ?? toolContext?.currentChannelId}`
-            : undefined;
+        const rawChannelId = channelIdParam ?? toParam ?? toolContext?.currentChannelId;
+        const channelId = rawChannelId ? `channel:${rawChannelId}` : undefined;
         if (!channelId) {
           throw new Error("thread-reply requires channelId or to parameter");
         }

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -226,8 +226,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         // Prefer threadId, fall back to replyTo, then context
         const threadId = readStringParam(params, "threadId");
         const replyTo = readStringParam(params, "replyTo");
-        const threadTs =
-          threadId ?? replyTo ?? toolContext?.currentThreadTs ?? toolContext?.replyToMessageId;
+        const threadTs = threadId ?? replyTo ?? toolContext?.currentThreadTs;
         if (!threadTs) {
           throw new Error("thread-reply requires threadId or replyTo parameter");
         }

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -233,9 +233,10 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         // Resolve channel: to is used as-is, channelId and context need prefix
         const toParam = readStringParam(params, "to");
         const channelIdParam = readStringParam(params, "channelId");
-        const channelId = toParam
-          ?? (channelIdParam ? `channel:${channelIdParam}` : undefined)
-          ?? (toolContext?.currentChannelId ? `channel:${toolContext.currentChannelId}` : undefined);
+        const channelId =
+          toParam ??
+          (channelIdParam ? `channel:${channelIdParam}` : undefined) ??
+          (toolContext?.currentChannelId ? `channel:${toolContext.currentChannelId}` : undefined);
         if (!channelId) {
           throw new Error("thread-reply requires channelId or to parameter");
         }

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -230,11 +230,9 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         if (!threadTs) {
           throw new Error("thread-reply requires threadId or replyTo parameter");
         }
-        // Resolve channel: prefer channelId param, then to param, then context
-        const channelIdParam = readStringParam(params, "channelId");
-        const toParam = readStringParam(params, "to");
-        const rawChannelId = channelIdParam ?? toParam ?? toolContext?.currentChannelId;
-        const channelId = rawChannelId ? `channel:${rawChannelId}` : undefined;
+        // Resolve channel: prefer to/channelId param as-is, only prefix context fallback
+        const toParam = readStringParam(params, "to") ?? readStringParam(params, "channelId");
+        const channelId = toParam ?? (toolContext?.currentChannelId ? `channel:${toolContext.currentChannelId}` : undefined);
         if (!channelId) {
           throw new Error("thread-reply requires channelId or to parameter");
         }


### PR DESCRIPTION
## Summary

Expose `thread-reply` as a first-class action for Slack so agents don't need to discover the workaround (`send` + `replyTo`) through trial and error.

## Problem

When an agent tries `thread-reply` on Slack, it fails:
```
Action thread-reply is not supported for provider slack.
```

The agent then has to fall back to using `send` with `replyTo` - which works, but requires trial-and-error discovery.

## Solution

- Add `thread-reply` to `listActions()` under the `messages` gate
- Add handler that routes to `sendMessage` with `threadTs`
- The underlying functionality already existed, this just exposes it properly

## Changes

- `src/channels/plugins/slack.actions.ts`: Add `thread-reply` to actions list and add handler
- `src/channels/plugins/slack.actions.test.ts`: Add tests for listing, handling, and error cases

## Test plan

- [x] `thread-reply` appears in `listActions()` when messages enabled
- [x] `thread-reply` does not appear when messages disabled
- [x] `thread-reply` action routes to `sendMessage` with correct `threadTs`
- [x] `thread-reply` throws helpful error when `threadId` missing

Fixes #6542

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR exposes a new Slack channel action, `thread-reply`, by adding it to `listActions()` (behind the existing `messages` action gate) and implementing a handler that forwards to the existing Slack tool action `sendMessage` with `threadTs` set (falling back from `threadId` → `replyTo` → `toolContext.currentThreadTs`). Tests were added to validate that the action is listed when enabled, hidden when disabled, and that invoking it maps to `sendMessage` with the expected parameters and errors when `threadId` is missing.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with only minor correctness and test robustness issues.
- Changes are localized to Slack action listing/dispatch and a small test extension. Previously-reported logic issues cover the main behavioral risks; beyond those, remaining concerns are mainly around misleading error messaging and tests that can be order-dependent due to mock call state.
- src/channels/plugins/slack.actions.ts, src/channels/plugins/slack.actions.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->