### PR TITLE
feat(onboard): add Ollama provider support

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -58,7 +58,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|ollama|skip",
     )
     .option(
       "--token-provider <id>",
@@ -83,6 +83,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--synthetic-api-key <key>", "Synthetic API key")
     .option("--venice-api-key <key>", "Venice API key")
     .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
+    .option("--ollama-base-url <url>", "Ollama server URL (e.g., http://192.168.1.100:11434)")
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
@@ -134,6 +135,7 @@ export function registerOnboardCommand(program: Command) {
             syntheticApiKey: opts.syntheticApiKey as string | undefined,
             veniceApiKey: opts.veniceApiKey as string | undefined,
             opencodeZenApiKey: opts.opencodeZenApiKey as string | undefined,
+            ollamaBaseUrl: opts.ollamaBaseUrl as string | undefined,
             gatewayPort:
               typeof gatewayPort === "number" && Number.isFinite(gatewayPort)
                 ? gatewayPort

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -21,7 +21,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "ollama";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -120,6 +121,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "Privacy-focused (uncensored models)",
     choices: ["venice-api-key"],
   },
+  {
+    value: "ollama",
+    label: "Ollama",
+    hint: "Local + cloud models",
+    choices: ["ollama"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -198,6 +205,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "ollama",
+    label: "Ollama",
+    hint: "Sign-in is handled by Ollama when required",
   });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice.apply.ollama.ts
+++ b/src/commands/auth-choice.apply.ollama.ts
@@ -64,7 +64,7 @@ export async function applyAuthChoiceOllama(
     [
       "Ollama configured successfully.",
       "Models will be discovered automatically from your Ollama server.",
-      "Use `ollama pull <model>` to download models, then `moltbot models list` to see them.",
+      "Use `ollama pull <model>` to download models, then `openclaw models list` to see them.",
     ].join("\n"),
     "Setup complete",
   );

--- a/src/commands/auth-choice.apply.ollama.ts
+++ b/src/commands/auth-choice.apply.ollama.ts
@@ -1,0 +1,73 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import {
+  applyAuthProfileConfig,
+  applyOllamaProviderConfig,
+  OLLAMA_BASE_URL,
+  OLLAMA_DEFAULT_API_KEY,
+  setOllamaApiKey,
+} from "./onboard-auth.js";
+
+export async function applyAuthChoiceOllama(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "ollama") {
+    return null;
+  }
+
+  let nextConfig = params.config;
+
+  await params.prompter.note(
+    [
+      "Ollama runs models locally or in the cloud.",
+      "Make sure Ollama is installed and running: https://ollama.com",
+      "Default server: http://127.0.0.1:11434",
+    ].join("\n"),
+    "Ollama",
+  );
+
+  const useDefault = await params.prompter.confirm({
+    message: `Use default Ollama server (${OLLAMA_BASE_URL.replace("/v1", "")})?`,
+    initialValue: true,
+  });
+
+  let baseUrl = OLLAMA_BASE_URL;
+  if (!useDefault) {
+    const customUrl = await params.prompter.text({
+      message: "Enter Ollama server URL (e.g., http://192.168.1.100:11434)",
+      validate: (value) => {
+        if (!value?.trim()) return "URL is required";
+        try {
+          new URL(value.trim());
+          return undefined;
+        } catch {
+          return "Invalid URL format";
+        }
+      },
+    });
+    // Append /v1 if not present for OpenAI-compatible endpoint
+    const trimmedUrl = String(customUrl).trim().replace(/\/+$/, "");
+    baseUrl = trimmedUrl.endsWith("/v1") ? trimmedUrl : `${trimmedUrl}/v1`;
+  }
+
+  // Store the placeholder API key to enable provider discovery
+  await setOllamaApiKey(OLLAMA_DEFAULT_API_KEY, params.agentDir);
+
+  nextConfig = applyAuthProfileConfig(nextConfig, {
+    profileId: "ollama:default",
+    provider: "ollama",
+    mode: "api_key",
+  });
+
+  nextConfig = applyOllamaProviderConfig(nextConfig, { baseUrl });
+
+  await params.prompter.note(
+    [
+      "Ollama configured successfully.",
+      "Models will be discovered automatically from your Ollama server.",
+      "Use `ollama pull <model>` to download models, then `moltbot models list` to see them.",
+    ].join("\n"),
+    "Setup complete",
+  );
+
+  return { config: nextConfig };
+}

--- a/src/commands/auth-choice.apply.ollama.ts
+++ b/src/commands/auth-choice.apply.ollama.ts
@@ -7,6 +7,20 @@ import {
   setOllamaApiKey,
 } from "./onboard-auth.js";
 
