### PR TITLE
CRASH FIX in CLI runner: route null‑byte prompts via stdin to prevent argv crash

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -502,6 +502,9 @@ export function resolvePromptInput(params: { backend: CliBackendConfig; prompt: 
   if (inputMode === "stdin") {
     return { stdin: params.prompt };
   }
+  if (params.prompt.includes("\u0000")) {
+    return { stdin: params.prompt };
+  }
   if (params.backend.maxPromptArgChars && params.prompt.length > params.backend.maxPromptArgChars) {
     return { stdin: params.prompt };
   }


### PR DESCRIPTION
- What: Detect \u0000 in CLI prompts and send those prompts via stdin instead of argv.
- Why: Slack voice messages can include null bytes; Node rejects argv strings with \0, which crashes the cli‑runner.
- How: Add a null‑byte guard in resolvePromptInput and a regression test in claude-cli-runner.test.ts.


Testing

- new unit test added: claude-cli-runner.test.ts

AI‑assisted

- Yes (Codex). I reviewed and understand the change.