### PR TITLE
fix: exclude .venv and __pycache__ from skills file watcher

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,8 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
## Summary
Fixes file descriptor exhaustion causing EBADF errors on exec.

## Problem
The skills file watcher (chokidar) was watching Python virtual environment directories. Skills with `.venv` folders containing thousands of .py/.pyc files caused FD count to explode to 16,000+, leading to:
1. File descriptor exhaustion (16,000+ open FDs)
2. `spawn EBADF` errors on exec calls
3. Gateway instability

Observed behavior: ~7,900 .py files + ~6,800 .pyc files from skill venvs resulted in every exec call failing with EBADF.

## Root Cause
`DEFAULT_SKILLS_WATCH_IGNORED` in `src/agents/skills/refresh.ts` only excludes:
- `.git`
- `node_modules`
- `dist`

But does NOT exclude Python-specific directories like `.venv` and `__pycache__`.

## Solution
Add `.venv` and `__pycache__` to `DEFAULT_SKILLS_WATCH_IGNORED` patterns, similar to how `node_modules` is already ignored.

## Files Changed
- `src/agents/skills/refresh.ts`

## Test Plan
- [x] Build passes
- [x] Created skills with Python venvs
- [x] Started gateway and monitored FD count with `lsof -p <pid> | wc -l`
- [x] Verified FD count stays stable (~30-50) instead of growing to thousands
- [x] Verified skill hot-reload still works for actual skill files

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the skills file watcher configuration (`src/agents/skills/refresh.ts`) to ignore Python virtual environment and cache directories by default. Specifically, `.venv` and `__pycache__` are added to `DEFAULT_SKILLS_WATCH_IGNORED`, which is passed to the `chokidar.watch()` call that monitors skill directories for hot-reload. This prevents the watcher from traversing thousands of Python files/bytecode artifacts in embedded venvs, reducing open file descriptors and avoiding `spawn EBADF` failures and gateway instability while preserving watch behavior for actual skill source changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (two additional ignore regexes) and affects only the chokidar watcher ignore list; it reduces resource usage without altering core skill loading logic. No behavioral regressions are apparent beyond intentionally not hot-reloading changes inside `.venv`/`__pycache__` trees.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->