### PR TITLE
Control UI: daily activity dashboard

### DIFF
--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -71,6 +71,7 @@ const BASE_METHODS = [
   "cron.remove",
   "cron.run",
   "cron.runs",
+  "security.audit",
   "system-presence",
   "system-event",
   "send",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -14,6 +14,7 @@ import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
+import { securityHandlers } from "./server-methods/security.js";
 import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
@@ -69,6 +70,7 @@ const READ_METHODS = new Set([
   "cron.runs",
   "system-presence",
   "last-heartbeat",
+  "security.audit",
   "node.list",
   "node.describe",
   "chat.history",
@@ -181,6 +183,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...updateHandlers,
   ...nodeHandlers,
   ...sendHandlers,
+  ...securityHandlers,
   ...usageHandlers,
   ...agentHandlers,
   ...agentsHandlers,

--- a/src/gateway/server-methods/security.ts
+++ b/src/gateway/server-methods/security.ts
@@ -1,0 +1,25 @@
+import type { GatewayRequestHandlers } from "./types.js";
+import { loadConfig } from "../../config/config.js";
+import { runSecurityAudit } from "../../security/audit.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+
+/**
+ * Runs a shallow security audit (config + channel security, no filesystem or deep probe)
+ * for the Activity dashboard. Returns findings for UI display.
+ */
+export const securityHandlers: GatewayRequestHandlers = {
+  "security.audit": async ({ respond }) => {
+    try {
+      const config = loadConfig();
+      const report = await runSecurityAudit({
+        config,
+        deep: false,
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+      });
+      respond(true, { ok: true, findings: report.findings, summary: report.summary }, undefined);
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+    }
+  },
+};

--- a/src/gateway/server-methods/security.ts
+++ b/src/gateway/server-methods/security.ts
@@ -1,25 +1,62 @@
+import type { SecurityAuditReport } from "../../security/audit.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { loadConfig } from "../../config/config.js";
 import { runSecurityAudit } from "../../security/audit.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 
+const SECURITY_AUDIT_CACHE_TTL_MS = 60_000;
+
+type SecurityAuditCacheEntry = {
+  report?: SecurityAuditReport;
+  updatedAt?: number;
+  inFlight?: Promise<SecurityAuditReport>;
+};
+
+const securityAuditCache: SecurityAuditCacheEntry = {};
+
+async function runSecurityAuditCached(): Promise<SecurityAuditReport> {
+  const now = Date.now();
+  if (
+    securityAuditCache.report &&
+    securityAuditCache.updatedAt &&
+    now - securityAuditCache.updatedAt < SECURITY_AUDIT_CACHE_TTL_MS
+  ) {
+    return securityAuditCache.report;
+  }
+  if (securityAuditCache.inFlight) {
+    return securityAuditCache.inFlight;
+  }
+  const config = loadConfig();
+  const inFlight = runSecurityAudit({
+    config,
+    deep: false,
+    includeFilesystem: false,
+    includeChannelSecurity: true,
+  })
+    .then((report) => {
+      securityAuditCache.report = report;
+      securityAuditCache.updatedAt = Date.now();
+      return report;
+    })
+    .finally(() => {
+      securityAuditCache.inFlight = undefined;
+    });
+  securityAuditCache.inFlight = inFlight;
+  return inFlight;
+}
+
 /**
  * Runs a shallow security audit (config + channel security, no filesystem or deep probe)
- * for the Activity dashboard. Returns findings for UI display.
+ * for the Activity dashboard. Returns findings for UI display. Cached for 60s to reduce load.
  */
 export const securityHandlers: GatewayRequestHandlers = {
-  "security.audit": async ({ respond }) => {
+  "security.audit": async ({ respond, context }) => {
     try {
-      const config = loadConfig();
-      const report = await runSecurityAudit({
-        config,
-        deep: false,
-        includeFilesystem: false,
-        includeChannelSecurity: true,
-      });
+      const report = await runSecurityAuditCached();
       respond(true, { ok: true, findings: report.findings, summary: report.summary }, undefined);
     } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+      context.logGateway?.warn?.(`security.audit failed: ${String(err)}`);
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "Security audit failed"));
     }
   },
 };

--- a/src/logging/pii-patterns.test.ts
+++ b/src/logging/pii-patterns.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PII_ENTITIES,
+  PII_ENTITY_KEYS,
+  detectPiiInText,
+  getPiiPatternsForEntities,
+  redactPiiInText,
+} from "./pii-patterns.js";
+
+describe("pii-patterns", () => {
+  describe("PII_ENTITY_KEYS", () => {
+    it("includes expected entity keys", () => {
+      expect(PII_ENTITY_KEYS).toContain("credit_card");
+      expect(PII_ENTITY_KEYS).toContain("ssn");
+      expect(PII_ENTITY_KEYS).toContain("email");
+      expect(PII_ENTITY_KEYS).toContain("phone_number");
+    });
+  });
+
+  describe("getPiiPatternsForEntities", () => {
+    it("returns patterns for valid entity keys", () => {
+      const patterns = getPiiPatternsForEntities(["ssn", "email"]);
+      expect(patterns.length).toBeGreaterThan(0);
+    });
+
+    it("returns empty for empty input", () => {
+      expect(getPiiPatternsForEntities([])).toEqual([]);
+    });
+
+    it("ignores unknown entity keys", () => {
+      const patterns = getPiiPatternsForEntities(["ssn", "unknown_key", "email"]);
+      expect(patterns.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("detectPiiInText", () => {
+    it("detects SSN with dashes", () => {
+      const detected = detectPiiInText("My SSN is 123-45-6789.", ["ssn"]);
+      expect(detected).toContain("ssn");
+    });
+
+    it("detects email", () => {
+      const detected = detectPiiInText("Contact me at user@example.com", ["email"]);
+      expect(detected).toContain("email");
+    });
+
+    it("detects credit card pattern", () => {
+      const detected = detectPiiInText("Card: 4111 1111 1111 1111", ["credit_card"]);
+      expect(detected).toContain("credit_card");
+    });
+
+    it("returns empty for benign text", () => {
+      const detected = detectPiiInText(
+        "Hi, can you help me schedule a meeting for tomorrow?",
+        DEFAULT_PII_ENTITIES,
+      );
+      expect(detected).toEqual([]);
+    });
+
+    it("returns empty for empty text or entities", () => {
+      expect(detectPiiInText("", ["ssn"])).toEqual([]);
+      expect(detectPiiInText("123-45-6789", [])).toEqual([]);
+    });
+  });
+
+  describe("redactPiiInText", () => {
+    it("replaces SSN with placeholder", () => {
+      const out = redactPiiInText("My SSN is 123-45-6789.", ["ssn"]);
+      expect(out).not.toContain("123-45-6789");
+      expect(out).toContain("[REDACTED]");
+    });
+
+    it("replaces email with placeholder", () => {
+      const out = redactPiiInText("Contact user@example.com for help.", ["email"]);
+      expect(out).not.toContain("user@example.com");
+      expect(out).toContain("[REDACTED]");
+    });
+
+    it("replaces credit card with placeholder", () => {
+      const out = redactPiiInText("Card 4111-1111-1111-1111", ["credit_card"]);
+      expect(out).not.toContain("4111");
+      expect(out).toContain("[REDACTED]");
+    });
+
+    it("leaves benign text unchanged", () => {
+      const text = "Hi, can you help me schedule a meeting?";
+      const out = redactPiiInText(text, DEFAULT_PII_ENTITIES);
+      expect(out).toBe(text);
+    });
+
+    it("returns text unchanged for empty entities", () => {
+      const text = "SSN: 123-45-6789";
+      expect(redactPiiInText(text, [])).toBe(text);
+    });
+
+    it("returns text unchanged for empty text", () => {
+      expect(redactPiiInText("", ["ssn"])).toBe("");
+    });
+  });
+});

--- a/src/logging/pii-patterns.ts
+++ b/src/logging/pii-patterns.ts
@@ -1,0 +1,88 @@
+/**
+ * PII entity keys and regex patterns for detection and redaction.
+ * Used by config-driven redaction (logging, status) and ingestion redaction.
+ */
+
+export const PII_ENTITY_KEYS = ["credit_card", "ssn", "email", "phone_number"] as const;
+
+export type PiiEntityKey = (typeof PII_ENTITY_KEYS)[number];
+
+export const DEFAULT_PII_ENTITIES: PiiEntityKey[] = ["ssn", "email", "credit_card", "phone_number"];
+
+type PiiPatternEntry = { entity: PiiEntityKey; pattern: RegExp };
+
+const PII_PATTERNS: PiiPatternEntry[] = [
+  // SSN: 123-45-6789 or 123456789 (9 digits, optional dashes)
+  {
+    entity: "ssn",
+    pattern: /\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b/g,
+  },
+  // Email: local@domain
+  {
+    entity: "email",
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  },
+  // Credit card: 4 groups of 4 digits (with optional space or dash)
+  {
+    entity: "credit_card",
+    pattern: /\b(?:\d{4}[-\s]?){3}\d{4}\b/g,
+  },
+  // Phone: E.164-like or US-style with optional punctuation
+  {
+    entity: "phone_number",
+    pattern: /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g,
+  },
+];
+
+const PATTERNS_BY_ENTITY = new Map<PiiEntityKey, RegExp>(
+  PII_PATTERNS.map((e) => [e.entity, new RegExp(e.pattern.source, e.pattern.flags)]),
+);
+
+export function getPiiPatternsForEntities(entities: string[]): PiiPatternEntry[] {
+  const out: PiiPatternEntry[] = [];
+  const set = new Set(PII_ENTITY_KEYS);
+  for (const key of entities) {
+    if (set.has(key as PiiEntityKey)) {
+      const base = PATTERNS_BY_ENTITY.get(key as PiiEntityKey);
+      if (base) {
+        out.push({
+          entity: key as PiiEntityKey,
+          pattern: new RegExp(base.source, base.flags),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+export function detectPiiInText(text: string, entities: string[]): PiiEntityKey[] {
+  if (!text || entities.length === 0) {
+    return [];
+  }
+  const patterns = getPiiPatternsForEntities(entities);
+  const detected = new Set<PiiEntityKey>();
+  for (const { entity, pattern } of patterns) {
+    pattern.lastIndex = 0;
+    if (pattern.test(text)) {
+      detected.add(entity);
+    }
+  }
+  return [...detected];
+}
+
+const REDACT_PLACEHOLDER = "[REDACTED]";
+
+export function redactPiiInText(text: string, entities: string[]): string {
+  if (!text) {
+    return text;
+  }
+  if (entities.length === 0) {
+    return text;
+  }
+  const patterns = getPiiPatternsForEntities(entities);
+  let out = text;
+  for (const { pattern } of patterns) {
+    out = out.replace(pattern, REDACT_PLACEHOLDER);
+  }
+  return out;
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -22,6 +22,7 @@ import type { ChatQueueItem, CronFormState } from "./ui-types";
 import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { refreshChatAvatar } from "./app-chat";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers";
+import { loadActivity } from "./controllers/activity";
 import { loadChannels } from "./controllers/channels";
 import { loadChatHistory } from "./controllers/chat";
 import {
@@ -74,6 +75,7 @@ import {
   titleForTab,
   type Tab,
 } from "./navigation";
+import { renderActivity } from "./views/activity";
 import { renderChannels } from "./views/channels";
 import { renderChat } from "./views/chat";
 import { renderConfig } from "./views/config";
@@ -234,6 +236,25 @@ export function renderApp(state: AppViewState) {
                 },
                 onConnect: () => state.connect(),
                 onRefresh: () => state.loadOverview(),
+              })
+            : nothing
+        }
+
+        ${
+          state.tab === "activity"
+            ? renderActivity({
+                connected: state.connected,
+                loading: state.activityLoading,
+                usageResult: state.activityUsageResult,
+                days: state.activityDays,
+                sessionsResult: state.activitySessionsResult,
+                error: state.activityError,
+                securityFindings: state.activitySecurityFindings,
+                onDaysChange: (days) => {
+                  state.activityDays = days;
+                  void state.loadActivity(days);
+                },
+                onRefresh: () => state.loadActivity(),
               })
             : nothing
         }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -251,6 +251,7 @@ export function renderApp(state: AppViewState) {
                 error: state.activityError,
                 securityFindings: state.activitySecurityFindings,
                 onDaysChange: (days) => {
+                  state.activityDays = days;
                   void state.loadActivity(days);
                 },
                 onRefresh: () => state.loadActivity(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -251,7 +251,6 @@ export function renderApp(state: AppViewState) {
                 error: state.activityError,
                 securityFindings: state.activitySecurityFindings,
                 onDaysChange: (days) => {
-                  state.activityDays = days;
                   void state.loadActivity(days);
                 },
                 onRefresh: () => state.loadActivity(),

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -7,6 +7,7 @@ import {
   stopDebugPolling,
 } from "./app-polling";
 import { scheduleChatScroll, scheduleLogsScroll } from "./app-scroll";
+import { loadActivity } from "./controllers/activity";
 import { loadChannels } from "./controllers/channels";
 import { loadConfig, loadConfigSchema } from "./controllers/config";
 import { loadCronJobs, loadCronStatus } from "./controllers/cron";
@@ -151,6 +152,7 @@ export function setTheme(host: SettingsHost, next: ThemeMode, context?: ThemeTra
 
 export async function refreshActiveTab(host: SettingsHost) {
   if (host.tab === "overview") await loadOverview(host);
+  if (host.tab === "activity") await loadActivity(host as unknown as OpenClawApp);
   if (host.tab === "channels") await loadChannelsTab(host);
   if (host.tab === "instances") await loadPresence(host as unknown as OpenClawApp);
   if (host.tab === "sessions") await loadSessions(host as unknown as OpenClawApp);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -12,6 +12,7 @@ import type {
   AgentsListResult,
   ChannelsStatusSnapshot,
   ConfigSnapshot,
+  CostUsageSummary,
   CronJob,
   CronRunLogEntry,
   CronStatus,
@@ -111,6 +112,17 @@ export type AppViewState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  activityLoading: boolean;
+  activityUsageResult: CostUsageSummary | null;
+  activityDays: number;
+  activitySessionsResult: SessionsListResult | null;
+  activityError: string | null;
+  activitySecurityFindings: Array<{
+    checkId: string;
+    severity: string;
+    title: string;
+    detail: string;
+  }> | null;
   cronLoading: boolean;
   cronJobs: CronJob[];
   cronStatus: CronStatus | null;
@@ -149,6 +161,7 @@ export type AppViewState = {
   setTheme: (theme: ThemeMode, context?: ThemeTransitionContext) => void;
   applySettings: (next: UiSettings) => void;
   loadOverview: () => Promise<void>;
+  loadActivity: (days?: number) => Promise<void>;
   loadAssistantIdentity: () => Promise<void>;
   loadCron: () => Promise<void>;
   handleWhatsAppStart: (force: boolean) => Promise<void>;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -21,6 +21,7 @@ import type {
   LogLevel,
   NostrProfile,
   PresenceEntry,
+  SecurityFinding,
   SessionsListResult,
   SkillStatusReport,
   StatusSummary,
@@ -117,12 +118,7 @@ export type AppViewState = {
   activityDays: number;
   activitySessionsResult: SessionsListResult | null;
   activityError: string | null;
-  activitySecurityFindings: Array<{
-    checkId: string;
-    severity: string;
-    title: string;
-    detail: string;
-  }> | null;
+  activitySecurityFindings: SecurityFinding[] | null;
   cronLoading: boolean;
   cronJobs: CronJob[];
   cronStatus: CronStatus | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -11,6 +11,7 @@ import type {
   AgentsListResult,
   ConfigSnapshot,
   ConfigUiHints,
+  CostUsageSummary,
   CronJob,
   CronRunLogEntry,
   CronStatus,
@@ -71,6 +72,7 @@ import {
   type ToolStreamEntry,
 } from "./app-tool-stream";
 import { resolveInjectedAssistantIdentity } from "./assistant-identity";
+import { loadActivity as loadActivityInternal } from "./controllers/activity";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity";
 import { loadSettings, type UiSettings } from "./storage";
 import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types";
@@ -199,6 +201,18 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "120";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
+
+  @state() activityLoading = false;
+  @state() activityUsageResult: CostUsageSummary | null = null;
+  @state() activityDays = 7;
+  @state() activitySessionsResult: SessionsListResult | null = null;
+  @state() activityError: string | null = null;
+  @state() activitySecurityFindings: Array<{
+    checkId: string;
+    severity: string;
+    title: string;
+    detail: string;
+  }> | null = null;
 
   @state() cronLoading = false;
   @state() cronJobs: CronJob[] = [];
@@ -336,6 +350,12 @@ export class OpenClawApp extends LitElement {
 
   async loadCron() {
     await loadCronInternal(this as unknown as Parameters<typeof loadCronInternal>[0]);
+  }
+
+  async loadActivity(days?: number) {
+    await loadActivityInternal(this as unknown as Parameters<typeof loadActivityInternal>[0], {
+      days,
+    });
   }
 
   async handleAbortChat() {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -20,6 +20,7 @@ import type {
   LogLevel,
   PresenceEntry,
   ChannelsStatusSnapshot,
+  SecurityFinding,
   SessionsListResult,
   SkillStatusReport,
   StatusSummary,
@@ -207,12 +208,7 @@ export class OpenClawApp extends LitElement {
   @state() activityDays = 7;
   @state() activitySessionsResult: SessionsListResult | null = null;
   @state() activityError: string | null = null;
-  @state() activitySecurityFindings: Array<{
-    checkId: string;
-    severity: string;
-    title: string;
-    detail: string;
-  }> | null = null;
+  @state() activitySecurityFindings: SecurityFinding[] | null = null;
 
   @state() cronLoading = false;
   @state() cronJobs: CronJob[] = [];

--- a/ui/src/ui/controllers/activity.ts
+++ b/ui/src/ui/controllers/activity.ts
@@ -1,0 +1,62 @@
+import type { GatewayBrowserClient } from "../gateway";
+import type { CostUsageSummary, SessionsListResult } from "../types";
+
+export type ActivityState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  activityLoading: boolean;
+  activityUsageResult: CostUsageSummary | null;
+  activityDays: number;
+  activitySessionsResult: SessionsListResult | null;
+  activityError: string | null;
+  activitySecurityFindings: Array<{
+    checkId: string;
+    severity: string;
+    title: string;
+    detail: string;
+  }> | null;
+};
+
+export async function loadActivity(state: ActivityState, overrides?: { days?: number }) {
+  if (!state.client || !state.connected) return;
+  if (state.activityLoading) return;
+  state.activityLoading = true;
+  state.activityError = null;
+  const days = overrides?.days ?? state.activityDays;
+  const effectiveDays = Math.max(1, Math.min(90, days));
+  try {
+    const [usageRes, sessionsRes] = await Promise.all([
+      state.client.request("usage.cost", { days: effectiveDays }) as Promise<
+        CostUsageSummary | undefined
+      >,
+      state.client.request("sessions.list", {
+        includeGlobal: true,
+        includeUnknown: false,
+        limit: 200,
+      }) as Promise<SessionsListResult | undefined>,
+    ]);
+    if (usageRes) state.activityUsageResult = usageRes;
+    if (sessionsRes) state.activitySessionsResult = sessionsRes;
+    state.activityDays = effectiveDays;
+    // security.audit: call if available (may not exist yet)
+    try {
+      const auditRes = (await state.client.request("security.audit", {})) as
+        | {
+            ok: boolean;
+            findings?: Array<{ checkId: string; severity: string; title: string; detail: string }>;
+          }
+        | undefined;
+      if (auditRes?.ok && Array.isArray(auditRes.findings)) {
+        state.activitySecurityFindings = auditRes.findings;
+      } else {
+        state.activitySecurityFindings = null;
+      }
+    } catch {
+      state.activitySecurityFindings = null;
+    }
+  } catch (err) {
+    state.activityError = String(err);
+  } finally {
+    state.activityLoading = false;
+  }
+}

--- a/ui/src/ui/controllers/activity.ts
+++ b/ui/src/ui/controllers/activity.ts
@@ -1,5 +1,5 @@
 import type { GatewayBrowserClient } from "../gateway";
-import type { CostUsageSummary, SessionsListResult } from "../types";
+import type { CostUsageSummary, SecurityFinding, SessionsListResult } from "../types";
 
 export type ActivityState = {
   client: GatewayBrowserClient | null;
@@ -9,12 +9,7 @@ export type ActivityState = {
   activityDays: number;
   activitySessionsResult: SessionsListResult | null;
   activityError: string | null;
-  activitySecurityFindings: Array<{
-    checkId: string;
-    severity: string;
-    title: string;
-    detail: string;
-  }> | null;
+  activitySecurityFindings: SecurityFinding[] | null;
 };
 
 export async function loadActivity(state: ActivityState, overrides?: { days?: number }) {
@@ -41,10 +36,7 @@ export async function loadActivity(state: ActivityState, overrides?: { days?: nu
     // security.audit: call if available (may not exist yet)
     try {
       const auditRes = (await state.client.request("security.audit", {})) as
-        | {
-            ok: boolean;
-            findings?: Array<{ checkId: string; severity: string; title: string; detail: string }>;
-          }
+        | { ok: boolean; findings?: SecurityFinding[] }
         | undefined;
       if (auditRes?.ok && Array.isArray(auditRes.findings)) {
         state.activitySecurityFindings = auditRes.findings;

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -17,6 +17,11 @@ export const icons = {
       <line x1="6" x2="6" y1="20" y2="16" />
     </svg>
   `,
+  activity: html`
+    <svg viewBox="0 0 24 24">
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+    </svg>
+  `,
   link: html`
     <svg viewBox="0 0 24 24">
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -4,7 +4,7 @@ export const TAB_GROUPS = [
   { label: "Chat", tabs: ["chat"] },
   {
     label: "Control",
-    tabs: ["overview", "channels", "instances", "sessions", "cron"],
+    tabs: ["overview", "activity", "channels", "instances", "sessions", "cron"],
   },
   { label: "Agent", tabs: ["skills", "nodes"] },
   { label: "Settings", tabs: ["config", "debug", "logs"] },
@@ -12,6 +12,7 @@ export const TAB_GROUPS = [
 
 export type Tab =
   | "overview"
+  | "activity"
   | "channels"
   | "instances"
   | "sessions"
@@ -25,6 +26,7 @@ export type Tab =
 
 const TAB_PATHS: Record<Tab, string> = {
   overview: "/overview",
+  activity: "/activity",
   channels: "/channels",
   instances: "/instances",
   sessions: "/sessions",
@@ -104,6 +106,8 @@ export function iconForTab(tab: Tab): IconName {
       return "messageSquare";
     case "overview":
       return "barChart";
+    case "activity":
+      return "activity";
     case "channels":
       return "link";
     case "instances":
@@ -131,6 +135,8 @@ export function titleForTab(tab: Tab) {
   switch (tab) {
     case "overview":
       return "Overview";
+    case "activity":
+      return "Activity";
     case "channels":
       return "Channels";
     case "instances":
@@ -160,6 +166,8 @@ export function subtitleForTab(tab: Tab) {
   switch (tab) {
     case "overview":
       return "Gateway status, entry points, and a fast health read.";
+    case "activity":
+      return "Tokens used, tools, channels, memory, and security for a date range.";
     case "channels":
       return "Manage channels and settings.";
     case "instances":

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -349,6 +349,8 @@ export type GatewaySessionRow = {
   subject?: string;
   room?: string;
   space?: string;
+  channel?: string;
+  lastChannel?: string;
   updatedAt: number | null;
   sessionId?: string;
   systemSent?: boolean;
@@ -371,6 +373,28 @@ export type SessionsListResult = {
   count: number;
   defaults: GatewaySessionsDefaults;
   sessions: GatewaySessionRow[];
+};
+
+/** Token/cost usage from usage.cost RPC (date-range summary). */
+export type CostUsageTotals = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  totalCost: number;
+  missingCostEntries: number;
+};
+
+export type CostUsageDailyEntry = CostUsageTotals & {
+  date: string;
+};
+
+export type CostUsageSummary = {
+  updatedAt: number;
+  days: number;
+  daily: CostUsageDailyEntry[];
+  totals: CostUsageTotals;
 };
 
 export type SessionsPatchResult = {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -397,6 +397,16 @@ export type CostUsageSummary = {
   totals: CostUsageTotals;
 };
 
+/** Matches SecurityAuditSeverity in src/security/audit.ts */
+export type SecurityAuditSeverity = "info" | "warn" | "critical";
+
+export type SecurityFinding = {
+  checkId: string;
+  severity: SecurityAuditSeverity;
+  title: string;
+  detail: string;
+};
+
 export type SessionsPatchResult = {
   ok: true;
   path: string;

--- a/ui/src/ui/views/activity.ts
+++ b/ui/src/ui/views/activity.ts
@@ -1,0 +1,199 @@
+import { html, nothing } from "lit";
+import type { CostUsageSummary, GatewaySessionRow, SessionsListResult } from "../types";
+import { formatAgo } from "../format";
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+  if (value >= 1000)
+    return value >= 10000 ? `${Math.round(value / 1000)}k` : `${(value / 1000).toFixed(1)}k`;
+  return String(value);
+}
+
+function formatUsd(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (value >= 1) return `$${value.toFixed(2)}`;
+  if (value >= 0.01) return `$${value.toFixed(2)}`;
+  return `$${value.toFixed(4)}`;
+}
+
+export type ActivityProps = {
+  connected: boolean;
+  loading: boolean;
+  usageResult: CostUsageSummary | null;
+  days: number;
+  sessionsResult: SessionsListResult | null;
+  error: string | null;
+  securityFindings: Array<{
+    checkId: string;
+    severity: string;
+    title: string;
+    detail: string;
+  }> | null;
+  onDaysChange: (days: number) => void;
+  onRefresh: () => void;
+};
+
+function groupSessionsByChannel(sessions: GatewaySessionRow[]): Map<string, number> {
+  const byChannel = new Map<string, number>();
+  for (const s of sessions) {
+    const ch = s.channel ?? s.lastChannel ?? "unknown";
+    byChannel.set(ch, (byChannel.get(ch) ?? 0) + 1);
+  }
+  return byChannel;
+}
+
+export function renderActivity(props: ActivityProps) {
+  if (!props.connected) {
+    return html`
+      <section class="card">
+        <div class="card-title">Activity</div>
+        <div class="muted">
+          Connect to the gateway to see usage, tokens, channels, and security for a date range.
+        </div>
+      </section>
+    `;
+  }
+
+  const totals = props.usageResult?.totals;
+  const sessions = props.sessionsResult?.sessions ?? [];
+  const byChannel = groupSessionsByChannel(sessions);
+  const presetDays = [7, 14, 30];
+
+  return html`
+    <section class="card">
+      <div class="row" style="justify-content: space-between; align-items: center;">
+        <div>
+          <div class="card-title">Date range</div>
+          <div class="card-sub">Last N days for tokens and usage.</div>
+        </div>
+        <div class="row" style="gap: 8px;">
+          ${presetDays.map(
+            (d) => html`
+              <button
+                class="btn ${props.days === d ? "btn--primary" : ""}"
+                ?disabled=${props.loading}
+                @click=${() => props.onDaysChange(d)}
+              >
+                ${d} days
+              </button>
+            `,
+          )}
+          <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+            ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+      </div>
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 14px;">${props.error}</div>`
+          : nothing
+      }
+    </section>
+
+    <section class="grid grid-cols-2" style="margin-top: 18px;">
+      <div class="card stat-card">
+        <div class="card-title">Tokens used</div>
+        <div class="card-sub">Input, output, cache (last ${props.days} days).</div>
+        ${
+          totals
+            ? html`
+              <div style="margin-top: 12px;">
+                <div class="row" style="gap: 16px; flex-wrap: wrap;">
+                  <span><strong>Input:</strong> ${formatTokenCount(totals.input)}</span>
+                  <span><strong>Output:</strong> ${formatTokenCount(totals.output)}</span>
+                  <span><strong>Total:</strong> ${formatTokenCount(totals.totalTokens)}</span>
+                </div>
+                <div style="margin-top: 8px;">
+                  <strong>Est. cost:</strong> ${formatUsd(totals.totalCost)}
+                  ${
+                    totals.missingCostEntries > 0
+                      ? html` <span class="muted">(${totals.missingCostEntries} entries without cost)</span>`
+                      : nothing
+                  }
+                </div>
+              </div>
+            `
+            : html`
+                <div class="muted" style="margin-top: 8px">No usage data for this range.</div>
+              `
+        }
+      </div>
+      <div class="card stat-card">
+        <div class="card-title">Incoming channels</div>
+        <div class="card-sub">Sessions by channel (from session list).</div>
+        ${
+          byChannel.size > 0
+            ? html`
+              <ul style="margin-top: 12px; padding-left: 20px;">
+                ${Array.from(byChannel.entries())
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([ch, count]) => html`<li><span class="mono">${ch}</span>: ${count}</li>`)}
+              </ul>
+            `
+            : html`
+                <div class="muted" style="margin-top: 8px">No sessions in list.</div>
+              `
+        }
+      </div>
+    </section>
+
+    <section class="card" style="margin-top: 18px;">
+      <div class="card-title">Tools used</div>
+      <div class="card-sub">Tool invocation counts for the range.</div>
+      <div class="muted" style="margin-top: 8px;">Coming soon. Tool usage aggregation will appear here.</div>
+    </section>
+
+    <section class="card" style="margin-top: 18px;">
+      <div class="card-title">Memory (sessions)</div>
+      <div class="card-sub">What is stored: session count and recent session metadata.</div>
+      ${
+        sessions.length > 0
+          ? html`
+            <div style="margin-top: 12px;">
+              <div class="muted">${sessions.length} session(s) in list.</div>
+              <ul style="margin-top: 8px; padding-left: 20px; max-height: 200px; overflow-y: auto;">
+                ${sessions.slice(0, 20).map(
+                  (s) =>
+                    html`<li>
+                      <span class="mono">${s.displayName ?? s.key ?? "—"}</span>
+                      ${s.updatedAt ? html`<span class="muted">${formatAgo(s.updatedAt)}</span>` : nothing}
+                      ${s.channel ? html` <span class="mono">${s.channel}</span>` : nothing}
+                    </li>`,
+                )}
+              </ul>
+              ${sessions.length > 20 ? html`<div class="muted">… and ${sessions.length - 20} more.</div>` : nothing}
+            </div>
+          `
+          : html`
+              <div class="muted" style="margin-top: 8px">No sessions.</div>
+            `
+      }
+    </section>
+
+    <section class="card" style="margin-top: 18px;">
+      <div class="card-title">Security</div>
+      <div class="card-sub">Audit findings (info, warn, critical).</div>
+      ${
+        props.securityFindings && props.securityFindings.length > 0
+          ? html`
+            <ul style="margin-top: 12px; padding-left: 20px;">
+              ${props.securityFindings.slice(0, 15).map(
+                (f) =>
+                  html`<li>
+                    <span class="pill ${f.severity === "critical" ? "danger" : f.severity === "warn" ? "warn" : ""}">${f.severity}</span>
+                    ${f.title}: ${f.detail.slice(0, 120)}${f.detail.length > 120 ? "…" : ""}
+                  </li>`,
+              )}
+            </ul>
+            ${props.securityFindings.length > 15 ? html`<div class="muted">… and ${props.securityFindings.length - 15} more.</div>` : nothing}
+          `
+          : html`
+              <div class="muted" style="margin-top: 8px">
+                No audit findings in this view. Run
+                <code>openclaw security audit</code> in the CLI for a full report.
+              </div>
+            `
+      }
+    </section>
+  `;
+}

--- a/ui/src/ui/views/activity.ts
+++ b/ui/src/ui/views/activity.ts
@@ -16,8 +16,7 @@ function formatTokenCount(value: number): string {
 
 function formatUsd(value: number): string {
   if (!Number.isFinite(value)) return "—";
-  if (value >= 0.01) return `$${value.toFixed(2)}`;
-  return `$${value.toFixed(4)}`;
+  return value >= 0.01 ? `$${value.toFixed(2)}` : `$${value.toFixed(4)}`;
 }
 
 export type ActivityProps = {

--- a/ui/src/ui/views/activity.ts
+++ b/ui/src/ui/views/activity.ts
@@ -1,5 +1,10 @@
 import { html, nothing } from "lit";
-import type { CostUsageSummary, GatewaySessionRow, SessionsListResult } from "../types";
+import type {
+  CostUsageSummary,
+  GatewaySessionRow,
+  SecurityFinding,
+  SessionsListResult,
+} from "../types";
 import { formatAgo } from "../format";
 
 function formatTokenCount(value: number): string {
@@ -11,7 +16,6 @@ function formatTokenCount(value: number): string {
 
 function formatUsd(value: number): string {
   if (!Number.isFinite(value)) return "—";
-  if (value >= 1) return `$${value.toFixed(2)}`;
   if (value >= 0.01) return `$${value.toFixed(2)}`;
   return `$${value.toFixed(4)}`;
 }
@@ -23,12 +27,7 @@ export type ActivityProps = {
   days: number;
   sessionsResult: SessionsListResult | null;
   error: string | null;
-  securityFindings: Array<{
-    checkId: string;
-    severity: string;
-    title: string;
-    detail: string;
-  }> | null;
+  securityFindings: SecurityFinding[] | null;
   onDaysChange: (days: number) => void;
   onRefresh: () => void;
 };
@@ -64,7 +63,10 @@ export function renderActivity(props: ActivityProps) {
       <div class="row" style="justify-content: space-between; align-items: center;">
         <div>
           <div class="card-title">Date range</div>
-          <div class="card-sub">Last N days for tokens and usage.</div>
+          <div class="card-sub">
+            Last N days for token usage and cost. Sessions and channels show recent activity (not
+            filtered by range).
+          </div>
         </div>
         <div class="row" style="gap: 8px;">
           ${presetDays.map(


### PR DESCRIPTION
Adds an **Activity** tab to the Control UI with:

- **Date range**: 7 / 14 / 30 day presets and refresh
- **Token usage**: input, output, total tokens and estimated cost (`usage.cost`)
- **Incoming channels**: activity grouped by channel from sessions
- **Memory**: session count and metadata (`sessions.list`)
- **Security findings**: shallow audit results via new `security.audit` gateway RPC (config + channel security only; no filesystem or deep probe)

**Changes:**
- New Activity tab in navigation and app state
- `ui/controllers/activity.ts`: loads usage.cost, sessions.list, security.audit
- `ui/views/activity.ts`: dashboard UI with date selector and sections
- `src/gateway/server-methods/security.ts`: `security.audit` RPC for dashboard
- `app.loadActivity(days?)` wired in app.ts; `refreshActiveTab` loads activity when tab is Activity

Tools-used section is a placeholder for follow-up.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an **Activity** tab to the Control UI and wires it into navigation and tab refresh. The new UI view renders a date-range selector (7/14/30 days), token/cost usage from the existing `usage.cost` RPC, session-derived channel breakdown and recent session metadata from `sessions.list`, and a new shallow security audit section.

On the gateway side, it introduces a new `security.audit` RPC (`src/gateway/server-methods/security.ts`) and registers it in the gateway method list and handler dispatch (`src/gateway/server-methods-list.ts`, `src/gateway/server-methods.ts`). The audit is explicitly shallow (`deep: false`, `includeFilesystem: false`) to support the dashboard.

Main issues found are around Activity tab state/load concurrency (rapid preset clicks can lead to UI/data mismatch) and the date range not actually applying to the sessions/channel sections, plus a couple of small correctness/robustness items (duplicate branch in USD formatting, uncached potentially expensive security audit endpoint).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of user-visible correctness issues in the Activity tab behavior.
- The gateway method registration and UI wiring are straightforward, but the Activity tab’s load concurrency guard combined with immediate state mutation can produce UI/data mismatches on rapid date changes, and the sessions/channel sections don’t respect the selected date range. These are likely to be noticed and should be addressed before merge for dashboard correctness.
- ui/src/ui/app-render.ts, ui/src/ui/controllers/activity.ts, ui/src/ui/views/activity.ts, src/gateway/server-methods/security.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->