### PR TITLE
fix(ui): handle assistant stream events to display full responses in control UI

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -190,6 +190,36 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+
+  // Handle assistant stream events
+  if (payload.stream === "assistant") {
+    const data = payload.data ?? {};
+    const text = data.text;
+
+    if (typeof text === 'string' && text.length > 0) {
+      const appHost = host as unknown as {
+        chatStream: string | null;
+        chatStreamStartedAt: number | null;
+        chatRunId: string | null;
+        requestUpdate?: () => void;
+      };
+
+      if (!appHost.chatRunId) {
+        appHost.chatRunId = payload.runId;
+      }
+
+      if (payload.runId === appHost.chatRunId) {
+        appHost.chatStream = text;
+        if (!appHost.chatStreamStartedAt) {
+          appHost.chatStreamStartedAt = payload.ts;
+        }
+      
+      }
+    }
+    return;
+  }
+
+
   if (payload.stream !== "tool") return;
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
   if (sessionKey && sessionKey !== host.sessionKey) return;

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -190,13 +190,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
-
   // Handle assistant stream events
   if (payload.stream === "assistant") {
     const data = payload.data ?? {};
     const text = data.text;
 
-    if (typeof text === 'string' && text.length > 0) {
+    if (typeof text === "string" && text.length > 0) {
       const appHost = host as unknown as {
         chatStream: string | null;
         chatStreamStartedAt: number | null;
@@ -213,12 +212,10 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
         if (!appHost.chatStreamStartedAt) {
           appHost.chatStreamStartedAt = payload.ts;
         }
-      
       }
     }
     return;
   }
-
 
   if (payload.stream !== "tool") return;
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;


### PR DESCRIPTION
## Summary

Fixed an issue where the assistant's response in the control UI only displayed a truncated message until the page was refreshed, despite the WebSocket successfully receiving the complete response.

## Problem

When sending a message in the control UI:
- ❌ Assistant responses only showed short, truncated messages
- ❌ Full content only appeared after page refresh
- ✅ WebSocket was receiving complete response content via `assistant` stream events
- ❌ UI was not updating in real-time

## Root Cause

The `handleAgentEvent` function in `app-tool-stream.ts` only handled `tool` and `compaction` stream events. Assistant response text sent via `assistant` stream events was **ignored**, leaving the `chatStream` state unchanged.

Since `chatStream` is a `@state()` property in the Lit element (`app.ts:121`), changes trigger UI re-renders. Without handling assistant stream events, `chatStream` remained `null` or showed only initial truncated content.

## Solution

Added a new handler for `assistant` stream events in `handleAgentEvent` that:

1. **Extracts** text content from the payload data
2. **Updates** `appHost.chatStream` with the full text content  
3. **Tracks** stream start time via `chatStreamStartedAt`
4. **Validates** `runId` matches the current chat session

The `chatStream` property is already wired into the UI rendering pipeline via `app-lifecycle.ts:72`, which triggers chat scroll updates when `chatStream` changes. This ensures the full assistant response displays in real-time as it streams via WebSocket.

## Technical Details

- Uses type casting to access `chatStream` properties on the host object
- Properly handles `null`/`undefined` values to satisfy TypeScript strict checks
- Maintains consistency with existing tool stream event handling patterns
- No changes needed to WebSocket connection or message receiving logic

## Testing

- [x] Verified assistant responses now display in real-time
- [x] Confirmed no page refresh required to see full content
- [x] Validated WebSocket stream events are properly handled

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds handling for `assistant` stream events in `ui/src/ui/app-tool-stream.ts` so the control UI updates `chatStream` during streaming, fixing previously truncated assistant responses that only resolved after refresh. The change hooks into the existing Lit state-driven render/scroll pipeline by mutating host state when assistant text arrives.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but has a couple of run/session-correlation edge cases that could cause incorrect UI updates in multi-session scenarios.
- The change is small and localized, but the new `assistant` stream handler sets/uses `chatRunId` without the same session gating used for `tool` events, which can allow stale or other-session assistant events to overwrite the active UI state. Also, it assumes a `data.text` payload shape and may drop other formats silently.
- ui/src/ui/app-tool-stream.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->