### PR TITLE
docs: add secure update procedure checklist

### DIFF
--- a/docs/cli/update-procedure.md
+++ b/docs/cli/update-procedure.md
@@ -1,0 +1,53 @@
+# Clawdbot Update Procedure
+
+Reference for secure self-updates during daily maintenance.
+
+## Pre-Update Checks
+```bash
+# Security audit BEFORE updating
+clawdbot security audit
+
+# Check system health
+clawdbot doctor
+```
+
+## Update Commands
+```bash
+# Standard update (use --channel stable for safest)
+clawdbot update
+
+# Or interactive wizard for more control
+clawdbot update wizard
+```
+
+### Channels
+- `--channel stable` — safest for production (use this)
+- `--channel beta` — tested but newer
+- `--channel dev` — bleeding edge, requires git checkout
+
+## Post-Update Verification
+```bash
+# Fix config issues
+clawdbot doctor --fix
+
+# Tighten permissions, flag misconfigurations
+clawdbot security audit --fix
+
+# Verify health
+clawdbot health
+```
+
+## Critical Security Notes
+- Gateway authentication is required by default
+- Ensure Node.js 22.12.0+ (required for security patches)
+- Never bind to 0.0.0.0 without authentication configured
+- If network-exposed: review docs.clawd.bot/gateway/security
+
+## Full Sequence
+1. `clawdbot security audit`
+2. `clawdbot doctor`
+3. Review changelog & code changes
+4. If safe: `clawdbot update` (stable channel)
+5. `clawdbot doctor --fix`
+6. `clawdbot security audit --fix`
+7. `clawdbot health`


### PR DESCRIPTION
## Summary

Adds a quick-reference runbook for safely updating OpenClaw with security checks before and after.

## What's included

- Pre-update security audit and health checks
- Recommended update commands with channel guidance  
- Post-update verification steps
- Critical security notes (authentication, Node.js version, network exposure)
- Complete step-by-step sequence

## Why

Complements the existing `docs/cli/update.md` CLI reference with operational best practices in a checklist format for daily maintenance.

---

*Generated by an OpenClaw agent* 🤖

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new checklist-style runbook (`docs/cli/update-procedure.md`) describing pre-update security/health checks, recommended update commands, post-update verification, and a “full sequence” for safe daily maintenance. It’s intended as an operational companion to the existing `docs/cli/update.md` CLI reference.

Main issues are around consistency/accuracy with existing docs: the runbook currently uses a different CLI name (`clawdbot` vs `openclaw`), includes a likely incorrect docs domain, and makes more specific Node version claims than the repo guidance.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it documents commands/links that are likely wrong for users.
- Although it’s a docs-only change, the runbook currently refers to `clawdbot` commands (which don’t match the existing `openclaw` CLI docs), includes a likely incorrect docs domain, and asserts a more specific Node.js version requirement than the repository guidance. These are high-impact correctness issues for an operational checklist.
- docs/cli/update-procedure.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->