### PR TITLE
feat(telegram): add thread-create action for forum topics

### DIFF
--- a/src/channels/plugins/actions/telegram.test.ts
+++ b/src/channels/plugins/actions/telegram.test.ts
@@ -140,4 +140,46 @@ describe("telegramMessageActions", () => {
     expect(String(call.messageId)).toBe("456");
     expect(call.emoji).toBe("ok");
   });
+
+  it("excludes thread-create when createForumTopic not enabled", () => {
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).not.toContain("thread-create");
+  });
+
+  it("includes thread-create when createForumTopic enabled", () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { createForumTopic: true } } },
+    } as OpenClawConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).toContain("thread-create");
+  });
+
+  it("maps thread-create params with color name", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { createForumTopic: true } } },
+    } as OpenClawConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "thread-create",
+      params: {
+        to: "-100123",
+        threadName: "Test Topic",
+        iconColor: "yellow",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "createForumTopic",
+        chatId: "-100123",
+        name: "Test Topic",
+        iconColor: "yellow",
+      }),
+      cfg,
+    );
+  });
 });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -60,6 +60,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
+    if (gate("createForumTopic", false)) {
+      actions.add("thread-create");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -193,6 +196,31 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "thread-create") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const name = readStringParam(params, "threadName", { required: true });
+      // Accept iconColor as string (color name) or number
+      const iconColor =
+        readStringParam(params, "iconColor") ??
+        readNumberParam(params, "iconColor", { integer: true });
+      const iconCustomEmojiId =
+        readStringParam(params, "iconCustomEmojiId") ?? readStringParam(params, "iconEmoji");
+      return await handleTelegramAction(
+        {
+          action: "createForumTopic",
+          chatId,
+          name,
+          iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/cli/program/message/register.thread.ts
+++ b/src/cli/program/message/register.thread.ts
@@ -13,8 +13,13 @@ export function registerMessageThreadCommands(message: Command, helpers: Message
           .requiredOption("--thread-name <name>", "Thread name"),
       ),
     )
-    .option("--message-id <id>", "Message id (optional)")
-    .option("--auto-archive-min <n>", "Thread auto-archive minutes")
+    .option("--message-id <id>", "Message id (optional, Discord only)")
+    .option("--auto-archive-min <n>", "Thread auto-archive minutes (Discord only)")
+    .option(
+      "--icon-color <color>",
+      "Topic icon color: blue/yellow/purple/green/pink/red (Telegram only)",
+    )
+    .option("--icon-emoji <id>", "Custom emoji ID for topic icon (Telegram Premium only)")
     .action(async (opts) => {
       await helpers.runMessageAction("thread-create", opts);
     });

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable forum topic creation (thread-create action). Bot must be admin in a forum-enabled supergroup. */
+  createForumTopic?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/telegram/send.forum-topic.test.ts
+++ b/src/telegram/send.forum-topic.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramTopicColor, TELEGRAM_TOPIC_COLORS } from "./send.js";
+
+describe("resolveTelegramTopicColor", () => {
+  it("returns undefined for undefined", () => {
+    expect(resolveTelegramTopicColor(undefined)).toBeUndefined();
+  });
+
+  it("passes through numeric values", () => {
+    expect(resolveTelegramTopicColor(7322096)).toBe(7322096);
+    expect(resolveTelegramTopicColor(16766590)).toBe(16766590);
+  });
+
+  it("resolves color names case-insensitively", () => {
+    expect(resolveTelegramTopicColor("blue")).toBe(TELEGRAM_TOPIC_COLORS.blue);
+    expect(resolveTelegramTopicColor("YELLOW")).toBe(TELEGRAM_TOPIC_COLORS.yellow);
+    expect(resolveTelegramTopicColor("Purple")).toBe(TELEGRAM_TOPIC_COLORS.purple);
+  });
+
+  it("returns undefined for invalid color names", () => {
+    expect(resolveTelegramTopicColor("orange")).toBeUndefined();
+    expect(resolveTelegramTopicColor("")).toBeUndefined();
+  });
+});
+
+describe("TELEGRAM_TOPIC_COLORS", () => {
+  it("contains all 6 valid Telegram topic colors", () => {
+    expect(Object.keys(TELEGRAM_TOPIC_COLORS)).toHaveLength(6);
+    expect(TELEGRAM_TOPIC_COLORS.blue).toBe(7322096);
+    expect(TELEGRAM_TOPIC_COLORS.yellow).toBe(16766590);
+    expect(TELEGRAM_TOPIC_COLORS.purple).toBe(13338331);
+    expect(TELEGRAM_TOPIC_COLORS.green).toBe(9367192);
+    expect(TELEGRAM_TOPIC_COLORS.pink).toBe(16749490);
+    expect(TELEGRAM_TOPIC_COLORS.red).toBe(16478047);
+  });
+});

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -748,3 +748,87 @@ export async function sendStickerTelegram(
 
   return { messageId, chatId: resolvedChatId };
 }
