### PR TITLE
feat: Rate limiting for HTTP, WebSocket, auth brute-force, and TTS

### DIFF
--- a/RATE-LIMIT-REVIEW.md
+++ b/RATE-LIMIT-REVIEW.md
@@ -1,0 +1,323 @@
+# Rate Limiting Review — OpenClaw
+
+**Date:** 2025-07-25  
+**Reviewer:** Subagent (rate-limit analysis)  
+**Scope:** Full codebase analysis for rate limiting gaps and recommendations
+
+---
+
+## 1. Project Overview
+
+### What is OpenClaw?
+
+OpenClaw is a **personal AI assistant** you self-host. It runs a Gateway (Node.js, TypeScript) that acts as a control plane connecting:
+- **Messaging channels** (WhatsApp/Baileys, Telegram/grammY, Discord/discord.js, Slack/Bolt, Signal, iMessage, Microsoft Teams, Google Chat, Matrix, WebChat, etc.)
+- **AI providers** (Anthropic Claude, OpenAI, etc.) via OAuth or API keys
+- **Companion apps** (macOS, iOS, Android nodes)
+- **Tools** (browser control via Playwright, canvas, cron, skills, exec)
+
+### Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Language | TypeScript (Node ≥22) |
+| HTTP server | Raw `node:http` (`createServer`) + Express (browser control only) |
+| WebSocket | `ws` library |
+| Build | `tsc` + `pnpm` |
+| Channels | Baileys (WhatsApp), grammY (Telegram), discord.js, @slack/bolt, etc. |
+| AI providers | @mariozechner/pi-ai, @mariozechner/pi-agent-core |
+| TTS | ElevenLabs API, Edge TTS, OpenAI TTS |
+| Browser | Playwright-core |
+
+### Architecture
+
+```
+Messaging Channels (WhatsApp/Telegram/Discord/Slack/Signal/etc.)
+        │
+        ▼
+┌─────────────────────────────┐
+│       Gateway Server        │  ← Single Node.js process
+│   HTTP + WebSocket (ws)     │
+│   ws://127.0.0.1:18789      │
+└──────────┬──────────────────┘
+           │
+           ├── HTTP routes: /hooks/*, /v1/chat/completions, /v1/responses, /tools/invoke, /slack/*, control-ui, canvas
+           ├── WebSocket RPC: ~50+ methods (agent, send, chat, config, sessions, cron, etc.)
+           ├── Browser control server (Express, separate port, localhost-only)
+           └── Channel-specific transports (Baileys WS, grammY polling/webhook, etc.)
+```
+
+### Deployment Model
+
+- **Single-server, single-process** — the Gateway is one Node.js process
+- Default bind: **loopback** (`127.0.0.1`) — not internet-facing
+- Optional exposure via **Tailscale Serve** (tailnet-only) or **Tailscale Funnel** (public internet)
+- Can also be exposed via SSH tunnels or reverse proxies
+- **No Redis, no external state store** — everything is in-memory or on-disk (SQLite for memory plugin)
+
+---
+
+## 2. Current State — Existing Rate Limiting / Throttling
+
+### What exists today
+
+| Area | Mechanism | File |
+|---|---|---|
+| **Telegram outbound** | `@grammyjs/transformer-throttler` — throttles outbound Telegram API calls to respect Telegram's rate limits | `src/telegram/bot.ts` |
+| **Discord outbound** | Retry with exponential backoff on `RateLimitError` from `@buape/carbon` | `src/infra/retry-policy.ts` |
+| **AI provider rate limits** | Profile-level cooldown/backoff when rate limited (429s) — exponential backoff with configurable billing backoff | `src/agents/auth-profiles/usage.ts`, `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/model-fallback.ts` |
+| **Agent concurrency** | Lane-based concurrency limits for cron, main agent, and subagent runs | `src/gateway/server-lanes.ts`, `src/process/command-queue.ts` |
+| **Hook body size** | `maxBodyBytes` on hooks (default 256KB), OpenAI endpoint (1MB), Responses endpoint (20MB), tools-invoke (2MB) | `src/gateway/hooks.ts`, `src/gateway/openai-http.ts`, etc. |
+| **Browser control body** | Express `json({ limit: "1mb" })` | `src/browser/server.ts` |
+
+### What does NOT exist
+
+- **No HTTP request rate limiting** on any endpoint (hooks, OpenAI-compat, Responses, tools-invoke, control-ui)
+- **No WebSocket message rate limiting** (no per-client message throttle)
+- **No per-IP connection limiting** on the HTTP or WebSocket server
+- **No auth brute-force protection** (no lockout after N failed attempts)
+- **No WebChat rate limiting** (WebChat clients connect via WebSocket with password auth)
+- **No DM flood protection** on messaging channels (handled per-channel by allowlists, but no rate gate)
+
+---
+
+## 3. Vulnerability Analysis
+
+Ranked by priority (P0 = critical, P3 = nice-to-have). Severity accounts for the fact that **most deployments are loopback-only** — the exposure surface expands significantly when Tailscale Funnel or a reverse proxy is used.
+
+### P0 — Critical (when internet-exposed)
+
+| Endpoint | Risk | Why |
+|---|---|---|
+| **`POST /hooks/agent`** | **Agent invocation flooding** | Each call dispatches a full AI agent run (expensive: LLM API calls, tool execution). An attacker with a leaked hook token can burn API credits rapidly. Token auth exists but no rate cap. |
+| **`POST /v1/chat/completions`** | **AI credit burn** | OpenAI-compatible endpoint. Each request triggers a full agent run. Auth required (Bearer token), but no rate limit after auth. |
+| **`POST /v1/responses`** | **AI credit burn** | OpenResponses endpoint. Same risk as above — full agent run per request with file upload support (20MB body limit). |
+| **`POST /tools/invoke`** | **Arbitrary tool execution** | Allows invoking any tool the agent has access to. Auth required, but no rate limit. Could be abused for exec, browser control, etc. |
+
+### P1 — High
+
+| Endpoint | Risk | Why |
+|---|---|---|
+| **WebSocket `connect` + auth** | **Auth brute-force** | WS handshake includes token/password. No lockout or rate limit on failed auth attempts. Timing-safe compare exists but doesn't prevent enumeration attempts. |
+| **WebSocket `agent` / `agent.wait` / `chat.send` methods** | **Agent flooding via WS** | Authenticated WS clients can spam agent runs with no throttle. |
+| **`POST /hooks/wake`** | **Wake flooding** | Triggers heartbeat/wake cycles. Less expensive than agent, but still triggers processing. |
+| **WebSocket connection flood** | **Resource exhaustion** | No max connections limit. Each WS connection consumes memory for message handlers, presence tracking, etc. |
+
+### P2 — Medium
+
+| Endpoint | Risk | Why |
+|---|---|---|
+| **Control UI (static files)** | **Bandwidth abuse** | Serves static files (HTML/JS/CSS). Low risk but no caching headers or rate limits. |
+| **`POST /slack/*`** | **Slack event replay** | Slack webhook events are forwarded here. Slack has its own retry logic. |
+| **TTS conversion (`tts.convert` WS method)** | **ElevenLabs credit burn** | Each call hits ElevenLabs API. No per-client rate limit. |
+| **Browser control (Express, localhost)** | **Browser abuse** | Localhost-only, but any local process can hit it. Each request can launch browsers, navigate, screenshot. |
+
+### P3 — Nice-to-Have
+
+| Area | Risk |
+|---|---|
+| **Inbound messaging channel flood** | Users on allowlist could spam messages. Current protection is allowlist only. |
+| **Cron job creation** | Authenticated users can create unlimited cron jobs. |
+| **Session creation** | No limit on concurrent sessions. |
+
+---
+
+## 4. Recommended Approach
+
+### In-Memory vs Redis
+
+**Recommendation: In-memory rate limiting.**
+
+Rationale:
+- OpenClaw is a **single-process, single-server** application
+- No Redis dependency exists in the project
+- Adding Redis would be a significant operational burden for a personal assistant
+- In-memory is sufficient since all requests go through one process
+- If the process restarts, rate limit counters reset — acceptable for this use case
+
+### Library Choice
+
+**Recommendation: Custom lightweight in-memory rate limiter (token bucket or sliding window).**
+
+Rationale:
+- `express-rate-limit` only works for Express routes (browser server only)
+- The main Gateway HTTP server uses raw `node:http`, not Express
+- The WebSocket server needs rate limiting too
+- A simple `Map<string, { tokens: number, lastRefill: number }>` token bucket is ~30 lines
+- No new dependency needed
+
+Alternative: Extract the rate limiter into a shared utility (`src/infra/rate-limiter.ts`) that works for both HTTP and WS.
+
+### Middleware vs Per-Route
+
+**Recommendation: Layered approach.**
+
+1. **Global HTTP middleware** — applied in `createGatewayHttpServer` before any route handler
+   - IP-based rate limit: 100 req/min per IP (generous, catches floods)
+   - Applies to all HTTP routes
+   
+2. **Per-endpoint-group limits** — applied within specific handlers
+   - Expensive endpoints (agent, chat completions, responses, tools-invoke): stricter limits
+   - Hook endpoints: moderate limits
+   - Static assets: generous limits
+   
+3. **WebSocket message rate limiting** — in `ws-connection/message-handler.ts`
+   - Per-client message rate: 60 msg/min
+   - Per-client agent invocations: 10/min
+   
+4. **Auth failure rate limiting** — in `auth.ts`
+   - Per-IP: 10 failed auth attempts / 15 min, then 429 for 15 min
+
+---
+
+## 5. Implementation Plan
+
+### Step 1: Create rate limiter utility
+
+**New file: `src/infra/rate-limiter.ts`**
+
+```typescript
+// Token-bucket rate limiter
+// - Keyed by string (IP, client ID, etc.)
+// - Configurable: maxTokens, refillRate, refillIntervalMs
+// - Auto-cleanup of stale entries (GC every 5 min)
+// - Returns { allowed: boolean, retryAfterMs?: number }
+```
+
+### Step 2: HTTP rate limiting
+
+**File: `src/gateway/server-http.ts`** — modify `createGatewayHttpServer`
+
+Add at the top of `handleRequest()`:
+```
+1. Extract client IP (already have resolveGatewayClientIp in net.ts)
+2. Check global rate limit (100 req/min per IP)
+3. If exceeded, return 429 with Retry-After header
+```
+
+**Per-endpoint limits** (add checks inside each handler):
+
+| Endpoint | Limit | Key |
+|---|---|---|
+| `POST /hooks/agent` | 10 req/min per token | hook token hash |
+| `POST /hooks/wake` | 20 req/min per token | hook token hash |
+| `POST /v1/chat/completions` | 10 req/min per IP | client IP |
+| `POST /v1/responses` | 10 req/min per IP | client IP |
+| `POST /tools/invoke` | 20 req/min per IP | client IP |
+| Control UI static | 200 req/min per IP | client IP |
+
+Files to modify:
+- `src/gateway/server-http.ts` — global middleware
+- `src/gateway/openai-http.ts` — per-endpoint
+- `src/gateway/openresponses-http.ts` — per-endpoint
+- `src/gateway/tools-invoke-http.ts` — per-endpoint
+
+### Step 3: WebSocket rate limiting
+
+**File: `src/gateway/server/ws-connection.ts`** — in the connection handler
+
+- Track per-client message rate
+- Add to `GatewayWsClient` type: `{ messageCount: number, windowStart: number }`
+- In message handler: check 60 msg/min per client, close connection if exceeded
+
+**File: `src/gateway/server/ws-connection/message-handler.ts`** — per-method limits
+
+- `agent`, `agent.wait`, `chat.send`: 10/min per client
+- `tts.convert`: 20/min per client
+
+### Step 4: Auth brute-force protection
+
+**File: `src/gateway/auth.ts`** — modify `authorizeGatewayConnect`
+
+- Track failed auth attempts per IP (in-memory Map)
+- After 10 failures in 15 min → reject with 429 for 15 min
+- Reset on successful auth
+
+**File: `src/gateway/server/ws-connection.ts`** — WS auth failures
+
+- Same per-IP tracking for WebSocket handshake auth failures
+- Close connection immediately on rate limit
+
+### Step 5: Configuration
+
+**File: `src/config/types.gateway.ts`** — add rate limit config
+
+```typescript
+rateLimits?: {
+  enabled?: boolean; // default: true
+  http?: {
+    globalPerMinute?: number; // default: 100
+    agentPerMinute?: number; // default: 10
+    hookPerMinute?: number; // default: 20
+  };
+  ws?: {
+    messagesPerMinute?: number; // default: 60
+    agentPerMinute?: number; // default: 10
+  };
+  auth?: {
+    maxFailures?: number; // default: 10
+    windowMinutes?: number; // default: 15
+  };
+};
+```
+
+### Files to modify (summary)
+
+| File | Change |
+|---|---|
+| `src/infra/rate-limiter.ts` | **NEW** — token bucket implementation |
+| `src/gateway/server-http.ts` | Add global HTTP rate limiting in `handleRequest()` |
+| `src/gateway/openai-http.ts` | Add per-endpoint rate limit check after auth |
+| `src/gateway/openresponses-http.ts` | Add per-endpoint rate limit check after auth |
+| `src/gateway/tools-invoke-http.ts` | Add per-endpoint rate limit check after auth |
+| `src/gateway/hooks.ts` or `server-http.ts` | Add per-hook rate limit |
+| `src/gateway/auth.ts` | Add auth failure tracking |
+| `src/gateway/server/ws-connection.ts` | Add per-client WS rate limiting |
+| `src/gateway/server/ws-connection/message-handler.ts` | Add per-method WS rate limiting |
+| `src/config/types.gateway.ts` | Add `rateLimits` config type |
+| `src/config/schema.ts` | Add descriptions for rate limit config keys |
+
+---
+
+## 6. External API Rate Limits — Client-Side Throttling
+
+### Already handled ✅
+
+| External API | Mechanism | Status |
+|---|---|---|
+| **Telegram Bot API** | `@grammyjs/transformer-throttler` auto-throttles outbound calls | ✅ Good |
+| **Discord API** | Retry with backoff on `RateLimitError` | ✅ Good |
+| **AI Providers (Anthropic/OpenAI/etc.)** | Profile cooldown with exponential backoff on 429s; automatic failover to next auth profile | ✅ Good |
+
+### Needs attention ⚠️
+
+| External API | Current State | Recommendation |
+|---|---|---|
+| **ElevenLabs TTS** | No client-side rate limiting. Each `tts.convert` call directly hits the ElevenLabs API. | Add a token-bucket limiter in `src/tts/tts.ts` — suggest 10 req/min default, configurable |
+| **Brave Search** (if used via skills) | No built-in throttle | Skills are user-managed; document best practices |
+| **Gmail Pub/Sub** | Webhook-driven, Google controls the rate | ✅ OK (Google handles backoff) |
+| **WhatsApp (Baileys)** | Baileys has internal queuing but no explicit rate limit for outbound messages | Low risk for personal use, but could add a per-chat send throttle if needed |
+| **Slack Web API** | `@slack/web-api` has built-in retry for rate limits | ✅ OK |
+
+### No action needed
+
+- **Playwright/Browser**: localhost-only, single browser instance, inherently serial
+- **Signal-cli**: process-based, inherently serial
+- **iMessage**: macOS API, no HTTP rate limits
+
+---
+
+## Summary
+
+OpenClaw currently has **no HTTP or WebSocket rate limiting** on the Gateway. The main risk is when the Gateway is exposed to the internet (via Tailscale Funnel or reverse proxy), where unauthenticated or authenticated attackers could:
+
+1. **Burn AI API credits** by flooding agent endpoints
+2. **Brute-force auth** on WebSocket connections
+3. **Exhaust server resources** via connection floods
+
+The recommended approach is a **lightweight in-memory token-bucket rate limiter** (no new dependencies) applied at three layers:
+1. Global HTTP rate limit per IP
+2. Per-endpoint limits for expensive operations
+3. Per-client WebSocket message rate limiting + auth failure protection
+
+This is straightforward to implement (~200-300 lines of new code across ~10 files) and the configuration should be opt-out (enabled by default with sensible defaults).

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -16,8 +16,12 @@ export type RateLimitsWsConfig = {
   messagesPerMinute?: number;
   /** Agent invocations per client per minute — default: 10. */
   agentPerMinute?: number;
+  /** TTS conversions per client per minute — default: 20. */
+  ttsPerMinute?: number;
   /** Max concurrent WS connections — default: 50. */
   maxConnections?: number;
+  /** Max concurrent WS connections per IP — default: 5. */
+  perIpMaxConnections?: number;
 };
 
 export type RateLimitsAuthConfig = {
@@ -56,7 +60,9 @@ const RATE_LIMITS_HTTP_DEFAULTS: ResolvedRateLimitsHttpConfig = {
 const RATE_LIMITS_WS_DEFAULTS: ResolvedRateLimitsWsConfig = {
   messagesPerMinute: 60,
   agentPerMinute: 10,
+  ttsPerMinute: 20,
   maxConnections: 50,
+  perIpMaxConnections: 5,
 };
 
 const RATE_LIMITS_AUTH_DEFAULTS: ResolvedRateLimitsAuthConfig = {

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -9,6 +9,8 @@ export type RateLimitsHttpConfig = {
   hookPerMinute?: number;
   /** Static/control-ui per-IP req/min — default: 200. */
   staticPerMinute?: number;
+  /** Tool invocation per-IP req/min — default: 20. */
+  toolsPerMinute?: number;
 };
 
 export type RateLimitsWsConfig = {
@@ -64,6 +66,7 @@ const RATE_LIMITS_HTTP_DEFAULTS: ResolvedRateLimitsHttpConfig = {
   agentPerMinute: 10,
   hookPerMinute: 20,
   staticPerMinute: 200,
+  toolsPerMinute: 20,
 };
 
 const RATE_LIMITS_WS_DEFAULTS: ResolvedRateLimitsWsConfig = {

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,3 +1,82 @@
+// --- Rate Limits ---
+
+export type RateLimitsHttpConfig = {
+  /** Global per-IP requests/min — default: 100. */
+  globalPerMinute?: number;
+  /** Agent-invoking endpoints per-IP req/min — default: 10. */
+  agentPerMinute?: number;
+  /** Hook endpoints per-token req/min — default: 20. */
+  hookPerMinute?: number;
+  /** Static/control-ui per-IP req/min — default: 200. */
+  staticPerMinute?: number;
+};
+
+export type RateLimitsWsConfig = {
+  /** Messages per client per minute — default: 60. */
+  messagesPerMinute?: number;
+  /** Agent invocations per client per minute — default: 10. */
+  agentPerMinute?: number;
+  /** Max concurrent WS connections — default: 50. */
+  maxConnections?: number;
+};
+
+export type RateLimitsAuthConfig = {
+  /** Failed attempts before lockout — default: 10. */
+  maxFailures?: number;
+  /** Lockout window in minutes — default: 15. */
+  windowMinutes?: number;
+};
+
+export type RateLimitsConfig = {
+  /** Master switch — default: true. */
+  enabled?: boolean;
+  http?: RateLimitsHttpConfig;
+  ws?: RateLimitsWsConfig;
+  auth?: RateLimitsAuthConfig;
+};
+
+export type ResolvedRateLimitsHttpConfig = Required<RateLimitsHttpConfig>;
+export type ResolvedRateLimitsWsConfig = Required<RateLimitsWsConfig>;
+export type ResolvedRateLimitsAuthConfig = Required<RateLimitsAuthConfig>;
+
+export type ResolvedRateLimitsConfig = {
+  enabled: boolean;
+  http: ResolvedRateLimitsHttpConfig;
+  ws: ResolvedRateLimitsWsConfig;
+  auth: ResolvedRateLimitsAuthConfig;
+};
+
+const RATE_LIMITS_HTTP_DEFAULTS: ResolvedRateLimitsHttpConfig = {
+  globalPerMinute: 100,
+  agentPerMinute: 10,
+  hookPerMinute: 20,
+  staticPerMinute: 200,
+};
+
+const RATE_LIMITS_WS_DEFAULTS: ResolvedRateLimitsWsConfig = {
+  messagesPerMinute: 60,
+  agentPerMinute: 10,
+  maxConnections: 50,
+};
+
+const RATE_LIMITS_AUTH_DEFAULTS: ResolvedRateLimitsAuthConfig = {
+  maxFailures: 10,
+  windowMinutes: 15,
+};
+
+/** Merge user-provided rate limit config with sensible defaults. */
+export function resolveRateLimitsConfig(raw?: RateLimitsConfig): ResolvedRateLimitsConfig {
+  const enabled = raw?.enabled !== false;
+  return {
+    enabled,
+    http: { ...RATE_LIMITS_HTTP_DEFAULTS, ...raw?.http },
+    ws: { ...RATE_LIMITS_WS_DEFAULTS, ...raw?.ws },
+    auth: { ...RATE_LIMITS_AUTH_DEFAULTS, ...raw?.auth },
+  };
+}
+
+// --- Gateway ---
+
 export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
 
 export type GatewayTlsConfig = {
@@ -241,4 +320,6 @@ export type GatewayConfig = {
    * `x-real-ip`) to determine the client IP for local pairing and HTTP checks.
    */
   trustedProxies?: string[];
+  /** Rate limiting configuration. Enabled by default with sensible defaults. */
+  rateLimits?: RateLimitsConfig;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -31,23 +31,32 @@ export type RateLimitsAuthConfig = {
   windowMinutes?: number;
 };
 
+export type RateLimitsExternalConfig = {
+  /** ElevenLabs TTS requests per minute — default: 10. */
+  ttsPerMinute?: number;
+};
+
 export type RateLimitsConfig = {
   /** Master switch — default: true. */
   enabled?: boolean;
   http?: RateLimitsHttpConfig;
   ws?: RateLimitsWsConfig;
   auth?: RateLimitsAuthConfig;
+  external?: RateLimitsExternalConfig;
 };
 
 export type ResolvedRateLimitsHttpConfig = Required<RateLimitsHttpConfig>;
 export type ResolvedRateLimitsWsConfig = Required<RateLimitsWsConfig>;
 export type ResolvedRateLimitsAuthConfig = Required<RateLimitsAuthConfig>;
 
+export type ResolvedRateLimitsExternalConfig = Required<RateLimitsExternalConfig>;
+
 export type ResolvedRateLimitsConfig = {
   enabled: boolean;
   http: ResolvedRateLimitsHttpConfig;
   ws: ResolvedRateLimitsWsConfig;
   auth: ResolvedRateLimitsAuthConfig;
+  external: ResolvedRateLimitsExternalConfig;
 };
 
 const RATE_LIMITS_HTTP_DEFAULTS: ResolvedRateLimitsHttpConfig = {
@@ -70,6 +79,10 @@ const RATE_LIMITS_AUTH_DEFAULTS: ResolvedRateLimitsAuthConfig = {
   windowMinutes: 15,
 };
 
+const RATE_LIMITS_EXTERNAL_DEFAULTS: ResolvedRateLimitsExternalConfig = {
+  ttsPerMinute: 10,
+};
+
 /** Merge user-provided rate limit config with sensible defaults. */
 export function resolveRateLimitsConfig(raw?: RateLimitsConfig): ResolvedRateLimitsConfig {
   const enabled = raw?.enabled !== false;
@@ -78,6 +91,7 @@ export function resolveRateLimitsConfig(raw?: RateLimitsConfig): ResolvedRateLim
     http: { ...RATE_LIMITS_HTTP_DEFAULTS, ...raw?.http },
     ws: { ...RATE_LIMITS_WS_DEFAULTS, ...raw?.ws },
     auth: { ...RATE_LIMITS_AUTH_DEFAULTS, ...raw?.auth },
+    external: { ...RATE_LIMITS_EXTERNAL_DEFAULTS, ...raw?.external },
   };
 }
 

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ResolvedRateLimitsAuthConfig } from "../config/types.gateway.js";
+import { AuthRateLimiter } from "./auth-rate-limit.js";
+
+function makeConfig(
+  overrides?: Partial<ResolvedRateLimitsAuthConfig>,
+): ResolvedRateLimitsAuthConfig {
+  return {
+    maxFailures: overrides?.maxFailures ?? 10,
+    windowMinutes: overrides?.windowMinutes ?? 15,
+  };
+}
+
+describe("AuthRateLimiter", () => {
+  let limiter: AuthRateLimiter;
+
+  afterEach(() => {
+    limiter?.destroy();
+  });
+
+  it("allows auth attempts within limit", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 5 }));
+    for (let i = 0; i < 5; i++) {
+      const result = limiter.checkAuthAllowed("192.168.1.1");
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it("blocks auth after maxFailures exceeded", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 3 }));
+    for (let i = 0; i < 3; i++) {
+      limiter.checkAuthAllowed("192.168.1.1");
+      limiter.recordFailure("192.168.1.1");
+    }
+    const result = limiter.checkAuthAllowed("192.168.1.1");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("returns retryAfterMs when blocked", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1, windowMinutes: 15 }));
+    limiter.checkAuthAllowed("192.168.1.1");
+    limiter.recordFailure("192.168.1.1");
+    const result = limiter.checkAuthAllowed("192.168.1.1");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeDefined();
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("resets failure count on successful auth", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 2 }));
+    // Consume tokens
+    limiter.checkAuthAllowed("192.168.1.1");
+    limiter.recordFailure("192.168.1.1");
+    limiter.checkAuthAllowed("192.168.1.1");
+
+    // Reset on success
+    limiter.recordSuccess("192.168.1.1");
+
+    // Should be allowed again
+    const result = limiter.checkAuthAllowed("192.168.1.1");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("separate tracking per IP", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1 }));
+    limiter.checkAuthAllowed("10.0.0.1");
+    limiter.recordFailure("10.0.0.1");
+
+    // 10.0.0.1 should be blocked
+    expect(limiter.checkAuthAllowed("10.0.0.1").allowed).toBe(false);
+
+    // 10.0.0.2 should still be allowed
+    expect(limiter.checkAuthAllowed("10.0.0.2").allowed).toBe(true);
+  });
+
+  it("failures expire after windowMinutes", () => {
+    // Use a tiny window to test expiry via the token bucket refill.
+    // The RateLimiter refills after refillIntervalMs = windowMinutes * 60_000.
+    // With maxFailures=1, windowMinutes=15 → refill at 900_000 ms.
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1, windowMinutes: 15 }));
+    limiter.checkAuthAllowed("192.168.1.1");
+    limiter.recordFailure("192.168.1.1");
+
+    // Blocked immediately
+    expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(false);
+
+    // After window expires, a new limiter instance would have refilled.
+    // Since we can't easily control time in the RateLimiter without exposing
+    // the `now` parameter, we verify the retryAfterMs is set correctly.
+    // The retryAfterMs should be <= windowMinutes * 60_000.
+    const blocked = limiter.checkAuthAllowed("192.168.1.1");
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeLessThanOrEqual(15 * 60 * 1000);
+  });
+
+  it("does not block when rateLimits.enabled is false", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1 }), false);
+    // Even after many "failures", should always be allowed
+    for (let i = 0; i < 20; i++) {
+      limiter.checkAuthAllowed("192.168.1.1");
+      limiter.recordFailure("192.168.1.1");
+    }
+    expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(true);
+  });
+
+  it("destroy cleans up", () => {
+    limiter = new AuthRateLimiter(makeConfig());
+    limiter.checkAuthAllowed("192.168.1.1");
+    expect(limiter.size).toBe(1);
+    limiter.destroy();
+    // Double destroy should be safe
+    limiter.destroy();
+  });
+});

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -18,27 +18,35 @@ describe("AuthRateLimiter", () => {
     limiter?.destroy();
   });
 
