### PR TITLE
fix(tts): always load fresh config for voice selection

### DIFF
--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -27,7 +27,8 @@ export function createTtsTool(opts?: {
       const params = args as Record<string, unknown>;
       const text = readStringParam(params, "text", { required: true });
       const channel = readStringParam(params, "channel");
-      const cfg = opts?.config ?? loadConfig();
+      // Always load fresh config to pick up runtime changes (e.g. voice selection)
+      const cfg = loadConfig();
       const result = await textToSpeech({
         text,
         cfg,


### PR DESCRIPTION
## Problem
The TTS tool was caching config at tool creation time, causing voice/provider changes to be ignored until gateway restart.

When users changed the TTS voice via config (e.g. from `alloy` to `fable`), the change wouldn't take effect because the tool kept using the stale config object passed during initialization.

## Solution
Changed `tts-tool.ts` to call `loadConfig()` on each invocation instead of using the cached `opts?.config`.

This ensures runtime config changes (voice selection, provider changes via `/tts` command or config updates) are picked up immediately.

## Testing
- Verified voice changes take effect immediately after config update
- Confirmed OpenAI TTS uses correct voice from config

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the TTS agent tool to call `loadConfig()` on each `execute` invocation instead of using the config captured at tool creation time, so runtime updates (voice/provider selection) are picked up without restarting the gateway.

Change is localized to `src/agents/tools/tts-tool.ts`, and it feeds the freshly loaded config into the existing `textToSpeech` pipeline while keeping channel selection behavior the same.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; behavior change is straightforward and localized.
- The change removes reliance on a captured config object and instead uses the existing `loadConfig()` API (which already has internal caching/invalidations). Primary concern is interface drift: `opts.config` is now effectively ignored, which may surprise callers/tests, but runtime TTS behavior should improve as intended.
- src/agents/tools/tts-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->