### PR TITLE
UX: clearer /queue and /subagents output

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -15,10 +15,14 @@ import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 
-const OAUTH_PROVIDER_IDS = new Set(getOAuthProviders().map((provider) => provider.id));
+const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) => provider.id));
+
+function isOAuthProvider(provider: string): provider is OAuthProvider {
+  return OAUTH_PROVIDER_IDS.has(provider);
+}
 
 const resolveOAuthProvider = (provider: string): OAuthProvider | null =>
-  OAUTH_PROVIDER_IDS.has(provider as OAuthProvider) ? (provider as OAuthProvider) : null;
+  isOAuthProvider(provider) ? provider : null;
 
 function buildOAuthApiKey(provider: string, credentials: OAuthCredentials): string {
   const needsProjectId = provider === "google-gemini-cli" || provider === "google-antigravity";

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -178,8 +178,7 @@ export async function buildStatusReply(params: {
     channel: command.channel,
     sessionEntry,
   });
-  const queueKey = sessionKey ?? sessionEntry?.sessionId;
-  const queueDepth = queueKey ? getFollowupQueueDepth(queueKey) : 0;
+  const queueDepth = sessionKey ? getFollowupQueueDepth(sessionKey) : 0;
   const queueOverrides = Boolean(
     sessionEntry?.queueDebounceMs ?? sessionEntry?.queueCap ?? sessionEntry?.queueDrop,
   );

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -208,19 +208,25 @@ export const handleSubagentsCommand: CommandHandler = async (params, allowTextCo
     const sorted = sortSubagentRuns(runs);
     const active = sorted.filter((entry) => !entry.endedAt);
     const done = sorted.length - active.length;
-    const lines = ["🧭 Subagents (current session)", `Active: ${active.length} · Done: ${done}`];
+    const lines = [
+      "🧭 Subagents (current session)",
+      `Active: ${active.length} · Done: ${done}`,
+      "",
+    ];
+
     sorted.forEach((entry, index) => {
-      const status = formatRunStatus(entry);
+      const status = formatRunStatus(entry).toUpperCase();
       const label = formatRunLabel(entry);
       const runtime =
         entry.endedAt && entry.startedAt
           ? formatDurationShort(entry.endedAt - entry.startedAt)
           : formatAgeShort(Date.now() - (entry.startedAt ?? entry.createdAt));
       const runId = entry.runId.slice(0, 8);
-      lines.push(
-        `${index + 1}) ${status} · ${label} · ${runtime} · run ${runId} · ${entry.childSessionKey}`,
-      );
+
+      lines.push(`${index + 1}) ${status} · ${label}`);
+      lines.push(`    ${runtime} · run ${runId} · ${entry.childSessionKey}`);
     });
+
     return { shouldContinue: false, reply: { text: lines.join("\n") } };
   }
 

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -269,6 +269,7 @@ export async function handleDirectiveOnly(params: {
     directives,
     cfg: params.cfg,
     channel: provider,
+    sessionKey: params.sessionKey,
     sessionEntry,
   });
   if (queueAck) {

--- a/src/auto-reply/reply/directive-handling.queue-validation.ts
+++ b/src/auto-reply/reply/directive-handling.queue-validation.ts
@@ -38,8 +38,8 @@ export function maybeHandleQueueDirective(params: {
 
     // Followup queues are keyed by the same string used in enqueue APIs.
     // SessionEntry.sessionId is the session key string for the current conversation.
-    const queueKey = params.sessionEntry?.sessionId;
-    const depth = queueKey ? getFollowupQueueDepth(queueKey) : 0;
+    const sessionKey = params.sessionEntry?.sessionId;
+    const depth = sessionKey ? getFollowupQueueDepth(sessionKey) : 0;
 
     // Treat explicit 0 values as overrides (e.g., debounce=0).
     const overrides = Boolean(

--- a/src/auto-reply/reply/directive-handling.queue-validation.ts
+++ b/src/auto-reply/reply/directive-handling.queue-validation.ts
@@ -10,6 +10,7 @@ export function maybeHandleQueueDirective(params: {
   directives: InlineDirectives;
   cfg: OpenClawConfig;
   channel: string;
+  sessionKey: string;
   sessionEntry?: SessionEntry;
 }): ReplyPayload | undefined {
   const { directives } = params;
@@ -38,8 +39,7 @@ export function maybeHandleQueueDirective(params: {
 
     // Followup queues are keyed by the same string used in enqueue APIs.
     // SessionEntry.sessionId is the session key string for the current conversation.
-    const sessionKey = params.sessionEntry?.sessionId;
-    const depth = sessionKey ? getFollowupQueueDepth(sessionKey) : 0;
+    const depth = getFollowupQueueDepth(params.sessionKey);
 
     // Treat explicit 0 values as overrides (e.g., debounce=0).
     const overrides = Boolean(

--- a/src/auto-reply/reply/directive-handling.queue-validation.ts
+++ b/src/auto-reply/reply/directive-handling.queue-validation.ts
@@ -36,12 +36,17 @@ export function maybeHandleQueueDirective(params: {
     const capLabel = typeof settings.cap === "number" ? String(settings.cap) : "default";
     const dropLabel = settings.dropPolicy ?? "default";
 
+    // Followup queues are keyed by the same string used in enqueue APIs.
+    // SessionEntry.sessionId is the session key string for the current conversation.
     const queueKey = params.sessionEntry?.sessionId;
     const depth = queueKey ? getFollowupQueueDepth(queueKey) : 0;
+
+    // Treat explicit 0 values as overrides (e.g., debounce=0).
     const overrides = Boolean(
-      params.sessionEntry?.queueDebounceMs ??
-      params.sessionEntry?.queueCap ??
-      params.sessionEntry?.queueDrop,
+      params.sessionEntry &&
+      (params.sessionEntry.queueDebounceMs !== undefined ||
+        params.sessionEntry.queueCap !== undefined ||
+        params.sessionEntry.queueDrop !== undefined),
     );
 
     const lines = [


### PR DESCRIPTION
Small UX-only change for chat commands:

- /queue (no args) now shows a multi-line status card including followup queue depth and whether session settings override defaults.
- /subagents list output is split into two lines per run (status/label then timing + ids) and uses uppercase status for scanability.

Testing: pnpm vitest run src/process/command-queue.test.ts src/auto-reply/reply/subagents-utils.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tweaks the UX for two chat commands:

- `/subagents list` output is reformatted into a header plus two lines per run (status/label, then timing + IDs) and uppercases status for scanability.
- `/queue` status output (no args) becomes a small multi-line “status card” that includes followup queue depth and whether session-level queue settings override defaults.

Changes are localized to the auto-reply command handling layer (`src/auto-reply/reply/*`) and do not alter queue/subagent mechanics themselves, only how the current state is rendered in replies.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but `/queue` status may show misleading values in common cases.
- The PR is mostly presentation-only, but the new `/queue` status card introduces two behavioral accuracy risks: `followup_depth` appears keyed off `sessionId` rather than the string key used by followup queues in other paths, and the new `overrides` detector can miss explicit zero values. If these assumptions are wrong, users will see incorrect status output.
- src/auto-reply/reply/directive-handling.queue-validation.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->