### PR TITLE
fix: thread fileName through WhatsApp document send path

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.test.ts
+++ b/src/web/inbound/send-api.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWebSendApi } from "./send-api.js";
+
+function createMockSock() {
+  return {
+    sendMessage: vi.fn().mockResolvedValue({ key: { id: "msg-1" } }),
+    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("createWebSendApi", () => {
+  describe("sendMessage", () => {
+    it("uses provided fileName for document payloads", async () => {
+      const sock = createMockSock();
+      const api = createWebSendApi({ sock, defaultAccountId: "default" });
+
+      await api.sendMessage(
+        "1234567890",
+        "here is your report",
+        Buffer.from("pdf-data"),
+        "application/pdf",
+        { fileName: "report.pdf" },
+      );
+
+      const payload = sock.sendMessage.mock.calls[0][1];
+      expect(payload).toHaveProperty("document");
+      expect(payload).toHaveProperty("fileName", "report.pdf");
+      expect(payload).toHaveProperty("caption", "here is your report");
+    });
+
+    it('defaults to "file" when no fileName provided for documents', async () => {
+      const sock = createMockSock();
+      const api = createWebSendApi({ sock, defaultAccountId: "default" });
+
+      await api.sendMessage("1234567890", "a file", Buffer.from("data"), "application/pdf");
+
+      const payload = sock.sendMessage.mock.calls[0][1];
+      expect(payload).toHaveProperty("document");
+      expect(payload).toHaveProperty("fileName", "file");
+    });
+
+    it("sends image payloads without fileName", async () => {
+      const sock = createMockSock();
+      const api = createWebSendApi({ sock, defaultAccountId: "default" });
+
+      await api.sendMessage("1234567890", "a photo", Buffer.from("img"), "image/jpeg");
+
+      const payload = sock.sendMessage.mock.calls[0][1];
+      expect(payload).toHaveProperty("image");
+      expect(payload).not.toHaveProperty("fileName");
+    });
+
+    it("sends video payloads with gifPlayback when set", async () => {
+      const sock = createMockSock();
+      const api = createWebSendApi({ sock, defaultAccountId: "default" });
+
+      await api.sendMessage("1234567890", "a video", Buffer.from("vid"), "video/mp4", {
+        gifPlayback: true,
+      });
+
+      const payload = sock.sendMessage.mock.calls[0][1];
+      expect(payload).toHaveProperty("video");
+      expect(payload).toHaveProperty("gifPlayback", true);
+    });
+  });
+});

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -130,7 +130,9 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
   });
 
   it("sends polls via active listener", async () => {


### PR DESCRIPTION
When sending non-image/audio/video files via WhatsApp, the Baileys payload always used `fileName: "file"` regardless of the actual file name. The fileName from `loadWebMedia` (or an explicit option) was never passed through the send chain.

## Changes
- Add `fileName` to `ActiveWebSendOptions`
- Extract `media.fileName` in `sendMessageWhatsApp` and pass it via `sendOptions`
- Use `sendOptions.fileName` in `send-api` document payload (fallback: `"file"`)
- Add unit tests for send-api fileName handling

## Files changed
- `src/web/active-listener.ts` — add `fileName?: string` to options type
- `src/web/outbound.ts` — extract and pass `media.fileName`
- `src/web/inbound/send-api.ts` — use `sendOptions?.fileName` instead of hardcoded `"file"`
- `src/web/inbound/send-api.test.ts` — new tests

Fixes #6455

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a `fileName` option through the WhatsApp Web send pipeline so document uploads use the correct filename. It extends `ActiveWebSendOptions`, propagates `media.fileName` (or an explicit override) from `sendMessageWhatsApp` into the send options, and updates `createWebSendApi` to set `fileName` on Baileys document payloads with a default fallback. Unit tests were added to validate filename behavior for document messages and to ensure non-document payloads don’t get a `fileName`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and covered by focused unit tests.
- The change is a straightforward data plumbing update with limited surface area (options type + payload construction) and adds tests that exercise the new behavior. Main remaining risk is subtle semantics around falsy `fileName` values and minor option-shape consistency.
- src/web/inbound/send-api.ts (filename fallback semantics), src/web/outbound.ts (sendOptions shape)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->