-  it("allows auth attempts within limit", () => {
-    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 5 }));
-    for (let i = 0; i < 5; i++) {
-      const result = limiter.checkAuthAllowed("192.168.1.1");
-      expect(result.allowed).toBe(true);
+  it("checkAuthAllowed does NOT consume tokens (read-only)", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 3 }));
+    // Call checkAuthAllowed many times — should never block on its own
+    for (let i = 0; i < 20; i++) {
+      expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(true);
     }
   });
 
-  it("blocks auth after maxFailures exceeded", () => {
+  it("blocks auth only after maxFailures recorded failures", () => {
     limiter = new AuthRateLimiter(makeConfig({ maxFailures: 3 }));
     for (let i = 0; i < 3; i++) {
-      limiter.checkAuthAllowed("192.168.1.1");
       limiter.recordFailure("192.168.1.1");
     }
     const result = limiter.checkAuthAllowed("192.168.1.1");
     expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("successful auths do not count toward lockout", () => {
+    limiter = new AuthRateLimiter(makeConfig({ maxFailures: 3 }));
+    // 20 successes should never lock out
+    for (let i = 0; i < 20; i++) {
+      expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(true);
+      limiter.recordSuccess("192.168.1.1");
+    }
   });
 
   it("returns retryAfterMs when blocked", () => {
     limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1, windowMinutes: 15 }));
-    limiter.checkAuthAllowed("192.168.1.1");
     limiter.recordFailure("192.168.1.1");
     const result = limiter.checkAuthAllowed("192.168.1.1");
     expect(result.allowed).toBe(false);
@@ -48,46 +56,31 @@ describe("AuthRateLimiter", () => {
 
   it("resets failure count on successful auth", () => {
     limiter = new AuthRateLimiter(makeConfig({ maxFailures: 2 }));
-    // Consume tokens
-    limiter.checkAuthAllowed("192.168.1.1");
     limiter.recordFailure("192.168.1.1");
-    limiter.checkAuthAllowed("192.168.1.1");
+    limiter.recordFailure("192.168.1.1");
+
+    // Blocked
+    expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(false);
 
     // Reset on success
     limiter.recordSuccess("192.168.1.1");
 
     // Should be allowed again
-    const result = limiter.checkAuthAllowed("192.168.1.1");
-    expect(result.allowed).toBe(true);
+    expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(true);
   });
 
   it("separate tracking per IP", () => {
     limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1 }));
-    limiter.checkAuthAllowed("10.0.0.1");
     limiter.recordFailure("10.0.0.1");
 
-    // 10.0.0.1 should be blocked
     expect(limiter.checkAuthAllowed("10.0.0.1").allowed).toBe(false);
-
-    // 10.0.0.2 should still be allowed
     expect(limiter.checkAuthAllowed("10.0.0.2").allowed).toBe(true);
   });
 
   it("failures expire after windowMinutes", () => {
-    // Use a tiny window to test expiry via the token bucket refill.
-    // The RateLimiter refills after refillIntervalMs = windowMinutes * 60_000.
-    // With maxFailures=1, windowMinutes=15 → refill at 900_000 ms.
     limiter = new AuthRateLimiter(makeConfig({ maxFailures: 1, windowMinutes: 15 }));
-    limiter.checkAuthAllowed("192.168.1.1");
     limiter.recordFailure("192.168.1.1");
 
-    // Blocked immediately
-    expect(limiter.checkAuthAllowed("192.168.1.1").allowed).toBe(false);
-
-    // After window expires, a new limiter instance would have refilled.
-    // Since we can't easily control time in the RateLimiter without exposing
-    // the `now` parameter, we verify the retryAfterMs is set correctly.
-    // The retryAfterMs should be <= windowMinutes * 60_000.
     const blocked = limiter.checkAuthAllowed("192.168.1.1");
     expect(blocked.allowed).toBe(false);
     expect(blocked.retryAfterMs).toBeLessThanOrEqual(15 * 60 * 1000);
@@ -105,7 +98,7 @@ describe("AuthRateLimiter", () => {
 
   it("destroy cleans up", () => {
     limiter = new AuthRateLimiter(makeConfig());
-    limiter.checkAuthAllowed("192.168.1.1");
+    limiter.recordFailure("192.168.1.1"); // creates a bucket via check()
     expect(limiter.size).toBe(1);
     limiter.destroy();
     // Double destroy should be safe

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -1,0 +1,83 @@
+/**
+ * Auth brute-force protection.
+ *
+ * Tracks authentication attempts per IP using a token-bucket. Each auth
+ * attempt (success or failure) consumes a token. When tokens are exhausted
+ * the IP is locked out until refill. Successful auth resets the bucket,
+ * giving the IP a fresh set of tokens.
+ *
+ * Shared between HTTP and WebSocket auth paths.
+ */
+
+import type { ResolvedRateLimitsAuthConfig } from "../config/types.gateway.js";
+import { RateLimiter } from "../infra/rate-limiter.js";
+
+export type AuthRateLimitResult = {
+  /** Whether the auth attempt is allowed. */
+  allowed: boolean;
+  /** Milliseconds until the lockout expires (set when denied). */
+  retryAfterMs?: number;
+};
+
+/**
+ * Auth brute-force rate limiter.
+ *
+ * Uses a token-bucket where `maxFailures` is the burst capacity and the
+ * bucket refills every `windowMinutes`. Each call to `checkAuthAllowed`
+ * consumes a token; `recordSuccess` resets the bucket for that IP.
+ */
+export class AuthRateLimiter {
+  private readonly limiter: RateLimiter;
+  private readonly enabled: boolean;
+
+  constructor(config: ResolvedRateLimitsAuthConfig, enabled = true) {
+    this.enabled = enabled;
+    this.limiter = new RateLimiter({
+      maxTokens: config.maxFailures,
+      refillRate: config.maxFailures,
+      refillIntervalMs: config.windowMinutes * 60 * 1000,
+    });
+  }
+
+  /**
+   * Check whether an auth attempt from `ip` is allowed.
+   * Consumes one token from the bucket.
+   */
+  checkAuthAllowed(ip: string): AuthRateLimitResult {
+    if (!this.enabled) {
+      return { allowed: true };
+    }
+    const result = this.limiter.check(ip);
+    if (result.allowed) {
+      return { allowed: true };
+    }
+    return { allowed: false, retryAfterMs: result.retryAfterMs };
+  }
+
+  /**
+   * Record a failed auth attempt for `ip`.
+   * Token was already consumed in `checkAuthAllowed`, so this is a no-op.
+   * Provided for semantic clarity and future extensibility.
+   */
+  recordFailure(_ip: string): void {
+    // Token already consumed in checkAuthAllowed.
+  }
+
+  /** Record a successful auth for `ip` — resets the failure count. */
+  recordSuccess(ip: string): void {
+    if (!this.enabled) {
+      return;
+    }
+    this.limiter.reset(ip);
+  }
+
+  /** Stop the internal GC timer. */
+  destroy(): void {
+    this.limiter.destroy();
+  }
+
+  /** Visible for testing — number of tracked buckets. */
+  get size(): number {
+    return this.limiter.size;
+  }
+}

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -47,6 +47,17 @@ export function writeDone(res: ServerResponse) {
   res.write("data: [DONE]\n\n");
 }
 
+export function sendTooManyRequests(res: ServerResponse, retryAfterMs: number) {
+  res.setHeader("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+  sendJson(res, 429, {
+    error: {
+      message: "Rate limit exceeded",
+      type: "rate_limit_error",
+      retry_after_ms: retryAfterMs,
+    },
+  });
+}
+
 export function setSseHeaders(res: ServerResponse) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");

--- a/src/gateway/http-rate-limit.test.ts
+++ b/src/gateway/http-rate-limit.test.ts
@@ -1,0 +1,298 @@
+import type { ServerResponse } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveRateLimitsConfig } from "../config/types.gateway.js";
+import { RateLimiter } from "../infra/rate-limiter.js";
+import {
+  checkRateLimit,
+  createHttpRateLimiters,
+  destroyHttpRateLimiters,
+  send429,
+  type HttpRateLimiters,
+} from "./http-rate-limit.js";
+
+/** Minimal mock of ServerResponse for testing 429 responses. */
+function createMockResponse(): {
+  res: ServerResponse;
+  statusCode: () => number;
+  headers: () => Record<string, string>;
+  body: () => string;
+} {
+  let _statusCode = 200;
+  const _headers: Record<string, string> = {};
+  let _body = "";
+
+  const res = {
+    get statusCode() {
+      return _statusCode;
+    },
+    set statusCode(code: number) {
+      _statusCode = code;
+    },
+    setHeader(name: string, value: string) {
+      _headers[name.toLowerCase()] = value;
+    },
+    end(data?: string) {
+      if (data) {
+        _body = data;
+      }
+    },
+    getHeader(name: string) {
+      return _headers[name.toLowerCase()];
+    },
+  } as unknown as ServerResponse;
+
+  return {
+    res,
+    statusCode: () => _statusCode,
+    headers: () => _headers,
+    body: () => _body,
+  };
+}
+
+describe("HTTP Rate Limiting", () => {
+  let limiters: HttpRateLimiters | undefined;
+
+  afterEach(() => {
+    if (limiters) {
+      destroyHttpRateLimiters(limiters);
+      limiters = undefined;
+    }
+  });
+
+  describe("createHttpRateLimiters", () => {
+    it("creates limiters from resolved config", () => {
+      const config = resolveRateLimitsConfig({});
+      limiters = createHttpRateLimiters(config);
+      expect(limiters.global).toBeInstanceOf(RateLimiter);
+      expect(limiters.agent).toBeInstanceOf(RateLimiter);
+      expect(limiters.hook).toBeInstanceOf(RateLimiter);
+      expect(limiters.static).toBeInstanceOf(RateLimiter);
+      expect(limiters.tools).toBeInstanceOf(RateLimiter);
+    });
+
+    it("custom globalPerMinute value is respected", () => {
+      const config = resolveRateLimitsConfig({ http: { globalPerMinute: 5 } });
+      limiters = createHttpRateLimiters(config);
+      // Exhaust 5 tokens
+      for (let i = 0; i < 5; i++) {
+        const mock = createMockResponse();
+        expect(checkRateLimit(limiters.global, "ip1", mock.res)).toBe(true);
+      }
+      // 6th should be denied
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip1", mock.res)).toBe(false);
+      expect(mock.statusCode()).toBe(429);
+    });
+
+    it("custom agentPerMinute value is respected", () => {
+      const config = resolveRateLimitsConfig({ http: { agentPerMinute: 3 } });
+      limiters = createHttpRateLimiters(config);
+      for (let i = 0; i < 3; i++) {
+        const mock = createMockResponse();
+        expect(checkRateLimit(limiters.agent, "ip1", mock.res)).toBe(true);
+      }
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.agent, "ip1", mock.res)).toBe(false);
+    });
+  });
+
+  describe("Global rate limit", () => {
+    it("allows requests within global limit", () => {
+      const config = resolveRateLimitsConfig({});
+      limiters = createHttpRateLimiters(config);
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.global, "192.168.1.1", mock.res)).toBe(true);
+    });
+
+    it("returns 429 when global limit exceeded", () => {
+      const config = resolveRateLimitsConfig({ http: { globalPerMinute: 2 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      const m2 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip1", m1.res)).toBe(true);
+      expect(checkRateLimit(limiters.global, "ip1", m2.res)).toBe(true);
+
+      const m3 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip1", m3.res)).toBe(false);
+      expect(m3.statusCode()).toBe(429);
+    });
+
+    it("includes Retry-After header in 429 response", () => {
+      const config = resolveRateLimitsConfig({ http: { globalPerMinute: 1 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      checkRateLimit(limiters.global, "ip1", m1.res);
+
+      const m2 = createMockResponse();
+      checkRateLimit(limiters.global, "ip1", m2.res);
+      expect(m2.headers()["retry-after"]).toBeDefined();
+      expect(Number(m2.headers()["retry-after"])).toBeGreaterThan(0);
+    });
+
+    it("different IPs have independent limits", () => {
+      const config = resolveRateLimitsConfig({ http: { globalPerMinute: 1 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip1", m1.res)).toBe(true);
+
+      const m2 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip2", m2.res)).toBe(true);
+
+      // ip1 is now exhausted
+      const m3 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip1", m3.res)).toBe(false);
+
+      // ip2 is also exhausted
+      const m4 = createMockResponse();
+      expect(checkRateLimit(limiters.global, "ip2", m4.res)).toBe(false);
+    });
+
+    it("skipped entirely when rateLimits.enabled is false", () => {
+      const config = resolveRateLimitsConfig({ enabled: false });
+      // When enabled is false, no limiters should be created.
+      expect(config.enabled).toBe(false);
+      // In real code, the server would skip creating limiters entirely.
+    });
+  });
+
+  describe("Per-endpoint rate limits", () => {
+    it("/v1/chat/completions returns 429 after limit exceeded", () => {
+      const config = resolveRateLimitsConfig({ http: { agentPerMinute: 2 } });
+      limiters = createHttpRateLimiters(config);
+
+      for (let i = 0; i < 2; i++) {
+        const mock = createMockResponse();
+        expect(checkRateLimit(limiters.agent, "chat:ip1", mock.res, "openai")).toBe(true);
+      }
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.agent, "chat:ip1", mock.res, "openai")).toBe(false);
+      expect(mock.statusCode()).toBe(429);
+    });
+
+    it("/v1/chat/completions 429 uses OpenAI error format", () => {
+      const config = resolveRateLimitsConfig({ http: { agentPerMinute: 1 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      checkRateLimit(limiters.agent, "chat:ip1", m1.res, "openai");
+
+      const m2 = createMockResponse();
+      checkRateLimit(limiters.agent, "chat:ip1", m2.res, "openai");
+      const parsed = JSON.parse(m2.body());
+      expect(parsed.error.type).toBe("rate_limit_error");
+      expect(parsed.error.message).toBe("Rate limit exceeded");
+      expect(parsed.error.retry_after_ms).toBeGreaterThan(0);
+    });
+
+    it("/v1/responses returns 429 after limit exceeded", () => {
+      const config = resolveRateLimitsConfig({ http: { agentPerMinute: 1 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      checkRateLimit(limiters.agent, "responses:ip1", m1.res, "openai");
+
+      const m2 = createMockResponse();
+      expect(checkRateLimit(limiters.agent, "responses:ip1", m2.res, "openai")).toBe(false);
+      expect(m2.statusCode()).toBe(429);
+    });
+
+    it("/tools/invoke returns 429 after limit exceeded", () => {
+      const config = resolveRateLimitsConfig({});
+      limiters = createHttpRateLimiters(config);
+      // tools limiter defaults to 20/min
+      for (let i = 0; i < 20; i++) {
+        const mock = createMockResponse();
+        expect(checkRateLimit(limiters.tools, "tools:ip1", mock.res)).toBe(true);
+      }
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.tools, "tools:ip1", mock.res)).toBe(false);
+      expect(mock.statusCode()).toBe(429);
+    });
+
+    it("/hooks/agent returns 429 after limit exceeded per token", () => {
+      const config = resolveRateLimitsConfig({ http: { hookPerMinute: 2 } });
+      limiters = createHttpRateLimiters(config);
+
+      for (let i = 0; i < 2; i++) {
+        const mock = createMockResponse();
+        expect(checkRateLimit(limiters.hook, "hook:token-a", mock.res)).toBe(true);
+      }
+      const mock = createMockResponse();
+      expect(checkRateLimit(limiters.hook, "hook:token-a", mock.res)).toBe(false);
+      expect(mock.statusCode()).toBe(429);
+    });
+
+    it("different hook tokens have independent limits", () => {
+      const config = resolveRateLimitsConfig({ http: { hookPerMinute: 1 } });
+      limiters = createHttpRateLimiters(config);
+
+      const m1 = createMockResponse();
+      expect(checkRateLimit(limiters.hook, "hook:token-a", m1.res)).toBe(true);
+
+      const m2 = createMockResponse();
+      expect(checkRateLimit(limiters.hook, "hook:token-b", m2.res)).toBe(true);
+
+      // token-a exhausted
+      const m3 = createMockResponse();
+      expect(checkRateLimit(limiters.hook, "hook:token-a", m3.res)).toBe(false);
+
+      // token-b also exhausted
+      const m4 = createMockResponse();
+      expect(checkRateLimit(limiters.hook, "hook:token-b", m4.res)).toBe(false);
+    });
+  });
+
+  describe("429 response format", () => {
+    it("includes retry_after_ms in JSON body", () => {
+      const mock = createMockResponse();
+      send429(mock.res, 5000);
+      const parsed = JSON.parse(mock.body());
+      expect(parsed.error.retry_after_ms).toBe(5000);
+    });
+
+    it("sets Retry-After header in seconds (rounded up)", () => {
+      const mock = createMockResponse();
+      send429(mock.res, 1500);
+      expect(mock.headers()["retry-after"]).toBe("2");
+    });
+
+    it("Content-Type is application/json", () => {
+      const mock = createMockResponse();
+      send429(mock.res, 1000);
+      expect(mock.headers()["content-type"]).toBe("application/json; charset=utf-8");
+    });
+
+    it("status code is 429", () => {
+      const mock = createMockResponse();
+      send429(mock.res, 1000);
+      expect(mock.statusCode()).toBe(429);
+    });
+  });
+
+  describe("Config integration", () => {
+    it("enabled: false bypasses all rate limit checks", () => {
+      const config = resolveRateLimitsConfig({ enabled: false });
+      expect(config.enabled).toBe(false);
+      // In server code, limiters are not created when enabled is false.
+      // This test documents the contract.
+    });
+
+    it("defaults are applied when no config provided", () => {
+      const config = resolveRateLimitsConfig(undefined);
+      expect(config.enabled).toBe(true);
+      expect(config.http.globalPerMinute).toBe(100);
+      expect(config.http.agentPerMinute).toBe(10);
+      expect(config.http.hookPerMinute).toBe(20);
+      expect(config.http.staticPerMinute).toBe(200);
+    });
+
+    it("partial config merges with defaults", () => {
+      const config = resolveRateLimitsConfig({ http: { globalPerMinute: 50 } });
+      expect(config.http.globalPerMinute).toBe(50);
+      expect(config.http.agentPerMinute).toBe(10); // default
+    });
+  });
+});

--- a/src/gateway/http-rate-limit.ts
+++ b/src/gateway/http-rate-limit.ts
@@ -57,8 +57,8 @@ export function createHttpRateLimiters(config: ResolvedRateLimitsConfig): HttpRa
       refillIntervalMs: intervalMs,
     }),
     tools: new RateLimiter({
-      maxTokens: 20,
-      refillRate: 20,
+      maxTokens: config.http.toolsPerMinute,
+      refillRate: config.http.toolsPerMinute,
       refillIntervalMs: intervalMs,
     }),
   };

--- a/src/gateway/http-rate-limit.ts
+++ b/src/gateway/http-rate-limit.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP rate limiting helpers.
+ *
+ * Provides factory functions to create per-endpoint rate limiters and a
+ * shared `checkRateLimit` helper that sends a 429 response when denied.
+ */
+
+import type { ServerResponse } from "node:http";
+import type { ResolvedRateLimitsConfig } from "../config/types.gateway.js";
+import { RateLimiter } from "../infra/rate-limiter.js";
+
+export type HttpRateLimiters = {
+  /** Global per-IP limiter applied before route matching. */
+  global: RateLimiter;
+  /** Per-IP limiter for agent-invoking endpoints (/v1/chat/completions, /v1/responses). */
+  agent: RateLimiter;
+  /** Per-token limiter for hook endpoints (/hooks/agent, /hooks/wake). */
+  hook: RateLimiter;
+  /** Per-IP limiter for static/control-ui requests. */
+  static: RateLimiter;
+  /** Per-IP limiter for tool invocation endpoint. */
+  tools: RateLimiter;
+};
+
+/** 429 response body format. */
+export type RateLimitErrorFormat = "openai" | "default";
+
+/**
+ * Create all HTTP rate limiter instances from resolved config.
+ *
+ * Each per-minute value is converted to a token-bucket with:
+ * - `maxTokens` = per-minute value (burst capacity)
+ * - `refillRate` = per-minute value (refill full bucket each interval)
+ * - `refillIntervalMs` = 60 000 ms (1 minute)
+ */
+export function createHttpRateLimiters(config: ResolvedRateLimitsConfig): HttpRateLimiters {
+  const intervalMs = 60_000;
+  return {
+    global: new RateLimiter({
+      maxTokens: config.http.globalPerMinute,
+      refillRate: config.http.globalPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    agent: new RateLimiter({
+      maxTokens: config.http.agentPerMinute,
+      refillRate: config.http.agentPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    hook: new RateLimiter({
+      maxTokens: config.http.hookPerMinute,
+      refillRate: config.http.hookPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    static: new RateLimiter({
+      maxTokens: config.http.staticPerMinute,
+      refillRate: config.http.staticPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    tools: new RateLimiter({
+      maxTokens: 20,
+      refillRate: 20,
+      refillIntervalMs: intervalMs,
+    }),
+  };
+}
+
+/** Destroy all limiter instances (clears GC timers). */
+export function destroyHttpRateLimiters(limiters: HttpRateLimiters): void {
+  limiters.global.destroy();
+  limiters.agent.destroy();
+  limiters.hook.destroy();
+  limiters.static.destroy();
+  limiters.tools.destroy();
+}
+
+/**
+ * Send a 429 Too Many Requests response.
+ *
+ * @param res - HTTP server response
+ * @param retryAfterMs - milliseconds until a token is available
+ * @param format - response body format ("openai" for OpenAI-compatible endpoints)
+ */
+export function send429(
+  res: ServerResponse,
+  retryAfterMs: number,
+  format: RateLimitErrorFormat = "default",
+): void {
+  const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+  res.statusCode = 429;
+  res.setHeader("Retry-After", String(retryAfterSec));
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+
+  if (format === "openai") {
+    res.end(
+      JSON.stringify({
+        error: {
+          message: "Rate limit exceeded",
+          type: "rate_limit_error",
+          retry_after_ms: retryAfterMs,
+        },
+      }),
+    );
+  } else {
+    res.end(
+      JSON.stringify({
+        error: {
+          message: "Rate limit exceeded",
+          type: "rate_limit_error",
+          retry_after_ms: retryAfterMs,
+        },
+      }),
+    );
+  }
+}
+
+/**
+ * Check a rate limiter for a given key. If denied, sends a 429 response.
+ *
+ * @returns `true` if the request is **allowed**, `false` if denied (429 sent).
+ */
+export function checkRateLimit(
+  limiter: RateLimiter,
+  key: string,
+  res: ServerResponse,
+  format: RateLimitErrorFormat = "default",
+): boolean {
+  const result = limiter.check(key);
+  if (result.allowed) {
+    return true;
+  }
+  send429(res, result.retryAfterMs ?? 60_000, format);
+  return false;
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -318,6 +318,19 @@ export function createGatewayHttpServer(opts: {
           return;
         }
       }
+      // Per-IP rate limit for static/canvas/control-UI traffic.
+      if (rateLimiters) {
+        const staticIp = resolveGatewayClientIp({
+          remoteAddr: req.socket.remoteAddress,
+          forwardedFor: req.headers["x-forwarded-for"] as string | undefined,
+          realIp: req.headers["x-real-ip"] as string | undefined,
+          trustedProxies,
+        });
+        if (staticIp && !checkRateLimit(rateLimiters.static, `static:${staticIp}`, res)) {
+          return;
+        }
+      }
+
       if (canvasHost) {
         if (await handleA2uiHttpRequest(req, res)) {
           return;

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -1,8 +1,10 @@
 import type { WebSocketServer } from "ws";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import type { WsConnectionTracker, WsMessageRateLimitState } from "./ws-rate-limit.js";
 import { attachGatewayWsConnectionHandler } from "./server/ws-connection.js";
 
 export function attachGatewayWsHandlers(params: {
@@ -28,6 +30,9 @@ export function attachGatewayWsHandlers(params: {
     },
   ) => void;
   context: GatewayRequestContext;
+  wsConnectionTracker?: WsConnectionTracker | null;
+  wsMessageRateLimiters?: WsMessageRateLimitState | null;
+  authRateLimiter?: AuthRateLimiter | null;
 }) {
   attachGatewayWsConnectionHandler({
     wss: params.wss,
@@ -45,5 +50,8 @@ export function attachGatewayWsHandlers(params: {
     extraHandlers: params.extraHandlers,
     broadcast: params.broadcast,
     buildRequestContext: () => params.context,
+    wsConnectionTracker: params.wsConnectionTracker,
+    wsMessageRateLimiters: params.wsMessageRateLimiters,
+    authRateLimiter: params.authRateLimiter,
   });
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -285,6 +285,9 @@ export async function startGatewayServer(
     addChatRun,
     removeChatRun,
     chatAbortControllers,
+    wsConnectionTracker,
+    wsMessageRateLimiters,
+    authRateLimiter,
   } = await createGatewayRuntimeState({
     cfg: cfgAtStart,
     bindHost,
@@ -441,6 +444,9 @@ export async function startGatewayServer(
       ...execApprovalHandlers,
     },
     broadcast,
+    wsConnectionTracker,
+    wsMessageRateLimiters,
+    authRateLimiter,
     context: {
       deps,
       cron,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -3,6 +3,7 @@ import type { CliDeps } from "../../cli/deps.js";
 import type { CronJob } from "../../cron/types.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { HookMessageChannel, HooksConfigResolved } from "../hooks.js";
+import type { HttpRateLimiters } from "../http-rate-limit.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
 import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
@@ -18,6 +19,7 @@ export function createGatewayHooksRequestHandler(params: {
   bindHost: string;
   port: number;
   logHooks: SubsystemLogger;
+  rateLimiters?: HttpRateLimiters;
 }) {
   const { deps, getHooksConfig, bindHost, port, logHooks } = params;
 
@@ -111,5 +113,6 @@ export function createGatewayHooksRequestHandler(params: {
     logHooks,
     dispatchAgentHook,
     dispatchWakeHook,
+    rateLimiters: params.rateLimiters,
   });
 }

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -6,4 +6,6 @@ export type GatewayWsClient = {
   connect: ConnectParams;
   connId: string;
   presenceKey?: string;
+  /** Client IP for rate limiting and connection tracking. */
+  clientIp?: string;
 };

--- a/src/gateway/ws-rate-limit.test.ts
+++ b/src/gateway/ws-rate-limit.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ResolvedRateLimitsWsConfig } from "../config/types.gateway.js";
+import {
+  checkWsConnection,
+  checkWsMessageRate,
+  checkWsMethodRate,
+  createWsConnectionTracker,
+  createWsMessageRateLimiters,
+  destroyWsMessageRateLimiters,
+  trackWsConnect,
+  trackWsDisconnect,
+  type WsConnectionTracker,
+  type WsMessageRateLimitState,
+} from "./ws-rate-limit.js";
+
+function makeWsConfig(overrides?: Partial<ResolvedRateLimitsWsConfig>): ResolvedRateLimitsWsConfig {
+  return {
+    messagesPerMinute: overrides?.messagesPerMinute ?? 60,
+    agentPerMinute: overrides?.agentPerMinute ?? 10,
+    ttsPerMinute: overrides?.ttsPerMinute ?? 20,
+    maxConnections: overrides?.maxConnections ?? 50,
+    perIpMaxConnections: overrides?.perIpMaxConnections ?? 5,
+  };
+}
+
+describe("WS Rate Limiting", () => {
+  describe("Connection limits", () => {
+    let tracker: WsConnectionTracker;
+
+    it("allows connections within maxConnections limit", () => {
+      tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 3 }));
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.2");
+      const result = checkWsConnection(tracker, "10.0.0.3");
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects connections when maxConnections reached", () => {
+      tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 2 }));
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.2");
+      const result = checkWsConnection(tracker, "10.0.0.3");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("max_connections");
+    });
+
+    it("allows new connection after a previous one closes", () => {
+      tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 2 }));
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.2");
+      expect(checkWsConnection(tracker, "10.0.0.3").allowed).toBe(false);
+
+      trackWsDisconnect(tracker, "10.0.0.1");
+      expect(checkWsConnection(tracker, "10.0.0.3").allowed).toBe(true);
+    });
+
+    it("limits per-IP concurrent connections to configured max", () => {
+      tracker = createWsConnectionTracker(
+        makeWsConfig({ maxConnections: 50, perIpMaxConnections: 3 }),
+      );
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.1");
+
+      const result = checkWsConnection(tracker, "10.0.0.1");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("per_ip_max_connections");
+    });
+
+    it("different IPs have independent connection counts", () => {
+      tracker = createWsConnectionTracker(
+        makeWsConfig({ maxConnections: 50, perIpMaxConnections: 2 }),
+      );
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.1");
+      // 10.0.0.1 is at limit
+      expect(checkWsConnection(tracker, "10.0.0.1").allowed).toBe(false);
+      // 10.0.0.2 should be fine
+      expect(checkWsConnection(tracker, "10.0.0.2").allowed).toBe(true);
+    });
+
+    it("disconnect prevents counter from going negative", () => {
+      tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 50 }));
+      trackWsDisconnect(tracker, "10.0.0.1");
+      expect(tracker.totalConnections).toBe(0);
+      expect(tracker.perIpConnections.size).toBe(0);
+    });
+
+    it("disconnect cleans up IP entry when count reaches zero", () => {
+      tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 50 }));
+      trackWsConnect(tracker, "10.0.0.1");
+      expect(tracker.perIpConnections.has("10.0.0.1")).toBe(true);
+      trackWsDisconnect(tracker, "10.0.0.1");
+      expect(tracker.perIpConnections.has("10.0.0.1")).toBe(false);
+    });
+  });
+
+  describe("Message throttling", () => {
+    let state: WsMessageRateLimitState;
+
+    afterEach(() => {
+      if (state) {
+        destroyWsMessageRateLimiters(state);
+      }
+    });
+
+    it("allows messages within per-client limit", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ messagesPerMinute: 5 }));
+      for (let i = 0; i < 5; i++) {
+        expect(checkWsMessageRate(state, "client-1").allowed).toBe(true);
+      }
+    });
+
+    it("sends rate_limit error when exceeded", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ messagesPerMinute: 2 }));
+      checkWsMessageRate(state, "client-1");
+      checkWsMessageRate(state, "client-1");
+      const result = checkWsMessageRate(state, "client-1");
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBeDefined();
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it("separate tracking per client", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ messagesPerMinute: 1 }));
+      expect(checkWsMessageRate(state, "client-1").allowed).toBe(true);
+      expect(checkWsMessageRate(state, "client-2").allowed).toBe(true);
+      // Both exhausted
+      expect(checkWsMessageRate(state, "client-1").allowed).toBe(false);
+      expect(checkWsMessageRate(state, "client-2").allowed).toBe(false);
+    });
+  });
+
+  describe("Per-method limits", () => {
+    let state: WsMessageRateLimitState;
+
+    afterEach(() => {
+      if (state) {
+        destroyWsMessageRateLimiters(state);
+      }
+    });
+
+    it("agent method limited to configured rate per client", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 2 }));
+      expect(checkWsMethodRate(state, "client-1", "agent").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "client-1", "agent").allowed).toBe(true);
+      const result = checkWsMethodRate(state, "client-1", "agent");
+      expect(result.allowed).toBe(false);
+      expect(result.method).toBe("agent");
+    });
+
+    it("agent.wait uses same limiter as agent", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 1 }));
+      expect(checkWsMethodRate(state, "client-1", "agent").allowed).toBe(true);
+      // agent.wait shares the agent limiter
+      expect(checkWsMethodRate(state, "client-1", "agent.wait").allowed).toBe(false);
+    });
+
+    it("chat.send limited by agent limiter", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 2 }));
+      expect(checkWsMethodRate(state, "client-1", "chat.send").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "client-1", "chat.send").allowed).toBe(true);
+      const result = checkWsMethodRate(state, "client-1", "chat.send");
+      expect(result.allowed).toBe(false);
+      expect(result.method).toBe("chat.send");
+    });
+
+    it("tts.convert method limited to configured rate per client", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ ttsPerMinute: 3 }));
+      for (let i = 0; i < 3; i++) {
+        expect(checkWsMethodRate(state, "client-1", "tts.convert").allowed).toBe(true);
+      }
+      const result = checkWsMethodRate(state, "client-1", "tts.convert");
+      expect(result.allowed).toBe(false);
+      expect(result.method).toBe("tts.convert");
+    });
+
+    it("non-limited methods unaffected", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 1 }));
+      // Exhaust agent limit
+      checkWsMethodRate(state, "client-1", "agent");
+      // Non-limited methods should pass
+      expect(checkWsMethodRate(state, "client-1", "health.get").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "client-1", "presence.list").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "client-1", "config.get").allowed).toBe(true);
+    });
+
+    it("error response includes method name and retryAfterMs", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 1 }));
+      checkWsMethodRate(state, "client-1", "agent");
+      const result = checkWsMethodRate(state, "client-1", "agent");
+      expect(result.allowed).toBe(false);
+      expect(result.method).toBe("agent");
+      expect(result.retryAfterMs).toBeDefined();
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it("different clients have independent method limits", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 1 }));
+      expect(checkWsMethodRate(state, "client-1", "agent").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "client-2", "agent").allowed).toBe(true);
+      // Both exhausted independently
+      expect(checkWsMethodRate(state, "client-1", "agent").allowed).toBe(false);
+      expect(checkWsMethodRate(state, "client-2", "agent").allowed).toBe(false);
+    });
+  });
+
+  describe("Config integration", () => {
+    let state: WsMessageRateLimitState;
+
+    afterEach(() => {
+      if (state) {
+        destroyWsMessageRateLimiters(state);
+      }
+    });
+
+    it("custom messagesPerMinute respected", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ messagesPerMinute: 3 }));
+      for (let i = 0; i < 3; i++) {
+        expect(checkWsMessageRate(state, "c1").allowed).toBe(true);
+      }
+      expect(checkWsMessageRate(state, "c1").allowed).toBe(false);
+    });
+
+    it("custom agentPerMinute respected", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ agentPerMinute: 2 }));
+      expect(checkWsMethodRate(state, "c1", "agent").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "c1", "agent").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "c1", "agent").allowed).toBe(false);
+    });
+
+    it("custom maxConnections respected", () => {
+      const tracker = createWsConnectionTracker(makeWsConfig({ maxConnections: 1 }));
+      trackWsConnect(tracker, "10.0.0.1");
+      expect(checkWsConnection(tracker, "10.0.0.2").allowed).toBe(false);
+    });
+
+    it("custom ttsPerMinute respected", () => {
+      state = createWsMessageRateLimiters(makeWsConfig({ ttsPerMinute: 2 }));
+      expect(checkWsMethodRate(state, "c1", "tts.convert").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "c1", "tts.convert").allowed).toBe(true);
+      expect(checkWsMethodRate(state, "c1", "tts.convert").allowed).toBe(false);
+    });
+
+    it("custom perIpMaxConnections respected", () => {
+      const tracker = createWsConnectionTracker(
+        makeWsConfig({ maxConnections: 50, perIpMaxConnections: 2 }),
+      );
+      trackWsConnect(tracker, "10.0.0.1");
+      trackWsConnect(tracker, "10.0.0.1");
+      expect(checkWsConnection(tracker, "10.0.0.1").allowed).toBe(false);
+    });
+
+    it("enabled: false bypasses all WS rate limiting", () => {
+      // When enabled is false, the server should not create limiters.
+      // This test documents the contract — the server checks config.enabled
+      // before creating/checking WS rate limiters.
+      const config = makeWsConfig({ messagesPerMinute: 1 });
+      // The ws-rate-limit module itself doesn't have an enabled flag;
+      // the server is responsible for skipping rate limit checks when disabled.
+      // Verify that the module works correctly when used.
+      state = createWsMessageRateLimiters(config);
+      expect(checkWsMessageRate(state, "c1").allowed).toBe(true);
+    });
+  });
+});

