### PR TITLE
fix: configure npm global prefix for non-root user in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
+# Configure npm to use a user-writable directory for global packages
+# This prevents EACCES errors when installing skills via ClawHub or npm install -g
+RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
+ENV PATH="/home/node/.npm-global/bin:${PATH}"
+
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #


### PR DESCRIPTION
## Problem

The Dockerfile switches to the non-root `node` user for security hardening, but npm's default global prefix (`/usr/local`) is not writable by this user. This causes `EACCES: permission denied` errors when installing skills via ClawdHub or any `npm install -g` command.

```
Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/clawdhub'
```

## Fix

Add two lines after `USER node` to configure npm to use a user-writable directory:

```dockerfile
RUN npm config set prefix /home/node/.npm-global
ENV PATH="/home/node/.npm-global/bin:${PATH}"
```

This is the standard Node.js recommended fix for [resolving EACCES permissions errors](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally).

## Scope

Dockerfile only — 2 lines added. No other changes.

Fixes #6620
Related: #4130

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the runtime Docker image to support global npm installs while running as the non-root `node` user. After switching to `USER node`, it creates a user-writable global prefix directory under `/home/node/.npm-global`, sets npm’s global prefix to that path, and adds the corresponding `bin` directory to `PATH`, preventing `EACCES` errors for `npm install -g` (e.g., when installing skills via ClawHub).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is isolated to the Dockerfile and follows standard npm guidance; it creates the prefix directory before setting it and only affects runtime global install behavior for the non-root `node` user.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->