### PR TITLE
docs(nodes): add SSH tunnel example for loopback-bound gateway

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -313,6 +313,29 @@ Notes:
   the app, or `OPENCLAW_NODE_EXEC_FALLBACK=0` to disable fallback.
 - Add `--tls` / `--tls-fingerprint` when the Gateway WS uses TLS.
 
+
+### Remote Gateway via SSH tunnel (loopback bind)
+
+If your Gateway binds to loopback (`gateway.bind=loopback`, default in local mode),
+remote clients cannot connect directly. Use an SSH tunnel and point the node host
+at the local end of the tunnel.
+
+Example (Mac → VPS):
+
+```bash
+# Terminal A (keep running): forward local 18790 -> VPS 127.0.0.1:18789
+ssh -N -L 18790:127.0.0.1:18789 ubuntu@<vps-host>
+
+# Terminal B: pass the gateway token and connect through the tunnel
+export OPENCLAW_GATEWAY_TOKEN="<gateway-token>"
+openclaw node run --host 127.0.0.1 --port 18790 --display-name "My Mac"
+```
+
+Notes:
+
+- The token is `gateway.auth.token` from the Gateway config (`~/.openclaw/openclaw.json` on the Gateway host).
+- In current CLI versions, `openclaw node run` uses `OPENCLAW_GATEWAY_TOKEN` for auth.
+
 ## Mac node mode
 
 - The macOS menubar app connects to the Gateway WS server as a node (so `openclaw nodes …` works against this Mac).


### PR DESCRIPTION
### What changed

 Added a short “Remote Gateway via SSH tunnel (loopback bind)” section under Headless node host
 (cross-platform) docs. It includes a copy‑paste example for connecting a remote node host to a
 Gateway that listens on loopback only (gateway.bind=loopback), using an SSH local port forward.

 ### Why

 When the Gateway is loopback-bound (the default for local mode), remote clients can’t connect
 directly. In practice this is a common setup for VPS deployments where the UI/Gateway is kept
 private and accessed via SSH tunneling. Without an explicit example, users frequently run into:
 - unauthorized: gateway token missing
 - confusion about which host/port to pass to openclaw node run
 - “it works in browser but node run can’t connect” type issues

 This doc update gives a clear, minimal path:
 - one terminal keeps the SSH tunnel running
 - the other exports OPENCLAW_GATEWAY_TOKEN and runs openclaw node run against the local forwarded
 port

 ### How to test

 1. Run a Gateway bound to loopback on a remote host.
 2. Create an SSH tunnel: ssh -N -L 18790:127.0.0.1:18789 user@host
 3. In another terminal: export OPENCLAW_GATEWAY_TOKEN=...
 4. Start node host through the tunnel with openclaw node run --host 127.0.0.1 --port 18790
 5. Confirm pairing + successful connection.

 ### Scope

 Docs-only change. No code behavior changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Nodes documentation by adding a short section explaining how to connect a remote headless node host to a Gateway that is bound to loopback (`gateway.bind=loopback`) using an SSH local port-forward. The example shows keeping an SSH `-L` tunnel running, exporting `OPENCLAW_GATEWAY_TOKEN`, and running `openclaw node run` against the forwarded local port.

This fits into the existing `docs/nodes/index.md` “Headless node host (cross-platform)” guidance by addressing a common deployment pattern (private Gateway/UI on a VPS, accessed via SSH tunneling) that otherwise leads to connection/auth confusion.

<h3>Confidence Score: 4/5</h3>

- This docs-only PR is safe to merge; suggested tweaks are minor clarity/style fixes.
- Changes are confined to a single documentation file and don’t affect runtime behavior. The only concerns are minor formatting and ensuring placeholders/config references are consistent with repo docs conventions.
- docs/nodes/index.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->