### PR TITLE
feat(telegram): add topic names to session keys for better readability

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -23,6 +23,7 @@ import { resolveTelegramForumThreadId } from "./bot/helpers.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
+import { cacheTopicName } from "./topic-cache.js";
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -471,6 +472,48 @@ export const registerTelegramHandlers = ({
       }
     } catch (err) {
       runtime.error?.(danger(`[telegram] Group migration handler failed: ${String(err)}`));
+    }
+  });
+
+  // Handle forum topic created - cache the topic name for readable session keys
+  bot.on("message:forum_topic_created", (ctx) => {
+    try {
+      const msg = ctx.message;
+      if (!msg?.forum_topic_created?.name) {
+        return;
+      }
+      const chatId = msg.chat.id;
+      const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+      if (messageThreadId != null) {
+        cacheTopicName(chatId, messageThreadId, msg.forum_topic_created.name);
+        logVerbose(
+          `[telegram] Cached topic name: chat=${chatId} topic=${messageThreadId} name="${msg.forum_topic_created.name}"`,
+        );
+      }
+    } catch (err) {
+      logVerbose(`[telegram] forum_topic_created handler error: ${String(err)}`);
+    }
+  });
+
+  // Handle forum topic edited - update the cached topic name
+  bot.on("message:forum_topic_edited", (ctx) => {
+    try {
+      const msg = ctx.message;
+      const topicEdited = msg?.forum_topic_edited;
+      // forum_topic_edited may only contain icon changes, name is optional
+      if (!topicEdited?.name) {
+        return;
+      }
+      const chatId = msg.chat.id;
+      const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+      if (messageThreadId != null) {
+        cacheTopicName(chatId, messageThreadId, topicEdited.name);
+        logVerbose(
+          `[telegram] Updated cached topic name: chat=${chatId} topic=${messageThreadId} name="${topicEdited.name}"`,
+        );
+      }
+    } catch (err) {
+      logVerbose(`[telegram] forum_topic_edited handler error: ${String(err)}`);
     }
   });
 

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -1,10 +1,57 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { cacheTopicName, clearTopicCache } from "../topic-cache.js";
 import {
+  buildTelegramGroupPeerId,
   buildTelegramThreadParams,
   buildTypingThreadParams,
   normalizeForwardedContext,
   resolveTelegramForumThreadId,
 } from "./helpers.js";