--- a/src/gateway/ws-rate-limit.ts
+++ b/src/gateway/ws-rate-limit.ts
@@ -1,0 +1,173 @@
+/**
+ * WebSocket rate limiting helpers.
+ *
+ * Provides connection tracking (global + per-IP), per-client message throttling,
+ * and per-method rate limits for expensive operations.
+ */
+
+import type { ResolvedRateLimitsWsConfig } from "../config/types.gateway.js";
+import { RateLimiter } from "../infra/rate-limiter.js";
+
+// --- Connection tracking ---
+
+export type WsConnectionTracker = {
+  /** Total active WS connections. */
+  totalConnections: number;
+  /** Per-IP active connection counts. */
+  perIpConnections: Map<string, number>;
+  /** Max total concurrent connections. */
+  maxConnections: number;
+  /** Max concurrent connections per IP. */
+  perIpMaxConnections: number;
+};
+
+/** Create a fresh connection tracker from config. */
+export function createWsConnectionTracker(config: ResolvedRateLimitsWsConfig): WsConnectionTracker {
+  return {
+    totalConnections: 0,
+    perIpConnections: new Map(),
+    maxConnections: config.maxConnections,
+    perIpMaxConnections: config.perIpMaxConnections,
+  };
+}
+
+export type WsConnectionCheckResult = {
+  allowed: boolean;
+  reason?: "max_connections" | "per_ip_max_connections";
+};
+
+/** Check whether a new connection from `ip` is allowed. Does NOT increment counters. */
+export function checkWsConnection(
+  tracker: WsConnectionTracker,
+  ip: string,
+): WsConnectionCheckResult {
+  if (tracker.totalConnections >= tracker.maxConnections) {
+    return { allowed: false, reason: "max_connections" };
+  }
+  const ipCount = tracker.perIpConnections.get(ip) ?? 0;
+  if (ipCount >= tracker.perIpMaxConnections) {
+    return { allowed: false, reason: "per_ip_max_connections" };
+  }
+  return { allowed: true };
+}
+
+/** Record a new connection from `ip`. Call after successful upgrade. */
+export function trackWsConnect(tracker: WsConnectionTracker, ip: string): void {
+  tracker.totalConnections += 1;
+  const prev = tracker.perIpConnections.get(ip) ?? 0;
+  tracker.perIpConnections.set(ip, prev + 1);
+}
+
+/** Record a disconnection from `ip`. Call on ws close. */
+export function trackWsDisconnect(tracker: WsConnectionTracker, ip: string): void {
+  tracker.totalConnections = Math.max(0, tracker.totalConnections - 1);
+  const prev = tracker.perIpConnections.get(ip) ?? 0;
+  if (prev <= 1) {
+    tracker.perIpConnections.delete(ip);
+  } else {
+    tracker.perIpConnections.set(ip, prev - 1);
+  }
+}
+
+// --- Per-client message throttling ---
+
+export type WsMessageRateLimitState = {
+  /** Per-client overall message limiter. */
+  messageLimiter: RateLimiter;
+  /** Per-client agent method limiter. */
+  agentLimiter: RateLimiter;
+  /** Per-client TTS method limiter. */
+  ttsLimiter: RateLimiter;
+};
+
+/** Create message rate limiters from config. */
+export function createWsMessageRateLimiters(
+  config: ResolvedRateLimitsWsConfig,
+): WsMessageRateLimitState {
+  const intervalMs = 60_000;
+  return {
+    messageLimiter: new RateLimiter({
+      maxTokens: config.messagesPerMinute,
+      refillRate: config.messagesPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    agentLimiter: new RateLimiter({
+      maxTokens: config.agentPerMinute,
+      refillRate: config.agentPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+    ttsLimiter: new RateLimiter({
+      maxTokens: config.ttsPerMinute,
+      refillRate: config.ttsPerMinute,
+      refillIntervalMs: intervalMs,
+    }),
+  };
+}
+
+/** Destroy all WS message rate limiter instances (clears GC timers). */
+export function destroyWsMessageRateLimiters(state: WsMessageRateLimitState): void {
+  state.messageLimiter.destroy();
+  state.agentLimiter.destroy();
+  state.ttsLimiter.destroy();
+}
+
+export type WsRateLimitCheckResult = {
+  allowed: boolean;
+  retryAfterMs?: number;
+};
+
+/**
+ * Check per-client overall message rate.
+ * @param clientKey - unique client identifier (connId).
+ */
+export function checkWsMessageRate(
+  state: WsMessageRateLimitState,
+  clientKey: string,
+): WsRateLimitCheckResult {
+  const result = state.messageLimiter.check(clientKey);
+  if (result.allowed) {
+    return { allowed: true };
+  }
+  return { allowed: false, retryAfterMs: result.retryAfterMs };
+}
+
+/** Methods that invoke the agent (expensive LLM operations). */
+const AGENT_METHODS = new Set(["agent", "agent.wait", "chat.send"]);
+
+/** Methods that hit external TTS APIs. */
+const TTS_METHODS = new Set(["tts.convert"]);
+
+export type WsMethodRateLimitCheckResult = {
+  allowed: boolean;
+  method?: string;
+  retryAfterMs?: number;
+};
+
+/**
+ * Check per-client per-method rate limit for expensive operations.
+ * Returns allowed=true for methods that are not rate-limited.
+ *
+ * @param clientKey - unique client identifier (connId).
+ * @param method - WS method name.
+ */
+export function checkWsMethodRate(
+  state: WsMessageRateLimitState,
+  clientKey: string,
+  method: string,
+): WsMethodRateLimitCheckResult {
+  if (AGENT_METHODS.has(method)) {
+    const result = state.agentLimiter.check(clientKey);
+    if (result.allowed) {
+      return { allowed: true };
+    }
+    return { allowed: false, method, retryAfterMs: result.retryAfterMs };
+  }
+  if (TTS_METHODS.has(method)) {
+    const result = state.ttsLimiter.check(clientKey);
+    if (result.allowed) {
+      return { allowed: true };
+    }
+    return { allowed: false, method, retryAfterMs: result.retryAfterMs };
+  }
+  return { allowed: true };
+}

--- a/src/infra/rate-limit-logger.test.ts
+++ b/src/infra/rate-limit-logger.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SubsystemLogger } from "../logging/subsystem.js";
+import {
+  logRateLimitDenied,
+  logAuthLockout,
+  maskKey,
+  RateLimitStats,
+  getRateLimitStats,
+  resetRateLimitStats,
+} from "./rate-limit-logger.js";
+
+function makeMockLogger(): SubsystemLogger & { calls: { level: string; args: unknown[] }[] } {
+  const calls: { level: string; args: unknown[] }[] = [];
+  const mock =
+    (level: string) =>
+    (...args: unknown[]) =>
+      calls.push({ level, args });
+  return {
+    calls,
+    subsystem: "test",
+    trace: mock("trace"),
+    debug: mock("debug"),
+    info: mock("info"),
+    warn: mock("warn"),
+    error: mock("error"),
+    fatal: mock("fatal"),
+    raw: mock("raw"),
+    child: () => makeMockLogger(),
+  };
+}
+
+describe("maskKey", () => {
+  it("returns short keys unchanged", () => {
+    expect(maskKey("abc")).toBe("abc");
+    expect(maskKey("123456")).toBe("123456");
+  });
+
+  it("masks keys longer than 6 chars", () => {
+    expect(maskKey("192.168.1.100")).toBe("192.16***");
+    expect(maskKey("abcdefghij")).toBe("abcdef***");
+  });
+});
+
+describe("logRateLimitDenied", () => {
+  it("calls logger.warn with correct structure", () => {
+    const logger = makeMockLogger();
+    logRateLimitDenied(logger, {
+      layer: "http",
+      endpoint: "/v1/chat/completions",
+      key: "192.168.1.100",
+      remaining: 0,
+      retryAfterMs: 5000,
+      limiterName: "agent-per-ip",
+    });
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0].level).toBe("warn");
+    expect(logger.calls[0].args[0]).toBe("rate-limit-denied");
+    expect(logger.calls[0].args[1]).toEqual({
+      layer: "http",
+      endpoint: "/v1/chat/completions",
+      key: "192.16***",
+      remaining: 0,
+      retryAfterMs: 5000,
+      limiterName: "agent-per-ip",
+    });
+  });
+
+  it("does not log sensitive data (full tokens, passwords)", () => {
+    const logger = makeMockLogger();
+    logRateLimitDenied(logger, {
+      layer: "ws",
+      key: "super-secret-token-value",
+      remaining: 0,
+    });
+    const meta = logger.calls[0].args[1] as Record<string, unknown>;
+    expect(meta.key).toBe("super-***");
+    expect(meta.key).not.toContain("secret");
+  });
+
+  it("key field is truncated/masked for privacy", () => {
+    const logger = makeMockLogger();
+    logRateLimitDenied(logger, {
+      layer: "external",
+      key: "long-api-key-here",
+      remaining: 0,
+    });
+    const meta = logger.calls[0].args[1] as Record<string, unknown>;
+    expect(meta.key).toBe("long-a***");
+  });
+});
+
+describe("logAuthLockout", () => {
+  it("calls logger.warn with correct structure", () => {
+    const logger = makeMockLogger();
+    logAuthLockout(logger, {
+      ip: "192.168.1.100",
+      failures: 10,
+      windowMinutes: 15,
+    });
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0].level).toBe("warn");
+    expect(logger.calls[0].args[0]).toBe("auth-lockout");
+    expect(logger.calls[0].args[1]).toEqual({
+      ip: "192.16***",
+      failures: 10,
+      windowMinutes: 15,
+    });
+  });
+});
+
+describe("RateLimitStats", () => {
+  let stats: RateLimitStats;
+
+  afterEach(() => {
+    stats?.reset();
+    resetRateLimitStats();
+  });
+
+  it("tracks denial counts per layer", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    stats.recordDenial("http", "ip1", now);
+    stats.recordDenial("http", "ip1", now + 100);
+    stats.recordDenial("ws", "ip2", now + 200);
+    stats.recordDenial("auth", "ip3", now + 300);
+
+    const summary = stats.getSummary(now + 400);
+    expect(summary.denials.http).toBe(2);
+    expect(summary.denials.ws).toBe(1);
+    expect(summary.denials.auth).toBe(1);
+    expect(summary.denials.external).toBe(0);
+  });
+
+  it("getSummary returns correct totals", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    stats.recordDenial("http", "ip1", now);
+    stats.recordDenial("external", "elevenlabs", now + 100);
+
+    const summary = stats.getSummary(now + 200);
+    expect(summary.period).toBe("5m");
+    expect(summary.denials.http).toBe(1);
+    expect(summary.denials.external).toBe(1);
+  });
+
+  it("rolling 5-min window excludes old events", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    const fiveMinutesAgo = now - 5 * 60 * 1000 - 1;
+
+    stats.recordDenial("http", "ip1", fiveMinutesAgo);
+    stats.recordDenial("http", "ip2", now);
+
+    const summary = stats.getSummary(now);
+    expect(summary.denials.http).toBe(1);
+  });
+
+  it("topKeys returns top offenders sorted by count", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    // ip1: 3 denials, ip2: 1 denial
+    stats.recordDenial("http", "ip1", now);
+    stats.recordDenial("http", "ip1", now + 1);
+    stats.recordDenial("http", "ip1", now + 2);
+    stats.recordDenial("http", "ip2", now + 3);
+
+    const summary = stats.getSummary(now + 4);
+    expect(summary.topKeys[0]).toEqual({ key: "ip1", denials: 3 });
+    expect(summary.topKeys[1]).toEqual({ key: "ip2", denials: 1 });
+  });
+
+  it("reset clears all stats", () => {
+    stats = new RateLimitStats();
+    stats.recordDenial("http", "ip1", Date.now());
+    expect(stats.size).toBeGreaterThan(0);
+
+    stats.reset();
+    expect(stats.size).toBe(0);
+    expect(stats.hasDenials()).toBe(false);
+  });
+
+  it("prune removes old records", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    const old = now - 6 * 60 * 1000;
+    stats.recordDenial("http", "ip1", old);
+    stats.recordDenial("http", "ip2", now);
+    expect(stats.size).toBe(2);
+
+    stats.prune(now);
+    expect(stats.size).toBe(1);
+  });
+
+  it("hasDenials returns false when no recent denials", () => {
+    stats = new RateLimitStats();
+    const now = 1000000;
+    const old = now - 6 * 60 * 1000;
+    stats.recordDenial("http", "ip1", old);
+    expect(stats.hasDenials(now)).toBe(false);
+  });
+
+  it("getRateLimitStats returns singleton", () => {
+    const a = getRateLimitStats();
+    const b = getRateLimitStats();
+    expect(a).toBe(b);
+  });
+});

