### PR TITLE
feat(ui): add per-code-block copy button in chat

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -122,3 +122,68 @@
   border-top: 1px solid var(--border);
   margin: 1em 0;
 }
+
+/* =============================================
+   CODE BLOCK COPY BUTTON
+   ============================================= */
+
+.chat-text .cb-code-wrapper {
+  position: relative;
+}
+
+.chat-text .cb-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+  border-radius: var(--radius-md);
+  padding: 4px 6px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease-out,
+    background 120ms ease-out;
+  z-index: 1;
+}
+
+.chat-text .cb-copy-btn__icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.chat-text .cb-code-wrapper:hover .cb-copy-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.chat-text .cb-copy-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+.chat-text .cb-copy-btn[data-copied="1"] {
+  opacity: 1;
+  pointer-events: auto;
+  border-color: var(--ok-subtle);
+  background: var(--ok-subtle);
+  color: var(--ok);
+}
+
+.chat-text .cb-copy-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (hover: none) {
+  .chat-text .cb-copy-btn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/ui/src/ui/chat/code-block-copy.ts
+++ b/ui/src/ui/chat/code-block-copy.ts
@@ -1,0 +1,105 @@
+/**
+ * Inject copy buttons into rendered code blocks (<pre> elements).
+ *
+ * Call `observeCodeBlocks(root)` on the chat container. Returns a cleanup
+ * function that disconnects the MutationObserver.
+ */
+
+const COPIED_MS = 1500;
+const MARKER = "cbCopyInjected";
+
+const COPY_ICON = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+const CHECK_ICON = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+function getCodeText(pre: HTMLPreElement): string {
+  const code = pre.querySelector("code");
+  return (code ?? pre).textContent ?? "";
+}
+
+function createCopyBtn(pre: HTMLPreElement): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "cb-copy-btn";
+  btn.title = "Copy code";
+  btn.setAttribute("aria-label", "Copy code");
+  btn.innerHTML = `<span class="cb-copy-btn__icon">${COPY_ICON}</span>`;
+
+  btn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    if (btn.dataset.copying === "1") return;
+
+    btn.dataset.copying = "1";
+    const text = getCodeText(pre);
+
+    let ok = false;
+    try {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    } catch {
+      /* clipboard write failed */
+    }
+
+    delete btn.dataset.copying;
+
+    if (ok) {
+      btn.dataset.copied = "1";
+      btn.innerHTML = `<span class="cb-copy-btn__icon">${CHECK_ICON}</span>`;
+      btn.title = "Copied";
+      setTimeout(() => {
+        if (!btn.isConnected) return;
+        delete btn.dataset.copied;
+        btn.innerHTML = `<span class="cb-copy-btn__icon">${COPY_ICON}</span>`;
+        btn.title = "Copy code";
+      }, COPIED_MS);
+    }
+  });
+
+  return btn;
+}
+
+function processPreElement(pre: HTMLPreElement): void {
+  if (pre.dataset[MARKER]) return;
+  pre.dataset[MARKER] = "1";
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "cb-code-wrapper";
+  pre.parentNode?.insertBefore(wrapper, pre);
+  wrapper.appendChild(pre);
+  wrapper.appendChild(createCopyBtn(pre));
+}
+
+function scanForPreElements(root: HTMLElement): void {
+  const pres = root.querySelectorAll<HTMLPreElement>("pre");
+  for (const pre of pres) {
+    processPreElement(pre);
+  }
+}
+
+/**
+ * Set up a MutationObserver on `root` to automatically inject copy buttons
+ * into any <pre> elements that appear. Also does an initial sweep.
+ *
+ * Returns a cleanup function that disconnects the observer.
+ */
+export function observeCodeBlocks(root: HTMLElement): () => void {
+  scanForPreElements(root);
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (!(node instanceof HTMLElement)) continue;
+        if (node.tagName === "PRE") {
+          processPreElement(node as HTMLPreElement);
+        }
+        const pres = node.querySelectorAll<HTMLPreElement>("pre");
+        for (const pre of pres) {
+          processPreElement(pre);
+        }
+      }
+    }
+  });
+
+  observer.observe(root, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+}


### PR DESCRIPTION
Adds a copy button to each fenced code block in the webchat markdown output. The button appears on hover in the top-right corner of the block and copies just that block's content.

Previously, the only copy option was the message-level "Copy as markdown" button which copies the entire message.

**How it works:**
- `MutationObserver` watches `.chat-thread` for new `<pre>` elements
- Each `<pre>` gets wrapped in a `.cb-code-wrapper` container with a positioned copy button
- Uses `navigator.clipboard.writeText` with a checkmark confirmation (1.5s)
- Idempotent: `WeakSet` prevents double-observing, `data-` attribute skips processed blocks
- Touch devices: button always visible (no hover)

**Files:**
- `ui/src/ui/chat/code-block-copy.ts` (new)
- `ui/src/styles/chat/text.css` (css additions)
- `ui/src/ui/app-lifecycle.ts` (hook)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds per-code-block copy buttons to the web chat markdown output by injecting a wrapper + positioned button around each rendered `<pre>` element. A `MutationObserver` is registered from the UI lifecycle to handle newly streamed/added code blocks, and chat CSS is updated to show the button on hover (always visible on touch devices) with a copied-state checkmark.

This integrates with the existing chat rendering by augmenting DOM output post-render rather than changing the markdown renderer itself.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but the MutationObserver lifecycle needs attention to avoid leaks in long-lived sessions.
- The change is UI-only and self-contained, but it introduces a persistent `MutationObserver` without teardown and adds repeated DOM querying in `handleUpdated`; both can cause performance/memory issues over time depending on how the chat view mounts/unmounts.
- ui/src/ui/chat/code-block-copy.ts; ui/src/ui/app-lifecycle.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->