### PR TITLE
fix(security): add timeout to webhook body reading (CWE-400)

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -450,14 +450,27 @@ export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => v
   };
 }
 
-async function readJsonBody(req: IncomingMessage, maxBytes: number) {
+async function readJsonBody(req: IncomingMessage, maxBytes: number, timeoutMs = 30_000) {
   const chunks: Buffer[] = [];
   let total = 0;
   return await new Promise<{ ok: boolean; value?: unknown; error?: string }>((resolve) => {
+    let done = false;
+    const finish = (result: { ok: boolean; value?: unknown; error?: string }) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish({ ok: false, error: "request body timeout" });
+      req.destroy();
+    }, timeoutMs);
+
     req.on("data", (chunk: Buffer) => {
       total += chunk.length;
       if (total > maxBytes) {
-        resolve({ ok: false, error: "payload too large" });
+        finish({ ok: false, error: "payload too large" });
         req.destroy();
         return;
       }
@@ -467,27 +480,30 @@ async function readJsonBody(req: IncomingMessage, maxBytes: number) {
       try {
         const raw = Buffer.concat(chunks).toString("utf8");
         if (!raw.trim()) {
-          resolve({ ok: false, error: "empty payload" });
+          finish({ ok: false, error: "empty payload" });
           return;
         }
         try {
-          resolve({ ok: true, value: JSON.parse(raw) as unknown });
+          finish({ ok: true, value: JSON.parse(raw) as unknown });
           return;
         } catch {
           const params = new URLSearchParams(raw);
           const payload = params.get("payload") ?? params.get("data") ?? params.get("message");
           if (payload) {
-            resolve({ ok: true, value: JSON.parse(payload) as unknown });
+            finish({ ok: true, value: JSON.parse(payload) as unknown });
             return;
           }
           throw new Error("invalid json");
         }
       } catch (err) {
-        resolve({ ok: false, error: err instanceof Error ? err.message : String(err) });
+        finish({ ok: false, error: err instanceof Error ? err.message : String(err) });
       }
     });
     req.on("error", (err) => {
-      resolve({ ok: false, error: err instanceof Error ? err.message : String(err) });
+      finish({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    });
+    req.on("close", () => {
+      finish({ ok: false, error: "connection closed" });
     });
   });
 }

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -456,7 +456,9 @@ async function readJsonBody(req: IncomingMessage, maxBytes: number, timeoutMs = 
   return await new Promise<{ ok: boolean; value?: unknown; error?: string }>((resolve) => {
     let done = false;
     const finish = (result: { ok: boolean; value?: unknown; error?: string }) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timer);
       resolve(result);

--- a/extensions/nostr/src/nostr-profile-http.ts
+++ b/extensions/nostr/src/nostr-profile-http.ts
@@ -210,31 +210,55 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
-async function readJsonBody(req: IncomingMessage, maxBytes = 64 * 1024): Promise<unknown> {
+async function readJsonBody(
+  req: IncomingMessage,
+  maxBytes = 64 * 1024,
+  timeoutMs = 30_000,
+): Promise<unknown> {
   return new Promise((resolve, reject) => {
+    let done = false;
+    const finish = (fn: () => void) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      finish(() => {
+        req.destroy(new Error("Body read timeout"));
+        reject(new Error("Request body timeout"));
+      });
+    }, timeoutMs);
+
     const chunks: Buffer[] = [];
     let totalBytes = 0;
 
     req.on("data", (chunk: Buffer) => {
       totalBytes += chunk.length;
       if (totalBytes > maxBytes) {
-        reject(new Error("Request body too large"));
-        req.destroy();
+        finish(() => {
+          reject(new Error("Request body too large"));
+          req.destroy();
+        });
         return;
       }
       chunks.push(chunk);
     });
 
     req.on("end", () => {
-      try {
-        const body = Buffer.concat(chunks).toString("utf-8");
-        resolve(body ? JSON.parse(body) : {});
-      } catch {
-        reject(new Error("Invalid JSON"));
-      }
+      finish(() => {
+        try {
+          const body = Buffer.concat(chunks).toString("utf-8");
+          resolve(body ? JSON.parse(body) : {});
+        } catch {
+          reject(new Error("Invalid JSON"));
+        }
+      });
     });
 
-    req.on("error", reject);
+    req.on("error", (err) => finish(() => reject(err)));
+    req.on("close", () => finish(() => reject(new Error("Connection closed"))));
   });
 }
 

--- a/extensions/nostr/src/nostr-profile-http.ts
+++ b/extensions/nostr/src/nostr-profile-http.ts
@@ -218,7 +218,9 @@ async function readJsonBody(
   return new Promise((resolve, reject) => {
     let done = false;
     const finish = (fn: () => void) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timer);
       fn();
@@ -226,8 +228,9 @@ async function readJsonBody(
 
     const timer = setTimeout(() => {
       finish(() => {
-        req.destroy(new Error("Body read timeout"));
-        reject(new Error("Request body timeout"));
+        const err = new Error("Request body timeout");
+        req.destroy(err);
+        reject(err);
       });
     }, timeoutMs);
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -302,7 +302,9 @@ export class VoiceCallWebhookServer {
     return new Promise((resolve, reject) => {
       let done = false;
       const finish = (fn: () => void) => {
-        if (done) return;
+        if (done) {
+          return;
+        }
         done = true;
         clearTimeout(timer);
         fn();
@@ -310,8 +312,9 @@ export class VoiceCallWebhookServer {
 
       const timer = setTimeout(() => {
         finish(() => {
-          req.destroy(new Error("Body read timeout"));
-          reject(new Error("Request body timeout"));
+          const err = new Error("Request body timeout");
+          req.destroy(err);
+          reject(err);
         });
       }, timeoutMs);
 


### PR DESCRIPTION
## Summary

Add 30-second timeout protection to prevent Slowloris DoS attacks on webhook body reading across 3 extensions.

Fixes #6023

## Risk Summary

- **Severity**: High (CWE-400 — CVSS 7.5, Slowloris DoS on webhook endpoints)
- **Regression risk**: Low — 30s timeout is generous for normal webhook payloads
- **Scope**: 3 files, isolated to body-reading helpers

## Changes

| File | Change |
|------|--------|
| `extensions/voice-call/src/webhook.ts` | Add timeout to `readBody()` |
| `extensions/bluebubbles/src/monitor.ts` | Add timeout to `readJsonBody()` |
| `extensions/nostr/src/nostr-profile-http.ts` | Add timeout to `readJsonBody()` |

- Implements `done` guard + `finish()` helper pattern to prevent double-settling promises
- Adds `close` event handler for connection drop detection

## Verification

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (208 tests)

## Sign-Off

- Models used: Claude Opus 4.6
- Submitter effort: Reviewed all 3 webhook body readers, verified done-guard prevents double-settle, confirmed timeout clears on normal completion
- Agent notes: N/A

lobster-biscuit