--- a/src/infra/rate-limit-logger.ts
+++ b/src/infra/rate-limit-logger.ts
@@ -1,0 +1,188 @@
+/**
+ * Structured logging and stats tracking for rate limit events.
+ *
+ * Provides helpers that emit structured log entries for rate limit denials,
+ * auth lockouts, and periodic summaries. The `RateLimitStats` class tracks
+ * denial counts per layer with a rolling 5-minute window for summaries.
+ */
+
+import type { SubsystemLogger } from "../logging/subsystem.js";
+
+// --- Log event types ---
+
+export type RateLimitLayer = "http" | "ws" | "auth" | "external";
+
+export type RateLimitDeniedEvent = {
+  layer: RateLimitLayer;
+  endpoint?: string;
+  key: string;
+  remaining: number;
+  retryAfterMs?: number;
+  limiterName?: string;
+};
+
+export type AuthLockoutEvent = {
+  ip: string;
+  failures: number;
+  windowMinutes: number;
+};
+
+// --- Privacy helpers ---
+
+/** Mask a key for logging — show first 6 chars max, mask the rest. */
+export function maskKey(key: string): string {
+  if (key.length <= 6) {
+    return key;
+  }
+  return `${key.slice(0, 6)}***`;
+}
+
+// --- Structured logging ---
+
+/** Log a rate limit denial event. */
+export function logRateLimitDenied(logger: SubsystemLogger, event: RateLimitDeniedEvent): void {
+  logger.warn("rate-limit-denied", {
+    layer: event.layer,
+    endpoint: event.endpoint,
+    key: maskKey(event.key),
+    remaining: event.remaining,
+    retryAfterMs: event.retryAfterMs,
+    limiterName: event.limiterName,
+  });
+}
+
+/** Log an auth lockout event. */
+export function logAuthLockout(logger: SubsystemLogger, event: AuthLockoutEvent): void {
+  logger.warn("auth-lockout", {
+    ip: maskKey(event.ip),
+    failures: event.failures,
+    windowMinutes: event.windowMinutes,
+  });
+}
+
+// --- Stats tracking ---
+
+type DenialRecord = {
+  layer: RateLimitLayer;
+  key: string;
+  timestamp: number;
+};
+
+export type RateLimitSummary = {
+  period: string;
+  denials: Record<RateLimitLayer, number>;
+  topKeys: Array<{ key: string; denials: number }>;
+};
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const TOP_KEYS_LIMIT = 5;
+
+/**
+ * Tracks rate limit denial counts per layer with a rolling window.
+ * Thread-safe for single-threaded Node.js event loop.
+ */
+export class RateLimitStats {
+  private records: DenialRecord[] = [];
+
+  /** Record a denial event. */
+  recordDenial(layer: RateLimitLayer, key: string, now: number = Date.now()): void {
+    this.records.push({ layer, key, timestamp: now });
+  }
+
+  /** Get a summary of denials within the rolling window. */
+  getSummary(now: number = Date.now()): RateLimitSummary {
+    const cutoff = now - FIVE_MINUTES_MS;
+    const recent = this.records.filter((r) => r.timestamp > cutoff);
+
+    const denials: Record<RateLimitLayer, number> = { http: 0, ws: 0, auth: 0, external: 0 };
+    const keyCounts = new Map<string, number>();
+
+    for (const record of recent) {
+      denials[record.layer] += 1;
+      const masked = maskKey(record.key);
+      keyCounts.set(masked, (keyCounts.get(masked) ?? 0) + 1);
+    }
+
+    const topKeys = [...keyCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, TOP_KEYS_LIMIT)
+      .map(([key, count]) => ({ key, denials: count }));
+
+    return { period: "5m", denials, topKeys };
+  }
+
+  /** Whether any denials have been recorded in the rolling window. */
+  hasDenials(now: number = Date.now()): boolean {
+    const cutoff = now - FIVE_MINUTES_MS;
+    return this.records.some((r) => r.timestamp > cutoff);
+  }
+
+  /** Prune old records outside the rolling window. */
+  prune(now: number = Date.now()): void {
+    const cutoff = now - FIVE_MINUTES_MS;
+    this.records = this.records.filter((r) => r.timestamp > cutoff);
+  }
+
+  /** Clear all stats. */
+  reset(): void {
+    this.records = [];
+  }
+
+  /** Total denial records (visible for testing). */
+  get size(): number {
+    return this.records.length;
+  }
+}
+
+// --- Singleton stats instance ---
+
+let globalStats: RateLimitStats | null = null;
+
+/** Get or create the global rate limit stats instance. */
+export function getRateLimitStats(): RateLimitStats {
+  if (!globalStats) {
+    globalStats = new RateLimitStats();
+  }
+  return globalStats;
+}
+
+/** Reset the global stats instance (for testing). */
+export function resetRateLimitStats(): void {
+  globalStats?.reset();
+  globalStats = null;
+}
+
+// --- Periodic summary ---
+
+let summaryTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Start periodic summary logging. Logs a summary every 5 minutes
+ * if any denials occurred in the window. No-op if already started.
+ */
+export function startPeriodicSummary(logger: SubsystemLogger): void {
+  if (summaryTimer) {
+    return;
+  }
+  const stats = getRateLimitStats();
+  summaryTimer = setInterval(() => {
+    stats.prune();
+    if (stats.hasDenials()) {
+      const summary = stats.getSummary();
+      logger.info("rate-limit-summary", {
+        period: summary.period,
+        denials: summary.denials,
+        topKeys: summary.topKeys,
+      });
+    }
+  }, FIVE_MINUTES_MS);
+  summaryTimer.unref();
+}
+
+/** Stop periodic summary logging. */
+export function stopPeriodicSummary(): void {
+  if (summaryTimer) {
+    clearInterval(summaryTimer);
+    summaryTimer = undefined;
+  }
+}

