### PR TITLE
fix: resolve CI failures (lint + format + test env isolation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Browser: secure Chrome extension relay CDP sessions.
 - Docker: use container port for gateway command instead of host port. (#5110) Thanks @mise42.
 - fix(lobster): block arbitrary exec via lobsterPath/cwd injection (GHSA-4mhr-g7xj-cg8j). (#5335) Thanks @vignesh07.
-- Security: block LD_/DYLD_ env overrides for host exec. (#4896) Thanks @HassanFleyah.
+- Security: block LD*/DYLD* env overrides for host exec. (#4896) Thanks @HassanFleyah.
 - Security: harden web tool content wrapping + file parsing safeguards. (#4058) Thanks @VACInc.
 - Security: enforce Twitch `allowFrom` allowlist gating (deny non-allowlisted senders). Thanks @MegaManSec.
 

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -14,6 +14,7 @@ provider and set the default model to `moonshot/kimi-k2.5`, or use
 Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
+
 <!-- moonshot-kimi-k2-ids:start -->
 
 - `kimi-k2.5`

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -349,9 +349,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       let lastResult: { messageId: string; chatId: string } | null = null;
       const quickReplies = lineData.quickReplies ?? [];
       const hasQuickReplies = quickReplies.length > 0;
-      const quickReply = hasQuickReplies
-        ? createQuickReplyItems(quickReplies)
-        : undefined;
+      const quickReply = hasQuickReplies ? createQuickReplyItems(quickReplies) : undefined;
 
       const sendMessageBatch = async (messages: Array<Record<string, unknown>>) => {
         if (messages.length === 0) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -15,12 +15,10 @@ import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 
-const OAUTH_PROVIDER_IDS = new Set<OAuthProvider>(
-  getOAuthProviders().map((provider) => provider.id),
-);
+const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) => provider.id));
 
 const isOAuthProvider = (provider: string): provider is OAuthProvider =>
-  OAUTH_PROVIDER_IDS.has(provider as OAuthProvider);
+  OAUTH_PROVIDER_IDS.has(provider);
 
 const resolveOAuthProvider = (provider: string): OAuthProvider | null =>
   isOAuthProvider(provider) ? provider : null;


### PR DESCRIPTION
## Problem

`main` currently has three CI issues:

1. **Lint failure** — `oxlint` reports `no-unnecessary-type-assertion` in `src/agents/auth-profiles/oauth.ts` (the `Set<OAuthProvider>` constructor and `.has()` call don't need explicit casts)
2. **Format failure** — `CHANGELOG.md` and `extensions/line/src/channel.ts` have formatting issues caught by `oxfmt`
3. **Flaky test** — `skips writing models.json when no env token or profile exists` fails when the runner has provider env vars (e.g. `OPENAI_API_KEY`), because the test only stubbed 9 specific vars instead of matching all provider key patterns

## Fix

- Remove unnecessary type assertions in oauth provider resolution
- Fix formatting in CHANGELOG.md and extensions/line/src/channel.ts  
- Replace specific env var stubs with pattern-based `vi.stubEnv()` that catches all `_API_KEY`, `_TOKEN`, `_OAUTH_TOKEN` patterns plus AWS/GCP specifics. Uses `vi.unstubAllEnvs()` for cleanup.

## Verification

Local: `pnpm build && pnpm lint && pnpm format` all pass.

---
All code is AI-generated (Codex / Claude Code), directed and reviewed by a human architect.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses CI failures by (1) removing unnecessary type assertions in OAuth provider resolution, (2) applying oxfmt-driven formatting fixes in the changelog and LINE extension channel code, and (3) hardening a flaky models-config test by stubbing auth-related environment variables more broadly and cleaning them up via `vi.unstubAllEnvs()`.

The main behavioral change is limited to `src/agents/auth-profiles/oauth.ts`, where provider ID membership is now checked against a `Set<string>` built from `getOAuthProviders()`, and to `src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`, where the test environment is isolated from host/runner credentials.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with minor type-safety/test-robustness concerns.
- Changes are mostly formatting and test isolation, but the OAuth type predicate now relies on a `Set<string>` which can drift from the `OAuthProvider` union, and the env-stubbing heuristic may still miss credential variables on some CI runners.
- src/agents/auth-profiles/oauth.ts; src/agents/models-config.skips-writing-models-json-no-env-token.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->