+
+describe("buildTelegramGroupPeerId", () => {
+  afterEach(() => {
+    clearTopicCache();
+  });
+
+  it("returns chat ID as string when no topic", () => {
+    expect(buildTelegramGroupPeerId(-1003856094222)).toBe("-1003856094222");
+    expect(buildTelegramGroupPeerId("-1003856094222")).toBe("-1003856094222");
+  });
+
+  it("returns chat:topic:id format when topic provided without name", () => {
+    expect(buildTelegramGroupPeerId(-1003856094222, 49)).toBe("-1003856094222:topic:49");
+  });
+
+  it("appends slugified topic name when provided", () => {
+    expect(buildTelegramGroupPeerId(-1003856094222, 49, "Telegram Ops")).toBe(
+      "-1003856094222:topic:49-telegram-ops",
+    );
+  });
+
+  it("uses cached topic name when not explicitly provided", () => {
+    cacheTopicName(-1003856094222, 49, "Cached Topic Name");
+    expect(buildTelegramGroupPeerId(-1003856094222, 49)).toBe(
+      "-1003856094222:topic:49-cached-topic-name",
+    );
+  });
+
+  it("prefers explicit topic name over cached name", () => {
+    cacheTopicName(-1003856094222, 49, "Cached Name");
+    expect(buildTelegramGroupPeerId(-1003856094222, 49, "Explicit Name")).toBe(
+      "-1003856094222:topic:49-explicit-name",
+    );
+  });
+
+  it("falls back to id-only format when slug is empty", () => {
+    // Topic name with only special characters produces empty slug
+    expect(buildTelegramGroupPeerId(-1003856094222, 49, "🎉🎊🎁")).toBe("-1003856094222:topic:49");
+  });
+
+  it("handles General topic (id=1)", () => {
+    cacheTopicName(-1003856094222, 1, "General");
+    expect(buildTelegramGroupPeerId(-1003856094222, 1)).toBe("-1003856094222:topic:1-general");
+  });
+});
 
 describe("resolveTelegramForumThreadId", () => {
   it("returns undefined for non-forum groups even with messageThreadId", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -70,8 +70,36 @@ export function resolveTelegramStreamMode(telegramCfg?: {
   return "partial";
 }
 
-export function buildTelegramGroupPeerId(chatId: number | string, messageThreadId?: number) {
-  return messageThreadId != null ? `${chatId}:topic:${messageThreadId}` : String(chatId);
+import { getCachedTopicName, slugifyTopicName } from "../topic-cache.js";
+
+/**
+ * Build a peer ID for Telegram group/topic.
+ *
+ * If topicName is provided (or cached), appends a slugified version for readability:
+ * - Without topic name: "-1003856094222:topic:49"
+ * - With topic name: "-1003856094222:topic:49-telegram-ops"
+ *
+ * The topic ID remains the canonical identifier; the name is purely cosmetic.
+ */
+export function buildTelegramGroupPeerId(
+  chatId: number | string,
+  messageThreadId?: number,
+  topicName?: string,
+) {
+  if (messageThreadId == null) {
+    return String(chatId);
+  }
+
+  // Try to use provided name, or look up cached name
+  const name = topicName ?? getCachedTopicName(chatId, messageThreadId);
+  if (name) {
+    const slug = slugifyTopicName(name);
+    if (slug) {
+      return `${chatId}:topic:${messageThreadId}-${slug}`;
+    }
+  }
+
+  return `${chatId}:topic:${messageThreadId}`;
 }
 
 export function buildTelegramGroupFrom(chatId: number | string, messageThreadId?: number) {

--- a/src/telegram/topic-cache.test.ts
+++ b/src/telegram/topic-cache.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cacheTopicName,
+  clearTopicCache,
+  getCachedTopicName,
+  getTopicCacheSize,
+  slugifyTopicName,
+} from "./topic-cache.js";
+
+describe("topic-cache", () => {
+  afterEach(() => {
+    clearTopicCache();
+  });
+
+  describe("cacheTopicName", () => {
+    it("stores topic name by chat and topic ID", () => {
+      cacheTopicName(-1003856094222, 49, "Telegram Ops");
+      expect(getCachedTopicName(-1003856094222, 49)).toBe("Telegram Ops");
+    });
+
+    it("accepts string chat IDs", () => {
+      cacheTopicName("-1003856094222", 49, "Telegram Ops");
+      expect(getCachedTopicName("-1003856094222", 49)).toBe("Telegram Ops");
+    });
+
+    it("overwrites existing entries", () => {
+      cacheTopicName(-100123, 1, "Original Name");
+      cacheTopicName(-100123, 1, "Updated Name");
+      expect(getCachedTopicName(-100123, 1)).toBe("Updated Name");
+    });
+
+    it("stores multiple topics for the same chat", () => {
+      cacheTopicName(-100123, 1, "General");
+      cacheTopicName(-100123, 2, "Random");
+      cacheTopicName(-100123, 3, "Announcements");
+
+      expect(getCachedTopicName(-100123, 1)).toBe("General");
+      expect(getCachedTopicName(-100123, 2)).toBe("Random");
+      expect(getCachedTopicName(-100123, 3)).toBe("Announcements");
+    });
+
+    it("stores topics across different chats", () => {
+      cacheTopicName(-100123, 1, "Chat A Topic");
+      cacheTopicName(-100456, 1, "Chat B Topic");
+
+      expect(getCachedTopicName(-100123, 1)).toBe("Chat A Topic");
+      expect(getCachedTopicName(-100456, 1)).toBe("Chat B Topic");
+    });
+  });
+
+  describe("getCachedTopicName", () => {
+    it("returns undefined for unknown topics", () => {
+      expect(getCachedTopicName(-100123, 99)).toBeUndefined();
+    });
+
+    it("returns undefined for unknown chats", () => {
+      cacheTopicName(-100123, 1, "Known Topic");
+      expect(getCachedTopicName(-100999, 1)).toBeUndefined();
+    });
+
+    it("returns cached name after caching", () => {
+      cacheTopicName(-100123, 42, "My Topic");
+      expect(getCachedTopicName(-100123, 42)).toBe("My Topic");
+    });
+
+    it("handles numeric string chat ID matching", () => {
+      cacheTopicName(-100123, 1, "Test");
+      // String and number should use the same cache key format
+      expect(getCachedTopicName("-100123", 1)).toBe("Test");
+    });
+  });
+
+  describe("slugifyTopicName", () => {
+    it("converts to lowercase", () => {
+      expect(slugifyTopicName("UPPERCASE")).toBe("uppercase");
+      expect(slugifyTopicName("MixedCase")).toBe("mixedcase");
+    });
+
+    it("replaces spaces with dashes", () => {
+      expect(slugifyTopicName("hello world")).toBe("hello-world");
+      expect(slugifyTopicName("multiple   spaces")).toBe("multiple-spaces");
+    });
+
+    it("replaces underscores with dashes", () => {
+      expect(slugifyTopicName("hello_world")).toBe("hello-world");
+      expect(slugifyTopicName("multiple___underscores")).toBe("multiple-underscores");
+    });
+
+    it("removes special characters", () => {
+      expect(slugifyTopicName("hello!")).toBe("hello");
+      expect(slugifyTopicName("test@#$%")).toBe("test");
+      expect(slugifyTopicName("what's up?")).toBe("whats-up");
+    });
+
+    it("preserves numbers", () => {
+      expect(slugifyTopicName("test123")).toBe("test123");
+      expect(slugifyTopicName("topic 42")).toBe("topic-42");
+    });
+
+    it("collapses multiple dashes", () => {
+      expect(slugifyTopicName("hello---world")).toBe("hello-world");
+      expect(slugifyTopicName("a - b - c")).toBe("a-b-c");
+    });
+
+    it("trims leading and trailing dashes", () => {
+      expect(slugifyTopicName("-hello-")).toBe("hello");
+      expect(slugifyTopicName("---test---")).toBe("test");
+      expect(slugifyTopicName("  spaced  ")).toBe("spaced");
+    });
+
+    it("handles emoji and unicode", () => {
+      expect(slugifyTopicName("🎉 Party")).toBe("party");
+      expect(slugifyTopicName("Café Discussion")).toBe("caf-discussion");
+    });
+
+    it("truncates long names to max 50 characters", () => {
+      const longName =
+        "this is a very long topic name that should be truncated to fit within the limit";
+      const result = slugifyTopicName(longName);
+      expect(result.length).toBeLessThanOrEqual(50);
+      expect(result.endsWith("-")).toBe(false);
+    });
+
+    it("truncates at word boundary when possible", () => {
+      // 51+ chars: "this-is-a-really-long-topic-name-that-exceeds-limit-x"
+      const longName = "this is a really long topic name that exceeds limit x";
+      const result = slugifyTopicName(longName);
+      expect(result.length).toBeLessThanOrEqual(50);
+      // Should end at a word boundary (no partial words)
+      expect(result.endsWith("-")).toBe(false);
+    });
+
+    it("handles real-world topic names", () => {
+      expect(slugifyTopicName("Telegram Ops")).toBe("telegram-ops");
+      expect(slugifyTopicName("General Discussion")).toBe("general-discussion");
+      expect(slugifyTopicName("🔔 Announcements")).toBe("announcements");
+      expect(slugifyTopicName("Q&A / Support")).toBe("qa-support");
+      expect(slugifyTopicName("Off-Topic Chat")).toBe("off-topic-chat");
+    });
+
+    it("returns empty string for names with only special characters", () => {
+      expect(slugifyTopicName("🎉🎊🎁")).toBe("");
+      expect(slugifyTopicName("!!!")).toBe("");
+      expect(slugifyTopicName("   ")).toBe("");
+    });
+  });
+
+  describe("clearTopicCache", () => {
+    it("removes all cached entries", () => {
+      cacheTopicName(-100123, 1, "Topic A");
+      cacheTopicName(-100123, 2, "Topic B");
+      cacheTopicName(-100456, 1, "Topic C");
+
+      expect(getTopicCacheSize()).toBe(3);
+
+      clearTopicCache();
+
+      expect(getTopicCacheSize()).toBe(0);
+      expect(getCachedTopicName(-100123, 1)).toBeUndefined();
+      expect(getCachedTopicName(-100123, 2)).toBeUndefined();
+      expect(getCachedTopicName(-100456, 1)).toBeUndefined();
+    });
+  });
+
+  describe("getTopicCacheSize", () => {
+    it("returns 0 when cache is empty", () => {
+      expect(getTopicCacheSize()).toBe(0);
+    });
+
+    it("returns correct count after adding entries", () => {
+      cacheTopicName(-100123, 1, "Topic 1");
+      expect(getTopicCacheSize()).toBe(1);
+
+      cacheTopicName(-100123, 2, "Topic 2");
+      expect(getTopicCacheSize()).toBe(2);
+
+      cacheTopicName(-100456, 1, "Topic 3");
+      expect(getTopicCacheSize()).toBe(3);
+    });
+
+    it("does not double-count updates to existing entries", () => {
+      cacheTopicName(-100123, 1, "Original");
+      cacheTopicName(-100123, 1, "Updated");
+      expect(getTopicCacheSize()).toBe(1);
+    });
+  });
+});

--- a/src/telegram/topic-cache.ts
+++ b/src/telegram/topic-cache.ts
@@ -1,0 +1,99 @@
+/**
+ * Topic Name Cache for Telegram Forum Topics
+ *
+ * Stores topic names from forum_topic_created and forum_topic_edited events
+ * for use in building human-readable session keys.
+ *
+ * This is a simple in-memory cache that doesn't need persistence -
+ * topic names are refreshed from service messages as they occur.
+ */
+
+const MAX_SLUG_LENGTH = 50;
+
+/**
+ * In-memory cache for topic names.
+ * Key format: `${chatId}:${topicId}`
+ * Value: topic name (original, not slugified)
+ */
+const topicNameCache = new Map<string, string>();
+
+/**
+ * Build the cache key for a topic.
+ */
+function buildCacheKey(chatId: number | string, topicId: number): string {
+  return `${chatId}:${topicId}`;
+}
+
+/**
+ * Cache a topic name for a given chat and topic ID.
+ */
+export function cacheTopicName(chatId: number | string, topicId: number, name: string): void {
+  const key = buildCacheKey(chatId, topicId);
+  topicNameCache.set(key, name);
+}
+
+/**
+ * Retrieve a cached topic name for a given chat and topic ID.
+ * Returns undefined if not cached.
+ */
+export function getCachedTopicName(chatId: number | string, topicId: number): string | undefined {
+  const key = buildCacheKey(chatId, topicId);
+  return topicNameCache.get(key);
+}
+
+/**
+ * Convert a topic name to a URL-safe slug suitable for session keys.
+ *
+ * Rules:
+ * - Lowercase
+ * - Replace spaces and underscores with dashes
+ * - Remove non-alphanumeric characters (except dashes)
+ * - Collapse multiple dashes
+ * - Trim leading/trailing dashes
+ * - Truncate to MAX_SLUG_LENGTH characters
+ *
+ * Examples:
+ * - "Telegram Ops" -> "telegram-ops"
+ * - "General Discussion!" -> "general-discussion"
+ * - "Test_Topic__123" -> "test-topic-123"
+ */
+export function slugifyTopicName(name: string): string {
+  let slug = name
+    .toLowerCase()
+    // Replace spaces and underscores with dashes
+    .replace(/[\s_]+/g, "-")
+    // Remove non-alphanumeric characters except dashes
+    .replace(/[^a-z0-9-]/g, "")
+    // Collapse multiple dashes
+    .replace(/-+/g, "-")
+    // Trim leading/trailing dashes
+    .replace(/^-+|-+$/g, "");
+
+  // Truncate to max length, avoiding cutting in the middle of a word
+  if (slug.length > MAX_SLUG_LENGTH) {
+    slug = slug.slice(0, MAX_SLUG_LENGTH);
+    // If we cut in the middle, trim to the last dash
+    const lastDash = slug.lastIndexOf("-");
+    if (lastDash > MAX_SLUG_LENGTH / 2) {
+      slug = slug.slice(0, lastDash);
+    }
+    // Trim trailing dash if truncation left one
+    slug = slug.replace(/-+$/, "");
+  }
+
+  return slug;
+}
+
+/**
+ * Clear all cached topic names (primarily for testing).
+ */
+export function clearTopicCache(): void {
+  topicNameCache.clear();
+}
+
+/**
+ * Get the number of cached topic names (primarily for testing/debugging).
+ */
+export function getTopicCacheSize(): number {
+  return topicNameCache.size;
+}


### PR DESCRIPTION
## Summary

Makes Telegram forum topic session keys more human-readable by appending slugified topic names.

**Before:**
```
agent:main:telegram:group:-1003856094222:topic:49
```

**After:**
```
agent:main:telegram:group:-1003856094222:topic:49-telegram-ops
```

## Implementation

1. **New file: `src/telegram/topic-cache.ts`**
   - In-memory cache for topic ID → name mapping
   - `cacheTopicName(chatId, topicId, name)` - store a topic name
   - `getCachedTopicName(chatId, topicId)` - retrieve cached name
   - `slugifyTopicName(name)` - convert to URL-safe slug (lowercase, dashes, max 50 chars)

2. **Updated `src/telegram/bot-handlers.ts`**
   - Captures `forum_topic_created` service messages
   - Captures `forum_topic_edited` service messages
   - Caches topic names when these events occur

3. **Updated `src/telegram/bot/helpers.ts`**
   - `buildTelegramGroupPeerId()` now accepts optional `topicName` parameter
   - Appends slugified name to topic ID when available
   - Falls back to ID-only format if no cached name exists (backward compatible)

4. **Tests**
   - Added `src/telegram/topic-cache.test.ts` with comprehensive tests
   - Added tests for `buildTelegramGroupPeerId` with topic names

## Key Design Decisions

- **Topic ID remains canonical** - the ID is always present and is the primary identifier
- **Names are cosmetic** - stale/outdated names don't break anything
- **Backward compatible** - if no name is cached, falls back to current format
- **Slugified names** - max 50 chars, lowercase, spaces → dashes, special chars removed

## Testing

All new tests pass. Existing tests unaffected.