--- a/src/infra/rate-limiter.test.ts
+++ b/src/infra/rate-limiter.test.ts
@@ -179,7 +179,9 @@ describe("resolveRateLimitsConfig", () => {
     expect(resolved.http.staticPerMinute).toBe(200);
     expect(resolved.ws.messagesPerMinute).toBe(60);
     expect(resolved.ws.agentPerMinute).toBe(10);
+    expect(resolved.ws.ttsPerMinute).toBe(20);
     expect(resolved.ws.maxConnections).toBe(50);
+    expect(resolved.ws.perIpMaxConnections).toBe(5);
     expect(resolved.auth.maxFailures).toBe(10);
     expect(resolved.auth.windowMinutes).toBe(15);
   });

--- a/src/infra/rate-limiter.test.ts
+++ b/src/infra/rate-limiter.test.ts
@@ -242,6 +242,7 @@ describe("resolveRateLimitsConfig", () => {
     expect(resolved.http.agentPerMinute).toBe(10);
     expect(resolved.http.hookPerMinute).toBe(20);
     expect(resolved.http.staticPerMinute).toBe(200);
+    expect(resolved.http.toolsPerMinute).toBe(20);
     expect(resolved.ws.messagesPerMinute).toBe(60);
     expect(resolved.ws.agentPerMinute).toBe(10);
     expect(resolved.ws.ttsPerMinute).toBe(20);

--- a/src/infra/rate-limiter.test.ts
+++ b/src/infra/rate-limiter.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type RateLimitsConfig, resolveRateLimitsConfig } from "../config/types.gateway.js";
+import { RateLimiter } from "./rate-limiter.js";
+
+// Helper: create a limiter with simple 10 tokens / 1 token per 1 000 ms config.
+function makeLimiter(
+  overrides?: Partial<{ maxTokens: number; refillRate: number; refillIntervalMs: number }>,
+) {
+  return new RateLimiter({
+    maxTokens: overrides?.maxTokens ?? 10,
+    refillRate: overrides?.refillRate ?? 1,
+    refillIntervalMs: overrides?.refillIntervalMs ?? 1000,
+  });
+}
+
+describe("RateLimiter", () => {
+  let limiter: RateLimiter;
+
+  afterEach(() => {
+    limiter?.destroy();
+  });
+
+  it("allows requests within capacity", () => {
+    limiter = makeLimiter({ maxTokens: 5 });
+    const result = limiter.check("ip1", 0);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(result.retryAfterMs).toBeUndefined();
+  });
+
+  it("denies requests when bucket is empty", () => {
+    limiter = makeLimiter({ maxTokens: 2 });
+    limiter.check("ip1", 0);
+    limiter.check("ip1", 0);
+    const result = limiter.check("ip1", 0);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it("returns correct retryAfterMs when denied", () => {
+    limiter = makeLimiter({ maxTokens: 1, refillRate: 1, refillIntervalMs: 500 });
+    limiter.check("ip1", 0); // consume the only token
+    const denied = limiter.check("ip1", 0);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterMs).toBe(500);
+  });
+
+  it("returns correct remaining count", () => {
+    limiter = makeLimiter({ maxTokens: 5 });
+    expect(limiter.check("ip1", 0).remaining).toBe(4);
+    expect(limiter.check("ip1", 0).remaining).toBe(3);
+    expect(limiter.check("ip1", 0).remaining).toBe(2);
+    expect(limiter.check("ip1", 0).remaining).toBe(1);
+    expect(limiter.check("ip1", 0).remaining).toBe(0);
+  });
+
+  it("refills tokens after interval elapses", () => {
+    limiter = makeLimiter({ maxTokens: 2, refillRate: 1, refillIntervalMs: 1000 });
+    limiter.check("ip1", 0);
+    limiter.check("ip1", 0);
+    // Bucket empty at t=0
+    expect(limiter.check("ip1", 0).allowed).toBe(false);
+    // After 1 second, 1 token refilled
+    const result = limiter.check("ip1", 1000);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(0);
+  });
+
+  it("does not exceed maxTokens on refill", () => {
+    limiter = makeLimiter({ maxTokens: 3, refillRate: 10, refillIntervalMs: 100 });
+    // consume one token
+    limiter.check("ip1", 0);
+    // Wait a long time — refill should cap at maxTokens
+    const result = limiter.check("ip1", 100_000);
+    expect(result.allowed).toBe(true);
+    // remaining should be maxTokens - 1 (we just consumed one)
+    expect(result.remaining).toBe(2);
+  });
+
+  it("tracks separate buckets per key", () => {
+    limiter = makeLimiter({ maxTokens: 1 });
+    expect(limiter.check("ip1", 0).allowed).toBe(true);
+    expect(limiter.check("ip2", 0).allowed).toBe(true);
+    // ip1 should be denied, ip2 independent
+    expect(limiter.check("ip1", 0).allowed).toBe(false);
+    expect(limiter.check("ip2", 0).allowed).toBe(false);
+  });
+
+  it("reset() clears a specific bucket", () => {
+    limiter = makeLimiter({ maxTokens: 1 });
+    limiter.check("ip1", 0);
+    expect(limiter.check("ip1", 0).allowed).toBe(false);
+    limiter.reset("ip1");
+    // After reset, bucket is gone — next check creates a fresh one
+    expect(limiter.check("ip1", 0).allowed).toBe(true);
+  });
+
+  it("GC removes stale entries", () => {
+    limiter = makeLimiter();
+    limiter.check("old-ip", 0);
+    expect(limiter.size).toBe(1);
+    // 10 minutes later, the entry is stale
+    limiter._gcForTest(10 * 60 * 1000);
+    expect(limiter.size).toBe(0);
+  });
+
+  it("GC does not remove active entries", () => {
+    limiter = makeLimiter();
+    limiter.check("active-ip", 0);
+    // GC at 5 minutes — entry is 5 min old, under the 10 min threshold
+    limiter._gcForTest(5 * 60 * 1000);
+    expect(limiter.size).toBe(1);
+  });
+
+  it("GC removes stale but keeps active", () => {
+    limiter = makeLimiter();
+    limiter.check("old-ip", 0);
+    limiter.check("fresh-ip", 8 * 60 * 1000);
+    // GC at 10 minutes: old-ip is 10 min stale, fresh-ip is 2 min stale
+    limiter._gcForTest(10 * 60 * 1000);
+    expect(limiter.size).toBe(1);
+  });
+
+  it("destroy() stops the GC timer", () => {
+    limiter = makeLimiter();
+    limiter.destroy();
+    // Double destroy should be safe
+    limiter.destroy();
+    // After destroy, the limiter still works for check/reset, just no GC
+    expect(limiter.check("ip1", 0).allowed).toBe(true);
+  });
+
+  it("handles rapid sequential calls correctly", () => {
+    limiter = makeLimiter({ maxTokens: 3 });
+    const r0 = limiter.check("ip1", 0);
+    const r1 = limiter.check("ip1", 0);
+    const r2 = limiter.check("ip1", 0);
+    const r3 = limiter.check("ip1", 0);
+    expect(r0.allowed).toBe(true);
+    expect(r1.allowed).toBe(true);
+    expect(r2.allowed).toBe(true);
+    expect(r3.allowed).toBe(false);
+    expect(r0.remaining).toBe(2);
+    expect(r1.remaining).toBe(1);
+    expect(r2.remaining).toBe(0);
+    expect(r3.remaining).toBe(0);
+  });
+
+  it("burst: allows maxTokens requests then denies", () => {
+    const max = 5;
+    limiter = makeLimiter({ maxTokens: max });
+    for (let i = 0; i < max; i++) {
+      expect(limiter.check("burst", 0).allowed).toBe(true);
+    }
+    expect(limiter.check("burst", 0).allowed).toBe(false);
+  });
+
+  it("partial refill across multiple intervals", () => {
+    limiter = makeLimiter({ maxTokens: 10, refillRate: 2, refillIntervalMs: 500 });
+    // Consume all
+    for (let i = 0; i < 10; i++) {
+      limiter.check("ip", 0);
+    }
+    expect(limiter.check("ip", 0).allowed).toBe(false);
+    // 1.5 seconds later → 3 intervals × 2 = 6 tokens refilled
+    const r = limiter.check("ip", 1500);
+    expect(r.allowed).toBe(true);
+    expect(r.remaining).toBe(5); // 6 refilled - 1 consumed = 5
+  });
+});
+
+describe("resolveRateLimitsConfig", () => {
+  it("returns defaults when called with undefined", () => {
+    const resolved = resolveRateLimitsConfig(undefined);
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.http.globalPerMinute).toBe(100);
+    expect(resolved.http.agentPerMinute).toBe(10);
+    expect(resolved.http.hookPerMinute).toBe(20);
+    expect(resolved.http.staticPerMinute).toBe(200);
+    expect(resolved.ws.messagesPerMinute).toBe(60);
+    expect(resolved.ws.agentPerMinute).toBe(10);
+    expect(resolved.ws.maxConnections).toBe(50);
+    expect(resolved.auth.maxFailures).toBe(10);
+    expect(resolved.auth.windowMinutes).toBe(15);
+  });
+
+  it("enabled: false disables all limiting", () => {
+    const resolved = resolveRateLimitsConfig({ enabled: false });
+    expect(resolved.enabled).toBe(false);
+    // Defaults are still populated so consumers can check values without null checks
+    expect(resolved.http.globalPerMinute).toBe(100);
+  });
+
+  it("partial config merges with defaults correctly", () => {
+    const raw: RateLimitsConfig = {
+      http: { globalPerMinute: 200 },
+      auth: { maxFailures: 5 },
+    };
+    const resolved = resolveRateLimitsConfig(raw);
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.http.globalPerMinute).toBe(200);
+    expect(resolved.http.agentPerMinute).toBe(10); // default preserved
+    expect(resolved.auth.maxFailures).toBe(5);
+    expect(resolved.auth.windowMinutes).toBe(15); // default preserved
+    expect(resolved.ws.messagesPerMinute).toBe(60); // entirely defaulted
+  });
+
+  it("returns defaults for empty object", () => {
+    const resolved = resolveRateLimitsConfig({});
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.http.globalPerMinute).toBe(100);
+  });
+});

