### PR TITLE
fix: default background exec to no timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@
 - Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
+- Full test suite takes a while to run; make sure to set timeout appropriately or run async.
+- Full test suite takes a while to run; make sure to set timeout appropriately or run async.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
 - Full kit + what’s covered: `docs/testing.md`.
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1028,10 +1028,14 @@ export function createExecTool(
           allowlistSatisfied,
         });
         const commandText = params.command;
-        const invokeTimeoutMs = Math.max(
-          10_000,
-          (typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec) * 1000 + 5_000,
-        );
+        const nodeEffectiveTimeout =
+          typeof params.timeout === "number"
+            ? params.timeout
+            : params.background
+              ? 0
+              : defaultTimeoutSec;
+        const invokeTimeoutMs =
+          nodeEffectiveTimeout > 0 ? Math.max(10_000, nodeEffectiveTimeout * 1000 + 5_000) : 0;
         const buildInvokeParams = (
           approvedByAsk: boolean,
           approvalDecision: "allow-once" | "allow-always" | null,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -760,7 +760,7 @@ export function createExecTool(
   );
   const allowBackground = defaults?.allowBackground ?? true;
   const defaultTimeoutSec =
-    typeof defaults?.timeoutSec === "number" && defaults.timeoutSec > 0
+    typeof defaults?.timeoutSec === "number" && defaults.timeoutSec >= 0
       ? defaults.timeoutSec
       : 1800;
   const defaultPathPrepend = normalizePathPrepend(defaults?.pathPrepend);
@@ -1243,7 +1243,11 @@ export function createExecTool(
           const noticeSeconds = Math.max(1, Math.round(approvalRunningNoticeMs / 1000));
           const commandText = params.command;
           const effectiveTimeout =
-            typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec;
+            typeof params.timeout === "number"
+              ? params.timeout
+              : params.background
+                ? 0
+                : defaultTimeoutSec;
           const warningText = warnings.length ? `${warnings.join("\n")}\n\n` : "";
 
           void (async () => {
@@ -1438,7 +1442,11 @@ export function createExecTool(
       }
 
       const effectiveTimeout =
-        typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec;
+        typeof params.timeout === "number"
+          ? params.timeout
+          : params.background
+            ? 0
+            : defaultTimeoutSec;
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
       const run = await runExecProcess({


### PR DESCRIPTION
## Problem

When an agent spawns a long-running background process via `exec` with `background: true` (e.g., a coding agent like Claude Code or Codex), the process inherits the default foreground timeout of 1800 seconds (30 minutes). After 30 minutes, the process is SIGKILL'd — even though the user explicitly requested background execution.

This makes it impossible to reliably run coding agents, long builds, or any task that takes more than 30 minutes as a background process without manually specifying `timeout: 0` on every call.

## Root Cause

In `bash-tools.exec.ts`, `effectiveTimeout` falls through to `defaultTimeoutSec` (1800) when no explicit `timeout` param is provided, regardless of whether `background: true` is set. This happens in two places — the normal exec path and the approval-gated exec path.

## Proposed Fix

When `background: true` is set and no explicit `timeout` is provided, default `effectiveTimeout` to `0` (no timeout) instead of `defaultTimeoutSec`. The existing guard `if (opts.timeoutSec > 0)` already correctly treats 0 as "no timeout," so no other changes are needed.

Foreground commands continue to use the 1800s safety timeout. Users who want a max timeout on background processes can still pass `timeout: <seconds>` explicitly.

Also fixes `defaultTimeoutSec` resolution to accept `0` as a valid configured value (`>= 0` instead of `> 0`), so `tools.exec.timeoutSec: 0` in config works as expected.

## Changes

- `bash-tools.exec.ts`: Two `effectiveTimeout` calculations updated to check `params.background` before falling through to default
- `bash-tools.exec.ts`: `defaultTimeoutSec` resolution changed from `> 0` to `>= 0`

## Use Case

Running Claude Code or Codex as a background coding agent:
```
exec({ command: "claude ...", background: true })
```
Previously: killed after 30 min
Now: runs to completion (or until explicitly killed)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `exec` timeout defaults so that background executions (`background: true`) no longer inherit the 1800s foreground timeout unless the caller explicitly sets `timeout`. It also allows configuring `tools.exec.timeoutSec: 0` to mean “no timeout” by accepting `>= 0`.

These changes are localized to `src/agents/bash-tools.exec.ts` and affect both the normal exec path and the approval-gated gateway path, keeping the existing behavior that `timeoutSec > 0` schedules a kill timer while `0` disables it.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and fixes the intended background-timeout behavior for local and gateway paths.
- The change is small and consistent with existing semantics (`timeoutSec > 0` schedules a timer). The main remaining risk is an inconsistency: the `host=node` code path still derives `invokeTimeoutMs` from the old default, which can continue to cap long-running background node executions.
- src/agents/bash-tools.exec.ts (host=node invokeTimeoutMs calculation)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

---

**🤖 AI-Assisted Development**

All code is AI-generated (Codex / Claude Code), directed and reviewed by a human architect. My workflow: deep research → detailed spec → AI implementation → human review → iterate. I understand every line that ships and test locally before submitting.