### PR TITLE
Update installation script URL in ansible.md

### DIFF
--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -16,7 +16,7 @@ The recommended way to deploy OpenClaw to production servers is via **[openclaw-
 One-command install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openclaw/clawdbot-ansible/main/install.sh | bash
 ```
 
 > **📦 Full guide: [github.com/openclaw/openclaw-ansible](https://github.com/openclaw/openclaw-ansible)**


### PR DESCRIPTION
The current bash URL is wrong. We should either merge this now or actually rename the repo.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Ansible quick-start `curl | bash` command in `docs/install/ansible.md` to point at a different GitHub raw URL for `install.sh`.

This fits into the docs set under `docs/install/` by providing a one-liner install entrypoint for the separate Ansible deployment repo; however, the rest of the page still references `openclaw-ansible` as the canonical repository, so the quick-start URL should be aligned with the repo/link text used elsewhere in the same guide.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk but the docs change likely needs alignment with other references on the same page.
- Only a documentation URL changed, so merge risk is low. The main concern is correctness: the quick-start script source now conflicts with the repo name and other links in the guide, which will confuse users or send them to the wrong installer.
- docs/install/ansible.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->