### PR TITLE
fix(agents): support thinking tags with attributes

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -17,7 +17,8 @@ import {
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
 import { formatReasoningMessage } from "./pi-embedded-utils.js";
 
-const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+// Match thinking tags with optional attributes (e.g., <thinking reason="...">)
+const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
 const log = createSubsystemLogger("agent/embedded");
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -399,8 +399,9 @@ export function extractThinkingFromTaggedStream(text: string): string {
     return closed;
   }
 
-  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
-  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  // Match thinking tags with optional attributes (e.g., <thinking reason="...">)
+  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
   const openMatches = [...text.matchAll(openRe)];
   if (openMatches.length === 0) {
     return "";

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -268,8 +268,9 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
   if (!trimmedStart.startsWith("<")) {
     return null;
   }
-  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
-  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+  // Match thinking tags with optional attributes (e.g., <thinking reason="...">)
+  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
+  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
   if (!openRe.test(trimmedStart)) {
     return null;
   }
@@ -277,7 +278,7 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
     return null;
   }
 
-  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
   let inThinking = false;
   let cursor = 0;
   let thinkingStart = 0;
@@ -372,7 +373,8 @@ export function extractThinkingFromTaggedText(text: string): string {
   if (!text) {
     return "";
   }
-  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  // Match thinking tags with optional attributes (e.g., <thinking reason="...">)
+  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
   let result = "";
   let lastIndex = 0;
   let inThinking = false;


### PR DESCRIPTION
Updated regex patterns to match thinking tags with attributes:
- Modified `THINKING_TAG_SCAN_RE` and related patterns to capture optional attributes
- Changed from `\s*>` to `\b[^<>]*>` pattern

## AI Assistance
Used Claude Code to:
- Identify regex patterns that needed updating for thinking tags with attributes
- Write regression test for Gemini-style attribute-bearing thinking tags

Fully tested locally (build + tests pass).

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (untested / lightly tested / fully tested)
- [x] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded agent streaming logic to treat `<think>`/`<thinking>`/`<thought>`/`<antthinking>` tags as reasoning blocks even when the opening/closing tags include attributes (e.g. `<thinking reason="...">`). It does this by widening the regexes used to scan and strip thinking tags during streaming, and adds a regression test that simulates Gemini-style attribute-bearing thinking tags to ensure hidden reasoning is suppressed and only the visible answer is emitted.

These changes fit into the existing embedded PI session subscription pipeline (`subscribeEmbeddedPiSession`) which already strips/segments reasoning and enforces final-tag handling while preserving inline-code spans; this PR makes the thinking-tag detection more robust for providers that emit attributes in their tag syntax.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one consistency bug around streaming extraction of attribute-bearing thinking tags.
- The change is narrowly scoped (regex widening + a focused regression test) and aligns with existing thinking-tag stripping behavior. The main concern is `extractThinkingFromTaggedStream` still using the pre-change regex patterns, which can lead to inconsistent behavior for streaming providers that emit thinking tags with attributes before closure.
- src/agents/pi-embedded-utils.ts (extractThinkingFromTaggedStream regexes)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->