### PR TITLE
fix: remove unnecessary type assertions in oauth provider resolution

### DIFF
--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,6 +14,7 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
+
 <!-- moonshot-kimi-k2-ids:start -->
 
 - `kimi-k2.5`

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -15,10 +15,13 @@ import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 
-const OAUTH_PROVIDER_IDS = new Set(getOAuthProviders().map((provider) => provider.id));
+const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) => provider.id));
+
+const isOAuthProvider = (provider: string): provider is OAuthProvider =>
+  OAUTH_PROVIDER_IDS.has(provider);
 
 const resolveOAuthProvider = (provider: string): OAuthProvider | null =>
-  OAUTH_PROVIDER_IDS.has(provider) ? provider : null;
+  isOAuthProvider(provider) ? provider : null;
 
 function buildOAuthApiKey(provider: string, credentials: OAuthCredentials): string {
   const needsProjectId = provider === "google-gemini-cli" || provider === "google-antigravity";


### PR DESCRIPTION
## Problem

`oxlint` with `--type-aware` flags two `no-unnecessary-type-assertion` errors in `src/agents/auth-profiles/oauth.ts` line 21. This breaks CI lint checks for all PRs on `main`.

## Fix

Replace inline `as OAuthProvider` casts with a proper type guard (`isOAuthProvider`) that uses TypeScript's `provider is OAuthProvider` predicate. This:

- Eliminates both lint errors
- Preserves correct type narrowing for the return value
- Is idiomatic TypeScript (type guards > type assertions)

## Verification

- `pnpm build && pnpm lint` passes locally with **0 warnings, 0 errors**

---

**🤖 AI-Assisted Development**

All code is AI-generated (Codex / Claude Code), directed and reviewed by a human architect. My workflow: deep research → detailed spec → AI implementation → human review → iterate. I understand every line that ships and test locally before submitting.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes CI lint failures from `oxlint --type-aware` by removing two unnecessary `as OAuthProvider` assertions in `src/agents/auth-profiles/oauth.ts` and replacing them with an explicit TypeScript type guard (`isOAuthProvider`). The provider resolution now narrows `provider: string` to `OAuthProvider` via a `provider is OAuthProvider` predicate backed by a set of known provider IDs, keeping the return type of `resolveOAuthProvider` as `OAuthProvider | null` without relying on assertions.

This change is localized to OAuth profile/token refresh logic: `resolveOAuthProvider` is used when calling `getOAuthApiKey(...)` for standard OAuth providers (non-"chutes" / non-"qwen-portal" special cases), so the type guard maintains the expected typing at that integration point while satisfying the linter.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and type-level only: it replaces inline assertions with a type guard backed by an existing provider-ID set, preserving runtime behavior while unblocking type-aware linting. No control flow or side effects were introduced beyond factoring the membership check into a helper.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->