### PR TITLE
Fix missing before_tool_call hook integration

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.before-tool-call-hook.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.before-tool-call-hook.test.ts
@@ -1,0 +1,299 @@
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { handleToolExecutionStart } from "./pi-embedded-subscribe.handlers.tools.js";
+
+// Mock dependencies
+vi.mock("../plugins/hook-runner-global.js");
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+}));
+vi.mock("./pi-embedded-helpers.js");
+vi.mock("./pi-embedded-messaging.js");
+vi.mock("./pi-embedded-subscribe.tools.js");
+vi.mock("./pi-embedded-utils.js", () => ({
+  inferToolMetaFromArgs: vi.fn(() => undefined),
+}));
+vi.mock("./tool-policy.js", () => ({
+  normalizeToolName: vi.fn((name: string) => name.toLowerCase()),
+}));
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+describe("before_tool_call hook integration", () => {
+  let mockContext: EmbeddedPiSubscribeContext;
+  let mockHookRunner: any;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock context
+    mockContext = {
+      params: {
+        runId: "test-run-123",
+        session: { key: "test-session" },
+        onBlockReplyFlush: vi.fn(),
+      },
+      state: {
+        toolMetaById: new Map(),
+      },
+      log: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+      },
+      flushBlockReplyBuffer: vi.fn(),
+      shouldEmitToolResult: vi.fn().mockReturnValue(true),
+    } as any;
+
+    // Mock hook runner
+    mockHookRunner = {
+      hasHooks: vi.fn(),
+      runBeforeToolCall: vi.fn(),
+    };
+
+    mockGetGlobalHookRunner.mockReturnValue(mockHookRunner);
+  });
+
+  describe("when no hooks are registered", () => {
+    beforeEach(() => {
+      mockHookRunner.hasHooks.mockReturnValue(false);
+    });
+
+    it("should proceed with tool execution normally", async () => {
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "TestTool",
+        toolCallId: "tool-call-123",
+        args: { param: "value" },
+      };
+
+      // Should not throw
+      await expect(handleToolExecutionStart(mockContext, event)).resolves.toBeUndefined();
+
+      // Hook runner should check for hooks but not run them
+      expect(mockHookRunner.hasHooks).toHaveBeenCalledWith("before_tool_call");
+      expect(mockHookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when hooks are registered", () => {
+    beforeEach(() => {
+      mockHookRunner.hasHooks.mockReturnValue(true);
+    });
+
+    it("should call the hook with correct parameters", async () => {
+      mockHookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "TestTool",
+        toolCallId: "tool-call-123",
+        args: { param: "value" },
+      };
+
+      await handleToolExecutionStart(mockContext, event);
+
+      expect(mockHookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+        {
+          toolName: "testtool", // normalized
+          params: { param: "value" },
+        },
+        {
+          toolName: "testtool",
+        },
+      );
+    });
+
+    it("should allow hook to modify parameters", async () => {
+      const modifiedParams = { param: "modified_value", newParam: "added" };
+      mockHookRunner.runBeforeToolCall.mockResolvedValue({
+        params: modifiedParams,
+      });
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "TestTool",
+        toolCallId: "tool-call-123",
+        args: { param: "value" },
+      };
+
+      // The function should complete without error
+      await expect(handleToolExecutionStart(mockContext, event)).resolves.toBeUndefined();
+
+      expect(mockHookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+        {
+          toolName: "testtool",
+          params: { param: "value" },
+        },
+        {
+          toolName: "testtool",
+        },
+      );
+
+      // Note: We can't directly test parameter modification without more complex mocking,
+      // but we can verify the hook was called and returned the modification
+      expect(mockHookRunner.runBeforeToolCall).toHaveBeenCalled();
+    });
+
+    it("should block tool call when hook returns block=true", async () => {
+      const blockReason = "Tool blocked by security policy";
+      const mockResult = {
+        block: true,
+        blockReason,
+      };
+
+      mockHookRunner.runBeforeToolCall.mockResolvedValue(mockResult);
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "BlockedTool",
+        toolCallId: "tool-call-456",
+        args: { dangerous: "payload" },
+      };
+
+      // Should throw an error with the block reason
+      await expect(handleToolExecutionStart(mockContext, event)).rejects.toThrow(blockReason);
+
+      // Should log the block
+      expect(mockContext.log.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Tool call blocked by plugin hook"),
+      );
+      expect(mockContext.log.debug).toHaveBeenCalledWith(expect.stringContaining(blockReason));
+    });
+
+    it("should block tool call with default reason when no blockReason provided", async () => {
+      mockHookRunner.runBeforeToolCall.mockResolvedValue({
+        block: true,
+        // no blockReason
+      });
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "BlockedTool",
+        toolCallId: "tool-call-789",
+        args: {},
+      };
+
+      // Should throw with default message
+      await expect(handleToolExecutionStart(mockContext, event)).rejects.toThrow(
+        "Tool call blocked by plugin hook",
+      );
+    });
+
+    it("should handle hook errors gracefully and continue execution", async () => {
+      const hookError = new Error("Hook implementation error");
+      mockHookRunner.runBeforeToolCall.mockRejectedValue(hookError);
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "TestTool",
+        toolCallId: "tool-call-999",
+        args: { param: "value" },
+      };
+
+      // Should not throw - hook errors should be caught
+      await expect(handleToolExecutionStart(mockContext, event)).resolves.toBeUndefined();
+
+      // Should log the hook error
+      expect(mockContext.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("before_tool_call hook failed"),
+      );
+      expect(mockContext.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Hook implementation error"),
+      );
+    });
+
+    it("should re-throw blocking errors even when caught", async () => {
+      const blockReason = "Blocked by security";
+      mockHookRunner.runBeforeToolCall.mockResolvedValue({
+        block: true,
+        blockReason,
+      });
+
+      const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+        type: "tool_start",
+        toolName: "TestTool",
+        toolCallId: "tool-call-000",
+        args: {},
+      };
+
+      // The blocking error should still be thrown
+      await expect(handleToolExecutionStart(mockContext, event)).rejects.toThrow(blockReason);
+    });
+  });
+
+  describe("hook context handling", () => {
+    beforeEach(() => {
+      mockHookRunner.hasHooks.mockReturnValue(true);
+      mockHookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+    });
+
+    it("should handle various tool name formats", async () => {
+      const testCases = [
+        { input: "ReadFile", expected: "readfile" },
+        { input: "EXEC", expected: "exec" },
+        { input: "bash-command", expected: "bash-command" },
+        { input: " SpacedTool ", expected: " spacedtool " },
+      ];
+
+      for (const { input, expected } of testCases) {
+        mockHookRunner.runBeforeToolCall.mockClear();
+
+        const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+          type: "tool_start",
+          toolName: input,
+          toolCallId: `call-${input}`,
+          args: {},
+        };
+
+        await handleToolExecutionStart(mockContext, event);
+
+        expect(mockHookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+          {
+            toolName: expected,
+            params: {},
+          },
+          {
+            toolName: expected,
+          },
+        );
+      }
+    });
+
+    it("should handle different argument types", async () => {
+      const testCases = [
+        { args: null, expected: null },
+        { args: undefined, expected: undefined },
+        { args: "string", expected: "string" },
+        { args: 123, expected: 123 },
+        { args: { key: "value" }, expected: { key: "value" } },
+        { args: [1, 2, 3], expected: [1, 2, 3] },
+      ];
+
+      for (const { args, expected } of testCases) {
+        mockHookRunner.runBeforeToolCall.mockClear();
+
+        const event: AgentEvent & { toolName: string; toolCallId: string; args: unknown } = {
+          type: "tool_start",
+          toolName: "TestTool",
+          toolCallId: `call-${typeof args}`,
+          args,
+        };
+
+        await handleToolExecutionStart(mockContext, event);
+
+        expect(mockHookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+          {
+            toolName: "testtool",
+            params: expected as Record<string, unknown>,
+          },
+          {
+            toolName: "testtool",
+          },
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
## **Fix missing `before_tool_call` hook integration**

Fixes the `before_tool_call` hook which was defined in the plugin type system but never actually called during tool execution.

### **Problem**
The `before_tool_call` hook was defined in `src/plugins/types.ts` and had a complete runner function in `src/plugins/hooks.ts`, but was never wired into the actual tool execution flow. Plugin developers could register handlers that would never execute.

This addresses 1 of the 8 unimplemented hooks identified in #6535.

### **Solution**
- Added hook call in `handleToolExecutionStart()` before tool execution begins
- Hook can modify tool parameters via `hookResult.params`
- Hook can block tool calls via `hookResult.block` with custom `blockReason`
- Added proper error handling to distinguish between hook blocking vs hook failures
- Maintains tool event consistency by emitting start/end events even when blocked

### **API Usage**
Plugins can now register `before_tool_call` handlers:
```typescript
// Block dangerous tools
if (event.toolName === "exec" && isUnsafeCommand(event.params.command)) {
  return { block: true, blockReason: "Command blocked by security policy" };
}

// Modify parameters
if (event.toolName === "read" && !event.params.path.startsWith("/safe/")) {
  return { params: { ...event.params, path: `/safe/${event.params.path}` } };
}
```

### **Testing**
Comprehensive test suite (9 tests covering all hook scenarios) available at: https://github.com/ryancnelson/openclaw/blob/feature/implement-before-tool-call-hook/src/agents/pi-embedded-subscribe.handlers.tools.before-tool-call-hook.test.ts

### **Breaking Changes**
None - this is purely additive functionality that was already documented as available.

---

**Related:** #6535

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the previously-declared `before_tool_call` plugin hook into the embedded Pi tool execution path (`handleToolExecutionStart`), allowing plugins to block tool calls or mutate tool params before execution. It also adds a dedicated Vitest suite covering the main hook scenarios.

The changes fit into the existing agent event pipeline by attempting to preserve tool event consistency (emitting start/end events even on block) and keeping hook failures non-fatal (logged warnings).

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but there are a couple of edge-case correctness issues around non-object tool args and blocked-call state consistency.
- Hook integration is localized and guarded by `hasHooks`, but the current implementation assumes tool args are spreadable objects when applying hook param overrides, which can throw at runtime for non-object args. Additionally, the blocked-call path emits events but bypasses other internal state/callback behavior, which could create observable inconsistencies depending on downstream usage.
- src/agents/pi-embedded-subscribe.handlers.tools.ts (hook param merging and blocked-call flow); src/agents/pi-embedded-subscribe.handlers.tools.before-tool-call-hook.test.ts (assertions that currently mask params shape issues).

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->