### PR TITLE
fix: add null checks for stdout/stderr when using inherit-stdio fallback

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -647,8 +647,8 @@ async function runExecProcess(opts: {
       handleStdout(cleaned);
     });
   } else if (child) {
-    child.stdout.on("data", handleStdout);
-    child.stderr.on("data", handleStderr);
+    child.stdout?.on("data", handleStdout);
+    child.stderr?.on("data", handleStderr);
   }
 
   const promise = new Promise<ExecProcessOutcome>((resolve) => {

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -109,10 +109,10 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
 
       let stdout = "";
       let stderr = "";
-      child.stdout.on("data", (buf) => {
+      child.stdout?.on("data", (buf) => {
         stdout += buf.toString("utf8");
       });
-      child.stderr.on("data", (buf) => {
+      child.stderr?.on("data", (buf) => {
         stderr += buf.toString("utf8");
       });
 


### PR DESCRIPTION
## Summary
Fixes `Cannot read properties of null (reading 'on')` error when exec falls back to `inherit-stdio` mode.

## Problem
When the gateway has file descriptor pressure, spawn can fail with EBADF. The fallback mechanism correctly retries with `stdio: "inherit"`, but the stream listeners were calling `.on()` directly on potentially null stdout/stderr streams, causing crashes.

## Solution
Add optional chaining (`?.`) to the `.on()` calls in two locations:
- `src/agents/bash-tools.exec.ts` (lines 650-651)
- `src/tui/tui-local-shell.ts` (lines 112, 115)

## Files Changed
- `src/agents/bash-tools.exec.ts`
- `src/tui/tui-local-shell.ts`

## Test Plan
- [x] Build passes
- [x] Tested on machine with file descriptor pressure
- [x] Verified exec calls no longer crash when falling back to inherit-stdio

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents crashes when `spawnWithFallback` falls back to `stdio: "inherit"` (where `child.stdout`/`child.stderr` can be `null`). It updates the two call sites that attach `data` listeners to use optional chaining so listener setup is skipped when streams are absent:

- `src/agents/bash-tools.exec.ts`: `runExecProcess` now uses `child.stdout?.on(...)` / `child.stderr?.on(...)`.
- `src/tui/tui-local-shell.ts`: the local shell runner similarly guards `child.stdout`/`child.stderr`.

These changes fit the existing fallback behavior: the process still runs with inherited stdio, but the code no longer assumes pipes are available to capture output.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (adds null guards on stdout/stderr listener attachment) and directly addresses a known runtime crash in inherit-stdio fallback mode; it does not alter control flow beyond skipping listener setup when streams are absent.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->