### PR TITLE
feat(config): add supportsStrictMode compat option for model definitions

### DIFF
--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -10,6 +10,7 @@ export type ModelCompatConfig = {
   supportsStore?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
+  supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
 };
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -15,6 +15,7 @@ export const ModelCompatSchema = z
     supportsStore: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
+    supportsStrictMode: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),

--- a/src/config/zod-schema.model-compat.test.ts
+++ b/src/config/zod-schema.model-compat.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { ModelCompatSchema, ModelDefinitionSchema } from "./zod-schema.core.js";
+
+describe("ModelCompatSchema", () => {
+  it("accepts supportsStrictMode: true", () => {
+    const result = ModelCompatSchema.safeParse({ supportsStrictMode: true });
+    expect(result.success).toBe(true);
+    expect(result.data?.supportsStrictMode).toBe(true);
+  });
+
+  it("accepts supportsStrictMode: false", () => {
+    const result = ModelCompatSchema.safeParse({ supportsStrictMode: false });
+    expect(result.success).toBe(true);
+    expect(result.data?.supportsStrictMode).toBe(false);
+  });
+
+  it("accepts undefined supportsStrictMode", () => {
+    const result = ModelCompatSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data?.supportsStrictMode).toBeUndefined();
+  });
+});
+
+describe("ModelDefinitionSchema with compat.supportsStrictMode", () => {
+  it("accepts model with supportsStrictMode: false", () => {
+    const modelDef = {
+      id: "route-llm",
+      name: "RouteLLM",
+      compat: { supportsStrictMode: false },
+    };
+    const result = ModelDefinitionSchema.safeParse(modelDef);
+    expect(result.success).toBe(true);
+    expect(result.data?.compat?.supportsStrictMode).toBe(false);
+  });
+
+  it("accepts model with multiple compat options including supportsStrictMode", () => {
+    const modelDef = {
+      id: "custom-model",
+      name: "Custom Model",
+      compat: {
+        supportsDeveloperRole: false,
+        supportsStrictMode: false,
+        supportsReasoningEffort: true,
+      },
+    };
+    const result = ModelDefinitionSchema.safeParse(modelDef);
+    expect(result.success).toBe(true);
+    expect(result.data?.compat?.supportsDeveloperRole).toBe(false);
+    expect(result.data?.compat?.supportsStrictMode).toBe(false);
+    expect(result.data?.compat?.supportsReasoningEffort).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Some OpenAI-compatible endpoints reject requests that include the `strict: true` parameter in tool/function definitions. This parameter was added by OpenAI for structured outputs but isn't universally supported.

This PR adds a `supportsStrictMode` option to the `compat` field in model definitions, allowing providers to be configured to omit the strict parameter when making API calls.

**Changes:**
- Added `supportsStrictMode?: boolean` to `ModelCompatSchema` in `zod-schema.core.ts`
- Added `supportsStrictMode?: boolean` to `ModelCompatConfig` type in `types.models.ts`
- Added unit tests for the new schema option

## Example Config

```json
{
  "models": {
    "providers": {
      "routellm": {
        "baseUrl": "https://routellm.abacus.ai/v1",
        "api": "openai-completions",
        "models": [{
          "id": "route-llm",
          "name": "RouteLLM",
          "compat": { "supportsStrictMode": false }
        }]
      }
    }
  }
}
```

## Note

This PR adds the config option on the openclaw side. The `@mariozechner/pi-ai` library will need a corresponding update to read this compat option and conditionally omit the strict parameter from tool definitions when building API requests.

## Test Plan

- [x] Added unit tests for `ModelCompatSchema` with `supportsStrictMode`
- [x] Existing model-related tests pass
- [ ] Integration testing pending pi-ai library support

Closes #6674

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new optional `compat.supportsStrictMode` flag to the model config surface (both the `ModelCompatConfig` TS type and the `ModelCompatSchema` zod schema) so providers that reject OpenAI’s `strict: true` tool/function metadata can be configured to omit it. Includes unit tests validating `supportsStrictMode` is accepted both on the compat object itself and when nested under a model definition.

This fits alongside the existing `compat` toggles (`supportsDeveloperRole`, `supportsReasoningEffort`, etc.) that let OpenClaw adapt request shaping per-provider without forking model definitions.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and primarily extends config schemas/types with tests.
- Changes are additive (new optional boolean) and localized to config typing/validation. No runtime behavior changes are introduced in this repo, and tests are straightforward; however, I couldn’t execute the test suite in this environment (npm unavailable), so confidence isn’t maxed.
- src/config/zod-schema.model-compat.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->