### PR TITLE
feat: add raysurfer code caching skill

### DIFF
--- a/skills/raysurfer/SKILL.md
+++ b/skills/raysurfer/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: raysurfer
+description: "Cache and reuse code from prior AI agent executions via Raysurfer. Search before coding, upload after success."
+argument-hint: "[search query or \"upload\"]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+---
+
+# Raysurfer Code Caching Skill
+
+You have access to Raysurfer, a code caching system that stores and retrieves code from prior AI agent executions. Always check the cache before writing new code and upload successful results afterward.
+
+## Environment
+
+- **API Base URL**: `https://api.raysurfer.com`
+- **Auth**: Bearer token via the `RAYSURFER_API_KEY` environment variable
+- All API calls use `Content-Type: application/json`
+
+## Workflow
+
+Follow this sequence for every coding task:
+
+### Step 1: Search the Cache
+
+Before writing any code, search for existing cached solutions.
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/retrieve/search \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "<describe the task here>", "top_k": 5, "min_verdict_score": 0.3}'
+```
+
+The response contains:
+```json
+{
+  "matches": [
+    {
+      "code_block": {
+        "id": "uuid",
+        "name": "descriptive name",
+        "source": "the actual code content",
+        "language": "python"
+      },
+      "combined_score": 0.85,
+      "thumbs_up": 12,
+      "thumbs_down": 1
+    }
+  ],
+  "total_found": 3
+}
+```
+
+**Decision logic:**
+- If `total_found > 0` and the top match has `combined_score >= 0.7` and a favorable vote ratio (`thumbs_up > thumbs_down`), use the cached code.
+- If matches exist but scores are low, use them as a starting point and adapt.
+- If no matches, generate the code from scratch.
+
+### Step 2a: Use Cached Code (Cache Hit)
+
+When a good cache hit is found:
+1. Extract the `source` field from the best matching `code_block`.
+2. Write it to the appropriate file(s).
+3. Adapt paths, variable names, or configuration to the current project if needed.
+4. Run the code to verify it works.
+5. Proceed to Step 3 (Vote).
+
+### Step 2b: Generate Code (Cache Miss)
+
+When no suitable cache hit exists:
+1. Write the code as you normally would.
+2. Run the code to verify it works.
+3. Proceed to Step 4 (Upload).
+
+### Step 3: Vote on Cached Code
+
+After using cached code, report whether it worked:
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/store/cache-usage \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"code_block_id": "<id from the match>", "succeeded": true, "task": "<the task description>"}'
+```
+
+Set `succeeded` to `true` if the code ran correctly, `false` if it failed or needed significant changes.
+
+### Step 4: Upload New Code
+
+After successfully generating and running new code (cache miss), upload it for future reuse:
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/store/execution-result \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "<describe what this code does>",
+    "files_written": [
+      {"path": "relative/path/to/file.py", "content": "<full file content>"},
+      {"path": "relative/path/to/other.py", "content": "<full file content>"}
+    ],
+    "succeeded": true,
+    "auto_vote": true
+  }'
+```
+
+Only upload code that executed successfully. Set `auto_vote` to `true` to automatically register a positive vote.
+
+## Handling Arguments
+
+- If invoked with a search query (e.g., `/raysurfer parse CSV and generate chart`), run Step 1 with that query as the task.
+- If invoked with `upload` (e.g., `/raysurfer upload`), run Step 4 for the most recently generated code in the conversation.
+- If invoked with no arguments, display a summary of the workflow and ask what the user wants to do.
+
+When `$ARGUMENTS` is provided, use it as: `$ARGUMENTS`
+
+## Runnable Scripts
+
+Ready-to-run scripts are in this skill's directory. Requires `RAYSURFER_API_KEY` to be set.
+
+### Search
+
+```
+python search.py "Parse a CSV and plot a chart"
+bun search.ts "Parse a CSV and plot a chart"
+bash search.sh "Parse a CSV and plot a chart"
+```
+
+### Upload
+
+```
+python upload.py "Generate a bar chart" chart.py
+bun upload.ts "Generate a bar chart" chart.py
+bash upload.sh "Generate a bar chart" chart.py
+```
+
+## Guidelines
+
+- Always verify `RAYSURFER_API_KEY` is set before making API calls. If unset, inform the user and skip cache operations.
+- Write descriptive `task` strings that capture what the code does, not how it does it (e.g., "Parse CSV file and generate a bar chart with matplotlib" rather than "run pandas read_csv and plt.bar").
+- Never hardcode API keys in any command or file.
+- If the API is unreachable, proceed with normal code generation without blocking the user.
+- Keep uploaded code self-contained when possible so it is maximally reusable.
+
+## Quick Reference
+
+| Action | Endpoint | Method |
+|--------|----------|--------|
+| Search cache | `/api/retrieve/search` | POST |
+| Upload code | `/api/store/execution-result` | POST |
+| Vote on code | `/api/store/cache-usage` | POST |
+
+See `references/api-reference.md` for full request and response schemas.

--- a/skills/raysurfer/references/api-reference.md
+++ b/skills/raysurfer/references/api-reference.md
@@ -1,0 +1,185 @@
+# Raysurfer API Reference
+
+Base URL: `https://api.raysurfer.com`
+
+All endpoints require authentication via Bearer token in the `Authorization` header. The token is read from the `RAYSURFER_API_KEY` environment variable.
+
+Common headers for all requests:
+```
+Authorization: Bearer $RAYSURFER_API_KEY
+Content-Type: application/json
+```
+
+---
+
+## POST /api/retrieve/search
+
+Search the cache for code matching a task description.
+
+### Request Body
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `task` | string | yes | - | Natural language description of the coding task |
+| `top_k` | int | no | 5 | Maximum number of results to return |
+| `min_verdict_score` | float | no | 0.3 | Minimum combined score threshold (0.0 to 1.0) |
+
+### Example Request
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/retrieve/search \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Read a CSV file and plot a histogram with matplotlib",
+    "top_k": 5,
+    "min_verdict_score": 0.3
+  }'
+```
+
+### Response Body
+
+```json
+{
+  "matches": [
+    {
+      "code_block": {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "name": "csv-histogram-matplotlib",
+        "source": "import pandas as pd\nimport matplotlib.pyplot as plt\n...",
+        "language": "python"
+      },
+      "combined_score": 0.87,
+      "thumbs_up": 14,
+      "thumbs_down": 2
+    }
+  ],
+  "total_found": 1
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `matches` | array | List of matching cached code blocks |
+| `matches[].code_block.id` | string | Unique identifier for the code block (used for voting) |
+| `matches[].code_block.name` | string | Human-readable name |
+| `matches[].code_block.source` | string | The cached source code |
+| `matches[].code_block.language` | string | Programming language |
+| `matches[].combined_score` | float | Relevance score from 0.0 to 1.0 |
+| `matches[].thumbs_up` | int | Number of positive votes |
+| `matches[].thumbs_down` | int | Number of negative votes |
+| `total_found` | int | Total number of matches found |
+
+---
+
+## POST /api/store/execution-result
+
+Upload code that was successfully generated and executed.
+
+### Request Body
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `task` | string | yes | - | Natural language description of what the code does |
+| `files_written` | array | yes | - | List of files to cache |
+| `files_written[].path` | string | yes | - | Relative file path |
+| `files_written[].content` | string | yes | - | Full file content |
+| `succeeded` | bool | yes | - | Whether the code executed successfully |
+| `auto_vote` | bool | no | true | Automatically register a positive vote |
+
+### Example Request
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/store/execution-result \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Read a CSV file and plot a histogram with matplotlib",
+    "files_written": [
+      {
+        "path": "plot_histogram.py",
+        "content": "import pandas as pd\nimport matplotlib.pyplot as plt\n\ndf = pd.read_csv(\"data.csv\")\ndf[\"value\"].hist(bins=20)\nplt.savefig(\"histogram.png\")\n"
+      }
+    ],
+    "succeeded": true,
+    "auto_vote": true
+  }'
+```
+
+### Response Body
+
+```json
+{
+  "success": true,
+  "code_block_ids": ["550e8400-e29b-41d4-a716-446655440000"]
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | Whether the upload was accepted |
+| `code_block_ids` | string[] | IDs of the created code blocks |
+
+---
+
+## POST /api/store/cache-usage
+
+Vote on a cached code block after using it.
+
+### Request Body
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `code_block_id` | string | yes | - | ID of the code block being voted on |
+| `succeeded` | bool | yes | - | `true` for upvote (code worked), `false` for downvote (code failed) |
+| `task` | string | yes | - | Description of the task the code was used for |
+
+### Example Request
+
+```bash
+curl -s -X POST https://api.raysurfer.com/api/store/cache-usage \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "code_block_id": "550e8400-e29b-41d4-a716-446655440000",
+    "succeeded": true,
+    "task": "Read a CSV file and plot a histogram with matplotlib"
+  }'
+```
+
+### Response Body
+
+```json
+{
+  "success": true
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | Whether the vote was recorded |
+
+---
+
+## Error Responses
+
+All endpoints return standard HTTP error codes:
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Missing or invalid `RAYSURFER_API_KEY` |
+| 422 | Invalid request body (check required fields) |
+| 500 | Server error (retry or skip cache operations) |
+
+Error response body:
+```json
+{
+  "detail": "Human-readable error message"
+}
+```

--- a/skills/raysurfer/search.py
+++ b/skills/raysurfer/search.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Search Raysurfer cache. Usage: python search.py "task description" """
+import json, os, sys, urllib.request
+
+task = sys.argv[1] if len(sys.argv) > 1 else "Parse a CSV file and generate a bar chart"
+req = urllib.request.Request(
+    "https://api.raysurfer.com/api/retrieve/search",
+    data=json.dumps({"task": task, "top_k": 5, "min_verdict_score": 0.3}).encode(),
+    headers={"Authorization": f"Bearer {os.environ['RAYSURFER_API_KEY']}", "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    print(json.dumps(json.loads(resp.read()), indent=2))

--- a/skills/raysurfer/search.py
+++ b/skills/raysurfer/search.py
@@ -2,11 +2,16 @@
 """Search Raysurfer cache. Usage: python search.py "task description" """
 import json, os, sys, urllib.request
 
+api_key = os.environ.get("RAYSURFER_API_KEY")
+if not api_key:
+    print("RAYSURFER_API_KEY is not set, skipping cache search.", file=sys.stderr)
+    sys.exit(0)
+
 task = sys.argv[1] if len(sys.argv) > 1 else "Parse a CSV file and generate a bar chart"
 req = urllib.request.Request(
     "https://api.raysurfer.com/api/retrieve/search",
     data=json.dumps({"task": task, "top_k": 5, "min_verdict_score": 0.3}).encode(),
-    headers={"Authorization": f"Bearer {os.environ['RAYSURFER_API_KEY']}", "Content-Type": "application/json"},
+    headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
 )
 with urllib.request.urlopen(req) as resp:
     print(json.dumps(json.loads(resp.read()), indent=2))

--- a/skills/raysurfer/search.sh
+++ b/skills/raysurfer/search.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Search Raysurfer cache. Usage: bash search.sh "task description"
+TASK="${1:-Parse a CSV file and generate a bar chart}"
+curl -s -X POST https://api.raysurfer.com/api/retrieve/search \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"task\": \"$TASK\", \"top_k\": 5, \"min_verdict_score\": 0.3}" | python3 -m json.tool 2>/dev/null

--- a/skills/raysurfer/search.sh
+++ b/skills/raysurfer/search.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Search Raysurfer cache. Usage: bash search.sh "task description"
+if [ -z "$RAYSURFER_API_KEY" ]; then echo "RAYSURFER_API_KEY is not set, skipping cache search." >&2; exit 0; fi
+
 TASK="${1:-Parse a CSV file and generate a bar chart}"
-curl -s -X POST https://api.raysurfer.com/api/retrieve/search \
-  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"task\": \"$TASK\", \"top_k\": 5, \"min_verdict_score\": 0.3}" | python3 -m json.tool 2>/dev/null
+jq -n --arg task "$TASK" '{"task": $task, "top_k": 5, "min_verdict_score": 0.3}' | \
+  curl -s -X POST https://api.raysurfer.com/api/retrieve/search \
+    -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d @- | python3 -m json.tool 2>/dev/null

--- a/skills/raysurfer/search.ts
+++ b/skills/raysurfer/search.ts
@@ -1,0 +1,8 @@
+// Search Raysurfer cache. Usage: bun search.ts "task description"
+const task = process.argv[2] ?? "Parse a CSV file and generate a bar chart";
+const resp = await fetch("https://api.raysurfer.com/api/retrieve/search", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${process.env.RAYSURFER_API_KEY}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ task, top_k: 5, min_verdict_score: 0.3 }),
+});
+console.log(JSON.stringify(await resp.json(), null, 2));

--- a/skills/raysurfer/search.ts
+++ b/skills/raysurfer/search.ts
@@ -1,8 +1,11 @@
 // Search Raysurfer cache. Usage: bun search.ts "task description"
+const apiKey = process.env.RAYSURFER_API_KEY;
+if (!apiKey) { console.error("RAYSURFER_API_KEY is not set, skipping cache search."); process.exit(0); }
+
 const task = process.argv[2] ?? "Parse a CSV file and generate a bar chart";
 const resp = await fetch("https://api.raysurfer.com/api/retrieve/search", {
   method: "POST",
-  headers: { Authorization: `Bearer ${process.env.RAYSURFER_API_KEY}`, "Content-Type": "application/json" },
+  headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
   body: JSON.stringify({ task, top_k: 5, min_verdict_score: 0.3 }),
 });
 console.log(JSON.stringify(await resp.json(), null, 2));

--- a/skills/raysurfer/upload.py
+++ b/skills/raysurfer/upload.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Upload code to Raysurfer cache. Usage: python upload.py "task description" path/to/file.py"""
+import json, os, sys, urllib.request
+
+task, filepath = sys.argv[1], sys.argv[2]
+content = open(filepath).read()
+req = urllib.request.Request(
+    "https://api.raysurfer.com/api/store/execution-result",
+    data=json.dumps({
+        "task": task,
+        "files_written": [{"path": os.path.basename(filepath), "content": content}],
+        "succeeded": True,
+        "auto_vote": True,
+    }).encode(),
+    headers={"Authorization": f"Bearer {os.environ['RAYSURFER_API_KEY']}", "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    print(json.dumps(json.loads(resp.read()), indent=2))

--- a/skills/raysurfer/upload.py
+++ b/skills/raysurfer/upload.py
@@ -2,8 +2,17 @@
 """Upload code to Raysurfer cache. Usage: python upload.py "task description" path/to/file.py"""
 import json, os, sys, urllib.request
 
+if len(sys.argv) < 3:
+    print("Usage: python upload.py <task> <file>", file=sys.stderr)
+    sys.exit(1)
+
+api_key = os.environ.get("RAYSURFER_API_KEY")
+if not api_key:
+    print("RAYSURFER_API_KEY is not set, skipping cache upload.", file=sys.stderr)
+    sys.exit(0)
+
 task, filepath = sys.argv[1], sys.argv[2]
-content = open(filepath).read()
+content = open(filepath, encoding="utf-8").read()
 req = urllib.request.Request(
     "https://api.raysurfer.com/api/store/execution-result",
     data=json.dumps({
@@ -12,7 +21,7 @@ req = urllib.request.Request(
         "succeeded": True,
         "auto_vote": True,
     }).encode(),
-    headers={"Authorization": f"Bearer {os.environ['RAYSURFER_API_KEY']}", "Content-Type": "application/json"},
+    headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
 )
 with urllib.request.urlopen(req) as resp:
     print(json.dumps(json.loads(resp.read()), indent=2))

--- a/skills/raysurfer/upload.sh
+++ b/skills/raysurfer/upload.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Upload code to Raysurfer cache. Usage: bash upload.sh "task description" path/to/file.py
+TASK="${1:?Usage: upload.sh <task> <file>}"
+FILE="${2:?Usage: upload.sh <task> <file>}"
+CONTENT=$(cat "$FILE" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+curl -s -X POST https://api.raysurfer.com/api/store/execution-result \
+  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"task\": \"$TASK\", \"files_written\": [{\"path\": \"$(basename "$FILE")\", \"content\": $CONTENT}], \"succeeded\": true, \"auto_vote\": true}" | python3 -m json.tool 2>/dev/null

--- a/skills/raysurfer/upload.sh
+++ b/skills/raysurfer/upload.sh
@@ -2,8 +2,12 @@
 # Upload code to Raysurfer cache. Usage: bash upload.sh "task description" path/to/file.py
 TASK="${1:?Usage: upload.sh <task> <file>}"
 FILE="${2:?Usage: upload.sh <task> <file>}"
-CONTENT=$(cat "$FILE" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
-curl -s -X POST https://api.raysurfer.com/api/store/execution-result \
-  -H "Authorization: Bearer $RAYSURFER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"task\": \"$TASK\", \"files_written\": [{\"path\": \"$(basename "$FILE")\", \"content\": $CONTENT}], \"succeeded\": true, \"auto_vote\": true}" | python3 -m json.tool 2>/dev/null
+if [ -z "$RAYSURFER_API_KEY" ]; then echo "RAYSURFER_API_KEY is not set, skipping cache upload." >&2; exit 0; fi
+
+CONTENT=$(cat "$FILE")
+jq -n --arg task "$TASK" --arg path "$(basename "$FILE")" --arg content "$CONTENT" \
+  '{"task": $task, "files_written": [{"path": $path, "content": $content}], "succeeded": true, "auto_vote": true}' | \
+  curl -s -X POST https://api.raysurfer.com/api/store/execution-result \
+    -H "Authorization: Bearer $RAYSURFER_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d @- | python3 -m json.tool 2>/dev/null

--- a/skills/raysurfer/upload.ts
+++ b/skills/raysurfer/upload.ts
@@ -1,0 +1,13 @@
+// Upload code to Raysurfer cache. Usage: bun upload.ts "task description" path/to/file.py
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+const [task, filepath] = [process.argv[2], process.argv[3]];
+if (!task || !filepath) { console.error("Usage: bun upload.ts <task> <file>"); process.exit(1); }
+const content = readFileSync(filepath, "utf-8");
+const resp = await fetch("https://api.raysurfer.com/api/store/execution-result", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${process.env.RAYSURFER_API_KEY}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ task, files_written: [{ path: basename(filepath), content }], succeeded: true, auto_vote: true }),
+});
+console.log(JSON.stringify(await resp.json(), null, 2));

--- a/skills/raysurfer/upload.ts
+++ b/skills/raysurfer/upload.ts
@@ -4,10 +4,14 @@ import { basename } from "node:path";
 
 const [task, filepath] = [process.argv[2], process.argv[3]];
 if (!task || !filepath) { console.error("Usage: bun upload.ts <task> <file>"); process.exit(1); }
+
+const apiKey = process.env.RAYSURFER_API_KEY;
+if (!apiKey) { console.error("RAYSURFER_API_KEY is not set, skipping cache upload."); process.exit(0); }
+
 const content = readFileSync(filepath, "utf-8");
 const resp = await fetch("https://api.raysurfer.com/api/store/execution-result", {
   method: "POST",
-  headers: { Authorization: `Bearer ${process.env.RAYSURFER_API_KEY}`, "Content-Type": "application/json" },
+  headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
   body: JSON.stringify({ task, files_written: [{ path: basename(filepath), content }], succeeded: true, auto_vote: true }),
 });
 console.log(JSON.stringify(await resp.json(), null, 2));


### PR DESCRIPTION
## Summary

- Adds the **raysurfer** skill to the bundled skills directory
- Raysurfer lets AI agents cache and reuse code from prior executions, avoiding redundant code generation by searching a shared cache before writing new code and uploading successful results afterward
- Includes ready-to-run search and upload scripts in Python, Bash, and TypeScript
- Includes full API reference documentation in `references/api-reference.md`

## Files Added

```
skills/raysurfer/
├── SKILL.md                    # Skill definition with workflow instructions
├── references/
│   └── api-reference.md        # Full API docs (search, upload, vote endpoints)
├── search.py                   # Python search script
├── search.sh                   # Bash search script
├── search.ts                   # TypeScript search script
├── upload.py                   # Python upload script
├── upload.sh                   # Bash upload script
└── upload.ts                   # TypeScript upload script
```

## Test plan

- [ ] Verify skill loads correctly via `openclaw skills list`
- [ ] Test search with `RAYSURFER_API_KEY` set: `/raysurfer parse CSV and plot chart`
- [ ] Test upload flow: `/raysurfer upload`
- [ ] Verify skill works without API key (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new bundled skill, `skills/raysurfer`, intended to let agents search a hosted cache for prior code and upload successful “execution results” back to the service. It includes the skill definition (`SKILL.md`), API reference docs, and helper scripts in Python/Bash/TypeScript for search and upload.

Overall the additions are straightforward, but a few sharp edges will likely show up in the advertised “works without API key” flow and in the shell scripts’ JSON construction.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge but has a couple of user-facing reliability/security footguns in the helper scripts.
- Changes are additive (new skill + scripts + docs) and don’t touch core runtime, but multiple scripts will currently crash or misbehave when `RAYSURFER_API_KEY` is missing (despite docs/test plan expecting graceful skip), and the Bash scripts build JSON via interpolation which can break on quoted/newline task strings or allow payload injection.
- skills/raysurfer/search.py, skills/raysurfer/upload.py, skills/raysurfer/search.sh, skills/raysurfer/upload.sh

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->