### PR TITLE
fix(signal): preserve case for Base64 group IDs in target normalization

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -27,6 +27,11 @@ describe("signal target normalization", () => {
     ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
   });
 
+  it("strips whitespace from group IDs (handles copy-paste errors)", () => {
+    expect(normalizeSignalMessagingTarget("group: aBcDeF gHiJkL =")).toBe("group:aBcDeFgHiJkL=");
+    expect(normalizeSignalMessagingTarget("group:aBc\nDeF\t=")).toBe("group:aBcDeF=");
+  });
+
   it("accepts uuid prefixes for target detection", () => {
     expect(looksLikeSignalTargetId("uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);
     expect(looksLikeSignalTargetId("signal:uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);

--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -14,6 +14,19 @@ describe("signal target normalization", () => {
     );
   });
 
+  it("preserves case for Base64 group IDs", () => {
+    // Signal group IDs are Base64-encoded and case-sensitive
+    expect(
+      normalizeSignalMessagingTarget("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg="),
+    ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
+  });
+
+  it("preserves case for group IDs with signal: prefix", () => {
+    expect(
+      normalizeSignalMessagingTarget("signal:group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg="),
+    ).toBe("group:aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdefg=");
+  });
+
   it("accepts uuid prefixes for target detection", () => {
     expect(looksLikeSignalTargetId("uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);
     expect(looksLikeSignalTargetId("signal:uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     // Signal group IDs are Base64-encoded and case-sensitive - preserve original case
-    const id = normalized.slice("group:".length).trim();
+    // Strip all whitespace since Base64 shouldn't contain spaces (handles copy-paste errors)
+    const id = normalized.slice("group:".length).replace(/\s+/g, "");
     return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -12,8 +12,9 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   }
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
+    // Signal group IDs are Base64-encoded and case-sensitive - preserve original case
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary

Fixes #5578 - Signal group IDs were being lowercased during target normalization, breaking group allowlist matching.

### Root Cause

Signal group IDs are Base64-encoded and case-sensitive (e.g., `aBcDeFgHiJkLmNoPqRsTuVwXyZ...`). The `normalizeSignalMessagingTarget()` function was lowercasing the entire group target:

```typescript
// Before (broken)
return id ? `group:${id}`.toLowerCase() : undefined;
```

This caused allowlist matching to fail because:
- Config stores: `group:aBcDeFgHiJ...` (proper case)
- Runtime comparison: `group:abcdefghij...` (lowercased)

### Fix

Preserve the original case for group IDs while keeping other target types (UUIDs, usernames, phone numbers) lowercase as they are case-insensitive:

```typescript
// After (fixed)
const id = normalized.slice("group:".length).replace(/\s+/g, "");
return id ? `group:${id}` : undefined;
```

Also strips all whitespace from group IDs since Base64 shouldn't contain spaces (handles copy-paste errors where users might paste formatted text with newlines/spaces).

## Test plan

- [x] Added test cases for Base64 group ID case preservation
- [x] Added test cases for whitespace stripping in group IDs
- [x] `pnpm test src/channels/plugins/normalize/signal.test.ts` - all pass
- [x] `pnpm lint` - 0 warnings, 0 errors
- [x] `pnpm build` - success

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Preserves case for Signal `group:` targets during normalization so Base64 group IDs remain intact for allowlist matching, while keeping existing lowercasing behavior for case-insensitive target types. Also strips all whitespace from group IDs to tolerate copy/paste formatting. Adds Vitest coverage for case preservation (with/without `signal:` prefix) and whitespace stripping.

This fits into the channel plugin normalization utilities under `src/channels/plugins/normalize/`, which standardize user-provided targets before routing/allowlist comparison.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to `group:` normalization, aligns with Signal group ID semantics (Base64 case sensitivity), and is covered by targeted unit tests; it does not affect other normalization paths beyond removing whitespace in group IDs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->