### PR TITLE
Config: move backups into backups folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.31
 
 ### Changes
-
-- Config: store config backups under `backups/` and add `openclaw config backups` migration command. (#6697) Thanks @BrennerSpear.
 - Docs: onboarding/install/i18n/exec-approvals/Control UI/exe.dev/cacheRetention updates + misc nav/typos.
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
 - Agents: add OpenRouter app attribution headers. (#5050) Thanks @alexanderatallah.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.31
 
 ### Changes
+
 - Docs: onboarding/install/i18n/exec-approvals/Control UI/exe.dev/cacheRetention updates + misc nav/typos.
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
 - Agents: add OpenRouter app attribution headers. (#5050) Thanks @alexanderatallah.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Config: store config backups under `backups/` and add `openclaw config backups` migration command. (#6697) Thanks @BrennerSpear.
 - Docs: onboarding/install/i18n/exec-approvals/Control UI/exe.dev/cacheRetention updates + misc nav/typos.
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
 - Agents: add OpenRouter app attribution headers. (#5050) Thanks @alexanderatallah.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw config` (get/set/unset config values)"
+summary: "CLI reference for `openclaw config` (get/set/unset config values, manage backups)"
 read_when:
   - You want to read or edit config non-interactively
 title: "config"
@@ -48,3 +48,11 @@ openclaw config set channels.whatsapp.groups '["*"]' --json
 ```
 
 Restart the gateway after edits.
+
+## Backups
+
+Move legacy config backups (e.g. `openclaw.json.bak.*`) into the `backups/` folder:
+
+```bash
+openclaw config backups
+```

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -26,7 +26,7 @@ openclaw doctor --deep
 Notes:
 
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
-- `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/openclaw.json.bak` and drops unknown config keys, listing each removal.
+- `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/backups/openclaw.json.bak` and drops unknown config keys, listing each removal.
 
 ## macOS: `launchctl` env overrides
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -11,7 +11,12 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import {
+  CONFIG_PATH,
+  readConfigFileSnapshot,
+  resolveConfigBackupBasePath,
+  writeConfigFile,
+} from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
@@ -278,7 +283,7 @@ export async function doctorCommand(
     cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
     await writeConfigFile(cfg);
     logConfigUpdated(runtime);
-    const backupPath = `${CONFIG_PATH}.bak`;
+    const backupPath = resolveConfigBackupBasePath(configPath);
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./types.js";
 import { withTempHome } from "./test-helpers.js";
@@ -6,8 +7,10 @@ import { withTempHome } from "./test-helpers.js";
 describe("config backup rotation", () => {
   it("keeps a 5-deep backup ring for config writes", async () => {
     await withTempHome(async () => {
-      const { resolveConfigPath, writeConfigFile } = await import("./config.js");
+      const { resolveConfigBackupBasePath, resolveConfigPath, writeConfigFile } =
+        await import("./config.js");
       const configPath = resolveConfigPath();
+      const backupBase = resolveConfigBackupBasePath(configPath);
       const buildConfig = (version: number): OpenClawConfig =>
         ({
           agents: { list: [{ id: `v${version}` }] },
@@ -17,21 +20,45 @@ describe("config backup rotation", () => {
         await writeConfigFile(buildConfig(version));
       }
 
-      const readName = async (suffix = "") => {
-        const raw = await fs.readFile(`${configPath}${suffix}`, "utf-8");
+      const readName = async (filePath: string) => {
+        const raw = await fs.readFile(filePath, "utf-8");
         return (
           (JSON.parse(raw) as { agents?: { list?: Array<{ id?: string }> } }).agents?.list?.[0]
             ?.id ?? null
         );
       };
 
-      await expect(readName()).resolves.toBe("v6");
-      await expect(readName(".bak")).resolves.toBe("v5");
-      await expect(readName(".bak.1")).resolves.toBe("v4");
-      await expect(readName(".bak.2")).resolves.toBe("v3");
-      await expect(readName(".bak.3")).resolves.toBe("v2");
-      await expect(readName(".bak.4")).resolves.toBe("v1");
-      await expect(fs.stat(`${configPath}.bak.5`)).rejects.toThrow();
+      await expect(readName(configPath)).resolves.toBe("v6");
+      await expect(readName(backupBase)).resolves.toBe("v5");
+      await expect(readName(`${backupBase}.1`)).resolves.toBe("v4");
+      await expect(readName(`${backupBase}.2`)).resolves.toBe("v3");
+      await expect(readName(`${backupBase}.3`)).resolves.toBe("v2");
+      await expect(readName(`${backupBase}.4`)).resolves.toBe("v1");
+      await expect(fs.stat(`${backupBase}.5`)).rejects.toThrow();
+    });
+  });
+
+  it("moves legacy backups into the backups folder", async () => {
+    await withTempHome(async () => {
+      const { migrateLegacyConfigBackups, resolveConfigBackupDir, resolveConfigPath } =
+        await import("./config.js");
+      const configPath = resolveConfigPath();
+      const configDir = path.dirname(configPath);
+      const backupDir = resolveConfigBackupDir(configPath);
+
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(`${configPath}.bak`, "legacy");
+      await fs.writeFile(`${configPath}.bak.1`, "legacy-1");
+
+      const result = await migrateLegacyConfigBackups();
+      await expect(
+        fs.stat(path.join(backupDir, `${path.basename(configPath)}.bak`)),
+      ).resolves.toBeDefined();
+      await expect(
+        fs.stat(path.join(backupDir, `${path.basename(configPath)}.bak.1`)),
+      ).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak`)).rejects.toThrow();
+      expect(result.moved.length).toBe(2);
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,11 +1,13 @@
 export {
   createConfigIO,
   loadConfig,
+  migrateLegacyConfigBackups,
   parseConfigJson5,
   readConfigFileSnapshot,
   resolveConfigSnapshotHash,
   writeConfigFile,
 } from "./io.js";
+export type { ConfigBackupMigrationResult } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";
 export * from "./paths.js";
 export * from "./runtime-overrides.js";

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -179,9 +179,7 @@ export async function migrateLegacyConfigBackups(
           continue;
         } catch (innerErr) {
           skipped.push(entry);
-          deps.logger.warn(
-            `Failed to move legacy config backup ${source}: ${String(innerErr)}`,
-          );
+          deps.logger.warn(`Failed to move legacy config backup ${source}: ${String(innerErr)}`);
           continue;
         }
       }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -27,7 +27,13 @@ import { collectConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
-import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
+import {
+  resolveConfigBackupBasePath,
+  resolveConfigBackupDir,
+  resolveConfigPath,
+  resolveDefaultConfigCandidates,
+  resolveStateDir,
+} from "./paths.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 import { compareOpenClawVersions } from "./version.js";
@@ -90,11 +96,23 @@ function coerceConfig(value: unknown): OpenClawConfig {
   return value as OpenClawConfig;
 }
 
+async function ensureConfigBackupDir(
+  configPath: string,
+  ioFs: typeof fs.promises,
+): Promise<string> {
+  const backupDir = resolveConfigBackupDir(configPath);
+  await ioFs.mkdir(backupDir, { recursive: true, mode: 0o700 }).catch(() => {
+    // best-effort
+  });
+  return backupDir;
+}
+
 async function rotateConfigBackups(configPath: string, ioFs: typeof fs.promises): Promise<void> {
+  await ensureConfigBackupDir(configPath, ioFs);
   if (CONFIG_BACKUP_COUNT <= 1) {
     return;
   }
-  const backupBase = `${configPath}.bak`;
+  const backupBase = resolveConfigBackupBasePath(configPath);
   const maxIndex = CONFIG_BACKUP_COUNT - 1;
   await ioFs.unlink(`${backupBase}.${maxIndex}`).catch(() => {
     // best-effort
@@ -107,6 +125,71 @@ async function rotateConfigBackups(configPath: string, ioFs: typeof fs.promises)
   await ioFs.rename(backupBase, `${backupBase}.1`).catch(() => {
     // best-effort
   });
+}
+
+export type ConfigBackupMigrationResult = {
+  configPath: string;
+  backupDir: string;
+  moved: string[];
+  skipped: string[];
+};
+
+export async function migrateLegacyConfigBackups(
+  overrides: ConfigIoDeps = {},
+): Promise<ConfigBackupMigrationResult> {
+  const deps = normalizeDeps(overrides);
+  const configPath = resolveConfigPathForDeps(deps);
+  const backupDir = resolveConfigBackupDir(configPath);
+  const configDir = path.dirname(configPath);
+  let entries: string[] = [];
+  try {
+    entries = await deps.fs.promises.readdir(configDir);
+  } catch {
+    return { configPath, backupDir, moved: [], skipped: [] };
+  }
+  const baseName = path.basename(configPath);
+  const backupPrefix = `${baseName}.bak`;
+  const legacyNames = entries.filter(
+    (entry) => entry === backupPrefix || entry.startsWith(`${backupPrefix}.`),
+  );
+  if (legacyNames.length === 0) {
+    return { configPath, backupDir, moved: [], skipped: [] };
+  }
+  await ensureConfigBackupDir(configPath, deps.fs.promises);
+
+  const moved: string[] = [];
+  const skipped: string[] = [];
+  for (const entry of legacyNames) {
+    const source = path.join(configDir, entry);
+    const target = path.join(backupDir, entry);
+    try {
+      await deps.fs.promises.rename(source, target);
+      moved.push(entry);
+      continue;
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === "ENOENT") {
+        continue;
+      }
+      if (code === "EEXIST" || code === "ENOTEMPTY") {
+        const uniqueTarget = path.join(backupDir, `${entry}.legacy.${Date.now()}`);
+        try {
+          await deps.fs.promises.rename(source, uniqueTarget);
+          moved.push(entry);
+          continue;
+        } catch (innerErr) {
+          skipped.push(entry);
+          deps.logger.warn(
+            `Failed to move legacy config backup ${source}: ${String(innerErr)}`,
+          );
+          continue;
+        }
+      }
+      skipped.push(entry);
+      deps.logger.warn(`Failed to move legacy config backup ${source}: ${String(err)}`);
+    }
+  }
+  return { configPath, backupDir, moved, skipped };
 }
 
 export type ConfigIoDeps = {
@@ -508,10 +591,19 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     });
 
     if (deps.fs.existsSync(configPath)) {
-      await rotateConfigBackups(configPath, deps.fs.promises);
-      await deps.fs.promises.copyFile(configPath, `${configPath}.bak`).catch(() => {
-        // best-effort
+      await migrateLegacyConfigBackups({
+        fs: deps.fs,
+        env: deps.env,
+        homedir: deps.homedir,
+        configPath,
+        logger: deps.logger,
       });
+      await rotateConfigBackups(configPath, deps.fs.promises);
+      await deps.fs.promises
+        .copyFile(configPath, resolveConfigBackupBasePath(configPath))
+        .catch(() => {
+          // best-effort
+        });
     }
 
     try {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -19,6 +19,7 @@ export const isNixMode = resolveIsNixMode();
 const LEGACY_STATE_DIRNAMES = [".clawdbot", ".moltbot", ".moldbot"] as const;
 const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
+const CONFIG_BACKUP_DIRNAME = "backups";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json", "moltbot.json", "moldbot.json"] as const;
 
 function legacyStateDirs(homedir: () => string = os.homedir): string[] {
@@ -101,6 +102,14 @@ export function resolveCanonicalConfigPath(
     return resolveUserPath(override);
   }
   return path.join(stateDir, CONFIG_FILENAME);
+}
+
+export function resolveConfigBackupDir(configPath: string): string {
+  return path.join(path.dirname(configPath), CONFIG_BACKUP_DIRNAME);
+}
+
+export function resolveConfigBackupBasePath(configPath: string): string {
+  return path.join(resolveConfigBackupDir(configPath), `${path.basename(configPath)}.bak`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- move config backups into a `backups/` folder and migrate legacy backup files
- add `openclaw config backups` to move existing backups on demand
- update doctor output + docs + tests for new backup location

## Testing
- `bun check` (fails: Script not found "check")
- `bun typecheck` (fails: Script not found "typecheck")
- `bunx vitest run src/config/config.backup-rotation.test.ts` (fails: vitest not installed)