--- a/src/infra/rate-limiter.ts
+++ b/src/infra/rate-limiter.ts
@@ -1,0 +1,129 @@
+/**
+ * In-memory token-bucket rate limiter.
+ *
+ * Each instance tracks buckets keyed by a string (IP, client ID, token hash, etc.).
+ * A background GC sweep removes stale entries to prevent unbounded memory growth.
+ */
+
+export type RateLimiterConfig = {
+  /** Maximum tokens (burst capacity). */
+  maxTokens: number;
+  /** Tokens refilled per interval. */
+  refillRate: number;
+  /** Refill interval in milliseconds. */
+  refillIntervalMs: number;
+};
+
+export type RateLimitResult = {
+  /** Whether the request is allowed. */
+  allowed: boolean;
+  /** Milliseconds until a token is available (set when denied). */
+  retryAfterMs?: number;
+  /** Remaining tokens after this check. */
+  remaining: number;
+};
+
+type Bucket = {
+  tokens: number;
+  lastRefill: number;
+  lastAccess: number;
+};
+
+/** How often the GC sweep runs (ms). */
+const GC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+/** Buckets untouched for this long are evicted (ms). */
+const GC_STALE_MS = 10 * 60 * 1000; // 10 minutes
+
+export class RateLimiter {
+  private readonly config: Readonly<RateLimiterConfig>;
+  private readonly buckets = new Map<string, Bucket>();
+  private gcTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(config: RateLimiterConfig) {
+    this.config = Object.freeze({ ...config });
+    this.gcTimer = setInterval(() => this.gc(), GC_INTERVAL_MS);
+    this.gcTimer.unref();
+  }
+
+  /**
+   * Consume one token for `key`. Returns whether the request is allowed,
+   * plus remaining tokens and an optional retry-after hint.
+   */
+  check(key: string, now: number = Date.now()): RateLimitResult {
+    let bucket = this.buckets.get(key);
+
+    if (!bucket) {
+      bucket = { tokens: this.config.maxTokens, lastRefill: now, lastAccess: now };
+      this.buckets.set(key, bucket);
+    }
+
+    // Refill tokens based on elapsed time.
+    this.refill(bucket, now);
+    bucket.lastAccess = now;
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return { allowed: true, remaining: bucket.tokens };
+    }
+
+    // Denied — compute how long until at least one token is available.
+    const deficit = 1 - bucket.tokens;
+    const intervalsNeeded = Math.ceil(deficit / this.config.refillRate);
+    const retryAfterMs = intervalsNeeded * this.config.refillIntervalMs;
+
+    return { allowed: false, retryAfterMs, remaining: 0 };
+  }
+
+  /** Clear the bucket for a specific key (e.g. on successful auth). */
+  reset(key: string): void {
+    this.buckets.delete(key);
+  }
+
+  /** Stop the GC timer. Call this in test teardown or clean shutdown. */
+  destroy(): void {
+    if (this.gcTimer !== undefined) {
+      clearInterval(this.gcTimer);
+      this.gcTimer = undefined;
+    }
+  }
+
+  /** Visible for testing — number of tracked buckets. */
+  get size(): number {
+    return this.buckets.size;
+  }
+
+  // --- internal ---
+
+  private refill(bucket: Bucket, now: number): void {
+    const elapsed = now - bucket.lastRefill;
+    if (elapsed <= 0) {
+      return;
+    }
+
+    const intervals = Math.floor(elapsed / this.config.refillIntervalMs);
+    if (intervals <= 0) {
+      return;
+    }
+
+    const refilled = intervals * this.config.refillRate;
+    bucket.tokens = Math.min(this.config.maxTokens, bucket.tokens + refilled);
+    bucket.lastRefill += intervals * this.config.refillIntervalMs;
+  }
+
+  /** Remove buckets that have not been accessed recently. */
+  private gc(now: number = Date.now()): void {
+    for (const [key, bucket] of this.buckets) {
+      if (now - bucket.lastAccess >= GC_STALE_MS) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Exposed for testing only — run the GC sweep with a custom timestamp.
+   * @internal
+   */
+  _gcForTest(now: number): void {
+    this.gc(now);
+  }
+}

--- a/src/infra/rate-limiter.ts
+++ b/src/infra/rate-limiter.ts
@@ -67,9 +67,12 @@ export class RateLimiter {
     }
 
     // Denied — compute how long until at least one token is available.
+    // `refill()` already ran, so `now - bucket.lastRefill` is the elapsed
+    // time within the current (incomplete) interval: always in [0, refillIntervalMs).
     const deficit = 1 - bucket.tokens;
     const intervalsNeeded = Math.ceil(deficit / this.config.refillRate);
-    const retryAfterMs = intervalsNeeded * this.config.refillIntervalMs;
+    const elapsedInCurrentInterval = now - bucket.lastRefill;
+    const retryAfterMs = intervalsNeeded * this.config.refillIntervalMs - elapsedInCurrentInterval;
 
     return { allowed: false, retryAfterMs, remaining: 0 };
   }

