### PR TITLE
feat(hooks): add session:compact:pre and session:compact:post events

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -246,6 +246,15 @@ These hooks are not event-stream listeners; they let plugins synchronously adjus
 
 - **`tool_result_persist`**: transform tool results before they are written to the session transcript. Must be synchronous; return the updated tool result payload or `undefined` to keep it as-is. See [Agent Loop](/concepts/agent-loop).
 
+### Session Events
+
+Triggered during session lifecycle:
+
+- **`session:compact:pre`**: Before context compaction begins. Use to save working state.
+  - Context includes: `sessionId`, `sessionFile`, `workspaceDir`, `messageCount`
+- **`session:compact:post`**: After context compaction completes. Use to inject state back.
+  - Context includes: `sessionId`, `sessionFile`, `workspaceDir`, `summary`, `tokensBefore`, `tokensAfter`, `firstKeptEntryId`
+
 ### Future Events
 
 Planned event types:

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -4,6 +4,7 @@ import {
   SessionManager,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
@@ -425,6 +426,21 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Trigger pre-compaction hook
+        const preCompactEvent = createInternalHookEvent(
+          "session",
+          "compact:pre",
+          params.sessionKey ?? params.sessionId,
+          {
+            sessionId: params.sessionId,
+            sessionFile: params.sessionFile,
+            workspaceDir: effectiveWorkspace,
+            messageCount: session.messages.length,
+          },
+        );
+        await triggerInternalHook(preCompactEvent);
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -441,6 +457,24 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Trigger post-compaction hook
+        const postCompactEvent = createInternalHookEvent(
+          "session",
+          "compact:post",
+          params.sessionKey ?? params.sessionId,
+          {
+            sessionId: params.sessionId,
+            sessionFile: params.sessionFile,
+            workspaceDir: effectiveWorkspace,
+            summary: result.summary,
+            tokensBefore: result.tokensBefore,
+            tokensAfter,
+            firstKeptEntryId: result.firstKeptEntryId,
+          },
+        );
+        await triggerInternalHook(postCompactEvent);
+
         return {
           ok: true,
           compacted: true,


### PR DESCRIPTION
## Summary

Adds hook events before and after context compaction to allow agents to save and restore working state across compaction boundaries.

## Motivation

When context compaction occurs (either manually via `/compact` or automatically on context overflow), agents lose their working state. This makes it difficult for memory systems to preserve continuity across compaction.

With these hooks, a memory skill can:
1. **Pre-compaction**: Capture the current task state, recent decisions, and working context
2. **Post-compaction**: Inject that state back into the agent's context

## Events

### `session:compact:pre`
Fired before compaction begins. Context includes:
- `sessionId`: Session identifier
- `sessionFile`: Path to session transcript
- `workspaceDir`: Agent workspace directory
- `messageCount`: Number of messages before compaction

### `session:compact:post`
Fired after compaction completes. Context includes:
- `sessionId`: Session identifier
- `sessionFile`: Path to session transcript
- `workspaceDir`: Agent workspace directory
- `summary`: Compaction summary generated by the model
- `tokensBefore`: Token count before compaction
- `tokensAfter`: Token count after compaction
- `firstKeptEntryId`: ID of first kept message

## Example Hook

```typescript
const handler: HookHandler = async (event) => {
  if (event.type === 'session' && event.action === 'compact:pre') {
    // Save working state before compaction
    const state = await captureAgentState(event.context.workspaceDir);
    await saveToMemory(state);
  }
  
  if (event.type === 'session' && event.action === 'compact:post') {
    // Inject state back after compaction
    const state = await loadFromMemory();
    await injectContext(event.context.workspaceDir, state);
  }
};
```

## Testing

- [ ] Tested with manual `/compact` command
- [ ] Tested with auto-compaction on context overflow
- [ ] Hooks fire in correct order (pre before, post after)

## Related

This enables memory skills like [openclaw-memory](https://pypi.org/project/openclaw-memory/) to maintain continuity across compaction events.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds two new internal hook events around Pi session compaction (`session:compact:pre` and `session:compact:post`) so hooks can persist and restore agent working state across manual or automatic compaction. Implementation wires these events into the embedded Pi compaction flow (`src/agents/pi-embedded-runner/compact.ts`) and documents the new events and their context fields in `docs/hooks.md`.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but event timing/semantics likely don’t match the documented intent for pre-compaction state capture.
- Changes are localized and straightforward, but `session:compact:pre` currently fires after history is already pruned/replaced, which undermines the primary use-case (capturing full pre-compaction state). Additionally, hook errors are swallowed by the internal hook dispatcher so failures won’t be visible to callers.
- src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->