### PR TITLE
fix(telegram): format pairing command as code

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -53,6 +53,7 @@ import {
   hasBotMention,
   resolveTelegramForumThreadId,
 } from "./bot/helpers.js";
+import { escapeHtml } from "./format.js";
 
 type TelegramMediaRef = {
   path: string;
@@ -281,13 +282,14 @@ export const buildTelegramMessageContext = async ({
                     [
                       "OpenClaw: access not configured.",
                       "",
-                      `Your Telegram user id: ${telegramUserId}`,
+                      `Your Telegram user id: <code>${escapeHtml(telegramUserId)}</code>`,
                       "",
-                      `Pairing code: ${code}`,
+                      `Pairing code: <code>${escapeHtml(code)}</code>`,
                       "",
                       "Ask the bot owner to approve with:",
-                      formatCliCommand("openclaw pairing approve telegram <code>"),
+                      `<code>${escapeHtml(formatCliCommand("openclaw pairing approve telegram <code>"))}</code>`,
                     ].join("\n"),
+                    { parse_mode: "HTML" },
                   ),
               });
             }

--- a/src/telegram/bot.create-telegram-bot.installs-grammy-throttler.test.ts
+++ b/src/telegram/bot.create-telegram-bot.installs-grammy-throttler.test.ts
@@ -378,9 +378,15 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(sendMessageSpy.mock.calls[0]?.[0]).toBe(1234);
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Your Telegram user id: 999");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Pairing code:");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("PAIRME12");
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Your Telegram user id: <code>999</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Pairing code: <code>PAIRME12</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "openclaw pairing approve telegram &lt;code&gt;",
+    );
   });
   it("does not resend pairing code when a request is already pending", async () => {
     onSpy.mockReset();

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -591,9 +591,15 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(sendMessageSpy.mock.calls[0]?.[0]).toBe(1234);
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Your Telegram user id: 999");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Pairing code:");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("PAIRME12");
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Your Telegram user id: <code>999</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Pairing code: <code>PAIRME12</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "openclaw pairing approve telegram &lt;code&gt;",
+    );
   });
 
   it("does not resend pairing code when a request is already pending", async () => {

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -12,7 +12,7 @@ export type TelegramFormattedChunk = {
   text: string;
 };
 
-function escapeHtml(text: string): string {
+export function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 


### PR DESCRIPTION
## Summary

Formats the Telegram pairing code message to use HTML formatting, making the command easier to read and copy for users.

**Changes:**
- Added `parse_mode: "HTML"` to the pairing message in `bot-message-context.ts`
- Wrapped user ID, pairing code, and approval command in `<code>` tags
- Escaped HTML entities in the command placeholder (`<code>` → `&lt;code&gt;`)
- Updated test expectations to match new HTML formatting

**Before:**
```
OpenClaw: access not configured.

Your Telegram user id: 123456789

Pairing code: ABCD1234

Ask the bot owner to approve with:
openclaw pairing approve telegram <code>
```

**After (rendered):**
```
OpenClaw: access not configured.

Your Telegram user id: 123456789 (in code format)

Pairing code: ABCD1234 (in code format)

Ask the bot owner to approve with:
openclaw pairing approve telegram <code> (in code format)
```

## Test plan

- [x] Updated test expectations in `bot.test.ts` and `bot.create-telegram-bot.installs-grammy-throttler.test.ts`
- [x] All Telegram tests pass (82 tests in bot.test.ts, 10 tests in throttler test)
- [x] Formatted with oxfmt
- [x] Linted with oxlint (0 warnings, 0 errors)
- [x] Built successfully with pnpm build

## AI-Assisted Contribution

- ✅ This PR was created with AI assistance (Claude via Cursor)
- ✅ Testing: Fully tested - all unit tests pass
- ✅ Code understanding: Changes reviewed and understood - adds HTML formatting to match the codebase standard (all other Telegram messages use `parse_mode: "HTML"`)

## Notes

This change aligns the pairing message with the rest of the codebase, which uses HTML formatting for all Telegram messages. The HTML mode is more reliable than MarkdownV2 (no complex escaping requirements) and provides consistent fallback handling.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telegram DM pairing/onboarding message to use `parse_mode: "HTML"` and wraps the user id, pairing code, and approval command in `<code>` tags for improved readability/copyability. Corresponding unit test expectations were adjusted to match the new HTML output.

The change lives in `src/telegram/bot-message-context.ts` inside the DM `dmPolicy === "pairing"` flow (the message sent when an unknown DM sender triggers a pairing request). The two affected tests assert the updated message string content.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main risk is HTML-escaping correctness for interpolated values in Telegram messages.
- Changes are small and localized (one Telegram message + test updates) and should not affect routing or access control. The only notable concern is that switching to `parse_mode: "HTML"` introduces a need to consistently HTML-escape any interpolated content to avoid malformed messages or unintended rendering if upstream values ever change.
- src/telegram/bot-message-context.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->