### PR TITLE
fix(cli-runner): replace {model} placeholder in resumeArgs

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -146,7 +146,7 @@ export async function runCliAgent(params: {
   const stdinPayload = stdin ?? "";
   const baseArgs = useResume ? (backend.resumeArgs ?? backend.args ?? []) : (backend.args ?? []);
   const resolvedArgs = useResume
-    ? baseArgs.map((entry) => entry.replaceAll("{sessionId}", cliSessionIdToSend ?? ""))
+    ? baseArgs.map((entry) => entry.replaceAll("{sessionId}", cliSessionIdToSend ?? "").replaceAll("{model}", normalizedModel))
     : baseArgs;
   const args = buildCliArgs({
     backend,


### PR DESCRIPTION
## Summary
- Fixes `{model}` placeholder not being replaced in `resumeArgs` for CLI backends
- Ensures configured model is used on resume calls instead of defaulting to sonnet

## Problem
When using CLI backends with custom `resumeArgs` that include a `{model}` placeholder:
```json
"resumeArgs": ["-p", "--resume", "{sessionId}", "--model", "{model}"]
```

The `{model}` placeholder was not being replaced, causing:
1. First message: `--model opus` ✅ (new session with correct model)
2. Subsequent messages: `--model {model}` ❌ (literal string, API error or default model)

This made it impossible to maintain a specific model across resume calls.

## Solution
Add `.replaceAll("{model}", normalizedModel)` to the resumeArgs processing in `cli-runner.ts`, matching how `{sessionId}` is already handled.

## Testing
- Configured `claude-cli/opus` as primary model for an agent
- First message created new session with Opus
- Subsequent messages (resume) now correctly pass `--model opus`
- Model usage in responses confirms Opus is used throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a placeholder substitution bug in the CLI runner’s resume path. When `backend.resumeArgs` contained `{model}`, it was previously passed through as a literal string on resume executions; the change mirrors existing `{sessionId}` handling by also replacing `{model}` with the normalized model ID before building the final CLI argv. This keeps resume calls consistent with initial session creation, preventing unexpected fallback/default model selection or CLI errors when resuming.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to resume-argument placeholder substitution in `runCliAgent`, uses an already-computed `normalizedModel`, and mirrors existing `{sessionId}` replacement logic without affecting non-resume execution paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->