### PR TITLE
feat(hooks): add agent:response hook event

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -4,7 +4,7 @@ import type { TypingMode } from "../../config/types.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { TypingController } from "./typing.js";
-import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -4,12 +4,14 @@ import type { TypingMode } from "../../config/types.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { TypingController } from "./typing.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../../agents/workspace.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -18,6 +20,11 @@ import {
   updateSessionStore,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
+import {
+  createInternalHookEvent,
+  triggerInternalHook,
+  type AgentResponseHookContext,
+} from "../../hooks/internal-hooks.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
@@ -511,6 +518,36 @@ export async function runReplyAgent(params: {
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
+
+    // Trigger agent:response hook for post-response processing
+    const responseText = finalPayloads
+      .map((p) => (typeof p === "string" ? p : p.text))
+      .filter(Boolean)
+      .join("\n");
+    const agentId = sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
+    const workspaceDir =
+      cfg && agentId
+        ? (resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR)
+        : undefined;
+    const responseContext: AgentResponseHookContext = {
+      responseText: responseText || undefined,
+      payloads: finalPayloads,
+      model: modelUsed,
+      provider: providerUsed,
+      cfg,
+      sessionKey,
+      sessionId: followupRun.run.sessionId,
+      agentId,
+      workspaceDir,
+    };
+    const responseEvent = createInternalHookEvent(
+      "agent",
+      "response",
+      sessionKey ?? "unknown",
+      responseContext,
+    );
+    // Fire-and-forget to avoid blocking response delivery
+    void triggerInternalHook(responseEvent);
 
     return finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
@@ -26,10 +27,10 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
 };
 
 export type AgentResponseHookContext = {
-  /** The agent's response text (may be undefined if only tool calls) */
+  /** The agent's response text (combined from text payloads, may be undefined if only tool calls) */
   responseText?: string;
-  /** All response payloads */
-  payloads: Array<{ text?: string; [key: string]: unknown }>;
+  /** All response payloads (same type as agent runner output) */
+  payloads: ReplyPayload[];
   /** Model used for this response */
   model?: string;
   /** Provider used for this response */
@@ -42,6 +43,10 @@ export type AgentResponseHookContext = {
   workspaceDir?: string;
 };
 
+/**
+ * Event fired after agent generates a user-visible response.
+ * Only fires when there are payloads to send (not for tool-only or empty responses).
+ */
 export type AgentResponseHookEvent = InternalHookEvent & {
   type: "agent";
   action: "response";

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -25,6 +25,29 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   context: AgentBootstrapHookContext;
 };
 
+export type AgentResponseHookContext = {
+  /** The agent's response text (may be undefined if only tool calls) */
+  responseText?: string;
+  /** All response payloads */
+  payloads: Array<{ text?: string; [key: string]: unknown }>;
+  /** Model used for this response */
+  model?: string;
+  /** Provider used for this response */
+  provider?: string;
+  /** Session configuration */
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  workspaceDir?: string;
+};
+
+export type AgentResponseHookEvent = InternalHookEvent & {
+  type: "agent";
+  action: "response";
+  context: AgentResponseHookContext;
+};
+
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */
   type: InternalHookEventType;
@@ -178,4 +201,15 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
     return false;
   }
   return Array.isArray(context.bootstrapFiles);
+}
+
+export function isAgentResponseEvent(event: InternalHookEvent): event is AgentResponseHookEvent {
+  if (event.type !== "agent" || event.action !== "response") {
+    return false;
+  }
+  const context = event.context as Partial<AgentResponseHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return Array.isArray(context.payloads);
 }


### PR DESCRIPTION
## Summary

Adds a new `agent:response` hook event that fires after the agent generates a response, before it's sent to the user.

## Motivation

This enables post-response processing like:
- Logging/auditing agent outputs  
- Response analytics and monitoring
- Custom notification triggers
- Integration with external systems

Currently the only agent hook is `agent:bootstrap` which fires *before* the response, not after. The docs mention planned `message:sent` and `message:received` events — this provides a more specific hook for agent response handling.

## Implementation

The hook fires only for user-visible responses (not empty/tool-only responses). It's triggered fire-and-forget (`void triggerInternalHook(...)`) to avoid blocking response delivery.

### New Types

```typescript
export type AgentResponseHookContext = {
  responseText?: string;  // Combined text from payloads
  payloads: ReplyPayload[];  // Full payload array
  model?: string;
  provider?: string;
  cfg?: OpenClawConfig;
  sessionKey?: string;
  sessionId?: string;
  agentId?: string;
  workspaceDir?: string;
};

export type AgentResponseHookEvent = InternalHookEvent & {
  type: "agent";
  action: "response";
  context: AgentResponseHookContext;
};
```

### Type Guard

```typescript
export function isAgentResponseEvent(event: InternalHookEvent): event is AgentResponseHookEvent
```

## Usage Example

```typescript
// hooks/my-hook/handler.ts
const handler: HookHandler = async (event) => {
  if (event.type !== 'agent' || event.action !== 'response') {
    return;
  }
  
  const { responseText, model, sessionKey } = event.context;
  console.log(`Agent responded with ${responseText?.length ?? 0} chars using ${model}`);
};

export default handler;
```

## Testing

- [x] TypeScript compiles without errors
- [ ] Unit tests (happy to add if approach is approved)

Closes #6701