### PR TITLE
feat(web-search): add Tavily search provider support

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -432,6 +432,8 @@ async function runTavilySearch(params: {
     headers: {
       "Content-Type": "application/json",
     },
+    // Note: Tavily API expects api_key in the request body, not as a header.
+    // See: https://docs.tavily.com/documentation/api-reference/search
     body: JSON.stringify({
       api_key: params.apiKey,
       query: params.query,
@@ -533,7 +535,11 @@ async function runWebSearch(params: {
   }
 
   if (params.provider !== "brave") {
-    throw new Error("Unsupported web search provider.");
+    return {
+      error: "unsupported_provider",
+      message: `Unsupported web search provider: ${params.provider}`,
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
   }
 
   const url = new URL(BRAVE_SEARCH_ENDPOINT);
@@ -642,7 +648,7 @@ export function createWebSearchTool(options?: {
         });
       }
       // Guard: country, search_lang, ui_lang are Brave-only parameters
-      if ((country || search_lang || ui_lang) && (provider === "tavily" || provider === "perplexity")) {
+      if ((country || search_lang || ui_lang) && provider !== "brave") {
         const unsupportedParams = [
           country && "country",
           search_lang && "search_lang",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -426,7 +426,17 @@ async function runTavilySearch(params: {
   maxResults: number;
   searchDepth: "basic" | "advanced";
   timeoutSeconds: number;
-}): Promise<{ answer?: string; results: Array<{ title: string; url: string; content: string; score?: number; published?: string; siteName?: string }> }> {
+}): Promise<{
+  answer?: string;
+  results: Array<{
+    title: string;
+    url: string;
+    content: string;
+    score?: number;
+    published?: string;
+    siteName?: string;
+  }>;
+}> {
   const res = await fetch(TAVILY_SEARCH_ENDPOINT, {
     method: "POST",
     headers: {
@@ -621,7 +631,8 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
-      const tavilyApiKey = provider === "tavily" ? resolveTavilyApiKey(tavilyConfig, search) : undefined;
+      const tavilyApiKey =
+        provider === "tavily" ? resolveTavilyApiKey(tavilyConfig, search) : undefined;
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -547,7 +547,7 @@ async function runWebSearch(params: {
   if (params.provider !== "brave") {
     return {
       error: "unsupported_provider",
-      message: `Unsupported web search provider: ${params.provider}`,
+      message: `Unsupported web search provider: ${String(params.provider)}`,
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "tavily"). */
+      provider?: "brave" | "perplexity" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -354,6 +354,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "perplexity/sonar-pro"). */
         model?: string;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
+        apiKey?: string;
+        /** Search depth: "basic" for faster results, "advanced" for more comprehensive search (default: "basic"). */
+        searchDepth?: "basic" | "advanced";
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,7 +170,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("tavily")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("tavily")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,7 +170,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("tavily")]).optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -180,6 +180,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: z.string().optional(),
+        searchDepth: z.union([z.literal("basic"), z.literal("advanced")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
Add Tavily as a new web search provider option.

## Changes
- Add tavily to supported search providers
- Support TAVILY_API_KEY env var and config
- Add searchDepth option (basic/advanced)
- Fallback to tools.web.search.apiKey for consistency with Brave
- Add guard for unsupported locale params

## Fixes from previous review
- ✅ apiKey now falls back to tools.web.search.apiKey
- ✅ country/search_lang/ui_lang return error for Tavily/Perplexity

## Configuration
```yaml
tools:
  web:
    search:
      provider: tavily
      tavily:
        apiKey: tvly-xxxxx
        searchDepth: basic
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Tavily as a third `web_search` provider alongside Brave and Perplexity.

- Extends config/types + runtime Zod schema to accept `tools.web.search.provider: tavily` and a `tools.web.search.tavily` block with `apiKey` + `searchDepth`.
- Implements Tavily execution path in `src/agents/tools/web-search.ts`, including API key resolution (tavily-specific config → `TAVILY_API_KEY` env → fallback to `tools.web.search.apiKey`), request/response mapping, and caching keyed by `searchDepth`.
- Adds user-facing errors for missing Tavily key and rejects Brave-only locale params for Perplexity/Tavily (similar to the existing freshness guard).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but Tavily’s request/auth shape should be verified to avoid a broken provider at runtime.
- Changes are localized to the web-search tool and config schemas, and the provider selection + caching logic is straightforward. Main uncertainty is the Tavily API contract (auth/payload fields) and a couple of forward-compatibility/error-handling edges that could surface as runtime errors if configs drift.
- src/agents/tools/web-search.ts (Tavily request/auth contract and provider/error handling)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->