### PR TITLE
fix: preserve allowAny flag in createModelSelectionState for custom providers (#2144)

### DIFF
--- a/src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts
+++ b/src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+
+// Mock loadModelCatalog to return a small built-in catalog (no custom providers).
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => [
+    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+    { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+    { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+  ]),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: vi.fn(async () => {}),
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
+}));
+
+vi.mock("../../agents/auth-profiles/session-override.js", () => ({
+  clearSessionAuthProfileOverride: vi.fn(async () => {}),
+}));
+
+import { createModelSelectionState } from "./model-selection.js";
+
+describe("createModelSelectionState: allowAny with custom providers (#2144)", () => {
+  const baseCfg: OpenClawConfig = {
+    models: {
+      providers: {
+        deepseek: {
+          baseUrl: "https://api.deepseek.com/v1",
+          apiKey: "sk-test",
+          api: "openai-completions",
+          models: [{ id: "deepseek-chat", name: "DeepSeek Chat" }],
+        },
+      },
+    },
+    // No agents.defaults.models allowlist → allowAny = true
+  } as unknown as OpenClawConfig;
+
+  const defaultProvider = "anthropic";
+  const defaultModel = "claude-opus-4-5";
+
+  it("preserves custom provider model override when allowAny is true", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "sub-1",
+      updatedAt: Date.now(),
+      providerOverride: "deepseek",
+      modelOverride: "deepseek-chat",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:subagent:sub-1": sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg: baseCfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:subagent:sub-1",
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    // The override should be applied, NOT silently reset
+    expect(state.provider).toBe("deepseek");
+    expect(state.model).toBe("deepseek-chat");
+    expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("preserves OpenRouter model override when allowAny is true", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "sub-2",
+      updatedAt: Date.now(),
+      providerOverride: "openrouter",
+      modelOverride: "google/gemini-2.5-flash",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:subagent:sub-2": sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg: baseCfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:subagent:sub-2",
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("google/gemini-2.5-flash");
+    expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("still allows built-in Anthropic model overrides", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "sub-3",
+      updatedAt: Date.now(),
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-5",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:subagent:sub-3": sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg: baseCfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:subagent:sub-3",
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-5");
+    expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("still rejects models not in allowlist when allowlist is configured", async () => {
+    const cfgWithAllowlist: OpenClawConfig = {
+      ...baseCfg,
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-5": {},
+            "anthropic/claude-sonnet-4-5": {},
+            // DeepSeek NOT in allowlist
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "sub-4",
+      updatedAt: Date.now(),
+      providerOverride: "deepseek",
+      modelOverride: "deepseek-chat",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:subagent:sub-4": sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg: cfgWithAllowlist,
+      agentCfg: cfgWithAllowlist.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:subagent:sub-4",
+      storePath: undefined,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    // Should reset to default because DeepSeek is NOT in the explicit allowlist
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts
+++ b/src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts
@@ -31,7 +31,7 @@ describe("createModelSelectionState: allowAny with custom providers (#2144)", ()
       providers: {
         deepseek: {
           baseUrl: "https://api.deepseek.com/v1",
-          apiKey: "sk-test",
+          apiKey: "FAKE",
           api: "openai-completions",
           models: [{ id: "deepseek-chat", name: "DeepSeek Chat" }],
         },

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -299,6 +299,7 @@ export async function createModelSelectionState(params: {
 
   let allowedModelKeys = new Set<string>();
   let allowedModelCatalog: ModelCatalog = [];
+  let allowAnyModel = false;
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
 
@@ -312,6 +313,7 @@ export async function createModelSelectionState(params: {
     });
     allowedModelCatalog = allowed.allowedCatalog;
     allowedModelKeys = allowed.allowedKeys;
+    allowAnyModel = allowed.allowAny;
   }
 
   if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
@@ -319,7 +321,7 @@ export async function createModelSelectionState(params: {
     const overrideModel = sessionEntry.modelOverride?.trim();
     if (overrideModel) {
       const key = modelKey(overrideProvider, overrideModel);
-      if (allowedModelKeys.size > 0 && !allowedModelKeys.has(key)) {
+      if (!allowAnyModel && allowedModelKeys.size > 0 && !allowedModelKeys.has(key)) {
         const { updated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
           selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -346,7 +348,7 @@ export async function createModelSelectionState(params: {
   if (storedOverride?.model) {
     const candidateProvider = storedOverride.provider || defaultProvider;
     const key = modelKey(candidateProvider, storedOverride.model);
-    if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
+    if (allowAnyModel || allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
       provider = candidateProvider;
       model = storedOverride.model;
     }


### PR DESCRIPTION
## Summary

Fix sub-agent model overrides being silently discarded for custom (non-catalog) providers like DeepSeek, OpenRouter, and other user-configured providers.

**Fixes:** #2144, #2489, #3145

## Problem

When `sessions_spawn` is called with a `model` override pointing to a custom provider (e.g., `deepseek/deepseek-chat`):

1. `sessions.patch` correctly validates the model using `buildAllowedModelSet().allowAny` → sets `modelApplied: true` ✅
2. But when the sub-agent actually runs, `createModelSelectionState` **discards the `allowAny` flag** and uses only `allowedModelKeys` (the built-in catalog)
3. Custom provider models aren't in the Pi SDK catalog → `allowedModelKeys.has(key)` returns `false`
4. **Check 1 (L322):** Silently resets the override back to the default model
5. **Check 2 (L349):** Refuses to apply the stored override
6. Sub-agent runs on the default Anthropic model despite `modelApplied: true`

This only affects **custom providers** — built-in catalog models (Anthropic, OpenAI, Google) work fine because they're in `allowedModelKeys`.

## Root Cause

`createModelSelectionState` in `src/auto-reply/reply/model-selection.ts` reads `allowedKeys` and `allowedCatalog` from `buildAllowedModelSet()` but **never reads `allowAny`**:

```typescript
// BEFORE (bug):
const allowed = buildAllowedModelSet({ cfg, catalog, defaultProvider, defaultModel });
allowedModelCatalog = allowed.allowedCatalog;
allowedModelKeys = allowed.allowedKeys;
// ^^^ allowed.allowAny is DISCARDED
```

Then two validation checks use only the key set:

```typescript
// Check 1 (~L322): Resets override if not in catalog
if (allowedModelKeys.size > 0 && !allowedModelKeys.has(key)) {
    applyModelOverrideToSessionEntry({ entry, selection: { ...default } }); // SILENT RESET!
}

// Check 2 (~L349): Applies override only if in catalog
if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
    provider = candidateProvider;
    model = storedOverride.model;
}
```

When `allowAny = true` (no explicit allowlist configured — the common case), `allowedModelKeys` still contains all catalog models, so `size > 0` is true, but custom provider models aren't in the set.

## Fix

**4-line change** — capture `allowAny` and use it in both checks:

```typescript
// AFTER (fix):
const allowed = buildAllowedModelSet({ cfg, catalog, defaultProvider, defaultModel });
allowedModelCatalog = allowed.allowedCatalog;
allowedModelKeys = allowed.allowedKeys;
let allowAnyModel = allowed.allowAny;  // ← NEW

// Check 1: Don't reset if allowAny is true
if (!allowAnyModel && allowedModelKeys.size > 0 && !allowedModelKeys.has(key)) { ... }

// Check 2: Apply if allowAny is true
if (allowAnyModel || allowedModelKeys.size === 0 || allowedModelKeys.has(key)) { ... }
```

This makes `createModelSelectionState` consistent with the `sessions.patch` path, which already uses `allowAny` correctly.

## Testing

### Unit Tests (4 new, all existing pass)

| Test | Description | Status |
|------|-------------|--------|
| Custom provider preserved (DeepSeek) | Override `deepseek/deepseek-chat` not reset when `allowAny=true` | ✅ |
| Custom provider preserved (OpenRouter) | Override `openrouter/google/gemini-2.5-flash` not reset | ✅ |
| Built-in model still works | Anthropic model override unaffected (regression) | ✅ |
| Allowlist still enforced | Explicit allowlist rejects unlisted models | ✅ |

**Existing test suite:** 22 test files in `src/auto-reply/reply/`, all passing (0 regressions).

### Live Instance Validation

Tested on a running Clawdbot `2026.1.24-3` instance (Ubuntu ARM64, Node 22) with DeepSeek configured as a custom provider:

| Test Case | Model Requested | Model Used | Result |
|-----------|----------------|------------|--------|
| TC-01: Custom provider | `deepseek/deepseek-chat` | `deepseek/deepseek-chat` | ✅ Confirmed via API response |
| TC-02: Built-in model | `anthropic/claude-sonnet-4-5` | `anthropic/claude-sonnet-4-5` | ✅ |
| TC-03: Default (no override) | *(none)* | `anthropic/claude-sonnet-4-5` (config default) | ✅ |
| TC-04: Invalid model | `fakeprovider/nonexistent-model-9000` | Falls back to instance default | ✅ Graceful degradation |

**Before fix:** TC-01 silently fell back to `anthropic/claude-opus-4-5` despite `modelApplied: true`.
**After fix:** TC-01 correctly routes to DeepSeek and receives a response from `deepseek-chat`.

### Verification Method

Sub-agent transcript confirmed actual API calls:
```json
{
  "api": "openai-completions",
  "provider": "deepseek",
  "model": "deepseek-chat",
  "stopReason": "stop"
}
```

## Impact

- **Scope:** Only affects `createModelSelectionState` in model-selection.ts
- **Risk:** Minimal — adds a boolean guard to two existing conditionals
- **Backward compatible:** When `allowAny = false` (explicit allowlist configured), behavior is unchanged
- **No breaking changes:** All 22 existing test files pass without modification

## Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/reply/model-selection.ts` | +2 lines (capture `allowAny`), ~2 lines modified (add guards) |
| `src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts` | New file: 4 test cases |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes model override handling for sub-agents when the override points to a custom (non-catalog) provider. `createModelSelectionState` now preserves and consults `allowAny` from `buildAllowedModelSet`, preventing overrides like `deepseek/deepseek-chat` from being silently reset to defaults when no explicit allowlist is configured. It also adds a focused Vitest suite that covers allowAny + custom providers, a built-in model regression case, and allowlist enforcement.

The change aligns the runtime selection path (`createModelSelectionState` in `src/auto-reply/reply/model-selection.ts`) with the existing validation semantics used elsewhere (via `buildAllowedModelSet`), so “modelApplied” and actual model execution behavior stay consistent for user-configured providers.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small behavioral fix with targeted tests, though the new tests could be tightened and local test execution wasn’t verified here.
- The runtime change is minimal (threading `allowAny` into two existing conditionals) and matches the intended semantics already encoded in `buildAllowedModelSet`. Added tests cover the previously broken path and allowlist enforcement. Confidence isn’t 5/5 because I couldn’t run the tests in this environment (missing pnpm) and the tests currently don’t assert that the session override reset side effect doesn’t occur in allowAny cases.
- src/auto-reply/reply/model-selection.allow-any-custom-provider.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->