### PR TITLE
feat(hooks): add agent:turn_start and agent:turn_end lifecycle events

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -270,8 +270,8 @@ Planned event types:
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
-- **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
+
+> **Note:** The previously planned `message:sent` and `message:received` events are superseded by the more precise `agent:turn_start` and `agent:turn_end` events above.
 
 ## Creating Custom Hooks
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -233,6 +233,23 @@ Triggered when agent commands are issued:
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)
+- **`agent:turn_start`**: When the agent begins processing an inbound message
+- **`agent:turn_end`**: When the agent finishes processing and has sent a response
+
+#### Turn Event Context
+
+The `agent:turn_start` and `agent:turn_end` events include the following context:
+
+```typescript
+{
+  source: string;          // Channel (e.g., "telegram", "whatsapp")
+  senderId?: string;       // Sender's ID
+  senderName?: string;     // Sender's display name
+  chatType?: string;       // Chat type (e.g., "private", "group")
+  groupSubject?: string;   // Group name if applicable
+  messagePreview?: string; // First 100 chars of message
+  success?: boolean;       // (turn_end only) Whether processing succeeded
+}
 
 ### Gateway Events
 

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -22,13 +23,41 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
-  return await dispatchReplyFromConfig({
-    ctx: finalized,
-    cfg: params.cfg,
-    dispatcher: params.dispatcher,
-    replyOptions: params.replyOptions,
-    replyResolver: params.replyResolver,
-  });
+  const sessionKey = finalized.SessionKey ?? "";
+
+  // Build context for hooks
+  const hookContext = {
+    source: finalized.Surface ?? finalized.Provider ?? "unknown",
+    senderId: finalized.SenderId,
+    senderName: finalized.SenderName,
+    chatType: finalized.ChatType,
+    groupSubject: finalized.GroupSubject,
+    messagePreview: finalized.RawBody?.slice(0, 100),
+  };
+
+  // Trigger turn_start hook
+  const startEvent = createInternalHookEvent("agent", "turn_start", sessionKey, hookContext);
+  await triggerInternalHook(startEvent);
+
+  let result: DispatchFromConfigResult;
+  try {
+    result = await dispatchReplyFromConfig({
+      ctx: finalized,
+      cfg: params.cfg,
+      dispatcher: params.dispatcher,
+      replyOptions: params.replyOptions,
+      replyResolver: params.replyResolver,
+    });
+  } finally {
+    // Trigger turn_end hook (always, even on error)
+    const endEvent = createInternalHookEvent("agent", "turn_end", sessionKey, {
+      ...hookContext,
+      success: true,
+    });
+    await triggerInternalHook(endEvent);
+  }
+
+  return result;
 }
 
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {


### PR DESCRIPTION
Add two new hook events that fire when the agent begins and finishes processing an inbound message:

- agent:turn_start: Fires before the agent processes a message
- agent:turn_end: Fires after the agent sends a response (in finally block)

Both events include context about the message source, sender, and a preview of the message content. This enables integrations like status dashboards to show real-time agent activity.

Example use case: A Mission Control dashboard that shows when the agent is actively working vs idle.

Implements planned events from docs/hooks.md (replaces message:sent and message:received with more precise turn-based events).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new internal hook events (`agent:turn_start` and `agent:turn_end`) emitted from the inbound message dispatch path, and documents their context payload fields in `docs/hooks.md`. The intent is to provide a turn-based lifecycle signal (start/end of processing) for integrations like dashboards.

Main concern: the `turn_end` event is emitted from a `finally` block but currently hardcodes `success: true`, so failures will be reported as successes. Additionally, `turn_start` is awaited before the main dispatch, so any unexpected failure in the hook trigger path could block message processing. The docs update is helpful, but it still lists `message:sent`/`message:received` under “Future Events” despite the PR describing them as replaced by the new turn events.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the new hook telemetry semantics are currently incorrect for error cases.
- Changes are small and localized, but `agent:turn_end` always sets `success: true`, which can mislead downstream consumers and is likely a bug for the intended API. The hook triggers are also on the critical dispatch path, so any unexpected failure there could impact message processing.
- src/auto-reply/dispatch.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->