### PR TITLE
feat(web-search): add Brave Search API base URL override

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -78,9 +78,7 @@ describe("web_search brave baseUrl resolution", () => {
   });
 
   it("uses config baseUrl when set", () => {
-    expect(resolveBraveBaseUrl({ baseUrl: "http://localhost:3015" })).toBe(
-      "http://localhost:3015",
-    );
+    expect(resolveBraveBaseUrl({ baseUrl: "http://localhost:3015" })).toBe("http://localhost:3015");
   });
 
   it("strips trailing slashes from config baseUrl", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -159,10 +159,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
 }
 
 function resolveBraveBaseUrl(search?: WebSearchConfig): string | undefined {
-  const fromConfig =
-    search && typeof search === "object" && "baseUrl" in search
-      ? (search.baseUrl as string | undefined)
-      : undefined;
+  const raw =
+    search && typeof search === "object" && "baseUrl" in search ? search.baseUrl : undefined;
+  const fromConfig = typeof raw === "string" ? raw.trim() : "";
   if (fromConfig) return fromConfig.replace(/\/+$/, "");
   const fromEnv = (process.env.BRAVE_API_URL ?? "").trim();
   if (fromEnv) return fromEnv.replace(/\/+$/, "");

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -162,9 +162,13 @@ function resolveBraveBaseUrl(search?: WebSearchConfig): string | undefined {
   const raw =
     search && typeof search === "object" && "baseUrl" in search ? search.baseUrl : undefined;
   const fromConfig = typeof raw === "string" ? raw.trim() : "";
-  if (fromConfig) return fromConfig.replace(/\/+$/, "");
+  if (fromConfig) {
+    return fromConfig.replace(/\/+$/, "");
+  }
   const fromEnv = (process.env.BRAVE_API_URL ?? "").trim();
-  if (fromEnv) return fromEnv.replace(/\/+$/, "");
+  if (fromEnv) {
+    return fromEnv.replace(/\/+$/, "");
+  }
   return undefined;
 }
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -20,7 +20,8 @@ const SEARCH_PROVIDERS = ["brave", "perplexity"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+const DEFAULT_BRAVE_BASE_URL = "https://api.search.brave.com";
+const BRAVE_SEARCH_PATH = "/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
@@ -155,6 +156,17 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
     return "brave";
   }
   return "brave";
+}
+
+function resolveBraveBaseUrl(search?: WebSearchConfig): string | undefined {
+  const fromConfig =
+    search && typeof search === "object" && "baseUrl" in search
+      ? (search.baseUrl as string | undefined)
+      : undefined;
+  if (fromConfig) return fromConfig.replace(/\/+$/, "");
+  const fromEnv = (process.env.BRAVE_API_URL ?? "").trim();
+  if (fromEnv) return fromEnv.replace(/\/+$/, "");
+  return undefined;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -360,6 +372,7 @@ async function runWebSearch(params: {
   search_lang?: string;
   ui_lang?: string;
   freshness?: string;
+  braveBaseUrl?: string;
   perplexityBaseUrl?: string;
   perplexityModel?: string;
 }): Promise<Record<string, unknown>> {
@@ -400,7 +413,8 @@ async function runWebSearch(params: {
     throw new Error("Unsupported web search provider.");
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const braveBase = (params.braveBaseUrl || "").replace(/\/+$/, "") || DEFAULT_BRAVE_BASE_URL;
+  const url = new URL(`${braveBase}${BRAVE_SEARCH_PATH}`);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -517,6 +531,7 @@ export function createWebSearchTool(options?: {
         search_lang,
         ui_lang,
         freshness,
+        braveBaseUrl: resolveBraveBaseUrl(search),
         perplexityBaseUrl: resolvePerplexityBaseUrl(
           perplexityConfig,
           perplexityAuth?.source,
@@ -532,5 +547,6 @@ export function createWebSearchTool(options?: {
 export const __testing = {
   inferPerplexityBaseUrlFromApiKey,
   resolvePerplexityBaseUrl,
+  resolveBraveBaseUrl,
   normalizeFreshness,
 } as const;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -190,6 +190,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.enabled": "Enable Web Search Tool",
   "tools.web.search.provider": "Web Search Provider",
   "tools.web.search.apiKey": "Brave Search API Key",
+  "tools.web.search.baseUrl": "Brave Search Base URL",
   "tools.web.search.maxResults": "Web Search Max Results",
   "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
   "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
@@ -439,6 +440,8 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
+  "tools.web.search.baseUrl":
+    "Brave Search API base URL override (default: https://api.search.brave.com). Useful for self-hosted proxies (e.g., SearXNG adapters). Fallback: BRAVE_API_URL env var.",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -340,6 +340,8 @@ export type ToolsConfig = {
       provider?: "brave" | "perplexity";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
+      /** Brave Search API base URL override (default: https://api.search.brave.com). Useful for self-hosted proxies like SearXNG adapters. */
+      baseUrl?: string;
       /** Default search results count (1-10). */
       maxResults?: number;
       /** Timeout in seconds for search requests. */


### PR DESCRIPTION
## Summary

Adds `tools.web.search.baseUrl` config option and `BRAVE_API_URL` env var to allow overriding the Brave Search API endpoint.

## Motivation

This enables self-hosted search proxies that implement the Brave API format — for example, a SearXNG adapter that translates Brave API requests to SearXNG. Consuming applications (like OpenClaw itself) need zero code changes; they just point the base URL at the proxy.

## Changes

- **`src/agents/tools/web-search.ts`** — Added `resolveBraveBaseUrl()` function that checks config → env var → default. Split hardcoded endpoint into base URL + path.
- **`src/config/types.tools.ts`** — Added `baseUrl?: string` to web search config type.
- **`src/config/schema.ts`** — Added title and description for `tools.web.search.baseUrl`.
- **`src/agents/tools/web-search.test.ts`** — Added 5 tests for base URL resolution (config, env, precedence, trailing slash handling).

## Config

```json
{
  "tools": {
    "web": {
      "search": {
        "baseUrl": "http://localhost:3015"
      }
    }
  }
}
```

Or via env var:
```bash
BRAVE_API_URL=http://localhost:3015
```

Precedence: config `baseUrl` > `BRAVE_API_URL` env > default (`https://api.search.brave.com`).

This mirrors the existing `perplexity.baseUrl` pattern.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable Brave Search API base URL override for the `web_search` tool. The Brave endpoint is split into a default base (`https://api.search.brave.com`) plus a fixed path, and `resolveBraveBaseUrl()` selects the base URL from config (`tools.web.search.baseUrl`) or `BRAVE_API_URL` env var before falling back to the default.

It also updates the config type and UI schema hints, and adds unit tests covering the base URL resolution and trailing-slash normalization. This fits the existing pattern used for Perplexity’s `baseUrl` selection in the same tool module.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the behavior change is isolated and well-tested, with a small edge-case type issue in config handling.
- Most changes are straightforward (URL composition + config/env precedence) and include targeted tests. The main concern is `resolveBraveBaseUrl()` not type-checking `search.baseUrl`, which can throw if config contains a non-string truthy value; otherwise impact is low.
- src/agents/tools/web-search.ts (config value normalization)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->