### PR TITLE
fix(browser): enable CDP download events for connected browsers

### DIFF
--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -195,7 +195,6 @@ async function configureDownloadBehavior(page: Page): Promise<void> {
   if (downloadBehaviorConfigured.has(page)) {
     return;
   }
-  downloadBehaviorConfigured.add(page);
 
   try {
     const session = await page.context().newCDPSession(page);
@@ -210,6 +209,9 @@ async function configureDownloadBehavior(page: Page): Promise<void> {
         downloadPath: CDP_DOWNLOAD_PATH,
         eventsEnabled: true,
       });
+
+      // Only mark as configured after successful setup
+      downloadBehaviorConfigured.add(page);
     } finally {
       await session.detach().catch(() => {});
     }


### PR DESCRIPTION
## Problem

When Playwright connects to Chrome via CDP (`connectOverCDP`), download events are not automatically captured. This causes:

1. Downloads handled by Chrome's default behavior
2. Files saved with UUID names instead of proper filenames (especially on sites like Canvas LMS)
3. Playwright's `download.saveAs()` failing because files aren't in Playwright's artifact folder

## Root Cause

Chrome DevTools Protocol requires `Browser.setDownloadBehavior` to be called with `eventsEnabled: true` for Playwright to receive download events. Without this, Chrome handles downloads independently.

## Solution

This PR adds automatic download behavior configuration when attaching to pages via CDP:

- Calls `Browser.setDownloadBehavior` with:
  - `behavior: 'allowAndName'`
  - `eventsEnabled: true`
  - `downloadPath: '/tmp/openclaw/downloads'`
- Tracks pages via WeakSet to avoid duplicate configuration
- Best-effort handling: gracefully ignores CDP connections that don't support this (e.g., extension relay)
- Configured in `getPageForTargetId()` to ensure downloads work before any download operations

## Testing

Tested against Canvas LMS (gatech.instructure.com):
- Before: Downloads saved with UUID names, `download.saveAs()` failed
- After: Download events fire correctly with proper `suggestedFilename()`, files save to correct location

## Files Changed

- `src/browser/pw-session.ts`: Added `configureDownloadBehavior()` function and calls in `getPageForTargetId()`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes add a best-effort CDP download configuration step when resolving/observing Playwright `Page` objects for `connectOverCDP` sessions. A new `configureDownloadBehavior(page)` helper uses a per-page `WeakSet` to avoid duplicate work, creates a download directory, and sends `Browser.setDownloadBehavior` with `eventsEnabled: true` so Playwright receives download events and can correctly name/save downloads. The helper is invoked both opportunistically in `ensurePageState` and synchronously before returning pages from `getPageForTargetId`, improving reliability for early download operations.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should improve downloads for CDP-connected browsers, with a couple reliability/portability edge cases to consider.
- The change is small and scoped to CDP-connected page handling, and failures are intentionally best-effort. Main remaining concern is that transient failures can mark a page as “configured” permanently, and the hard-coded `/tmp` download path may be problematic in some environments.
- src/browser/pw-session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->