--- a/tasks/PRD-01-core-rate-limiter.md
+++ b/tasks/PRD-01-core-rate-limiter.md
@@ -1,0 +1,167 @@
+# PRD-01: Core Rate Limiter Middleware
+
+**Status:** Not Started  
+**Priority:** P0 — Foundation for all other rate limiting PRDs  
+**Depends on:** Nothing  
+**Blocks:** PRD-02, PRD-03, PRD-04
+
+---
+
+## Summary
+
+Implement a lightweight, in-memory token-bucket rate limiter as a shared utility. This is the foundational building block used by all subsequent rate limiting work (HTTP endpoints, WebSocket throttling, auth brute-force protection, external API throttling).
+
+## Findings Reference (RATE-LIMIT-REVIEW.md)
+
+- **Section 2 — "What does NOT exist"**: No HTTP request rate limiting, no WebSocket message rate limiting, no per-IP connection limiting, no auth brute-force protection.
+- **Section 4 — "In-Memory vs Redis"**: Single-process, single-server app. No Redis. In-memory `Map<string, { tokens, lastRefill }>` is sufficient (~30 lines).
+- **Section 4 — "Library Choice"**: `express-rate-limit` only works for Express; Gateway uses raw `node:http`. Custom lightweight implementation recommended.
+- **Section 5 — Step 1**: Token-bucket with auto-cleanup of stale entries.
+
+## Design
+
+### Token Bucket Algorithm
+
+Each limiter instance tracks buckets keyed by a string (IP address, client ID, token hash, etc.):
+
+```typescript
+interface RateLimiterConfig {
+  /** Maximum tokens (burst capacity) */
+  maxTokens: number;
+  /** Tokens refilled per interval */
+  refillRate: number;
+  /** Refill interval in milliseconds */
+  refillIntervalMs: number;
+}
+
+interface RateLimitResult {
+  allowed: boolean;
+  /** Milliseconds until a token is available (set when denied) */
+  retryAfterMs?: number;
+  /** Remaining tokens after this check */
+  remaining: number;
+}
+```
+
+### Feature Flag / Config Schema
+
+Add a `rateLimits` section to the gateway config. Rate limiting is **enabled by default** with sensible defaults and can be toggled off.
+
+```typescript
+rateLimits?: {
+  /** Master switch — default: true */
+  enabled?: boolean;
+  http?: {
+    /** Global per-IP requests/min — default: 100 */
+    globalPerMinute?: number;
+    /** Agent-invoking endpoints per-IP req/min — default: 10 */
+    agentPerMinute?: number;
+    /** Hook endpoints per-token req/min — default: 20 */
+    hookPerMinute?: number;
+    /** Static/control-ui per-IP req/min — default: 200 */
+    staticPerMinute?: number;
+  };
+  ws?: {
+    /** Messages per client per minute — default: 60 */
+    messagesPerMinute?: number;
+    /** Agent invocations per client per minute — default: 10 */
+    agentPerMinute?: number;
+    /** Max concurrent WS connections — default: 50 */
+    maxConnections?: number;
+  };
+  auth?: {
+    /** Failed attempts before lockout — default: 10 */
+    maxFailures?: number;
+    /** Lockout window in minutes — default: 15 */
+    windowMinutes?: number;
+  };
+};
+```
+
+### Stale Entry Cleanup
+
+A GC sweep runs every 5 minutes, removing buckets that haven't been touched in 10+ minutes. This prevents unbounded memory growth from unique IPs.
+
+## Files to Create
+
+| File | Description |
+|---|---|
+| `src/infra/rate-limiter.ts` | Token bucket implementation, `RateLimiter` class |
+| `src/infra/rate-limiter.test.ts` | Unit tests for the rate limiter |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/config/types.gateway.ts` | Add `RateLimitsConfig` type and `rateLimits?` field to `GatewayConfig` |
+| `src/config/schema.ts` | Add config key descriptions for `rateLimits.*` (if schema descriptions exist here) |
+
+## Implementation Steps
+
+1. **Create `src/infra/rate-limiter.ts`**
+   - Export `RateLimiter` class with constructor taking `RateLimiterConfig`
+   - `check(key: string): RateLimitResult` — consume a token or deny
+   - `reset(key: string): void` — clear a bucket (for use on successful auth)
+   - `destroy(): void` — stop GC timer (for clean shutdown in tests)
+   - Internal: `Map<string, { tokens: number; lastRefill: number; lastAccess: number }>`
+   - GC interval: `setInterval` with `unref()` so it doesn't keep the process alive
+
+2. **Create `src/config/types.gateway.ts` additions**
+   - Add `RateLimitsConfig` type (nested: `http`, `ws`, `auth`)
+   - Add `rateLimits?: RateLimitsConfig` to the existing gateway config type
+
+3. **Add defaults resolver**
+   - Helper function `resolveRateLimitsConfig(raw?: RateLimitsConfig): ResolvedRateLimitsConfig`
+   - Fills in defaults for any unset values
+   - Returns `{ enabled: false, ... }` when `enabled` is explicitly `false`
+
+4. **Write comprehensive tests**
+
+## Tests Required
+
+### `src/infra/rate-limiter.test.ts`
+
+```
+describe("RateLimiter")
+  ✓ allows requests within capacity
+  ✓ denies requests when bucket is empty
+  ✓ returns correct retryAfterMs when denied
+  ✓ returns correct remaining count
+  ✓ refills tokens after interval elapses
+  ✓ does not exceed maxTokens on refill
+  ✓ tracks separate buckets per key
+  ✓ reset() clears a specific bucket
+  ✓ GC removes stale entries (mock timers)
+  ✓ GC does not remove active entries
+  ✓ destroy() stops the GC timer
+  ✓ handles rapid sequential calls correctly
+  ✓ burst: allows maxTokens requests then denies
+```
+
+### Config type tests (if project has config validation tests)
+
+```
+  ✓ rateLimits config is optional (undefined → defaults)
+  ✓ rateLimits.enabled: false disables all limiting
+  ✓ partial config merges with defaults correctly
+```
+
+## Conventions to Follow
+
+- **File naming**: kebab-case (`rate-limiter.ts`), matching existing `src/infra/` patterns (see `retry-policy.ts`, `backoff.ts`)
+- **Exports**: Named exports only (no default exports — project convention)
+- **Tests**: Co-located `.test.ts` files (project uses vitest, tests live next to source)
+- **Types**: Use TypeScript strict mode; project uses `@sinclair/typebox` for schemas but plain TS types for internal config
+- **No new dependencies**: Pure TypeScript implementation
+- **Timer cleanup**: Use `timer.unref()` to avoid keeping the process alive
+
+## Acceptance Criteria
+
+- [ ] `RateLimiter` class created in `src/infra/rate-limiter.ts`
+- [ ] Config types added to `src/config/types.gateway.ts`
+- [ ] All unit tests pass: `pnpm test -- src/infra/rate-limiter.test.ts`
+- [ ] `pnpm build` succeeds (TypeScript compiles without errors)
+- [ ] `pnpm lint` passes with no new warnings
+- [ ] No new dependencies added to `package.json`
+- [ ] GC cleanup prevents memory leaks from stale entries
+- [ ] `destroy()` method for clean test teardown

--- a/tasks/PRD-02-http-rate-limiting.md
+++ b/tasks/PRD-02-http-rate-limiting.md
@@ -1,0 +1,185 @@
+# PRD-02: HTTP Endpoint Rate Limiting
+
+**Status:** Not Started  
+**Priority:** P0 — Critical when internet-exposed  
+**Depends on:** PRD-01 (Core Rate Limiter)  
+**Blocks:** Nothing (can be done in parallel with PRD-03)
+
+---
+
+## Summary
+
+Apply rate limiting to all HTTP endpoints on the Gateway server. This covers a global per-IP rate limit applied early in the request pipeline, plus stricter per-endpoint limits on expensive operations (agent invocation, chat completions, tool execution).
+
+## Findings Reference (RATE-LIMIT-REVIEW.md)
+
+### P0 — Critical (when internet-exposed)
+
+- **`POST /hooks/agent`**: Each call dispatches a full AI agent run. Token auth exists but no rate cap. Attacker with leaked hook token can burn API credits.
+- **`POST /v1/chat/completions`**: OpenAI-compatible endpoint. Each request triggers a full agent run. Auth required, but no rate limit after auth.
+- **`POST /v1/responses`**: OpenResponses endpoint. Full agent run per request with 20MB body limit.
+- **`POST /tools/invoke`**: Allows invoking any tool. Auth required, no rate limit.
+
+### P1 — High
+
+- **`POST /hooks/wake`**: Triggers heartbeat/wake cycles. Less expensive but still triggers processing.
+
+### P2 — Medium
+
+- **Control UI (static files)**: Serves static files, no caching headers or rate limits.
+- **`POST /slack/*`**: Slack webhook events forwarded here.
+
+### Existing patterns
+
+- IP resolution already exists: `resolveGatewayClientIp()` in `src/gateway/net.ts`
+- Body size limits already applied: `maxBodyBytes` on hooks (256KB), OpenAI (1MB), Responses (20MB)
+- Auth checks already in place via `authorizeGatewayConnect()` in `src/gateway/auth.ts`
+
+## Design
+
+### Layer 1: Global HTTP Middleware
+
+Applied at the top of `handleRequest()` in `server-http.ts`, before any route matching:
+
+```
+1. Extract client IP via resolveGatewayClientIp()
+2. Check global rate limiter (default: 100 req/min per IP)
+3. If exceeded → 429 with Retry-After header, return immediately
+4. If rateLimits.enabled === false → skip entirely
+```
+
+### Layer 2: Per-Endpoint Limits
+
+Applied within each handler, after auth but before processing:
+
+| Endpoint | Default Limit | Key | Rationale |
+|---|---|---|---|
+| `POST /hooks/agent` | 10 req/min | hook token hash | Full agent run = expensive LLM call |
+| `POST /hooks/wake` | 20 req/min | hook token hash | Triggers processing cycle |
+| `POST /v1/chat/completions` | 10 req/min | client IP | Full agent run |
+| `POST /v1/responses` | 10 req/min | client IP | Full agent run + file uploads |
+| `POST /tools/invoke` | 20 req/min | client IP | Tool execution |
+| `GET /control-ui/*` | 200 req/min | client IP | Static files, generous |
+| `POST /slack/*` | 50 req/min | client IP | Slack has own retry logic |
+
+### 429 Response Format
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 5
+Content-Type: application/json
+
+{"error": {"message": "Rate limit exceeded", "type": "rate_limit_error", "retry_after_ms": 5000}}
+```
+
+For OpenAI-compatible endpoints, match the OpenAI error format so clients handle it correctly.
+
+## Files to Create
+
+| File | Description |
+|---|---|
+| `src/gateway/http-rate-limit.ts` | Helper: creates rate limiter instances, shared `send429()` response helper |
+| `src/gateway/http-rate-limit.test.ts` | Integration tests for HTTP rate limiting |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/gateway/server-http.ts` | Add global rate limit check at top of `handleRequest()`. Import rate limiter config. Create global limiter instance on server start. |
+| `src/gateway/openai-http.ts` | Add per-endpoint rate limit check in `handleOpenAiHttpRequest()` after auth, before processing |
+| `src/gateway/openresponses-http.ts` | Add per-endpoint rate limit check in `handleOpenResponsesHttpRequest()` after auth |
+| `src/gateway/tools-invoke-http.ts` | Add per-endpoint rate limit check after auth |
+| `src/gateway/hooks.ts` | Add per-hook-token rate limit check (or in `server-http.ts` hook handling section) |
+| `src/gateway/http-common.ts` | Add `send429(res, retryAfterMs)` helper alongside existing `sendUnauthorized`, `sendMethodNotAllowed` |
+
+## Implementation Steps
+
+1. **Create `src/gateway/http-rate-limit.ts`**
+   - Export factory: `createHttpRateLimiters(config: ResolvedRateLimitsConfig)` → returns object with named limiters (global, agent, hook, static)
+   - Export `send429(res: ServerResponse, retryAfterMs: number, format?: "openai" | "default")` helper
+   - Export `checkRateLimit(limiter: RateLimiter, key: string, res: ServerResponse, format?): boolean` — returns true if allowed, sends 429 and returns false if denied
+
+2. **Add `send429` to `src/gateway/http-common.ts`**
+   - Follow existing pattern of `sendUnauthorized()`, `sendMethodNotAllowed()`, `sendJson()`
+
+3. **Integrate global limit in `src/gateway/server-http.ts`**
+   - At server creation time, instantiate rate limiters from config
+   - At the very top of `handleRequest()`, before route matching:
+     ```typescript
+     const clientIp = resolveGatewayClientIp(req, trustedProxies);
+     if (!checkGlobalRateLimit(clientIp, res)) return;
+     ```
+   - Pass limiters through to route handlers or attach to server context
+
+4. **Integrate per-endpoint limits**
+   - `openai-http.ts`: After `authorizeGatewayConnect()` succeeds, check agent limiter
+   - `openresponses-http.ts`: Same pattern
+   - `tools-invoke-http.ts`: Same pattern  
+   - `hooks.ts` / `server-http.ts` hook section: Check hook limiter keyed by token hash
+
+5. **Wire config**
+   - Read `rateLimits` from loaded config in server-http.ts
+   - Pass resolved config to `createHttpRateLimiters()`
+   - Skip all checks when `config.rateLimits.enabled === false`
+
+6. **Write tests**
+
+## Tests Required
+
+### `src/gateway/http-rate-limit.test.ts`
+
+```
+describe("HTTP Rate Limiting")
+  describe("Global rate limit")
+    ✓ allows requests within global limit
+    ✓ returns 429 when global limit exceeded
+    ✓ includes Retry-After header in 429 response
+    ✓ different IPs have independent limits
+    ✓ limit resets after refill interval
+    ✓ skipped entirely when rateLimits.enabled is false
+
+  describe("Per-endpoint rate limits")
+    ✓ /v1/chat/completions returns 429 after 10 req/min from same IP
+    ✓ /v1/chat/completions 429 uses OpenAI error format
+    ✓ /v1/responses returns 429 after limit exceeded
+    ✓ /tools/invoke returns 429 after limit exceeded
+    ✓ /hooks/agent returns 429 after 10 req/min per token
+    ✓ /hooks/wake returns 429 after 20 req/min per token
+    ✓ different hook tokens have independent limits
+
+  describe("429 response format")
+    ✓ includes retry_after_ms in JSON body
+    ✓ sets Retry-After header in seconds (rounded up)
+    ✓ Content-Type is application/json
+
+  describe("Config integration")
+    ✓ custom globalPerMinute value is respected
+    ✓ custom agentPerMinute value is respected
+    ✓ enabled: false bypasses all rate limit checks
+```
+
+### Modify existing tests (if they mock HTTP requests)
+
+- `src/gateway/hooks.test.ts` — ensure existing tests still pass with rate limiting enabled
+- `src/gateway/openai-http.ts` tests — if they exist, verify no regressions
+
+## Conventions to Follow
+
+- **HTTP helpers**: Follow existing `http-common.ts` patterns (`sendJson`, `sendUnauthorized`, etc.)
+- **IP resolution**: Use existing `resolveGatewayClientIp()` from `net.ts` — do NOT re-implement
+- **Config loading**: Follow existing `loadConfig()` pattern — rate limits config flows through the same path
+- **Error response**: Match existing error shapes. For OpenAI-compat endpoints, use OpenAI's error format
+- **No Express middleware**: The main server is raw `node:http`. Only `src/browser/server.ts` uses Express
+
+## Acceptance Criteria
+
+- [ ] Global per-IP rate limit applied to all HTTP requests
+- [ ] Per-endpoint limits applied to `/hooks/agent`, `/hooks/wake`, `/v1/chat/completions`, `/v1/responses`, `/tools/invoke`
+- [ ] 429 responses include `Retry-After` header and JSON body with `retry_after_ms`
+- [ ] OpenAI-compat endpoints return OpenAI-formatted 429 errors
+- [ ] Rate limiting is configurable via `rateLimits.http.*` config
+- [ ] Rate limiting can be disabled via `rateLimits.enabled: false`
+- [ ] All new and existing tests pass: `pnpm test`
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm lint` passes
+- [ ] No new dependencies

--- a/tasks/PRD-03-websocket-rate-limiting.md
+++ b/tasks/PRD-03-websocket-rate-limiting.md
@@ -1,0 +1,205 @@
+# PRD-03: WebSocket Rate Limiting & Auth Brute-Force Protection
+
+**Status:** Not Started  
+**Priority:** P1 — High  
+**Depends on:** PRD-01 (Core Rate Limiter)  
+**Blocks:** Nothing
+
+---
+
+## Summary
+
+Add rate limiting to the WebSocket control plane: per-client message throttling, connection limits, per-method rate limits for expensive operations (agent invocations, TTS), and auth brute-force protection with per-IP lockout.
+
+## Findings Reference (RATE-LIMIT-REVIEW.md)
+
+### P1 — High
+
+- **WebSocket `connect` + auth**: WS handshake includes token/password. No lockout or rate limit on failed auth attempts. Timing-safe compare exists but doesn't prevent enumeration attempts.
+- **WebSocket `agent` / `agent.wait` / `chat.send` methods**: Authenticated WS clients can spam agent runs with no throttle.
+- **WebSocket connection flood**: No max connections limit. Each WS connection consumes memory for message handlers, presence tracking, etc.
+
+### P2 — Medium
+
+- **TTS conversion (`tts.convert` WS method)**: Each call hits ElevenLabs API. No per-client rate limit.
+
+### Existing patterns
+
+- WebSocket server uses `ws` library
+- Connection handling in `src/gateway/server/ws-connection.ts`
+- Message handling in `src/gateway/server/ws-connection/message-handler.ts`
+- Auth via `authorizeGatewayConnect()` in `src/gateway/auth.ts` — already uses `timingSafeEqual`
+- Client type: `GatewayWsClient` in `src/gateway/server/ws-types.ts`
+
+## Design
+
+### 1. Connection Limiting
+
+Applied during WebSocket upgrade in `ws-connection.ts`:
+- Track active connection count
+- Reject new connections with 429 when `maxConnections` (default: 50) is reached
+- Per-IP connection limit: max 5 concurrent connections from same IP
+
+### 2. Auth Brute-Force Protection
+
+Applied in `src/gateway/auth.ts`:
+- Track failed auth attempts per IP: `Map<string, { failures: number; windowStart: number }>`
+- After `maxFailures` (default: 10) in `windowMinutes` (default: 15) → reject immediately with 429
+- Reset failure count on successful auth
+- Works for both HTTP auth and WS handshake auth
+
+### 3. Per-Client Message Throttling
+
+Applied in the WS message handler:
+- Track messages per client per window: extend `GatewayWsClient` with rate limit state
+- Default: 60 messages/min per client
+- When exceeded: send error message over WS, then close connection if continued
+
+### 4. Per-Method Rate Limits
+
+Applied in the message handler for specific expensive methods:
+- `agent`, `agent.wait`, `chat.send`: 10/min per client (each triggers a full LLM run)
+- `tts.convert`: 20/min per client (each hits ElevenLabs API)
+- When exceeded: send JSON error response on the WS with `{ error: "rate_limit", method, retryAfterMs }`
+
+## Files to Create
+
+| File | Description |
+|---|---|
+| `src/gateway/ws-rate-limit.ts` | WS-specific rate limit helpers, auth failure tracker |
+| `src/gateway/ws-rate-limit.test.ts` | Tests for WS rate limiting |
+| `src/gateway/auth-rate-limit.ts` | Auth brute-force tracker (shared between HTTP and WS auth) |
+| `src/gateway/auth-rate-limit.test.ts` | Tests for auth brute-force protection |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/gateway/auth.ts` | Integrate auth failure tracking: check before auth, record failures, reset on success |
+| `src/gateway/server/ws-connection.ts` | Add connection count limit, per-IP connection limit, wire message rate limiting |
+| `src/gateway/server/ws-connection/message-handler.ts` | Add per-method rate limit checks before dispatching expensive methods |
+| `src/gateway/server/ws-types.ts` | Extend `GatewayWsClient` type with rate limit tracking fields |
+
+## Implementation Steps
+
+1. **Create `src/gateway/auth-rate-limit.ts`**
+   - `AuthRateLimiter` class using `RateLimiter` from PRD-01
+   - `checkAuthAllowed(ip: string): { allowed: boolean; retryAfterMs?: number }`
+   - `recordFailure(ip: string): void`
+   - `recordSuccess(ip: string): void` — resets the failure count
+   - Configurable via `rateLimits.auth` settings
+
+2. **Integrate auth protection in `src/gateway/auth.ts`**
+   - Accept `AuthRateLimiter` as parameter to `authorizeGatewayConnect()`
+   - Before checking credentials: `if (!authLimiter.checkAuthAllowed(ip).allowed)` → return failure
+   - After auth result: call `recordFailure()` or `recordSuccess()`
+   - The limiter instance is created at server startup and shared
+
+3. **Add connection limiting in `src/gateway/server/ws-connection.ts`**
+   - Track active connections in a counter (increment on connect, decrement on close)
+   - Track per-IP connections: `Map<string, number>`
+   - On upgrade: check total < maxConnections AND per-IP < 5, otherwise reject
+
+4. **Extend `GatewayWsClient` in `src/gateway/server/ws-types.ts`**
+   - Add optional `rateLimit?: { messageCount: number; windowStart: number }`
+   - Populated lazily on first message
+
+5. **Add message throttling in `message-handler.ts`**
+   - At the top of message handling, before method dispatch:
+     ```typescript
+     if (!checkWsMessageRate(client)) {
+       ws.send(JSON.stringify({ error: "rate_limit", message: "Too many messages" }));
+       return;
+     }
+     ```
+   - For specific methods (`agent`, `agent.wait`, `chat.send`, `tts.convert`):
+     ```typescript
+     if (!checkWsMethodRate(client, method)) {
+       ws.send(JSON.stringify({ error: "rate_limit", method, retryAfterMs }));
+       return;
+     }
+     ```
+
+6. **Wire config**
+   - Read `rateLimits.ws` and `rateLimits.auth` from config
+   - Pass to connection handler and message handler
+   - Skip when `rateLimits.enabled === false`
+
+7. **Write tests**
+
+## Tests Required
+
+### `src/gateway/auth-rate-limit.test.ts`
+
+```
+describe("AuthRateLimiter")
+  ✓ allows auth attempts within limit
+  ✓ blocks auth after maxFailures exceeded
+  ✓ returns retryAfterMs when blocked
+  ✓ resets failure count on successful auth
+  ✓ separate tracking per IP
+  ✓ failures expire after windowMinutes
+  ✓ does not block when rateLimits.enabled is false
+```
+
+### `src/gateway/ws-rate-limit.test.ts`
+
+```
+describe("WS Rate Limiting")
+  describe("Connection limits")
+    ✓ allows connections within maxConnections limit
+    ✓ rejects connections when maxConnections reached
+    ✓ allows new connection after a previous one closes
+    ✓ limits per-IP concurrent connections to 5
+    ✓ different IPs have independent connection counts
+
+  describe("Message throttling")
+    ✓ allows messages within per-client limit
+    ✓ sends rate_limit error when exceeded
+    ✓ window resets after interval
+    ✓ separate tracking per client
+
+  describe("Per-method limits")
+    ✓ agent method limited to 10/min per client
+    ✓ chat.send method limited to 10/min per client
+    ✓ tts.convert method limited to 20/min per client
+    ✓ non-limited methods unaffected
+    ✓ error response includes method name and retryAfterMs
+
+  describe("Config integration")
+    ✓ custom messagesPerMinute respected
+    ✓ custom agentPerMinute respected
+    ✓ custom maxConnections respected
+    ✓ enabled: false bypasses all WS rate limiting
+```
+
+### Existing test modifications
+
+- `src/gateway/auth.test.ts` — add test cases verifying auth rate limiting integration
+- `src/gateway/client.test.ts` — ensure existing WS client tests pass with rate limiting active
+
+## Conventions to Follow
+
+- **WS error format**: Use JSON `{ error: string, method?: string, retryAfterMs?: number }` — check existing WS error patterns in the codebase
+- **Connection close**: When closing due to rate limiting, use appropriate WS close code (1008 = Policy Violation)
+- **Client state**: Extend `GatewayWsClient` type minimally — add optional fields, don't break existing consumers
+- **Auth function signature**: `authorizeGatewayConnect` is called from multiple places — keep changes backward-compatible (optional limiter param)
+- **Cleanup**: Decrement counters on `ws.on("close")` — prevent counter drift
+
+## Acceptance Criteria
+
+- [ ] Auth brute-force protection: 10 failures in 15 min triggers lockout
+- [ ] Lockout cleared on successful auth
+- [ ] WebSocket connections capped at configurable maximum (default: 50)
+- [ ] Per-IP connection limit enforced (default: 5)
+- [ ] Per-client message rate limited (default: 60/min)
+- [ ] Agent-invoking WS methods rate limited (default: 10/min per client)
+- [ ] TTS method rate limited (default: 20/min per client)
+- [ ] Rate limit errors sent as JSON over WS before close
+- [ ] WS close code 1008 used for rate limit disconnections
+- [ ] All configurable via `rateLimits.ws.*` and `rateLimits.auth.*`
+- [ ] Disabled when `rateLimits.enabled: false`
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm lint` passes
+- [ ] No new dependencies

--- a/tasks/PRD-04-external-api-throttling-monitoring.md
+++ b/tasks/PRD-04-external-api-throttling-monitoring.md
@@ -1,0 +1,191 @@
+# PRD-04: External API Throttling (ElevenLabs TTS) & Rate Limit Monitoring/Logging
+
+**Status:** Not Started  
+**Priority:** P2 — Medium  
+**Depends on:** PRD-01 (Core Rate Limiter)  
+**Blocks:** Nothing
+
+---
+
+## Summary
+
+Close the ElevenLabs TTS client-side throttling gap (the one external API without rate protection), and add structured logging + monitoring for all rate limiting events across the system. This provides visibility into rate limit enforcement and helps operators tune limits.
+
+## Findings Reference (RATE-LIMIT-REVIEW.md)
+
+### Section 6 — External API Rate Limits
+
+- **ElevenLabs TTS — ⚠️ Needs Attention**: "No client-side rate limiting. Each `tts.convert` call directly hits the ElevenLabs API." Recommendation: token-bucket limiter, 10 req/min default.
+- **Already handled ✅**: Telegram (`@grammyjs/transformer-throttler`), Discord (retry + backoff), AI Providers (profile cooldown + exponential backoff + failover).
+- **Slack Web API**: Built-in retry. ✅
+- **Gmail Pub/Sub**: Google controls rate. ✅
+
+### Monitoring gap
+
+- No structured logging exists for rate limit events
+- No visibility into which IPs/clients are being rate limited
+- No metrics for tuning rate limit values
+
+## Design
+
+### Part 1: ElevenLabs TTS Throttling
+
+Add a token-bucket rate limiter in the TTS module to cap outbound ElevenLabs API calls:
+
+- Default: 10 requests/min (ElevenLabs starter tier allows ~10 concurrent)
+- Configurable via `rateLimits.external.ttsPerMinute`
+- When exceeded: queue or reject with a user-friendly error ("TTS rate limit — try again in Xs")
+- Applied in `src/tts/tts.ts` before the actual ElevenLabs API call
+
+### Part 2: Rate Limit Event Logging
+
+Structured log entries for all rate limiting events using the project's existing `tslog` logger:
+
+```typescript
+// On rate limit deny
+logger.warn("rate-limit-denied", {
+  layer: "http" | "ws" | "auth" | "external",
+  endpoint: "/v1/chat/completions",
+  key: "192.168.1.100",  // IP or client ID (don't log full tokens)
+  remaining: 0,
+  retryAfterMs: 5000,
+  limiterName: "agent-per-ip",
+});
+
+// On auth lockout
+logger.warn("auth-lockout", {
+  ip: "192.168.1.100",
+  failures: 10,
+  windowMinutes: 15,
+});
+
+// Periodic summary (every 5 min if any denials occurred)
+logger.info("rate-limit-summary", {
+  period: "5m",
+  denials: { http: 12, ws: 3, auth: 1, external: 0 },
+  topKeys: [{ key: "192.168.1.100", denials: 10 }],
+});
+```
+
+### Part 3: Rate Limit Stats API (WS method)
+
+Expose a `rateLimits.stats` WS method for the control UI:
+
+```typescript
+// Response
+{
+  enabled: true,
+  denials: {
+    http: { total: 45, last5m: 3 },
+    ws: { total: 12, last5m: 0 },
+    auth: { total: 2, last5m: 0 },
+    external: { total: 0, last5m: 0 },
+  },
+  config: { /* resolved config snapshot */ }
+}
+```
+
+## Files to Create
+
+| File | Description |
+|---|---|
+| `src/infra/rate-limit-logger.ts` | Structured logging helpers for rate limit events |
+| `src/infra/rate-limit-logger.test.ts` | Tests for logging helpers |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/tts/tts.ts` | Add rate limiter before ElevenLabs API calls. When limit exceeded, return error or queue. |
+| `src/config/types.gateway.ts` | Add `external?: { ttsPerMinute?: number }` to `RateLimitsConfig` |
+| `src/gateway/server-http.ts` | Add logging calls on rate limit denials (uses helpers from PRD-02) |
+| `src/gateway/server/ws-connection/message-handler.ts` | Add logging calls on WS rate limit denials (uses helpers from PRD-03) |
+| `src/gateway/auth.ts` | Add logging on auth lockout events |
+
+## Implementation Steps
+
+1. **Add ElevenLabs throttling in `src/tts/tts.ts`**
+   - Import `RateLimiter` from `src/infra/rate-limiter.ts`
+   - Create module-level limiter: `new RateLimiter({ maxTokens: 10, refillRate: 10, refillIntervalMs: 60_000 })`
+   - Before ElevenLabs API call: `check("elevenlabs")`
+   - If denied: throw or return error with `retryAfterMs`
+   - Read config from `rateLimits.external.ttsPerMinute` if available
+
+2. **Create `src/infra/rate-limit-logger.ts`**
+   - `logRateLimitDenied(logger, { layer, endpoint, key, remaining, retryAfterMs, limiterName })`
+   - `logAuthLockout(logger, { ip, failures, windowMinutes })`
+   - `RateLimitStats` class: tracks denial counts per layer, computes 5-min rolling window
+   - `getSummary(): RateLimitSummary` for periodic logging and stats API
+
+3. **Integrate logging into HTTP rate limiting (PRD-02 files)**
+   - In `server-http.ts` global rate limit: call `logRateLimitDenied()` on 429
+   - In per-endpoint handlers: call `logRateLimitDenied()` with endpoint name
+
+4. **Integrate logging into WS rate limiting (PRD-03 files)**
+   - In `message-handler.ts`: call `logRateLimitDenied()` on WS rate limit
+   - In `auth.ts`: call `logAuthLockout()` on lockout
+
+5. **Add periodic summary logging**
+   - Every 5 minutes (piggybacking on existing GC timer or separate), log a summary if any denials occurred
+   - Use `logger.info()` level — not warn (summary is informational)
+
+6. **Wire `rateLimits.stats` WS method** (optional, lower priority)
+   - Register in WS method handler
+   - Return current stats from `RateLimitStats` instance
+   - Requires auth (control-level access)
+
+7. **Write tests**
+
+## Tests Required
+
+### `src/infra/rate-limit-logger.test.ts`
+
+```
+describe("RateLimitLogger")
+  ✓ logRateLimitDenied calls logger.warn with correct structure
+  ✓ logAuthLockout calls logger.warn with correct structure
+  ✓ does not log sensitive data (full tokens, passwords)
+  ✓ key field is truncated/masked for privacy
+
+describe("RateLimitStats")
+  ✓ tracks denial counts per layer
+  ✓ getSummary returns correct totals
+  ✓ rolling 5-min window excludes old events
+  ✓ topKeys returns top offenders sorted by count
+  ✓ reset clears all stats
+```
+
+### TTS throttling tests (in existing or new TTS test file)
+
+```
+describe("TTS ElevenLabs throttling")
+  ✓ allows TTS calls within rate limit
+  ✓ rejects TTS calls when rate limit exceeded
+  ✓ returns retryAfterMs on rejection
+  ✓ rate limit resets after refill interval
+  ✓ config ttsPerMinute overrides default
+  ✓ skipped when rateLimits.enabled is false
+```
+
+## Conventions to Follow
+
+- **Logging**: Use existing `tslog` logger from `src/logging/` — follow existing subsystem logger patterns (`createSubsystemLogger`)
+- **Privacy**: Never log full tokens, passwords, or Bearer values. Mask IPs in logs if needed (or log full IP — check project's existing logging practices)
+- **TTS module**: Check existing error handling patterns in `src/tts/tts.ts` — follow the same error propagation style
+- **Config extension**: Add to existing `RateLimitsConfig` type from PRD-01 — don't create separate config
+- **WS methods**: If adding `rateLimits.stats`, follow existing WS method registration pattern
+
+## Acceptance Criteria
+
+- [ ] ElevenLabs TTS calls rate limited to configurable req/min (default: 10)
+- [ ] TTS rate limit returns user-friendly error with retry timing
+- [ ] All rate limit denials logged with structured data (layer, endpoint, key)
+- [ ] Auth lockouts logged with IP and failure count
+- [ ] No sensitive data in logs (tokens, passwords)
+- [ ] `RateLimitStats` tracks denial counts per layer
+- [ ] Periodic summary logged every 5 min when denials occurred
+- [ ] `rateLimits.external.ttsPerMinute` config respected
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm lint` passes
+- [ ] No new dependencies

--- a/tasks/STATUS.md
+++ b/tasks/STATUS.md
@@ -11,8 +11,8 @@
 | PRD | Title | Priority | Status | Depends On |
 |---|---|---|---|---|
 | [PRD-01](PRD-01-core-rate-limiter.md) | Core Rate Limiter Middleware | P0 | ✅ Done | — |
-| [PRD-02](PRD-02-http-rate-limiting.md) | HTTP Endpoint Rate Limiting | P0 | ⬜ Not Started | PRD-01 |
-| [PRD-03](PRD-03-websocket-rate-limiting.md) | WebSocket Rate Limiting & Auth Brute-Force | P1 | ⬜ Not Started | PRD-01 |
+| [PRD-02](PRD-02-http-rate-limiting.md) | HTTP Endpoint Rate Limiting | P0 | ✅ Done | PRD-01 |
+| [PRD-03](PRD-03-websocket-rate-limiting.md) | WebSocket Rate Limiting & Auth Brute-Force | P1 | ✅ Done | PRD-01 |
 | [PRD-04](PRD-04-external-api-throttling-monitoring.md) | External API Throttling & Monitoring | P2 | ⬜ Not Started | PRD-01 |
 
 ## Implementation Order

--- a/tasks/STATUS.md
+++ b/tasks/STATUS.md
@@ -1,0 +1,72 @@
+# Rate Limiting Implementation — Status Tracker
+
+**Created:** 2025-07-25  
+**Source:** [RATE-LIMIT-REVIEW.md](../RATE-LIMIT-REVIEW.md)  
+**Total estimated new code:** ~300-400 lines across ~12 files
+
+---
+
+## PRD Overview
+
+| PRD | Title | Priority | Status | Depends On |
+|---|---|---|---|---|
+| [PRD-01](PRD-01-core-rate-limiter.md) | Core Rate Limiter Middleware | P0 | ⬜ Not Started | — |
+| [PRD-02](PRD-02-http-rate-limiting.md) | HTTP Endpoint Rate Limiting | P0 | ⬜ Not Started | PRD-01 |
+| [PRD-03](PRD-03-websocket-rate-limiting.md) | WebSocket Rate Limiting & Auth Brute-Force | P1 | ⬜ Not Started | PRD-01 |
+| [PRD-04](PRD-04-external-api-throttling-monitoring.md) | External API Throttling & Monitoring | P2 | ⬜ Not Started | PRD-01 |
+
+## Implementation Order
+
+```
+PRD-01 (Core Rate Limiter)
+   │
+   ├──→ PRD-02 (HTTP Rate Limiting)     ← can run in parallel
+   ├──→ PRD-03 (WS Rate Limiting)       ← can run in parallel
+   └──→ PRD-04 (External API + Logging) ← can run in parallel, or last
+```
+
+**PRD-01 must be completed first.** PRDs 02, 03, and 04 can be implemented in parallel after that, or sequentially in priority order.
+
+## Key Files Touched
+
+### New Files
+- `src/infra/rate-limiter.ts` — Token bucket implementation (PRD-01)
+- `src/infra/rate-limiter.test.ts` — Core limiter tests (PRD-01)
+- `src/gateway/http-rate-limit.ts` — HTTP rate limit helpers (PRD-02)
+- `src/gateway/http-rate-limit.test.ts` — HTTP rate limit tests (PRD-02)
+- `src/gateway/ws-rate-limit.ts` — WS rate limit helpers (PRD-03)
+- `src/gateway/ws-rate-limit.test.ts` — WS rate limit tests (PRD-03)
+- `src/gateway/auth-rate-limit.ts` — Auth brute-force tracker (PRD-03)
+- `src/gateway/auth-rate-limit.test.ts` — Auth brute-force tests (PRD-03)
+- `src/infra/rate-limit-logger.ts` — Logging helpers (PRD-04)
+- `src/infra/rate-limit-logger.test.ts` — Logging tests (PRD-04)
+
+### Modified Files
+- `src/config/types.gateway.ts` — Config types (PRD-01)
+- `src/gateway/server-http.ts` — Global HTTP rate limit (PRD-02)
+- `src/gateway/openai-http.ts` — Per-endpoint limit (PRD-02)
+- `src/gateway/openresponses-http.ts` — Per-endpoint limit (PRD-02)
+- `src/gateway/tools-invoke-http.ts` — Per-endpoint limit (PRD-02)
+- `src/gateway/hooks.ts` — Hook rate limit (PRD-02)
+- `src/gateway/http-common.ts` — `send429()` helper (PRD-02)
+- `src/gateway/auth.ts` — Auth failure tracking (PRD-03)
+- `src/gateway/server/ws-connection.ts` — Connection limits (PRD-03)
+- `src/gateway/server/ws-connection/message-handler.ts` — Message throttling (PRD-03)
+- `src/gateway/server/ws-types.ts` — Client type extension (PRD-03)
+- `src/tts/tts.ts` — ElevenLabs throttling (PRD-04)
+
+## Validation Checklist (per PRD)
+
+- [ ] `pnpm build` — TypeScript compiles
+- [ ] `pnpm lint` — No new lint warnings
+- [ ] `pnpm test` — All tests pass
+- [ ] No new dependencies in `package.json`
+- [ ] Config is backward-compatible (all new fields optional with defaults)
+- [ ] Rate limiting enabled by default, disableable via `rateLimits.enabled: false`
+
+## Status Legend
+
+- ⬜ Not Started
+- 🟡 In Progress
+- 🟢 Complete
+- 🔴 Blocked

--- a/tasks/STATUS.md
+++ b/tasks/STATUS.md
@@ -13,7 +13,7 @@
 | [PRD-01](PRD-01-core-rate-limiter.md) | Core Rate Limiter Middleware | P0 | ✅ Done | — |
 | [PRD-02](PRD-02-http-rate-limiting.md) | HTTP Endpoint Rate Limiting | P0 | ✅ Done | PRD-01 |
 | [PRD-03](PRD-03-websocket-rate-limiting.md) | WebSocket Rate Limiting & Auth Brute-Force | P1 | ✅ Done | PRD-01 |
-| [PRD-04](PRD-04-external-api-throttling-monitoring.md) | External API Throttling & Monitoring | P2 | ⬜ Not Started | PRD-01 |
+| [PRD-04](PRD-04-external-api-throttling-monitoring.md) | External API Throttling & Monitoring | P2 | ✅ Done | PRD-01 |
 
 ## Implementation Order
 

--- a/tasks/STATUS.md
+++ b/tasks/STATUS.md
@@ -10,7 +10,7 @@
 
 | PRD | Title | Priority | Status | Depends On |
 |---|---|---|---|---|
-| [PRD-01](PRD-01-core-rate-limiter.md) | Core Rate Limiter Middleware | P0 | ⬜ Not Started | — |
+| [PRD-01](PRD-01-core-rate-limiter.md) | Core Rate Limiter Middleware | P0 | ✅ Done | — |
 | [PRD-02](PRD-02-http-rate-limiting.md) | HTTP Endpoint Rate Limiting | P0 | ⬜ Not Started | PRD-01 |
 | [PRD-03](PRD-03-websocket-rate-limiting.md) | WebSocket Rate Limiting & Auth Brute-Force | P1 | ⬜ Not Started | PRD-01 |
 | [PRD-04](PRD-04-external-api-throttling-monitoring.md) | External API Throttling & Monitoring | P2 | ⬜ Not Started | PRD-01 |


### PR DESCRIPTION
## Summary

Adds comprehensive rate limiting to OpenClaw Gateway — HTTP endpoints, WebSocket connections/messages, auth brute-force protection, and ElevenLabs TTS throttling.

### PRDs Implemented

| PRD | Scope |
|-----|-------|
| PRD-01 | Core token-bucket rate limiter (`src/infra/rate-limiter.ts`) with config schema |
| PRD-02 | HTTP endpoint rate limiting — global per-IP (100/min), agent endpoints (10/min), hooks (20/min) |
| PRD-03 | WebSocket rate limiting — message throttling (60/min), connection limits (50 total, 5/IP), auth brute-force (10 failures → 15min lockout) |
| PRD-04 | ElevenLabs TTS throttling (10/min) + structured rate limit event logging |

### Design Decisions

- **In-memory token bucket** — no Redis needed (single-process architecture)
- **Feature-flagged** via `gateway.rateLimits.enabled` config (enabled by default)
- **Zero new dependencies** — pure TypeScript implementation
- **Additive changes** — all rate limiting is middleware/checks layered on existing handlers
- **Auto-cleanup** — stale buckets GC'd every 5 minutes to prevent memory growth

### Files

- 8 new source files + 8 co-located test files
- ~10 modified files (HTTP handlers, WS connection, auth, TTS, config types)
- ~1,500 lines of new code

### Testing

All new code has co-located `.test.ts` files with vitest. Core rate limiter has 19 unit tests covering token consumption, refill, GC, burst, and config resolution.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds in-memory token-bucket rate limiting across the Gateway: a core `RateLimiter`, HTTP per-IP/per-endpoint limiters, WS connection + per-client/per-method throttles, and an auth brute-force limiter integrated into the Gateway auth flow. It also adds TTS throttling for an external provider and introduces a structured rate-limit logging module.

Key integration points:
- HTTP: global per-IP limiter in the gateway HTTP server, plus per-endpoint checks for agent-invoking and tools/hook endpoints.
- WS: connection cap via a tracker, plus message/method limiting in the WS message handler.
- Auth: auth attempts are rate-limited early during connection authorization.

Findings below focus on correctness/intent mismatches and configuration gaps in the new rate limiting logic.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a few correctness/configuration gaps in the new rate limiting behavior.
- Core rate limiting primitives and wiring look coherent and are backed by tests, but there are a couple of behavior/intent mismatches (auth limiter counting successes) and a configuration/enforcement gap (unused `static` limiter, hard-coded tools limit). `retryAfterMs` calculation also appears inaccurate, which can degrade client behavior and observability.
- src/gateway/auth-rate-limit.ts, src/gateway/http-rate-limit.ts, src/infra/rate-limiter.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->