+const DEFAULT_OLLAMA_HOST = OLLAMA_BASE_URL.replace("/v1", "");
+
+/** Check if Ollama is reachable at the given base URL (without /v1 suffix). */
+async function checkOllamaReachable(host: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${host}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function applyAuthChoiceOllama(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
@@ -16,26 +30,28 @@ export async function applyAuthChoiceOllama(
 
   let nextConfig = params.config;
 
-  await params.prompter.note(
-    [
-      "Ollama runs models locally or in the cloud.",
-      "Make sure Ollama is installed and running: https://ollama.com",
-      "Default server: http://127.0.0.1:11434",
-    ].join("\n"),
-    "Ollama",
-  );
-
-  const useDefault = await params.prompter.confirm({
-    message: `Use default Ollama server (${OLLAMA_BASE_URL.replace("/v1", "")})?`,
-    initialValue: true,
-  });
+  // Try auto-detecting Ollama at the default URL
+  const defaultReachable = await checkOllamaReachable(DEFAULT_OLLAMA_HOST);
 
   let baseUrl = OLLAMA_BASE_URL;
-  if (!useDefault) {
+  if (defaultReachable) {
+    await params.prompter.note(`Ollama detected at ${DEFAULT_OLLAMA_HOST}`, "Ollama");
+  } else {
+    await params.prompter.note(
+      [
+        "Ollama runs models locally or in the cloud.",
+        "Make sure Ollama is installed and running: https://ollama.com",
+      ].join("\n"),
+      "Ollama",
+    );
+
     const customUrl = await params.prompter.text({
-      message: "Enter Ollama server URL (e.g., http://192.168.1.100:11434)",
+      message: `Ollama not detected at default. Enter server URL:`,
+      initialValue: DEFAULT_OLLAMA_HOST,
       validate: (value) => {
-        if (!value?.trim()) return "URL is required";
+        if (!value?.trim()) {
+          return "URL is required";
+        }
         try {
           new URL(value.trim());
           return undefined;

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -10,6 +10,7 @@ import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-ant
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
+import { applyAuthChoiceOllama } from "./auth-choice.apply.ollama.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
 import { applyAuthChoiceQwenPortal } from "./auth-choice.apply.qwen-portal.js";
 
@@ -46,6 +47,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
     applyAuthChoiceQwenPortal,
+    applyAuthChoiceOllama,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -30,6 +30,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
+  ollama: "ollama",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -469,6 +469,8 @@ export function applyOllamaProviderConfig(
 ): OpenClawConfig {
   const providers = { ...cfg.models?.providers };
   const existingProvider = providers.ollama;
+  // Preserve existing models if configured; otherwise use empty array for dynamic discovery
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   const { apiKey: existingApiKey, ...existingProviderRest } = (existingProvider ?? {}) as Record<
     string,
     unknown
@@ -483,7 +485,7 @@ export function applyOllamaProviderConfig(
     api: "openai-completions",
     apiKey: normalizedApiKey,
     // Models are discovered dynamically via Ollama's /api/tags endpoint
-    models: [],
+    models: existingModels,
   };
 
   return {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -178,3 +178,15 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export async function setOllamaApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "ollama:default",
+    credential: {
+      type: "api_key",
+      provider: "ollama",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -15,6 +15,9 @@ export const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 export const KIMI_CODING_MODEL_ID = "k2p5";
 export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
 
+export const OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
+export const OLLAMA_DEFAULT_API_KEY = "ollama";
+
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 export const MINIMAX_API_COST = {
   input: 15,

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -9,6 +9,8 @@ export {
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
   applyMoonshotProviderConfig,
+  applyOllamaConfig,
+  applyOllamaProviderConfig,
   applyOpenrouterConfig,
   applyOpenrouterProviderConfig,
   applySyntheticConfig,
@@ -41,6 +43,7 @@ export {
   setKimiCodingApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
+  setOllamaApiKey,
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
   setSyntheticApiKey,
@@ -66,4 +69,6 @@ export {
   MOONSHOT_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
+  OLLAMA_BASE_URL,
+  OLLAMA_DEFAULT_API_KEY,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -14,6 +14,7 @@ import {
   applyMinimaxApiConfig,
   applyMinimaxConfig,
   applyMoonshotConfig,
+  applyOllamaProviderConfig,
   applyOpencodeZenConfig,
   applyOpenrouterConfig,
   applySyntheticConfig,
@@ -21,11 +22,14 @@ import {
   applyVercelAiGatewayConfig,
   applyXiaomiConfig,
   applyZaiConfig,
+  OLLAMA_BASE_URL,
+  OLLAMA_DEFAULT_API_KEY,
   setAnthropicApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
+  setOllamaApiKey,
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
   setSyntheticApiKey,
@@ -426,6 +430,26 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyOpencodeZenConfig(nextConfig);
+  }
+
+  if (authChoice === "ollama") {
+    // Resolve base URL: CLI flag > default
+    let baseUrl = OLLAMA_BASE_URL;
+    if (opts.ollamaBaseUrl) {
+      const trimmedUrl = opts.ollamaBaseUrl.trim().replace(/\/+$/, "");
+      baseUrl = trimmedUrl.endsWith("/v1") ? trimmedUrl : `${trimmedUrl}/v1`;
+    }
+
+    // Store placeholder API key to enable provider discovery
+    await setOllamaApiKey(OLLAMA_DEFAULT_API_KEY);
+
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "ollama:default",
+      provider: "ollama",
+      mode: "api_key",
+    });
+
+    return applyOllamaProviderConfig(nextConfig, { baseUrl });
   }
 
   if (

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -46,8 +46,9 @@ export async function applyNonInteractiveAuthChoice(params: {
   opts: OnboardOptions;
   runtime: RuntimeEnv;
   baseConfig: OpenClawConfig;
+  agentDir?: string;
 }): Promise<OpenClawConfig | null> {
-  const { authChoice, opts, runtime, baseConfig } = params;
+  const { authChoice, opts, runtime, baseConfig, agentDir } = params;
   let nextConfig = params.nextConfig;
 
   if (authChoice === "claude-cli" || authChoice === "codex-cli") {
@@ -441,7 +442,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     }
 
     // Store placeholder API key to enable provider discovery
-    await setOllamaApiKey(OLLAMA_DEFAULT_API_KEY);
+    await setOllamaApiKey(OLLAMA_DEFAULT_API_KEY, agentDir);
 
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: "ollama:default",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -33,6 +33,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "ollama"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -74,6 +75,7 @@ export type OnboardOptions = {
   syntheticApiKey?: string;
   veniceApiKey?: string;
   opencodeZenApiKey?: string;
+  ollamaBaseUrl?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
## Summary
```bash
◇  Onboarding mode
│  QuickStart
│
◇  QuickStart ─────────────────────────╮
│                                      │
│  Gateway port: 18789                 │
│  Gateway bind: Loopback (127.0.0.1)  │
│  Gateway auth: Token (default)       │
│  Tailscale exposure: Off             │
│  Direct to chat channels.            │
│                                      │
├──────────────────────────────────────╯
│
◇  Model/auth provider
│  Ollama
│
◇  Ollama auth method
│  Ollama
│
◇  Ollama ────────────────────────────────────╮
│                                             │
│  Ollama detected at http://127.0.0.1:11434  │
│                                             │
├─────────────────────────────────────────────╯
│
◇  Setup complete ─────────────────────────────────────────────────────────────────────────╮
│                                                                                          │
│  Ollama configured successfully.                                                         │
│  Models will be discovered automatically from your Ollama server.                        │
│  Use `ollama pull <model>` to download models, then `openclaw models list` to see them.  │
│                                                                                          │
├──────────────────────────────────────────────────────────────────────────────────────────╯
│
◇  Default model
│  ollama/glm-4.7:cloud
│
```

- Adds Ollama as a provider option in the onboarding wizard
- Supports both default local server (127.0.0.1:11434) and custom URLs
- Models are discovered dynamically from the Ollama server at runtime

## Test plan

- [x] Ran onboarding wizard and selected Ollama provider
- [x] Tested with default localhost URL
- [x] Tested with custom Ollama server URL

Generated partially with `Claude Code`/`Kimi-K2.5`/`Ollama`

Resolves #3494

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds **Ollama** as an onboarding auth/provider option in both interactive and non-interactive flows. It introduces a new `applyAuthChoiceOllama` handler that auto-detects a local Ollama server (via `/api/tags`), allows a custom server URL, and then writes an `ollama:default` auth profile plus an `ollama` provider entry using an OpenAI-compatible base URL (`.../v1`). It also wires the new `ollama` auth choice through option/group lists, preferred-provider resolution, CLI flags (`--ollama-base-url`), and onboarding option types.

Key integration points are the onboarding auth-choice dispatcher (`src/commands/auth-choice.apply.ts`) and the config/credential helpers in `src/commands/onboard-auth.*` used by both interactive and non-interactive onboarding.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there are a couple of configuration/credentials edge cases worth fixing first.
- The changes are localized to onboarding/config wiring and don’t touch core runtime behavior heavily, but the non-interactive path appears to write the Ollama credential without honoring the onboarding agent directory context, and the provider-config helper unconditionally resets the provider model list which could surprise existing configs.
- src/commands/onboard-non-interactive/local/auth-choice.ts, src/commands/onboard-auth.config-core.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->