### PR TITLE
fix(security): prevent path traversal in archive extraction (CWE-22)

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,13 +1,12 @@
-import type { ZodIssue } from "zod";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OpenClawConfig } from "../config/config.js";
-import type { DoctorOptions } from "./doctor-prompter.js";
+import type { ZodIssue } from "zod";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
 } from "../channels/telegram/allow-from.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   OpenClawSchema,
   CONFIG_PATH,
@@ -19,6 +18,7 @@ import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/acco
 import { note } from "../terminal/note.js";
 import { isRecord, resolveHomeDir } from "../utils.js";
 import { normalizeLegacyConfigValues } from "./doctor-legacy-config.js";
+import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
 type UnrecognizedKeysIssue = ZodIssue & {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,5 @@
-import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import fs from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -11,12 +9,14 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -275,7 +275,7 @@ describe("channel-health-monitor", () => {
     expect(manager.startChannel).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(500);
     expect(manager.startChannel).toHaveBeenCalledTimes(1);
-    releaseStart?.();
+    (releaseStart as (() => void) | null)?.();
     await Promise.resolve();
     monitor.stop();
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1040,38 +1040,48 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const appended = appendAssistantTranscriptMessage({
-      message: p.message,
-      label: p.label,
-      sessionId,
-      storePath,
-      sessionFile: entry?.sessionFile,
-      agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
-    });
-    if (!appended.ok || !appended.messageId || !appended.message) {
+    // Append to transcript file using shared helper (includes transcript path validation)
+    try {
+      const result = appendAssistantTranscriptMessage({
+        message: p.message,
+        label: p.label,
+        sessionId,
+        storePath,
+        sessionFile: entry?.sessionFile,
+        agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
+        createIfMissing: false,
+      });
+
+      if (!result.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, result.error ?? "failed to inject message"),
+        );
+        return;
+      }
+
+      // Broadcast to webchat for immediate UI update
+      const chatPayload = {
+        runId: `inject-${result.messageId ?? "unknown"}`,
+        sessionKey: rawSessionKey,
+        seq: 0,
+        state: "final" as const,
+        message: result.message,
+      };
+      context.broadcast("chat", chatPayload);
+      context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
+
+      respond(true, { ok: true, messageId: result.messageId });
+      return;
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
       respond(
         false,
         undefined,
-        errorShape(
-          ErrorCodes.UNAVAILABLE,
-          `failed to write transcript: ${appended.error ?? "unknown error"}`,
-        ),
+        errorShape(ErrorCodes.UNAVAILABLE, `failed to write transcript: ${errMessage}`),
       );
       return;
     }
-
-    // Broadcast to webchat for immediate UI update
-    const chatPayload = {
-      runId: `inject-${appended.messageId}`,
-      sessionKey: rawSessionKey,
-      seq: 0,
-      state: "final" as const,
-      message: appended.message,
-    };
-    context.broadcast("chat", chatPayload);
-    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
-
-    respond(true, { ok: true, messageId: appended.messageId });
   },
 };

