### PR TITLE
fix(cli): guard os.networkInterfaces under restricted envs

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -254,13 +254,16 @@ This prevents the user from seeing only "Agent failed before reply" and having n
 
 ## Auto-Notify on Completion
 
-For long-running background tasks, append a wake trigger to your prompt so OpenClaw gets notified immediately when the agent finishes (instead of waiting for the next heartbeat):
+For long-running background tasks, append a trigger to your prompt so OpenClaw gets notified immediately when the agent finishes (instead of waiting for the next heartbeat).
+
+Use a one-shot cron job to inject a main-session system event immediately:
 
 ```
 ... your task here.
 
 When completely finished, run this command to notify me:
-openclaw gateway wake --text "Done: [brief summary of what was built]" --mode now
+openclaw cron add --name "agent-done" --at +0s --wake now --delete-after-run \
+  --session main --system-event "Done: [brief summary of what was built]"
 ```
 
 **Example:**
@@ -268,10 +271,10 @@ openclaw gateway wake --text "Done: [brief summary of what was built]" --mode no
 ```bash
 bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
 
-When completely finished, run: openclaw gateway wake --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
+When completely finished, run: openclaw cron add --name \"agent-done\" --at +0s --wake now --delete-after-run --session main --system-event \"Done: Built todos REST API with CRUD endpoints\"'"
 ```
 
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This posts immediately back into the main session.
 
 ---
 

--- a/src/infra/system-presence.networkinterfaces-error.test.ts
+++ b/src/infra/system-presence.networkinterfaces-error.test.ts
@@ -1,0 +1,17 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+
+describe("system-presence", () => {
+  it("does not crash when os.networkInterfaces throws", async () => {
+    vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+
+    // system-presence seeds self presence at module init time, so we must
+    // mock before importing the module.
+    const mod = await import(`./system-presence.js?test=${Date.now()}`);
+
+    const entries = mod.listSystemPresence();
+    expect(entries.length).toBeGreaterThan(0);
+  });
+});

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -43,7 +43,14 @@ function normalizePresenceKey(key: string | undefined): string | undefined {
 }
 
 function resolvePrimaryIPv4(): string | undefined {
-  const nets = os.networkInterfaces();
+  let nets: Record<string, os.NetworkInterfaceInfo[] | undefined> = {};
+  try {
+    nets = os.networkInterfaces() ?? {};
+  } catch {
+    // In restricted environments (e.g. Node permission model / sandboxing),
+    // os.networkInterfaces() can throw. Presence should degrade gracefully.
+    return os.hostname();
+  }
   const prefer = ["en0", "eth0"];
   const pick = (names: string[]) => {
     for (const name of names) {

--- a/src/infra/tailnet.test.ts
+++ b/src/infra/tailnet.test.ts
@@ -1,8 +1,12 @@
 import os from "node:os";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { listTailnetAddresses } from "./tailnet.js";
 
 describe("tailnet address detection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("detects tailscale IPv4 and IPv6 addresses", () => {
     vi.spyOn(os, "networkInterfaces").mockReturnValue({
       lo0: [
@@ -27,5 +31,14 @@ describe("tailnet address detection", () => {
     const out = listTailnetAddresses();
     expect(out.ipv4).toEqual(["100.123.224.76"]);
     expect(out.ipv6).toEqual(["fd7a:115c:a1e0::8801:e04c"]);
+  });
+
+  it("returns empty lists when os.networkInterfaces throws", () => {
+    vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+
+    const out = listTailnetAddresses();
+    expect(out).toEqual({ ipv4: [], ipv6: [] });
   });
 });

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -32,7 +32,12 @@ export function listTailnetAddresses(): TailnetAddresses {
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
-  const ifaces = os.networkInterfaces();
+  let ifaces: Record<string, os.NetworkInterfaceInfo[] | undefined> = {};
+  try {
+    ifaces = os.networkInterfaces() ?? {};
+  } catch {
+    return { ipv4, ipv6 };
+  }
   for (const entries of Object.values(ifaces)) {
     if (!entries) {
       continue;


### PR DESCRIPTION
## Summary
On some environments (notably certain VPS setups or Node permission-model constrained runtimes), `os.networkInterfaces()` can throw (libuv `uv_interface_addresses` failure). This can crash OpenClaw during startup / presence init.

This PR:
- wraps `os.networkInterfaces()` with try/catch in:
  - `src/infra/system-presence.ts`
  - `src/infra/tailnet.ts`
- adds regression tests for both codepaths
- updates `skills/coding-agent/SKILL.md` to use a working completion-notify command (`openclaw cron add ...`) instead of the non-existent `openclaw gateway wake --text ...`

## Context
- Related: #3199 (and duplicate #3200)
- Prior attempt: #4216 (similar fix for system-presence; this extends coverage and adds the tailnet guard + docs correction)

## Authorship / credit
This patch was prepared by an OpenClaw instance called **H.U.E (Heuristic Unified Entity)**. 
[Daniel Constantin](https://danielconstantin.net/) reviewed it, ran it locally, and is submitting it from `@kernelwhisperer`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents startup/presence initialization crashes in restricted Node environments by guarding `os.networkInterfaces()` with try/catch in `src/infra/system-presence.ts` and `src/infra/tailnet.ts`, and adds regression tests to cover the throwing code paths. It also updates the `skills/coding-agent` documentation to use a working completion notification command.

The change fits the codebase by making presence/tailnet discovery resilient to platform/runtime constraints while preserving existing behavior when `os.networkInterfaces()` is available.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and primarily improves resilience in restricted runtimes.
- Changes are localized try/catch guards around `os.networkInterfaces()` plus targeted tests; main remaining concern is a small flakiness risk in the dynamic-import cache-busting approach in the new system-presence test.
- src/infra/system-presence.networkinterfaces-error.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->