### PR TITLE
fix: suppress thinking leak for Synthetic reasoning models

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test.ts
@@ -1,0 +1,81 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createThinkingDisabledWrapper } from "./extra-params.js";
+
+function makeModel(overrides: Partial<Model<Api>> = {}): Model<Api> {
+  return {
+    id: "test-model",
+    name: "Test Model",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    reasoning: true,
+    input: ["text"],
+    maxTokens: 4096,
+    contextWindow: 200_000,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ...overrides,
+  } as Model<Api>;
+}
+
+describe("createThinkingDisabledWrapper", () => {
+  it("injects thinking: disabled for anthropic-messages reasoning model", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseFn: StreamFn = vi.fn((_model, _ctx, _options) => {
+      return { push: vi.fn(), end: vi.fn() } as never;
+    });
+
+    const wrapped = createThinkingDisabledWrapper(baseFn, makeModel());
+    void wrapped(
+      makeModel(),
+      { messages: [], tools: [] },
+      {
+        onPayload: (p) => capturedPayloads.push(p),
+      },
+    );
+
+    expect(baseFn).toHaveBeenCalledOnce();
+
+    const call = vi.mocked(baseFn).mock.calls[0];
+    const optionsArg = call[2] as { onPayload?: (p: unknown) => void };
+    const payload: Record<string, unknown> = { model: "test", max_tokens: 1024 };
+    optionsArg.onPayload!(payload);
+
+    expect(payload.thinking).toEqual({ type: "disabled" });
+    expect(capturedPayloads).toHaveLength(1);
+  });
+
+  it("does not overwrite when thinking is already set", () => {
+    const baseFn: StreamFn = vi.fn((_model, _ctx, _options) => {
+      return { push: vi.fn(), end: vi.fn() } as never;
+    });
+
+    const wrapped = createThinkingDisabledWrapper(baseFn, makeModel());
+    void wrapped(makeModel(), { messages: [], tools: [] }, {});
+
+    const call = vi.mocked(baseFn).mock.calls[0];
+    const optionsArg = call[2] as { onPayload?: (p: unknown) => void };
+    const payload: Record<string, unknown> = {
+      model: "test",
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    };
+    optionsArg.onPayload!(payload);
+
+    expect(payload.thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+  });
+
+  it("returns base streamFn unchanged for non-reasoning model", () => {
+    const baseFn: StreamFn = vi.fn();
+    const result = createThinkingDisabledWrapper(baseFn, makeModel({ reasoning: false }));
+    expect(result).toBe(baseFn);
+  });
+
+  it("returns base streamFn unchanged for non-anthropic API", () => {
+    const baseFn: StreamFn = vi.fn();
+    const result = createThinkingDisabledWrapper(
+      baseFn,
+      makeModel({ api: "openai-responses" as Api }),
+    );
+    expect(result).toBe(baseFn);
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,5 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
+import type { Api, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { log } from "./logger.js";
@@ -153,4 +153,34 @@ export function applyExtraParamsToAgent(
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);
     agent.streamFn = createOpenRouterHeadersWrapper(agent.streamFn);
   }
+}
+
+/**
+ * Wrap a streamFn to inject `thinking: { type: "disabled" }` into the Anthropic
+ * API payload for reasoning-capable models when thinking is not enabled.
+ *
+ * Without this, some Anthropic-compatible providers (e.g. Synthetic/Kimi K2.5)
+ * default to emitting thinking as plain text in regular content blocks when the
+ * thinking parameter is absent, which leaks into user-visible output.
+ */
+export function createThinkingDisabledWrapper(baseStreamFn: StreamFn, model: Model<Api>): StreamFn {
+  if (!model.reasoning || model.api !== "anthropic-messages") {
+    return baseStreamFn;
+  }
+
+  log.debug("wrapping streamFn with thinking: disabled for anthropic-messages reasoning model");
+
+  return (mdl, context, options) => {
+    const nextOnPayload = (payload: unknown) => {
+      const p = payload as Record<string, unknown>;
+      if (!p.thinking) {
+        p.thinking = { type: "disabled" };
+      }
+      options?.onPayload?.(payload);
+    };
+    return baseStreamFn(mdl, context, {
+      ...options,
+      onPayload: nextOnPayload,
+    });
+  };
 }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -173,7 +173,7 @@ export function createThinkingDisabledWrapper(baseStreamFn: StreamFn, model: Mod
   return (mdl, context, options) => {
     const nextOnPayload = (payload: unknown) => {
       const p = payload as Record<string, unknown>;
-      if (!p.thinking) {
+      if (!("thinking" in p)) {
         p.thinking = { type: "disabled" };
       }
       options?.onPayload?.(payload);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -66,7 +66,7 @@ import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
-import { applyExtraParamsToAgent } from "../extra-params.js";
+import { applyExtraParamsToAgent, createThinkingDisabledWrapper } from "../extra-params.js";
 import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
@@ -524,6 +524,16 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+
+      // Explicitly disable thinking for reasoning-capable models when thinking is off.
+      // Without this, providers like Synthetic/Kimi K2.5 emit thinking as plain text
+      // (no tags, no structured blocks) when the thinking parameter is absent.
+      if (params.thinkLevel === "off" && activeSession.agent.streamFn) {
+        activeSession.agent.streamFn = createThinkingDisabledWrapper(
+          activeSession.agent.streamFn,
+          params.model,
+        );
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {


### PR DESCRIPTION
## Summary

Fixes #6442

When using Synthetic provider with reasoning-capable models (e.g. Kimi K2.5), thinking text leaks into user-facing output as plain text. This happens because pi-ai's Anthropic provider sends no `thinking` parameter when `thinkLevel` is `"off"` (the default), and Synthetic/Kimi defaults to emitting thinking as plain text content blocks.

- Adds `createThinkingDisabledWrapper()` in `extra-params.ts` that injects `thinking: { type: "disabled" }` into the Anthropic API payload via the `onPayload` callback
- Only applies when: `thinkLevel === "off"`, `model.reasoning === true`, and `model.api === "anthropic-messages"`
- No effect on actual Anthropic models (Claude already handles absent `thinking` param correctly; `disabled` is a valid no-op)
- No effect on non-anthropic-messages providers (Venice, OpenRouter, Ollama all use `openai-completions`/`openai-responses`)

## Test plan

- [x] New unit tests for `createThinkingDisabledWrapper` (4 tests covering inject, no-overwrite, non-reasoning skip, non-anthropic skip)
- [x] `pnpm lint && pnpm build && pnpm test` pass
- [x] Manual test: sent messages via Synthetic/Kimi K2.5 with `thinkLevel: "off"` — thinking no longer leaks into user output
- [x] Manual test: sent messages with `--thinking medium` — model reasons, structured thinking blocks properly filtered from output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents “thinking” text from leaking into user-visible output when using Anthropic-compatible providers (notably Synthetic/Kimi) with reasoning-capable models and `thinkLevel: "off"`. It does so by adding a `createThinkingDisabledWrapper()` stream wrapper that injects `thinking: { type: "disabled" }` into the Anthropic Messages payload (via `onPayload`) when the model is marked `reasoning: true` and uses the `anthropic-messages` API, and then applying that wrapper during embedded runs when thinking is disabled. Unit tests cover injection, non-overwrite, and skip conditions for non-reasoning / non-anthropic APIs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, targeted payload mutation with tests.
- The change is narrowly scoped (only wraps streamFn when thinkLevel is off and model is reasoning + anthropic-messages) and has unit tests for core behavior. Main remaining risk is subtle onPayload chaining/ordering or models/providers where forcing `thinking: disabled` has unintended effects, but the wrapper avoids overwriting existing thinking settings.
- src/agents/pi-embedded-runner/extra-params.ts and src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->