### PR TITLE
fix: clear Playwright colorScheme override for Chrome extension relay

### DIFF
--- a/src/browser/pw-ai.ts
+++ b/src/browser/pw-ai.ts
@@ -22,6 +22,7 @@ export {
   downloadViaPlaywright,
   dragViaPlaywright,
   emulateMediaViaPlaywright,
+  clearMediaEmulationOverrideViaPlaywright,
   evaluateViaPlaywright,
   fillFormViaPlaywright,
   getConsoleMessagesViaPlaywright,

--- a/src/browser/pw-tools-core.state.ts
+++ b/src/browser/pw-tools-core.state.ts
@@ -101,6 +101,32 @@ export async function emulateMediaViaPlaywright(opts: {
   await page.emulateMedia({ colorScheme: opts.colorScheme });
 }
 
+/**
+ * Clear Playwright's default media emulation override via CDP.
+ *
+ * When Playwright connects to an existing browser via `connectOverCDP()`,
+ * it sends `Emulation.setEmulatedMedia` with `prefers-color-scheme: light`
+ * (Playwright's hardcoded default). This overrides the user's OS/browser
+ * dark mode preference and persists after Playwright disconnects.
+ *
+ * This function sends an empty `prefers-color-scheme` value via CDP,
+ * which tells Chrome to stop overriding and use the system default.
+ */
+export async function clearMediaEmulationOverrideViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<void> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await withCdpSession(page, async (session) => {
+    await session.send("Emulation.setEmulatedMedia" as any, {
+      features: [
+        { name: "prefers-color-scheme", value: "" },
+      ],
+    });
+  });
+}
+
 export async function setLocaleViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -115,6 +115,14 @@ export function registerBrowserAgentSnapshotRoutes(
         if (!pw) {
           return;
         }
+        // Clear Playwright's default colorScheme override for extension relay profiles
+        // so screenshots capture the user's actual OS/browser color scheme.
+        if (profileCtx.profile.driver === "extension") {
+          await pw.clearMediaEmulationOverrideViaPlaywright({
+            cdpUrl: profileCtx.profile.cdpUrl,
+            targetId: tab.targetId,
+          }).catch(() => {});
+        }
         const snap = await pw.takeScreenshotViaPlaywright({
           cdpUrl: profileCtx.profile.cdpUrl,
           targetId: tab.targetId,
@@ -200,6 +208,18 @@ export function registerBrowserAgentSnapshotRoutes(
       if ((labels || mode === "efficient") && format === "aria") {
         return jsonError(res, 400, "labels/mode=efficient require format=ai");
       }
+      // Clear Playwright's default colorScheme override for extension relay profiles.
+      // Playwright defaults to "light" when connecting via CDP, which overrides OS dark mode.
+      if (profileCtx.profile.driver === "extension") {
+        const pw0 = await getPwAiModule();
+        if (pw0) {
+          await pw0.clearMediaEmulationOverrideViaPlaywright({
+            cdpUrl: profileCtx.profile.cdpUrl,
+            targetId: tab.targetId,
+          }).catch(() => {});
+        }
+      }
+
       if (format === "ai") {
         const pw = await requirePwAi(res, "ai snapshot");
         if (!pw) {


### PR DESCRIPTION
## Problem

When using the Chrome extension relay (`profile=chrome`), Playwright's `connectOverCDP()` initializes pages with `Emulation.setEmulatedMedia` defaulting `prefers-color-scheme` to `light` — a hardcoded fallback in Playwright's `page.ts` (line 419: `contextOptions.colorScheme ?? "light"`). This overrides the user's OS/browser dark mode preference and **persists after the operation completes**.

### Steps to reproduce
1. User has their browser/OS in dark mode
2. Agent takes a screenshot or snapshot via Chrome extension relay
3. The tab flips to light mode and **stays that way**

### Root cause trace
- `connectOverCDP()` → `observeBrowser()` → page `_initialize()` → `_updateEmulateMedia()`
- `emulatedMedia().colorScheme` resolves to `contextOptions.colorScheme ?? "light"`
- Since the context was not created by Playwright (it's an existing Chrome context), `contextOptions.colorScheme` is `undefined`
- Playwright sends `Emulation.setEmulatedMedia` with `prefers-color-scheme: light` to Chrome
- Chrome overrides the OS preference; the override persists even after Playwright disconnects

## Fix

For extension relay profiles (`driver=extension`), clear the `prefers-color-scheme` override via a direct CDP call before screenshot/snapshot operations. Sending an empty string (`""`) for the feature value tells Chrome to stop overriding and use the system default.

### Changes
- **`pw-tools-core.state.ts`**: New `clearMediaEmulationOverrideViaPlaywright()` function that sends `Emulation.setEmulatedMedia` with empty `prefers-color-scheme` via CDP session
- **`agent.snapshot.ts`**: Call the clear function before screenshot and snapshot operations, only for `driver=extension` profiles
- **`pw-ai.ts`**: Export the new function

### Scope
- Only affects extension relay profiles (`driver=extension`). Managed browser profiles are unchanged.
- No breaking changes. Existing behavior preserved when no extension relay is used.
- Error-safe: the clear call is wrapped in `.catch(() => {})` so failures don't block operations.

Fixes #6167

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a CDP-based workaround for Chrome extension relay (`driver=extension`) sessions where Playwright’s `connectOverCDP()` applies a persistent `prefers-color-scheme: light` emulation. It introduces `clearMediaEmulationOverrideViaPlaywright()` (sending `Emulation.setEmulatedMedia` with an empty `prefers-color-scheme` value) and calls it before screenshot and snapshot operations to restore the user’s system/browser color scheme.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and narrowly scoped, with minor behavioral edge cases to verify around CDP emulation state.
- The change is small and gated to extension relay profiles, and the workaround aligns with the described Playwright/Chrome behavior. Main risk is unintended side effects from the `Emulation.setEmulatedMedia` payload potentially resetting other emulation fields, plus silent error swallowing making failures hard to detect.
- src/browser/pw-tools-core.state.ts; src/browser/routes/agent.snapshot.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->