### PR TITLE
fix(voice-call): mark calls as ended when media stream disconnects

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -142,29 +142,43 @@ export class VoiceCallWebhookServer {
         // states (like "speaking" or "listening"), blocking new calls due to the
         // maxConcurrentCalls limit.
         //
-        // Note: We only emit call.ended if the call is NOT already in a terminal
-        // state. Network blips or WS proxy timeouts may cause disconnects while
-        // the call is still active, but if Twilio's status callback already
-        // transitioned the call to a terminal state, we skip this fallback.
-        const call = this.manager.getCallByProviderCallId(callId);
-        if (call && !TerminalStates.has(call.state)) {
-          const event: NormalizedEvent = {
-            id: `stream-disconnect-${call.callId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            type: "call.ended",
-            callId: call.callId,
-            providerCallId: callId,
-            timestamp: Date.now(),
-            reason: "completed",
-          };
-          this.manager.processEvent(event);
+        // Grace period: Wait 2 seconds before marking as ended. This allows time for:
+        // - Twilio status callbacks to arrive and handle the transition properly
+        // - Brief network interruptions to recover without falsely ending the call
+        //
+        // After the grace period, we re-check the call state. If it's still active,
+        // we emit call.ended. If Twilio's status callback already transitioned the
+        // call to a terminal state, we skip this fallback.
+        const DISCONNECT_GRACE_PERIOD_MS = 2000;
+        const initialCall = this.manager.getCallByProviderCallId(callId);
+        if (initialCall) {
           console.log(
-            `[voice-call] Call ${call.callId} marked as completed (stream disconnect fallback)`,
-          );
-        } else if (call) {
-          console.log(
-            `[voice-call] Call ${call.callId} already in terminal state (${call.state}), skipping disconnect fallback`,
+            `[voice-call] Call ${initialCall.callId} stream disconnected, waiting ${DISCONNECT_GRACE_PERIOD_MS}ms before fallback cleanup`,
           );
         }
+
+        setTimeout(() => {
+          // Re-fetch call state after grace period (may have changed)
+          const call = this.manager.getCallByProviderCallId(callId);
+          if (call && !TerminalStates.has(call.state)) {
+            const event: NormalizedEvent = {
+              id: `stream-disconnect-${call.callId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              type: "call.ended",
+              callId: call.callId,
+              providerCallId: callId,
+              timestamp: Date.now(),
+              reason: "completed",
+            };
+            this.manager.processEvent(event);
+            console.log(
+              `[voice-call] Call ${call.callId} marked as completed (stream disconnect fallback after ${DISCONNECT_GRACE_PERIOD_MS}ms grace period)`,
+            );
+          } else if (call) {
+            console.log(
+              `[voice-call] Call ${call.callId} already in terminal state (${call.state}), skipping disconnect fallback`,
+            );
+          }
+        }, DISCONNECT_GRACE_PERIOD_MS);
       },
     };
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -8,9 +8,9 @@ import type { MediaStreamConfig } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
-import { TerminalStates } from "./types.js";
 import { MediaStreamHandler } from "./media-stream.js";
 import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
+import { TerminalStates } from "./types.js";
 
 /**
  * HTTP server for receiving voice call webhooks from providers.


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                    
  Fixes a bug where inbound voice calls were not properly cleaned up when disconnected, leaving them stuck in non-terminal states   
  (like "speaking" or "listening"). This caused the `maxConcurrentCalls` limit to be exhausted, blocking all new calls with "Maximum
   concurrent calls reached" errors.                                                                                                
                                                                                                                                    
  ## Root Cause                                                                                                                     
                                                                                                                                    
  - For **outbound calls**, `StatusCallback` is set programmatically via the Twilio API, so call completion is properly detected.   
  - For **inbound calls**, status callbacks must be configured in the Twilio console. If not configured, the `call.ended` event is  
  never received and calls remain "active" forever.                                                                                 
                                                                                                                                    
  ## Solution                                                                                                                       
                                                                                                                                    
  Use media stream disconnect as a reliable fallback signal that the call has ended. When the WebSocket closes, check if the call is
   still in an active state and transition it to "completed".                                                                       
                                                                                                                                    
  This is safe because:                                                                                                             
  - `processEvent` has idempotency checks for terminal states                                                                       
  - If a proper status callback arrives first, this event is ignored                                                                
  - Works for all providers, not just Twilio                                                                                        
                                                                                                                                    
  ## Test Plan                                                                                                                      
                                                                                                                                    
  - [x] Tested locally with OpenClaw instance                                                                                       
  - [x] Made inbound call, talked, hung up → call marked as completed                                                               
  - [x] Made subsequent outbound call → succeeded (no "Maximum concurrent calls" error)                                             
  - [x] `pnpm tsgo && pnpm format && pnpm lint && pnpm build && pnpm test` - all 208 tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a fallback cleanup path for voice calls: when the media stream WebSocket disconnects, the webhook server looks up the active call and emits a `call.ended` normalized event to move the call into a terminal state. This addresses cases (notably inbound Twilio calls without console-configured status callbacks) where `call.ended` webhooks never arrive, leaving calls stuck in active states and exhausting the `maxConcurrentCalls` limit.

The change fits into the existing architecture by reusing the existing `CallManager.processEvent` pipeline and provider call-id mapping, rather than introducing new provider-specific teardown logic.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the disconnect→ended fallback may prematurely terminate calls in some disconnect scenarios.
- Change is localized and uses existing event-processing flow, but it currently fires `call.ended` on any media stream disconnect without checking call state or accounting for transient WS drops/reconnects, which can cause incorrect terminal transitions depending on provider/network behavior.
- extensions/voice-call/src/webhook.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->