### PR TITLE
fix(security): cap Slack media downloads and validate Slack file URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 - Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.
 - Tools: treat `"*"` tool allowlist entries as valid to avoid spurious unknown-entry warnings.
+- Slack: harden media fetch limits and Slack file URL validation. (#6639) Thanks @davidiach.
 - Process: resolve Windows `spawn()` failures for npm-family CLIs by appending `.cmd` when needed. (#5815) Thanks @thejhinvirtuoso.
 - Discord: resolve PluralKit proxied senders for allowlists and labels. (#5838) Thanks @thewilloftheshadow.
 - Agents: ensure OpenRouter attribution headers apply in the embedded runner.

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -74,11 +74,8 @@ export function buildEmbeddedSystemPrompt(params: {
   });
 }
 
-export function createSystemPromptOverride(
-  systemPrompt: string,
-): (defaultPrompt?: string) => string {
-  const trimmed = systemPrompt.trim();
-  return () => trimmed;
+export function createSystemPromptOverride(systemPrompt: string): string {
+  return systemPrompt.trim();
 }
 
 export function applySystemPromptOverrideToSession(

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -40,6 +40,17 @@ describe("fetchWithSlackAuth", () => {
     });
   });
 
+  it("rejects non-Slack hosts to avoid leaking tokens", async () => {
+    const { fetchWithSlackAuth } = await import("./media.js");
+
+    await expect(
+      fetchWithSlackAuth("https://example.com/test.jpg", "xoxb-test-token"),
+    ).rejects.toThrow(/non-Slack host|non-Slack/i);
+
+    // Should fail fast without attempting a fetch.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("follows redirects without Authorization header", async () => {
     const { fetchWithSlackAuth } = await import("./media.js");
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -4,15 +4,57 @@ import type { SlackFile } from "../types.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isSlackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized) {
+    return false;
+  }
+  // Slack-hosted files typically come from *.slack.com and redirect to Slack CDN domains.
+  // Include a small allowlist of known Slack domains to avoid leaking tokens if a file URL
+  // is ever spoofed or mishandled.
+  const allowedSuffixes = ["slack.com", "slack-edge.com", "slack-files.com"];
+  return allowedSuffixes.some(
+    (suffix) => normalized === suffix || normalized.endsWith(`.${suffix}`),
+  );
+}
+
+function assertSlackFileUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid Slack file URL: ${rawUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Refusing Slack file URL with non-HTTPS protocol: ${parsed.protocol}`);
+  }
+  if (!isSlackHostname(parsed.hostname)) {
+    throw new Error(
+      `Refusing to send Slack token to non-Slack host "${parsed.hostname}" (url: ${rawUrl})`,
+    );
+  }
+  return parsed;
+}
+
 /**
  * Fetches a URL with Authorization header, handling cross-origin redirects.
  * Node.js fetch strips Authorization headers on cross-origin redirects for security.
- * Slack's files.slack.com URLs redirect to CDN domains with pre-signed URLs that
- * don't need the Authorization header, so we handle the initial auth request manually.
+ * Slack's file URLs redirect to CDN domains with pre-signed URLs that don't need the
+ * Authorization header, so we handle the initial auth request manually.
  */
 export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
+  const parsed = assertSlackFileUrl(url);
+
   // Initial request with auth and manual redirect handling
-  const initialRes = await fetch(url, {
+  const initialRes = await fetch(parsed.href, {
     headers: { Authorization: `Bearer ${token}` },
     redirect: "manual",
   });
@@ -29,11 +71,16 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
   }
 
   // Resolve relative URLs against the original
-  const resolvedUrl = new URL(redirectUrl, url).toString();
+  const resolvedUrl = new URL(redirectUrl, parsed.href);
+
+  // Only follow safe protocols (we do NOT include Authorization on redirects).
+  if (resolvedUrl.protocol !== "https:") {
+    return initialRes;
+  }
 
   // Follow the redirect without the Authorization header
   // (Slack's CDN URLs are pre-signed and don't need it)
-  return fetch(resolvedUrl, { redirect: "follow" });
+  return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
 export async function resolveSlackMedia(params: {
@@ -63,6 +110,7 @@ export async function resolveSlackMedia(params: {
         url,
         fetchImpl,
         filePathHint: file.name,
+        maxBytes: params.maxBytes,
       });
       if (fetched.buffer.byteLength > params.maxBytes) {
         continue;

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -99,8 +99,9 @@ export async function resolveSlackMedia(params: {
       continue;
     }
     try {
-      // Note: We ignore init options because fetchWithSlackAuth handles
-      // redirect behavior specially. fetchRemoteMedia only passes the URL.
+      // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
+      // handles size limits internally. We ignore init options because
+      // fetchWithSlackAuth handles redirect/auth behavior specially.
       const fetchImpl: FetchLike = (input) => {
         const inputUrl =
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url;

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -201,9 +201,14 @@ async function loadWebMediaInternal(
 
   if (/^https?:\/\//i.test(mediaUrl)) {
     // Enforce a download cap during fetch to avoid unbounded memory usage.
-    // Use the largest per-kind cap (documents) to allow oversize images to
-    // be fetched and then compressed under a smaller maxBytes.
-    const fetchCap = Math.max(maxBytes ?? 0, maxBytesForKind("unknown"));
+    // For optimized images, allow fetching larger payloads before compression.
+    const defaultFetchCap = maxBytesForKind("unknown");
+    const fetchCap =
+      maxBytes === undefined
+        ? defaultFetchCap
+        : optimizeImages
+          ? Math.max(maxBytes, defaultFetchCap)
+          : maxBytes;
     const fetched = await fetchRemoteMedia({ url: mediaUrl, maxBytes: fetchCap });
     const { buffer, contentType, fileName } = fetched;
     const kind = mediaKindFromMime(contentType);

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -200,7 +200,11 @@ async function loadWebMediaInternal(
   };
 
   if (/^https?:\/\//i.test(mediaUrl)) {
-    const fetched = await fetchRemoteMedia({ url: mediaUrl });
+    // Enforce a download cap during fetch to avoid unbounded memory usage.
+    // If the caller provided maxBytes, use it; otherwise fall back to the
+    // largest per-kind cap (documents).
+    const fetchCap = maxBytes !== undefined ? maxBytes : maxBytesForKind("unknown");
+    const fetched = await fetchRemoteMedia({ url: mediaUrl, maxBytes: fetchCap });
     const { buffer, contentType, fileName } = fetched;
     const kind = mediaKindFromMime(contentType);
     return await clampAndFinalize({ buffer, contentType, kind, fileName });

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -201,9 +201,9 @@ async function loadWebMediaInternal(
 
   if (/^https?:\/\//i.test(mediaUrl)) {
     // Enforce a download cap during fetch to avoid unbounded memory usage.
-    // If the caller provided maxBytes, use it; otherwise fall back to the
-    // largest per-kind cap (documents).
-    const fetchCap = maxBytes !== undefined ? maxBytes : maxBytesForKind("unknown");
+    // Use the largest per-kind cap (documents) to allow oversize images to
+    // be fetched and then compressed under a smaller maxBytes.
+    const fetchCap = Math.max(maxBytes ?? 0, maxBytesForKind("unknown"));
     const fetched = await fetchRemoteMedia({ url: mediaUrl, maxBytes: fetchCap });
     const { buffer, contentType, fileName } = fetched;
     const kind = mediaKindFromMime(contentType);


### PR DESCRIPTION
## Summary
- Prevents accidental Slack token leakage by refusing to attach auth headers to non-Slack file hosts.
- Ensures Slack inbound media downloads are bounded via fetchRemoteMedia(..., maxBytes).
- Ensures outbound mediaUrl fetches used by Slack uploads are bounded at fetch-time.

## Testing
- Not run (not requested).

## AI Assistance
- AI-assisted (OpenAI Codex).
- Prompts/logs: not included.
- I understand the changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Slack media handling by (1) validating Slack file URLs and refusing to attach Slack Authorization headers to non-Slack hosts, (2) adding a `maxBytes` cap to inbound Slack media downloads via `fetchRemoteMedia`, and (3) ensuring outbound `mediaUrl` downloads in the web media loader are capped during fetch to avoid unbounded memory usage.

Changes integrate cleanly with the existing `fetchRemoteMedia` implementation in `src/media/fetch.ts`, which already supports `maxBytes` enforcement using both `Content-Length` and streaming limits. Tests in `src/slack/monitor/media.test.ts` cover host rejection and redirect behavior for the Slack-auth fetch wrapper.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and meaningfully improves media download safety, with small edge-case considerations around URL enforcement assumptions.
- Key changes are localized and backed by tests for `fetchWithSlackAuth` behavior. `maxBytes` enforcement is delegated to an existing well-scoped helper (`fetchRemoteMedia`). Remaining concerns are mostly about future-proofing assumptions (e.g., how `fetchImpl` is invoked) rather than clear regressions today.
- src/slack/monitor/media.ts (URL/host enforcement assumptions and comment accuracy)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