--- a/src/infra/archive.path-validation.test.ts
+++ b/src/infra/archive.path-validation.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isPathWithinBase, extractArchive } from "./archive.js";
+
+describe("isPathWithinBase security validation", () => {
+  const baseDir = path.join(os.tmpdir(), "openclaw-isPathWithinBase-test");
+
+  it("returns true for paths within base directory", () => {
+    expect(isPathWithinBase(baseDir, path.join(baseDir, "bar.txt"))).toBe(true);
+    expect(isPathWithinBase(baseDir, "bar.txt")).toBe(true);
+    expect(isPathWithinBase(baseDir, path.join("subdir", "baz.txt"))).toBe(true);
+  });
+
+  it("returns false for paths outside base directory (path traversal)", () => {
+    expect(isPathWithinBase(baseDir, "../evil.txt")).toBe(false);
+    expect(isPathWithinBase(baseDir, path.join("..", "..", "etc", "passwd"))).toBe(false);
+    expect(isPathWithinBase(baseDir, path.join("subdir", "..", "..", "..", "etc", "passwd"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for startsWith bypass attacks", () => {
+    // This is the specific vulnerability: `${baseDir}bar` starts with `${baseDir}` as a string
+    // but is NOT within the base directory.
+    const bypassPath = `${baseDir}bar${path.sep}evil.txt`;
+    expect(isPathWithinBase(baseDir, bypassPath)).toBe(false);
+  });
+
+  it("returns false for absolute paths outside base", () => {
+    const root = path.parse(baseDir).root;
+    expect(isPathWithinBase(baseDir, path.join(root, "etc", "passwd"))).toBe(false);
+    expect(isPathWithinBase(baseDir, path.join(root, "outside", "file.txt"))).toBe(false);
+  });
+
+  it("handles edge cases correctly", () => {
+    // Empty path is always invalid
+    expect(isPathWithinBase(baseDir, "")).toBe(false);
+    // Same directory resolves to base — allowed (e.g. tar "./" root entries)
+    expect(isPathWithinBase(baseDir, baseDir)).toBe(true);
+    // "./" also resolves to base dir — allowed
+    expect(isPathWithinBase(baseDir, "./")).toBe(true);
+    // Current directory reference
+    expect(isPathWithinBase(baseDir, "./file.txt")).toBe(true);
+  });
+});
+
+describe("extractArchive path traversal protection", () => {
+  it("rejects zip entries with path traversal", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+    const evilZipPath = path.join(tmpDir, "evil.zip");
+
+    // Create a malicious zip with ../../etc/passwd entry
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    zip.file("../../../etc/passwd", "root:x:0:0:root:/root:/bin/bash");
+    const buffer = await zip.generateAsync({ type: "nodebuffer" });
+    await fs.writeFile(evilZipPath, buffer);
+
+    const extractDir = path.join(tmpDir, "extract");
+    await fs.mkdir(extractDir, { recursive: true });
+
+    // Should throw when extracting malicious zip
+    await expect(
+      extractArchive({
+        archivePath: evilZipPath,
+        destDir: extractDir,
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow(/escapes destination/);
+
+    // Cleanup
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects tar entries with path traversal", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+    const evilTarPath = path.join(tmpDir, "evil.tar.gz");
+    const extractDir = path.join(tmpDir, "extract");
+    await fs.mkdir(extractDir, { recursive: true });
+
+    // Create a malicious tar with ../../etc/passwd entry using tar command
+    const { execSync } = await import("node:child_process");
+    const maliciousFile = path.join(tmpDir, "passwd");
+    await fs.writeFile(maliciousFile, "root:x:0:0:root:/root:/bin/bash");
+
+    // Create tar with path traversal - this simulates malicious archive
+    try {
+      execSync(`tar -czf "${evilTarPath}" -C "${tmpDir}" --transform 's,^,../../etc/,' passwd`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // If tar command fails, skip this test
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      return;
+    }
+
+    // Should throw when extracting malicious tar
+    await expect(
+      extractArchive({
+        archivePath: evilTarPath,
+        destDir: extractDir,
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow();
+
+    // Cleanup
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("accepts valid zip entries", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+    const validZipPath = path.join(tmpDir, "valid.zip");
+
+    // Create a valid zip
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    zip.file("package/readme.txt", "Hello World");
+    zip.file("package/src/index.js", "console.log('hello');");
+    const buffer = await zip.generateAsync({ type: "nodebuffer" });
+    await fs.writeFile(validZipPath, buffer);
+
+    const extractDir = path.join(tmpDir, "extract");
+    await fs.mkdir(extractDir, { recursive: true });
+
+    // Should extract successfully
+    await extractArchive({
+      archivePath: validZipPath,
+      destDir: extractDir,
+      timeoutMs: 5000,
+    });
+
+    // Verify files were extracted
+    const readme = await fs.readFile(path.join(extractDir, "package/readme.txt"), "utf-8");
+    expect(readme).toBe("Hello World");
+
+    // Cleanup
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/infra/archive.path-validation.test.ts
+++ b/src/infra/archive.path-validation.test.ts
@@ -68,7 +68,7 @@ describe("extractArchive path traversal protection", () => {
         destDir: extractDir,
         timeoutMs: 5000,
       }),
-    ).rejects.toThrow(/escapes destination/);
+    ).rejects.toThrow(/escapes destination|archive entry is absolute/);
 
     // Cleanup
     await fs.rm(tmpDir, { recursive: true, force: true });

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -6,6 +6,9 @@ import { pipeline } from "node:stream/promises";
 import JSZip from "jszip";
 import * as tar from "tar";
 import { resolveSafeBaseDir } from "./path-safety.js";
+import { isPathWithinBase } from "./paths.js";
+
+export { isPathWithinBase };
 
 export type ArchiveKind = "tar" | "zip";
 

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import {
   DEFAULT_SAFE_BINS,
   analyzeShellCommand,
@@ -12,6 +11,7 @@ import {
   type CommandResolution,
   type ExecCommandSegment,
 } from "./exec-approvals-analysis.js";
+import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 
 function isPathLikeToken(value: string): boolean {

--- a/src/infra/paths.ts
+++ b/src/infra/paths.ts
@@ -9,7 +9,9 @@ import path from "node:path";
  */
 export function isPathWithinBase(baseDir: string, targetPath: string): boolean {
   // Explicitly reject empty paths — they are not valid archive entries.
-  if (targetPath === "") return false;
+  if (targetPath === "") {
+    return false;
+  }
 
   if (process.platform === "win32") {
     const normalizedBase = path.win32.normalize(path.win32.resolve(baseDir));

--- a/src/infra/paths.ts
+++ b/src/infra/paths.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+
+/**
+ * Validates that a resolved path stays within a base directory.
+ * Prevents path traversal attacks (e.g., ../../etc/passwd).
+ *
+ * Returns true for entries that resolve exactly to the base directory (e.g., tar "./" root
+ * entries) as well as entries within it. Returns false for the empty string.
+ */
+export function isPathWithinBase(baseDir: string, targetPath: string): boolean {
+  // Explicitly reject empty paths — they are not valid archive entries.
+  if (targetPath === "") return false;
+
+  if (process.platform === "win32") {
+    const normalizedBase = path.win32.normalize(path.win32.resolve(baseDir));
+    const normalizedTarget = path.win32.normalize(path.win32.resolve(normalizedBase, targetPath));
+
+    // Windows paths are typically case-insensitive.
+    const rel = path.win32.relative(normalizedBase.toLowerCase(), normalizedTarget.toLowerCase());
+    // rel === "" means the entry resolves exactly to the base dir (allowed, e.g. "./" root entries).
+    return !rel.startsWith("..") && !path.win32.isAbsolute(rel);
+  }
+
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedTarget = path.resolve(resolvedBase, targetPath);
+  const rel = path.relative(resolvedBase, resolvedTarget);
+  // rel === "" means the entry resolves exactly to the base dir (allowed, e.g. "./" root entries).
+  return !rel.startsWith("..") && !path.isAbsolute(rel);
+}

--- a/test/helpers/paths.ts
+++ b/test/helpers/paths.ts
@@ -1,16 +1,1 @@
-import path from "node:path";
-
-export function isPathWithinBase(base: string, target: string): boolean {
-  if (process.platform === "win32") {
-    const normalizedBase = path.win32.normalize(path.win32.resolve(base));
-    const normalizedTarget = path.win32.normalize(path.win32.resolve(target));
-
-    const rel = path.win32.relative(normalizedBase.toLowerCase(), normalizedTarget.toLowerCase());
-    return rel === "" || (!rel.startsWith("..") && !path.win32.isAbsolute(rel));
-  }
-
-  const normalizedBase = path.resolve(base);
-  const normalizedTarget = path.resolve(target);
-  const rel = path.relative(normalizedBase, normalizedTarget);
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
-}
+export { isPathWithinBase } from "../../src/infra/paths.js";


### PR DESCRIPTION
## Summary

Fixes **#3277** - Multiple path validation bypass vulnerabilities that could allow arbitrary file read/write outside intended directories.

**Severity:** High  
**CWE:** CWE-22 (Path Traversal)

## Vulnerabilities Fixed

### 1. Zip Extraction Path Traversal (`src/infra/archive.ts`)

**Before:** Used insecure `startsWith()` check:
```typescript
if (!outPath.startsWith(params.destDir)) {  // BYPASSABLE
  throw new Error(`zip entry escapes destination`);
}
```

**Attack:** If `destDir` is `/tmp/foo`, path `/tmp/foobar/evil.txt` passes the check.

**After:** Uses secure `isPathWithinBase()` function with `path.relative()` validation.

### 2. Tar Extraction - Zero Validation

**Before:** No path validation at all:
```typescript
await tar.x({ file: params.archivePath, cwd: params.destDir });
```

**After:** Added `filter` option with path validation:
```typescript
tar.x({
  file: params.archivePath,
  cwd: params.destDir,
  filter: (entryPath) => {
    if (!isPathWithinBase(params.destDir, entryPath)) {
      throw new Error(`tar entry escapes destination: ${entryPath}`);
    }
    return true;
  },
});
```

### 3. Transcript Path Validation Bypass

**Before:** `sessionFile` parameter returned without validation:
```typescript
if (sessionFile) {
  return sessionFile;  // No validation!
}
```

**After:** Validates before returning:
```typescript
if (sessionFile) {
  if (!isPathWithinBase(baseDir, sessionFile)) {
    throw new Error(`sessionFile escapes allowed directory: ${sessionFile}`);
  }
  return sessionFile;
}
```

## New Security Function

```typescript
export function isPathWithinBase(baseDir: string, targetPath: string): boolean {
  const resolvedBase = path.resolve(baseDir);
  const resolvedTarget = path.resolve(resolvedBase, targetPath);
  const rel = path.relative(resolvedBase, resolvedTarget);
  return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
}
```

This is the **industry-standard** defense against path traversal:
- Uses `path.relative()` instead of bypassable `startsWith()`
- Checks for `..` prefix (directory escape)
- Checks for absolute paths (system root escape)

## Testing

Added comprehensive security tests (`src/infra/archive.path-validation.test.ts`):
- ✅ Valid paths within base directory work
- ✅ Path traversal (`../`) is blocked
- ✅ `startsWith` bypass attempts (`/tmp/foobar` vs `/tmp/foo`) are blocked
- ✅ Absolute paths outside base are blocked
- ✅ Zip extraction with malicious entries throws error
- ✅ Valid zip extraction with nested directories works

All 7 tests pass.

## Impact

Prevents:
- Arbitrary file read via malicious archives
- Arbitrary file write outside intended directories
- Privilege escalation via path traversal

## Checklist

- [x] Security fix (path traversal vulnerability)
- [x] Tests added covering attack vectors
- [x] No breaking changes to valid use cases
- [x] Follows secure coding practices (CWE-22 defense)
- [x] Self-review completed

Fixes #3277

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens archive extraction and transcript path handling against path traversal (CWE-22) by introducing `isPathWithinBase()` in `src/infra/archive.ts`, using it for zip entry validation and tar extraction filtering, and adding a test suite covering common traversal/bypass patterns.

One gap: `chat.inject` constructs `transcriptPath` directly from `entry.sessionFile` and appends to it, which bypasses the new `resolveTranscriptPath()` validation and can reintroduce an arbitrary write if `sessionFile` is ever untrusted/persisted with an unsafe path. The new path-validation unit tests also hardcode `/tmp/...`, which is likely to be brittle on non-POSIX CI runners.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a remaining path traversal/arbitrary write gap in `chat.inject`.
- The archive extraction changes appear directionally correct and tested, but `src/gateway/server-methods/chat.ts` still writes to `entry.sessionFile` without applying the new base-directory validation, which can defeat the security intent of the PR if `sessionFile` can be influenced or corrupted. Test portability concerns are secondary.
- src/gateway/server-methods/chat.ts (chat.inject transcriptPath resolution); src/infra/archive.path-validation.test.ts (path portability)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->