### PR TITLE
fix: persist archived session entry on /new or /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -337,6 +337,13 @@ export async function initSessionState(params: {
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
   await updateSessionStore(storePath, (store) => {
+    // If this is a reset, archive the previous session entry so it remains
+    // visible in the sessions list. Without this, the old session transcript
+    // exists on disk but sessions.json loses the reference (keyed by sessionKey).
+    if (resetTriggered && previousSessionEntry) {
+      const archivedKey = `${sessionKey}:session:${previousSessionEntry.sessionId}`;
+      store[archivedKey] = previousSessionEntry;
+    }
     // Preserve per-session overrides while resetting compaction state on /new.
     store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
   });


### PR DESCRIPTION
## Problem

When users trigger `/new` or `/reset`, the previous session entry was being overwritten in `sessions.json` because the store is keyed by `sessionKey` (e.g., `agent:main:webchat`), not by `sessionId`. 

This caused old sessions to disappear from the sessions list in the UI, even though their transcript files (`.jsonl`) still existed on disk. Users could see 7 transcript files but only 1 entry in `sessions.json`.

## Solution

Archive the previous session entry with a unique key (`${sessionKey}:session:${previousSessionId}`) before saving the new session. This preserves the old session metadata while still allowing the new session to be the active one at the original `sessionKey`.

## Changes

- Modified `src/auto-reply/reply/session.ts` to persist `previousSessionEntry` to the store when `resetTriggered` is true

## Testing

- ✅ All 14 tests in `src/auto-reply/reply/session.test.ts` pass
- ✅ All 41 tests in `src/config/sessions` pass  
- ✅ Build completes successfully (`pnpm build`)

## AI-Assisted Disclosure

This fix was identified and implemented with AI assistance (Claude). The bug was traced through analysis of the session initialization flow, where `previousSessionEntry` was captured but never persisted to the store during a reset.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `initSessionState` to persist the prior session’s metadata when a `/new` or `/reset` trigger starts a new session. Before writing the new `sessionEntry` at `sessionKey`, it now archives the previous entry under a unique key (`${sessionKey}:session:${previousSessionId}`), preventing the sessions store (keyed by `sessionKey`) from overwriting and effectively “losing” older sessions that still have transcript files on disk.

The change fits into the existing session-store architecture by using `updateSessionStore` (which re-reads inside a lock and writes back atomically) to safely mutate `sessions.json` while keeping the active session at the canonical `sessionKey`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real data-loss-in-index bug, with limited behavioral impact.
- Change is localized and uses existing locked session-store update path; tests were reported passing. Main residual risk is UX/behavioral noise from archived entries being treated as “normal” sessions by consumers that enumerate all store keys.
- src/auto-reply/reply/session.ts; downstream session listing/snapshot consumers that iterate the store

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->