### PR TITLE
fix(session-repair): strip malformed tool_use blocks to prevent permanent session corruption

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -12,7 +12,7 @@ import {
   sanitizeSessionMessagesImages,
 } from "../pi-embedded-helpers.js";
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
-import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
+import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { log } from "./logger.js";
 import { describeUnknownError } from "./utils.js";
@@ -346,9 +346,16 @@ export async function sanitizeSessionHistory(params: {
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;
-  const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedThinking)
-    : sanitizedThinking;
+  let repairedTools = sanitizedThinking;
+  if (policy.repairToolUseResultPairing) {
+    const report = repairToolUseResultPairing(sanitizedThinking);
+    repairedTools = report.messages;
+    if (report.droppedMalformedToolUseCount > 0) {
+      log.warn(
+        `session repair: stripped ${report.droppedMalformedToolUseCount} malformed tool_use block(s)`,
+      );
+    }
+  }
 
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -350,10 +350,22 @@ export async function sanitizeSessionHistory(params: {
   if (policy.repairToolUseResultPairing) {
     const report = repairToolUseResultPairing(sanitizedThinking);
     repairedTools = report.messages;
+    // Log all non-zero repair counters for easier debugging of transcript issues
+    const parts: string[] = [];
     if (report.droppedMalformedToolUseCount > 0) {
-      log.warn(
-        `session repair: stripped ${report.droppedMalformedToolUseCount} malformed tool_use block(s)`,
-      );
+      parts.push(`${report.droppedMalformedToolUseCount} malformed tool_use block(s) stripped`);
+    }
+    if (report.droppedOrphanCount > 0) {
+      parts.push(`${report.droppedOrphanCount} orphan result(s) dropped`);
+    }
+    if (report.droppedDuplicateCount > 0) {
+      parts.push(`${report.droppedDuplicateCount} duplicate result(s) dropped`);
+    }
+    if (report.added.length > 0) {
+      parts.push(`${report.added.length} synthetic result(s) added`);
+    }
+    if (parts.length > 0) {
+      log.warn(`session repair: ${parts.join(", ")}`);
     }
   }
 

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -161,7 +161,13 @@ describe("repairToolUseResultPairing malformed tool_use stripping", () => {
       {
         role: "assistant",
         content: [
-          { type: "toolCall", id: "call_1", name: "read", arguments: {}, partialJson: '{"foo":' },
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "read",
+            arguments: {},
+            partialJson: '{"foo":',
+          },
           { type: "text", text: "done" },
         ],
       },

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import {
+  repairToolUseResultPairing,
+  sanitizeToolUseResultPairing,
+} from "./session-transcript-repair.js";
 
 describe("sanitizeToolUseResultPairing", () => {
   it("moves tool results directly after tool calls and inserts missing results", () => {
@@ -108,5 +111,195 @@ describe("sanitizeToolUseResultPairing", () => {
     const out = sanitizeToolUseResultPairing(input);
     expect(out.some((m) => m.role === "toolResult")).toBe(false);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+});
+
+describe("repairToolUseResultPairing malformed tool_use stripping", () => {
+  // Reproduces the root cause of issues #5497, #5481, #5430, #5518:
+  // Malformed tool_use blocks (from interrupted tool calls) cause API rejections:
+  // - "unexpected tool_use_id found in tool_result blocks"
+  // - "tool result's tool id not found (2013)"
+  // The fix: strip malformed blocks before pairing repair runs.
+
+  it("strips tool_use blocks with missing id", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", name: "read", arguments: {} },
+          { type: "text", text: "hello" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+    expect((assistantContent![0] as { type: string }).type).toBe("text");
+  });
+
+  it("strips tool_use blocks with empty string id", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "", name: "read", arguments: {} },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+  });
+
+  it("strips tool_use blocks with partialJson field", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "read", arguments: {}, partialJson: '{"foo":' },
+          { type: "text", text: "done" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+    expect((assistantContent![0] as { type: string }).type).toBe("text");
+  });
+
+  it("strips tool_use blocks with missing name", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", arguments: {} },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+  });
+
+  it("keeps valid blocks while stripping malformed ones", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_valid", name: "read", arguments: {} },
+          { type: "toolCall", id: "", name: "write", arguments: {} }, // malformed: empty id
+          { type: "text", text: "text block" },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_valid",
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    const assistantContent = (report.messages[0] as { content?: unknown[] }).content;
+    expect(assistantContent).toHaveLength(2); // valid toolCall + text
+    expect((assistantContent![0] as { id?: string }).id).toBe("call_valid");
+    // Should not create synthetic result for the stripped malformed block
+    expect(report.added).toHaveLength(0);
+  });
+
+  it("preserves error assistant messages after stripping all tool blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: {} }], // missing id
+        stopReason: "error",
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    expect(report.messages).toHaveLength(1);
+    expect((report.messages[0] as { stopReason?: string }).stopReason).toBe("error");
+    expect((report.messages[0] as { content?: unknown[] }).content).toHaveLength(0);
+  });
+
+  it("does not create synthetic results for stripped malformed blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", name: "read", arguments: {} }, // malformed: no id
+        ],
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    expect(report.added).toHaveLength(0);
+  });
+
+  it("report includes droppedMalformedToolUseCount", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(input);
+    expect(report).toHaveProperty("droppedMalformedToolUseCount");
+    expect(report.droppedMalformedToolUseCount).toBe(0);
+  });
+
+  it("recovers from interrupted tool call (session corruption scenario)", () => {
+    // This simulates the exact scenario from issues #5497, #5481, #5430, #5518:
+    // A tool call is interrupted mid-stream (error, timeout, content filtering, or process death).
+    // The session file contains a malformed tool_use block with no id.
+    // Without the fix, every subsequent API request fails because the API expects
+    // a matching tool_result for every tool_use, but we can't provide one for an id-less block.
+    const corruptedSession = [
+      { role: "user", content: "read file.txt" },
+      {
+        role: "assistant",
+        content: [
+          // Interrupted tool call - no id assigned before the stream was cut
+          { type: "toolCall", name: "read", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      // User tries again after the error
+      { role: "user", content: "try again" },
+    ] as AgentMessage[];
+
+    const report = repairToolUseResultPairing(corruptedSession);
+
+    // The malformed tool_use block should be stripped
+    expect(report.droppedMalformedToolUseCount).toBe(1);
+    // No synthetic results should be created for the stripped block
+    expect(report.added).toHaveLength(0);
+    // Session should be usable again: user, (empty) assistant with error, user
+    expect(report.messages).toHaveLength(3);
+    expect(report.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    // The error assistant message is preserved (with empty content) for debugging
+    const errorAssistant = report.messages[1] as { stopReason?: string; content?: unknown[] };
+    expect(errorAssistant.stopReason).toBe("error");
+    expect(errorAssistant.content).toHaveLength(0);
   });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -10,6 +10,9 @@ type ToolCallLike = {
  * Returns true for non-tool blocks (they pass through) and valid tool blocks.
  * Returns false for malformed tool blocks that should be stripped.
  *
+ * Handles both camelCase (toolCall, toolUse, functionCall) and snake_case
+ * (tool_use, function_call) type variants to support all provider SDKs.
+ *
  * Malformed conditions (indicate interrupted/incomplete tool calls):
  * - Missing or empty `id` field (tool call wasn't fully initialized)
  * - Has `partialJson` field (Anthropic SDK streaming artifact)
@@ -30,8 +33,9 @@ function isValidToolUseBlock(block: unknown): boolean {
     partial?: unknown;
     incomplete?: unknown;
   };
-  // Only validate tool-related types
-  if (rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall") {
+  // Only validate tool-related types (both camelCase and snake_case variants)
+  const toolTypes = ["toolCall", "toolUse", "functionCall", "tool_use", "function_call"];
+  if (!toolTypes.includes(rec.type as string)) {
     return true;
   }
   // Malformed: missing/invalid id (tool call wasn't fully initialized)

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -5,6 +5,15 @@ type ToolCallLike = {
   name?: string;
 };
 
+/** Tool block type values to match (both camelCase and snake_case variants) */
+const TOOL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_use",
+  "function_call",
+]);
+
 /**
  * Check if a content block is a valid tool_use/toolCall/functionCall block.
  * Returns true for non-tool blocks (they pass through) and valid tool blocks.
@@ -34,8 +43,7 @@ function isValidToolUseBlock(block: unknown): boolean {
     incomplete?: unknown;
   };
   // Only validate tool-related types (both camelCase and snake_case variants)
-  const toolTypes = ["toolCall", "toolUse", "functionCall", "tool_use", "function_call"];
-  if (!toolTypes.includes(rec.type as string)) {
+  if (!TOOL_BLOCK_TYPES.has(rec.type as string)) {
     return true;
   }
   // Malformed: missing/invalid id (tool call wasn't fully initialized)
@@ -126,7 +134,7 @@ function extractToolCallsFromAssistant(
       continue;
     }
 
-    if (rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall") {
+    if (TOOL_BLOCK_TYPES.has(rec.type as string)) {
       toolCalls.push({
         id: rec.id,
         name: typeof rec.name === "string" ? rec.name : undefined,

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -5,6 +5,92 @@ type ToolCallLike = {
   name?: string;
 };
 
+/**
+ * Check if a content block is a valid tool_use/toolCall/functionCall block.
+ * Returns true for non-tool blocks (they pass through) and valid tool blocks.
+ * Returns false for malformed tool blocks that should be stripped.
+ */
+function isValidToolUseBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return true; // Non-objects pass through
+  }
+  const rec = block as {
+    type?: unknown;
+    id?: unknown;
+    name?: unknown;
+    partialJson?: unknown;
+  };
+  // Only validate tool-related types
+  if (rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall") {
+    return true;
+  }
+  // Malformed: missing/invalid id, missing name, or has partialJson (indicates interrupted serialization)
+  if (typeof rec.id !== "string" || !rec.id) {
+    return false;
+  }
+  if (typeof rec.name !== "string") {
+    return false;
+  }
+  if (rec.partialJson !== undefined) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Strip malformed tool_use blocks from assistant messages.
+ * This must run BEFORE pairing repair to prevent creating synthetic results for invalid blocks.
+ */
+function stripMalformedToolUseBlocks(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  droppedMalformedCount: number;
+} {
+  let droppedMalformedCount = 0;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      out.push(msg);
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    const content = assistant.content;
+    if (!Array.isArray(content)) {
+      out.push(msg);
+      continue;
+    }
+
+    const validContent = content.filter((block) => {
+      const valid = isValidToolUseBlock(block);
+      if (!valid) {
+        droppedMalformedCount += 1;
+      }
+      return valid;
+    });
+
+    if (validContent.length === content.length) {
+      out.push(msg);
+    } else if (validContent.length === 0) {
+      // Keep empty assistant with stopReason: "error" for error tracking
+      const stopReason = (assistant as { stopReason?: unknown }).stopReason;
+      if (stopReason === "error") {
+        out.push({ ...assistant, content: [] } as typeof assistant);
+      }
+      // Otherwise drop the empty assistant message entirely
+    } else {
+      out.push({ ...assistant, content: validContent } as typeof assistant);
+    }
+  }
+
+  return { messages: droppedMalformedCount > 0 ? out : messages, droppedMalformedCount };
+}
+
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
@@ -75,10 +161,15 @@ export type ToolUseRepairReport = {
   added: Array<Extract<AgentMessage, { role: "toolResult" }>>;
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
+  droppedMalformedToolUseCount: number;
   moved: boolean;
 };
 
 export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRepairReport {
+  // Strip malformed tool_use blocks first to prevent creating synthetic results for invalid blocks
+  const { messages: cleanedMessages, droppedMalformedCount } =
+    stripMalformedToolUseBlocks(messages);
+
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
   // displaced (e.g. after user turns) or duplicated. Repair by:
@@ -91,7 +182,7 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
   let droppedDuplicateCount = 0;
   let droppedOrphanCount = 0;
   let moved = false;
-  let changed = false;
+  let changed = droppedMalformedCount > 0;
 
   const pushToolResult = (msg: Extract<AgentMessage, { role: "toolResult" }>) => {
     const id = extractToolResultId(msg);
@@ -106,8 +197,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     out.push(msg);
   };
 
-  for (let i = 0; i < messages.length; i += 1) {
-    const msg = messages[i];
+  for (let i = 0; i < cleanedMessages.length; i += 1) {
+    const msg = cleanedMessages[i];
     if (!msg || typeof msg !== "object") {
       out.push(msg);
       continue;
@@ -140,8 +231,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     const remainder: AgentMessage[] = [];
 
     let j = i + 1;
-    for (; j < messages.length; j += 1) {
-      const next = messages[j];
+    for (; j < cleanedMessages.length; j += 1) {
+      const next = cleanedMessages[j];
       if (!next || typeof next !== "object") {
         remainder.push(next);
         continue;
@@ -211,10 +302,11 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
   const changedOrMoved = changed || moved;
   return {
-    messages: changedOrMoved ? out : messages,
+    messages: changedOrMoved ? out : cleanedMessages,
     added,
     droppedDuplicateCount,
     droppedOrphanCount,
+    droppedMalformedToolUseCount: droppedMalformedCount,
     moved: changedOrMoved,
   };
 }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -39,9 +39,12 @@ function isValidToolUseBlock(block: unknown): boolean {
     return false;
   }
   // Malformed: has streaming/partial indicators (tool call was interrupted mid-stream)
-  if (rec.partialJson !== undefined) {
+  // Use property presence check ("in") to catch partialJson regardless of its value
+  if ("partialJson" in rec) {
     return false;
   }
+  // Use strict boolean checks for partial/incomplete to avoid false positives from
+  // falsy values like 0 or "" which don't indicate a partial tool call
   if (rec.partial === true) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Strips malformed `tool_use`/`toolCall`/`functionCall` blocks from assistant messages BEFORE the existing pairing repair runs
- Adds `droppedMalformedToolUseCount` to the repair report for observability
- Prevents creating synthetic error results for blocks that were never valid tool calls

## Problem
When tool calls are interrupted (by error, timeout, content filtering, or process termination), sessions become **permanently corrupted**. Every subsequent API request fails with:
- `unexpected tool_use_id found in tool_result blocks`
- `tool result's tool id not found (2013)`

**Root cause:** The existing `extractToolCallsFromAssistant()` skips malformed blocks (missing id) but **leaves them in the message content**. The blocks remain in the transcript, causing API rejections.

## Solution
Add a pre-processing step that strips malformed tool_use blocks before the pairing repair runs:

**Malformed conditions detected:**
- Missing or empty `id` field (tool call wasn't fully initialized)
- Has `partialJson` field present (Anthropic SDK streaming artifact) - uses property presence check (`"partialJson" in rec`) to catch regardless of value
- Has `partial` field set to `true` (generic streaming indicator)
- Has `incomplete` field set to `true` (OpenAI-style indicator)

**Type variants supported (via shared `TOOL_BLOCK_TYPES` Set):**
- camelCase: `toolCall`, `toolUse`, `functionCall`
- snake_case: `tool_use`, `function_call`

Both `isValidToolUseBlock` and `extractToolCallsFromAssistant` use the same `TOOL_BLOCK_TYPES` Set to ensure consistent handling across validation and extraction.

The `name` field is intentionally NOT required - `extractToolCallsFromAssistant` already handles missing names gracefully by defaulting to `undefined`.

### Design decisions
- **Shared constant:** `TOOL_BLOCK_TYPES` is a Set used by both functions to ensure consistency.
- **Property presence vs value check:** For `partialJson`, we use `"partialJson" in rec` rather than `!== undefined` because the mere presence of this field (even if explicitly `undefined`) indicates a streaming artifact.
- **Strict boolean checks for partial/incomplete:** We use `=== true` rather than truthy checks to avoid false positives from falsy values like `0`, `""`, or `null` which don't indicate a partial tool call.
- **Expanded logging:** All non-zero repair counters are now logged (malformed stripped, orphans dropped, duplicates dropped, synthetic results added) for easier debugging.

## Test plan
- [x] Added comprehensive tests for malformed block detection
- [x] Existing tests pass (`pnpm test src/agents/session-transcript-repair.test.ts`)
- [x] Full test suite passes (`pnpm test`)
- [x] Lint passes (`pnpm lint`)

Fixes #5497, #5481, #5430, #5518

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens session transcript repair by stripping malformed assistant tool blocks (e.g., missing/empty `id` or streaming artifacts like `partialJson`, `partial: true`, `incomplete: true`) before the existing tool-call/tool-result pairing logic runs. It also unifies tool-block type detection across validation and extraction via a shared `TOOL_BLOCK_TYPES` set (supporting both camelCase and snake_case variants), adds `droppedMalformedToolUseCount` to the repair report for observability, and updates the Google embedded runner to log non-zero repair counters.

The change integrates cleanly with existing transcript sanitation: `sanitizeToolUseResultPairing()` now delegates to `repairToolUseResultPairing()`, which first cleans assistant content and then enforces strict provider requirements by moving matching `toolResult` messages directly after the corresponding assistant tool-call turn, dropping orphan/duplicate results, and synthesizing missing results only for valid tool calls.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to transcript sanitation, include defensive runtime checks, preserve message ordering/metadata, and are covered by targeted unit tests that exercise the new malformed-block stripping and reporting behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->