### PR TITLE
fix(docker): add gateway subcommand and cloud-compatible flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Agents: wire before_tool_call plugin hook into tool execution. (#6570, #6660) Thanks @ryancnelson.
 - Browser: secure Chrome extension relay CDP sessions.
 - Docker: use container port for gateway command instead of host port. (#5110) Thanks @mise42.
+- Docker: start gateway CMD by default for container deployments. (#6635) Thanks @kaizen403.
 - fix(lobster): block arbitrary exec via lobsterPath/cwd injection (GHSA-4mhr-g7xj-cg8j). (#5335) Thanks @vignesh07.
 - Security: sanitize WhatsApp accountId to prevent path traversal. (#4610)
 - Security: restrict MEDIA path extraction to prevent LFI. (#4930)

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,10 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
-CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured", "--bind", "lan"]
+# Start gateway server with default config.
+# Binds to loopback (127.0.0.1) by default for security.
+#
+# For container platforms requiring external health checks:
+#   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
+#   2. Override CMD: ["node","dist/index.js","gateway","--allow-unconfigured","--bind","lan"]
+CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured", "--bind", "lan"]

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -275,6 +275,7 @@ pnpm test:docker:qr
 ### Notes
 
 - Gateway bind defaults to `lan` for container use.
+- Dockerfile CMD uses `--allow-unconfigured`; mounted config with `gateway.mode` not `local` will still start. Override CMD to enforce the guard.
 - The gateway container is the source of truth for sessions (`~/.openclaw/agents/<agentId>/sessions/`).
 
 ## Agent Sandbox (host gateway + Docker tools)


### PR DESCRIPTION
## Summary

The Dockerfile's `CMD` runs `node dist/index.js` without specifying the `gateway` subcommand, causing the CLI to print help and exit with code 1. This breaks deployment on container platforms that rely on the Dockerfile's CMD.

## Changes

```diff
- CMD ["node", "dist/index.js"]
+ CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]
```

- **`gateway`** - Actually start the gateway server instead of printing CLI help
- **`--allow-unconfigured`** - Allow startup without a pre-existing config file (users configure via environment variables or the web UI after first launch)

## Container Platform Deployments

The default CMD binds to loopback (`127.0.0.1`) for security. For container platforms that require external health checks (Render, Railway, Fly.io, etc.):

1. **Set an auth token** via `OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD` environment variable
2. **Override the CMD** to enable LAN binding:
   ```
   ["node", "dist/index.js", "gateway", "--allow-unconfigured", "--bind", "lan"]
   ```

This is by design - OpenClaw requires authentication when binding to non-loopback addresses (see `src/cli/gateway-cli/run.ts:246-257`).

## Tested On

- ✅ Docker container starts successfully with default CMD
- ✅ Container with LAN binding + token responds to health checks
- ✅ Web UI accessible, setup flow works

## Related Issues

- Fixes #5685 
- Related to #5966 (also mentions this issue)

## Notes

The port defaults to 18789 and can be customized via the `OPENCLAW_GATEWAY_PORT` environment variable.