### PR TITLE
feat(web-search): add Tavily search provider support

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "tavily"). */
+      provider?: "brave" | "perplexity" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -354,6 +354,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "perplexity/sonar-pro"). */
         model?: string;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
+        apiKey?: string;
+        /** Search depth: "basic" for faster results, "advanced" for more comprehensive search (default: "basic"). */
+        searchDepth?: "basic" | "advanced";
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,7 +170,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("tavily")]).optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -180,6 +180,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: z.string().optional(),
+        searchDepth: z.union([z.literal("basic"), z.literal("advanced")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
Add Tavily as a new web search provider option.

## Changes
- Add tavily to supported search providers
- Support TAVILY_API_KEY environment variable
- Add searchDepth option (basic/advanced)
- Update TypeScript types and Zod schema

## Configuration
See PR description for usage examples.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Tavily as a third `web_search` provider alongside Brave and Perplexity. This includes new config/types (`tools.web.search.provider: "tavily"`, `tools.web.search.tavily.*`), runtime config validation via Zod, and a new Tavily request path in `src/agents/tools/web-search.ts` that calls Tavily’s `/search` endpoint, supports `searchDepth`, and returns `{answer, results}` with caching.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a couple of user-facing behavioral inconsistencies worth addressing.
- Changes are localized and follow existing patterns for provider selection, request execution, and caching. The main concerns are config/key resolution consistency for Tavily and the tool schema exposing provider-specific parameters that are silently ignored for non-Brave providers.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->