+
+// ----- Forum Topic Creation -----
+
+/** Valid Telegram topic icon colors (decimal values) */
+export const TELEGRAM_TOPIC_COLORS = {
+  blue: 7322096,
+  yellow: 16766590,
+  purple: 13338331,
+  green: 9367192,
+  pink: 16749490,
+  red: 16478047,
+} as const;
+
+export type TelegramTopicColorName = keyof typeof TELEGRAM_TOPIC_COLORS;
+type TelegramTopicColorValue = (typeof TELEGRAM_TOPIC_COLORS)[TelegramTopicColorName];
+
+/** Resolve color name or number to Telegram's expected value */
+export function resolveTelegramTopicColor(
+  color: string | number | undefined,
+): TelegramTopicColorValue | undefined {
+  if (color === undefined) return undefined;
+  if (typeof color === "number") return color as TelegramTopicColorValue;
+  return TELEGRAM_TOPIC_COLORS[color.toLowerCase() as TelegramTopicColorName];
+}
+
+export interface CreateForumTopicOptions {
+  token?: string;
+  accountId?: string;
+  /** Icon color: name (blue/yellow/purple/green/pink/red) or decimal value */
+  iconColor?: string | number;
+  /** Custom emoji ID (requires Telegram Premium on bot) */
+  iconCustomEmojiId?: string;
+  /** Optional pre-configured Bot API instance */
+  api?: Bot["api"];
+}
+
+export interface ForumTopicResult {
+  message_thread_id: number;
+  name: string;
+  icon_color?: number;
+  icon_custom_emoji_id?: string;
+}
+
+/**
+ * Create a forum topic in a Telegram supergroup with forum mode enabled.
+ * @param chatId - Chat ID of the forum-enabled supergroup
+ * @param name - Topic name (1-128 characters)
+ * @param opts - Optional configuration
+ */
+export async function createForumTopicTelegram(
+  chatId: string | number,
+  name: string,
+  opts: CreateForumTopicOptions = {},
+): Promise<ForumTopicResult> {
+  const cfg = loadConfig();
+  const account = resolveTelegramAccount({ cfg, accountId: opts.accountId });
+  const token = resolveToken(opts.token, account);
+  const normalizedChatId = normalizeChatId(String(chatId));
+  const client = resolveTelegramClientOptions(account);
+  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
+
+  const iconColor = resolveTelegramTopicColor(opts.iconColor);
+
+  const result = await api.createForumTopic(
+    normalizedChatId,
+    name,
+    iconColor !== undefined || opts.iconCustomEmojiId
+      ? { icon_color: iconColor, icon_custom_emoji_id: opts.iconCustomEmojiId }
+      : undefined,
+  );
+
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return {
+    message_thread_id: result.message_thread_id,
+    name: result.name,
+    icon_color: result.icon_color,
+    icon_custom_emoji_id: result.icon_custom_emoji_id,
+  };
+}


