### PR TITLE
fix: preserve iMessage accountId across config-triggered restarts

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -92,6 +92,7 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
         sessionKey,
         to: resolved.to,
         channel,
+        accountId: origin?.accountId,
         deliver: true,
         bestEffortDeliver: true,
         messageChannel: channel,


### PR DESCRIPTION
## Summary

- Pass `accountId` from delivery context to `agentCommand` in restart sentinel wake
- Fixes issue where messages sent after config-triggered gateway restarts were routed through the wrong iMessage account (defaulting to personal instead of configured bot account)

## Testing

- Tested locally by triggering config changes via agent and verifying restart notification messages land in the correct iMessage account
- All existing tests pass (`pnpm test`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR preserves the configured iMessage `accountId` when the gateway wakes from a restart sentinel by passing the resolved delivery context’s `accountId` through to `agentCommand`. Without this, the post-restart notification could be delivered via a default (personal) iMessage account instead of the intended bot account.

Changes are localized to the restart-sentinel wake path (`src/gateway/server-restart-sentinel.ts`), aligning it with other announcement flows (e.g., subagent announce) that already forward `accountId` alongside `channel` and `to`. A changelog entry records the fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line propagation of an existing optional field (`accountId`) through an established command path, and it matches patterns used elsewhere in the gateway for outbound delivery context. No behavioral changes occur unless multi-account routing is in use, where this fixes incorrect account selection.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->