### PR TITLE
Fix Windows Build: Convert bash script to cross-platform TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "build": "pnpm canvas:a2ui:bundle && tsc -p tsconfig.json --noEmit false && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts",
-    "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
+    "canvas:a2ui:bundle": "node --import tsx scripts/bundle-a2ui.ts",
     "check:loc": "node --import tsx scripts/check-ts-max-loc.ts --max 500",
     "dev": "node scripts/run-node.mjs",
     "docs:bin": "node scripts/build-docs-list.mjs",

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# DEPRECATED: Use scripts/bundle-a2ui.ts instead
+# This script is kept for reference and backward compatibility only
 set -euo pipefail
 
 on_error() {

--- a/scripts/bundle-a2ui.ts
+++ b/scripts/bundle-a2ui.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(here, "..");
+const hashFile = path.resolve(rootDir, "src/canvas-host/a2ui/.bundle.hash");
+const outputFile = path.resolve(rootDir, "src/canvas-host/a2ui/a2ui.bundle.js");
+const a2uiRendererDir = path.resolve(rootDir, "vendor/a2ui/renderers/lit");
+const a2uiAppDir = path.resolve(
+  rootDir,
+  "apps/shared/OpenClawKit/Tools/CanvasA2UI",
+);
+
+async function onError(): Promise<never> {
+  console.error("A2UI bundling failed. Re-run with: pnpm canvas:a2ui:bundle");
+  console.error("If this persists, verify pnpm deps and try again.");
+  process.exit(1);
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walk(entryPath: string, files: string[]): Promise<void> {
+  const st = await fs.stat(entryPath);
+  if (st.isDirectory()) {
+    const entries = await fs.readdir(entryPath);
+    for (const entry of entries) {
+      await walk(path.join(entryPath, entry), files);
+    }
+    return;
+  }
+  files.push(entryPath);
+}
+
+function normalizePath(p: string): string {
+  return p.split(path.sep).join("/");
+}
+
+async function computeHash(inputPaths: string[]): Promise<string> {
+  const files: string[] = [];
+
+  for (const input of inputPaths) {
+    await walk(input, files);
+  }
+
+  files.sort((a, b) => normalizePath(a).localeCompare(normalizePath(b)));
+
+  const hash = createHash("sha256");
+  for (const filePath of files) {
+    const rel = normalizePath(path.relative(rootDir, filePath));
+    hash.update(rel);
+    hash.update("\0");
+    hash.update(await fs.readFile(filePath));
+    hash.update("\0");
+  }
+
+  return hash.digest("hex");
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  cwd?: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, {
+      cwd: cwd ?? rootDir,
+      stdio: "inherit",
+      shell: true,
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+
+    proc.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  try {
+    // Docker builds exclude vendor/apps via .dockerignore.
+    // In that environment we must keep the prebuilt bundle.
+    const hasA2uiRenderer = await exists(a2uiRendererDir);
+    const hasA2uiApp = await exists(a2uiAppDir);
+
+    if (!hasA2uiRenderer || !hasA2uiApp) {
+      console.log("A2UI sources missing; keeping prebuilt bundle.");
+      return;
+    }
+
+    const inputPaths = [
+      path.resolve(rootDir, "package.json"),
+      path.resolve(rootDir, "pnpm-lock.yaml"),
+      a2uiRendererDir,
+      a2uiAppDir,
+    ];
+
+    const currentHash = await computeHash(inputPaths);
+
+    const hashFileExists = await exists(hashFile);
+    if (hashFileExists) {
+      const previousHash = (await fs.readFile(hashFile, "utf-8")).trim();
+      const outputFileExists = await exists(outputFile);
+
+      if (previousHash === currentHash && outputFileExists) {
+        console.log("A2UI bundle up to date; skipping.");
+        return;
+      }
+    }
+
+    // Run tsc to compile a2ui renderer
+    const tsconfigPath = path.resolve(a2uiRendererDir, "tsconfig.json");
+    console.log("Compiling A2UI renderer...");
+    await runCommand("pnpm", ["-s", "exec", "tsc", "-p", tsconfigPath]);
+
+    // Run rolldown to bundle
+    const rolldownConfigPath = path.resolve(a2uiAppDir, "rolldown.config.mjs");
+    console.log("Bundling A2UI...");
+    await runCommand("rolldown", ["-c", rolldownConfigPath]);
+
+    // Save hash
+    await fs.mkdir(path.dirname(hashFile), { recursive: true });
+    await fs.writeFile(hashFile, currentHash);
+
+    console.log("A2UI bundle completed successfully.");
+  } catch (err) {
+    console.error(err);
+    await onError();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Fixes build failures on Windows environments by converting the `bundle-a2ui.sh` bash script to a cross-platform Node.js TypeScript implementation.

## Problem

When running `pnpm build` on Windows, the build process fails with a `MODULE_NOT_FOUND` error for `@rolldown/binding-linux-x64-gnu`. This occurs because:

1. The `bundle-a2ui.sh` bash script runs in WSL environment
2. WSL's Node.js attempts to load the Linux-specific rolldown native binding
3. However, node_modules are installed for Windows, causing a platform mismatch
4. Build fails with missing native module error

Error:

```
Error: Cannot find module '@rolldown/binding-linux-x64-gnu'
```

## Changes

### New Files

- **`scripts/bundle-a2ui.ts`**: Cross-platform TypeScript implementation that replaces the bash script
  - Hash-based caching to skip bundling when sources haven't changed
  - Docker environment support (preserves prebuilt bundle when vendor/apps are missing)
  - Clear error handling with actionable messages
  - Platform-agnostic path handling and command execution

### Modified Files

- **`package.json`**: Updated `canvas:a2ui:bundle` script to use Node.js instead of bash

  ```diff
  -"canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
  +"canvas:a2ui:bundle": "node --import tsx scripts/bundle-a2ui.ts",
  ```

- **`scripts/bundle-a2ui.sh`**: Added deprecation notice (kept for reference)
  ```bash
  # DEPRECATED: Use scripts/bundle-a2ui.ts instead
  # This script is kept for reference and backward compatibility only
  ```

## Benefits

- ✅ **Cross-platform compatibility**: Works on Windows, macOS, and Linux
- ✅ **Consistent behavior**: Same bundling logic across all platforms
- ✅ **No WSL dependency**: Windows users can build without WSL installed
- ✅ **Maintained functionality**: All existing features preserved (caching, Docker support, etc.)

## Testing

Verified on Windows environment:

```powershell
PS> pnpm build

> openclaw@2026.1.30 canvas:a2ui:bundle
> node --import tsx scripts/bundle-a2ui.ts

Compiling A2UI renderer...
Bundling A2UI...
<DIR>/a2ui.bundle.js  chunk │ size: 537.66 kB

√ rolldown v1.0.0-rc.2 Finished in 95.97 ms
A2UI bundle completed successfully.

Exit code: 0
```

Build completes successfully with:

- A2UI bundling ✓
- TypeScript compilation ✓
- Metadata copying ✓

## Migration Notes

The bash script (`bundle-a2ui.sh`) is retained with a deprecation notice for reference purposes. It can be removed in a future cleanup if desired.

## Related Issues

Fixes build failures on Windows environments when running `pnpm build`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR replaces the A2UI bundling bash script with a TypeScript/Node implementation and updates `package.json` so `pnpm build` runs the new script, aiming to avoid Windows/WSL native binding mismatches. The new script computes a content hash over relevant inputs to skip work when unchanged, compiles the renderer via `tsc`, and bundles via `rolldown`, while preserving the previous “Docker keeps prebuilt bundle if sources are absent” behavior.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but the new bundling script has a Windows-path fragility that may reintroduce build failures in common setups.
- The functional change is localized (build script + package.json) and mirrors prior behavior, but `spawn(..., { shell: true })` can break argument quoting on Windows/macOS with spaced paths, which directly affects build reliability. Other notes are lower-probability edge cases (symlink cycles) or performance considerations (full-tree hashing).
- scripts/bundle-a2ui.ts (process spawning/quoting and directory walk robustness)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->