### PR DESCRIPTION
## Summary

Implements `thread-create` action for Telegram, enabling programmatic creation of forum topics in supergroups.

**Closes #5737**

---

## Context

The `thread-create` action exists in OpenClaw but returned `"Action thread-create is not supported for provider telegram"`. This PR adds the missing implementation.

**Telegram Bot API Reference:** [createForumTopic](https://core.telegram.org/bots/api#createforumtopic)

---

## Changes

### 1. Config Type (`src/config/types.telegram.ts`)
```diff
 export type TelegramActionConfig = {
   reactions?: boolean;
   sendMessage?: boolean;
   deleteMessage?: boolean;
   editMessage?: boolean;
   sticker?: boolean;
+  /** Enable forum topic creation. Bot must be admin with Manage Topics permission. */
+  createForumTopic?: boolean;
 };
```

### 2. Action Registration (`src/channels/plugins/actions/telegram.ts`)
- Added `thread-create` to `listActions` (gated by `createForumTopic` config)
- Added handler that maps `thread-create` → `createForumTopic` internal action

### 3. Action Handler (`src/agents/tools/telegram-actions.ts`)
- Added `createForumTopic` case with:
  - Config gate check (disabled by default)
  - Name validation (1-128 chars per Telegram API)
  - Token resolution
  - Returns `{ threadId, name, iconColor?, iconCustomEmojiId? }`

### 4. API Function (`src/telegram/send.ts`)
- Added `createForumTopicTelegram(chatId, name, opts)`
- Uses grammY's typed `api.createForumTopic()`
- Supports optional `iconColor` and `iconCustomEmojiId`

---

## Safety

| Concern | Mitigation |
|---------|------------|
| Accidental use | **Disabled by default** — requires `channels.telegram.actions.createForumTopic: true` |
| Invalid input | Name validated (1-128 chars) before API call |
| Missing token | Fails fast with clear error message |
| Missing permissions | Telegram API returns clear error if bot isn't admin |

---

## Usage

```bash
# CLI
openclaw message thread-create \\
  --channel telegram \\
  --target -100123456789 \\
  --thread-name "My Topic"

# Config required
channels:
  telegram:
    actions:
      createForumTopic: true
```

**Response:**
```json
{
  "ok": true,
  "threadId": 123,
  "name": "My Topic",
  "iconColor": 7322096
}
```

---
 
## Testing

- ✅ `pnpm tsc --noEmit` — no type errors
- ✅ `pnpm build` — builds successfully  
- ✅ Function import test — `createForumTopicTelegram` loads correctly
- ✅ API integration test — reaches Telegram API (returns expected permission error when bot lacks admin rights)

---

## Files Changed

| File | Lines | Purpose |
|------|-------|---------|
| `src/config/types.telegram.ts` | +2 | Add config option |
| `src/channels/plugins/actions/telegram.ts` | +24 | Register action + handler |
| `src/agents/tools/telegram-actions.ts` | +38 | Implement action logic |
| `src/telegram/send.ts` | +75 | Telegram API wrapper |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Telegram message action (`thread-create`) that maps to a new internal Telegram tool action (`createForumTopic`) and a new Telegram API helper (`createForumTopicTelegram`) to create forum topics in forum-enabled supergroups. Also extends `TelegramActionConfig` with a `createForumTopic` flag and gates exposure of the new action behind that config.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and feature-gated, with a couple of consistency/testability nits.
- No obvious functional regressions in existing actions; the new action is behind an explicit config gate and uses existing Telegram client patterns. Main concerns are minor: `createForumTopicTelegram` doesn’t follow the local cfg-injection pattern used elsewhere in this module, and there’s a small unreachable fallback that could hide type assumptions.
- src/telegram/send.ts (config loading/testability consistency), src/agents/tools/telegram-actions.ts (parameter handling consistency).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->